### PR TITLE
[api][SIMS #532]Institution User Edits Student Enrolment (CoE)

### DIFF
--- a/sources/packages/api/src-sql/Types/alter-application-status.sql
+++ b/sources/packages/api/src-sql/Types/alter-application-status.sql
@@ -1,0 +1,4 @@
+-- Add new Overwritten enum option.
+ALTER TYPE sims.application_status
+ADD
+  VALUE 'Overwritten'

--- a/sources/packages/api/src-sql/Types/rollback-alter-application-status.sql
+++ b/sources/packages/api/src-sql/Types/rollback-alter-application-status.sql
@@ -1,0 +1,26 @@
+-- Postgres does not allow the removal of items of an enum, only add or rename.
+-- To remove the previously added items, a temporary enum will be created to
+-- allow the creation of the enum as it was before.
+CREATE TYPE sims.application_status_to_rollback AS ENUM (
+  'Draft',
+  'In Progress',
+  'Assessment',
+  'Enrollment',
+  'Completed',
+  'Cancelled',
+  'Submitted'
+);
+
+-- Update the dependent column to start using the new enum with the expected values.
+ALTER TABLE
+  sims.applications
+ALTER COLUMN
+  application_status TYPE sims.application_status_to_rollback USING CASE
+    WHEN application_status = 'Overwritten' THEN 'Submitted' :: sims.application_status_to_rollback
+  END;
+
+-- Remove the entire enum that is no longer being used.
+DROP TYPE sims.application_status;
+
+-- Rename the enum to what it was in the begining.
+ALTER TYPE sims.application_status_to_rollback RENAME TO application_status;

--- a/sources/packages/api/src/database/entities/application-status.type.ts
+++ b/sources/packages/api/src/database/entities/application-status.type.ts
@@ -38,6 +38,9 @@ export enum ApplicationStatus {
    * an edit on Confirmation of Enrollment that forces the assessment to
    * be reevaluated. Is this case the application is cloned and and the
    * old version is marked as 'Overwritten'.
+   * An Overwritten application should never be modified, once an application
+   * is Overwritten and a clone/new version is created all edits should take
+   * place on new record.
    */
   overwritten = "Overwritten",
 }

--- a/sources/packages/api/src/database/entities/application-status.type.ts
+++ b/sources/packages/api/src/database/entities/application-status.type.ts
@@ -30,7 +30,14 @@ export enum ApplicationStatus {
    */
   completed = "Completed",
   /**
-   * TThe application has been cancelled by the student
+   * The application has been cancelled by the student
    */
   cancelled = "Cancelled",
+  /**
+   * The application was replaced by a new version due to some event like
+   * an edit on Confirmation of Enrollment that forces the assessment to
+   * be reevaluated. Is this case the application is cloned and and the
+   * old version is marked as 'Overwritten'.
+   */
+  overwritten = "Overwritten",
 }

--- a/sources/packages/api/src/database/entities/application-student-file.model.ts
+++ b/sources/packages/api/src/database/entities/application-student-file.model.ts
@@ -1,4 +1,10 @@
-import { Entity, JoinColumn, ManyToOne, PrimaryGeneratedColumn } from "typeorm";
+import {
+  Entity,
+  JoinColumn,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+  RelationId,
+} from "typeorm";
 import { StudentFile } from ".";
 import { ColumnNames, TableNames } from "../constant";
 import { Application } from "./application.model";
@@ -24,6 +30,9 @@ export class ApplicationStudentFile extends RecordDataModel {
     referencedColumnName: ColumnNames.ID,
   })
   application: Application;
+
+  @RelationId((file: ApplicationStudentFile) => file.studentFile)
+  studentFileId: number;
 
   @ManyToOne(() => StudentFile, {
     eager: false,

--- a/sources/packages/api/src/database/entities/application.model.ts
+++ b/sources/packages/api/src/database/entities/application.model.ts
@@ -6,6 +6,7 @@ import {
   OneToMany,
   OneToOne,
   PrimaryGeneratedColumn,
+  RelationId,
 } from "typeorm";
 import {
   EducationProgram,
@@ -46,6 +47,9 @@ export class Application extends RecordDataModel {
   })
   assessment: any;
 
+  @RelationId((application: Application) => application.student)
+  studentId: number;
+
   @OneToOne(() => Student, { eager: false, cascade: true })
   @JoinColumn({
     name: "student_id",
@@ -53,12 +57,18 @@ export class Application extends RecordDataModel {
   })
   student: Student;
 
+  @RelationId((application: Application) => application.location)
+  locationId: number;
+
   @ManyToOne(() => InstitutionLocation, { eager: false, cascade: true })
   @JoinColumn({
     name: "location_id",
     referencedColumnName: ColumnNames.ID,
   })
   location: InstitutionLocation;
+
+  @RelationId((application: Application) => application.pirProgram)
+  pirProgramId?: number;
 
   /**
    * References the program related to the application
@@ -77,6 +87,9 @@ export class Application extends RecordDataModel {
   })
   pirProgram?: EducationProgram;
 
+  @RelationId((application: Application) => application.programYear)
+  programYearId: number;
+
   /**
    * References the program year related to the application.
    * This will be populated only when an active program year application is Submitted
@@ -90,6 +103,9 @@ export class Application extends RecordDataModel {
     referencedColumnName: ColumnNames.ID,
   })
   programYear: ProgramYear;
+
+  @RelationId((application: Application) => application.offering)
+  offeringId?: number;
 
   @ManyToOne(() => EducationProgramOffering, {
     eager: false,
@@ -112,6 +128,9 @@ export class Application extends RecordDataModel {
     type: "uuid",
   })
   assessmentWorkflowId: string;
+
+  @RelationId((application: Application) => application.studentFiles)
+  studentFilesIds: number[];
 
   @OneToMany(
     () => ApplicationStudentFile,

--- a/sources/packages/api/src/database/migrations/1629400247363-AddOverwrittenToApplicationStatus.ts
+++ b/sources/packages/api/src/database/migrations/1629400247363-AddOverwrittenToApplicationStatus.ts
@@ -1,0 +1,18 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+import { getSQLFileData } from "../../utilities";
+
+export class AddOverwrittenToApplicationStatus1629400247363
+  implements MigrationInterface
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      getSQLFileData("alter-application-status.sql", "Types"),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      getSQLFileData("rollback-alter-application-status.sql", "Types"),
+    );
+  }
+}

--- a/sources/packages/api/src/route-controllers/application/application.system.controller.e2e-spec.ts
+++ b/sources/packages/api/src/route-controllers/application/application.system.controller.e2e-spec.ts
@@ -8,10 +8,14 @@ import { DatabaseModule } from "../../database/database.module";
 import { AuthModule } from "../../auth/auth.module";
 import {
   ApplicationService,
+  ConfigService,
   EducationProgramOfferingService,
   KeycloakService,
   SequenceControlService,
   StudentFileService,
+  TokensService,
+  WorkflowActionsService,
+  WorkflowService,
 } from "../../services";
 import { createFakeApplication } from "../../testHelpers/fake-entities/application-fake";
 import { setGlobalPipes } from "../../utilities/auth-utils";
@@ -29,6 +33,7 @@ import {
   createFakeEducationProgram,
   createFakeEducationProgramOffering,
 } from "../../testHelpers/fake-entities";
+import { createMockedJwtService } from "../../testHelpers/mocked-providers/jwt-service-mock";
 
 describe("Test system-access/application Controller", () => {
   let accesstoken: string;
@@ -46,7 +51,6 @@ describe("Test system-access/application Controller", () => {
       process.env.FORMS_FLOW_BPM_CLIENT_SECRET,
     );
     accesstoken = token.access_token;
-
     const module: TestingModule = await Test.createTestingModule({
       imports: [DatabaseModule, AuthModule],
       controllers: [ApplicationSystemController],
@@ -55,6 +59,12 @@ describe("Test system-access/application Controller", () => {
         StudentFileService,
         EducationProgramOfferingService,
         SequenceControlService,
+        WorkflowActionsService,
+        WorkflowService,
+        KeycloakService,
+        ConfigService,
+        TokensService,
+        createMockedJwtService(),
       ],
     }).compile();
 

--- a/sources/packages/api/src/route-controllers/confirmation-of-enrollment/confirmation-of-enrollment.controller.ts
+++ b/sources/packages/api/src/route-controllers/confirmation-of-enrollment/confirmation-of-enrollment.controller.ts
@@ -1,14 +1,20 @@
-import { Controller, Param, Get } from "@nestjs/common";
+import {
+  Controller,
+  Param,
+  Get,
+  Post,
+  NotFoundException,
+  UnprocessableEntityException,
+} from "@nestjs/common";
 import { HasLocationAccess, AllowAuthorizedParty } from "../../auth/decorators";
 import { AuthorizedParties } from "../../auth/authorized-parties.enum";
 import {
   ApplicationService,
-  InstitutionService,
-  InstitutionLocationService,
+  INVALID_OPERATION_IN_THE_CURRENT_STATUS,
+  APPLICATION_NOT_FOUND,
+  WorkflowActionsService,
 } from "../../services";
 import { Application } from "../../database/entities";
-import { UserToken } from "../../auth/decorators/userToken.decorator";
-import { IInstitutionUserToken } from "../../auth/userToken.interface";
 import { COESummaryDTO } from "../application/models/application.model";
 
 @AllowAuthorizedParty(AuthorizedParties.institution)
@@ -16,8 +22,7 @@ import { COESummaryDTO } from "../application/models/application.model";
 export class ConfirmationOfEnrollmentController {
   constructor(
     private readonly applicationService: ApplicationService,
-    private readonly institutionService: InstitutionService,
-    private readonly locationService: InstitutionLocationService,
+    private readonly workflow: WorkflowActionsService,
   ) {}
 
   /**
@@ -26,12 +31,10 @@ export class ConfirmationOfEnrollmentController {
    * @param locationId location that is completing the COE.
    * @returns student application list of an institution location
    */
-  @AllowAuthorizedParty(AuthorizedParties.institution)
   @HasLocationAccess("locationId")
   @Get(":locationId/confirmation-of-enrollment")
   async getCOESummary(
     @Param("locationId") locationId: number,
-    @UserToken() userToken: IInstitutionUserToken,
   ): Promise<COESummaryDTO[]> {
     const applications = await this.applicationService.getCOEApplications(
       locationId,
@@ -47,5 +50,48 @@ export class ConfirmationOfEnrollmentController {
         lastName: eachApplication.student.user.lastName,
       };
     }) as COESummaryDTO[];
+  }
+
+  /**
+   * Creates a new Student Application overriding the current one
+   * in order to rollback the process and start the assessment
+   * all over again.
+   * @param locationId location id executing the COE rollback.
+   * @param applicationId application to be rolled back.
+   * @returns the id of the newly created Student Application.
+   */
+  @HasLocationAccess("locationId")
+  @Post(":locationId/confirmation-of-enrollment/:applicationId/rollback")
+  async startCOERollback(
+    @Param("locationId") locationId: number,
+    @Param("applicationId") applicationId: number,
+  ): Promise<number> {
+    try {
+      const result = await this.applicationService.overrideApplicationForCOE(
+        locationId,
+        applicationId,
+      );
+
+      if (result.overriddenApplication.assessmentWorkflowId) {
+        await this.workflow.deleteApplicationAssessment(
+          result.overriddenApplication.assessmentWorkflowId,
+        );
+      }
+
+      await this.applicationService.startApplicationAssessment(
+        result.createdApplication.id,
+      );
+
+      return result.createdApplication.id;
+    } catch (error) {
+      switch (error.name) {
+        case APPLICATION_NOT_FOUND:
+          throw new NotFoundException(error.message);
+        case INVALID_OPERATION_IN_THE_CURRENT_STATUS:
+          throw new UnprocessableEntityException(error.message);
+        default:
+          throw error;
+      }
+    }
   }
 }

--- a/sources/packages/api/src/route-controllers/confirmation-of-enrollment/confirmation-of-enrollment.controller.ts
+++ b/sources/packages/api/src/route-controllers/confirmation-of-enrollment/confirmation-of-enrollment.controller.ts
@@ -53,15 +53,17 @@ export class ConfirmationOfEnrollmentController {
   }
 
   /**
-   * Creates a new Student Application overriding the current one
-   * in order to rollback the process and start the assessment
-   * all over again.
+   * Creates a new Student Application to maintain history,
+   * overriding the current one in order to rollback the
+   * process and start the assessment all over again.
    * @param locationId location id executing the COE rollback.
    * @param applicationId application to be rolled back.
    * @returns the id of the newly created Student Application.
    */
   @HasLocationAccess("locationId")
-  @Post(":locationId/confirmation-of-enrollment/:applicationId/rollback")
+  @Post(
+    ":locationId/confirmation-of-enrollment/application/:applicationId/rollback",
+  )
   async startCOERollback(
     @Param("locationId") locationId: number,
     @Param("applicationId") applicationId: number,

--- a/sources/packages/api/src/route-controllers/student/student.controller.spec.ts
+++ b/sources/packages/api/src/route-controllers/student/student.controller.spec.ts
@@ -9,10 +9,15 @@ import {
   StudentFileService,
   ApplicationService,
   SequenceControlService,
+  WorkflowActionsService,
+  WorkflowService,
+  KeycloakService,
+  TokensService,
 } from "../../services";
 import { StudentController } from "./student.controller";
 import { DatabaseModule } from "../../database/database.module";
 import { DatabaseService } from "../../database/database.service";
+import { createMockedJwtService } from "../../testHelpers/mocked-providers/jwt-service-mock";
 
 describe("StudentController", () => {
   let controller: StudentController;
@@ -29,6 +34,12 @@ describe("StudentController", () => {
         SequenceControlService,
         StudentFileService,
         ApplicationService,
+        WorkflowActionsService,
+        WorkflowService,
+        KeycloakService,
+        ConfigService,
+        TokensService,
+        createMockedJwtService(),
       ],
       controllers: [StudentController],
     }).compile();

--- a/sources/packages/api/src/services/application/application.models.ts
+++ b/sources/packages/api/src/services/application/application.models.ts
@@ -1,4 +1,4 @@
-import { Application } from "src/database/entities";
+import { Application } from "../../database/entities";
 
 export interface ApplicationOverriddenResult {
   overriddenApplication: Application;

--- a/sources/packages/api/src/services/application/application.models.ts
+++ b/sources/packages/api/src/services/application/application.models.ts
@@ -1,0 +1,6 @@
+import { Application } from "src/database/entities";
+
+export interface ApplicationOverriddenResult {
+  overriddenApplication: Application;
+  createdApplication: Application;
+}

--- a/sources/packages/api/src/services/application/application.service.ts
+++ b/sources/packages/api/src/services/application/application.service.ts
@@ -648,9 +648,9 @@ export class ApplicationService extends RecordDataModelService<Application> {
   }
 
   /**
-   * Creates a new Student Application overriding the current one
-   * in order to rollback the process and start the assessment
-   * all over again.
+   * Creates a new Student Application to maintain history,
+   * overriding the current one in order to rollback the
+   * process and start the assessment all over again.
    * @param locationId location id executing the COE rollback.
    * @param applicationId application to be rolled back.
    * @returns the overridden and the newly created application.
@@ -688,7 +688,8 @@ export class ApplicationService extends RecordDataModelService<Application> {
     appToOverride.applicationStatus = ApplicationStatus.overwritten;
     appToOverride.applicationStatusUpdatedOn = getUTCNow();
 
-    // Create a new application based in the previous one.
+    // Create a new application record based off Overwritten
+    // record to rollback state of application.
     const newApplication = new Application();
     newApplication.data = appToOverride.data;
     newApplication.applicationNumber = appToOverride.applicationNumber;

--- a/sources/packages/api/src/services/atbc/atbc.controller.e2e-spec.ts
+++ b/sources/packages/api/src/services/atbc/atbc.controller.e2e-spec.ts
@@ -10,6 +10,9 @@ import {
   StudentFileService,
   ApplicationService,
   SequenceControlService,
+  WorkflowActionsService,
+  WorkflowService,
+  TokensService,
 } from "..";
 import { KeycloakConfig } from "../../auth/keycloakConfig";
 import { KeycloakService } from "../auth/keycloak/keycloak.service";
@@ -21,6 +24,7 @@ import { ATBCCreateClientResponse } from "../../types";
 import { StudentController } from "../../route-controllers";
 import { DatabaseModule } from "../../database/database.module";
 import { AuthModule } from "../../auth/auth.module";
+import { createMockedJwtService } from "../../testHelpers/mocked-providers/jwt-service-mock";
 
 describe("Test ATBC Controller", () => {
   const clientId = "student";
@@ -38,7 +42,6 @@ describe("Test ATBC Controller", () => {
       clientId,
     );
     accesstoken = token.access_token;
-
     const moduleFixture: TestingModule = await Test.createTestingModule({
       imports: [DatabaseModule, AuthModule],
       controllers: [StudentController],
@@ -51,6 +54,12 @@ describe("Test ATBC Controller", () => {
         StudentService,
         ApplicationService,
         SequenceControlService,
+        WorkflowActionsService,
+        WorkflowService,
+        KeycloakService,
+        ConfigService,
+        TokensService,
+        createMockedJwtService(),
       ],
     }).compile();
     userService = await moduleFixture.get(UserService);

--- a/sources/packages/api/src/testHelpers/mocked-providers/jwt-service-mock.ts
+++ b/sources/packages/api/src/testHelpers/mocked-providers/jwt-service-mock.ts
@@ -1,0 +1,12 @@
+import { Provider } from "@nestjs/common";
+import { JwtService } from "@nestjs/jwt";
+
+export function createMockedJwtService(): Provider {
+  const jwtService = new JwtService({
+    secretOrPrivateKey: "Secret key",
+  });
+  return {
+    provide: JwtService,
+    useValue: jwtService,
+  };
+}

--- a/sources/packages/web/src/types/contracts/students/ApplicationContract.ts
+++ b/sources/packages/web/src/types/contracts/students/ApplicationContract.ts
@@ -30,7 +30,8 @@ export enum ApplicationStatus {
    */
   completed = "Completed",
   /**
-   * TThe application has been cancelled by the student
+   * The application has been cancelled by the student.
+   * A cancelled Application should never be modified.
    */
   cancelled = "Cancelled",
 }


### PR DESCRIPTION
- Partial delivery for ticket #532 ;
- No Vue changes included;
- Created the new enum value for application status called "Overwritten";
- Added @RelationId properties to application entity to allow the retrieval of many foreign keys without the need to create a join to satisfy Typeorm requirements. In this way, we can have easy access to foreign keys;
- Create a centralized method to start the application workflow and assign the workflow id to the application. This method is being shared between the submit application method (already existent) and the new one added to COE;
- Create a new API endpoint to:
    - Clone the Student Application;
    - Delete the current workflow;
    - Start a new workflow.
    
This API endpoint was created as a **POST** because it is creating a new resource and because **the operation is NOT idempotent** (open for suggestions 😉)
The endpoint also has the "rollback" appended because the COE is not being edited, from an API perspective, it is canceling the process and rolling back the assessment to a previous phase. It was also tricky to find a good way to name it, please let me know if someone has a better idea.