### PR TITLE
[Api][Web][SIMS #822] Populate NOA with all Assessment Values

### DIFF
--- a/sources/packages/api/src/database/entities/application.model.ts
+++ b/sources/packages/api/src/database/entities/application.model.ts
@@ -242,29 +242,36 @@ export class Application extends RecordDataModel {
 }
 
 /**
- * Interface for assessment payload
+ * Interface for assessment payload.
+ *
+ * This interface is to provide contract for the assessment payload
+ * which is stored to database by workflow.
+ * It is possible that more properties can be added to the assessment payload
+ * without updating this interface and displayed in NOA form.
+ * Whenever there is a source code update, please ensure that properties in this interface are in sync with
+ * assessment payload created by camunda workflow.
  */
 export interface Assessment {
   weeks: number;
-  totalFederalAward: string;
-  totalProvincialAward: string;
-  federalAssessmentNeed: string;
-  provincialAssessmentNeed: string;
-  tuitionCost: string;
-  booksAndSuppliesCost: string;
-  exceptionalEducationCost: string;
-  livingAllowance: string;
-  transportationCost: string;
-  childcareCost: string;
-  alimonyOrChildSupport: string;
-  secondResidenceCost: string;
-  partnerStudentLoanCost: string;
-  totalAssessedCost: string;
-  studentTotalFederalContribution: string;
-  studentTotalProvincialContribution: string;
-  partnerAssessedContribution: string;
-  parentAssessedContribution: string;
-  totalFederalContribution: string;
-  totalProvincialContribution: string;
-  otherAllowableCost: string;
+  totalFederalAward: number;
+  totalProvincialAward: number;
+  federalAssessmentNeed: number;
+  provincialAssessmentNeed: number;
+  tuitionCost: number;
+  booksAndSuppliesCost: number;
+  exceptionalEducationCost: number;
+  livingAllowance: number;
+  transportationCost: number;
+  childcareCost: number;
+  alimonyOrChildSupport: number;
+  secondResidenceCost: number;
+  partnerStudentLoanCost: number;
+  totalAssessedCost: number;
+  studentTotalFederalContribution: number;
+  studentTotalProvincialContribution: number;
+  partnerAssessedContribution: number;
+  parentAssessedContribution: number;
+  totalFederalContribution: number;
+  totalProvincialContribution: number;
+  otherAllowableCost: number;
 }

--- a/sources/packages/api/src/database/entities/application.model.ts
+++ b/sources/packages/api/src/database/entities/application.model.ts
@@ -49,7 +49,7 @@ export class Application extends RecordDataModel {
     type: "jsonb",
     nullable: true,
   })
-  assessment: any;
+  assessment: Assessment;
 
   @RelationId((application: Application) => application.student)
   studentId: number;
@@ -239,4 +239,32 @@ export class Application extends RecordDataModel {
     },
   )
   disbursementSchedules?: DisbursementSchedule[];
+}
+
+/**
+ * Interface for assessment payload
+ */
+export interface Assessment {
+  weeks: number;
+  totalFederalAward: string;
+  totalProvincialAward: string;
+  federalAssessmentNeed: string;
+  provincialAssessmentNeed: string;
+  tuitionCost: string;
+  booksAndSuppliesCost: string;
+  exceptionalEducationCost: string;
+  livingAllowance: string;
+  transportationCost: string;
+  childcareCost: string;
+  alimonyOrChildSupport: string;
+  secondResidenceCost: string;
+  partnerStudentLoanCost: string;
+  totalAssessedCost: string;
+  studentTotalFederalContribution: string;
+  studentTotalProvincialContribution: string;
+  partnerAssessedContribution: string;
+  parentAssessedContribution: string;
+  totalFederalContribution: string;
+  totalProvincialContribution: string;
+  otherAllowableCost: string;
 }

--- a/sources/packages/api/src/route-controllers/application/application.controller.ts
+++ b/sources/packages/api/src/route-controllers/application/application.controller.ts
@@ -263,14 +263,13 @@ export class ApplicationController extends BaseController {
     //Disbursement data is populated with dynamic key in a defined pattern to be compatible with form table.
     const disbursementDetails = {};
     application.disbursementSchedules.forEach((schedule, index) => {
-      const disbursementKey = `disbursement${index + 1}Date`;
+      const disbursementNumber = index + 1;
+      const disbursementKey = `disbursement${disbursementNumber}Date`;
       disbursementDetails[disbursementKey] = dateString(
         schedule.disbursementDate,
       );
       schedule.disbursementValues.forEach((disbursement) => {
-        const disbursementValueKey = `disbursement${
-          index + 1
-        }${disbursement.valueCode.toLowerCase()}`;
+        const disbursementValueKey = `disbursement${disbursementNumber}${disbursement.valueCode.toLowerCase()}`;
         disbursementDetails[disbursementValueKey] = disbursement.valueAmount;
       });
     });

--- a/sources/packages/api/src/route-controllers/application/application.controller.ts
+++ b/sources/packages/api/src/route-controllers/application/application.controller.ts
@@ -263,12 +263,15 @@ export class ApplicationController extends BaseController {
     //Disbursement data is populated with dynamic key in a defined pattern to be compatible with form table.
     const disbursementDetails = {};
     application.disbursementSchedules.forEach((schedule, index) => {
-      disbursementDetails["disbursement" + (index + 1) + "Date"] =
-        schedule.disbursementDate;
+      const disbursementKey = `disbursement${index + 1}Date`;
+      disbursementDetails[disbursementKey] = dateString(
+        schedule.disbursementDate,
+      );
       schedule.disbursementValues.forEach((disbursement) => {
-        disbursementDetails[
-          "disbursement" + (index + 1) + disbursement.valueCode.toLowerCase()
-        ] = disbursement.valueAmount;
+        const disbursementValueKey = `disbursement${
+          index + 1
+        }${disbursement.valueCode.toLowerCase()}`;
+        disbursementDetails[disbursementValueKey] = disbursement.valueAmount;
       });
     });
 

--- a/sources/packages/api/src/route-controllers/application/application.controller.ts
+++ b/sources/packages/api/src/route-controllers/application/application.controller.ts
@@ -263,13 +263,12 @@ export class ApplicationController extends BaseController {
     //Disbursement data is populated with dynamic key in a defined pattern to be compatible with form table.
     const disbursementDetails = {};
     application.disbursementSchedules.forEach((schedule, index) => {
-      const disbursementNumber = index + 1;
-      const disbursementKey = `disbursement${disbursementNumber}Date`;
-      disbursementDetails[disbursementKey] = dateString(
+      const disbursementIdentifier = `disbursement${index + 1}`;
+      disbursementDetails[`${disbursementIdentifier}Date`] = dateString(
         schedule.disbursementDate,
       );
       schedule.disbursementValues.forEach((disbursement) => {
-        const disbursementValueKey = `disbursement${disbursementNumber}${disbursement.valueCode.toLowerCase()}`;
+        const disbursementValueKey = `${disbursementIdentifier}${disbursement.valueCode.toLowerCase()}`;
         disbursementDetails[disbursementValueKey] = disbursement.valueAmount;
       });
     });

--- a/sources/packages/api/src/route-controllers/application/application.controller.ts
+++ b/sources/packages/api/src/route-controllers/application/application.controller.ts
@@ -260,7 +260,7 @@ export class ApplicationController extends BaseController {
         `Assessment for the application id ${applicationId} was not calculated.`,
       );
     }
-
+    //Disbursement data is populated with dynamic key in a defined pattern to be compatible with form table.
     const disbursementDetails = {};
     application.disbursementSchedules.forEach((schedule, index) => {
       disbursementDetails["disbursement" + (index + 1) + "Date"] =

--- a/sources/packages/api/src/route-controllers/application/application.controller.ts
+++ b/sources/packages/api/src/route-controllers/application/application.controller.ts
@@ -55,7 +55,6 @@ export class ApplicationController extends BaseController {
     private readonly workflow: WorkflowActionsService,
     private readonly studentService: StudentService,
     private readonly programYearService: ProgramYearService,
-    private readonly disbursementScheduleService: DisbursementScheduleService,
   ) {
     super();
   }
@@ -263,6 +262,17 @@ export class ApplicationController extends BaseController {
       );
     }
 
+    const disbursementDetails = {};
+    application.disbursementSchedules.forEach((schedule, index) => {
+      disbursementDetails["disbursement" + (index + 1) + "Date"] =
+        schedule.disbursementDate;
+      schedule.disbursementValues.forEach((disbursement) => {
+        disbursementDetails[
+          "disbursement" + (index + 1) + disbursement.valueCode.toLowerCase()
+        ] = disbursement.valueAmount;
+      });
+    });
+
     return {
       assessment: application.assessment,
       applicationNumber: application.applicationNumber,
@@ -272,6 +282,7 @@ export class ApplicationController extends BaseController {
       offeringStudyStartDate: dateString(application.offering.studyStartDate),
       offeringStudyEndDate: dateString(application.offering.studyEndDate),
       msfaaNumber: application.msfaaNumber.msfaaNumber,
+      disbursement: disbursementDetails,
     };
   }
 
@@ -444,36 +455,5 @@ export class ApplicationController extends BaseController {
         status: application.applicationStatus,
       } as ApplicationSummaryDTO;
     });
-  }
-  /**
-   * API to get the disbursement details for NOA.
-   * It has dynamic return type as the key of the response object
-   * is based on disbursement code and it lets dynamic codes to be added in future.
-   * @param applicationId
-   * @param userToken
-   * @returns
-   */
-  @Get(":applicationId/disbursements")
-  async getDisbursement(
-    @Param("applicationId") applicationId: number,
-    @UserToken() userToken: IUserToken,
-  ): Promise<any> {
-    const disbursementSchedules =
-      await this.disbursementScheduleService.getDisbursementSchedule(
-        applicationId,
-        userToken.userId,
-      );
-    const disbursementDetails = {};
-    disbursementSchedules.forEach((schedule, index) => {
-      disbursementDetails["disbursement" + (index + 1) + "Date"] =
-        schedule.disbursementDate;
-      schedule.disbursementValues.forEach((disbursement) => {
-        disbursementDetails[
-          "disbursement" + (index + 1) + disbursement.valueCode.toLowerCase()
-        ] = disbursement.valueAmount;
-      });
-    });
-
-    return disbursementDetails;
   }
 }

--- a/sources/packages/api/src/route-controllers/application/application.controller.ts
+++ b/sources/packages/api/src/route-controllers/application/application.controller.ts
@@ -20,7 +20,6 @@ import {
   MORE_THAN_ONE_APPLICATION_DRAFT_ERROR,
   APPLICATION_NOT_FOUND,
   APPLICATION_NOT_VALID,
-  DisbursementScheduleService,
 } from "../../services";
 import { IUserToken } from "../../auth/userToken.interface";
 import BaseController from "../BaseController";

--- a/sources/packages/api/src/route-controllers/application/models/application.model.ts
+++ b/sources/packages/api/src/route-controllers/application/models/application.model.ts
@@ -5,6 +5,7 @@ import {
   AssessmentStatus,
   COEStatus,
   Application,
+  Assessment,
 } from "../../../database/entities";
 import {
   dateString,
@@ -194,7 +195,7 @@ export interface ActiveApplicationDataDto {
 }
 
 export interface NOAApplicationDto {
-  assessment: any;
+  assessment: Assessment;
   applicationNumber: string;
   fullName: string;
   programName: string;
@@ -202,6 +203,7 @@ export interface NOAApplicationDto {
   offeringStudyStartDate: string;
   offeringStudyEndDate: string;
   msfaaNumber: string;
+  disbursement: any;
 }
 
 /**

--- a/sources/packages/api/src/route-controllers/application/models/application.model.ts
+++ b/sources/packages/api/src/route-controllers/application/models/application.model.ts
@@ -194,6 +194,9 @@ export interface ActiveApplicationDataDto {
   applicationStatus: string;
 }
 
+/**
+ * DTO for NOA view.
+ */
 export interface NOAApplicationDto {
   assessment: Assessment;
   applicationNumber: string;

--- a/sources/packages/api/src/services/application/application.service.ts
+++ b/sources/packages/api/src/services/application/application.service.ts
@@ -503,6 +503,10 @@ export class ApplicationService extends RecordDataModelService<Application> {
         "offering.studyStartDate",
         "offering.studyEndDate",
         "msfaaNumber.msfaaNumber",
+        "disbursementSchedule.disbursementDate",
+        "disbursementValue.valueType",
+        "disbursementValue.valueCode",
+        "disbursementValue.valueAmount",
       ])
       .innerJoin("application.student", "student")
       .innerJoin("student.user", "user")
@@ -510,8 +514,11 @@ export class ApplicationService extends RecordDataModelService<Application> {
       .innerJoin("offering.educationProgram", "educationProgram")
       .innerJoin("application.location", "location")
       .innerJoin("application.msfaaNumber", "msfaaNumber")
+      .innerJoin("application.disbursementSchedules", "disbursementSchedule")
+      .innerJoin("disbursementSchedule.disbursementValues", "disbursementValue")
       .where("application.id = :applicationId", { applicationId })
       .andWhere("student.id = :studentId", { studentId })
+      .addOrderBy("disbursementSchedule.disbursementDate")
       .getOne();
   }
 

--- a/sources/packages/api/src/services/application/application.service.ts
+++ b/sources/packages/api/src/services/application/application.service.ts
@@ -518,7 +518,7 @@ export class ApplicationService extends RecordDataModelService<Application> {
       .innerJoin("disbursementSchedule.disbursementValues", "disbursementValue")
       .where("application.id = :applicationId", { applicationId })
       .andWhere("student.id = :studentId", { studentId })
-      .addOrderBy("disbursementSchedule.disbursementDate")
+      .orderBy("disbursementSchedule.disbursementDate")
       .getOne();
   }
 

--- a/sources/packages/api/src/services/disbursement-schedule-service/disbursement-schedule-service.ts
+++ b/sources/packages/api/src/services/disbursement-schedule-service/disbursement-schedule-service.ts
@@ -223,48 +223,4 @@ export class DisbursementScheduleService extends RecordDataModelService<Disburse
     const repository = disbursementScheduleRepo ?? this.repo;
     return repository.update({ id: In(disbursementIds) }, { dateSent });
   }
-
-  /**
-   * Get disbursement schedule for an application.
-   * This method supports query by studentId | userId
-   * for the support of ministry APIs.
-   * @param applicationId
-   * @param userId
-   * @param studentId
-   * @returns
-   */
-  async getDisbursementSchedule(
-    applicationId: number,
-    userId?: number,
-    studentId?: number,
-  ): Promise<DisbursementSchedule[]> {
-    if (!userId && !studentId) {
-      throw new Error(
-        "Either student id or user id is mandatory to retrieve application disbursement details.",
-      );
-    }
-    const disbursementQuery = this.repo
-      .createQueryBuilder("disbursement")
-      .select([
-        "disbursement.disbursementDate",
-        "disbursementValue.valueType",
-        "disbursementValue.valueCode",
-        "disbursementValue.valueAmount",
-      ])
-      .innerJoin("disbursement.disbursementValues", "disbursementValue")
-      .innerJoin("disbursement.application", "application")
-      .innerJoin("application.student", "student")
-      .innerJoin("student.user", "user")
-      .where("application.id = :applicationId", { applicationId });
-    if (userId) {
-      disbursementQuery.andWhere("user.id = :userId", { userId });
-    }
-
-    if (!userId && studentId) {
-      disbursementQuery.andWhere("student.id = :studentId", { userId });
-    }
-    disbursementQuery.addOrderBy("disbursement.disbursementDate");
-
-    return disbursementQuery.getMany();
-  }
 }

--- a/sources/packages/forms/src/form-definitions/noticeofassessment.json
+++ b/sources/packages/forms/src/form-definitions/noticeofassessment.json
@@ -94,7 +94,7 @@
       "dbIndex": false,
       "encrypted": false,
       "redrawOn": "",
-      "customDefaultValue": "value=parseFloat(data.assessment.totalFederalAward)+ parseFloat(data.assessment.totalProvincialAward);",
+      "customDefaultValue": "value= ((typeof data.assessment.totalFederalAward === 'number' ? data.assessment.totalFederalAward : 0) \n        + (typeof data.assessment.totalProvincialAward === 'number' ? data.assessment.totalProvincialAward : 0)).toFixed(2);",
       "calculateValue": "",
       "calculateServer": false,
       "key": "eligibleAmount",
@@ -152,7 +152,7 @@
       "showWordCount": false,
       "allowMultipleMasks": false,
       "inputType": "hidden",
-      "id": "ee6tqid"
+      "id": "e87q2yg"
     },
     {
       "label": "NOA",
@@ -2987,7 +2987,7 @@
                         "value": ""
                       }
                     ],
-                    "content": "{{data.assessment?.tuitionCost ? '$' + data.assessment.tuitionCost : '-'}}",
+                    "content": "{{typeof data.assessment?.tuitionCost === 'number' ? '$' + (data.assessment.tuitionCost).toFixed(2) : '-'}}",
                     "refreshOnChange": false,
                     "customClass": "",
                     "hidden": false,
@@ -3054,7 +3054,7 @@
                     "showCharCount": false,
                     "showWordCount": false,
                     "allowMultipleMasks": false,
-                    "id": "e4tub7j"
+                    "id": "elj37y"
                   }
                 ]
               },
@@ -3070,7 +3070,7 @@
                         "value": ""
                       }
                     ],
-                    "content": "{{data.assessment?.tuitionCost ? '$' + data.assessment.tuitionCost : '-'}}",
+                    "content": "{{typeof data.assessment?.tuitionCost === 'number' ? '$' + (data.assessment.tuitionCost).toFixed(2) : '-'}}",
                     "refreshOnChange": false,
                     "customClass": "",
                     "hidden": false,
@@ -3137,7 +3137,7 @@
                     "showCharCount": false,
                     "showWordCount": false,
                     "allowMultipleMasks": false,
-                    "id": "e8rn8t8"
+                    "id": "ex14gq"
                   }
                 ]
               }
@@ -3233,7 +3233,7 @@
                         "value": ""
                       }
                     ],
-                    "content": "{{data.assessment?.booksAndSuppliesCost ? '$' + data.assessment?.booksAndSuppliesCost : '-'}}",
+                    "content": "{{typeof data.assessment?.booksAndSuppliesCost === 'number' ? '$' + (data.assessment.booksAndSuppliesCost).toFixed(2) : '-'}}",
                     "refreshOnChange": false,
                     "customClass": "",
                     "hidden": false,
@@ -3300,7 +3300,7 @@
                     "showCharCount": false,
                     "showWordCount": false,
                     "allowMultipleMasks": false,
-                    "id": "e2wzdwi"
+                    "id": "e2ph6ci"
                   }
                 ]
               },
@@ -3316,7 +3316,7 @@
                         "value": ""
                       }
                     ],
-                    "content": "{{data.assessment?.booksAndSuppliesCost ? '$' + data.assessment?.booksAndSuppliesCost : '-'}}",
+                    "content": "{{typeof data.assessment?.booksAndSuppliesCost === 'number' ? '$' + (data.assessment.booksAndSuppliesCost).toFixed(2) : '-'}}",
                     "refreshOnChange": false,
                     "customClass": "",
                     "hidden": false,
@@ -3383,7 +3383,7 @@
                     "showCharCount": false,
                     "showWordCount": false,
                     "allowMultipleMasks": false,
-                    "id": "emjcy8e"
+                    "id": "ev8kj2v"
                   }
                 ]
               }
@@ -3478,7 +3478,7 @@
                         "value": ""
                       }
                     ],
-                    "content": "{{data.assessment?.exceptionalEducationCost ? '$' + data.assessment.exceptionalEducationCost : '-'}}",
+                    "content": "{{typeof data.assessment?.exceptionalEducationCost === 'number' ? '$' + (data.assessment.exceptionalEducationCost).toFixed(2) : '-'}}",
                     "refreshOnChange": false,
                     "customClass": "",
                     "hidden": false,
@@ -3545,7 +3545,7 @@
                     "showCharCount": false,
                     "showWordCount": false,
                     "allowMultipleMasks": false,
-                    "id": "e9d2eo2"
+                    "id": "ebywupe"
                   }
                 ]
               },
@@ -3561,7 +3561,7 @@
                         "value": ""
                       }
                     ],
-                    "content": "{{data.assessment?.exceptionalEducationCost ? '$' + data.assessment.exceptionalEducationCost : '-'}}",
+                    "content": "{{typeof data.assessment?.exceptionalEducationCost === 'number' ? '$' + (data.assessment.exceptionalEducationCost).toFixed(2) : '-'}}",
                     "refreshOnChange": false,
                     "customClass": "",
                     "hidden": false,
@@ -3628,7 +3628,7 @@
                     "showCharCount": false,
                     "showWordCount": false,
                     "allowMultipleMasks": false,
-                    "id": "em69g0w"
+                    "id": "e0ndvcz"
                   }
                 ]
               }
@@ -3724,7 +3724,7 @@
                         "value": ""
                       }
                     ],
-                    "content": "{{data.assessment?.livingAllowance ? '$' + data.assessment.livingAllowance : '-'}}",
+                    "content": "{{typeof data.assessment?.livingAllowance === 'number' ? '$' + (data.assessment.livingAllowance).toFixed(2) : '-'}}",
                     "refreshOnChange": false,
                     "customClass": "",
                     "hidden": false,
@@ -3791,7 +3791,7 @@
                     "showCharCount": false,
                     "showWordCount": false,
                     "allowMultipleMasks": false,
-                    "id": "eqivx2c"
+                    "id": "e287oym"
                   }
                 ]
               },
@@ -3807,7 +3807,7 @@
                         "value": ""
                       }
                     ],
-                    "content": "{{data.assessment?.livingAllowance ? '$' + data.assessment.livingAllowance : '-'}}",
+                    "content": "{{typeof data.assessment?.livingAllowance === 'number' ? '$' + (data.assessment.livingAllowance).toFixed(2) : '-'}}",
                     "refreshOnChange": false,
                     "customClass": "",
                     "hidden": false,
@@ -3874,7 +3874,7 @@
                     "showCharCount": false,
                     "showWordCount": false,
                     "allowMultipleMasks": false,
-                    "id": "e9n3n4m"
+                    "id": "eyj4th4"
                   }
                 ]
               }
@@ -3969,7 +3969,7 @@
                         "value": ""
                       }
                     ],
-                    "content": "{{data.assessment?.transportationCost ? '$' + data.assessment.transportationCost : '-'}}",
+                    "content": "{{typeof data.assessment?.transportationCost === 'number' ? '$' + (data.assessment.transportationCost).toFixed(2) : '-'}}",
                     "refreshOnChange": false,
                     "customClass": "",
                     "hidden": false,
@@ -4036,7 +4036,7 @@
                     "showCharCount": false,
                     "showWordCount": false,
                     "allowMultipleMasks": false,
-                    "id": "efukg8"
+                    "id": "ekz47gn"
                   }
                 ]
               },
@@ -4052,7 +4052,7 @@
                         "value": ""
                       }
                     ],
-                    "content": "{{data.assessment?.transportationCost ? '$' + data.assessment.transportationCost : '-'}}",
+                    "content": "{{typeof data.assessment?.transportationCost === 'number' ? '$' + (data.assessment.transportationCost).toFixed(2) : '-'}}",
                     "refreshOnChange": false,
                     "customClass": "",
                     "hidden": false,
@@ -4119,7 +4119,7 @@
                     "showCharCount": false,
                     "showWordCount": false,
                     "allowMultipleMasks": false,
-                    "id": "e9ahepx"
+                    "id": "e9kgnnl"
                   }
                 ]
               }
@@ -4214,7 +4214,7 @@
                         "value": ""
                       }
                     ],
-                    "content": "{{data.assessment?.childcareCost ? '$' + data.assessment.childcareCost : '-'}}",
+                    "content": "{{typeof data.assessment?.childcareCost === 'number' ? '$' + (data.assessment.childcareCost).toFixed(2) : '-'}}",
                     "refreshOnChange": false,
                     "customClass": "",
                     "hidden": false,
@@ -4281,7 +4281,7 @@
                     "showCharCount": false,
                     "showWordCount": false,
                     "allowMultipleMasks": false,
-                    "id": "esiupeo"
+                    "id": "e8zp8i8"
                   }
                 ]
               },
@@ -4297,7 +4297,7 @@
                         "value": ""
                       }
                     ],
-                    "content": "{{data.assessment?.childcareCost ? '$' + data.assessment.childcareCost : '-'}}",
+                    "content": "{{typeof data.assessment?.childcareCost === 'number' ? '$' + (data.assessment.childcareCost).toFixed(2) : '-'}}",
                     "refreshOnChange": false,
                     "customClass": "",
                     "hidden": false,
@@ -4364,7 +4364,7 @@
                     "showCharCount": false,
                     "showWordCount": false,
                     "allowMultipleMasks": false,
-                    "id": "eg6ub3b"
+                    "id": "e77sj8"
                   }
                 ]
               }
@@ -4459,7 +4459,7 @@
                         "value": ""
                       }
                     ],
-                    "content": "{{data.assessment?.otherAllowableCost ? '$' + data.assessment.otherAllowableCost : '-'}}",
+                    "content": "{{typeof data.assessment?.otherAllowableCost === 'number' ? '$' + (data.assessment.otherAllowableCost).toFixed(2) : '-'}}",
                     "refreshOnChange": false,
                     "customClass": "",
                     "hidden": false,
@@ -4526,7 +4526,7 @@
                     "showCharCount": false,
                     "showWordCount": false,
                     "allowMultipleMasks": false,
-                    "id": "e1uq9vf"
+                    "id": "euptlp"
                   }
                 ]
               },
@@ -4534,32 +4534,53 @@
                 "components": [
                   {
                     "label": "HTML",
+                    "tag": "p",
+                    "className": "",
                     "attrs": [
                       {
                         "attr": "",
                         "value": ""
                       }
                     ],
-                    "content": "{{data.assessment?.otherAllowableCost ? '$' + data.assessment.otherAllowableCost : '-'}}",
+                    "content": "{{typeof data.assessment?.otherAllowableCost === 'number' ? '$' + (data.assessment.otherAllowableCost).toFixed(2) : '-'}}",
                     "refreshOnChange": false,
+                    "customClass": "",
+                    "hidden": false,
+                    "modalEdit": false,
                     "key": "html31",
+                    "tags": [],
+                    "properties": {},
+                    "conditional": {
+                      "show": null,
+                      "when": null,
+                      "eq": "",
+                      "json": ""
+                    },
+                    "customConditional": "",
+                    "logic": [],
+                    "attributes": {},
+                    "overlay": {
+                      "style": "",
+                      "page": "",
+                      "left": "",
+                      "top": "",
+                      "width": "",
+                      "height": ""
+                    },
                     "type": "htmlelement",
                     "input": false,
                     "tableView": false,
                     "placeholder": "",
                     "prefix": "",
-                    "customClass": "",
                     "suffix": "",
                     "multiple": false,
                     "defaultValue": null,
                     "protected": false,
                     "unique": false,
                     "persistent": false,
-                    "hidden": false,
                     "clearOnHide": true,
                     "refreshOn": "",
                     "redrawOn": "",
-                    "modalEdit": false,
                     "dataGridLabel": false,
                     "labelPosition": "top",
                     "description": "",
@@ -4574,7 +4595,6 @@
                     "calculateValue": "",
                     "calculateServer": false,
                     "widget": null,
-                    "attributes": {},
                     "validateOn": "change",
                     "validate": {
                       "required": false,
@@ -4584,26 +4604,12 @@
                       "multiple": false,
                       "unique": false
                     },
-                    "conditional": {
-                      "show": null,
-                      "when": null,
-                      "eq": ""
-                    },
-                    "overlay": {
-                      "style": "",
-                      "left": "",
-                      "top": "",
-                      "width": "",
-                      "height": ""
-                    },
                     "allowCalculateOverride": false,
                     "encrypted": false,
                     "showCharCount": false,
                     "showWordCount": false,
-                    "properties": {},
                     "allowMultipleMasks": false,
-                    "tag": "p",
-                    "id": "e9arhhn"
+                    "id": "e04egac"
                   }
                 ]
               }
@@ -4699,7 +4705,7 @@
                         "value": ""
                       }
                     ],
-                    "content": "{{data.assessment?.totalAssessedCost ? '$' + data.assessment.totalAssessedCost : '-'}}",
+                    "content": "{{typeof data.assessment?.totalAssessedCost === 'number' ? '$' + (data.assessment.totalAssessedCost).toFixed(2) : '-'}}",
                     "refreshOnChange": true,
                     "customClass": "header-md secondary-color",
                     "hidden": false,
@@ -4766,7 +4772,7 @@
                     "showCharCount": false,
                     "showWordCount": false,
                     "allowMultipleMasks": false,
-                    "id": "e7hfci5"
+                    "id": "ef4z5bi"
                   }
                 ]
               },
@@ -4782,7 +4788,7 @@
                         "value": ""
                       }
                     ],
-                    "content": "{{data.assessment?.totalAssessedCost ? '$' + data.assessment.totalAssessedCost : '-'}}",
+                    "content": "{{typeof data.assessment?.totalAssessedCost === 'number' ? '$' + (data.assessment.totalAssessedCost).toFixed(2) : '-'}}",
                     "refreshOnChange": true,
                     "customClass": "header-md secondary-color",
                     "hidden": false,
@@ -4849,7 +4855,7 @@
                     "showCharCount": false,
                     "showWordCount": false,
                     "allowMultipleMasks": false,
-                    "id": "e6ixdw"
+                    "id": "em658ve"
                   }
                 ]
               }
@@ -5258,33 +5264,54 @@
                 "components": [
                   {
                     "label": "HTML",
+                    "tag": "p",
+                    "className": "",
                     "attrs": [
                       {
                         "attr": "",
                         "value": ""
                       }
                     ],
-                    "content": "{{data.assessment?.studentTotalFederalContribution ? '$' + data.assessment.studentTotalFederalContribution : '-'}}",
+                    "content": "{{typeof data.assessment?.studentTotalFederalContribution === 'number' ? '$' + (data.assessment.studentTotalFederalContribution).toFixed(2) : '-'}}",
                     "refreshOnChange": false,
+                    "customClass": "",
+                    "hidden": false,
+                    "modalEdit": false,
                     "key": "html46",
+                    "tags": [],
+                    "properties": {},
+                    "conditional": {
+                      "show": null,
+                      "when": null,
+                      "eq": "",
+                      "json": ""
+                    },
+                    "customConditional": "",
+                    "logic": [],
+                    "attributes": {},
+                    "overlay": {
+                      "style": "",
+                      "page": "",
+                      "left": "",
+                      "top": "",
+                      "width": "",
+                      "height": ""
+                    },
                     "type": "htmlelement",
                     "input": false,
                     "tableView": false,
                     "hideOnChildrenHidden": false,
                     "placeholder": "",
                     "prefix": "",
-                    "customClass": "",
                     "suffix": "",
                     "multiple": false,
                     "defaultValue": null,
                     "protected": false,
                     "unique": false,
                     "persistent": false,
-                    "hidden": false,
                     "clearOnHide": true,
                     "refreshOn": "",
                     "redrawOn": "",
-                    "modalEdit": false,
                     "dataGridLabel": false,
                     "labelPosition": "top",
                     "description": "",
@@ -5299,7 +5326,6 @@
                     "calculateValue": "",
                     "calculateServer": false,
                     "widget": null,
-                    "attributes": {},
                     "validateOn": "change",
                     "validate": {
                       "required": false,
@@ -5309,26 +5335,12 @@
                       "multiple": false,
                       "unique": false
                     },
-                    "conditional": {
-                      "show": null,
-                      "when": null,
-                      "eq": ""
-                    },
-                    "overlay": {
-                      "style": "",
-                      "left": "",
-                      "top": "",
-                      "width": "",
-                      "height": ""
-                    },
                     "allowCalculateOverride": false,
                     "encrypted": false,
                     "showCharCount": false,
                     "showWordCount": false,
-                    "properties": {},
                     "allowMultipleMasks": false,
-                    "tag": "p",
-                    "id": "ejo14wd"
+                    "id": "euhigzi"
                   }
                 ]
               },
@@ -5336,33 +5348,54 @@
                 "components": [
                   {
                     "label": "HTML",
+                    "tag": "p",
+                    "className": "",
                     "attrs": [
                       {
                         "attr": "",
                         "value": ""
                       }
                     ],
-                    "content": "{{data.assessment?.studentTotalProvincialContribution ? '$' + data.assessment.studentTotalProvincialContribution : '-'}}",
+                    "content": "{{typeof data.assessment?.studentTotalProvincialContribution === 'number' ? '$' + (data.assessment.studentTotalProvincialContribution).toFixed(2) : '-'}}",
                     "refreshOnChange": false,
+                    "customClass": "",
+                    "hidden": false,
+                    "modalEdit": false,
                     "key": "html45",
+                    "tags": [],
+                    "properties": {},
+                    "conditional": {
+                      "show": null,
+                      "when": null,
+                      "eq": "",
+                      "json": ""
+                    },
+                    "customConditional": "",
+                    "logic": [],
+                    "attributes": {},
+                    "overlay": {
+                      "style": "",
+                      "page": "",
+                      "left": "",
+                      "top": "",
+                      "width": "",
+                      "height": ""
+                    },
                     "type": "htmlelement",
                     "input": false,
                     "tableView": false,
                     "hideOnChildrenHidden": false,
                     "placeholder": "",
                     "prefix": "",
-                    "customClass": "",
                     "suffix": "",
                     "multiple": false,
                     "defaultValue": null,
                     "protected": false,
                     "unique": false,
                     "persistent": false,
-                    "hidden": false,
                     "clearOnHide": true,
                     "refreshOn": "",
                     "redrawOn": "",
-                    "modalEdit": false,
                     "dataGridLabel": false,
                     "labelPosition": "top",
                     "description": "",
@@ -5377,7 +5410,6 @@
                     "calculateValue": "",
                     "calculateServer": false,
                     "widget": null,
-                    "attributes": {},
                     "validateOn": "change",
                     "validate": {
                       "required": false,
@@ -5387,26 +5419,12 @@
                       "multiple": false,
                       "unique": false
                     },
-                    "conditional": {
-                      "show": null,
-                      "when": null,
-                      "eq": ""
-                    },
-                    "overlay": {
-                      "style": "",
-                      "left": "",
-                      "top": "",
-                      "width": "",
-                      "height": ""
-                    },
                     "allowCalculateOverride": false,
                     "encrypted": false,
                     "showCharCount": false,
                     "showWordCount": false,
-                    "properties": {},
                     "allowMultipleMasks": false,
-                    "tag": "p",
-                    "id": "e9mpivg"
+                    "id": "eihqlj1u"
                   }
                 ]
               }
@@ -5494,32 +5512,53 @@
                 "components": [
                   {
                     "label": "HTML",
+                    "tag": "p",
+                    "className": "",
                     "attrs": [
                       {
                         "attr": "",
                         "value": ""
                       }
                     ],
-                    "content": "{{data.assessment?.partnerAssessedContribution ? '$' + data.assessment.partnerAssessedContribution : '-'}}",
+                    "content": "{{typeof data.assessment?.partnerAssessedContribution === 'number' ? '$' + (data.assessment.partnerAssessedContribution).toFixed(2) : '-'}}",
                     "refreshOnChange": false,
+                    "customClass": "",
+                    "hidden": false,
+                    "modalEdit": false,
                     "key": "html38",
+                    "tags": [],
+                    "properties": {},
+                    "conditional": {
+                      "show": null,
+                      "when": null,
+                      "eq": "",
+                      "json": ""
+                    },
+                    "customConditional": "",
+                    "logic": [],
+                    "attributes": {},
+                    "overlay": {
+                      "style": "",
+                      "page": "",
+                      "left": "",
+                      "top": "",
+                      "width": "",
+                      "height": ""
+                    },
                     "type": "htmlelement",
                     "input": false,
                     "tableView": false,
                     "placeholder": "",
                     "prefix": "",
-                    "customClass": "",
                     "suffix": "",
                     "multiple": false,
                     "defaultValue": null,
                     "protected": false,
                     "unique": false,
                     "persistent": false,
-                    "hidden": false,
                     "clearOnHide": true,
                     "refreshOn": "",
                     "redrawOn": "",
-                    "modalEdit": false,
                     "dataGridLabel": false,
                     "labelPosition": "top",
                     "description": "",
@@ -5534,7 +5573,6 @@
                     "calculateValue": "",
                     "calculateServer": false,
                     "widget": null,
-                    "attributes": {},
                     "validateOn": "change",
                     "validate": {
                       "required": false,
@@ -5544,26 +5582,12 @@
                       "multiple": false,
                       "unique": false
                     },
-                    "conditional": {
-                      "show": null,
-                      "when": null,
-                      "eq": ""
-                    },
-                    "overlay": {
-                      "style": "",
-                      "left": "",
-                      "top": "",
-                      "width": "",
-                      "height": ""
-                    },
                     "allowCalculateOverride": false,
                     "encrypted": false,
                     "showCharCount": false,
                     "showWordCount": false,
-                    "properties": {},
                     "allowMultipleMasks": false,
-                    "tag": "p",
-                    "id": "e3j3kfm"
+                    "id": "eo87b8b"
                   }
                 ]
               },
@@ -5571,33 +5595,54 @@
                 "components": [
                   {
                     "label": "HTML",
+                    "tag": "p",
+                    "className": "",
                     "attrs": [
                       {
                         "attr": "",
                         "value": ""
                       }
                     ],
-                    "content": "{{data.assessment?.partnerAssessedContribution ? '$' + data.assessment.partnerAssessedContribution : '-'}}",
+                    "content": "{{typeof data.assessment?.partnerAssessedContribution === 'number' ? '$' + (data.assessment.partnerAssessedContribution).toFixed(2) : '-'}}",
                     "refreshOnChange": false,
+                    "customClass": "",
+                    "hidden": false,
+                    "modalEdit": false,
                     "key": "html39",
+                    "tags": [],
+                    "properties": {},
+                    "conditional": {
+                      "show": null,
+                      "when": null,
+                      "eq": "",
+                      "json": ""
+                    },
+                    "customConditional": "",
+                    "logic": [],
+                    "attributes": {},
+                    "overlay": {
+                      "style": "",
+                      "page": "",
+                      "left": "",
+                      "top": "",
+                      "width": "",
+                      "height": ""
+                    },
                     "type": "htmlelement",
                     "input": false,
                     "tableView": false,
                     "hideOnChildrenHidden": false,
                     "placeholder": "",
                     "prefix": "",
-                    "customClass": "",
                     "suffix": "",
                     "multiple": false,
                     "defaultValue": null,
                     "protected": false,
                     "unique": false,
                     "persistent": false,
-                    "hidden": false,
                     "clearOnHide": true,
                     "refreshOn": "",
                     "redrawOn": "",
-                    "modalEdit": false,
                     "dataGridLabel": false,
                     "labelPosition": "top",
                     "description": "",
@@ -5612,7 +5657,6 @@
                     "calculateValue": "",
                     "calculateServer": false,
                     "widget": null,
-                    "attributes": {},
                     "validateOn": "change",
                     "validate": {
                       "required": false,
@@ -5622,26 +5666,12 @@
                       "multiple": false,
                       "unique": false
                     },
-                    "conditional": {
-                      "show": null,
-                      "when": null,
-                      "eq": ""
-                    },
-                    "overlay": {
-                      "style": "",
-                      "left": "",
-                      "top": "",
-                      "width": "",
-                      "height": ""
-                    },
                     "allowCalculateOverride": false,
                     "encrypted": false,
                     "showCharCount": false,
                     "showWordCount": false,
-                    "properties": {},
                     "allowMultipleMasks": false,
-                    "tag": "p",
-                    "id": "eiygx3p"
+                    "id": "e40wlva"
                   }
                 ]
               }
@@ -5729,32 +5759,53 @@
                 "components": [
                   {
                     "label": "HTML",
+                    "tag": "p",
+                    "className": "",
                     "attrs": [
                       {
                         "attr": "",
                         "value": ""
                       }
                     ],
-                    "content": "{{data.assessment?.parentAssessedContribution ? '$' + data.assessment.parentAssessedContribution : '-'}}",
+                    "content": "{{typeof data.assessment?.parentAssessedContribution === 'number' ? '$' + (data.assessment.parentAssessedContribution).toFixed(2) : '-'}}",
                     "refreshOnChange": false,
+                    "customClass": "",
+                    "hidden": false,
+                    "modalEdit": false,
                     "key": "html44",
+                    "tags": [],
+                    "properties": {},
+                    "conditional": {
+                      "show": null,
+                      "when": null,
+                      "eq": "",
+                      "json": ""
+                    },
+                    "customConditional": "",
+                    "logic": [],
+                    "attributes": {},
+                    "overlay": {
+                      "style": "",
+                      "page": "",
+                      "left": "",
+                      "top": "",
+                      "width": "",
+                      "height": ""
+                    },
                     "type": "htmlelement",
                     "input": false,
                     "tableView": false,
                     "placeholder": "",
                     "prefix": "",
-                    "customClass": "",
                     "suffix": "",
                     "multiple": false,
                     "defaultValue": null,
                     "protected": false,
                     "unique": false,
                     "persistent": false,
-                    "hidden": false,
                     "clearOnHide": true,
                     "refreshOn": "",
                     "redrawOn": "",
-                    "modalEdit": false,
                     "dataGridLabel": false,
                     "labelPosition": "top",
                     "description": "",
@@ -5769,7 +5820,6 @@
                     "calculateValue": "",
                     "calculateServer": false,
                     "widget": null,
-                    "attributes": {},
                     "validateOn": "change",
                     "validate": {
                       "required": false,
@@ -5779,26 +5829,12 @@
                       "multiple": false,
                       "unique": false
                     },
-                    "conditional": {
-                      "show": null,
-                      "when": null,
-                      "eq": ""
-                    },
-                    "overlay": {
-                      "style": "",
-                      "left": "",
-                      "top": "",
-                      "width": "",
-                      "height": ""
-                    },
                     "allowCalculateOverride": false,
                     "encrypted": false,
                     "showCharCount": false,
                     "showWordCount": false,
-                    "properties": {},
                     "allowMultipleMasks": false,
-                    "tag": "p",
-                    "id": "eo4lfme"
+                    "id": "en9n6an"
                   }
                 ]
               },
@@ -5806,32 +5842,53 @@
                 "components": [
                   {
                     "label": "HTML",
+                    "tag": "p",
+                    "className": "",
                     "attrs": [
                       {
                         "attr": "",
                         "value": ""
                       }
                     ],
-                    "content": "{{data.assessment?.parentAssessedContribution ? '$' + data.assessment.parentAssessedContribution : '-'}}",
+                    "content": "{{typeof data.assessment?.parentAssessedContribution === 'number' ? '$' + (data.assessment.parentAssessedContribution).toFixed(2) : '-'}}",
                     "refreshOnChange": false,
+                    "customClass": "",
+                    "hidden": false,
+                    "modalEdit": false,
                     "key": "html43",
+                    "tags": [],
+                    "properties": {},
+                    "conditional": {
+                      "show": null,
+                      "when": null,
+                      "eq": "",
+                      "json": ""
+                    },
+                    "customConditional": "",
+                    "logic": [],
+                    "attributes": {},
+                    "overlay": {
+                      "style": "",
+                      "page": "",
+                      "left": "",
+                      "top": "",
+                      "width": "",
+                      "height": ""
+                    },
                     "type": "htmlelement",
                     "input": false,
                     "tableView": false,
                     "placeholder": "",
                     "prefix": "",
-                    "customClass": "",
                     "suffix": "",
                     "multiple": false,
                     "defaultValue": null,
                     "protected": false,
                     "unique": false,
                     "persistent": false,
-                    "hidden": false,
                     "clearOnHide": true,
                     "refreshOn": "",
                     "redrawOn": "",
-                    "modalEdit": false,
                     "dataGridLabel": false,
                     "labelPosition": "top",
                     "description": "",
@@ -5846,7 +5903,6 @@
                     "calculateValue": "",
                     "calculateServer": false,
                     "widget": null,
-                    "attributes": {},
                     "validateOn": "change",
                     "validate": {
                       "required": false,
@@ -5856,26 +5912,12 @@
                       "multiple": false,
                       "unique": false
                     },
-                    "conditional": {
-                      "show": null,
-                      "when": null,
-                      "eq": ""
-                    },
-                    "overlay": {
-                      "style": "",
-                      "left": "",
-                      "top": "",
-                      "width": "",
-                      "height": ""
-                    },
                     "allowCalculateOverride": false,
                     "encrypted": false,
                     "showCharCount": false,
                     "showWordCount": false,
-                    "properties": {},
                     "allowMultipleMasks": false,
-                    "tag": "p",
-                    "id": "eox34a"
+                    "id": "eoxa9nc"
                   }
                 ]
               }
@@ -5963,16 +6005,39 @@
                 "components": [
                   {
                     "label": "HTML",
+                    "tag": "p",
+                    "className": "",
                     "attrs": [
                       {
                         "attr": "",
                         "value": ""
                       }
                     ],
-                    "content": "{{data.assessment?.totalFederalContribution ? '$' + data.assessment.totalFederalContribution : '-'}}",
+                    "content": "{{typeof data.assessment?.totalFederalContribution === 'number' ? '$' + (data.assessment.totalFederalContribution).toFixed(2) : '-'}}",
                     "refreshOnChange": false,
                     "customClass": "header-md secondary-color",
+                    "hidden": false,
+                    "modalEdit": false,
                     "key": "html34",
+                    "tags": [],
+                    "properties": {},
+                    "conditional": {
+                      "show": null,
+                      "when": null,
+                      "eq": "",
+                      "json": ""
+                    },
+                    "customConditional": "",
+                    "logic": [],
+                    "attributes": {},
+                    "overlay": {
+                      "style": "",
+                      "page": "",
+                      "left": "",
+                      "top": "",
+                      "width": "",
+                      "height": ""
+                    },
                     "type": "htmlelement",
                     "input": false,
                     "tableView": false,
@@ -5984,11 +6049,9 @@
                     "protected": false,
                     "unique": false,
                     "persistent": false,
-                    "hidden": false,
                     "clearOnHide": true,
                     "refreshOn": "",
                     "redrawOn": "",
-                    "modalEdit": false,
                     "dataGridLabel": false,
                     "labelPosition": "top",
                     "description": "",
@@ -6003,7 +6066,6 @@
                     "calculateValue": "",
                     "calculateServer": false,
                     "widget": null,
-                    "attributes": {},
                     "validateOn": "change",
                     "validate": {
                       "required": false,
@@ -6013,26 +6075,12 @@
                       "multiple": false,
                       "unique": false
                     },
-                    "conditional": {
-                      "show": null,
-                      "when": null,
-                      "eq": ""
-                    },
-                    "overlay": {
-                      "style": "",
-                      "left": "",
-                      "top": "",
-                      "width": "",
-                      "height": ""
-                    },
                     "allowCalculateOverride": false,
                     "encrypted": false,
                     "showCharCount": false,
                     "showWordCount": false,
-                    "properties": {},
                     "allowMultipleMasks": false,
-                    "tag": "p",
-                    "id": "e467lbl"
+                    "id": "ecigk1k"
                   }
                 ]
               },
@@ -6040,16 +6088,39 @@
                 "components": [
                   {
                     "label": "HTML",
+                    "tag": "p",
+                    "className": "",
                     "attrs": [
                       {
                         "attr": "",
                         "value": ""
                       }
                     ],
-                    "content": "{{data.assessment?.totalProvincialContribution ? '$' + data.assessment.totalProvincialContribution : '-'}}",
+                    "content": "{{typeof data.assessment?.totalProvincialContribution === 'number' ? '$' + (data.assessment.totalProvincialContribution).toFixed(2) : '-'}}",
                     "refreshOnChange": false,
                     "customClass": "header-md secondary-color",
+                    "hidden": false,
+                    "modalEdit": false,
                     "key": "html47",
+                    "tags": [],
+                    "properties": {},
+                    "conditional": {
+                      "show": null,
+                      "when": null,
+                      "eq": "",
+                      "json": ""
+                    },
+                    "customConditional": "",
+                    "logic": [],
+                    "attributes": {},
+                    "overlay": {
+                      "style": "",
+                      "page": "",
+                      "left": "",
+                      "top": "",
+                      "width": "",
+                      "height": ""
+                    },
                     "type": "htmlelement",
                     "input": false,
                     "tableView": false,
@@ -6062,11 +6133,9 @@
                     "protected": false,
                     "unique": false,
                     "persistent": false,
-                    "hidden": false,
                     "clearOnHide": true,
                     "refreshOn": "",
                     "redrawOn": "",
-                    "modalEdit": false,
                     "dataGridLabel": false,
                     "labelPosition": "top",
                     "description": "",
@@ -6081,7 +6150,6 @@
                     "calculateValue": "",
                     "calculateServer": false,
                     "widget": null,
-                    "attributes": {},
                     "validateOn": "change",
                     "validate": {
                       "required": false,
@@ -6091,26 +6159,12 @@
                       "multiple": false,
                       "unique": false
                     },
-                    "conditional": {
-                      "show": null,
-                      "when": null,
-                      "eq": ""
-                    },
-                    "overlay": {
-                      "style": "",
-                      "left": "",
-                      "top": "",
-                      "width": "",
-                      "height": ""
-                    },
                     "allowCalculateOverride": false,
                     "encrypted": false,
                     "showCharCount": false,
                     "showWordCount": false,
-                    "properties": {},
                     "allowMultipleMasks": false,
-                    "tag": "p",
-                    "id": "e6ldum"
+                    "id": "exip9r"
                   }
                 ]
               }
@@ -6276,16 +6330,39 @@
                 "components": [
                   {
                     "label": "HTML",
+                    "tag": "p",
+                    "className": "",
                     "attrs": [
                       {
                         "attr": "",
                         "value": ""
                       }
                     ],
-                    "content": "{{data.assessment?.federalAssessmentNeed ? '$' + data.assessment.federalAssessmentNeed : '-'}}",
+                    "content": "{{typeof data.assessment?.federalAssessmentNeed === 'number' ? '$' + (data.assessment.federalAssessmentNeed).toFixed(2) : '-'}}",
                     "refreshOnChange": false,
                     "customClass": "header-md secondary-color",
+                    "hidden": false,
+                    "modalEdit": false,
                     "key": "html35",
+                    "tags": [],
+                    "properties": {},
+                    "conditional": {
+                      "show": null,
+                      "when": null,
+                      "eq": "",
+                      "json": ""
+                    },
+                    "customConditional": "",
+                    "logic": [],
+                    "attributes": {},
+                    "overlay": {
+                      "style": "",
+                      "page": "",
+                      "left": "",
+                      "top": "",
+                      "width": "",
+                      "height": ""
+                    },
                     "type": "htmlelement",
                     "input": false,
                     "tableView": false,
@@ -6297,11 +6374,9 @@
                     "protected": false,
                     "unique": false,
                     "persistent": false,
-                    "hidden": false,
                     "clearOnHide": true,
                     "refreshOn": "",
                     "redrawOn": "",
-                    "modalEdit": false,
                     "dataGridLabel": false,
                     "labelPosition": "top",
                     "description": "",
@@ -6316,7 +6391,6 @@
                     "calculateValue": "",
                     "calculateServer": false,
                     "widget": null,
-                    "attributes": {},
                     "validateOn": "change",
                     "validate": {
                       "required": false,
@@ -6326,26 +6400,12 @@
                       "multiple": false,
                       "unique": false
                     },
-                    "conditional": {
-                      "show": null,
-                      "when": null,
-                      "eq": ""
-                    },
-                    "overlay": {
-                      "style": "",
-                      "left": "",
-                      "top": "",
-                      "width": "",
-                      "height": ""
-                    },
                     "allowCalculateOverride": false,
                     "encrypted": false,
                     "showCharCount": false,
                     "showWordCount": false,
-                    "properties": {},
                     "allowMultipleMasks": false,
-                    "tag": "p",
-                    "id": "ep0iuos"
+                    "id": "eh81f2k"
                   }
                 ]
               },
@@ -6353,16 +6413,39 @@
                 "components": [
                   {
                     "label": "HTML",
+                    "tag": "p",
+                    "className": "",
                     "attrs": [
                       {
                         "attr": "",
                         "value": ""
                       }
                     ],
-                    "content": "{{data.assessment?.provincialAssessmentNeed ? '$' + data.assessment.provincialAssessmentNeed : '-'}}",
+                    "content": "{{typeof data.assessment?.provincialAssessmentNeed === 'number' ? '$' + (data.assessment.provincialAssessmentNeed).toFixed(2) : '-'}}",
                     "refreshOnChange": false,
                     "customClass": "header-md secondary-color",
+                    "hidden": false,
+                    "modalEdit": false,
                     "key": "html36",
+                    "tags": [],
+                    "properties": {},
+                    "conditional": {
+                      "show": null,
+                      "when": null,
+                      "eq": "",
+                      "json": ""
+                    },
+                    "customConditional": "",
+                    "logic": [],
+                    "attributes": {},
+                    "overlay": {
+                      "style": "",
+                      "page": "",
+                      "left": "",
+                      "top": "",
+                      "width": "",
+                      "height": ""
+                    },
                     "type": "htmlelement",
                     "input": false,
                     "tableView": false,
@@ -6374,11 +6457,9 @@
                     "protected": false,
                     "unique": false,
                     "persistent": false,
-                    "hidden": false,
                     "clearOnHide": true,
                     "refreshOn": "",
                     "redrawOn": "",
-                    "modalEdit": false,
                     "dataGridLabel": false,
                     "labelPosition": "top",
                     "description": "",
@@ -6393,7 +6474,6 @@
                     "calculateValue": "",
                     "calculateServer": false,
                     "widget": null,
-                    "attributes": {},
                     "validateOn": "change",
                     "validate": {
                       "required": false,
@@ -6403,26 +6483,12 @@
                       "multiple": false,
                       "unique": false
                     },
-                    "conditional": {
-                      "show": null,
-                      "when": null,
-                      "eq": ""
-                    },
-                    "overlay": {
-                      "style": "",
-                      "left": "",
-                      "top": "",
-                      "width": "",
-                      "height": ""
-                    },
                     "allowCalculateOverride": false,
                     "encrypted": false,
                     "showCharCount": false,
                     "showWordCount": false,
-                    "properties": {},
                     "allowMultipleMasks": false,
-                    "tag": "p",
-                    "id": "ebu93v"
+                    "id": "echoww"
                   }
                 ]
               }
@@ -10506,6 +10572,6 @@
   "name": "noticeofassessment",
   "path": "noticeofassessment",
   "created": "2021-07-14T17:56:22.162Z",
-  "modified": "2021-12-01T08:20:51.413Z",
+  "modified": "2021-12-01T22:51:09.910Z",
   "machineName": "noticeOfAssessment"
 }

--- a/sources/packages/forms/src/form-definitions/noticeofassessment.json
+++ b/sources/packages/forms/src/form-definitions/noticeofassessment.json
@@ -94,7 +94,7 @@
       "dbIndex": false,
       "encrypted": false,
       "redrawOn": "",
-      "customDefaultValue": "value=data.assessment.totalFederalAward+data.assessment.totalProvincialAward;",
+      "customDefaultValue": "value=parseFloat(data.assessment.totalFederalAward)+ parseFloat(data.assessment.totalProvincialAward);",
       "calculateValue": "",
       "calculateServer": false,
       "key": "eligibleAmount",
@@ -152,7 +152,7 @@
       "showWordCount": false,
       "allowMultipleMasks": false,
       "inputType": "hidden",
-      "id": "ezu4jv5"
+      "id": "ee6tqid"
     },
     {
       "label": "NOA",
@@ -596,7 +596,7 @@
               "value": ""
             }
           ],
-          "content": "You are eligible for <b>{{data.eligibleAmount}}</b>",
+          "content": "You are eligible for <b>${{data.eligibleAmount}}</b>",
           "refreshOnChange": true,
           "customClass": "",
           "hidden": false,
@@ -663,7 +663,7 @@
           "showCharCount": false,
           "showWordCount": false,
           "allowMultipleMasks": false,
-          "id": "eljwos"
+          "id": "ea4bq4o"
         },
         {
           "label": "HTML",
@@ -742,7 +742,7 @@
           "showCharCount": false,
           "showWordCount": false,
           "allowMultipleMasks": false,
-          "id": "eey2d3"
+          "id": "en6j2ud"
         },
         {
           "label": "HTML",
@@ -781,7 +781,6 @@
           },
           "type": "htmlelement",
           "input": false,
-          "tableView": false,
           "placeholder": "",
           "prefix": "",
           "suffix": "",
@@ -793,6 +792,7 @@
           "clearOnHide": true,
           "refreshOn": "",
           "redrawOn": "",
+          "tableView": false,
           "dataGridLabel": false,
           "labelPosition": "top",
           "description": "",
@@ -821,7 +821,7 @@
           "showCharCount": false,
           "showWordCount": false,
           "allowMultipleMasks": false,
-          "id": "evrpej9"
+          "id": "etxnrq"
         },
         {
           "label": "Tuition Remittance",
@@ -1832,7 +1832,7 @@
                         "value": ""
                       }
                     ],
-                    "content": "$#######",
+                    "content": "{{data.disbursement?.disbursement1Date ? data.disbursement.disbursement1Date : ''}}",
                     "refreshOnChange": false,
                     "customClass": "",
                     "hidden": false,
@@ -1859,6 +1859,7 @@
                     },
                     "type": "htmlelement",
                     "input": false,
+                    "tableView": false,
                     "placeholder": "",
                     "prefix": "",
                     "suffix": "",
@@ -1870,7 +1871,6 @@
                     "clearOnHide": true,
                     "refreshOn": "",
                     "redrawOn": "",
-                    "tableView": false,
                     "dataGridLabel": false,
                     "labelPosition": "top",
                     "description": "",
@@ -1899,7 +1899,7 @@
                     "showCharCount": false,
                     "showWordCount": false,
                     "allowMultipleMasks": false,
-                    "id": "eywsi59"
+                    "id": "euuc1ko"
                   }
                 ]
               }
@@ -2000,7 +2000,7 @@
                         "value": ""
                       }
                     ],
-                    "content": "$#######",
+                    "content": "{{data.disbursement?.disbursement2Date ? data.disbursement.disbursement2Date : ''}}",
                     "refreshOnChange": false,
                     "customClass": "",
                     "hidden": false,
@@ -2027,6 +2027,7 @@
                     },
                     "type": "htmlelement",
                     "input": false,
+                    "tableView": false,
                     "placeholder": "",
                     "prefix": "",
                     "suffix": "",
@@ -2038,7 +2039,6 @@
                     "clearOnHide": true,
                     "refreshOn": "",
                     "redrawOn": "",
-                    "tableView": false,
                     "dataGridLabel": false,
                     "labelPosition": "top",
                     "description": "",
@@ -2067,7 +2067,7 @@
                     "showCharCount": false,
                     "showWordCount": false,
                     "allowMultipleMasks": false,
-                    "id": "e49tbci"
+                    "id": "eo54k6"
                   }
                 ]
               }
@@ -2571,7 +2571,6 @@
             "height": ""
           },
           "type": "table",
-          "numRows": 20,
           "numCols": 3,
           "input": false,
           "tableView": false,
@@ -2650,7 +2649,7 @@
                     "properties": {},
                     "allowMultipleMasks": false,
                     "tag": "p",
-                    "id": "egbeber"
+                    "id": "e57byaf"
                   }
                 ]
               },
@@ -2666,8 +2665,6 @@
                 "components": [
                   {
                     "label": "Assessed costs",
-                    "tag": "p",
-                    "className": "",
                     "attrs": [
                       {
                         "attr": "",
@@ -2677,28 +2674,7 @@
                     "content": "Assessed Costs",
                     "refreshOnChange": false,
                     "customClass": "header-md secondary-color",
-                    "hidden": false,
-                    "modalEdit": false,
                     "key": "assessedCosts",
-                    "tags": [],
-                    "properties": {},
-                    "conditional": {
-                      "show": null,
-                      "when": null,
-                      "eq": "",
-                      "json": ""
-                    },
-                    "customConditional": "",
-                    "logic": [],
-                    "attributes": {},
-                    "overlay": {
-                      "style": "",
-                      "page": "",
-                      "left": "",
-                      "top": "",
-                      "width": "",
-                      "height": ""
-                    },
                     "type": "htmlelement",
                     "input": false,
                     "tableView": false,
@@ -2711,9 +2687,11 @@
                     "protected": false,
                     "unique": false,
                     "persistent": false,
+                    "hidden": false,
                     "clearOnHide": true,
                     "refreshOn": "",
                     "redrawOn": "",
+                    "modalEdit": false,
                     "dataGridLabel": false,
                     "labelPosition": "top",
                     "description": "",
@@ -2728,6 +2706,7 @@
                     "calculateValue": "",
                     "calculateServer": false,
                     "widget": null,
+                    "attributes": {},
                     "validateOn": "change",
                     "validate": {
                       "required": false,
@@ -2737,12 +2716,26 @@
                       "multiple": false,
                       "unique": false
                     },
+                    "conditional": {
+                      "show": null,
+                      "when": null,
+                      "eq": ""
+                    },
+                    "overlay": {
+                      "style": "",
+                      "left": "",
+                      "top": "",
+                      "width": "",
+                      "height": ""
+                    },
                     "allowCalculateOverride": false,
                     "encrypted": false,
                     "showCharCount": false,
                     "showWordCount": false,
+                    "properties": {},
                     "allowMultipleMasks": false,
-                    "id": "enriwiu"
+                    "tag": "p",
+                    "id": "e995rz"
                   }
                 ]
               },
@@ -2750,8 +2743,6 @@
                 "components": [
                   {
                     "label": "Federal",
-                    "tag": "p",
-                    "className": "",
                     "attrs": [
                       {
                         "attr": "",
@@ -2761,28 +2752,7 @@
                     "content": "Federal",
                     "refreshOnChange": false,
                     "customClass": "header-md secondary-color",
-                    "hidden": false,
-                    "modalEdit": false,
                     "key": "federal",
-                    "tags": [],
-                    "properties": {},
-                    "conditional": {
-                      "show": null,
-                      "when": null,
-                      "eq": "",
-                      "json": ""
-                    },
-                    "customConditional": "",
-                    "logic": [],
-                    "attributes": {},
-                    "overlay": {
-                      "style": "",
-                      "page": "",
-                      "left": "",
-                      "top": "",
-                      "width": "",
-                      "height": ""
-                    },
                     "type": "htmlelement",
                     "input": false,
                     "tableView": false,
@@ -2795,9 +2765,11 @@
                     "protected": false,
                     "unique": false,
                     "persistent": false,
+                    "hidden": false,
                     "clearOnHide": true,
                     "refreshOn": "",
                     "redrawOn": "",
+                    "modalEdit": false,
                     "dataGridLabel": false,
                     "labelPosition": "top",
                     "description": "",
@@ -2812,6 +2784,7 @@
                     "calculateValue": "",
                     "calculateServer": false,
                     "widget": null,
+                    "attributes": {},
                     "validateOn": "change",
                     "validate": {
                       "required": false,
@@ -2821,12 +2794,26 @@
                       "multiple": false,
                       "unique": false
                     },
+                    "conditional": {
+                      "show": null,
+                      "when": null,
+                      "eq": ""
+                    },
+                    "overlay": {
+                      "style": "",
+                      "left": "",
+                      "top": "",
+                      "width": "",
+                      "height": ""
+                    },
                     "allowCalculateOverride": false,
                     "encrypted": false,
                     "showCharCount": false,
                     "showWordCount": false,
+                    "properties": {},
                     "allowMultipleMasks": false,
-                    "id": "ect461"
+                    "tag": "p",
+                    "id": "e4hf6pq"
                   }
                 ]
               },
@@ -2834,8 +2821,6 @@
                 "components": [
                   {
                     "label": "Provincial",
-                    "tag": "p",
-                    "className": "",
                     "attrs": [
                       {
                         "attr": "",
@@ -2845,28 +2830,7 @@
                     "content": "Provincial",
                     "refreshOnChange": false,
                     "customClass": "header-md secondary-color",
-                    "hidden": false,
-                    "modalEdit": false,
                     "key": "provincial",
-                    "tags": [],
-                    "properties": {},
-                    "conditional": {
-                      "show": null,
-                      "when": null,
-                      "eq": "",
-                      "json": ""
-                    },
-                    "customConditional": "",
-                    "logic": [],
-                    "attributes": {},
-                    "overlay": {
-                      "style": "",
-                      "page": "",
-                      "left": "",
-                      "top": "",
-                      "width": "",
-                      "height": ""
-                    },
                     "type": "htmlelement",
                     "input": false,
                     "tableView": false,
@@ -2879,9 +2843,11 @@
                     "protected": false,
                     "unique": false,
                     "persistent": false,
+                    "hidden": false,
                     "clearOnHide": true,
                     "refreshOn": "",
                     "redrawOn": "",
+                    "modalEdit": false,
                     "dataGridLabel": false,
                     "labelPosition": "top",
                     "description": "",
@@ -2896,6 +2862,7 @@
                     "calculateValue": "",
                     "calculateServer": false,
                     "widget": null,
+                    "attributes": {},
                     "validateOn": "change",
                     "validate": {
                       "required": false,
@@ -2905,12 +2872,26 @@
                       "multiple": false,
                       "unique": false
                     },
+                    "conditional": {
+                      "show": null,
+                      "when": null,
+                      "eq": ""
+                    },
+                    "overlay": {
+                      "style": "",
+                      "left": "",
+                      "top": "",
+                      "width": "",
+                      "height": ""
+                    },
                     "allowCalculateOverride": false,
                     "encrypted": false,
                     "showCharCount": false,
                     "showWordCount": false,
+                    "properties": {},
                     "allowMultipleMasks": false,
-                    "id": "e9w33ui"
+                    "tag": "p",
+                    "id": "e3sg5o"
                   }
                 ]
               }
@@ -2990,7 +2971,7 @@
                     "properties": {},
                     "allowMultipleMasks": false,
                     "tag": "p",
-                    "id": "eig3pf"
+                    "id": "e9iwhug"
                   }
                 ]
               },
@@ -2998,32 +2979,53 @@
                 "components": [
                   {
                     "label": "HTML",
+                    "tag": "p",
+                    "className": "",
                     "attrs": [
                       {
                         "attr": "",
                         "value": ""
                       }
                     ],
-                    "content": "$####",
+                    "content": "{{data.assessment?.tuitionCost ? '$' + data.assessment.tuitionCost : '-'}}",
                     "refreshOnChange": false,
+                    "customClass": "",
+                    "hidden": false,
+                    "modalEdit": false,
                     "key": "html24",
+                    "tags": [],
+                    "properties": {},
+                    "conditional": {
+                      "show": null,
+                      "when": null,
+                      "eq": "",
+                      "json": ""
+                    },
+                    "customConditional": "",
+                    "logic": [],
+                    "attributes": {},
+                    "overlay": {
+                      "style": "",
+                      "page": "",
+                      "left": "",
+                      "top": "",
+                      "width": "",
+                      "height": ""
+                    },
                     "type": "htmlelement",
                     "input": false,
                     "tableView": false,
                     "placeholder": "",
                     "prefix": "",
-                    "customClass": "",
                     "suffix": "",
                     "multiple": false,
                     "defaultValue": null,
                     "protected": false,
                     "unique": false,
                     "persistent": false,
-                    "hidden": false,
                     "clearOnHide": true,
                     "refreshOn": "",
                     "redrawOn": "",
-                    "modalEdit": false,
                     "dataGridLabel": false,
                     "labelPosition": "top",
                     "description": "",
@@ -3038,7 +3040,6 @@
                     "calculateValue": "",
                     "calculateServer": false,
                     "widget": null,
-                    "attributes": {},
                     "validateOn": "change",
                     "validate": {
                       "required": false,
@@ -3048,26 +3049,12 @@
                       "multiple": false,
                       "unique": false
                     },
-                    "conditional": {
-                      "show": null,
-                      "when": null,
-                      "eq": ""
-                    },
-                    "overlay": {
-                      "style": "",
-                      "left": "",
-                      "top": "",
-                      "width": "",
-                      "height": ""
-                    },
                     "allowCalculateOverride": false,
                     "encrypted": false,
                     "showCharCount": false,
                     "showWordCount": false,
-                    "properties": {},
                     "allowMultipleMasks": false,
-                    "tag": "p",
-                    "id": "e4fbt2e"
+                    "id": "e4tub7j"
                   }
                 ]
               },
@@ -3075,32 +3062,53 @@
                 "components": [
                   {
                     "label": "HTML",
+                    "tag": "p",
+                    "className": "",
                     "attrs": [
                       {
                         "attr": "",
                         "value": ""
                       }
                     ],
-                    "content": "$####",
+                    "content": "{{data.assessment?.tuitionCost ? '$' + data.assessment.tuitionCost : '-'}}",
                     "refreshOnChange": false,
+                    "customClass": "",
+                    "hidden": false,
+                    "modalEdit": false,
                     "key": "html23",
+                    "tags": [],
+                    "properties": {},
+                    "conditional": {
+                      "show": null,
+                      "when": null,
+                      "eq": "",
+                      "json": ""
+                    },
+                    "customConditional": "",
+                    "logic": [],
+                    "attributes": {},
+                    "overlay": {
+                      "style": "",
+                      "page": "",
+                      "left": "",
+                      "top": "",
+                      "width": "",
+                      "height": ""
+                    },
                     "type": "htmlelement",
                     "input": false,
                     "tableView": false,
                     "placeholder": "",
                     "prefix": "",
-                    "customClass": "",
                     "suffix": "",
                     "multiple": false,
                     "defaultValue": null,
                     "protected": false,
                     "unique": false,
                     "persistent": false,
-                    "hidden": false,
                     "clearOnHide": true,
                     "refreshOn": "",
                     "redrawOn": "",
-                    "modalEdit": false,
                     "dataGridLabel": false,
                     "labelPosition": "top",
                     "description": "",
@@ -3115,7 +3123,6 @@
                     "calculateValue": "",
                     "calculateServer": false,
                     "widget": null,
-                    "attributes": {},
                     "validateOn": "change",
                     "validate": {
                       "required": false,
@@ -3125,26 +3132,12 @@
                       "multiple": false,
                       "unique": false
                     },
-                    "conditional": {
-                      "show": null,
-                      "when": null,
-                      "eq": ""
-                    },
-                    "overlay": {
-                      "style": "",
-                      "left": "",
-                      "top": "",
-                      "width": "",
-                      "height": ""
-                    },
                     "allowCalculateOverride": false,
                     "encrypted": false,
                     "showCharCount": false,
                     "showWordCount": false,
-                    "properties": {},
                     "allowMultipleMasks": false,
-                    "tag": "p",
-                    "id": "e7kqrbd"
+                    "id": "e8rn8t8"
                   }
                 ]
               }
@@ -3224,7 +3217,7 @@
                     "properties": {},
                     "allowMultipleMasks": false,
                     "tag": "p",
-                    "id": "exacsts"
+                    "id": "ejgqmsi"
                   }
                 ]
               },
@@ -3232,32 +3225,53 @@
                 "components": [
                   {
                     "label": "HTML",
+                    "tag": "p",
+                    "className": "",
                     "attrs": [
                       {
                         "attr": "",
                         "value": ""
                       }
                     ],
-                    "content": "$####",
+                    "content": "{{data.assessment?.booksAndSuppliesCost ? '$' + data.assessment?.booksAndSuppliesCost : '-'}}",
                     "refreshOnChange": false,
+                    "customClass": "",
+                    "hidden": false,
+                    "modalEdit": false,
                     "key": "html18",
+                    "tags": [],
+                    "properties": {},
+                    "conditional": {
+                      "show": null,
+                      "when": null,
+                      "eq": "",
+                      "json": ""
+                    },
+                    "customConditional": "",
+                    "logic": [],
+                    "attributes": {},
+                    "overlay": {
+                      "style": "",
+                      "page": "",
+                      "left": "",
+                      "top": "",
+                      "width": "",
+                      "height": ""
+                    },
                     "type": "htmlelement",
                     "input": false,
                     "tableView": false,
                     "placeholder": "",
                     "prefix": "",
-                    "customClass": "",
                     "suffix": "",
                     "multiple": false,
                     "defaultValue": null,
                     "protected": false,
                     "unique": false,
                     "persistent": false,
-                    "hidden": false,
                     "clearOnHide": true,
                     "refreshOn": "",
                     "redrawOn": "",
-                    "modalEdit": false,
                     "dataGridLabel": false,
                     "labelPosition": "top",
                     "description": "",
@@ -3272,7 +3286,6 @@
                     "calculateValue": "",
                     "calculateServer": false,
                     "widget": null,
-                    "attributes": {},
                     "validateOn": "change",
                     "validate": {
                       "required": false,
@@ -3282,26 +3295,12 @@
                       "multiple": false,
                       "unique": false
                     },
-                    "conditional": {
-                      "show": null,
-                      "when": null,
-                      "eq": ""
-                    },
-                    "overlay": {
-                      "style": "",
-                      "left": "",
-                      "top": "",
-                      "width": "",
-                      "height": ""
-                    },
                     "allowCalculateOverride": false,
                     "encrypted": false,
                     "showCharCount": false,
                     "showWordCount": false,
-                    "properties": {},
                     "allowMultipleMasks": false,
-                    "tag": "p",
-                    "id": "euhhztp"
+                    "id": "e2wzdwi"
                   }
                 ]
               },
@@ -3309,32 +3308,53 @@
                 "components": [
                   {
                     "label": "HTML",
+                    "tag": "p",
+                    "className": "",
                     "attrs": [
                       {
                         "attr": "",
                         "value": ""
                       }
                     ],
-                    "content": "$####",
+                    "content": "{{data.assessment?.booksAndSuppliesCost ? '$' + data.assessment?.booksAndSuppliesCost : '-'}}",
                     "refreshOnChange": false,
+                    "customClass": "",
+                    "hidden": false,
+                    "modalEdit": false,
                     "key": "html22",
+                    "tags": [],
+                    "properties": {},
+                    "conditional": {
+                      "show": null,
+                      "when": null,
+                      "eq": "",
+                      "json": ""
+                    },
+                    "customConditional": "",
+                    "logic": [],
+                    "attributes": {},
+                    "overlay": {
+                      "style": "",
+                      "page": "",
+                      "left": "",
+                      "top": "",
+                      "width": "",
+                      "height": ""
+                    },
                     "type": "htmlelement",
                     "input": false,
                     "tableView": false,
                     "placeholder": "",
                     "prefix": "",
-                    "customClass": "",
                     "suffix": "",
                     "multiple": false,
                     "defaultValue": null,
                     "protected": false,
                     "unique": false,
                     "persistent": false,
-                    "hidden": false,
                     "clearOnHide": true,
                     "refreshOn": "",
                     "redrawOn": "",
-                    "modalEdit": false,
                     "dataGridLabel": false,
                     "labelPosition": "top",
                     "description": "",
@@ -3349,7 +3369,6 @@
                     "calculateValue": "",
                     "calculateServer": false,
                     "widget": null,
-                    "attributes": {},
                     "validateOn": "change",
                     "validate": {
                       "required": false,
@@ -3359,26 +3378,12 @@
                       "multiple": false,
                       "unique": false
                     },
-                    "conditional": {
-                      "show": null,
-                      "when": null,
-                      "eq": ""
-                    },
-                    "overlay": {
-                      "style": "",
-                      "left": "",
-                      "top": "",
-                      "width": "",
-                      "height": ""
-                    },
                     "allowCalculateOverride": false,
                     "encrypted": false,
                     "showCharCount": false,
                     "showWordCount": false,
-                    "properties": {},
                     "allowMultipleMasks": false,
-                    "tag": "p",
-                    "id": "e3dlc6p"
+                    "id": "emjcy8e"
                   }
                 ]
               }
@@ -3457,7 +3462,7 @@
                     "properties": {},
                     "allowMultipleMasks": false,
                     "tag": "p",
-                    "id": "eaybmk"
+                    "id": "e3nkbbw"
                   }
                 ]
               },
@@ -3465,32 +3470,53 @@
                 "components": [
                   {
                     "label": "HTML",
+                    "tag": "p",
+                    "className": "",
                     "attrs": [
                       {
                         "attr": "",
                         "value": ""
                       }
                     ],
-                    "content": "$####",
+                    "content": "{{data.assessment?.exceptionalEducationCost ? '$' + data.assessment.exceptionalEducationCost : '-'}}",
                     "refreshOnChange": false,
+                    "customClass": "",
+                    "hidden": false,
+                    "modalEdit": false,
                     "key": "html19",
+                    "tags": [],
+                    "properties": {},
+                    "conditional": {
+                      "show": null,
+                      "when": null,
+                      "eq": "",
+                      "json": ""
+                    },
+                    "customConditional": "",
+                    "logic": [],
+                    "attributes": {},
+                    "overlay": {
+                      "style": "",
+                      "page": "",
+                      "left": "",
+                      "top": "",
+                      "width": "",
+                      "height": ""
+                    },
                     "type": "htmlelement",
                     "input": false,
                     "tableView": false,
                     "placeholder": "",
                     "prefix": "",
-                    "customClass": "",
                     "suffix": "",
                     "multiple": false,
                     "defaultValue": null,
                     "protected": false,
                     "unique": false,
                     "persistent": false,
-                    "hidden": false,
                     "clearOnHide": true,
                     "refreshOn": "",
                     "redrawOn": "",
-                    "modalEdit": false,
                     "dataGridLabel": false,
                     "labelPosition": "top",
                     "description": "",
@@ -3505,7 +3531,6 @@
                     "calculateValue": "",
                     "calculateServer": false,
                     "widget": null,
-                    "attributes": {},
                     "validateOn": "change",
                     "validate": {
                       "required": false,
@@ -3515,26 +3540,12 @@
                       "multiple": false,
                       "unique": false
                     },
-                    "conditional": {
-                      "show": null,
-                      "when": null,
-                      "eq": ""
-                    },
-                    "overlay": {
-                      "style": "",
-                      "left": "",
-                      "top": "",
-                      "width": "",
-                      "height": ""
-                    },
                     "allowCalculateOverride": false,
                     "encrypted": false,
                     "showCharCount": false,
                     "showWordCount": false,
-                    "properties": {},
                     "allowMultipleMasks": false,
-                    "tag": "p",
-                    "id": "egqndaf"
+                    "id": "e9d2eo2"
                   }
                 ]
               },
@@ -3542,32 +3553,53 @@
                 "components": [
                   {
                     "label": "HTML",
+                    "tag": "p",
+                    "className": "",
                     "attrs": [
                       {
                         "attr": "",
                         "value": ""
                       }
                     ],
-                    "content": "$####",
+                    "content": "{{data.assessment?.exceptionalEducationCost ? '$' + data.assessment.exceptionalEducationCost : '-'}}",
                     "refreshOnChange": false,
+                    "customClass": "",
+                    "hidden": false,
+                    "modalEdit": false,
                     "key": "html27",
+                    "tags": [],
+                    "properties": {},
+                    "conditional": {
+                      "show": null,
+                      "when": null,
+                      "eq": "",
+                      "json": ""
+                    },
+                    "customConditional": "",
+                    "logic": [],
+                    "attributes": {},
+                    "overlay": {
+                      "style": "",
+                      "page": "",
+                      "left": "",
+                      "top": "",
+                      "width": "",
+                      "height": ""
+                    },
                     "type": "htmlelement",
                     "input": false,
                     "tableView": false,
                     "placeholder": "",
                     "prefix": "",
-                    "customClass": "",
                     "suffix": "",
                     "multiple": false,
                     "defaultValue": null,
                     "protected": false,
                     "unique": false,
                     "persistent": false,
-                    "hidden": false,
                     "clearOnHide": true,
                     "refreshOn": "",
                     "redrawOn": "",
-                    "modalEdit": false,
                     "dataGridLabel": false,
                     "labelPosition": "top",
                     "description": "",
@@ -3582,7 +3614,6 @@
                     "calculateValue": "",
                     "calculateServer": false,
                     "widget": null,
-                    "attributes": {},
                     "validateOn": "change",
                     "validate": {
                       "required": false,
@@ -3592,26 +3623,12 @@
                       "multiple": false,
                       "unique": false
                     },
-                    "conditional": {
-                      "show": null,
-                      "when": null,
-                      "eq": ""
-                    },
-                    "overlay": {
-                      "style": "",
-                      "left": "",
-                      "top": "",
-                      "width": "",
-                      "height": ""
-                    },
                     "allowCalculateOverride": false,
                     "encrypted": false,
                     "showCharCount": false,
                     "showWordCount": false,
-                    "properties": {},
                     "allowMultipleMasks": false,
-                    "tag": "p",
-                    "id": "e063wpr"
+                    "id": "em69g0w"
                   }
                 ]
               }
@@ -3691,7 +3708,7 @@
                     "properties": {},
                     "allowMultipleMasks": false,
                     "tag": "p",
-                    "id": "enbw6m"
+                    "id": "ehhmw87"
                   }
                 ]
               },
@@ -3699,32 +3716,53 @@
                 "components": [
                   {
                     "label": "HTML",
+                    "tag": "p",
+                    "className": "",
                     "attrs": [
                       {
                         "attr": "",
                         "value": ""
                       }
                     ],
-                    "content": "$####",
+                    "content": "{{data.assessment?.livingAllowance ? '$' + data.assessment.livingAllowance : '-'}}",
                     "refreshOnChange": false,
+                    "customClass": "",
+                    "hidden": false,
+                    "modalEdit": false,
                     "key": "html20",
+                    "tags": [],
+                    "properties": {},
+                    "conditional": {
+                      "show": null,
+                      "when": null,
+                      "eq": "",
+                      "json": ""
+                    },
+                    "customConditional": "",
+                    "logic": [],
+                    "attributes": {},
+                    "overlay": {
+                      "style": "",
+                      "page": "",
+                      "left": "",
+                      "top": "",
+                      "width": "",
+                      "height": ""
+                    },
                     "type": "htmlelement",
                     "input": false,
                     "tableView": false,
                     "placeholder": "",
                     "prefix": "",
-                    "customClass": "",
                     "suffix": "",
                     "multiple": false,
                     "defaultValue": null,
                     "protected": false,
                     "unique": false,
                     "persistent": false,
-                    "hidden": false,
                     "clearOnHide": true,
                     "refreshOn": "",
                     "redrawOn": "",
-                    "modalEdit": false,
                     "dataGridLabel": false,
                     "labelPosition": "top",
                     "description": "",
@@ -3739,7 +3777,6 @@
                     "calculateValue": "",
                     "calculateServer": false,
                     "widget": null,
-                    "attributes": {},
                     "validateOn": "change",
                     "validate": {
                       "required": false,
@@ -3749,26 +3786,12 @@
                       "multiple": false,
                       "unique": false
                     },
-                    "conditional": {
-                      "show": null,
-                      "when": null,
-                      "eq": ""
-                    },
-                    "overlay": {
-                      "style": "",
-                      "left": "",
-                      "top": "",
-                      "width": "",
-                      "height": ""
-                    },
                     "allowCalculateOverride": false,
                     "encrypted": false,
                     "showCharCount": false,
                     "showWordCount": false,
-                    "properties": {},
                     "allowMultipleMasks": false,
-                    "tag": "p",
-                    "id": "essg3sq"
+                    "id": "eqivx2c"
                   }
                 ]
               },
@@ -3776,32 +3799,53 @@
                 "components": [
                   {
                     "label": "HTML",
+                    "tag": "p",
+                    "className": "",
                     "attrs": [
                       {
                         "attr": "",
                         "value": ""
                       }
                     ],
-                    "content": "$####",
+                    "content": "{{data.assessment?.livingAllowance ? '$' + data.assessment.livingAllowance : '-'}}",
                     "refreshOnChange": false,
+                    "customClass": "",
+                    "hidden": false,
+                    "modalEdit": false,
                     "key": "html29",
+                    "tags": [],
+                    "properties": {},
+                    "conditional": {
+                      "show": null,
+                      "when": null,
+                      "eq": "",
+                      "json": ""
+                    },
+                    "customConditional": "",
+                    "logic": [],
+                    "attributes": {},
+                    "overlay": {
+                      "style": "",
+                      "page": "",
+                      "left": "",
+                      "top": "",
+                      "width": "",
+                      "height": ""
+                    },
                     "type": "htmlelement",
                     "input": false,
                     "tableView": false,
                     "placeholder": "",
                     "prefix": "",
-                    "customClass": "",
                     "suffix": "",
                     "multiple": false,
                     "defaultValue": null,
                     "protected": false,
                     "unique": false,
                     "persistent": false,
-                    "hidden": false,
                     "clearOnHide": true,
                     "refreshOn": "",
                     "redrawOn": "",
-                    "modalEdit": false,
                     "dataGridLabel": false,
                     "labelPosition": "top",
                     "description": "",
@@ -3816,7 +3860,6 @@
                     "calculateValue": "",
                     "calculateServer": false,
                     "widget": null,
-                    "attributes": {},
                     "validateOn": "change",
                     "validate": {
                       "required": false,
@@ -3826,26 +3869,12 @@
                       "multiple": false,
                       "unique": false
                     },
-                    "conditional": {
-                      "show": null,
-                      "when": null,
-                      "eq": ""
-                    },
-                    "overlay": {
-                      "style": "",
-                      "left": "",
-                      "top": "",
-                      "width": "",
-                      "height": ""
-                    },
                     "allowCalculateOverride": false,
                     "encrypted": false,
                     "showCharCount": false,
                     "showWordCount": false,
-                    "properties": {},
                     "allowMultipleMasks": false,
-                    "tag": "p",
-                    "id": "e3mxak3"
+                    "id": "e9n3n4m"
                   }
                 ]
               }
@@ -3924,7 +3953,7 @@
                     "properties": {},
                     "allowMultipleMasks": false,
                     "tag": "p",
-                    "id": "esl8mlo"
+                    "id": "ee1d8i7"
                   }
                 ]
               },
@@ -3932,32 +3961,53 @@
                 "components": [
                   {
                     "label": "HTML",
+                    "tag": "p",
+                    "className": "",
                     "attrs": [
                       {
                         "attr": "",
                         "value": ""
                       }
                     ],
-                    "content": "$####",
+                    "content": "{{data.assessment?.transportationCost ? '$' + data.assessment.transportationCost : '-'}}",
                     "refreshOnChange": false,
+                    "customClass": "",
+                    "hidden": false,
+                    "modalEdit": false,
                     "key": "html25",
+                    "tags": [],
+                    "properties": {},
+                    "conditional": {
+                      "show": null,
+                      "when": null,
+                      "eq": "",
+                      "json": ""
+                    },
+                    "customConditional": "",
+                    "logic": [],
+                    "attributes": {},
+                    "overlay": {
+                      "style": "",
+                      "page": "",
+                      "left": "",
+                      "top": "",
+                      "width": "",
+                      "height": ""
+                    },
                     "type": "htmlelement",
                     "input": false,
                     "tableView": false,
                     "placeholder": "",
                     "prefix": "",
-                    "customClass": "",
                     "suffix": "",
                     "multiple": false,
                     "defaultValue": null,
                     "protected": false,
                     "unique": false,
                     "persistent": false,
-                    "hidden": false,
                     "clearOnHide": true,
                     "refreshOn": "",
                     "redrawOn": "",
-                    "modalEdit": false,
                     "dataGridLabel": false,
                     "labelPosition": "top",
                     "description": "",
@@ -3972,7 +4022,6 @@
                     "calculateValue": "",
                     "calculateServer": false,
                     "widget": null,
-                    "attributes": {},
                     "validateOn": "change",
                     "validate": {
                       "required": false,
@@ -3982,26 +4031,12 @@
                       "multiple": false,
                       "unique": false
                     },
-                    "conditional": {
-                      "show": null,
-                      "when": null,
-                      "eq": ""
-                    },
-                    "overlay": {
-                      "style": "",
-                      "left": "",
-                      "top": "",
-                      "width": "",
-                      "height": ""
-                    },
                     "allowCalculateOverride": false,
                     "encrypted": false,
                     "showCharCount": false,
                     "showWordCount": false,
-                    "properties": {},
                     "allowMultipleMasks": false,
-                    "tag": "p",
-                    "id": "e6xjc3f"
+                    "id": "efukg8"
                   }
                 ]
               },
@@ -4009,32 +4044,53 @@
                 "components": [
                   {
                     "label": "HTML",
+                    "tag": "p",
+                    "className": "",
                     "attrs": [
                       {
                         "attr": "",
                         "value": ""
                       }
                     ],
-                    "content": "$####",
+                    "content": "{{data.assessment?.transportationCost ? '$' + data.assessment.transportationCost : '-'}}",
                     "refreshOnChange": false,
+                    "customClass": "",
+                    "hidden": false,
+                    "modalEdit": false,
                     "key": "html21",
+                    "tags": [],
+                    "properties": {},
+                    "conditional": {
+                      "show": null,
+                      "when": null,
+                      "eq": "",
+                      "json": ""
+                    },
+                    "customConditional": "",
+                    "logic": [],
+                    "attributes": {},
+                    "overlay": {
+                      "style": "",
+                      "page": "",
+                      "left": "",
+                      "top": "",
+                      "width": "",
+                      "height": ""
+                    },
                     "type": "htmlelement",
                     "input": false,
                     "tableView": false,
                     "placeholder": "",
                     "prefix": "",
-                    "customClass": "",
                     "suffix": "",
                     "multiple": false,
                     "defaultValue": null,
                     "protected": false,
                     "unique": false,
                     "persistent": false,
-                    "hidden": false,
                     "clearOnHide": true,
                     "refreshOn": "",
                     "redrawOn": "",
-                    "modalEdit": false,
                     "dataGridLabel": false,
                     "labelPosition": "top",
                     "description": "",
@@ -4049,7 +4105,6 @@
                     "calculateValue": "",
                     "calculateServer": false,
                     "widget": null,
-                    "attributes": {},
                     "validateOn": "change",
                     "validate": {
                       "required": false,
@@ -4059,26 +4114,12 @@
                       "multiple": false,
                       "unique": false
                     },
-                    "conditional": {
-                      "show": null,
-                      "when": null,
-                      "eq": ""
-                    },
-                    "overlay": {
-                      "style": "",
-                      "left": "",
-                      "top": "",
-                      "width": "",
-                      "height": ""
-                    },
                     "allowCalculateOverride": false,
                     "encrypted": false,
                     "showCharCount": false,
                     "showWordCount": false,
-                    "properties": {},
                     "allowMultipleMasks": false,
-                    "tag": "p",
-                    "id": "elx89ek"
+                    "id": "e9ahepx"
                   }
                 ]
               }
@@ -4157,7 +4198,7 @@
                     "properties": {},
                     "allowMultipleMasks": false,
                     "tag": "p",
-                    "id": "etnw2sa"
+                    "id": "e7kj7x"
                   }
                 ]
               },
@@ -4165,32 +4206,53 @@
                 "components": [
                   {
                     "label": "HTML",
+                    "tag": "p",
+                    "className": "",
                     "attrs": [
                       {
                         "attr": "",
                         "value": ""
                       }
                     ],
-                    "content": "$####",
+                    "content": "{{data.assessment?.childcareCost ? '$' + data.assessment.childcareCost : '-'}}",
                     "refreshOnChange": false,
+                    "customClass": "",
+                    "hidden": false,
+                    "modalEdit": false,
                     "key": "html26",
+                    "tags": [],
+                    "properties": {},
+                    "conditional": {
+                      "show": null,
+                      "when": null,
+                      "eq": "",
+                      "json": ""
+                    },
+                    "customConditional": "",
+                    "logic": [],
+                    "attributes": {},
+                    "overlay": {
+                      "style": "",
+                      "page": "",
+                      "left": "",
+                      "top": "",
+                      "width": "",
+                      "height": ""
+                    },
                     "type": "htmlelement",
                     "input": false,
                     "tableView": false,
                     "placeholder": "",
                     "prefix": "",
-                    "customClass": "",
                     "suffix": "",
                     "multiple": false,
                     "defaultValue": null,
                     "protected": false,
                     "unique": false,
                     "persistent": false,
-                    "hidden": false,
                     "clearOnHide": true,
                     "refreshOn": "",
                     "redrawOn": "",
-                    "modalEdit": false,
                     "dataGridLabel": false,
                     "labelPosition": "top",
                     "description": "",
@@ -4205,7 +4267,6 @@
                     "calculateValue": "",
                     "calculateServer": false,
                     "widget": null,
-                    "attributes": {},
                     "validateOn": "change",
                     "validate": {
                       "required": false,
@@ -4215,26 +4276,12 @@
                       "multiple": false,
                       "unique": false
                     },
-                    "conditional": {
-                      "show": null,
-                      "when": null,
-                      "eq": ""
-                    },
-                    "overlay": {
-                      "style": "",
-                      "left": "",
-                      "top": "",
-                      "width": "",
-                      "height": ""
-                    },
                     "allowCalculateOverride": false,
                     "encrypted": false,
                     "showCharCount": false,
                     "showWordCount": false,
-                    "properties": {},
                     "allowMultipleMasks": false,
-                    "tag": "p",
-                    "id": "eh21ecl"
+                    "id": "esiupeo"
                   }
                 ]
               },
@@ -4242,32 +4289,53 @@
                 "components": [
                   {
                     "label": "HTML",
+                    "tag": "p",
+                    "className": "",
                     "attrs": [
                       {
                         "attr": "",
                         "value": ""
                       }
                     ],
-                    "content": "$####",
+                    "content": "{{data.assessment?.childcareCost ? '$' + data.assessment.childcareCost : '-'}}",
                     "refreshOnChange": false,
+                    "customClass": "",
+                    "hidden": false,
+                    "modalEdit": false,
                     "key": "html30",
+                    "tags": [],
+                    "properties": {},
+                    "conditional": {
+                      "show": null,
+                      "when": null,
+                      "eq": "",
+                      "json": ""
+                    },
+                    "customConditional": "",
+                    "logic": [],
+                    "attributes": {},
+                    "overlay": {
+                      "style": "",
+                      "page": "",
+                      "left": "",
+                      "top": "",
+                      "width": "",
+                      "height": ""
+                    },
                     "type": "htmlelement",
                     "input": false,
                     "tableView": false,
                     "placeholder": "",
                     "prefix": "",
-                    "customClass": "",
                     "suffix": "",
                     "multiple": false,
                     "defaultValue": null,
                     "protected": false,
                     "unique": false,
                     "persistent": false,
-                    "hidden": false,
                     "clearOnHide": true,
                     "refreshOn": "",
                     "redrawOn": "",
-                    "modalEdit": false,
                     "dataGridLabel": false,
                     "labelPosition": "top",
                     "description": "",
@@ -4282,7 +4350,6 @@
                     "calculateValue": "",
                     "calculateServer": false,
                     "widget": null,
-                    "attributes": {},
                     "validateOn": "change",
                     "validate": {
                       "required": false,
@@ -4292,26 +4359,12 @@
                       "multiple": false,
                       "unique": false
                     },
-                    "conditional": {
-                      "show": null,
-                      "when": null,
-                      "eq": ""
-                    },
-                    "overlay": {
-                      "style": "",
-                      "left": "",
-                      "top": "",
-                      "width": "",
-                      "height": ""
-                    },
                     "allowCalculateOverride": false,
                     "encrypted": false,
                     "showCharCount": false,
                     "showWordCount": false,
-                    "properties": {},
                     "allowMultipleMasks": false,
-                    "tag": "p",
-                    "id": "epsgbgf"
+                    "id": "eg6ub3b"
                   }
                 ]
               }
@@ -4390,7 +4443,7 @@
                     "properties": {},
                     "allowMultipleMasks": false,
                     "tag": "p",
-                    "id": "ekxd1cg"
+                    "id": "ezrtuzb"
                   }
                 ]
               },
@@ -4398,32 +4451,53 @@
                 "components": [
                   {
                     "label": "HTML",
+                    "tag": "p",
+                    "className": "",
                     "attrs": [
                       {
                         "attr": "",
                         "value": ""
                       }
                     ],
-                    "content": "$####",
+                    "content": "{{data.assessment?.otherAllowableCost ? '$' + data.assessment.otherAllowableCost : '-'}}",
                     "refreshOnChange": false,
+                    "customClass": "",
+                    "hidden": false,
+                    "modalEdit": false,
                     "key": "html28",
+                    "tags": [],
+                    "properties": {},
+                    "conditional": {
+                      "show": null,
+                      "when": null,
+                      "eq": "",
+                      "json": ""
+                    },
+                    "customConditional": "",
+                    "logic": [],
+                    "attributes": {},
+                    "overlay": {
+                      "style": "",
+                      "page": "",
+                      "left": "",
+                      "top": "",
+                      "width": "",
+                      "height": ""
+                    },
                     "type": "htmlelement",
                     "input": false,
                     "tableView": false,
                     "placeholder": "",
                     "prefix": "",
-                    "customClass": "",
                     "suffix": "",
                     "multiple": false,
                     "defaultValue": null,
                     "protected": false,
                     "unique": false,
                     "persistent": false,
-                    "hidden": false,
                     "clearOnHide": true,
                     "refreshOn": "",
                     "redrawOn": "",
-                    "modalEdit": false,
                     "dataGridLabel": false,
                     "labelPosition": "top",
                     "description": "",
@@ -4438,7 +4512,6 @@
                     "calculateValue": "",
                     "calculateServer": false,
                     "widget": null,
-                    "attributes": {},
                     "validateOn": "change",
                     "validate": {
                       "required": false,
@@ -4448,26 +4521,12 @@
                       "multiple": false,
                       "unique": false
                     },
-                    "conditional": {
-                      "show": null,
-                      "when": null,
-                      "eq": ""
-                    },
-                    "overlay": {
-                      "style": "",
-                      "left": "",
-                      "top": "",
-                      "width": "",
-                      "height": ""
-                    },
                     "allowCalculateOverride": false,
                     "encrypted": false,
                     "showCharCount": false,
                     "showWordCount": false,
-                    "properties": {},
                     "allowMultipleMasks": false,
-                    "tag": "p",
-                    "id": "es6dgk9"
+                    "id": "e1uq9vf"
                   }
                 ]
               },
@@ -4481,7 +4540,7 @@
                         "value": ""
                       }
                     ],
-                    "content": "$####",
+                    "content": "{{data.assessment?.otherAllowableCost ? '$' + data.assessment.otherAllowableCost : '-'}}",
                     "refreshOnChange": false,
                     "key": "html31",
                     "type": "htmlelement",
@@ -4544,7 +4603,7 @@
                     "properties": {},
                     "allowMultipleMasks": false,
                     "tag": "p",
-                    "id": "epyvsu8"
+                    "id": "e9arhhn"
                   }
                 ]
               }
@@ -4554,8 +4613,6 @@
                 "components": [
                   {
                     "label": "Total assessed costs",
-                    "tag": "p",
-                    "className": "",
                     "attrs": [
                       {
                         "attr": "",
@@ -4565,28 +4622,7 @@
                     "content": "Total assessed costs",
                     "refreshOnChange": false,
                     "customClass": "header-md secondary-color",
-                    "hidden": false,
-                    "modalEdit": false,
                     "key": "totalAssessedCosts",
-                    "tags": [],
-                    "properties": {},
-                    "conditional": {
-                      "show": null,
-                      "when": null,
-                      "eq": "",
-                      "json": ""
-                    },
-                    "customConditional": "",
-                    "logic": [],
-                    "attributes": {},
-                    "overlay": {
-                      "style": "",
-                      "page": "",
-                      "left": "",
-                      "top": "",
-                      "width": "",
-                      "height": ""
-                    },
                     "type": "htmlelement",
                     "input": false,
                     "tableView": false,
@@ -4599,9 +4635,11 @@
                     "protected": false,
                     "unique": false,
                     "persistent": false,
+                    "hidden": false,
                     "clearOnHide": true,
                     "refreshOn": "",
                     "redrawOn": "",
+                    "modalEdit": false,
                     "dataGridLabel": false,
                     "labelPosition": "top",
                     "description": "",
@@ -4616,6 +4654,7 @@
                     "calculateValue": "",
                     "calculateServer": false,
                     "widget": null,
+                    "attributes": {},
                     "validateOn": "change",
                     "validate": {
                       "required": false,
@@ -4625,12 +4664,26 @@
                       "multiple": false,
                       "unique": false
                     },
+                    "conditional": {
+                      "show": null,
+                      "when": null,
+                      "eq": ""
+                    },
+                    "overlay": {
+                      "style": "",
+                      "left": "",
+                      "top": "",
+                      "width": "",
+                      "height": ""
+                    },
                     "allowCalculateOverride": false,
                     "encrypted": false,
                     "showCharCount": false,
                     "showWordCount": false,
+                    "properties": {},
                     "allowMultipleMasks": false,
-                    "id": "e5aewka"
+                    "tag": "p",
+                    "id": "edp5l4"
                   }
                 ]
               },
@@ -4646,7 +4699,7 @@
                         "value": ""
                       }
                     ],
-                    "content": "${{data.assessment.totalFederalAward}}",
+                    "content": "{{data.assessment?.totalAssessedCost ? '$' + data.assessment.totalAssessedCost : '-'}}",
                     "refreshOnChange": true,
                     "customClass": "header-md secondary-color",
                     "hidden": false,
@@ -4713,7 +4766,7 @@
                     "showCharCount": false,
                     "showWordCount": false,
                     "allowMultipleMasks": false,
-                    "id": "evjr3rs"
+                    "id": "e7hfci5"
                   }
                 ]
               },
@@ -4729,7 +4782,7 @@
                         "value": ""
                       }
                     ],
-                    "content": "${{data.assessment.totalProvincialAward}}",
+                    "content": "{{data.assessment?.totalAssessedCost ? '$' + data.assessment.totalAssessedCost : '-'}}",
                     "refreshOnChange": true,
                     "customClass": "header-md secondary-color",
                     "hidden": false,
@@ -4796,7 +4849,7 @@
                     "showCharCount": false,
                     "showWordCount": false,
                     "allowMultipleMasks": false,
-                    "id": "e1qk31"
+                    "id": "e6ixdw"
                   }
                 ]
               }
@@ -4875,7 +4928,7 @@
                     "properties": {},
                     "allowMultipleMasks": false,
                     "tag": "p",
-                    "id": "e8aaiw"
+                    "id": "ek124i"
                   }
                 ]
               },
@@ -4891,8 +4944,6 @@
                 "components": [
                   {
                     "label": "Student financial contributions",
-                    "tag": "p",
-                    "className": "",
                     "attrs": [
                       {
                         "attr": "",
@@ -4902,28 +4953,7 @@
                     "content": "Student financial contributions",
                     "refreshOnChange": false,
                     "customClass": "header-md secondary-color",
-                    "hidden": false,
-                    "modalEdit": false,
                     "key": "assessedCosts1",
-                    "tags": [],
-                    "properties": {},
-                    "conditional": {
-                      "show": null,
-                      "when": null,
-                      "eq": "",
-                      "json": ""
-                    },
-                    "customConditional": "",
-                    "logic": [],
-                    "attributes": {},
-                    "overlay": {
-                      "style": "",
-                      "page": "",
-                      "left": "",
-                      "top": "",
-                      "width": "",
-                      "height": ""
-                    },
                     "type": "htmlelement",
                     "input": false,
                     "tableView": false,
@@ -4936,9 +4966,11 @@
                     "protected": false,
                     "unique": false,
                     "persistent": false,
+                    "hidden": false,
                     "clearOnHide": true,
                     "refreshOn": "",
                     "redrawOn": "",
+                    "modalEdit": false,
                     "dataGridLabel": false,
                     "labelPosition": "top",
                     "description": "",
@@ -4953,6 +4985,7 @@
                     "calculateValue": "",
                     "calculateServer": false,
                     "widget": null,
+                    "attributes": {},
                     "validateOn": "change",
                     "validate": {
                       "required": false,
@@ -4962,12 +4995,26 @@
                       "multiple": false,
                       "unique": false
                     },
+                    "conditional": {
+                      "show": null,
+                      "when": null,
+                      "eq": ""
+                    },
+                    "overlay": {
+                      "style": "",
+                      "left": "",
+                      "top": "",
+                      "width": "",
+                      "height": ""
+                    },
                     "allowCalculateOverride": false,
                     "encrypted": false,
                     "showCharCount": false,
                     "showWordCount": false,
+                    "properties": {},
                     "allowMultipleMasks": false,
-                    "id": "eq15i5h"
+                    "tag": "p",
+                    "id": "ehxxh38"
                   }
                 ]
               },
@@ -4976,7 +5023,6 @@
                   {
                     "label": "Federal",
                     "tag": "o",
-                    "className": "",
                     "attrs": [
                       {
                         "attr": "",
@@ -4986,28 +5032,7 @@
                     "content": "Federal",
                     "refreshOnChange": false,
                     "customClass": "header-md secondary-color",
-                    "hidden": false,
-                    "modalEdit": false,
                     "key": "federal1",
-                    "tags": [],
-                    "properties": {},
-                    "conditional": {
-                      "show": null,
-                      "when": null,
-                      "eq": "",
-                      "json": ""
-                    },
-                    "customConditional": "",
-                    "logic": [],
-                    "attributes": {},
-                    "overlay": {
-                      "style": "",
-                      "page": "",
-                      "left": "",
-                      "top": "",
-                      "width": "",
-                      "height": ""
-                    },
                     "type": "htmlelement",
                     "input": false,
                     "tableView": false,
@@ -5020,9 +5045,11 @@
                     "protected": false,
                     "unique": false,
                     "persistent": false,
+                    "hidden": false,
                     "clearOnHide": true,
                     "refreshOn": "",
                     "redrawOn": "",
+                    "modalEdit": false,
                     "dataGridLabel": false,
                     "labelPosition": "top",
                     "description": "",
@@ -5037,6 +5064,7 @@
                     "calculateValue": "",
                     "calculateServer": false,
                     "widget": null,
+                    "attributes": {},
                     "validateOn": "change",
                     "validate": {
                       "required": false,
@@ -5046,12 +5074,25 @@
                       "multiple": false,
                       "unique": false
                     },
+                    "conditional": {
+                      "show": null,
+                      "when": null,
+                      "eq": ""
+                    },
+                    "overlay": {
+                      "style": "",
+                      "left": "",
+                      "top": "",
+                      "width": "",
+                      "height": ""
+                    },
                     "allowCalculateOverride": false,
                     "encrypted": false,
                     "showCharCount": false,
                     "showWordCount": false,
+                    "properties": {},
                     "allowMultipleMasks": false,
-                    "id": "enxkyg9"
+                    "id": "er0d5a5"
                   }
                 ]
               },
@@ -5059,8 +5100,6 @@
                 "components": [
                   {
                     "label": "Provincial",
-                    "tag": "p",
-                    "className": "",
                     "attrs": [
                       {
                         "attr": "",
@@ -5070,28 +5109,7 @@
                     "content": "Provincial",
                     "refreshOnChange": false,
                     "customClass": "header-md secondary-color",
-                    "hidden": false,
-                    "modalEdit": false,
                     "key": "provincial1",
-                    "tags": [],
-                    "properties": {},
-                    "conditional": {
-                      "show": null,
-                      "when": null,
-                      "eq": "",
-                      "json": ""
-                    },
-                    "customConditional": "",
-                    "logic": [],
-                    "attributes": {},
-                    "overlay": {
-                      "style": "",
-                      "page": "",
-                      "left": "",
-                      "top": "",
-                      "width": "",
-                      "height": ""
-                    },
                     "type": "htmlelement",
                     "input": false,
                     "tableView": false,
@@ -5104,9 +5122,11 @@
                     "protected": false,
                     "unique": false,
                     "persistent": false,
+                    "hidden": false,
                     "clearOnHide": true,
                     "refreshOn": "",
                     "redrawOn": "",
+                    "modalEdit": false,
                     "dataGridLabel": false,
                     "labelPosition": "top",
                     "description": "",
@@ -5121,6 +5141,7 @@
                     "calculateValue": "",
                     "calculateServer": false,
                     "widget": null,
+                    "attributes": {},
                     "validateOn": "change",
                     "validate": {
                       "required": false,
@@ -5130,12 +5151,26 @@
                       "multiple": false,
                       "unique": false
                     },
+                    "conditional": {
+                      "show": null,
+                      "when": null,
+                      "eq": ""
+                    },
+                    "overlay": {
+                      "style": "",
+                      "left": "",
+                      "top": "",
+                      "width": "",
+                      "height": ""
+                    },
                     "allowCalculateOverride": false,
                     "encrypted": false,
                     "showCharCount": false,
                     "showWordCount": false,
+                    "properties": {},
                     "allowMultipleMasks": false,
-                    "id": "epoiuxx"
+                    "tag": "p",
+                    "id": "ewgvmq"
                   }
                 ]
               }
@@ -5215,7 +5250,7 @@
                     "properties": {},
                     "allowMultipleMasks": false,
                     "tag": "p",
-                    "id": "e2vrqq"
+                    "id": "eor267c"
                   }
                 ]
               },
@@ -5229,7 +5264,7 @@
                         "value": ""
                       }
                     ],
-                    "content": "$####",
+                    "content": "{{data.assessment?.studentTotalFederalContribution ? '$' + data.assessment.studentTotalFederalContribution : '-'}}",
                     "refreshOnChange": false,
                     "key": "html46",
                     "type": "htmlelement",
@@ -5293,7 +5328,7 @@
                     "properties": {},
                     "allowMultipleMasks": false,
                     "tag": "p",
-                    "id": "ew0v0rn"
+                    "id": "ejo14wd"
                   }
                 ]
               },
@@ -5307,7 +5342,7 @@
                         "value": ""
                       }
                     ],
-                    "content": "$####",
+                    "content": "{{data.assessment?.studentTotalProvincialContribution ? '$' + data.assessment.studentTotalProvincialContribution : '-'}}",
                     "refreshOnChange": false,
                     "key": "html45",
                     "type": "htmlelement",
@@ -5371,7 +5406,7 @@
                     "properties": {},
                     "allowMultipleMasks": false,
                     "tag": "p",
-                    "id": "eaq6pp"
+                    "id": "e9mpivg"
                   }
                 ]
               }
@@ -5451,7 +5486,7 @@
                     "properties": {},
                     "allowMultipleMasks": false,
                     "tag": "p",
-                    "id": "e14fk0w"
+                    "id": "e7f7khl"
                   }
                 ]
               },
@@ -5465,7 +5500,7 @@
                         "value": ""
                       }
                     ],
-                    "content": "$####",
+                    "content": "{{data.assessment?.partnerAssessedContribution ? '$' + data.assessment.partnerAssessedContribution : '-'}}",
                     "refreshOnChange": false,
                     "key": "html38",
                     "type": "htmlelement",
@@ -5528,7 +5563,7 @@
                     "properties": {},
                     "allowMultipleMasks": false,
                     "tag": "p",
-                    "id": "ejrvu"
+                    "id": "e3j3kfm"
                   }
                 ]
               },
@@ -5542,7 +5577,7 @@
                         "value": ""
                       }
                     ],
-                    "content": "$####",
+                    "content": "{{data.assessment?.partnerAssessedContribution ? '$' + data.assessment.partnerAssessedContribution : '-'}}",
                     "refreshOnChange": false,
                     "key": "html39",
                     "type": "htmlelement",
@@ -5606,7 +5641,7 @@
                     "properties": {},
                     "allowMultipleMasks": false,
                     "tag": "p",
-                    "id": "egqysto"
+                    "id": "eiygx3p"
                   }
                 ]
               }
@@ -5686,7 +5721,7 @@
                     "properties": {},
                     "allowMultipleMasks": false,
                     "tag": "p",
-                    "id": "eh0lcl"
+                    "id": "ekk06fh"
                   }
                 ]
               },
@@ -5700,7 +5735,7 @@
                         "value": ""
                       }
                     ],
-                    "content": "$####",
+                    "content": "{{data.assessment?.parentAssessedContribution ? '$' + data.assessment.parentAssessedContribution : '-'}}",
                     "refreshOnChange": false,
                     "key": "html44",
                     "type": "htmlelement",
@@ -5763,7 +5798,7 @@
                     "properties": {},
                     "allowMultipleMasks": false,
                     "tag": "p",
-                    "id": "esgh5u"
+                    "id": "eo4lfme"
                   }
                 ]
               },
@@ -5777,7 +5812,7 @@
                         "value": ""
                       }
                     ],
-                    "content": "$####",
+                    "content": "{{data.assessment?.parentAssessedContribution ? '$' + data.assessment.parentAssessedContribution : '-'}}",
                     "refreshOnChange": false,
                     "key": "html43",
                     "type": "htmlelement",
@@ -5840,473 +5875,7 @@
                     "properties": {},
                     "allowMultipleMasks": false,
                     "tag": "p",
-                    "id": "ekhh75a"
-                  }
-                ]
-              }
-            ],
-            [
-              {
-                "components": [
-                  {
-                    "label": "HTML",
-                    "attrs": [
-                      {
-                        "attr": "",
-                        "value": ""
-                      }
-                    ],
-                    "content": "Scholarships and Bursaries",
-                    "refreshOnChange": false,
-                    "key": "html17",
-                    "type": "htmlelement",
-                    "input": false,
-                    "tableView": false,
-                    "placeholder": "",
-                    "prefix": "",
-                    "customClass": "",
-                    "suffix": "",
-                    "multiple": false,
-                    "defaultValue": null,
-                    "protected": false,
-                    "unique": false,
-                    "persistent": false,
-                    "hidden": false,
-                    "clearOnHide": true,
-                    "refreshOn": "",
-                    "redrawOn": "",
-                    "modalEdit": false,
-                    "dataGridLabel": false,
-                    "labelPosition": "top",
-                    "description": "",
-                    "errorLabel": "",
-                    "tooltip": "",
-                    "hideLabel": false,
-                    "tabindex": "",
-                    "disabled": false,
-                    "autofocus": false,
-                    "dbIndex": false,
-                    "customDefaultValue": "",
-                    "calculateValue": "",
-                    "calculateServer": false,
-                    "widget": null,
-                    "attributes": {},
-                    "validateOn": "change",
-                    "validate": {
-                      "required": false,
-                      "custom": "",
-                      "customPrivate": false,
-                      "strictDateValidation": false,
-                      "multiple": false,
-                      "unique": false
-                    },
-                    "conditional": {
-                      "show": null,
-                      "when": null,
-                      "eq": ""
-                    },
-                    "overlay": {
-                      "style": "",
-                      "left": "",
-                      "top": "",
-                      "width": "",
-                      "height": ""
-                    },
-                    "allowCalculateOverride": false,
-                    "encrypted": false,
-                    "showCharCount": false,
-                    "showWordCount": false,
-                    "properties": {},
-                    "allowMultipleMasks": false,
-                    "tag": "p",
-                    "id": "eq8jtlc"
-                  }
-                ]
-              },
-              {
-                "components": [
-                  {
-                    "label": "HTML",
-                    "attrs": [
-                      {
-                        "attr": "",
-                        "value": ""
-                      }
-                    ],
-                    "content": "$####",
-                    "refreshOnChange": false,
-                    "key": "html37",
-                    "type": "htmlelement",
-                    "input": false,
-                    "tableView": false,
-                    "placeholder": "",
-                    "prefix": "",
-                    "customClass": "",
-                    "suffix": "",
-                    "multiple": false,
-                    "defaultValue": null,
-                    "protected": false,
-                    "unique": false,
-                    "persistent": false,
-                    "hidden": false,
-                    "clearOnHide": true,
-                    "refreshOn": "",
-                    "redrawOn": "",
-                    "modalEdit": false,
-                    "dataGridLabel": false,
-                    "labelPosition": "top",
-                    "description": "",
-                    "errorLabel": "",
-                    "tooltip": "",
-                    "hideLabel": false,
-                    "tabindex": "",
-                    "disabled": false,
-                    "autofocus": false,
-                    "dbIndex": false,
-                    "customDefaultValue": "",
-                    "calculateValue": "",
-                    "calculateServer": false,
-                    "widget": null,
-                    "attributes": {},
-                    "validateOn": "change",
-                    "validate": {
-                      "required": false,
-                      "custom": "",
-                      "customPrivate": false,
-                      "strictDateValidation": false,
-                      "multiple": false,
-                      "unique": false
-                    },
-                    "conditional": {
-                      "show": null,
-                      "when": null,
-                      "eq": ""
-                    },
-                    "overlay": {
-                      "style": "",
-                      "left": "",
-                      "top": "",
-                      "width": "",
-                      "height": ""
-                    },
-                    "allowCalculateOverride": false,
-                    "encrypted": false,
-                    "showCharCount": false,
-                    "showWordCount": false,
-                    "properties": {},
-                    "allowMultipleMasks": false,
-                    "tag": "p",
-                    "id": "ewpy6mi"
-                  }
-                ]
-              },
-              {
-                "components": [
-                  {
-                    "label": "HTML",
-                    "attrs": [
-                      {
-                        "attr": "",
-                        "value": ""
-                      }
-                    ],
-                    "content": "$####",
-                    "refreshOnChange": false,
-                    "key": "html42",
-                    "type": "htmlelement",
-                    "input": false,
-                    "tableView": false,
-                    "placeholder": "",
-                    "prefix": "",
-                    "customClass": "",
-                    "suffix": "",
-                    "multiple": false,
-                    "defaultValue": null,
-                    "protected": false,
-                    "unique": false,
-                    "persistent": false,
-                    "hidden": false,
-                    "clearOnHide": true,
-                    "refreshOn": "",
-                    "redrawOn": "",
-                    "modalEdit": false,
-                    "dataGridLabel": false,
-                    "labelPosition": "top",
-                    "description": "",
-                    "errorLabel": "",
-                    "tooltip": "",
-                    "hideLabel": false,
-                    "tabindex": "",
-                    "disabled": false,
-                    "autofocus": false,
-                    "dbIndex": false,
-                    "customDefaultValue": "",
-                    "calculateValue": "",
-                    "calculateServer": false,
-                    "widget": null,
-                    "attributes": {},
-                    "validateOn": "change",
-                    "validate": {
-                      "required": false,
-                      "custom": "",
-                      "customPrivate": false,
-                      "strictDateValidation": false,
-                      "multiple": false,
-                      "unique": false
-                    },
-                    "conditional": {
-                      "show": null,
-                      "when": null,
-                      "eq": ""
-                    },
-                    "overlay": {
-                      "style": "",
-                      "left": "",
-                      "top": "",
-                      "width": "",
-                      "height": ""
-                    },
-                    "allowCalculateOverride": false,
-                    "encrypted": false,
-                    "showCharCount": false,
-                    "showWordCount": false,
-                    "properties": {},
-                    "allowMultipleMasks": false,
-                    "tag": "p",
-                    "id": "ez1af9p"
-                  }
-                ]
-              }
-            ],
-            [
-              {
-                "components": [
-                  {
-                    "label": "Other Contributions",
-                    "attrs": [
-                      {
-                        "attr": "",
-                        "value": ""
-                      }
-                    ],
-                    "content": "Other Contributions",
-                    "refreshOnChange": false,
-                    "key": "otherContributions",
-                    "type": "htmlelement",
-                    "input": false,
-                    "tableView": false,
-                    "placeholder": "",
-                    "prefix": "",
-                    "customClass": "",
-                    "suffix": "",
-                    "multiple": false,
-                    "defaultValue": null,
-                    "protected": false,
-                    "unique": false,
-                    "persistent": false,
-                    "hidden": false,
-                    "clearOnHide": true,
-                    "refreshOn": "",
-                    "redrawOn": "",
-                    "modalEdit": false,
-                    "dataGridLabel": false,
-                    "labelPosition": "top",
-                    "description": "",
-                    "errorLabel": "",
-                    "tooltip": "",
-                    "hideLabel": false,
-                    "tabindex": "",
-                    "disabled": false,
-                    "autofocus": false,
-                    "dbIndex": false,
-                    "customDefaultValue": "",
-                    "calculateValue": "",
-                    "calculateServer": false,
-                    "widget": null,
-                    "attributes": {},
-                    "validateOn": "change",
-                    "validate": {
-                      "required": false,
-                      "custom": "",
-                      "customPrivate": false,
-                      "strictDateValidation": false,
-                      "multiple": false,
-                      "unique": false
-                    },
-                    "conditional": {
-                      "show": null,
-                      "when": null,
-                      "eq": ""
-                    },
-                    "overlay": {
-                      "style": "",
-                      "left": "",
-                      "top": "",
-                      "width": "",
-                      "height": ""
-                    },
-                    "allowCalculateOverride": false,
-                    "encrypted": false,
-                    "showCharCount": false,
-                    "showWordCount": false,
-                    "properties": {},
-                    "allowMultipleMasks": false,
-                    "tag": "p",
-                    "id": "ezlrkzp"
-                  }
-                ]
-              },
-              {
-                "components": [
-                  {
-                    "label": "HTML",
-                    "attrs": [
-                      {
-                        "attr": "",
-                        "value": ""
-                      }
-                    ],
-                    "content": "$####",
-                    "refreshOnChange": false,
-                    "key": "html40",
-                    "type": "htmlelement",
-                    "input": false,
-                    "tableView": false,
-                    "placeholder": "",
-                    "prefix": "",
-                    "customClass": "",
-                    "suffix": "",
-                    "multiple": false,
-                    "defaultValue": null,
-                    "protected": false,
-                    "unique": false,
-                    "persistent": false,
-                    "hidden": false,
-                    "clearOnHide": true,
-                    "refreshOn": "",
-                    "redrawOn": "",
-                    "modalEdit": false,
-                    "dataGridLabel": false,
-                    "labelPosition": "top",
-                    "description": "",
-                    "errorLabel": "",
-                    "tooltip": "",
-                    "hideLabel": false,
-                    "tabindex": "",
-                    "disabled": false,
-                    "autofocus": false,
-                    "dbIndex": false,
-                    "customDefaultValue": "",
-                    "calculateValue": "",
-                    "calculateServer": false,
-                    "widget": null,
-                    "attributes": {},
-                    "validateOn": "change",
-                    "validate": {
-                      "required": false,
-                      "custom": "",
-                      "customPrivate": false,
-                      "strictDateValidation": false,
-                      "multiple": false,
-                      "unique": false
-                    },
-                    "conditional": {
-                      "show": null,
-                      "when": null,
-                      "eq": ""
-                    },
-                    "overlay": {
-                      "style": "",
-                      "left": "",
-                      "top": "",
-                      "width": "",
-                      "height": ""
-                    },
-                    "allowCalculateOverride": false,
-                    "encrypted": false,
-                    "showCharCount": false,
-                    "showWordCount": false,
-                    "properties": {},
-                    "allowMultipleMasks": false,
-                    "tag": "p",
-                    "id": "ewgrs07"
-                  }
-                ]
-              },
-              {
-                "components": [
-                  {
-                    "label": "HTML",
-                    "attrs": [
-                      {
-                        "attr": "",
-                        "value": ""
-                      }
-                    ],
-                    "content": "$####",
-                    "refreshOnChange": false,
-                    "key": "html41",
-                    "type": "htmlelement",
-                    "input": false,
-                    "tableView": false,
-                    "placeholder": "",
-                    "prefix": "",
-                    "customClass": "",
-                    "suffix": "",
-                    "multiple": false,
-                    "defaultValue": null,
-                    "protected": false,
-                    "unique": false,
-                    "persistent": false,
-                    "hidden": false,
-                    "clearOnHide": true,
-                    "refreshOn": "",
-                    "redrawOn": "",
-                    "modalEdit": false,
-                    "dataGridLabel": false,
-                    "labelPosition": "top",
-                    "description": "",
-                    "errorLabel": "",
-                    "tooltip": "",
-                    "hideLabel": false,
-                    "tabindex": "",
-                    "disabled": false,
-                    "autofocus": false,
-                    "dbIndex": false,
-                    "customDefaultValue": "",
-                    "calculateValue": "",
-                    "calculateServer": false,
-                    "widget": null,
-                    "attributes": {},
-                    "validateOn": "change",
-                    "validate": {
-                      "required": false,
-                      "custom": "",
-                      "customPrivate": false,
-                      "strictDateValidation": false,
-                      "multiple": false,
-                      "unique": false
-                    },
-                    "conditional": {
-                      "show": null,
-                      "when": null,
-                      "eq": ""
-                    },
-                    "overlay": {
-                      "style": "",
-                      "left": "",
-                      "top": "",
-                      "width": "",
-                      "height": ""
-                    },
-                    "allowCalculateOverride": false,
-                    "encrypted": false,
-                    "showCharCount": false,
-                    "showWordCount": false,
-                    "properties": {},
-                    "allowMultipleMasks": false,
-                    "tag": "p",
-                    "id": "eiuusea"
+                    "id": "eox34a"
                   }
                 ]
               }
@@ -6316,8 +5885,6 @@
                 "components": [
                   {
                     "label": "Total student contribution",
-                    "tag": "p",
-                    "className": "",
                     "attrs": [
                       {
                         "attr": "",
@@ -6327,28 +5894,7 @@
                     "content": "Total student contribution",
                     "refreshOnChange": false,
                     "customClass": "header-md secondary-color",
-                    "hidden": false,
-                    "modalEdit": false,
                     "key": "totalAssessedCosts1",
-                    "tags": [],
-                    "properties": {},
-                    "conditional": {
-                      "show": null,
-                      "when": null,
-                      "eq": "",
-                      "json": ""
-                    },
-                    "customConditional": "",
-                    "logic": [],
-                    "attributes": {},
-                    "overlay": {
-                      "style": "",
-                      "page": "",
-                      "left": "",
-                      "top": "",
-                      "width": "",
-                      "height": ""
-                    },
                     "type": "htmlelement",
                     "input": false,
                     "tableView": false,
@@ -6361,9 +5907,11 @@
                     "protected": false,
                     "unique": false,
                     "persistent": false,
+                    "hidden": false,
                     "clearOnHide": true,
                     "refreshOn": "",
                     "redrawOn": "",
+                    "modalEdit": false,
                     "dataGridLabel": false,
                     "labelPosition": "top",
                     "description": "",
@@ -6378,6 +5926,7 @@
                     "calculateValue": "",
                     "calculateServer": false,
                     "widget": null,
+                    "attributes": {},
                     "validateOn": "change",
                     "validate": {
                       "required": false,
@@ -6387,12 +5936,26 @@
                       "multiple": false,
                       "unique": false
                     },
+                    "conditional": {
+                      "show": null,
+                      "when": null,
+                      "eq": ""
+                    },
+                    "overlay": {
+                      "style": "",
+                      "left": "",
+                      "top": "",
+                      "width": "",
+                      "height": ""
+                    },
                     "allowCalculateOverride": false,
                     "encrypted": false,
                     "showCharCount": false,
                     "showWordCount": false,
+                    "properties": {},
                     "allowMultipleMasks": false,
-                    "id": "elqxi4k"
+                    "tag": "p",
+                    "id": "e1xy0tp"
                   }
                 ]
               },
@@ -6400,39 +5963,16 @@
                 "components": [
                   {
                     "label": "HTML",
-                    "tag": "p",
-                    "className": "",
                     "attrs": [
                       {
                         "attr": "",
                         "value": ""
                       }
                     ],
-                    "content": "$####",
+                    "content": "{{data.assessment?.totalFederalContribution ? '$' + data.assessment.totalFederalContribution : '-'}}",
                     "refreshOnChange": false,
                     "customClass": "header-md secondary-color",
-                    "hidden": false,
-                    "modalEdit": false,
                     "key": "html34",
-                    "tags": [],
-                    "properties": {},
-                    "conditional": {
-                      "show": null,
-                      "when": null,
-                      "eq": "",
-                      "json": ""
-                    },
-                    "customConditional": "",
-                    "logic": [],
-                    "attributes": {},
-                    "overlay": {
-                      "style": "",
-                      "page": "",
-                      "left": "",
-                      "top": "",
-                      "width": "",
-                      "height": ""
-                    },
                     "type": "htmlelement",
                     "input": false,
                     "tableView": false,
@@ -6444,9 +5984,11 @@
                     "protected": false,
                     "unique": false,
                     "persistent": false,
+                    "hidden": false,
                     "clearOnHide": true,
                     "refreshOn": "",
                     "redrawOn": "",
+                    "modalEdit": false,
                     "dataGridLabel": false,
                     "labelPosition": "top",
                     "description": "",
@@ -6461,6 +6003,7 @@
                     "calculateValue": "",
                     "calculateServer": false,
                     "widget": null,
+                    "attributes": {},
                     "validateOn": "change",
                     "validate": {
                       "required": false,
@@ -6470,12 +6013,26 @@
                       "multiple": false,
                       "unique": false
                     },
+                    "conditional": {
+                      "show": null,
+                      "when": null,
+                      "eq": ""
+                    },
+                    "overlay": {
+                      "style": "",
+                      "left": "",
+                      "top": "",
+                      "width": "",
+                      "height": ""
+                    },
                     "allowCalculateOverride": false,
                     "encrypted": false,
                     "showCharCount": false,
                     "showWordCount": false,
+                    "properties": {},
                     "allowMultipleMasks": false,
-                    "id": "eyjkh98"
+                    "tag": "p",
+                    "id": "e467lbl"
                   }
                 ]
               },
@@ -6483,39 +6040,16 @@
                 "components": [
                   {
                     "label": "HTML",
-                    "tag": "p",
-                    "className": "",
                     "attrs": [
                       {
                         "attr": "",
                         "value": ""
                       }
                     ],
-                    "content": "$####",
+                    "content": "{{data.assessment?.totalProvincialContribution ? '$' + data.assessment.totalProvincialContribution : '-'}}",
                     "refreshOnChange": false,
                     "customClass": "header-md secondary-color",
-                    "hidden": false,
-                    "modalEdit": false,
                     "key": "html47",
-                    "tags": [],
-                    "properties": {},
-                    "conditional": {
-                      "show": null,
-                      "when": null,
-                      "eq": "",
-                      "json": ""
-                    },
-                    "customConditional": "",
-                    "logic": [],
-                    "attributes": {},
-                    "overlay": {
-                      "style": "",
-                      "page": "",
-                      "left": "",
-                      "top": "",
-                      "width": "",
-                      "height": ""
-                    },
                     "type": "htmlelement",
                     "input": false,
                     "tableView": false,
@@ -6528,9 +6062,11 @@
                     "protected": false,
                     "unique": false,
                     "persistent": false,
+                    "hidden": false,
                     "clearOnHide": true,
                     "refreshOn": "",
                     "redrawOn": "",
+                    "modalEdit": false,
                     "dataGridLabel": false,
                     "labelPosition": "top",
                     "description": "",
@@ -6545,6 +6081,7 @@
                     "calculateValue": "",
                     "calculateServer": false,
                     "widget": null,
+                    "attributes": {},
                     "validateOn": "change",
                     "validate": {
                       "required": false,
@@ -6554,12 +6091,26 @@
                       "multiple": false,
                       "unique": false
                     },
+                    "conditional": {
+                      "show": null,
+                      "when": null,
+                      "eq": ""
+                    },
+                    "overlay": {
+                      "style": "",
+                      "left": "",
+                      "top": "",
+                      "width": "",
+                      "height": ""
+                    },
                     "allowCalculateOverride": false,
                     "encrypted": false,
                     "showCharCount": false,
                     "showWordCount": false,
+                    "properties": {},
                     "allowMultipleMasks": false,
-                    "id": "ed4qk59"
+                    "tag": "p",
+                    "id": "e6ldum"
                   }
                 ]
               }
@@ -6631,7 +6182,7 @@
                     "showWordCount": false,
                     "properties": {},
                     "allowMultipleMasks": false,
-                    "id": "ezei8jo"
+                    "id": "eozfbr9"
                   }
                 ]
               },
@@ -6647,8 +6198,6 @@
                 "components": [
                   {
                     "label": "HTML",
-                    "tag": "p",
-                    "className": "",
                     "attrs": [
                       {
                         "attr": "",
@@ -6658,28 +6207,7 @@
                     "content": "Total Assessed need",
                     "refreshOnChange": false,
                     "customClass": "header-md secondary-color",
-                    "hidden": false,
-                    "modalEdit": false,
                     "key": "html7",
-                    "tags": [],
-                    "properties": {},
-                    "conditional": {
-                      "show": null,
-                      "when": null,
-                      "eq": "",
-                      "json": ""
-                    },
-                    "customConditional": "",
-                    "logic": [],
-                    "attributes": {},
-                    "overlay": {
-                      "style": "",
-                      "page": "",
-                      "left": "",
-                      "top": "",
-                      "width": "",
-                      "height": ""
-                    },
                     "type": "htmlelement",
                     "input": false,
                     "tableView": false,
@@ -6692,9 +6220,11 @@
                     "protected": false,
                     "unique": false,
                     "persistent": false,
+                    "hidden": false,
                     "clearOnHide": true,
                     "refreshOn": "",
                     "redrawOn": "",
+                    "modalEdit": false,
                     "dataGridLabel": false,
                     "labelPosition": "top",
                     "description": "",
@@ -6709,6 +6239,7 @@
                     "calculateValue": "",
                     "calculateServer": false,
                     "widget": null,
+                    "attributes": {},
                     "validateOn": "change",
                     "validate": {
                       "required": false,
@@ -6718,12 +6249,26 @@
                       "multiple": false,
                       "unique": false
                     },
+                    "conditional": {
+                      "show": null,
+                      "when": null,
+                      "eq": ""
+                    },
+                    "overlay": {
+                      "style": "",
+                      "left": "",
+                      "top": "",
+                      "width": "",
+                      "height": ""
+                    },
                     "allowCalculateOverride": false,
                     "encrypted": false,
                     "showCharCount": false,
                     "showWordCount": false,
+                    "properties": {},
                     "allowMultipleMasks": false,
-                    "id": "encww0i"
+                    "tag": "p",
+                    "id": "epepm1r"
                   }
                 ]
               },
@@ -6731,39 +6276,16 @@
                 "components": [
                   {
                     "label": "HTML",
-                    "tag": "p",
-                    "className": "",
                     "attrs": [
                       {
                         "attr": "",
                         "value": ""
                       }
                     ],
-                    "content": "$####",
+                    "content": "{{data.assessment?.federalAssessmentNeed ? '$' + data.assessment.federalAssessmentNeed : '-'}}",
                     "refreshOnChange": false,
                     "customClass": "header-md secondary-color",
-                    "hidden": false,
-                    "modalEdit": false,
                     "key": "html35",
-                    "tags": [],
-                    "properties": {},
-                    "conditional": {
-                      "show": null,
-                      "when": null,
-                      "eq": "",
-                      "json": ""
-                    },
-                    "customConditional": "",
-                    "logic": [],
-                    "attributes": {},
-                    "overlay": {
-                      "style": "",
-                      "page": "",
-                      "left": "",
-                      "top": "",
-                      "width": "",
-                      "height": ""
-                    },
                     "type": "htmlelement",
                     "input": false,
                     "tableView": false,
@@ -6775,9 +6297,11 @@
                     "protected": false,
                     "unique": false,
                     "persistent": false,
+                    "hidden": false,
                     "clearOnHide": true,
                     "refreshOn": "",
                     "redrawOn": "",
+                    "modalEdit": false,
                     "dataGridLabel": false,
                     "labelPosition": "top",
                     "description": "",
@@ -6792,6 +6316,7 @@
                     "calculateValue": "",
                     "calculateServer": false,
                     "widget": null,
+                    "attributes": {},
                     "validateOn": "change",
                     "validate": {
                       "required": false,
@@ -6801,12 +6326,26 @@
                       "multiple": false,
                       "unique": false
                     },
+                    "conditional": {
+                      "show": null,
+                      "when": null,
+                      "eq": ""
+                    },
+                    "overlay": {
+                      "style": "",
+                      "left": "",
+                      "top": "",
+                      "width": "",
+                      "height": ""
+                    },
                     "allowCalculateOverride": false,
                     "encrypted": false,
                     "showCharCount": false,
                     "showWordCount": false,
+                    "properties": {},
                     "allowMultipleMasks": false,
-                    "id": "eq3t3ut"
+                    "tag": "p",
+                    "id": "ep0iuos"
                   }
                 ]
               },
@@ -6814,39 +6353,16 @@
                 "components": [
                   {
                     "label": "HTML",
-                    "tag": "p",
-                    "className": "",
                     "attrs": [
                       {
                         "attr": "",
                         "value": ""
                       }
                     ],
-                    "content": "$####",
+                    "content": "{{data.assessment?.provincialAssessmentNeed ? '$' + data.assessment.provincialAssessmentNeed : '-'}}",
                     "refreshOnChange": false,
                     "customClass": "header-md secondary-color",
-                    "hidden": false,
-                    "modalEdit": false,
                     "key": "html36",
-                    "tags": [],
-                    "properties": {},
-                    "conditional": {
-                      "show": null,
-                      "when": null,
-                      "eq": "",
-                      "json": ""
-                    },
-                    "customConditional": "",
-                    "logic": [],
-                    "attributes": {},
-                    "overlay": {
-                      "style": "",
-                      "page": "",
-                      "left": "",
-                      "top": "",
-                      "width": "",
-                      "height": ""
-                    },
                     "type": "htmlelement",
                     "input": false,
                     "tableView": false,
@@ -6858,9 +6374,11 @@
                     "protected": false,
                     "unique": false,
                     "persistent": false,
+                    "hidden": false,
                     "clearOnHide": true,
                     "refreshOn": "",
                     "redrawOn": "",
+                    "modalEdit": false,
                     "dataGridLabel": false,
                     "labelPosition": "top",
                     "description": "",
@@ -6875,6 +6393,7 @@
                     "calculateValue": "",
                     "calculateServer": false,
                     "widget": null,
+                    "attributes": {},
                     "validateOn": "change",
                     "validate": {
                       "required": false,
@@ -6884,12 +6403,26 @@
                       "multiple": false,
                       "unique": false
                     },
+                    "conditional": {
+                      "show": null,
+                      "when": null,
+                      "eq": ""
+                    },
+                    "overlay": {
+                      "style": "",
+                      "left": "",
+                      "top": "",
+                      "width": "",
+                      "height": ""
+                    },
                     "allowCalculateOverride": false,
                     "encrypted": false,
                     "showCharCount": false,
                     "showWordCount": false,
+                    "properties": {},
                     "allowMultipleMasks": false,
-                    "id": "e043xjlm"
+                    "tag": "p",
+                    "id": "ebu93v"
                   }
                 ]
               }
@@ -6936,7 +6469,8 @@
           "tree": false,
           "header": [],
           "caption": "",
-          "id": "eujw3p"
+          "id": "e1ktuz8",
+          "numRows": 18
         }
       ],
       "placeholder": "",
@@ -7047,11 +6581,321 @@
             "height": ""
           },
           "type": "table",
-          "numRows": 9,
-          "numCols": 2,
+          "numRows": 11,
+          "numCols": 4,
           "input": false,
           "tableView": false,
           "rows": [
+            [
+              {
+                "components": [
+                  {
+                    "label": "HTML",
+                    "attrs": [
+                      {
+                        "attr": "",
+                        "value": ""
+                      }
+                    ],
+                    "content": "Loan/Grant Type",
+                    "refreshOnChange": false,
+                    "customClass": "category-header-medium-small secondary-color",
+                    "key": "html59",
+                    "type": "htmlelement",
+                    "input": false,
+                    "tableView": false,
+                    "placeholder": "",
+                    "prefix": "",
+                    "suffix": "",
+                    "multiple": false,
+                    "defaultValue": null,
+                    "protected": false,
+                    "unique": false,
+                    "persistent": false,
+                    "hidden": false,
+                    "clearOnHide": true,
+                    "refreshOn": "",
+                    "redrawOn": "",
+                    "modalEdit": false,
+                    "dataGridLabel": false,
+                    "labelPosition": "top",
+                    "description": "",
+                    "errorLabel": "",
+                    "tooltip": "",
+                    "hideLabel": false,
+                    "tabindex": "",
+                    "disabled": false,
+                    "autofocus": false,
+                    "dbIndex": false,
+                    "customDefaultValue": "",
+                    "calculateValue": "",
+                    "calculateServer": false,
+                    "widget": null,
+                    "attributes": {},
+                    "validateOn": "change",
+                    "validate": {
+                      "required": false,
+                      "custom": "",
+                      "customPrivate": false,
+                      "strictDateValidation": false,
+                      "multiple": false,
+                      "unique": false
+                    },
+                    "conditional": {
+                      "show": null,
+                      "when": null,
+                      "eq": ""
+                    },
+                    "overlay": {
+                      "style": "",
+                      "left": "",
+                      "top": "",
+                      "width": "",
+                      "height": ""
+                    },
+                    "allowCalculateOverride": false,
+                    "encrypted": false,
+                    "showCharCount": false,
+                    "showWordCount": false,
+                    "properties": {},
+                    "allowMultipleMasks": false,
+                    "tag": "p",
+                    "id": "e02n7gi"
+                  }
+                ]
+              },
+              {
+                "components": [
+                  {
+                    "label": "HTML",
+                    "attrs": [
+                      {
+                        "attr": "",
+                        "value": ""
+                      }
+                    ],
+                    "content": "Disbursement 1",
+                    "refreshOnChange": false,
+                    "customClass": "category-header-medium-small secondary-color",
+                    "key": "html60",
+                    "type": "htmlelement",
+                    "input": false,
+                    "tableView": false,
+                    "placeholder": "",
+                    "prefix": "",
+                    "suffix": "",
+                    "multiple": false,
+                    "defaultValue": null,
+                    "protected": false,
+                    "unique": false,
+                    "persistent": false,
+                    "hidden": false,
+                    "clearOnHide": true,
+                    "refreshOn": "",
+                    "redrawOn": "",
+                    "modalEdit": false,
+                    "dataGridLabel": false,
+                    "labelPosition": "top",
+                    "description": "",
+                    "errorLabel": "",
+                    "tooltip": "",
+                    "hideLabel": false,
+                    "tabindex": "",
+                    "disabled": false,
+                    "autofocus": false,
+                    "dbIndex": false,
+                    "customDefaultValue": "",
+                    "calculateValue": "",
+                    "calculateServer": false,
+                    "widget": null,
+                    "attributes": {},
+                    "validateOn": "change",
+                    "validate": {
+                      "required": false,
+                      "custom": "",
+                      "customPrivate": false,
+                      "strictDateValidation": false,
+                      "multiple": false,
+                      "unique": false
+                    },
+                    "conditional": {
+                      "show": null,
+                      "when": null,
+                      "eq": ""
+                    },
+                    "overlay": {
+                      "style": "",
+                      "left": "",
+                      "top": "",
+                      "width": "",
+                      "height": ""
+                    },
+                    "allowCalculateOverride": false,
+                    "encrypted": false,
+                    "showCharCount": false,
+                    "showWordCount": false,
+                    "properties": {},
+                    "allowMultipleMasks": false,
+                    "tag": "p",
+                    "id": "ehcm1ru"
+                  }
+                ]
+              },
+              {
+                "components": [
+                  {
+                    "label": "HTML",
+                    "attrs": [
+                      {
+                        "attr": "",
+                        "value": ""
+                      }
+                    ],
+                    "content": "Disbursement 2",
+                    "refreshOnChange": false,
+                    "customClass": "category-header-medium-small secondary-color",
+                    "key": "html61",
+                    "type": "htmlelement",
+                    "input": false,
+                    "tableView": false,
+                    "placeholder": "",
+                    "prefix": "",
+                    "suffix": "",
+                    "multiple": false,
+                    "defaultValue": null,
+                    "protected": false,
+                    "unique": false,
+                    "persistent": false,
+                    "hidden": false,
+                    "clearOnHide": true,
+                    "refreshOn": "",
+                    "redrawOn": "",
+                    "modalEdit": false,
+                    "dataGridLabel": false,
+                    "labelPosition": "top",
+                    "description": "",
+                    "errorLabel": "",
+                    "tooltip": "",
+                    "hideLabel": false,
+                    "tabindex": "",
+                    "disabled": false,
+                    "autofocus": false,
+                    "dbIndex": false,
+                    "customDefaultValue": "",
+                    "calculateValue": "",
+                    "calculateServer": false,
+                    "widget": null,
+                    "attributes": {},
+                    "validateOn": "change",
+                    "validate": {
+                      "required": false,
+                      "custom": "",
+                      "customPrivate": false,
+                      "strictDateValidation": false,
+                      "multiple": false,
+                      "unique": false
+                    },
+                    "conditional": {
+                      "show": null,
+                      "when": null,
+                      "eq": ""
+                    },
+                    "overlay": {
+                      "style": "",
+                      "left": "",
+                      "top": "",
+                      "width": "",
+                      "height": ""
+                    },
+                    "allowCalculateOverride": false,
+                    "encrypted": false,
+                    "showCharCount": false,
+                    "showWordCount": false,
+                    "properties": {},
+                    "allowMultipleMasks": false,
+                    "tag": "p",
+                    "id": "eofrp69"
+                  }
+                ]
+              },
+              {
+                "components": [
+                  {
+                    "label": "HTML",
+                    "attrs": [
+                      {
+                        "attr": "",
+                        "value": ""
+                      }
+                    ],
+                    "content": "Total",
+                    "refreshOnChange": false,
+                    "customClass": "category-header-medium-small secondary-color",
+                    "key": "html62",
+                    "type": "htmlelement",
+                    "input": false,
+                    "tableView": false,
+                    "placeholder": "",
+                    "prefix": "",
+                    "suffix": "",
+                    "multiple": false,
+                    "defaultValue": null,
+                    "protected": false,
+                    "unique": false,
+                    "persistent": false,
+                    "hidden": false,
+                    "clearOnHide": true,
+                    "refreshOn": "",
+                    "redrawOn": "",
+                    "modalEdit": false,
+                    "dataGridLabel": false,
+                    "labelPosition": "top",
+                    "description": "",
+                    "errorLabel": "",
+                    "tooltip": "",
+                    "hideLabel": false,
+                    "tabindex": "",
+                    "disabled": false,
+                    "autofocus": false,
+                    "dbIndex": false,
+                    "customDefaultValue": "",
+                    "calculateValue": "",
+                    "calculateServer": false,
+                    "widget": null,
+                    "attributes": {},
+                    "validateOn": "change",
+                    "validate": {
+                      "required": false,
+                      "custom": "",
+                      "customPrivate": false,
+                      "strictDateValidation": false,
+                      "multiple": false,
+                      "unique": false
+                    },
+                    "conditional": {
+                      "show": null,
+                      "when": null,
+                      "eq": ""
+                    },
+                    "overlay": {
+                      "style": "",
+                      "left": "",
+                      "top": "",
+                      "width": "",
+                      "height": ""
+                    },
+                    "allowCalculateOverride": false,
+                    "encrypted": false,
+                    "showCharCount": false,
+                    "showWordCount": false,
+                    "properties": {},
+                    "allowMultipleMasks": false,
+                    "tag": "p",
+                    "id": "eg0bmn"
+                  }
+                ]
+              }
+            ],
             [
               {
                 "components": [
@@ -7126,40 +6970,61 @@
                     "properties": {},
                     "allowMultipleMasks": false,
                     "tag": "p",
-                    "id": "ev24ulm"
+                    "id": "ea91eyt"
                   }
                 ]
               },
               {
                 "components": [
                   {
-                    "label": "HTML",
+                    "label": "CSLF1",
+                    "tag": "p",
+                    "className": "",
                     "attrs": [
                       {
                         "attr": "",
                         "value": ""
                       }
                     ],
-                    "content": "$######",
+                    "content": "{{data.disbursement?.disbursement1cslf ? '$'+ data.disbursement.disbursement1cslf : '-'}}",
                     "refreshOnChange": false,
+                    "customClass": "",
+                    "hidden": false,
+                    "modalEdit": false,
                     "key": "html2",
+                    "tags": [],
+                    "properties": {},
+                    "conditional": {
+                      "show": null,
+                      "when": null,
+                      "eq": "",
+                      "json": ""
+                    },
+                    "customConditional": "",
+                    "logic": [],
+                    "attributes": {},
+                    "overlay": {
+                      "style": "",
+                      "page": "",
+                      "left": "",
+                      "top": "",
+                      "width": "",
+                      "height": ""
+                    },
                     "type": "htmlelement",
                     "input": false,
                     "tableView": false,
                     "placeholder": "",
                     "prefix": "",
-                    "customClass": "",
                     "suffix": "",
                     "multiple": false,
                     "defaultValue": null,
                     "protected": false,
                     "unique": false,
                     "persistent": false,
-                    "hidden": false,
                     "clearOnHide": true,
                     "refreshOn": "",
                     "redrawOn": "",
-                    "modalEdit": false,
                     "dataGridLabel": false,
                     "labelPosition": "top",
                     "description": "",
@@ -7174,7 +7039,6 @@
                     "calculateValue": "",
                     "calculateServer": false,
                     "widget": null,
-                    "attributes": {},
                     "validateOn": "change",
                     "validate": {
                       "required": false,
@@ -7184,26 +7048,178 @@
                       "multiple": false,
                       "unique": false
                     },
+                    "allowCalculateOverride": false,
+                    "encrypted": false,
+                    "showCharCount": false,
+                    "showWordCount": false,
+                    "allowMultipleMasks": false,
+                    "id": "eum0ak5"
+                  }
+                ]
+              },
+              {
+                "components": [
+                  {
+                    "label": "CSLF2",
+                    "tag": "p",
+                    "className": "",
+                    "attrs": [
+                      {
+                        "attr": "",
+                        "value": ""
+                      }
+                    ],
+                    "content": "{{data.disbursement?.disbursement2cslf ? '$'+ data.disbursement.disbursement2cslf : '-'}}",
+                    "refreshOnChange": false,
+                    "customClass": "",
+                    "hidden": false,
+                    "modalEdit": false,
+                    "key": "html58",
+                    "tags": [],
+                    "properties": {},
                     "conditional": {
                       "show": null,
                       "when": null,
-                      "eq": ""
+                      "eq": "",
+                      "json": ""
                     },
+                    "customConditional": "",
+                    "logic": [],
+                    "attributes": {},
                     "overlay": {
                       "style": "",
+                      "page": "",
                       "left": "",
                       "top": "",
                       "width": "",
                       "height": ""
                     },
+                    "type": "htmlelement",
+                    "input": false,
+                    "tableView": false,
+                    "placeholder": "",
+                    "prefix": "",
+                    "suffix": "",
+                    "multiple": false,
+                    "defaultValue": null,
+                    "protected": false,
+                    "unique": false,
+                    "persistent": false,
+                    "clearOnHide": true,
+                    "refreshOn": "",
+                    "redrawOn": "",
+                    "dataGridLabel": false,
+                    "labelPosition": "top",
+                    "description": "",
+                    "errorLabel": "",
+                    "tooltip": "",
+                    "hideLabel": false,
+                    "tabindex": "",
+                    "disabled": false,
+                    "autofocus": false,
+                    "dbIndex": false,
+                    "customDefaultValue": "",
+                    "calculateValue": "",
+                    "calculateServer": false,
+                    "widget": null,
+                    "validateOn": "change",
+                    "validate": {
+                      "required": false,
+                      "custom": "",
+                      "customPrivate": false,
+                      "strictDateValidation": false,
+                      "multiple": false,
+                      "unique": false
+                    },
                     "allowCalculateOverride": false,
                     "encrypted": false,
                     "showCharCount": false,
                     "showWordCount": false,
-                    "properties": {},
                     "allowMultipleMasks": false,
+                    "id": "evqdh87"
+                  }
+                ]
+              },
+              {
+                "components": [
+                  {
+                    "label": "CSLFTotal",
                     "tag": "p",
-                    "id": "e4wmtj"
+                    "className": "",
+                    "attrs": [
+                      {
+                        "attr": "",
+                        "value": ""
+                      }
+                    ],
+                    "content": "{{(data.disbursement?.disbursement1cslf ? data.disbursement.disbursement1cslf : 0) + (data.disbursement?.disbursement2cslf ? data.disbursement.disbursement2cslf : 0)}}",
+                    "refreshOnChange": false,
+                    "customClass": "",
+                    "hidden": false,
+                    "modalEdit": false,
+                    "key": "html63",
+                    "tags": [],
+                    "properties": {},
+                    "conditional": {
+                      "show": null,
+                      "when": null,
+                      "eq": "",
+                      "json": ""
+                    },
+                    "customConditional": "",
+                    "logic": [],
+                    "attributes": {},
+                    "overlay": {
+                      "style": "",
+                      "page": "",
+                      "left": "",
+                      "top": "",
+                      "width": "",
+                      "height": ""
+                    },
+                    "type": "htmlelement",
+                    "input": false,
+                    "tableView": false,
+                    "placeholder": "",
+                    "prefix": "",
+                    "suffix": "",
+                    "multiple": false,
+                    "defaultValue": null,
+                    "protected": false,
+                    "unique": false,
+                    "persistent": false,
+                    "clearOnHide": true,
+                    "refreshOn": "",
+                    "redrawOn": "",
+                    "dataGridLabel": false,
+                    "labelPosition": "top",
+                    "description": "",
+                    "errorLabel": "",
+                    "tooltip": "",
+                    "hideLabel": false,
+                    "tabindex": "",
+                    "disabled": false,
+                    "autofocus": false,
+                    "dbIndex": false,
+                    "customDefaultValue": "",
+                    "calculateValue": "",
+                    "calculateServer": false,
+                    "widget": null,
+                    "validateOn": "change",
+                    "validate": {
+                      "required": false,
+                      "custom": "",
+                      "customPrivate": false,
+                      "strictDateValidation": false,
+                      "multiple": false,
+                      "unique": false
+                    },
+                    "allowCalculateOverride": false,
+                    "encrypted": false,
+                    "showCharCount": false,
+                    "showWordCount": false,
+                    "allowMultipleMasks": false,
+                    "id": "e7x93j"
                   }
                 ]
               }
@@ -7283,41 +7299,62 @@
                     "properties": {},
                     "allowMultipleMasks": false,
                     "tag": "p",
-                    "id": "erf8uh"
+                    "id": "e65cl2c"
                   }
                 ]
               },
               {
                 "components": [
                   {
-                    "label": "HTML",
+                    "label": "BCSL1",
+                    "tag": "p",
+                    "className": "",
                     "attrs": [
                       {
                         "attr": "",
                         "value": ""
                       }
                     ],
-                    "content": "$######",
+                    "content": "{{data.disbursement?.disbursement1bcsl ? '$'+ data.disbursement.disbursement1bcsl : '-'}}",
                     "refreshOnChange": false,
+                    "customClass": "",
+                    "hidden": false,
+                    "modalEdit": false,
                     "key": "html5",
+                    "tags": [],
+                    "properties": {},
+                    "conditional": {
+                      "show": null,
+                      "when": null,
+                      "eq": "",
+                      "json": ""
+                    },
+                    "customConditional": "",
+                    "logic": [],
+                    "attributes": {},
+                    "overlay": {
+                      "style": "",
+                      "page": "",
+                      "left": "",
+                      "top": "",
+                      "width": "",
+                      "height": ""
+                    },
                     "type": "htmlelement",
                     "input": false,
                     "tableView": false,
                     "hideOnChildrenHidden": false,
                     "placeholder": "",
                     "prefix": "",
-                    "customClass": "",
                     "suffix": "",
                     "multiple": false,
                     "defaultValue": null,
                     "protected": false,
                     "unique": false,
                     "persistent": false,
-                    "hidden": false,
                     "clearOnHide": true,
                     "refreshOn": "",
                     "redrawOn": "",
-                    "modalEdit": false,
                     "dataGridLabel": false,
                     "labelPosition": "top",
                     "description": "",
@@ -7332,7 +7369,6 @@
                     "calculateValue": "",
                     "calculateServer": false,
                     "widget": null,
-                    "attributes": {},
                     "validateOn": "change",
                     "validate": {
                       "required": false,
@@ -7342,26 +7378,178 @@
                       "multiple": false,
                       "unique": false
                     },
+                    "allowCalculateOverride": false,
+                    "encrypted": false,
+                    "showCharCount": false,
+                    "showWordCount": false,
+                    "allowMultipleMasks": false,
+                    "id": "ey42yb"
+                  }
+                ]
+              },
+              {
+                "components": [
+                  {
+                    "label": "BCSL2",
+                    "tag": "p",
+                    "className": "",
+                    "attrs": [
+                      {
+                        "attr": "",
+                        "value": ""
+                      }
+                    ],
+                    "content": "{{data.disbursement?.disbursement2bcsl ? '$'+ data.disbursement.disbursement2bcsl : '-'}}",
+                    "refreshOnChange": false,
+                    "customClass": "",
+                    "hidden": false,
+                    "modalEdit": false,
+                    "key": "html72",
+                    "tags": [],
+                    "properties": {},
                     "conditional": {
                       "show": null,
                       "when": null,
-                      "eq": ""
+                      "eq": "",
+                      "json": ""
                     },
+                    "customConditional": "",
+                    "logic": [],
+                    "attributes": {},
                     "overlay": {
                       "style": "",
+                      "page": "",
                       "left": "",
                       "top": "",
                       "width": "",
                       "height": ""
                     },
+                    "type": "htmlelement",
+                    "input": false,
+                    "tableView": false,
+                    "placeholder": "",
+                    "prefix": "",
+                    "suffix": "",
+                    "multiple": false,
+                    "defaultValue": null,
+                    "protected": false,
+                    "unique": false,
+                    "persistent": false,
+                    "clearOnHide": true,
+                    "refreshOn": "",
+                    "redrawOn": "",
+                    "dataGridLabel": false,
+                    "labelPosition": "top",
+                    "description": "",
+                    "errorLabel": "",
+                    "tooltip": "",
+                    "hideLabel": false,
+                    "tabindex": "",
+                    "disabled": false,
+                    "autofocus": false,
+                    "dbIndex": false,
+                    "customDefaultValue": "",
+                    "calculateValue": "",
+                    "calculateServer": false,
+                    "widget": null,
+                    "validateOn": "change",
+                    "validate": {
+                      "required": false,
+                      "custom": "",
+                      "customPrivate": false,
+                      "strictDateValidation": false,
+                      "multiple": false,
+                      "unique": false
+                    },
                     "allowCalculateOverride": false,
                     "encrypted": false,
                     "showCharCount": false,
                     "showWordCount": false,
-                    "properties": {},
                     "allowMultipleMasks": false,
+                    "id": "ev3i26c"
+                  }
+                ]
+              },
+              {
+                "components": [
+                  {
+                    "label": "BCSLTotal",
                     "tag": "p",
-                    "id": "evcwgso"
+                    "className": "",
+                    "attrs": [
+                      {
+                        "attr": "",
+                        "value": ""
+                      }
+                    ],
+                    "content": "{{(data.disbursement?.disbursement1bcsl ? data.disbursement.disbursement1bcsl : 0) + (data.disbursement?.disbursement2bcsl ? data.disbursement.disbursement2bcsl : 0)}}",
+                    "refreshOnChange": false,
+                    "customClass": "",
+                    "hidden": false,
+                    "modalEdit": false,
+                    "key": "html64",
+                    "tags": [],
+                    "properties": {},
+                    "conditional": {
+                      "show": null,
+                      "when": null,
+                      "eq": "",
+                      "json": ""
+                    },
+                    "customConditional": "",
+                    "logic": [],
+                    "attributes": {},
+                    "overlay": {
+                      "style": "",
+                      "page": "",
+                      "left": "",
+                      "top": "",
+                      "width": "",
+                      "height": ""
+                    },
+                    "type": "htmlelement",
+                    "input": false,
+                    "tableView": false,
+                    "placeholder": "",
+                    "prefix": "",
+                    "suffix": "",
+                    "multiple": false,
+                    "defaultValue": null,
+                    "protected": false,
+                    "unique": false,
+                    "persistent": false,
+                    "clearOnHide": true,
+                    "refreshOn": "",
+                    "redrawOn": "",
+                    "dataGridLabel": false,
+                    "labelPosition": "top",
+                    "description": "",
+                    "errorLabel": "",
+                    "tooltip": "",
+                    "hideLabel": false,
+                    "tabindex": "",
+                    "disabled": false,
+                    "autofocus": false,
+                    "dbIndex": false,
+                    "customDefaultValue": "",
+                    "calculateValue": "",
+                    "calculateServer": false,
+                    "widget": null,
+                    "validateOn": "change",
+                    "validate": {
+                      "required": false,
+                      "custom": "",
+                      "customPrivate": false,
+                      "strictDateValidation": false,
+                      "multiple": false,
+                      "unique": false
+                    },
+                    "allowCalculateOverride": false,
+                    "encrypted": false,
+                    "showCharCount": false,
+                    "showWordCount": false,
+                    "allowMultipleMasks": false,
+                    "id": "eo4fu1g"
                   }
                 ]
               }
@@ -7440,40 +7628,61 @@
                     "properties": {},
                     "allowMultipleMasks": false,
                     "tag": "p",
-                    "id": "e4laxem"
+                    "id": "eiknnpa"
                   }
                 ]
               },
               {
                 "components": [
                   {
-                    "label": "HTML",
+                    "label": "CSGP1",
+                    "tag": "p",
+                    "className": "",
                     "attrs": [
                       {
                         "attr": "",
                         "value": ""
                       }
                     ],
-                    "content": "$######",
+                    "content": "{{data.disbursement?.disbursement1csgp ? '$'+ data.disbursement.disbursement1csgp : '-'}}",
                     "refreshOnChange": false,
+                    "customClass": "",
+                    "hidden": false,
+                    "modalEdit": false,
                     "key": "html3",
+                    "tags": [],
+                    "properties": {},
+                    "conditional": {
+                      "show": null,
+                      "when": null,
+                      "eq": "",
+                      "json": ""
+                    },
+                    "customConditional": "",
+                    "logic": [],
+                    "attributes": {},
+                    "overlay": {
+                      "style": "",
+                      "page": "",
+                      "left": "",
+                      "top": "",
+                      "width": "",
+                      "height": ""
+                    },
                     "type": "htmlelement",
                     "input": false,
                     "tableView": false,
                     "placeholder": "",
                     "prefix": "",
-                    "customClass": "",
                     "suffix": "",
                     "multiple": false,
                     "defaultValue": null,
                     "protected": false,
                     "unique": false,
                     "persistent": false,
-                    "hidden": false,
                     "clearOnHide": true,
                     "refreshOn": "",
                     "redrawOn": "",
-                    "modalEdit": false,
                     "dataGridLabel": false,
                     "labelPosition": "top",
                     "description": "",
@@ -7488,7 +7697,6 @@
                     "calculateValue": "",
                     "calculateServer": false,
                     "widget": null,
-                    "attributes": {},
                     "validateOn": "change",
                     "validate": {
                       "required": false,
@@ -7498,26 +7706,178 @@
                       "multiple": false,
                       "unique": false
                     },
+                    "allowCalculateOverride": false,
+                    "encrypted": false,
+                    "showCharCount": false,
+                    "showWordCount": false,
+                    "allowMultipleMasks": false,
+                    "id": "eg484j"
+                  }
+                ]
+              },
+              {
+                "components": [
+                  {
+                    "label": "CSGP2",
+                    "tag": "p",
+                    "className": "",
+                    "attrs": [
+                      {
+                        "attr": "",
+                        "value": ""
+                      }
+                    ],
+                    "content": "{{data.disbursement?.disbursement2csgp ? '$'+ data.disbursement.disbursement2csgp : '-'}}",
+                    "refreshOnChange": false,
+                    "customClass": "",
+                    "hidden": false,
+                    "modalEdit": false,
+                    "key": "html73",
+                    "tags": [],
+                    "properties": {},
                     "conditional": {
                       "show": null,
                       "when": null,
-                      "eq": ""
+                      "eq": "",
+                      "json": ""
                     },
+                    "customConditional": "",
+                    "logic": [],
+                    "attributes": {},
                     "overlay": {
                       "style": "",
+                      "page": "",
                       "left": "",
                       "top": "",
                       "width": "",
                       "height": ""
                     },
+                    "type": "htmlelement",
+                    "input": false,
+                    "tableView": false,
+                    "placeholder": "",
+                    "prefix": "",
+                    "suffix": "",
+                    "multiple": false,
+                    "defaultValue": null,
+                    "protected": false,
+                    "unique": false,
+                    "persistent": false,
+                    "clearOnHide": true,
+                    "refreshOn": "",
+                    "redrawOn": "",
+                    "dataGridLabel": false,
+                    "labelPosition": "top",
+                    "description": "",
+                    "errorLabel": "",
+                    "tooltip": "",
+                    "hideLabel": false,
+                    "tabindex": "",
+                    "disabled": false,
+                    "autofocus": false,
+                    "dbIndex": false,
+                    "customDefaultValue": "",
+                    "calculateValue": "",
+                    "calculateServer": false,
+                    "widget": null,
+                    "validateOn": "change",
+                    "validate": {
+                      "required": false,
+                      "custom": "",
+                      "customPrivate": false,
+                      "strictDateValidation": false,
+                      "multiple": false,
+                      "unique": false
+                    },
                     "allowCalculateOverride": false,
                     "encrypted": false,
                     "showCharCount": false,
                     "showWordCount": false,
-                    "properties": {},
                     "allowMultipleMasks": false,
+                    "id": "ej5cx5b"
+                  }
+                ]
+              },
+              {
+                "components": [
+                  {
+                    "label": "CSGPTotal",
                     "tag": "p",
-                    "id": "eteu33w"
+                    "className": "",
+                    "attrs": [
+                      {
+                        "attr": "",
+                        "value": ""
+                      }
+                    ],
+                    "content": "{{(data.disbursement?.disbursement1csgp ? data.disbursement.disbursement1csgp : 0) + (data.disbursement?.disbursement2csgp ? data.disbursement.disbursement2csgp : 0)}}",
+                    "refreshOnChange": false,
+                    "customClass": "",
+                    "hidden": false,
+                    "modalEdit": false,
+                    "key": "html65",
+                    "tags": [],
+                    "properties": {},
+                    "conditional": {
+                      "show": null,
+                      "when": null,
+                      "eq": "",
+                      "json": ""
+                    },
+                    "customConditional": "",
+                    "logic": [],
+                    "attributes": {},
+                    "overlay": {
+                      "style": "",
+                      "page": "",
+                      "left": "",
+                      "top": "",
+                      "width": "",
+                      "height": ""
+                    },
+                    "type": "htmlelement",
+                    "input": false,
+                    "tableView": false,
+                    "placeholder": "",
+                    "prefix": "",
+                    "suffix": "",
+                    "multiple": false,
+                    "defaultValue": null,
+                    "protected": false,
+                    "unique": false,
+                    "persistent": false,
+                    "clearOnHide": true,
+                    "refreshOn": "",
+                    "redrawOn": "",
+                    "dataGridLabel": false,
+                    "labelPosition": "top",
+                    "description": "",
+                    "errorLabel": "",
+                    "tooltip": "",
+                    "hideLabel": false,
+                    "tabindex": "",
+                    "disabled": false,
+                    "autofocus": false,
+                    "dbIndex": false,
+                    "customDefaultValue": "",
+                    "calculateValue": "",
+                    "calculateServer": false,
+                    "widget": null,
+                    "validateOn": "change",
+                    "validate": {
+                      "required": false,
+                      "custom": "",
+                      "customPrivate": false,
+                      "strictDateValidation": false,
+                      "multiple": false,
+                      "unique": false
+                    },
+                    "allowCalculateOverride": false,
+                    "encrypted": false,
+                    "showCharCount": false,
+                    "showWordCount": false,
+                    "allowMultipleMasks": false,
+                    "id": "exmr6dt"
                   }
                 ]
               }
@@ -7596,40 +7956,61 @@
                     "properties": {},
                     "allowMultipleMasks": false,
                     "tag": "p",
-                    "id": "ebrbpyf"
+                    "id": "eu1arwo"
                   }
                 ]
               },
               {
                 "components": [
                   {
-                    "label": "HTML",
+                    "label": "CSGD1",
+                    "tag": "p",
+                    "className": "",
                     "attrs": [
                       {
                         "attr": "",
                         "value": ""
                       }
                     ],
-                    "content": "$######",
+                    "content": "{{data.disbursement?.disbursement1csgd ? '$'+ data.disbursement.disbursement1csgd : '-'}}",
                     "refreshOnChange": false,
+                    "customClass": "",
+                    "hidden": false,
+                    "modalEdit": false,
                     "key": "html4",
+                    "tags": [],
+                    "properties": {},
+                    "conditional": {
+                      "show": null,
+                      "when": null,
+                      "eq": "",
+                      "json": ""
+                    },
+                    "customConditional": "",
+                    "logic": [],
+                    "attributes": {},
+                    "overlay": {
+                      "style": "",
+                      "page": "",
+                      "left": "",
+                      "top": "",
+                      "width": "",
+                      "height": ""
+                    },
                     "type": "htmlelement",
                     "input": false,
                     "tableView": false,
                     "placeholder": "",
                     "prefix": "",
-                    "customClass": "",
                     "suffix": "",
                     "multiple": false,
                     "defaultValue": null,
                     "protected": false,
                     "unique": false,
                     "persistent": false,
-                    "hidden": false,
                     "clearOnHide": true,
                     "refreshOn": "",
                     "redrawOn": "",
-                    "modalEdit": false,
                     "dataGridLabel": false,
                     "labelPosition": "top",
                     "description": "",
@@ -7644,7 +8025,6 @@
                     "calculateValue": "",
                     "calculateServer": false,
                     "widget": null,
-                    "attributes": {},
                     "validateOn": "change",
                     "validate": {
                       "required": false,
@@ -7654,26 +8034,178 @@
                       "multiple": false,
                       "unique": false
                     },
+                    "allowCalculateOverride": false,
+                    "encrypted": false,
+                    "showCharCount": false,
+                    "showWordCount": false,
+                    "allowMultipleMasks": false,
+                    "id": "efgolz"
+                  }
+                ]
+              },
+              {
+                "components": [
+                  {
+                    "label": "CSGD2",
+                    "tag": "p",
+                    "className": "",
+                    "attrs": [
+                      {
+                        "attr": "",
+                        "value": ""
+                      }
+                    ],
+                    "content": "{{data.disbursement?.disbursement2csgd ? '$'+ data.disbursement.disbursement2csgd : '-'}}",
+                    "refreshOnChange": false,
+                    "customClass": "",
+                    "hidden": false,
+                    "modalEdit": false,
+                    "key": "html74",
+                    "tags": [],
+                    "properties": {},
                     "conditional": {
                       "show": null,
                       "when": null,
-                      "eq": ""
+                      "eq": "",
+                      "json": ""
                     },
+                    "customConditional": "",
+                    "logic": [],
+                    "attributes": {},
                     "overlay": {
                       "style": "",
+                      "page": "",
                       "left": "",
                       "top": "",
                       "width": "",
                       "height": ""
                     },
+                    "type": "htmlelement",
+                    "input": false,
+                    "tableView": false,
+                    "placeholder": "",
+                    "prefix": "",
+                    "suffix": "",
+                    "multiple": false,
+                    "defaultValue": null,
+                    "protected": false,
+                    "unique": false,
+                    "persistent": false,
+                    "clearOnHide": true,
+                    "refreshOn": "",
+                    "redrawOn": "",
+                    "dataGridLabel": false,
+                    "labelPosition": "top",
+                    "description": "",
+                    "errorLabel": "",
+                    "tooltip": "",
+                    "hideLabel": false,
+                    "tabindex": "",
+                    "disabled": false,
+                    "autofocus": false,
+                    "dbIndex": false,
+                    "customDefaultValue": "",
+                    "calculateValue": "",
+                    "calculateServer": false,
+                    "widget": null,
+                    "validateOn": "change",
+                    "validate": {
+                      "required": false,
+                      "custom": "",
+                      "customPrivate": false,
+                      "strictDateValidation": false,
+                      "multiple": false,
+                      "unique": false
+                    },
                     "allowCalculateOverride": false,
                     "encrypted": false,
                     "showCharCount": false,
                     "showWordCount": false,
-                    "properties": {},
                     "allowMultipleMasks": false,
+                    "id": "exa1057"
+                  }
+                ]
+              },
+              {
+                "components": [
+                  {
+                    "label": "CSGDTotal",
                     "tag": "p",
-                    "id": "ej29leq"
+                    "className": "",
+                    "attrs": [
+                      {
+                        "attr": "",
+                        "value": ""
+                      }
+                    ],
+                    "content": "{{(data.disbursement?.disbursement1csgd ? data.disbursement.disbursement1csgd : 0) + (data.disbursement?.disbursement2csgd ? data.disbursement.disbursement2csgd : 0)}}",
+                    "refreshOnChange": false,
+                    "customClass": "",
+                    "hidden": false,
+                    "modalEdit": false,
+                    "key": "html66",
+                    "tags": [],
+                    "properties": {},
+                    "conditional": {
+                      "show": null,
+                      "when": null,
+                      "eq": "",
+                      "json": ""
+                    },
+                    "customConditional": "",
+                    "logic": [],
+                    "attributes": {},
+                    "overlay": {
+                      "style": "",
+                      "page": "",
+                      "left": "",
+                      "top": "",
+                      "width": "",
+                      "height": ""
+                    },
+                    "type": "htmlelement",
+                    "input": false,
+                    "tableView": false,
+                    "placeholder": "",
+                    "prefix": "",
+                    "suffix": "",
+                    "multiple": false,
+                    "defaultValue": null,
+                    "protected": false,
+                    "unique": false,
+                    "persistent": false,
+                    "clearOnHide": true,
+                    "refreshOn": "",
+                    "redrawOn": "",
+                    "dataGridLabel": false,
+                    "labelPosition": "top",
+                    "description": "",
+                    "errorLabel": "",
+                    "tooltip": "",
+                    "hideLabel": false,
+                    "tabindex": "",
+                    "disabled": false,
+                    "autofocus": false,
+                    "dbIndex": false,
+                    "customDefaultValue": "",
+                    "calculateValue": "",
+                    "calculateServer": false,
+                    "widget": null,
+                    "validateOn": "change",
+                    "validate": {
+                      "required": false,
+                      "custom": "",
+                      "customPrivate": false,
+                      "strictDateValidation": false,
+                      "multiple": false,
+                      "unique": false
+                    },
+                    "allowCalculateOverride": false,
+                    "encrypted": false,
+                    "showCharCount": false,
+                    "showWordCount": false,
+                    "allowMultipleMasks": false,
+                    "id": "eknwzha"
                   }
                 ]
               }
@@ -7752,40 +8284,61 @@
                     "properties": {},
                     "allowMultipleMasks": false,
                     "tag": "p",
-                    "id": "ekq6f6j"
+                    "id": "erz3wtd"
                   }
                 ]
               },
               {
                 "components": [
                   {
-                    "label": "HTML",
+                    "label": "CSGF1",
+                    "tag": "p",
+                    "className": "",
                     "attrs": [
                       {
                         "attr": "",
                         "value": ""
                       }
                     ],
-                    "content": "$######",
+                    "content": "{{data.disbursement?.disbursement1csgf ? '$'+ data.disbursement.disbursement1csgf : '-'}}",
                     "refreshOnChange": false,
+                    "customClass": "",
+                    "hidden": false,
+                    "modalEdit": false,
                     "key": "html6",
+                    "tags": [],
+                    "properties": {},
+                    "conditional": {
+                      "show": null,
+                      "when": null,
+                      "eq": "",
+                      "json": ""
+                    },
+                    "customConditional": "",
+                    "logic": [],
+                    "attributes": {},
+                    "overlay": {
+                      "style": "",
+                      "page": "",
+                      "left": "",
+                      "top": "",
+                      "width": "",
+                      "height": ""
+                    },
                     "type": "htmlelement",
                     "input": false,
                     "tableView": false,
                     "placeholder": "",
                     "prefix": "",
-                    "customClass": "",
                     "suffix": "",
                     "multiple": false,
                     "defaultValue": null,
                     "protected": false,
                     "unique": false,
                     "persistent": false,
-                    "hidden": false,
                     "clearOnHide": true,
                     "refreshOn": "",
                     "redrawOn": "",
-                    "modalEdit": false,
                     "dataGridLabel": false,
                     "labelPosition": "top",
                     "description": "",
@@ -7800,7 +8353,6 @@
                     "calculateValue": "",
                     "calculateServer": false,
                     "widget": null,
-                    "attributes": {},
                     "validateOn": "change",
                     "validate": {
                       "required": false,
@@ -7810,26 +8362,178 @@
                       "multiple": false,
                       "unique": false
                     },
+                    "allowCalculateOverride": false,
+                    "encrypted": false,
+                    "showCharCount": false,
+                    "showWordCount": false,
+                    "allowMultipleMasks": false,
+                    "id": "e88xy1l"
+                  }
+                ]
+              },
+              {
+                "components": [
+                  {
+                    "label": "CSGF2",
+                    "tag": "p",
+                    "className": "",
+                    "attrs": [
+                      {
+                        "attr": "",
+                        "value": ""
+                      }
+                    ],
+                    "content": "{{data.disbursement?.disbursement2csgf ? '$'+ data.disbursement.disbursement2csgf : '-'}}",
+                    "refreshOnChange": false,
+                    "customClass": "",
+                    "hidden": false,
+                    "modalEdit": false,
+                    "key": "html75",
+                    "tags": [],
+                    "properties": {},
                     "conditional": {
                       "show": null,
                       "when": null,
-                      "eq": ""
+                      "eq": "",
+                      "json": ""
                     },
+                    "customConditional": "",
+                    "logic": [],
+                    "attributes": {},
                     "overlay": {
                       "style": "",
+                      "page": "",
                       "left": "",
                       "top": "",
                       "width": "",
                       "height": ""
                     },
+                    "type": "htmlelement",
+                    "input": false,
+                    "tableView": false,
+                    "placeholder": "",
+                    "prefix": "",
+                    "suffix": "",
+                    "multiple": false,
+                    "defaultValue": null,
+                    "protected": false,
+                    "unique": false,
+                    "persistent": false,
+                    "clearOnHide": true,
+                    "refreshOn": "",
+                    "redrawOn": "",
+                    "dataGridLabel": false,
+                    "labelPosition": "top",
+                    "description": "",
+                    "errorLabel": "",
+                    "tooltip": "",
+                    "hideLabel": false,
+                    "tabindex": "",
+                    "disabled": false,
+                    "autofocus": false,
+                    "dbIndex": false,
+                    "customDefaultValue": "",
+                    "calculateValue": "",
+                    "calculateServer": false,
+                    "widget": null,
+                    "validateOn": "change",
+                    "validate": {
+                      "required": false,
+                      "custom": "",
+                      "customPrivate": false,
+                      "strictDateValidation": false,
+                      "multiple": false,
+                      "unique": false
+                    },
                     "allowCalculateOverride": false,
                     "encrypted": false,
                     "showCharCount": false,
                     "showWordCount": false,
-                    "properties": {},
                     "allowMultipleMasks": false,
+                    "id": "e5s5tcv"
+                  }
+                ]
+              },
+              {
+                "components": [
+                  {
+                    "label": "CSGFTotal",
                     "tag": "p",
-                    "id": "ey1h8je"
+                    "className": "",
+                    "attrs": [
+                      {
+                        "attr": "",
+                        "value": ""
+                      }
+                    ],
+                    "content": "{{(data.disbursement?.disbursement1csgf ? data.disbursement.disbursement1csgf : 0) + (data.disbursement?.disbursement2csgf ? data.disbursement.disbursement2csgf : 0)}}",
+                    "refreshOnChange": false,
+                    "customClass": "",
+                    "hidden": false,
+                    "modalEdit": false,
+                    "key": "html67",
+                    "tags": [],
+                    "properties": {},
+                    "conditional": {
+                      "show": null,
+                      "when": null,
+                      "eq": "",
+                      "json": ""
+                    },
+                    "customConditional": "",
+                    "logic": [],
+                    "attributes": {},
+                    "overlay": {
+                      "style": "",
+                      "page": "",
+                      "left": "",
+                      "top": "",
+                      "width": "",
+                      "height": ""
+                    },
+                    "type": "htmlelement",
+                    "input": false,
+                    "tableView": false,
+                    "placeholder": "",
+                    "prefix": "",
+                    "suffix": "",
+                    "multiple": false,
+                    "defaultValue": null,
+                    "protected": false,
+                    "unique": false,
+                    "persistent": false,
+                    "clearOnHide": true,
+                    "refreshOn": "",
+                    "redrawOn": "",
+                    "dataGridLabel": false,
+                    "labelPosition": "top",
+                    "description": "",
+                    "errorLabel": "",
+                    "tooltip": "",
+                    "hideLabel": false,
+                    "tabindex": "",
+                    "disabled": false,
+                    "autofocus": false,
+                    "dbIndex": false,
+                    "customDefaultValue": "",
+                    "calculateValue": "",
+                    "calculateServer": false,
+                    "widget": null,
+                    "validateOn": "change",
+                    "validate": {
+                      "required": false,
+                      "custom": "",
+                      "customPrivate": false,
+                      "strictDateValidation": false,
+                      "multiple": false,
+                      "unique": false
+                    },
+                    "allowCalculateOverride": false,
+                    "encrypted": false,
+                    "showCharCount": false,
+                    "showWordCount": false,
+                    "allowMultipleMasks": false,
+                    "id": "eqpt2gf"
                   }
                 ]
               }
@@ -7909,40 +8613,61 @@
                     "properties": {},
                     "allowMultipleMasks": false,
                     "tag": "p",
-                    "id": "erbftmi"
+                    "id": "ecdsj2"
                   }
                 ]
               },
               {
                 "components": [
                   {
-                    "label": "HTML",
+                    "label": "CSGT1",
+                    "tag": "p",
+                    "className": "",
                     "attrs": [
                       {
                         "attr": "",
                         "value": ""
                       }
                     ],
-                    "content": "$######",
+                    "content": "{{data.disbursement?.disbursement1csgt ? '$'+ data.disbursement.disbursement1csgt : '-'}}",
                     "refreshOnChange": false,
+                    "customClass": "",
+                    "hidden": false,
+                    "modalEdit": false,
                     "key": "html8",
+                    "tags": [],
+                    "properties": {},
+                    "conditional": {
+                      "show": null,
+                      "when": null,
+                      "eq": "",
+                      "json": ""
+                    },
+                    "customConditional": "",
+                    "logic": [],
+                    "attributes": {},
+                    "overlay": {
+                      "style": "",
+                      "page": "",
+                      "left": "",
+                      "top": "",
+                      "width": "",
+                      "height": ""
+                    },
                     "type": "htmlelement",
                     "input": false,
                     "tableView": false,
                     "placeholder": "",
                     "prefix": "",
-                    "customClass": "",
                     "suffix": "",
                     "multiple": false,
                     "defaultValue": null,
                     "protected": false,
                     "unique": false,
                     "persistent": false,
-                    "hidden": false,
                     "clearOnHide": true,
                     "refreshOn": "",
                     "redrawOn": "",
-                    "modalEdit": false,
                     "dataGridLabel": false,
                     "labelPosition": "top",
                     "description": "",
@@ -7957,7 +8682,6 @@
                     "calculateValue": "",
                     "calculateServer": false,
                     "widget": null,
-                    "attributes": {},
                     "validateOn": "change",
                     "validate": {
                       "required": false,
@@ -7967,26 +8691,178 @@
                       "multiple": false,
                       "unique": false
                     },
+                    "allowCalculateOverride": false,
+                    "encrypted": false,
+                    "showCharCount": false,
+                    "showWordCount": false,
+                    "allowMultipleMasks": false,
+                    "id": "e03nm6j"
+                  }
+                ]
+              },
+              {
+                "components": [
+                  {
+                    "label": "HTML",
+                    "tag": "p",
+                    "className": "",
+                    "attrs": [
+                      {
+                        "attr": "",
+                        "value": ""
+                      }
+                    ],
+                    "content": "{{data.disbursement?.disbursement2csgt ? '$'+ data.disbursement.disbursement2csgt : '-'}}",
+                    "refreshOnChange": false,
+                    "customClass": "",
+                    "hidden": false,
+                    "modalEdit": false,
+                    "key": "html76",
+                    "tags": [],
+                    "properties": {},
                     "conditional": {
                       "show": null,
                       "when": null,
-                      "eq": ""
+                      "eq": "",
+                      "json": ""
                     },
+                    "customConditional": "",
+                    "logic": [],
+                    "attributes": {},
                     "overlay": {
                       "style": "",
+                      "page": "",
                       "left": "",
                       "top": "",
                       "width": "",
                       "height": ""
                     },
+                    "type": "htmlelement",
+                    "input": false,
+                    "tableView": false,
+                    "placeholder": "",
+                    "prefix": "",
+                    "suffix": "",
+                    "multiple": false,
+                    "defaultValue": null,
+                    "protected": false,
+                    "unique": false,
+                    "persistent": false,
+                    "clearOnHide": true,
+                    "refreshOn": "",
+                    "redrawOn": "",
+                    "dataGridLabel": false,
+                    "labelPosition": "top",
+                    "description": "",
+                    "errorLabel": "",
+                    "tooltip": "",
+                    "hideLabel": false,
+                    "tabindex": "",
+                    "disabled": false,
+                    "autofocus": false,
+                    "dbIndex": false,
+                    "customDefaultValue": "",
+                    "calculateValue": "",
+                    "calculateServer": false,
+                    "widget": null,
+                    "validateOn": "change",
+                    "validate": {
+                      "required": false,
+                      "custom": "",
+                      "customPrivate": false,
+                      "strictDateValidation": false,
+                      "multiple": false,
+                      "unique": false
+                    },
                     "allowCalculateOverride": false,
                     "encrypted": false,
                     "showCharCount": false,
                     "showWordCount": false,
-                    "properties": {},
                     "allowMultipleMasks": false,
+                    "id": "e5l1wqs"
+                  }
+                ]
+              },
+              {
+                "components": [
+                  {
+                    "label": "CSGTTotal",
                     "tag": "p",
-                    "id": "eibesc"
+                    "className": "",
+                    "attrs": [
+                      {
+                        "attr": "",
+                        "value": ""
+                      }
+                    ],
+                    "content": "{{(data.disbursement?.disbursement1csgt ? data.disbursement.disbursement1csgt : 0) + (data.disbursement?.disbursement2csgt ? data.disbursement.disbursement2csgt : 0)}}",
+                    "refreshOnChange": false,
+                    "customClass": "",
+                    "hidden": false,
+                    "modalEdit": false,
+                    "key": "html68",
+                    "tags": [],
+                    "properties": {},
+                    "conditional": {
+                      "show": null,
+                      "when": null,
+                      "eq": "",
+                      "json": ""
+                    },
+                    "customConditional": "",
+                    "logic": [],
+                    "attributes": {},
+                    "overlay": {
+                      "style": "",
+                      "page": "",
+                      "left": "",
+                      "top": "",
+                      "width": "",
+                      "height": ""
+                    },
+                    "type": "htmlelement",
+                    "input": false,
+                    "tableView": false,
+                    "placeholder": "",
+                    "prefix": "",
+                    "suffix": "",
+                    "multiple": false,
+                    "defaultValue": null,
+                    "protected": false,
+                    "unique": false,
+                    "persistent": false,
+                    "clearOnHide": true,
+                    "refreshOn": "",
+                    "redrawOn": "",
+                    "dataGridLabel": false,
+                    "labelPosition": "top",
+                    "description": "",
+                    "errorLabel": "",
+                    "tooltip": "",
+                    "hideLabel": false,
+                    "tabindex": "",
+                    "disabled": false,
+                    "autofocus": false,
+                    "dbIndex": false,
+                    "customDefaultValue": "",
+                    "calculateValue": "",
+                    "calculateServer": false,
+                    "widget": null,
+                    "validateOn": "change",
+                    "validate": {
+                      "required": false,
+                      "custom": "",
+                      "customPrivate": false,
+                      "strictDateValidation": false,
+                      "multiple": false,
+                      "unique": false
+                    },
+                    "allowCalculateOverride": false,
+                    "encrypted": false,
+                    "showCharCount": false,
+                    "showWordCount": false,
+                    "allowMultipleMasks": false,
+                    "id": "es94ttkh"
                   }
                 ]
               }
@@ -8066,40 +8942,61 @@
                     "properties": {},
                     "allowMultipleMasks": false,
                     "tag": "p",
-                    "id": "epukuzb"
+                    "id": "efgshdt"
                   }
                 ]
               },
               {
                 "components": [
                   {
-                    "label": "HTML",
+                    "label": "BCAG1",
+                    "tag": "p",
+                    "className": "",
                     "attrs": [
                       {
                         "attr": "",
                         "value": ""
                       }
                     ],
-                    "content": "$######",
+                    "content": "{{data.disbursement?.disbursement1bcag ? '$'+ data.disbursement.disbursement1bcag : '-'}}",
                     "refreshOnChange": false,
+                    "customClass": "",
+                    "hidden": false,
+                    "modalEdit": false,
                     "key": "html9",
+                    "tags": [],
+                    "properties": {},
+                    "conditional": {
+                      "show": null,
+                      "when": null,
+                      "eq": "",
+                      "json": ""
+                    },
+                    "customConditional": "",
+                    "logic": [],
+                    "attributes": {},
+                    "overlay": {
+                      "style": "",
+                      "page": "",
+                      "left": "",
+                      "top": "",
+                      "width": "",
+                      "height": ""
+                    },
                     "type": "htmlelement",
                     "input": false,
                     "tableView": false,
                     "placeholder": "",
                     "prefix": "",
-                    "customClass": "",
                     "suffix": "",
                     "multiple": false,
                     "defaultValue": null,
                     "protected": false,
                     "unique": false,
                     "persistent": false,
-                    "hidden": false,
                     "clearOnHide": true,
                     "refreshOn": "",
                     "redrawOn": "",
-                    "modalEdit": false,
                     "dataGridLabel": false,
                     "labelPosition": "top",
                     "description": "",
@@ -8114,7 +9011,6 @@
                     "calculateValue": "",
                     "calculateServer": false,
                     "widget": null,
-                    "attributes": {},
                     "validateOn": "change",
                     "validate": {
                       "required": false,
@@ -8124,26 +9020,178 @@
                       "multiple": false,
                       "unique": false
                     },
+                    "allowCalculateOverride": false,
+                    "encrypted": false,
+                    "showCharCount": false,
+                    "showWordCount": false,
+                    "allowMultipleMasks": false,
+                    "id": "ex6l0jf"
+                  }
+                ]
+              },
+              {
+                "components": [
+                  {
+                    "label": "BCAG2",
+                    "tag": "p",
+                    "className": "",
+                    "attrs": [
+                      {
+                        "attr": "",
+                        "value": ""
+                      }
+                    ],
+                    "content": "{{data.disbursement?.disbursement2bcag ? '$'+ data.disbursement.disbursement2bcag : '-'}}",
+                    "refreshOnChange": false,
+                    "customClass": "",
+                    "hidden": false,
+                    "modalEdit": false,
+                    "key": "html77",
+                    "tags": [],
+                    "properties": {},
                     "conditional": {
                       "show": null,
                       "when": null,
-                      "eq": ""
+                      "eq": "",
+                      "json": ""
                     },
+                    "customConditional": "",
+                    "logic": [],
+                    "attributes": {},
                     "overlay": {
                       "style": "",
+                      "page": "",
                       "left": "",
                       "top": "",
                       "width": "",
                       "height": ""
                     },
+                    "type": "htmlelement",
+                    "input": false,
+                    "tableView": false,
+                    "placeholder": "",
+                    "prefix": "",
+                    "suffix": "",
+                    "multiple": false,
+                    "defaultValue": null,
+                    "protected": false,
+                    "unique": false,
+                    "persistent": false,
+                    "clearOnHide": true,
+                    "refreshOn": "",
+                    "redrawOn": "",
+                    "dataGridLabel": false,
+                    "labelPosition": "top",
+                    "description": "",
+                    "errorLabel": "",
+                    "tooltip": "",
+                    "hideLabel": false,
+                    "tabindex": "",
+                    "disabled": false,
+                    "autofocus": false,
+                    "dbIndex": false,
+                    "customDefaultValue": "",
+                    "calculateValue": "",
+                    "calculateServer": false,
+                    "widget": null,
+                    "validateOn": "change",
+                    "validate": {
+                      "required": false,
+                      "custom": "",
+                      "customPrivate": false,
+                      "strictDateValidation": false,
+                      "multiple": false,
+                      "unique": false
+                    },
                     "allowCalculateOverride": false,
                     "encrypted": false,
                     "showCharCount": false,
                     "showWordCount": false,
-                    "properties": {},
                     "allowMultipleMasks": false,
+                    "id": "e4la5nb"
+                  }
+                ]
+              },
+              {
+                "components": [
+                  {
+                    "label": "BCAGTotal",
                     "tag": "p",
-                    "id": "eg4v0q"
+                    "className": "",
+                    "attrs": [
+                      {
+                        "attr": "",
+                        "value": ""
+                      }
+                    ],
+                    "content": "{{(data.disbursement?.disbursement1bcag ? data.disbursement.disbursement1bcag : 0) + (data.disbursement?.disbursement2bcag ? data.disbursement.disbursement2bcag : 0)}}",
+                    "refreshOnChange": false,
+                    "customClass": "",
+                    "hidden": false,
+                    "modalEdit": false,
+                    "key": "html69",
+                    "tags": [],
+                    "properties": {},
+                    "conditional": {
+                      "show": null,
+                      "when": null,
+                      "eq": "",
+                      "json": ""
+                    },
+                    "customConditional": "",
+                    "logic": [],
+                    "attributes": {},
+                    "overlay": {
+                      "style": "",
+                      "page": "",
+                      "left": "",
+                      "top": "",
+                      "width": "",
+                      "height": ""
+                    },
+                    "type": "htmlelement",
+                    "input": false,
+                    "tableView": false,
+                    "placeholder": "",
+                    "prefix": "",
+                    "suffix": "",
+                    "multiple": false,
+                    "defaultValue": null,
+                    "protected": false,
+                    "unique": false,
+                    "persistent": false,
+                    "clearOnHide": true,
+                    "refreshOn": "",
+                    "redrawOn": "",
+                    "dataGridLabel": false,
+                    "labelPosition": "top",
+                    "description": "",
+                    "errorLabel": "",
+                    "tooltip": "",
+                    "hideLabel": false,
+                    "tabindex": "",
+                    "disabled": false,
+                    "autofocus": false,
+                    "dbIndex": false,
+                    "customDefaultValue": "",
+                    "calculateValue": "",
+                    "calculateServer": false,
+                    "widget": null,
+                    "validateOn": "change",
+                    "validate": {
+                      "required": false,
+                      "custom": "",
+                      "customPrivate": false,
+                      "strictDateValidation": false,
+                      "multiple": false,
+                      "unique": false
+                    },
+                    "allowCalculateOverride": false,
+                    "encrypted": false,
+                    "showCharCount": false,
+                    "showWordCount": false,
+                    "allowMultipleMasks": false,
+                    "id": "ek73st"
                   }
                 ]
               }
@@ -8223,41 +9271,62 @@
                     "properties": {},
                     "allowMultipleMasks": false,
                     "tag": "p",
-                    "id": "eqjvy13"
+                    "id": "emadokq"
                   }
                 ]
               },
               {
                 "components": [
                   {
-                    "label": "HTML",
+                    "label": "SBSD1",
+                    "tag": "p",
+                    "className": "",
                     "attrs": [
                       {
                         "attr": "",
                         "value": ""
                       }
                     ],
-                    "content": "$######",
+                    "content": "{{data.disbursement?.disbursement1sbsd ? '$'+ data.disbursement.disbursement1sbsd : '-'}}",
                     "refreshOnChange": false,
+                    "customClass": "",
+                    "hidden": false,
+                    "modalEdit": false,
                     "key": "html11",
+                    "tags": [],
+                    "properties": {},
+                    "conditional": {
+                      "show": null,
+                      "when": null,
+                      "eq": "",
+                      "json": ""
+                    },
+                    "customConditional": "",
+                    "logic": [],
+                    "attributes": {},
+                    "overlay": {
+                      "style": "",
+                      "page": "",
+                      "left": "",
+                      "top": "",
+                      "width": "",
+                      "height": ""
+                    },
                     "type": "htmlelement",
                     "input": false,
                     "tableView": false,
                     "hideOnChildrenHidden": false,
                     "placeholder": "",
                     "prefix": "",
-                    "customClass": "",
                     "suffix": "",
                     "multiple": false,
                     "defaultValue": null,
                     "protected": false,
                     "unique": false,
                     "persistent": false,
-                    "hidden": false,
                     "clearOnHide": true,
                     "refreshOn": "",
                     "redrawOn": "",
-                    "modalEdit": false,
                     "dataGridLabel": false,
                     "labelPosition": "top",
                     "description": "",
@@ -8272,7 +9341,6 @@
                     "calculateValue": "",
                     "calculateServer": false,
                     "widget": null,
-                    "attributes": {},
                     "validateOn": "change",
                     "validate": {
                       "required": false,
@@ -8282,26 +9350,178 @@
                       "multiple": false,
                       "unique": false
                     },
+                    "allowCalculateOverride": false,
+                    "encrypted": false,
+                    "showCharCount": false,
+                    "showWordCount": false,
+                    "allowMultipleMasks": false,
+                    "id": "elqynij"
+                  }
+                ]
+              },
+              {
+                "components": [
+                  {
+                    "label": "HTML",
+                    "tag": "p",
+                    "className": "",
+                    "attrs": [
+                      {
+                        "attr": "",
+                        "value": ""
+                      }
+                    ],
+                    "content": "{{data.disbursement?.disbursement2sbsd ? '$'+ data.disbursement.disbursement2sbsd : '-'}}",
+                    "refreshOnChange": false,
+                    "customClass": "",
+                    "hidden": false,
+                    "modalEdit": false,
+                    "key": "html78",
+                    "tags": [],
+                    "properties": {},
                     "conditional": {
                       "show": null,
                       "when": null,
-                      "eq": ""
+                      "eq": "",
+                      "json": ""
                     },
+                    "customConditional": "",
+                    "logic": [],
+                    "attributes": {},
                     "overlay": {
                       "style": "",
+                      "page": "",
                       "left": "",
                       "top": "",
                       "width": "",
                       "height": ""
                     },
+                    "type": "htmlelement",
+                    "input": false,
+                    "tableView": false,
+                    "placeholder": "",
+                    "prefix": "",
+                    "suffix": "",
+                    "multiple": false,
+                    "defaultValue": null,
+                    "protected": false,
+                    "unique": false,
+                    "persistent": false,
+                    "clearOnHide": true,
+                    "refreshOn": "",
+                    "redrawOn": "",
+                    "dataGridLabel": false,
+                    "labelPosition": "top",
+                    "description": "",
+                    "errorLabel": "",
+                    "tooltip": "",
+                    "hideLabel": false,
+                    "tabindex": "",
+                    "disabled": false,
+                    "autofocus": false,
+                    "dbIndex": false,
+                    "customDefaultValue": "",
+                    "calculateValue": "",
+                    "calculateServer": false,
+                    "widget": null,
+                    "validateOn": "change",
+                    "validate": {
+                      "required": false,
+                      "custom": "",
+                      "customPrivate": false,
+                      "strictDateValidation": false,
+                      "multiple": false,
+                      "unique": false
+                    },
                     "allowCalculateOverride": false,
                     "encrypted": false,
                     "showCharCount": false,
                     "showWordCount": false,
-                    "properties": {},
                     "allowMultipleMasks": false,
+                    "id": "ebf0xoh"
+                  }
+                ]
+              },
+              {
+                "components": [
+                  {
+                    "label": "SBSDTotal",
                     "tag": "p",
-                    "id": "e4aw8ed"
+                    "className": "",
+                    "attrs": [
+                      {
+                        "attr": "",
+                        "value": ""
+                      }
+                    ],
+                    "content": "{{(data.disbursement?.disbursement1sbsd ? data.disbursement.disbursement1sbsd : 0) + (data.disbursement?.disbursement2sbsd ? data.disbursement.disbursement2sbsd : 0)}}",
+                    "refreshOnChange": false,
+                    "customClass": "",
+                    "hidden": false,
+                    "modalEdit": false,
+                    "key": "html70",
+                    "tags": [],
+                    "properties": {},
+                    "conditional": {
+                      "show": null,
+                      "when": null,
+                      "eq": "",
+                      "json": ""
+                    },
+                    "customConditional": "",
+                    "logic": [],
+                    "attributes": {},
+                    "overlay": {
+                      "style": "",
+                      "page": "",
+                      "left": "",
+                      "top": "",
+                      "width": "",
+                      "height": ""
+                    },
+                    "type": "htmlelement",
+                    "input": false,
+                    "tableView": false,
+                    "placeholder": "",
+                    "prefix": "",
+                    "suffix": "",
+                    "multiple": false,
+                    "defaultValue": null,
+                    "protected": false,
+                    "unique": false,
+                    "persistent": false,
+                    "clearOnHide": true,
+                    "refreshOn": "",
+                    "redrawOn": "",
+                    "dataGridLabel": false,
+                    "labelPosition": "top",
+                    "description": "",
+                    "errorLabel": "",
+                    "tooltip": "",
+                    "hideLabel": false,
+                    "tabindex": "",
+                    "disabled": false,
+                    "autofocus": false,
+                    "dbIndex": false,
+                    "customDefaultValue": "",
+                    "calculateValue": "",
+                    "calculateServer": false,
+                    "widget": null,
+                    "validateOn": "change",
+                    "validate": {
+                      "required": false,
+                      "custom": "",
+                      "customPrivate": false,
+                      "strictDateValidation": false,
+                      "multiple": false,
+                      "unique": false
+                    },
+                    "allowCalculateOverride": false,
+                    "encrypted": false,
+                    "showCharCount": false,
+                    "showWordCount": false,
+                    "allowMultipleMasks": false,
+                    "id": "esgjy95"
                   }
                 ]
               }
@@ -8381,41 +9601,62 @@
                     "properties": {},
                     "allowMultipleMasks": false,
                     "tag": "p",
-                    "id": "e6kpt8"
+                    "id": "eb5fqrd"
                   }
                 ]
               },
               {
                 "components": [
                   {
-                    "label": "HTML",
+                    "label": "BGPD1",
+                    "tag": "p",
+                    "className": "",
                     "attrs": [
                       {
                         "attr": "",
                         "value": ""
                       }
                     ],
-                    "content": "$######",
+                    "content": "{{data.disbursement?.disbursement1bgpd ? '$'+ data.disbursement.disbursement1bgpd : '-'}}",
                     "refreshOnChange": false,
+                    "customClass": "",
+                    "hidden": false,
+                    "modalEdit": false,
                     "key": "html10",
+                    "tags": [],
+                    "properties": {},
+                    "conditional": {
+                      "show": null,
+                      "when": null,
+                      "eq": "",
+                      "json": ""
+                    },
+                    "customConditional": "",
+                    "logic": [],
+                    "attributes": {},
+                    "overlay": {
+                      "style": "",
+                      "page": "",
+                      "left": "",
+                      "top": "",
+                      "width": "",
+                      "height": ""
+                    },
                     "type": "htmlelement",
                     "input": false,
                     "tableView": false,
                     "hideOnChildrenHidden": false,
                     "placeholder": "",
                     "prefix": "",
-                    "customClass": "",
                     "suffix": "",
                     "multiple": false,
                     "defaultValue": null,
                     "protected": false,
                     "unique": false,
                     "persistent": false,
-                    "hidden": false,
                     "clearOnHide": true,
                     "refreshOn": "",
                     "redrawOn": "",
-                    "modalEdit": false,
                     "dataGridLabel": false,
                     "labelPosition": "top",
                     "description": "",
@@ -8430,7 +9671,6 @@
                     "calculateValue": "",
                     "calculateServer": false,
                     "widget": null,
-                    "attributes": {},
                     "validateOn": "change",
                     "validate": {
                       "required": false,
@@ -8440,26 +9680,512 @@
                       "multiple": false,
                       "unique": false
                     },
+                    "allowCalculateOverride": false,
+                    "encrypted": false,
+                    "showCharCount": false,
+                    "showWordCount": false,
+                    "allowMultipleMasks": false,
+                    "id": "es625p6"
+                  }
+                ]
+              },
+              {
+                "components": [
+                  {
+                    "label": "HTML",
+                    "tag": "p",
+                    "className": "",
+                    "attrs": [
+                      {
+                        "attr": "",
+                        "value": ""
+                      }
+                    ],
+                    "content": "{{data.disbursement?.disbursement2bgpd ? '$'+ data.disbursement.disbursement2bgpd : '-'}}",
+                    "refreshOnChange": false,
+                    "customClass": "",
+                    "hidden": false,
+                    "modalEdit": false,
+                    "key": "html79",
+                    "tags": [],
+                    "properties": {},
                     "conditional": {
                       "show": null,
                       "when": null,
-                      "eq": ""
+                      "eq": "",
+                      "json": ""
                     },
+                    "customConditional": "",
+                    "logic": [],
+                    "attributes": {},
                     "overlay": {
                       "style": "",
+                      "page": "",
                       "left": "",
                       "top": "",
                       "width": "",
                       "height": ""
                     },
+                    "type": "htmlelement",
+                    "input": false,
+                    "tableView": false,
+                    "placeholder": "",
+                    "prefix": "",
+                    "suffix": "",
+                    "multiple": false,
+                    "defaultValue": null,
+                    "protected": false,
+                    "unique": false,
+                    "persistent": false,
+                    "clearOnHide": true,
+                    "refreshOn": "",
+                    "redrawOn": "",
+                    "dataGridLabel": false,
+                    "labelPosition": "top",
+                    "description": "",
+                    "errorLabel": "",
+                    "tooltip": "",
+                    "hideLabel": false,
+                    "tabindex": "",
+                    "disabled": false,
+                    "autofocus": false,
+                    "dbIndex": false,
+                    "customDefaultValue": "",
+                    "calculateValue": "",
+                    "calculateServer": false,
+                    "widget": null,
+                    "validateOn": "change",
+                    "validate": {
+                      "required": false,
+                      "custom": "",
+                      "customPrivate": false,
+                      "strictDateValidation": false,
+                      "multiple": false,
+                      "unique": false
+                    },
                     "allowCalculateOverride": false,
                     "encrypted": false,
                     "showCharCount": false,
                     "showWordCount": false,
-                    "properties": {},
                     "allowMultipleMasks": false,
+                    "id": "e5j9n5u"
+                  }
+                ]
+              },
+              {
+                "components": [
+                  {
+                    "label": "BGPDTotal",
                     "tag": "p",
-                    "id": "ej1ryw4"
+                    "className": "",
+                    "attrs": [
+                      {
+                        "attr": "",
+                        "value": ""
+                      }
+                    ],
+                    "content": "{{(data.disbursement?.disbursement1bgpd ? data.disbursement.disbursement1bgpd : 0) + (data.disbursement?.disbursement2bgpd ? data.disbursement.disbursement2bgpd : 0)}}",
+                    "refreshOnChange": false,
+                    "customClass": "",
+                    "hidden": false,
+                    "modalEdit": false,
+                    "key": "html71",
+                    "tags": [],
+                    "properties": {},
+                    "conditional": {
+                      "show": null,
+                      "when": null,
+                      "eq": "",
+                      "json": ""
+                    },
+                    "customConditional": "",
+                    "logic": [],
+                    "attributes": {},
+                    "overlay": {
+                      "style": "",
+                      "page": "",
+                      "left": "",
+                      "top": "",
+                      "width": "",
+                      "height": ""
+                    },
+                    "type": "htmlelement",
+                    "input": false,
+                    "tableView": false,
+                    "placeholder": "",
+                    "prefix": "",
+                    "suffix": "",
+                    "multiple": false,
+                    "defaultValue": null,
+                    "protected": false,
+                    "unique": false,
+                    "persistent": false,
+                    "clearOnHide": true,
+                    "refreshOn": "",
+                    "redrawOn": "",
+                    "dataGridLabel": false,
+                    "labelPosition": "top",
+                    "description": "",
+                    "errorLabel": "",
+                    "tooltip": "",
+                    "hideLabel": false,
+                    "tabindex": "",
+                    "disabled": false,
+                    "autofocus": false,
+                    "dbIndex": false,
+                    "customDefaultValue": "",
+                    "calculateValue": "",
+                    "calculateServer": false,
+                    "widget": null,
+                    "validateOn": "change",
+                    "validate": {
+                      "required": false,
+                      "custom": "",
+                      "customPrivate": false,
+                      "strictDateValidation": false,
+                      "multiple": false,
+                      "unique": false
+                    },
+                    "allowCalculateOverride": false,
+                    "encrypted": false,
+                    "showCharCount": false,
+                    "showWordCount": false,
+                    "allowMultipleMasks": false,
+                    "id": "e52swuw"
+                  }
+                ]
+              }
+            ],
+            [
+              {
+                "components": [
+                  {
+                    "label": "BCSG",
+                    "tag": "p",
+                    "className": "",
+                    "attrs": [
+                      {
+                        "attr": "",
+                        "value": ""
+                      }
+                    ],
+                    "content": "BCSG",
+                    "refreshOnChange": false,
+                    "customClass": "",
+                    "hidden": false,
+                    "modalEdit": false,
+                    "key": "bcsg",
+                    "tags": [],
+                    "properties": {},
+                    "conditional": {
+                      "show": null,
+                      "when": null,
+                      "eq": "",
+                      "json": ""
+                    },
+                    "customConditional": "",
+                    "logic": [],
+                    "attributes": {},
+                    "overlay": {
+                      "style": "",
+                      "page": "",
+                      "left": "",
+                      "top": "",
+                      "width": "",
+                      "height": ""
+                    },
+                    "type": "htmlelement",
+                    "input": false,
+                    "placeholder": "",
+                    "prefix": "",
+                    "suffix": "",
+                    "multiple": false,
+                    "defaultValue": null,
+                    "protected": false,
+                    "unique": false,
+                    "persistent": false,
+                    "clearOnHide": true,
+                    "refreshOn": "",
+                    "redrawOn": "",
+                    "tableView": false,
+                    "dataGridLabel": false,
+                    "labelPosition": "top",
+                    "description": "",
+                    "errorLabel": "",
+                    "tooltip": "",
+                    "hideLabel": false,
+                    "tabindex": "",
+                    "disabled": false,
+                    "autofocus": false,
+                    "dbIndex": false,
+                    "customDefaultValue": "",
+                    "calculateValue": "",
+                    "calculateServer": false,
+                    "widget": null,
+                    "validateOn": "change",
+                    "validate": {
+                      "required": false,
+                      "custom": "",
+                      "customPrivate": false,
+                      "strictDateValidation": false,
+                      "multiple": false,
+                      "unique": false
+                    },
+                    "allowCalculateOverride": false,
+                    "encrypted": false,
+                    "showCharCount": false,
+                    "showWordCount": false,
+                    "allowMultipleMasks": false,
+                    "id": "eqcnmk"
+                  }
+                ]
+              },
+              {
+                "components": [
+                  {
+                    "label": "BCSG1",
+                    "tag": "p",
+                    "className": "",
+                    "attrs": [
+                      {
+                        "attr": "",
+                        "value": ""
+                      }
+                    ],
+                    "content": "{{data.disbursement?.disbursement1bcsg ? '$'+ data.disbursement.disbursement1bcsg : '-'}}",
+                    "refreshOnChange": false,
+                    "customClass": "",
+                    "hidden": false,
+                    "modalEdit": false,
+                    "key": "html80",
+                    "tags": [],
+                    "properties": {},
+                    "conditional": {
+                      "show": null,
+                      "when": null,
+                      "eq": "",
+                      "json": ""
+                    },
+                    "customConditional": "",
+                    "logic": [],
+                    "attributes": {},
+                    "overlay": {
+                      "style": "",
+                      "page": "",
+                      "left": "",
+                      "top": "",
+                      "width": "",
+                      "height": ""
+                    },
+                    "type": "htmlelement",
+                    "input": false,
+                    "tableView": false,
+                    "placeholder": "",
+                    "prefix": "",
+                    "suffix": "",
+                    "multiple": false,
+                    "defaultValue": null,
+                    "protected": false,
+                    "unique": false,
+                    "persistent": false,
+                    "clearOnHide": true,
+                    "refreshOn": "",
+                    "redrawOn": "",
+                    "dataGridLabel": false,
+                    "labelPosition": "top",
+                    "description": "",
+                    "errorLabel": "",
+                    "tooltip": "",
+                    "hideLabel": false,
+                    "tabindex": "",
+                    "disabled": false,
+                    "autofocus": false,
+                    "dbIndex": false,
+                    "customDefaultValue": "",
+                    "calculateValue": "",
+                    "calculateServer": false,
+                    "widget": null,
+                    "validateOn": "change",
+                    "validate": {
+                      "required": false,
+                      "custom": "",
+                      "customPrivate": false,
+                      "strictDateValidation": false,
+                      "multiple": false,
+                      "unique": false
+                    },
+                    "allowCalculateOverride": false,
+                    "encrypted": false,
+                    "showCharCount": false,
+                    "showWordCount": false,
+                    "allowMultipleMasks": false,
+                    "id": "e9dvzph"
+                  }
+                ]
+              },
+              {
+                "components": [
+                  {
+                    "label": "HTML",
+                    "tag": "p",
+                    "className": "",
+                    "attrs": [
+                      {
+                        "attr": "",
+                        "value": ""
+                      }
+                    ],
+                    "content": "{{data.disbursement?.disbursement2bcsg ? '$'+ data.disbursement.disbursement2bcsg : '-'}}",
+                    "refreshOnChange": false,
+                    "customClass": "",
+                    "hidden": false,
+                    "modalEdit": false,
+                    "key": "html81",
+                    "tags": [],
+                    "properties": {},
+                    "conditional": {
+                      "show": null,
+                      "when": null,
+                      "eq": "",
+                      "json": ""
+                    },
+                    "customConditional": "",
+                    "logic": [],
+                    "attributes": {},
+                    "overlay": {
+                      "style": "",
+                      "page": "",
+                      "left": "",
+                      "top": "",
+                      "width": "",
+                      "height": ""
+                    },
+                    "type": "htmlelement",
+                    "input": false,
+                    "tableView": false,
+                    "placeholder": "",
+                    "prefix": "",
+                    "suffix": "",
+                    "multiple": false,
+                    "defaultValue": null,
+                    "protected": false,
+                    "unique": false,
+                    "persistent": false,
+                    "clearOnHide": true,
+                    "refreshOn": "",
+                    "redrawOn": "",
+                    "dataGridLabel": false,
+                    "labelPosition": "top",
+                    "description": "",
+                    "errorLabel": "",
+                    "tooltip": "",
+                    "hideLabel": false,
+                    "tabindex": "",
+                    "disabled": false,
+                    "autofocus": false,
+                    "dbIndex": false,
+                    "customDefaultValue": "",
+                    "calculateValue": "",
+                    "calculateServer": false,
+                    "widget": null,
+                    "validateOn": "change",
+                    "validate": {
+                      "required": false,
+                      "custom": "",
+                      "customPrivate": false,
+                      "strictDateValidation": false,
+                      "multiple": false,
+                      "unique": false
+                    },
+                    "allowCalculateOverride": false,
+                    "encrypted": false,
+                    "showCharCount": false,
+                    "showWordCount": false,
+                    "allowMultipleMasks": false,
+                    "id": "eax637n"
+                  }
+                ]
+              },
+              {
+                "components": [
+                  {
+                    "label": "BCSGTotal",
+                    "tag": "p",
+                    "className": "",
+                    "attrs": [
+                      {
+                        "attr": "",
+                        "value": ""
+                      }
+                    ],
+                    "content": "{{(data.disbursement?.disbursement1bcsg ? data.disbursement.disbursement1bcsg : 0) + (data.disbursement?.disbursement2bcsg ? data.disbursement.disbursement2bcsg : 0)}}",
+                    "refreshOnChange": false,
+                    "customClass": "",
+                    "hidden": false,
+                    "modalEdit": false,
+                    "key": "html82",
+                    "tags": [],
+                    "properties": {},
+                    "conditional": {
+                      "show": null,
+                      "when": null,
+                      "eq": "",
+                      "json": ""
+                    },
+                    "customConditional": "",
+                    "logic": [],
+                    "attributes": {},
+                    "overlay": {
+                      "style": "",
+                      "page": "",
+                      "left": "",
+                      "top": "",
+                      "width": "",
+                      "height": ""
+                    },
+                    "type": "htmlelement",
+                    "input": false,
+                    "tableView": false,
+                    "placeholder": "",
+                    "prefix": "",
+                    "suffix": "",
+                    "multiple": false,
+                    "defaultValue": null,
+                    "protected": false,
+                    "unique": false,
+                    "persistent": false,
+                    "clearOnHide": true,
+                    "refreshOn": "",
+                    "redrawOn": "",
+                    "dataGridLabel": false,
+                    "labelPosition": "top",
+                    "description": "",
+                    "errorLabel": "",
+                    "tooltip": "",
+                    "hideLabel": false,
+                    "tabindex": "",
+                    "disabled": false,
+                    "autofocus": false,
+                    "dbIndex": false,
+                    "customDefaultValue": "",
+                    "calculateValue": "",
+                    "calculateServer": false,
+                    "widget": null,
+                    "validateOn": "change",
+                    "validate": {
+                      "required": false,
+                      "custom": "",
+                      "customPrivate": false,
+                      "strictDateValidation": false,
+                      "multiple": false,
+                      "unique": false
+                    },
+                    "allowCalculateOverride": false,
+                    "encrypted": false,
+                    "showCharCount": false,
+                    "showWordCount": false,
+                    "allowMultipleMasks": false,
+                    "id": "enl6yp7"
                   }
                 ]
               }
@@ -8506,7 +10232,7 @@
           "tree": false,
           "header": [],
           "caption": "",
-          "id": "epfesea"
+          "id": "e4u9cps"
         }
       ],
       "collapsed": true,
@@ -8780,6 +10506,6 @@
   "name": "noticeofassessment",
   "path": "noticeofassessment",
   "created": "2021-07-14T17:56:22.162Z",
-  "modified": "2021-10-14T21:45:55.738Z",
+  "modified": "2021-12-01T08:20:51.413Z",
   "machineName": "noticeOfAssessment"
 }

--- a/sources/packages/web/src/services/ApplicationService.ts
+++ b/sources/packages/web/src/services/ApplicationService.ts
@@ -6,6 +6,7 @@ import {
   GetApplicationDataDto,
   GetApplicationBaseDTO,
   ApplicationSummaryDTO,
+  NoticeOfAssessmentDTO,
 } from "@/types";
 import { MORE_THAN_ONE_APPLICATION_DRAFT_ERROR } from "@/types/contracts/ApiProcessError";
 import ApiClient from "../services/http/ApiClient";
@@ -17,7 +18,7 @@ export class ApplicationService {
     return this.instance || (this.instance = new this());
   }
 
-  public async getNOA(applicationId: number): Promise<any> {
+  public async getNOA(applicationId: number): Promise<NoticeOfAssessmentDTO> {
     return ApiClient.Application.getNOA(applicationId);
   }
 

--- a/sources/packages/web/src/services/http/ApplicationApi.ts
+++ b/sources/packages/web/src/services/http/ApplicationApi.ts
@@ -5,6 +5,7 @@ import {
   GetApplicationDataDto,
   GetApplicationBaseDTO,
   ApplicationSummaryDTO,
+  NoticeOfAssessmentDTO,
 } from "@/types";
 import HttpBaseClient from "./common/HttpBaseClient";
 
@@ -25,7 +26,7 @@ export class ApplicationApi extends HttpBaseClient {
   /**
    * Retrieve the Notice of Assessment (NOA) for a particular application.
    */
-  public async getNOA(applicationId: number): Promise<any> {
+  public async getNOA(applicationId: number): Promise<NoticeOfAssessmentDTO> {
     try {
       const response = await this.apiClient.get(
         `application/${applicationId}/assessment`,

--- a/sources/packages/web/src/types/contracts/student/ApplicationContract.ts
+++ b/sources/packages/web/src/types/contracts/student/ApplicationContract.ts
@@ -139,3 +139,46 @@ export interface ApplicationSummaryDTO {
   award: string;
   status: string;
 }
+
+/**
+ * DTO for Notice of Assessment view
+ */
+export interface NoticeOfAssessmentDTO {
+  assessment: Assessment;
+  applicationNumber: string;
+  fullName: string;
+  programName: string;
+  locationName: string;
+  offeringStudyStartDate: string;
+  offeringStudyEndDate: string;
+  msfaaNumber: string;
+  disbursement: any;
+}
+
+/**
+ * DTO for assessment payload
+ */
+export interface Assessment {
+  weeks: number;
+  totalFederalAward: string;
+  totalProvincialAward: string;
+  federalAssessmentNeed: string;
+  provincialAssessmentNeed: string;
+  tuitionCost: string;
+  booksAndSuppliesCost: string;
+  exceptionalEducationCost: string;
+  livingAllowance: string;
+  transportationCost: string;
+  childcareCost: string;
+  alimonyOrChildSupport: string;
+  secondResidenceCost: string;
+  partnerStudentLoanCost: string;
+  totalAssessedCost: string;
+  studentTotalFederalContribution: string;
+  studentTotalProvincialContribution: string;
+  partnerAssessedContribution: string;
+  parentAssessedContribution: string;
+  totalFederalContribution: string;
+  totalProvincialContribution: string;
+  otherAllowableCost: string;
+}

--- a/sources/packages/web/src/types/contracts/student/ApplicationContract.ts
+++ b/sources/packages/web/src/types/contracts/student/ApplicationContract.ts
@@ -156,29 +156,35 @@ export interface NoticeOfAssessmentDTO {
 }
 
 /**
- * DTO for assessment payload
+ * DTO for assessment payload.
+ * This interface is to provide contract for the assessment payload
+ * which is stored to database by workflow.
+ * It is possible that more properties can be added to the assessment payload
+ * without updating this interface and displayed in NOA form.
+ * Whenever there is a source code update, please ensure that properties in this interface are in sync with
+ * assessment payload created by camunda workflow.
  */
 export interface Assessment {
   weeks: number;
-  totalFederalAward: string;
-  totalProvincialAward: string;
-  federalAssessmentNeed: string;
-  provincialAssessmentNeed: string;
-  tuitionCost: string;
-  booksAndSuppliesCost: string;
-  exceptionalEducationCost: string;
-  livingAllowance: string;
-  transportationCost: string;
-  childcareCost: string;
-  alimonyOrChildSupport: string;
-  secondResidenceCost: string;
-  partnerStudentLoanCost: string;
-  totalAssessedCost: string;
-  studentTotalFederalContribution: string;
-  studentTotalProvincialContribution: string;
-  partnerAssessedContribution: string;
-  parentAssessedContribution: string;
-  totalFederalContribution: string;
-  totalProvincialContribution: string;
-  otherAllowableCost: string;
+  totalFederalAward: number;
+  totalProvincialAward: number;
+  federalAssessmentNeed: number;
+  provincialAssessmentNeed: number;
+  tuitionCost: number;
+  booksAndSuppliesCost: number;
+  exceptionalEducationCost: number;
+  livingAllowance: number;
+  transportationCost: number;
+  childcareCost: number;
+  alimonyOrChildSupport: number;
+  secondResidenceCost: number;
+  partnerStudentLoanCost: number;
+  totalAssessedCost: number;
+  studentTotalFederalContribution: number;
+  studentTotalProvincialContribution: number;
+  partnerAssessedContribution: number;
+  parentAssessedContribution: number;
+  totalFederalContribution: number;
+  totalProvincialContribution: number;
+  otherAllowableCost: number;
 }


### PR DESCRIPTION
- [x] Based off the disbursement schedules populate NOA values
- [x]  show 'Not Eligible' awards
- [x] Map all the required variables for assessment from assessment.bpmn
- [x] Update assessment in application table with all required assessment values

- Application Query for NOA enhanced with disbursement and the disbursement data is converted to json with dynamic key(s).
- Dynamic keys are to make the data compatible with Award Breakdown in form. 
- The pattern of the dynamic key is disbursement{disbursement no i.e 1|2}{value code eg: csgd} -> disbursement1csgd.
- Camunda updated with all required inputs to for assessment payload. Also the all the amounts are rounded to 2 decimal places.