### PR TITLE
[api][SIMS #555]Workflow approach fix's

### DIFF
--- a/sources/packages/api/src/route-controllers/application/application.system.controller.ts
+++ b/sources/packages/api/src/route-controllers/application/application.system.controller.ts
@@ -177,7 +177,7 @@ export class ApplicationSystemController {
   /**
    * Updates overall Application status and Assessment workflowId.
    * @param applicationId application id to be updated.
-   * @param payload contains the applicaitonstatus and the workflowId.
+   * @param payload contains the applicaiton status and the workflowId.
    */
   @Patch(":id/application-status-workflowId")
   async updateApplicationStatusWorkflowId(

--- a/sources/packages/api/src/route-controllers/application/application.system.controller.ts
+++ b/sources/packages/api/src/route-controllers/application/application.system.controller.ts
@@ -184,7 +184,6 @@ export class ApplicationSystemController {
     @Param("id") applicationId: number,
     @Body() payload: UpdateApplicationStatusWorkflowIdDto,
   ): Promise<void> {
-    console.log(payload.workflowId);
     const updateResult =
       await this.applicationService.updateApplicationStatusWorkflowId(
         applicationId,

--- a/sources/packages/api/src/route-controllers/application/application.system.controller.ts
+++ b/sources/packages/api/src/route-controllers/application/application.system.controller.ts
@@ -22,6 +22,7 @@ import {
   UpdateAssessmentStatusDto,
   UpdateCOEStatusDto,
   UpdateApplicationStatusDto,
+  UpdateApplicationStatusWorkflowIdDto,
 } from "./models/application.system.model";
 
 /**
@@ -169,6 +170,33 @@ export class ApplicationSystemController {
     if (updateResult.affected === 0) {
       throw new UnprocessableEntityException(
         "Not able to update the program information request status with provided data.",
+      );
+    }
+  }
+
+  /**
+   * Updates overall Application status and Assessment workflowId.
+   * @param applicationId application id to be updated.
+   * @param payload contains the applicaitonstatus and the workflowId.
+   */
+  @Patch(":id/application-status-workflowId")
+  async updateApplicationStatusWorkflowId(
+    @Param("id") applicationId: number,
+    @Body() payload: UpdateApplicationStatusWorkflowIdDto,
+  ): Promise<void> {
+    console.log(payload.workflowId);
+    const updateResult =
+      await this.applicationService.updateApplicationStatusWorkflowId(
+        applicationId,
+        payload.status,
+        payload.workflowId,
+      );
+
+    // Checks if some record was updated.
+    // If affected is zero it means that the update was not successful.
+    if (updateResult.affected === 0) {
+      throw new UnprocessableEntityException(
+        "Not able to update the overall Application status and workflowId with provided data.",
       );
     }
   }

--- a/sources/packages/api/src/route-controllers/application/application.system.controller.ts
+++ b/sources/packages/api/src/route-controllers/application/application.system.controller.ts
@@ -177,7 +177,7 @@ export class ApplicationSystemController {
   /**
    * Updates overall Application status and Assessment workflowId.
    * @param applicationId application id to be updated.
-   * @param payload contains the applicaiton status and the workflowId.
+   * @param payload contains the application status and the workflowId.
    */
   @Patch(":id/application-status-workflowId")
   async updateApplicationStatusWorkflowId(

--- a/sources/packages/api/src/route-controllers/application/models/application.system.model.ts
+++ b/sources/packages/api/src/route-controllers/application/models/application.system.model.ts
@@ -43,3 +43,8 @@ export class UpdateApplicationStatusDto {
   @IsEnum(ApplicationStatus)
   status: ApplicationStatus;
 }
+
+export class UpdateApplicationStatusWorkflowIdDto extends UpdateApplicationStatusDto {
+  @IsNotEmpty()
+  workflowId: string;
+}

--- a/sources/packages/api/src/route-controllers/confirmation-of-enrollment/confirmation-of-enrollment.controller.ts
+++ b/sources/packages/api/src/route-controllers/confirmation-of-enrollment/confirmation-of-enrollment.controller.ts
@@ -219,14 +219,14 @@ export class ConfirmationOfEnrollmentController {
       );
     }
 
-    const updatedCoeStatus =
+    const updatedCOEStatus =
       await this.applicationService.updateApplicationCOEStatus(
         applicationId,
         COEStatus.completed,
         ApplicationStatus.completed,
       );
 
-    if (updatedCoeStatus) {
+    if (updatedCOEStatus) {
       // Send a message to allow the workflow to proceed.
       await this.workflow.sendConfirmCOEMessage(
         application.assessmentWorkflowId,

--- a/sources/packages/api/src/route-controllers/confirmation-of-enrollment/confirmation-of-enrollment.controller.ts
+++ b/sources/packages/api/src/route-controllers/confirmation-of-enrollment/confirmation-of-enrollment.controller.ts
@@ -219,18 +219,14 @@ export class ConfirmationOfEnrollmentController {
       );
     }
 
-    const updatedCoeStatus = await this.applicationService.updateCOEStatus(
-      applicationId,
-      COEStatus.completed,
-    );
+    const updatedCoeStatus =
+      await this.applicationService.updateApplicationCOEStatus(
+        applicationId,
+        COEStatus.completed,
+        ApplicationStatus.completed,
+      );
 
     if (updatedCoeStatus) {
-      const updatedApplication =
-        await this.applicationService.updateApplicationStatus(
-          applicationId,
-          ApplicationStatus.completed,
-        );
-
       // Send a message to allow the workflow to proceed.
       await this.workflow.sendConfirmCOEMessage(
         application.assessmentWorkflowId,

--- a/sources/packages/api/src/route-controllers/confirmation-of-enrollment/confirmation-of-enrollment.controller.ts
+++ b/sources/packages/api/src/route-controllers/confirmation-of-enrollment/confirmation-of-enrollment.controller.ts
@@ -226,12 +226,13 @@ export class ConfirmationOfEnrollmentController {
         ApplicationStatus.completed,
       );
 
-    if (updatedCOEStatus) {
-      // Send a message to allow the workflow to proceed.
-      await this.workflow.sendConfirmCOEMessage(
-        application.assessmentWorkflowId,
+    if (updatedCOEStatus.affected === 0) {
+      throw new UnprocessableEntityException(
+        `Confirmation of Enrollment and application status update to completed is failed`,
       );
     }
+    // Send a message to allow the workflow to proceed.
+    await this.workflow.sendConfirmCOEMessage(application.assessmentWorkflowId);
   }
 
   /**

--- a/sources/packages/api/src/route-controllers/confirmation-of-enrollment/confirmation-of-enrollment.controller.ts
+++ b/sources/packages/api/src/route-controllers/confirmation-of-enrollment/confirmation-of-enrollment.controller.ts
@@ -228,7 +228,7 @@ export class ConfirmationOfEnrollmentController {
 
     if (updatedCOEStatus.affected === 0) {
       throw new UnprocessableEntityException(
-        `Confirmation of Enrollment and application status update to completed is failed`,
+        "Confirmation of Enrollment and application status update to completed is failed",
       );
     }
     // Send a message to allow the workflow to proceed.

--- a/sources/packages/api/src/route-controllers/confirmation-of-enrollment/confirmation-of-enrollment.controller.ts
+++ b/sources/packages/api/src/route-controllers/confirmation-of-enrollment/confirmation-of-enrollment.controller.ts
@@ -19,7 +19,11 @@ import {
   InstitutionLocationService,
   COEDeniedReasonService,
 } from "../../services";
-import { Application, COEStatus } from "../../database/entities";
+import {
+  Application,
+  COEStatus,
+  ApplicationStatus,
+} from "../../database/entities";
 import { UserToken } from "../../auth/decorators/userToken.decorator";
 import { IInstitutionUserToken } from "../../auth/userToken.interface";
 import { COESummaryDTO } from "../application/models/application.model";
@@ -215,13 +219,23 @@ export class ConfirmationOfEnrollmentController {
       );
     }
 
-    await this.applicationService.updateCOEStatus(
+    const updatedCoeStatus = await this.applicationService.updateCOEStatus(
       applicationId,
-      COEStatus.submitted,
+      COEStatus.completed,
     );
 
-    // Send a message to allow the workflow to proceed.
-    await this.workflow.sendConfirmCOEMessage(application.assessmentWorkflowId);
+    if (updatedCoeStatus) {
+      const updatedApplication =
+        await this.applicationService.updateApplicationStatus(
+          applicationId,
+          ApplicationStatus.completed,
+        );
+
+      // Send a message to allow the workflow to proceed.
+      await this.workflow.sendConfirmCOEMessage(
+        application.assessmentWorkflowId,
+      );
+    }
   }
 
   /**

--- a/sources/packages/api/src/services/application/application.service.ts
+++ b/sources/packages/api/src/services/application/application.service.ts
@@ -928,7 +928,7 @@ export class ApplicationService extends RecordDataModelService<Application> {
       );
     }
 
-    const assessmentWorkflow = await this.workflow.startApplicationAssessment(
+    await this.workflow.startApplicationAssessment(
       application.data.workflowName,
       application.id,
     );

--- a/sources/packages/api/src/services/application/application.service.ts
+++ b/sources/packages/api/src/services/application/application.service.ts
@@ -533,6 +533,31 @@ export class ApplicationService extends RecordDataModelService<Application> {
   }
 
   /**
+   * Updates Confirmation of Enrollment(COE) and application status.
+   * @param applicationId application id to be updated.
+   * @param coeStatus status of the Confirmation of Enrollment.
+   * @param applicationStatus status of the application
+   * Confirmation of Enrollment and application status need to happen.
+   * @returns Status update result.
+   */
+  async updateApplicationCOEStatus(
+    applicationId: number,
+    coeStatus: COEStatus,
+    applicationStatus: ApplicationStatus,
+  ): Promise<UpdateResult> {
+    return this.repo.update(
+      {
+        id: applicationId,
+        applicationStatus: Not(ApplicationStatus.overwritten),
+      },
+      {
+        coeStatus: coeStatus,
+        applicationStatus: applicationStatus,
+      },
+    );
+  }
+
+  /**
    * Updates Confirmation of Enrollment(COE) status.
    * @param applicationId application id to be updated.
    * @param status status of the Confirmation of Enrollment.
@@ -541,7 +566,7 @@ export class ApplicationService extends RecordDataModelService<Application> {
    */
   async updateCOEStatus(
     applicationId: number,
-    status: COEStatus,
+    coeStatus: COEStatus,
   ): Promise<UpdateResult> {
     return this.repo.update(
       {
@@ -549,7 +574,7 @@ export class ApplicationService extends RecordDataModelService<Application> {
         applicationStatus: Not(ApplicationStatus.overwritten),
       },
       {
-        coeStatus: status,
+        coeStatus: coeStatus,
       },
     );
   }
@@ -723,7 +748,6 @@ export class ApplicationService extends RecordDataModelService<Application> {
     applicationStatus: ApplicationStatus,
     workflowId: string,
   ): Promise<UpdateResult> {
-    console.log(workflowId);
     return this.repo.update(
       {
         id: applicationId,

--- a/sources/packages/api/src/services/application/application.service.ts
+++ b/sources/packages/api/src/services/application/application.service.ts
@@ -538,8 +538,8 @@ export class ApplicationService extends RecordDataModelService<Application> {
         applicationStatus: Not(ApplicationStatus.overwritten),
       },
       {
-        coeStatus: coeStatus,
-        applicationStatus: applicationStatus,
+        coeStatus,
+        applicationStatus,
       },
     );
   }
@@ -561,7 +561,7 @@ export class ApplicationService extends RecordDataModelService<Application> {
         applicationStatus: Not(ApplicationStatus.overwritten),
       },
       {
-        coeStatus: coeStatus,
+        coeStatus,
       },
     );
   }

--- a/sources/packages/api/src/services/application/application.service.ts
+++ b/sources/packages/api/src/services/application/application.service.ts
@@ -269,19 +269,6 @@ export class ApplicationService extends RecordDataModelService<Application> {
     });
   }
 
-  async associateAssessmentWorkflow(
-    applicationId: number,
-    assessmentWorkflowId: string,
-  ): Promise<UpdateResult> {
-    return this.repo.update(
-      {
-        id: applicationId,
-        applicationStatus: Not(ApplicationStatus.overwritten),
-      },
-      { assessmentWorkflowId },
-    );
-  }
-
   /**
    * Gets the Program Information Request
    * associated with the application.
@@ -945,17 +932,6 @@ export class ApplicationService extends RecordDataModelService<Application> {
       application.data.workflowName,
       application.id,
     );
-
-    const workflowAssociationResult = await this.associateAssessmentWorkflow(
-      application.id,
-      assessmentWorkflow.id,
-    );
-
-    // 1 means the number of affected rows expected while
-    // associating the workflow id.
-    if (workflowAssociationResult.affected !== 1) {
-      throw new Error("Error while associating the assessment workflow.");
-    }
   }
   /**
    * Deny the Program Info Request (PIR) for an Application.

--- a/sources/packages/api/src/services/workflow/workflow-actions.service.ts
+++ b/sources/packages/api/src/services/workflow/workflow-actions.service.ts
@@ -28,12 +28,11 @@ export class WorkflowActionsService {
         },
       });
     } catch (error) {
-      const errorMessage = `Error while starting application assessment workflow: ${workflowName}, error: ${error}`;
+      this.logger.error(
+        `Error while starting application assessment workflow: ${workflowName}`,
+      );
       this.logger.error(error);
-      this.logger.error(errorMessage);
-      /**
-       *The error is not thrown here, as we are failing silently
-       */
+      //The error is not thrown here, as we are failing silently
     }
   }
 
@@ -55,12 +54,11 @@ export class WorkflowActionsService {
         all: false, // false means that the message is correlated to exactly one entity.
       });
     } catch (error) {
-      const errorMessage = `Error while sending Program Info completed message to instance id: ${processInstanceId}`;
+      this.logger.error(
+        `Error while sending Program Info completed message to instance id: ${processInstanceId}`,
+      );
       this.logger.error(error);
-      this.logger.error(errorMessage);
-      /**
-       *The error is not thrown here, as we are failing silently
-       */
+      //The error is not thrown here, as we are failing silently
     }
   }
 
@@ -74,12 +72,11 @@ export class WorkflowActionsService {
     try {
       await this.workflowService.delete(assessmentWorkflowId);
     } catch (error) {
-      const errorMessage = `Error while deleting application assessment workflow: ${assessmentWorkflowId}, error: ${error}`;
+      this.logger.error(
+        `Error while deleting application assessment workflow: ${assessmentWorkflowId}, error: ${error}`,
+      );
       this.logger.error(error);
-      this.logger.error(errorMessage);
-      /**
-       *The error is not thrown here, as we are failing silently
-       */
+      //The error is not thrown here, as we are failing silently
     }
   }
 
@@ -98,12 +95,11 @@ export class WorkflowActionsService {
         all: false, // false means that the message is correlated to exactly one entity.
       });
     } catch (error) {
-      const errorMessage = `Error while sending Confirm Confirmation of Enrollment (COE) message to instance id: ${processInstanceId}`;
+      this.logger.error(
+        `Error while sending Confirm Confirmation of Enrollment (COE) message to instance id: ${processInstanceId}`,
+      );
       this.logger.error(error);
-      this.logger.error(errorMessage);
-      /**
-       *The error is not thrown here, as we are failing silently
-       */
+      //The error is not thrown here, as we are failing silently
     }
   }
 

--- a/sources/packages/api/src/services/workflow/workflow-actions.service.ts
+++ b/sources/packages/api/src/services/workflow/workflow-actions.service.ts
@@ -28,9 +28,12 @@ export class WorkflowActionsService {
         },
       });
     } catch (error) {
-      throw new Error(
-        `Error while starting application assessment workflow: ${workflowName}, error: ${error}`,
-      );
+      const errorMessage = `Error while starting application assessment workflow: ${workflowName}, error: ${error}`;
+      this.logger.error(error);
+      this.logger.error(errorMessage);
+      /**
+       *The error is not thrown here, as we are failing silently
+       */
     }
   }
 
@@ -55,7 +58,9 @@ export class WorkflowActionsService {
       const errorMessage = `Error while sending Program Info completed message to instance id: ${processInstanceId}`;
       this.logger.error(error);
       this.logger.error(errorMessage);
-      throw new Error(errorMessage);
+      /**
+       *The error is not thrown here, as we are failing silently
+       */
     }
   }
 
@@ -69,35 +74,38 @@ export class WorkflowActionsService {
     try {
       await this.workflowService.delete(assessmentWorkflowId);
     } catch (error) {
-      throw new Error(
-        `Error while deleting application assessment workflow: ${assessmentWorkflowId}, error: ${error}`,
-      );
+      const errorMessage = `Error while deleting application assessment workflow: ${assessmentWorkflowId}, error: ${error}`;
+      this.logger.error(error);
+      this.logger.error(errorMessage);
+      /**
+       *The error is not thrown here, as we are failing silently
+       */
     }
   }
 
-    /**
+  /**
    * When Confirmation of Enrollment (COE) needs to be confirmed by the institution user,
    * the workflows waits until it receives a message that the institution confirms the COE.
    * This method is going to send a message to the workflow allowing it to proceed.
    * This message should only be sent when the institution confirmation COE of an Application
    * @param processInstanceId workflow instance to receive the message.
    */
-     async sendConfirmCOEMessage(
-      processInstanceId: string,
-    ): Promise<void> {
-      try {
-        await this.workflowService.sendMessage({
-          messageName: "sims-coe-complete",
-          processInstanceId,
-          all: false, // false means that the message is correlated to exactly one entity.
-        });
-      } catch (error) {
-        const errorMessage = `Error while sending Confirm Confirmation of Enrollment (COE) message to instance id: ${processInstanceId}`;
-        this.logger.error(error);
-        this.logger.error(errorMessage);
-        throw new Error(errorMessage);
-      }
+  async sendConfirmCOEMessage(processInstanceId: string): Promise<void> {
+    try {
+      await this.workflowService.sendMessage({
+        messageName: "sims-coe-complete",
+        processInstanceId,
+        all: false, // false means that the message is correlated to exactly one entity.
+      });
+    } catch (error) {
+      const errorMessage = `Error while sending Confirm Confirmation of Enrollment (COE) message to instance id: ${processInstanceId}`;
+      this.logger.error(error);
+      this.logger.error(errorMessage);
+      /**
+       *The error is not thrown here, as we are failing silently
+       */
     }
+  }
 
   @InjectLogger()
   logger: LoggerService;


### PR DESCRIPTION
#555 

**Tasks**
- [x] Change Camunda to not call API to update status. Make API update status directly to SIMSDB (COE, PIR)

![image](https://user-images.githubusercontent.com/62901416/134989780-0e64cdbd-c3a6-4fe2-af67-f437dc3f65c7.png)

![image](https://user-images.githubusercontent.com/62901416/134989884-5ecc9229-3e4c-4468-a9be-974a44c7645a.png)

- [x] Change Assessment-Gateway workflow to update ProcessID (SIMSDB column) from Camunda. If workflowID is set, throw exception.

![image](https://user-images.githubusercontent.com/62901416/134990110-324fb95c-490d-4731-bc4d-1ce8387da4ce.png)

![image](https://user-images.githubusercontent.com/62901416/134990482-ac83abc0-694b-4b6d-a397-478f808c418a.png)

Application status update to in_progress and workflowId update has been taken care in a single method call, even though there is no business requirement, this creates a sync between the application status update and workflowid population

![image](https://user-images.githubusercontent.com/62901416/134990567-40445453-26ec-4147-b0a1-c369342945e2.png)


- [x] Camunda calls from simsapi should "fail quietly". (Application Submission, COE, PIR)

