### PR TITLE
Fix Form.IO cached form load data

### DIFF
--- a/sources/packages/web/src/components/generic/formio.vue
+++ b/sources/packages/web/src/components/generic/formio.vue
@@ -4,10 +4,11 @@
 </template>
 
 <script lang="ts">
-import { onMounted, ref } from "vue";
+import { onMounted, ref, watch } from "vue";
 import { Formio } from "formiojs";
 import { SetupContext } from "vue";
 import ApiClient from "../../services/http/ApiClient";
+import { prop } from "vue-class-component";
 
 export default {
   emits: ["submitted", "loaded", "changed"],
@@ -24,6 +25,7 @@ export default {
     const formioContainerRef = ref(null);
     // Wait to show the spinner when there is an API call.
     const hideSpinner = ref(true);
+    let form: any;
 
     onMounted(async () => {
       let cachedFormDefinition: string | null = null;
@@ -56,7 +58,7 @@ export default {
         }
       }
 
-      const form = await Formio.createForm(
+      form = await Formio.createForm(
         formioContainerRef.value,
         formDefinition.data,
       );
@@ -80,6 +82,17 @@ export default {
         context.emit("submitted", submision.data);
       });
     });
+
+    watch(
+      () => props.data,
+      () => {
+        if (form && props.data) {
+          form.submission = {
+            data: props.data,
+          };
+        }
+      },
+    );
 
     return { formioContainerRef, hideSpinner };
   },

--- a/sources/packages/web/src/components/generic/formio.vue
+++ b/sources/packages/web/src/components/generic/formio.vue
@@ -8,7 +8,6 @@ import { onMounted, ref, watch } from "vue";
 import { Formio } from "formiojs";
 import { SetupContext } from "vue";
 import ApiClient from "../../services/http/ApiClient";
-import { prop } from "vue-class-component";
 
 export default {
   emits: ["submitted", "loaded", "changed"],


### PR DESCRIPTION
While loading data into the Form.IO there was a race condition between the method loading the form definition and the method loading the form data to be displayed. The race condition was already in place but became evident when the form was cache and started to be always ready before the data loading to populate the form.