### PR TITLE
[SIMS #668][API]Workflow for Decline Confirmation of Enrolment (COE) and Program Information Request (PIR)

### DIFF
--- a/sources/packages/api/src/route-controllers/confirmation-of-enrollment/confirmation-of-enrollment.controller.ts
+++ b/sources/packages/api/src/route-controllers/confirmation-of-enrollment/confirmation-of-enrollment.controller.ts
@@ -16,7 +16,6 @@ import {
   INVALID_OPERATION_IN_THE_CURRENT_STATUS,
   APPLICATION_NOT_FOUND,
   WorkflowActionsService,
-  InstitutionLocationService,
   COEDeniedReasonService,
 } from "../../services";
 import {

--- a/sources/packages/api/src/route-controllers/confirmation-of-enrollment/confirmation-of-enrollment.controller.ts
+++ b/sources/packages/api/src/route-controllers/confirmation-of-enrollment/confirmation-of-enrollment.controller.ts
@@ -252,6 +252,17 @@ export class ConfirmationOfEnrollmentController {
         payload.coeDenyReasonId,
         payload.otherReasonDesc,
       );
+      const result =
+        await this.applicationService.getWorkflowIdOfDeniedApplication(
+          locationId,
+          applicationId,
+        );
+
+      if (result.assessmentWorkflowId) {
+        await this.workflow.deleteApplicationAssessment(
+          result.assessmentWorkflowId,
+        );
+      }
     } catch (error) {
       if (error.name === COE_REQUEST_NOT_FOUND_ERROR) {
         throw new UnprocessableEntityException(error.message);

--- a/sources/packages/api/src/route-controllers/confirmation-of-enrollment/confirmation-of-enrollment.controller.ts
+++ b/sources/packages/api/src/route-controllers/confirmation-of-enrollment/confirmation-of-enrollment.controller.ts
@@ -42,7 +42,6 @@ export class ConfirmationOfEnrollmentController {
   constructor(
     private readonly applicationService: ApplicationService,
     private readonly workflow: WorkflowActionsService,
-    private readonly locationService: InstitutionLocationService,
     private readonly deniedCOEReasonService: COEDeniedReasonService,
   ) {}
 
@@ -246,21 +245,15 @@ export class ConfirmationOfEnrollmentController {
     @Body() payload: DenyConfirmationOfEnrollmentDto,
   ): Promise<void> {
     try {
-      await this.applicationService.setDeniedReasonForCOE(
+      const application = await this.applicationService.setDeniedReasonForCOE(
         applicationId,
         locationId,
         payload.coeDenyReasonId,
         payload.otherReasonDesc,
       );
-      const result =
-        await this.applicationService.getWorkflowIdOfDeniedApplication(
-          locationId,
-          applicationId,
-        );
-
-      if (result.assessmentWorkflowId) {
+      if (application.assessmentWorkflowId) {
         await this.workflow.deleteApplicationAssessment(
-          result.assessmentWorkflowId,
+          application.assessmentWorkflowId,
         );
       }
     } catch (error) {

--- a/sources/packages/api/src/route-controllers/program-info-request/program-info-request.controller.ts
+++ b/sources/packages/api/src/route-controllers/program-info-request/program-info-request.controller.ts
@@ -47,6 +47,7 @@ export class ProgramInfoRequestController {
     private readonly institutionService: InstitutionService,
     private readonly locationService: InstitutionLocationService,
     private readonly pirDeniedReasonService: PIRDeniedReasonService,
+    private readonly workflow: WorkflowActionsService,
     private readonly formService: FormService,
   ) {}
 
@@ -151,6 +152,17 @@ export class ProgramInfoRequestController {
         payload.pirDenyReasonId,
         payload.otherReasonDesc,
       );
+      const result =
+        await this.applicationService.getWorkflowIdOfDeniedApplication(
+          locationId,
+          applicationId,
+        );
+
+      if (result.assessmentWorkflowId) {
+        await this.workflow.deleteApplicationAssessment(
+          result.assessmentWorkflowId,
+        );
+      }
     } catch (error) {
       if (error.name === PIR_REQUEST_NOT_FOUND_ERROR) {
         throw new UnprocessableEntityException(error.message);

--- a/sources/packages/api/src/route-controllers/program-info-request/program-info-request.controller.ts
+++ b/sources/packages/api/src/route-controllers/program-info-request/program-info-request.controller.ts
@@ -23,8 +23,6 @@ import {
   EducationProgramOfferingService,
   WorkflowActionsService,
   PIR_REQUEST_NOT_FOUND_ERROR,
-  InstitutionService,
-  InstitutionLocationService,
   FormService,
   PIRDeniedReasonService,
 } from "../../services";
@@ -44,8 +42,6 @@ export class ProgramInfoRequestController {
     private readonly applicationService: ApplicationService,
     private readonly workflowService: WorkflowActionsService,
     private readonly offeringService: EducationProgramOfferingService,
-    private readonly institutionService: InstitutionService,
-    private readonly locationService: InstitutionLocationService,
     private readonly pirDeniedReasonService: PIRDeniedReasonService,
     private readonly workflow: WorkflowActionsService,
     private readonly formService: FormService,

--- a/sources/packages/api/src/route-controllers/program-info-request/program-info-request.controller.ts
+++ b/sources/packages/api/src/route-controllers/program-info-request/program-info-request.controller.ts
@@ -43,7 +43,6 @@ export class ProgramInfoRequestController {
     private readonly workflowService: WorkflowActionsService,
     private readonly offeringService: EducationProgramOfferingService,
     private readonly pirDeniedReasonService: PIRDeniedReasonService,
-    private readonly workflow: WorkflowActionsService,
     private readonly formService: FormService,
   ) {}
 
@@ -142,21 +141,16 @@ export class ProgramInfoRequestController {
     @Body() payload: DenyProgramInfoRequestDto,
   ): Promise<void> {
     try {
-      await this.applicationService.setDeniedReasonForProgramInfoRequest(
-        applicationId,
-        locationId,
-        payload.pirDenyReasonId,
-        payload.otherReasonDesc,
-      );
-      const result =
-        await this.applicationService.getWorkflowIdOfDeniedApplication(
-          locationId,
+      const application =
+        await this.applicationService.setDeniedReasonForProgramInfoRequest(
           applicationId,
+          locationId,
+          payload.pirDenyReasonId,
+          payload.otherReasonDesc,
         );
-
-      if (result.assessmentWorkflowId) {
-        await this.workflow.deleteApplicationAssessment(
-          result.assessmentWorkflowId,
+      if (application.assessmentWorkflowId) {
+        await this.workflowService.deleteApplicationAssessment(
+          application.assessmentWorkflowId,
         );
       }
     } catch (error) {

--- a/sources/packages/api/src/services/application/application.service.ts
+++ b/sources/packages/api/src/services/application/application.service.ts
@@ -841,13 +841,13 @@ export class ApplicationService extends RecordDataModelService<Application> {
       .where("application.id = :applicationId", { applicationId })
       .andWhere("application.location.id = :locationId", { locationId })
       .andWhere(
-        new Brackets((whereStatus) =>
-          whereStatus
+        new Brackets((deniedStatus) =>
+          deniedStatus
             .where("application.pirStatus = :pirStatus", {
               pirStatus: ProgramInfoStatus.declined,
             })
             .orWhere("application.coeStatus = :coeStatus", {
-              coeStatus: ProgramInfoStatus.declined,
+              coeStatus: COEStatus.declined,
             }),
         ),
       )

--- a/sources/packages/api/src/services/application/application.service.ts
+++ b/sources/packages/api/src/services/application/application.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, Inject } from "@nestjs/common";
 import { RecordDataModelService } from "../../database/data.model.service";
-import { Connection, In, IsNull, Not, UpdateResult } from "typeorm";
+import { Brackets, Connection, In, IsNull, Not, UpdateResult } from "typeorm";
 import { LoggerService } from "../../logger/logger.service";
 import { InjectLogger } from "../../common";
 import {
@@ -823,6 +823,35 @@ export class ApplicationService extends RecordDataModelService<Application> {
       )
       .addOrderBy("application.applicationNumber")
       .getMany();
+  }
+
+  /**
+   * Get assessment workflowId for a particular application.
+   * @param locationId location id executing the call.
+   * @param applicationId application id to be fetched.
+   * @returns assessmentWorkflowId for a particular application.
+   */
+  async getWorkflowIdOfDeniedApplication(
+    locationId: number,
+    applicationId: number,
+  ): Promise<Application> {
+    return this.repo
+      .createQueryBuilder("application")
+      .select(["application.assessmentWorkflowId"])
+      .where("application.id = :applicationId", { applicationId })
+      .andWhere("application.location.id = :locationId", { locationId })
+      .andWhere(
+        new Brackets((whereStatus) =>
+          whereStatus
+            .where("application.pirStatus = :pirStatus", {
+              pirStatus: ProgramInfoStatus.declined,
+            })
+            .orWhere("application.coeStatus = :coeStatus", {
+              coeStatus: ProgramInfoStatus.declined,
+            }),
+        ),
+      )
+      .getOne();
   }
 
   /**

--- a/sources/packages/api/src/services/application/application.service.ts
+++ b/sources/packages/api/src/services/application/application.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, Inject } from "@nestjs/common";
 import { RecordDataModelService } from "../../database/data.model.service";
-import { Brackets, Connection, In, IsNull, Not, UpdateResult } from "typeorm";
+import { Connection, In, IsNull, Not, UpdateResult } from "typeorm";
 import { LoggerService } from "../../logger/logger.service";
 import { InjectLogger } from "../../common";
 import {
@@ -823,35 +823,6 @@ export class ApplicationService extends RecordDataModelService<Application> {
       )
       .addOrderBy("application.applicationNumber")
       .getMany();
-  }
-
-  /**
-   * Get assessment workflowId for a particular application.
-   * @param locationId location id executing the call.
-   * @param applicationId application id to be fetched.
-   * @returns assessmentWorkflowId for a particular application.
-   */
-  async getWorkflowIdOfDeniedApplication(
-    locationId: number,
-    applicationId: number,
-  ): Promise<Application> {
-    return this.repo
-      .createQueryBuilder("application")
-      .select(["application.assessmentWorkflowId"])
-      .where("application.id = :applicationId", { applicationId })
-      .andWhere("application.location.id = :locationId", { locationId })
-      .andWhere(
-        new Brackets((deniedStatus) =>
-          deniedStatus
-            .where("application.pirStatus = :pirStatus", {
-              pirStatus: ProgramInfoStatus.declined,
-            })
-            .orWhere("application.coeStatus = :coeStatus", {
-              coeStatus: COEStatus.declined,
-            }),
-        ),
-      )
-      .getOne();
   }
 
   /**


### PR DESCRIPTION
#668 
**Additional Context**
- When a COE or PIR is declined, the workflow in Camunda sits at the message waiting. This ticket is to stop the workflow when a COE or PIR and declined.
- Once a COE or PIR is declined the student will either edit their application and resubmit or cancel it and restart
**Tasks**
 - [x] When PIR or COE is declined, stop camunda process (cancel/delete).
 - [x] API log but don't report error to user (cancel/delete).