### PR TITLE
[SIMS#764][Form]Program Regulatory not saving 

### DIFF
--- a/sources/packages/forms/src/form-definitions/educationprogram.json
+++ b/sources/packages/forms/src/form-definitions/educationprogram.json
@@ -1075,6 +1075,76 @@
       "defaultValue": ""
     },
     {
+      "label": "isBCPrivate",
+      "customClass": "",
+      "modalEdit": false,
+      "defaultValue": null,
+      "persistent": true,
+      "protected": false,
+      "dbIndex": false,
+      "encrypted": false,
+      "redrawOn": "",
+      "customDefaultValue": "",
+      "calculateValue": "",
+      "calculateServer": false,
+      "key": "isBCPrivate",
+      "tags": [],
+      "properties": {},
+      "logic": [],
+      "attributes": {},
+      "overlay": {
+        "style": "",
+        "page": "",
+        "left": "",
+        "top": "",
+        "width": "",
+        "height": ""
+      },
+      "type": "hidden",
+      "input": true,
+      "tableView": false,
+      "placeholder": "",
+      "prefix": "",
+      "suffix": "",
+      "multiple": false,
+      "unique": false,
+      "hidden": false,
+      "clearOnHide": true,
+      "refreshOn": "",
+      "dataGridLabel": false,
+      "labelPosition": "top",
+      "description": "",
+      "errorLabel": "",
+      "tooltip": "",
+      "hideLabel": false,
+      "tabindex": "",
+      "disabled": false,
+      "autofocus": false,
+      "widget": {
+        "type": "input"
+      },
+      "validateOn": "change",
+      "validate": {
+        "required": false,
+        "custom": "",
+        "customPrivate": false,
+        "strictDateValidation": false,
+        "multiple": false,
+        "unique": false
+      },
+      "conditional": {
+        "show": null,
+        "when": null,
+        "eq": ""
+      },
+      "allowCalculateOverride": false,
+      "showCharCount": false,
+      "showWordCount": false,
+      "allowMultipleMasks": false,
+      "inputType": "hidden",
+      "id": "egqexmm"
+    },
+    {
       "label": "How will this program be delivered? (Select all that apply)",
       "labelPosition": "top",
       "optionsLabelPosition": "right",
@@ -3016,5 +3086,5 @@
   "path": "educationprogram",
   "machineName": "educationProgram",
   "created": "2021-08-05T18:32:10.610Z",
-  "modified": "2021-09-28T21:55:29.253Z"
+  "modified": "2021-10-05T23:06:36.311Z"
 }


### PR DESCRIPTION
#764 
When creating a program the below field is not being saved to SIMSDB, saving as null
![image.png](https://images.zenhubusercontent.com/5fce9c77aab275719112dc74/c717cff0-031f-4e10-8a89-4186aa74bc5b)


Added the missed hidden field isBCPrivate

The bug was happening, during the dry run submission of the saveEducationProgram call. The isBCPrivate variable which is used to manipulate regulatoryBody field in the conditional logic was not present in the form definition, so after the dry run submission, the value for regulatory body was undefined.