### PR TITLE
[api][SIMS #226]Enable Search for BCeID webservices

### DIFF
--- a/docs/bceid-webservice-integration.md
+++ b/docs/bceid-webservice-integration.md
@@ -5,10 +5,14 @@
 - [BCeID Web Service Integration](#bceid-web-service-integration)
   - [Table of Content](#table-of-content)
   - [Motivation](#motivation)
-  - [How to Retrieve Information From BCeID Web Service](#how-to-retrieve-information-from-bceid-web-service)
+  - [How Retrieve BCeID Account Details From BCeID Web Service](#how-retrieve-bceid-account-details-from-bceid-web-service)
     - [Request](#request)
     - [Response](#response)
   - [How Retrieve BCeID Account Details From SIMS-API](#how-retrieve-bceid-account-details-from-sims-api)
+  - [How Search BCeID Accounts Under a Business BCeID from BCeID Web Service](#how-search-bceid-accounts-under-a-business-bceid-from-bceid-web-service)
+    - [Request](#request-1)
+    - [Response](#response-1)
+  - [How Search BCeID Accounts Under a Business BCeID from SIMS-API](#how-search-bceid-accounts-under-a-business-bceid-from-sims-api)
 
 ## Motivation
 
@@ -17,7 +21,7 @@ BCeID is used to authenticate institution users that need to interact in some wa
 https://github.com/bcgov/ocp-sso/wiki/3.2-Identity-Provider-Attribute-Mapping
 
 To retrieve the additional information (e.g. Institution Legal Name) we need to request this data to [IDIM Web Services](https://images.zenhubusercontent.com/5fcebe3c076e6aaed83693fb/8fe2b927-6ce2-4278-aa11-4f8572c17877) using the BCeID Web Service. On the [IDIM Web Services](https://images.zenhubusercontent.com/5fcebe3c076e6aaed83693fb/8fe2b927-6ce2-4278-aa11-4f8572c17877) link we can find the documentation to the BCeID Client Web Services, currently name as "BCeID Client - New Web Services - Developers Guide".
-## How to Retrieve Information From BCeID Web Service
+## How Retrieve BCeID Account Details From BCeID Web Service
 
 To retrieve the additional information we are going to use the method *getAccountDetail* available on the BCeID Web Service. Please find below the sample SOAP to request account information (*below values are not real values*).
 
@@ -139,5 +143,152 @@ So, in order to allow our system to have access to the additional BCeID Web Serv
         "guid": "99998F10542349AC8574AE7184B0FAA9",
         "legalName": "College Legal Name"
     }
+}
+````
+
+## How Search BCeID Accounts Under a Business BCeID from BCeID Web Service
+
+The current requirement is to retrieve all the accounts under a particular institution. To do it we use the method *searchBCeIDAccount* available on the BCeID Web Service. Please find below the sample SOAP to request account information (*below values are not real values*).
+
+### Request
+
+````xml
+<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:v10="http://www.bceid.ca/webservices/Client/V10/">
+   <soapenv:Header/>
+   <soapenv:Body>
+      <v10:searchBCeIDAccount>
+         <v10:bceidAccountSearchRequest>
+            <v10:onlineServiceId>9191-9999-9999-9A9A</v10:onlineServiceId>
+            <v10:requesterAccountTypeCode>Business</v10:requesterAccountTypeCode>
+            <v10:requesterUserGuid>9999A99999BZ4884842Z999Z39Z99ZZZ</v10:requesterUserGuid>
+            <v10:pagination>
+               <v10:pageSizeMaximum>500</v10:pageSizeMaximum>
+               <v10:pageIndex>1</v10:pageIndex>
+            </v10:pagination>
+            <v10:sort>
+               <v10:direction>Ascending</v10:direction>
+               <v10:onProperty>Firstname</v10:onProperty>
+            </v10:sort>
+            <v10:accountMatch>
+               <v10:searchableAccountType>Business</v10:searchableAccountType>
+            </v10:accountMatch>
+            <v10:businessMatch>
+               <v10:businessGuid>99998F10542349AC8574AE7184B0FAA9</v10:businessGuid>
+            </v10:businessMatch>
+         </v10:bceidAccountSearchRequest>
+      </v10:searchBCeIDAccount>
+   </soapenv:Body>
+</soapenv:Envelope>
+````
+
+Please find below a sample SOAP response from the above call.
+The response was reduced to better readability.
+
+### Response
+
+````xml
+<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+   <soap:Body>
+      <searchBCeIDAccountResponse xmlns="http://www.bceid.ca/webservices/Client/V10/">
+         <searchBCeIDAccountResult>
+            <code>Success</code>
+            <failureCode>Void</failureCode>
+            <message/>
+            <pagination>
+               <totalItems>31</totalItems>
+               <totalVirtualItems>31</totalVirtualItems>
+               <requestedPageSize>500</requestedPageSize>
+               <requestedPageIndex>1</requestedPageIndex>
+            </pagination>
+            <accountList>
+               <BCeIDAccount>
+                  <guid isAllowed="true">
+                     <value>9999A99999BZ4884842Z999Z39Z99ZZZ</value>
+                  </guid>                 
+                  <dluid isAllowed="true">
+                     <value>AA9A9A</value>
+                  </dluid>
+                  <bceidDluid isAllowed="true">
+                     <value>AA9A8AAAAA9A</value>
+                  </bceidDluid>
+                  <userId isAllowed="true">
+                     <value>SomeUserId</value>
+                  </userId>
+                  <state>
+                     <isSuspended isAllowed="true">
+                        <value>false</value>
+                     </isSuspended>
+                     <isManagerDisabled isAllowed="true">
+                        <value>false</value>
+                     </isManagerDisabled>
+                  </state>
+                  <contact>
+                     <email isAllowed="true">
+                        <value>do_not_reply@aest.bc.gov</value>
+                     </email>
+                     <telephone isAllowed="true">
+                        <value>025 123456 1234</value>
+                     </telephone>
+                  </contact>
+                  <individualIdentity>
+                     <name>
+                        <firstname isAllowed="true">
+                           <value>John</value>
+                        </firstname>
+                        <surname isAllowed="true">
+                           <value>Doe</value>
+                        </surname>
+                     </name>
+                  </individualIdentity>
+                  <business>
+                     <guid isAllowed="true">
+                        <value>99998F10542349AC8574AE7184B0FAA9</value>
+                     </guid>
+                     <dluid isAllowed="true">
+                        <value>AAAA9A</value>
+                     </dluid>
+                     <legalName isAllowed="true">
+                        <value>College F</value>
+                     </legalName>
+                     <state>
+                        <isSuspended isAllowed="true">
+                           <value>false</value>
+                        </isSuspended>
+                     </state>
+                  </business>              
+               </BCeIDAccount>
+            </accountList>
+         </searchBCeIDAccountResult>
+      </searchBCeIDAccountResponse>
+   </soap:Body>
+</soap:Envelope>
+````
+
+## How Search BCeID Accounts Under a Business BCeID from SIMS-API
+
+An API endpoint was created on our SIMS-API to allow that an authenticated business BCeID user could have access to all others accounts under the same Business BCeID account. Tthe user requesting such information will only have access to BCeID accounts that he is allowed to access, what is enforced by *requesterUserGuid* parameter on SOAP request.
+
+So, in order to allow our system to search the other BCeID accounts under the same business account, the endpoint *api/users/bceid-accounts* was created and once it is acessed, with a valid business BCeID user token, the below information will be returned (*below values are not real values*).
+
+````json
+{
+  "accounts": [
+    {
+      "guid": "9861A92082AA4884842A304A39A63ACA",
+      "displayName": "John Doe",
+      "firstname": "John",
+      "surname": "Doe",
+      "email": "johndoe@aest.bc.gov",
+      "telephone": "778 912 1234"
+    },
+    {
+      "guid": "1BBB7B28BB994B9B83778BB71B338B2B",
+      "displayName": "Jane Doe",
+      "firstname": "Jane",
+      "surname": "Doe",
+      "email": "janedoe@aest.bc.gov",
+      "telephone": "778 912 5678"
+    }
+  ]
 }
 ````

--- a/sources/packages/api/package.json
+++ b/sources/packages/api/package.json
@@ -20,9 +20,11 @@
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
     "test:e2e": "ENVIRONMENT=test jest --config ./test/jest-e2e.json",
     "test:e2e:local": "NODE_ENV=local ENVIRONMENT=test jest --config ./test/jest-e2e.json",
+    "test:e2e:local:win": "SET NODE_ENV=local&&SET ENVIRONMENT=test&&jest --config ./test/jest-e2e.json",
     "setup:db": "ts-node scripts/setupDB",
     "local": "ENVIRONMENT=local NODE_ENV=local npm run start:dev",
     "test:local": "NODE_ENV=local ENVIRONMENT=test jest",
+    "test:local:win": "SET NODE_ENV=local&&SET ENVIRONMENT=test&&jest",
     "setup:archive:db": "ts-node scripts/setupArchiveDB",
     "docker:start": "npm run setup:db && npm run setup:archive:db && node dist/main"
   },

--- a/sources/packages/api/src/app.module.ts
+++ b/sources/packages/api/src/app.module.ts
@@ -8,8 +8,8 @@ import {
   ConfigService,
   ArchiveDbService,
   InstitutionService,
-  BCeIDService,
   ApplicationService,
+  BCeIDServiceProvider,
 } from "./services";
 import {
   UserController,
@@ -52,7 +52,7 @@ import {
     InstitutionService,
     ConfigService,
     ArchiveDbService,
-    BCeIDService,
+    BCeIDServiceProvider,
     ServiceAccountService,
     RuleEngineService,
     FormService,

--- a/sources/packages/api/src/route-controllers/user/models/bceid-accounts.dto.ts
+++ b/sources/packages/api/src/route-controllers/user/models/bceid-accounts.dto.ts
@@ -1,0 +1,12 @@
+export interface BCeIDAccountsDto {
+  accounts: BCeIDAccountDto[];
+}
+
+export interface BCeIDAccountDto {
+  guid: string;
+  displayName: string;
+  email: string;
+  firstname: string;
+  surname: string;
+  telephone: string;
+}

--- a/sources/packages/api/src/route-controllers/user/user.controller.ts
+++ b/sources/packages/api/src/route-controllers/user/user.controller.ts
@@ -4,7 +4,7 @@ import BaseController from "../BaseController";
 import { UserToken } from "../../auth/decorators/userToken.decorator";
 import { IUserToken } from "../../auth/userToken.interface";
 import { BCeIDDetailsDto } from "./models/bceid-account.dto";
-import { SearchAccountOptions } from "src/services/bceid/search-bceid.model";
+import { SearchAccountOptions } from "../../services/bceid/search-bceid.model";
 import { BCeIDAccountsDto } from "./models/bceid-accounts.dto";
 
 @Controller("users")

--- a/sources/packages/api/src/route-controllers/user/user.controller.ts
+++ b/sources/packages/api/src/route-controllers/user/user.controller.ts
@@ -1,9 +1,10 @@
-import { Controller, Get } from "@nestjs/common";
+import { Controller, Get, UnprocessableEntityException } from "@nestjs/common";
 import { BCeIDService, UserService } from "../../services";
 import BaseController from "../BaseController";
 import { UserToken } from "../../auth/decorators/userToken.decorator";
 import { IUserToken } from "../../auth/userToken.interface";
 import { BCeIDDetailsDto } from "./models/bceid-account.dto";
+import { SearchAccountOptions } from "src/services/bceid/search-bceid.model";
 
 @Controller("users")
 export class UserController extends BaseController {
@@ -53,5 +54,25 @@ export class UserController extends BaseController {
         },
       };
     }
-  } //Close getBCeID method
+  }
+
+  @Get("bceid-accounts")
+  async getAllBCeIDs(@UserToken() userToken: IUserToken): Promise<any> {
+    const account = await this.bceidService.getAccountDetails(
+      userToken.idp_user_name,
+    );
+
+    if (!account) {
+      throw new UnprocessableEntityException(
+        "Not able to retrieve BCeID business account details for the current authenticated user.",
+      );
+    }
+
+    const searchOptions = new SearchAccountOptions();
+    searchOptions.requesterUserGuid = account.user.guid;
+    searchOptions.businessGuid = account.institution.guid;
+    const accounts = await this.bceidService.searchBCeIDAccounts(searchOptions);
+
+    return accounts;
+  }
 }

--- a/sources/packages/api/src/route-controllers/user/user.controller.ts
+++ b/sources/packages/api/src/route-controllers/user/user.controller.ts
@@ -77,6 +77,7 @@ export class UserController extends BaseController {
     const searchResult = await this.bceidService.searchBCeIDAccounts(
       searchOptions,
     );
+
     const accounts = searchResult.accounts.map((account) => {
       return {
         guid: account.guid,

--- a/sources/packages/api/src/route-controllers/user/user.controller.ts
+++ b/sources/packages/api/src/route-controllers/user/user.controller.ts
@@ -5,6 +5,7 @@ import { UserToken } from "../../auth/decorators/userToken.decorator";
 import { IUserToken } from "../../auth/userToken.interface";
 import { BCeIDDetailsDto } from "./models/bceid-account.dto";
 import { SearchAccountOptions } from "src/services/bceid/search-bceid.model";
+import { BCeIDAccountsDto } from "./models/bceid-accounts.dto";
 
 @Controller("users")
 export class UserController extends BaseController {
@@ -57,7 +58,9 @@ export class UserController extends BaseController {
   }
 
   @Get("bceid-accounts")
-  async getAllBCeIDs(@UserToken() userToken: IUserToken): Promise<any> {
+  async getAllBCeIDs(
+    @UserToken() userToken: IUserToken,
+  ): Promise<BCeIDAccountsDto> {
     const account = await this.bceidService.getAccountDetails(
       userToken.idp_user_name,
     );
@@ -71,8 +74,22 @@ export class UserController extends BaseController {
     const searchOptions = new SearchAccountOptions();
     searchOptions.requesterUserGuid = account.user.guid;
     searchOptions.businessGuid = account.institution.guid;
-    const accounts = await this.bceidService.searchBCeIDAccounts(searchOptions);
+    const searchResult = await this.bceidService.searchBCeIDAccounts(
+      searchOptions,
+    );
+    const accounts = searchResult.accounts.map((account) => {
+      return {
+        guid: account.guid,
+        displayName: account.displayName,
+        email: account.email,
+        firstname: account.firstname,
+        surname: account.surname,
+        telephone: account.telephone,
+      };
+    });
 
-    return accounts;
+    return {
+      accounts,
+    };
   }
 }

--- a/sources/packages/api/src/route-controllers/user/user.e2e-spec.ts
+++ b/sources/packages/api/src/route-controllers/user/user.e2e-spec.ts
@@ -6,7 +6,7 @@ import { AppModule } from "../../app.module";
 import { KeycloakConfig } from "../../auth/keycloakConfig";
 import { KeycloakService } from "../../services/auth/keycloak/keycloak.service";
 
-describe("Users controller (e2e)", () => {
+describe.skip("Users controller (e2e)", () => {
   // Use the student client to retrieve the token from.
   // The BCeID user is a Keyclock user, so doesn't matter
   // from which client it will be retrieved.

--- a/sources/packages/api/src/route-controllers/user/user.e2e-spec.ts
+++ b/sources/packages/api/src/route-controllers/user/user.e2e-spec.ts
@@ -1,12 +1,12 @@
-require("../env_setup");
+require("../../../env_setup");
 import { Test, TestingModule } from "@nestjs/testing";
 import { HttpStatus, INestApplication } from "@nestjs/common";
 import * as request from "supertest";
-import { AppModule } from "../src/app.module";
-import { KeycloakConfig } from "../src/auth/keycloakConfig";
-import { KeycloakService } from "../src/services/auth/keycloak/keycloak.service";
+import { AppModule } from "../../app.module";
+import { KeycloakConfig } from "../../auth/keycloakConfig";
+import { KeycloakService } from "../../services/auth/keycloak/keycloak.service";
 
-describe.skip("Users controller (e2e)", () => {
+describe("Users controller (e2e)", () => {
   // Use the student client to retrieve the token from.
   // The BCeID user is a Keyclock user, so doesn't matter
   // from which client it will be retrieved.
@@ -35,7 +35,7 @@ describe.skip("Users controller (e2e)", () => {
     await app.init();
   });
 
-  describe.skip("bceid-account route", () => {
+  describe("bceid-account route", () => {
     it("Should return a HttpStatus OK(200) with user account information when user is valid", () => {
       return request(app.getHttpServer())
         .get("/users/bceid-account")
@@ -52,6 +52,29 @@ describe.skip("Users controller (e2e)", () => {
           expect(resp.body.institution).toBeDefined();
           expect(resp.body.institution.guid).toBeTruthy();
           expect(resp.body.institution.legalName).toBeTruthy();
+        });
+    });
+  });
+
+  describe("bceid-accounts route", () => {
+    it("Should return a HttpStatus OK(200) with user accounts information when user is valid", () => {
+      return request(app.getHttpServer())
+        .get("/users/bceid-accounts")
+        .auth(accesstoken, { type: "bearer" })
+        .expect(HttpStatus.OK)
+        .then((resp) => {
+          expect(resp.body).toBeDefined();
+          expect(resp.body.accounts).toBeDefined();
+          const account = resp.body.accounts[0];
+          expect(account.guid).toBeTruthy();
+          expect(account.firstname).toBeTruthy();
+          expect(account.surname).toBeTruthy();
+          expect(account.displayName).toBeTruthy();
+          expect(account.displayName).toBe(
+            `${account.firstname} ${account.surname}`,
+          );
+          expect(account.email).toBeTruthy();
+          expect(account.telephone).toBeDefined();
         });
     });
   });

--- a/sources/packages/api/src/services/bceid/bceid.models.ts
+++ b/sources/packages/api/src/services/bceid/bceid.models.ts
@@ -161,3 +161,35 @@ export enum SortDirection {
    */
   Descending = "Descending",
 }
+
+/**
+ * Raw value from BCeID Soap response.
+ */
+export interface SoapResponseRawValue {
+  readonly value: string;
+}
+
+export interface IndividualIdentitySoapResponse {
+  readonly name: IndividualIdentityNameSoapResponse;
+}
+
+export interface IndividualIdentityNameSoapResponse {
+  readonly firstname: SoapResponseRawValue;
+  readonly surname: SoapResponseRawValue;
+}
+
+export interface IndividualIdentityContactSoapResponse {
+  readonly email: SoapResponseRawValue;
+  readonly telephone: SoapResponseRawValue;
+}
+
+/**
+ * BCeID account soap response from searchBCeIDAccount
+ * method from BCeID Web Service.
+ */
+export interface BCeIDAccountSoapResponse {
+  readonly guid: SoapResponseRawValue;
+  readonly userId: SoapResponseRawValue;
+  readonly individualIdentity?: IndividualIdentitySoapResponse;
+  readonly contact?: IndividualIdentityContactSoapResponse;
+}

--- a/sources/packages/api/src/services/bceid/bceid.models.ts
+++ b/sources/packages/api/src/services/bceid/bceid.models.ts
@@ -105,3 +105,59 @@ export enum BCeIDAccountTypeCodes {
    */
   Business = "Business",
 }
+
+/**
+ * While executing a search on BCeID, these are the sort options.
+ */
+export enum SortBCeIDAccountOnProperty {
+  /**
+   * No sort field specified. Specifying this value will result in an error message.
+   */
+  Void = "Void",
+  /**
+   * Sort on User ID.
+   */
+  UserId = "UserId",
+  /**
+   * Sort on first name.
+   */
+  Firstname = "Firstname",
+  /**
+   * Sort on last name.
+   */
+  LastName = "LastName",
+  /**
+   * Sort on middle name.
+   */
+  MiddleName1 = "MiddleName1",
+  /**
+   * Sort on other middle name.
+   */
+  MiddleName2 = "MiddleName2",
+  /**
+   * Sort on email address
+   */
+  Email = "Email",
+  /**
+   * Sort on telephone.
+   */
+  Telephone = "Telephone",
+}
+
+/**
+ * While executing a search on BCeID, these are the sort direction options.
+ */
+export enum SortDirection {
+  /**
+   * No direction specified. Specifying this value will result in an error message.
+   */
+  Void = "Void",
+  /**
+   * Sort in ascending order.
+   */
+  Ascending = "Ascending",
+  /**
+   * Sort in descending order.
+   */
+  Descending = "Descending",
+}

--- a/sources/packages/api/src/services/bceid/bceid.service.mock.ts
+++ b/sources/packages/api/src/services/bceid/bceid.service.mock.ts
@@ -4,6 +4,8 @@ import {
   SearchAccountOptions,
   SearchBCeIDAccountResult,
 } from "./search-bceid.model";
+import getAccountDetailsMock from "./mockups/getAccountDetails.mock";
+import searchBCeIDAccountsMock from "./mockups/searchBCeIDAccounts.mock";
 
 // This service is intended to return only fake data for development purposes only.
 // It allows the simulation of the response from BCeID Web Service.
@@ -15,12 +17,12 @@ import {
 @Injectable()
 export class BCeIDServiceMock {
   public async getAccountDetails(userName: string): Promise<AccountDetails> {
-    return require("./mockups/getAccountDetails.mock").mock;
+    return getAccountDetailsMock;
   }
 
   public async searchBCeIDAccounts(
     options: SearchAccountOptions,
   ): Promise<SearchBCeIDAccountResult> {
-    return require("./mockups/searchBCeIDAccounts.mock").mock;
+    return searchBCeIDAccountsMock;
   }
 }

--- a/sources/packages/api/src/services/bceid/bceid.service.mock.ts
+++ b/sources/packages/api/src/services/bceid/bceid.service.mock.ts
@@ -1,0 +1,26 @@
+import { Injectable } from "@nestjs/common";
+import { AccountDetails } from "./account-details.model";
+import {
+  SearchAccountOptions,
+  SearchBCeIDAccountResult,
+} from "./search-bceid.model";
+
+// This service is intended to return only fake data for development purposes only.
+// It allows the simulation of the response from BCeID Web Service.
+// This service will be used when the below env variable is set
+// DUMMY_BCeID_ACCOUNT_RESPONSE === "yes"
+// IMPORTANT: This class will not be part of the production runtime code
+// because only the BCeIDService is added to the application (app.module.ts).
+// This is achieved through the use of the BCeIDServiceProvider.
+@Injectable()
+export class BCeIDServiceMock {
+  public async getAccountDetails(userName: string): Promise<AccountDetails> {
+    return require("./mockups/getAccountDetails.mock").mock;
+  }
+
+  public async searchBCeIDAccounts(
+    options: SearchAccountOptions,
+  ): Promise<SearchBCeIDAccountResult> {
+    return require("./mockups/searchBCeIDAccounts.mock").mock;
+  }
+}

--- a/sources/packages/api/src/services/bceid/bceid.service.provider.ts
+++ b/sources/packages/api/src/services/bceid/bceid.service.provider.ts
@@ -1,0 +1,15 @@
+import { BCeIDService } from "..";
+import { BCeIDServiceMock } from "../bceid/bceid.service.mock";
+
+/**
+ * Used to allow developers to consume a mocked version of
+ * BCeID WebService that makes it possible to run the
+ * solution locally without a VPN.
+ */
+export const BCeIDServiceProvider = {
+  provide: BCeIDService,
+  useClass:
+    process.env.DUMMY_BCeID_ACCOUNT_RESPONSE === "yes"
+      ? BCeIDServiceMock
+      : BCeIDService,
+};

--- a/sources/packages/api/src/services/bceid/bceid.service.ts
+++ b/sources/packages/api/src/services/bceid/bceid.service.ts
@@ -93,6 +93,12 @@ export class BCeIDService {
     }
   }
 
+  /**
+   * Retrieves business BCeIDs accounts under the specified institution (options.businessGuid)
+   * and that the user (options.requesterUserGuid) executing the search has access to.
+   * @param options Search parameters.
+   * @returns The list of BCeIDs for the institution.
+   */
   public async searchBCeIDAccounts(
     options: SearchAccountOptions,
   ): Promise<SearchBCeIDAccountResult> {

--- a/sources/packages/api/src/services/bceid/bceid.service.ts
+++ b/sources/packages/api/src/services/bceid/bceid.service.ts
@@ -11,6 +11,7 @@ import {
   SearchResultAccount,
 } from "./search-bceid.model";
 import {
+  BCeIDAccountSoapResponse,
   BCeIDAccountTypeCodes,
   ResponseBase,
   ResponseCodes,
@@ -136,17 +137,19 @@ export class BCeIDService {
       const accounts = result.searchBCeIDAccountResult.accountList.BCeIDAccount;
       const pagination = result.searchBCeIDAccountResult.pagination;
 
-      const accountResults = accounts.map((account: any) => {
-        return {
-          guid: account.guid.value,
-          userId: account.userId.value,
-          displayName: `${account.individualIdentity?.name?.firstname.value} ${account.individualIdentity?.name?.surname.value}`.trim(),
-          firstname: account.individualIdentity?.name?.firstname.value,
-          surname: account.individualIdentity?.name?.surname.value,
-          email: account.contact?.email.value,
-          telephone: account.contact?.telephone.value,
-        } as SearchResultAccount;
-      });
+      const accountResults = accounts.map(
+        (account: BCeIDAccountSoapResponse) => {
+          return {
+            guid: account.guid.value,
+            userId: account.userId.value,
+            displayName: `${account.individualIdentity?.name?.firstname.value} ${account.individualIdentity?.name?.surname.value}`.trim(),
+            firstname: account.individualIdentity?.name?.firstname.value,
+            surname: account.individualIdentity?.name?.surname.value,
+            email: account.contact?.email.value,
+            telephone: account.contact?.telephone.value,
+          } as SearchResultAccount;
+        },
+      );
 
       return {
         accounts: accountResults,

--- a/sources/packages/api/src/services/bceid/bceid.service.ts
+++ b/sources/packages/api/src/services/bceid/bceid.service.ts
@@ -40,21 +40,6 @@ export class BCeIDService {
    * @returns account details if the account was found, otherwise null.
    */
   public async getAccountDetails(userName: string): Promise<AccountDetails> {
-    if (process.env.DUMMY_BCeID_ACCOUNT_RESPONSE === "yes") {
-      return {
-        user: {
-          guid: "a90b3-ff78c-98b0c-2e5fb-7c667",
-          displayName: "Test Account",
-          firstname: "Test",
-          surname: "Account",
-          email: "test.account@sims.ca",
-        },
-        institution: {
-          guid: "b90a3-ee78b-98a0d-2f5db-7a457",
-          legalName: "Test Institute",
-        },
-      };
-    }
     var client = await this.getSoapClient();
     // SOAP call body to execute the getAccountDetail request.
     var body = {

--- a/sources/packages/api/src/services/bceid/bceid.service.ts
+++ b/sources/packages/api/src/services/bceid/bceid.service.ts
@@ -143,11 +143,13 @@ export class BCeIDService {
       this.ensureSuccessStatusResult(response);
       // Array os items from SOAP response that contains all accounts.
       const accounts = result.searchBCeIDAccountResult.accountList.BCeIDAccount;
+      const pagination = result.searchBCeIDAccountResult.pagination;
 
       const accountResults = accounts.map((account: any) => {
         return {
           guid: account.guid.value,
           userId: account.userId.value,
+          displayName: `${account.individualIdentity?.name?.firstname.value} ${account.individualIdentity?.name?.surname.value}`.trim(),
           firstname: account.individualIdentity?.name?.firstname.value,
           surname: account.individualIdentity?.name?.surname.value,
           email: account.contact?.email.value,
@@ -155,7 +157,14 @@ export class BCeIDService {
         } as SearchResultAccount;
       });
 
-      return { accounts: accountResults };
+      return {
+        accounts: accountResults,
+        paginationResult: {
+          totalItems: pagination.totalVirtualItems,
+          requestedPageSize: pagination.requestedPageSize,
+          requestedPageIndex: pagination.requestedPageIndex,
+        },
+      };
     } catch (error) {
       this.logger.error(
         `Error while searching BCeID accounts on BCeID Web Service. ${error}`,

--- a/sources/packages/api/src/services/bceid/mockups/getAccountDetails.mock.ts
+++ b/sources/packages/api/src/services/bceid/mockups/getAccountDetails.mock.ts
@@ -1,0 +1,18 @@
+// This is a sample response used for development purposes only
+// to allow to simulate the response from BCeID Web Service
+// processed by the service BCeIDService(bceid.service.ts).
+// This data will be returned when the below env variable is set
+// DUMMY_BCeID_ACCOUNT_RESPONSE === "yes"
+export const mock = {
+  user: {
+    guid: "a90b3-ff78c-98b0c-2e5fb-7c667",
+    displayName: "Test Account",
+    firstname: "Test",
+    surname: "Account",
+    email: "test.account@sims.ca",
+  },
+  institution: {
+    guid: "b90a3-ee78b-98a0d-2f5db-7a457",
+    legalName: "Test Institute",
+  },
+};

--- a/sources/packages/api/src/services/bceid/mockups/getAccountDetails.mock.ts
+++ b/sources/packages/api/src/services/bceid/mockups/getAccountDetails.mock.ts
@@ -3,7 +3,7 @@
 // processed by the service BCeIDService(bceid.service.ts).
 // This data will be returned when the below env variable is set
 // DUMMY_BCeID_ACCOUNT_RESPONSE === "yes"
-export const mock = {
+export default {
   user: {
     guid: "a90b3-ff78c-98b0c-2e5fb-7c667",
     displayName: "Test Account",

--- a/sources/packages/api/src/services/bceid/mockups/searchBCeIDAccounts.mock.ts
+++ b/sources/packages/api/src/services/bceid/mockups/searchBCeIDAccounts.mock.ts
@@ -5,7 +5,7 @@
 // DUMMY_BCeID_ACCOUNT_RESPONSE === "yes"
 // For a complete response from the BCeID Test Web Service please
 // copy the file available on "Teams>Files>BCeID Web Service Mockups"
-export const mock = {
+export default {
   accounts: [
     {
       guid: "4861E92082BD4884842F304C39F63FCB",

--- a/sources/packages/api/src/services/bceid/mockups/searchBCeIDAccounts.mock.ts
+++ b/sources/packages/api/src/services/bceid/mockups/searchBCeIDAccounts.mock.ts
@@ -1,0 +1,34 @@
+// This is a sample response used for development purposes only
+// to allow to simulate the response from BCeID Web Service
+// processed by the service BCeIDService(bceid.service.ts).
+// This data will be returned when the below env variable is set
+// DUMMY_BCeID_ACCOUNT_RESPONSE === "yes"
+// For a complete response from the BCeID Test Web Service please
+// copy the file available on "Teams>Files>BCeID Web Service Mockups"
+export const mock = {
+  accounts: [
+    {
+      guid: "4861E92082BD4884842F304C39F63FCB",
+      userId: "JohnDoe456",
+      displayName: "John Doe",
+      firstname: "John",
+      surname: "Doe",
+      email: "johndoe@aest.bc.gov",
+      telephone: "778 912 1234",
+    },
+    {
+      guid: "1BFF7C28BD994B9D83778FB71A33862E",
+      userId: "JaneDoe456",
+      displayName: "Jane Doe",
+      firstname: "Jane",
+      surname: "Doe",
+      email: "janedoe@aest.bc.gov",
+      telephone: "778 912 5678",
+    },
+  ],
+  paginationResult: {
+    totalItems: 2,
+    requestedPageSize: 500,
+    requestedPageIndex: 1,
+  },
+};

--- a/sources/packages/api/src/services/bceid/search-bceid.model.ts
+++ b/sources/packages/api/src/services/bceid/search-bceid.model.ts
@@ -1,0 +1,34 @@
+/**
+ * While executing a search on BCeID, this is considered
+ * the index of the first page.
+ */
+export const PAGINATION_FIRST_PAGE_INDEX = 1;
+/**
+ * While executing a search on BCeID, this is
+ * the maximun page size allowed.
+ */
+export const PAGINATION_MAX_PAGE_SIZE = 500;
+
+export class SearchAccountOptions {
+  requesterUserGuid: string;
+  businessGuid: string;
+  pagination = new PaginationOptions();
+}
+
+export class PaginationOptions {
+  pageSize?: Number = PAGINATION_MAX_PAGE_SIZE;
+  pageIndex?: Number = PAGINATION_FIRST_PAGE_INDEX;
+}
+
+export interface SearchBCeIDAccountResult {
+  accounts: SearchResultAccount[];
+}
+
+export interface SearchResultAccount {
+  guid: string;
+  userId: string;
+  email: string;
+  firstname: string;
+  surname: string;
+  telephone: string;
+}

--- a/sources/packages/api/src/services/bceid/search-bceid.model.ts
+++ b/sources/packages/api/src/services/bceid/search-bceid.model.ts
@@ -1,6 +1,8 @@
 /**
  * While executing a search on BCeID, this is considered
  * the index of the first page.
+ * It is initialized as 1 as per defined on
+ * BCeID Web Service documentation.
  */
 export const PAGINATION_FIRST_PAGE_INDEX = 1;
 /**
@@ -9,9 +11,23 @@ export const PAGINATION_FIRST_PAGE_INDEX = 1;
  */
 export const PAGINATION_MAX_PAGE_SIZE = 500;
 
+/**
+ * Search options to retrieve BCeID accounts.
+ */
 export class SearchAccountOptions {
+  /**
+   * Guid from the BCeID user executing th search.
+   */
   requesterUserGuid: string;
+  /**
+   * Guid from the institution where the search will be executed.
+   */
   businessGuid: string;
+  /**
+   * Pagination options. This is a required parameter, if not
+   * provided, the first page with the maximun allowed records
+   * will be retrieved.
+   */
   pagination = new PaginationOptions();
 }
 
@@ -21,14 +37,22 @@ export class PaginationOptions {
 }
 
 export interface SearchBCeIDAccountResult {
-  accounts: SearchResultAccount[];
+  readonly accounts: SearchResultAccount[];
+  readonly paginationResult: PaginationResult;
 }
 
 export interface SearchResultAccount {
-  guid: string;
-  userId: string;
-  email: string;
-  firstname: string;
-  surname: string;
-  telephone: string;
+  readonly guid: string;
+  readonly userId: string;
+  readonly displayName: string;
+  readonly email: string;
+  readonly firstname: string;
+  readonly surname: string;
+  readonly telephone: string;
+}
+
+export interface PaginationResult {
+  readonly totalItems: number;
+  readonly requestedPageSize: number;
+  readonly requestedPageIndex: number;
 }

--- a/sources/packages/api/src/services/bceid/search-bceid.model.ts
+++ b/sources/packages/api/src/services/bceid/search-bceid.model.ts
@@ -16,7 +16,7 @@ export const PAGINATION_MAX_PAGE_SIZE = 500;
  */
 export class SearchAccountOptions {
   /**
-   * Guid from the BCeID user executing th search.
+   * Guid from the BCeID user executing the search.
    */
   requesterUserGuid: string;
   /**
@@ -31,16 +31,25 @@ export class SearchAccountOptions {
   pagination = new PaginationOptions();
 }
 
+/**
+ * Pagination options allowed on BCeID Web Service search request.
+ */
 export class PaginationOptions {
   pageSize?: Number = PAGINATION_MAX_PAGE_SIZE;
   pageIndex?: Number = PAGINATION_FIRST_PAGE_INDEX;
 }
 
+/**
+ * Search result from a BCeID Web Service request.
+ */
 export interface SearchBCeIDAccountResult {
   readonly accounts: SearchResultAccount[];
   readonly paginationResult: PaginationResult;
 }
 
+/**
+ * Represents each BCeID account returned from the search operation.
+ */
 export interface SearchResultAccount {
   readonly guid: string;
   readonly userId: string;
@@ -51,8 +60,27 @@ export interface SearchResultAccount {
   readonly telephone: string;
 }
 
+/**
+ * Pagination result from the BCeID Web Service result
+ * that contains informations useful to handle the pagination,
+ * for instance, the total of items present on the server, that
+ * could be different from the total of items returned due to
+ * the size of the page requested.
+ */
 export interface PaginationResult {
+  /**
+   * Total of items that would be returned by the search
+   * disconsidering the page size requested.
+   */
   readonly totalItems: number;
+  /**
+   * Size of the page requested.
+   */
   readonly requestedPageSize: number;
+  /**
+   * Index of the page returned.
+   * Please note that the page index is not 0 based,
+   * the first page is the index 1.
+   */
   readonly requestedPageIndex: number;
 }

--- a/sources/packages/api/src/services/index.ts
+++ b/sources/packages/api/src/services/index.ts
@@ -3,6 +3,7 @@ export * from "./user/user.service";
 export * from "./config/config.service";
 export * from "./archive-db/archive-db.service";
 export * from "./bceid/bceid.service";
+export * from "./bceid/bceid.service.provider";
 export * from "./institution/institution.service";
 export * from "./service-account/service-account.service";
 export * from "./rule-engine/rule-engine.service";


### PR DESCRIPTION
- Created SOAP request to retrieve all the BCeID accounts that belong to a particular institution. The implementation is retrieving a maximum of 500 records. With the help of @abschwenker, we were able to check that the max amount of records currently on production is around 270 accounts. So far the decision is to retrieve the first page (500 maximum).
- Create a mocked version of BCeIDService to be used when "DUMMY_BCeID_ACCOUNT_RESPONSE=yes";
- Created mocked files with the full content from BCeID Web Service on "Teams>Files>BCeID Web Service Mockups" to allow the development without the Gov VPN enabled. IMPORTANT: the mocked classes will not be part of the production runtime code.
- Documentation updated