### PR TITLE
[API][SIMS-#647]PY_Prefix_ApplicationNumber

### DIFF
--- a/sources/packages/api/src-sql/ProgramYear/Add-col-program-year-prefix.sql
+++ b/sources/packages/api/src-sql/ProgramYear/Add-col-program-year-prefix.sql
@@ -1,0 +1,35 @@
+ALTER TABLE
+  sims.program_years
+ADD
+  COLUMN IF NOT EXISTS program_year_prefix VARCHAR(4) NOT NULL DEFAULT '';
+
+COMMENT ON COLUMN sims.program_years.program_year_prefix IS 'Program Year prefix for a particular Program year.';
+
+UPDATE
+  sims.program_years
+SET
+  program_year_prefix = '2021'
+WHERE
+  program_year = '2021-2022';
+
+UPDATE
+  sims.program_years
+SET
+  program_year_prefix = '2022'
+WHERE
+  program_year = '2022-2023';
+
+UPDATE
+  sims.program_years
+SET
+  program_year_prefix = '2023'
+WHERE
+  program_year = '2023-2024';
+
+-- Removing the dummy constraint created just to allow us
+-- to add a "NOT NULL" column in an exising table.
+
+ALTER TABLE
+  sims.program_years
+ALTER COLUMN
+  program_year_prefix DROP DEFAULT;

--- a/sources/packages/api/src-sql/ProgramYear/Drop-col-program-year-prefix.sql
+++ b/sources/packages/api/src-sql/ProgramYear/Drop-col-program-year-prefix.sql
@@ -1,0 +1,2 @@
+ALTER TABLE
+  sims.program_years DROP COLUMN IF EXISTS program_year_prefix;

--- a/sources/packages/api/src/database/entities/program-year.model.ts
+++ b/sources/packages/api/src/database/entities/program-year.model.ts
@@ -57,7 +57,7 @@ export class ProgramYear extends RecordDataModel {
    * particular ProgramYear.
    */
   @Column({
-    name: "program_year_perfix",
+    name: "program_year_prefix",
     nullable: false,
   })
   programYearPrefix: string;

--- a/sources/packages/api/src/database/entities/program-year.model.ts
+++ b/sources/packages/api/src/database/entities/program-year.model.ts
@@ -53,7 +53,7 @@ export class ProgramYear extends RecordDataModel {
   })
   partnerFormName: string;
   /**
-   * Program Year Prefix  for the
+   * Program Year Prefix for the
    * particular ProgramYear.
    */
   @Column({

--- a/sources/packages/api/src/database/entities/program-year.model.ts
+++ b/sources/packages/api/src/database/entities/program-year.model.ts
@@ -53,6 +53,15 @@ export class ProgramYear extends RecordDataModel {
   })
   partnerFormName: string;
   /**
+   * Program Year Prefix  for the
+   * particular ProgramYear.
+   */
+  @Column({
+    name: "program_year_perfix",
+    nullable: false,
+  })
+  programYearPrefix: string;
+  /**
    * Active Indicator
    */
   @Column({

--- a/sources/packages/api/src/database/migrations/1637263467635-AddColProgramYearPrefixToProgramYear.ts
+++ b/sources/packages/api/src/database/migrations/1637263467635-AddColProgramYearPrefixToProgramYear.ts
@@ -1,0 +1,18 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+import { getSQLFileData } from "../../utilities";
+
+export class AddColProgramYearPrefixToProgramYear1637263467635
+  implements MigrationInterface
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      getSQLFileData("Add-col-program-year-prefix.sql", "ProgramYear"),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      getSQLFileData("Drop-col-program-year-prefix.sql", "ProgramYear"),
+    );
+  }
+}

--- a/sources/packages/api/src/services/application/application.service.ts
+++ b/sources/packages/api/src/services/application/application.service.ts
@@ -117,9 +117,13 @@ export class ApplicationService extends RecordDataModelService<Application> {
       );
     }
     if (application.applicationStatus === ApplicationStatus.draft) {
-      // TODO:remove the static program year and add dynamic year, from program year table
+      /**
+       * Generate the application number with respect to the programYearPrefix.
+       * This ensures that respective sequence is created in the sequence_controls table
+       * for specific year 2021,2022 subsequently.
+       */
       application.applicationNumber = await this.generateApplicationNumber(
-        "2122",
+        application.programYear.programYearPrefix,
       );
       application.data = applicationData;
       application.applicationStatus = ApplicationStatus.submitted;
@@ -570,6 +574,7 @@ export class ApplicationService extends RecordDataModelService<Application> {
       .select([
         "application",
         "programYear.id",
+        "programYear.programYearPrefix",
         "studentFiles",
         "studentFile.uniqueFileName",
       ])


### PR DESCRIPTION
- [x] PY should start with the First four digits of the program year example: 2021XXXX  (2021-2022) 2022XXXX  (2022-2023)
- [x] Create new column in PY for PY prefix
- [x] Review constraint of more than 4 varchar -Not required, API to ensure 10 characters, and 0 fill up to 10 characters, pass PY variable and not 2122

![image](https://user-images.githubusercontent.com/62901416/142487264-fb8898ca-c020-4c75-9cbb-a4bdf59fae67.png)
