### PR TITLE
[devops][SIMS-#227][Hotfix] Increase readiness-probe delay/failure threshold for api deployment

### DIFF
--- a/devops/openshift/api-deploy.yml
+++ b/devops/openshift/api-deploy.yml
@@ -177,11 +177,11 @@ objects:
                   cpu: ${CPU_REQUEST}
                   memory: ${MEMORY_REQUEST}
               readinessProbe:
-                failureThreshold: 2
+                failureThreshold: 10
                 httpGet:
                   path: /api/
                   port: "${{PORT}}"
-                initialDelaySeconds: 10
+                initialDelaySeconds: 30
                 periodSeconds: 30
               livenessProbe:
                 failureThreshold: 10

--- a/devops/openshift/web-deploy.yml
+++ b/devops/openshift/web-deploy.yml
@@ -41,11 +41,11 @@ objects:
                   cpu: ${CPU_REQUEST}
                   memory: ${MEMORY_REQUEST}
               readinessProbe:
-                failureThreshold: 2
+                failureThreshold: 5
                 httpGet:
                   path: /
                   port: "${{PORT}}"
-                initialDelaySeconds: 10
+                initialDelaySeconds: 20
                 periodSeconds: 30
               livenessProbe:
                 failureThreshold: 10


### PR DESCRIPTION
1. Increase initial delay
2. Increase Failure threshold 