### PR TITLE
Fix for CRA bypass

### DIFF
--- a/sources/packages/api/src/services/cra-income-verification/cra-income-verification.service.ts
+++ b/sources/packages/api/src/services/cra-income-verification/cra-income-verification.service.ts
@@ -8,7 +8,6 @@ import {
 } from "../../database/entities";
 import { WorkflowActionsService } from "../workflow/workflow-actions.service";
 import { getUTCNow } from "../../utilities";
-import { ConfigService } from "..";
 import {
   InactiveCodes,
   MatchStatusCodes,
@@ -18,6 +17,8 @@ import {
 // Dummy files names for CRA income send/receive simulation process.
 const DUMMY_BYPASS_CRA_SENT_FILE = "DUMMY_BYPASS_CRA_SENT_FILE.txt";
 const DUMMY_BYPASS_CRA_RECEIVED_FILE = "DUMMY_BYPASS_CRA_RECEIVED_FILE.txt";
+const RETRY_BYPASS_CRA_RECEIVED_FILE_ATTEMPTS = 5;
+const RETRY_BYPASS_CRA_RECEIVED_FILE_TIME = 2000;
 
 /**
  * Service layer for CRA income verifications.
@@ -27,7 +28,6 @@ export class CRAIncomeVerificationService extends RecordDataModelService<CRAInco
   constructor(
     @Inject("Connection") connection: Connection,
     private readonly workflowService: WorkflowActionsService,
-    private readonly configService: ConfigService,
   ) {
     super(connection.getRepository(CRAIncomeVerification));
   }
@@ -203,27 +203,42 @@ export class CRAIncomeVerificationService extends RecordDataModelService<CRAInco
    * CRA verification happens. This is enabled based in a environment variable,
    * that is by default disabled and should ne enabled only for DEV purposes on
    * local developer machine or on an environment where the CRA process is not enabled.
+   * !This code should not be executed on production.
    * @param verificationId CRA verification id waiting to be processed.
    */
   async checkForCRAIncomeVerificationBypass(verificationId: number) {
-    if (this.configService.getConfig().bypassCRAIncomeVerification) {
-      const now = getUTCNow();
-      await this.updateSentFile(
-        [verificationId],
-        now,
-        DUMMY_BYPASS_CRA_SENT_FILE,
+    const now = getUTCNow();
+    await this.updateSentFile(
+      [verificationId],
+      now,
+      DUMMY_BYPASS_CRA_SENT_FILE,
+    );
+    await this.updateReceivedFile(
+      verificationId,
+      DUMMY_BYPASS_CRA_RECEIVED_FILE,
+      now,
+      MatchStatusCodes.successfulMatch,
+      RequestStatusCodes.successfulRequest,
+      InactiveCodes.inactiveCodeNotSet,
+    );
+
+    // !This is not a production code.
+    // While trying to bypass the CRA validation for non-prod
+    // environments, sometimes there is a delay between the API
+    // call and the workflow reaching the wait event. This code
+    // is a temporary fix since we do not have a retry strategy
+    // to handle failed HTTP requests.
+    for (let i = 0; i < RETRY_BYPASS_CRA_RECEIVED_FILE_ATTEMPTS; i++) {
+      await new Promise((resolve) =>
+        setTimeout(resolve, RETRY_BYPASS_CRA_RECEIVED_FILE_TIME),
       );
-      await this.updateReceivedFile(
-        verificationId,
-        DUMMY_BYPASS_CRA_RECEIVED_FILE,
-        now,
-        MatchStatusCodes.successfulMatch,
-        RequestStatusCodes.successfulRequest,
-        InactiveCodes.inactiveCodeNotSet,
-      );
-      await this.workflowService.sendCRAIncomeVerificationCompletedMessage(
-        verificationId,
-      );
+      const success =
+        await this.workflowService.sendCRAIncomeVerificationCompletedMessage(
+          verificationId,
+        );
+      if (success) {
+        break;
+      }
     }
   }
 }

--- a/sources/packages/api/src/services/workflow/workflow-actions.service.ts
+++ b/sources/packages/api/src/services/workflow/workflow-actions.service.ts
@@ -69,15 +69,17 @@ export class WorkflowActionsService {
    * when the data in available on database to be retrieved.
    * @param incomeVerificationId income verification id that will be appended to the
    * name of the message to uniquely identify it.
+   * @return true case a successful call happen, otherwise false.
    */
   async sendCRAIncomeVerificationCompletedMessage(
     incomeVerificationId: number,
-  ): Promise<void> {
+  ): Promise<boolean> {
     try {
       await this.workflowService.sendMessage({
         messageName: `sims-cra-income-verification-complete-${incomeVerificationId}`,
         all: false, // false means that the message is correlated to exactly one entity.
       });
+      return true;
     } catch (error) {
       this.logger.error(
         `Error while sending CRA income verification completed message using incomeVerificationId: ${incomeVerificationId}`,
@@ -85,6 +87,8 @@ export class WorkflowActionsService {
       this.logger.error(error);
       // The error is not thrown here, as we are failing silently.
     }
+
+    return false;
   }
 
   /**


### PR DESCRIPTION
Fix on the CRA bypass that is configured on DEV environment to allow the CRA verification to happen immediately after the workflow is started.
Since the CRA process was moved inside a subprocess it caused a small delay that make the call from SIMS-Api to release the workflow event not be waiting for the message when the message is sent. Basically, the message is sent to the workflow even before the workflow is waiting for it.
A basic retry was added to solve it quickly.
I avoided using a retry framework because I believe that we can discuss more broadly how to introduce a global retry strategy, for instance, to retry the failed HTTP requests from Axios.
I avoid adding a "delay" package or creating a "delay" method because the newer versions of Node already have it and we should be updating the node version soon (https://medium.com/the-node-js-collection/node-js-16-available-now-7f5099a97e70).