### PR TITLE
[Api][Web][SIMS #378] Update SFAS file integration#378

### DIFF
--- a/sources/packages/api/src-sql/SFASPartTimeApplications/Create-part-time-sfas-application-records.sql
+++ b/sources/packages/api/src-sql/SFASPartTimeApplications/Create-part-time-sfas-application-records.sql
@@ -1,0 +1,37 @@
+-- CREATE TABLE sfas_part_time_applications
+CREATE TABLE IF NOT EXISTS sims.sfas_part_time_applications (
+  id VARCHAR(10) PRIMARY KEY,
+  individual_id INT NOT NULL,
+  start_date DATE,
+  end_date DATE,
+  csgp_award NUMERIC(10),
+  sbsd_award NUMERIC(10),
+  -- Audit columns
+  created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+  updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+  extracted_at TIMESTAMP WITH TIME ZONE NOT NULL
+);
+
+CREATE INDEX sfas_part_time_applications_individual_id ON sims.sfas_part_time_applications(individual_id);
+
+-- ## Comments
+COMMENT ON TABLE sims.sfas_part_time_applications IS 'This record contain data related to an Student Application on SAIL(Part Time Application).';
+
+COMMENT ON COLUMN sims.sfas_part_time_applications.id IS 'The unique key/number used in SFAS to identify this application (Sail_extract_data.sail_application_no ).';
+
+COMMENT ON COLUMN sims.sfas_part_time_applications.individual_id IS 'The unique key/number used in SFAS to identify this individual (Sail_extract_data.individual_idx).';
+
+COMMENT ON COLUMN sims.sfas_part_time_applications.start_date IS 'Educational program start date (Sail_extract_data.educ_start_dte).';
+
+COMMENT ON COLUMN sims.sfas_part_time_applications.end_date IS 'Educational Program End date (Sail_extract_data.educ_end_dte).';
+
+COMMENT ON COLUMN sims.sfas_part_time_applications.csgp_award IS 'CSGP Award Amount (sail_extract_data.sail_csgp_award_amt).';
+
+COMMENT ON COLUMN sims.sfas_part_time_applications.sbsd_award IS 'SBSD Award Amount (sail_extract_data.sail_bcsl_sbsd_award_amt ).';
+
+-- Audit columns
+COMMENT ON COLUMN sims.sfas_part_time_applications.created_at IS 'Record creation timestamp.';
+
+COMMENT ON COLUMN sims.sfas_part_time_applications.updated_at IS 'Record update timestamp.';
+
+COMMENT ON COLUMN sims.sfas_part_time_applications.extracted_at IS 'Date that the record was extracted from SFAS.';

--- a/sources/packages/api/src-sql/SFASPartTimeApplications/Drop-part-time-sfas-application-records.sql
+++ b/sources/packages/api/src-sql/SFASPartTimeApplications/Drop-part-time-sfas-application-records.sql
@@ -1,0 +1,2 @@
+-- DROP TABLE sfas_part_time_applications
+DROP TABLE IF EXISTS sims.sfas_part_time_applications;

--- a/sources/packages/api/src/database/constant.ts
+++ b/sources/packages/api/src/database/constant.ts
@@ -37,4 +37,5 @@ export const TableNames = {
   StudentNotes: "student_notes",
   InstitutionNotes: "institution_notes",
   InstitutionRestrictions: "institution_restrictions",
+  SFASPartTimeApplications: "sfas_part_time_applications",
 };

--- a/sources/packages/api/src/database/entities/index.ts
+++ b/sources/packages/api/src/database/entities/index.ts
@@ -42,3 +42,4 @@ export * from "./relationship-status.type";
 export * from "./note.model";
 export * from "./note.type";
 export * from "./institution-restriction.model";
+export * from "./sfas-part-time-application.model";

--- a/sources/packages/api/src/database/entities/sfas-application.model.ts
+++ b/sources/packages/api/src/database/entities/sfas-application.model.ts
@@ -55,7 +55,7 @@ export class SFASApplication extends BaseModel {
    */
   @Column({
     name: "bsl_award",
-    nullable: false,
+    nullable: true,
   })
   bslAward: number;
   /**
@@ -63,7 +63,7 @@ export class SFASApplication extends BaseModel {
    */
   @Column({
     name: "csl_award",
-    nullable: false,
+    nullable: true,
   })
   cslAward: number;
   /**
@@ -71,7 +71,7 @@ export class SFASApplication extends BaseModel {
    */
   @Column({
     name: "bcag_award",
-    nullable: false,
+    nullable: true,
   })
   bcagAward: number;
   /**
@@ -79,7 +79,7 @@ export class SFASApplication extends BaseModel {
    */
   @Column({
     name: "bgpd_award",
-    nullable: false,
+    nullable: true,
   })
   bgpdAward: number;
   /**
@@ -87,7 +87,7 @@ export class SFASApplication extends BaseModel {
    */
   @Column({
     name: "csfg_award",
-    nullable: false,
+    nullable: true,
   })
   csfgAward: number;
   /**
@@ -95,7 +95,7 @@ export class SFASApplication extends BaseModel {
    */
   @Column({
     name: "csgt_award",
-    nullable: false,
+    nullable: true,
   })
   csgtAward: number;
   /**
@@ -103,7 +103,7 @@ export class SFASApplication extends BaseModel {
    */
   @Column({
     name: "csgd_award",
-    nullable: false,
+    nullable: true,
   })
   csgdAward: number;
   /**
@@ -111,7 +111,7 @@ export class SFASApplication extends BaseModel {
    */
   @Column({
     name: "csgp_award",
-    nullable: false,
+    nullable: true,
   })
   csgpAward: number;
   /**
@@ -119,7 +119,7 @@ export class SFASApplication extends BaseModel {
    */
   @Column({
     name: "sbsd_award",
-    nullable: false,
+    nullable: true,
   })
   sbsdAward: number;
   /**
@@ -137,6 +137,7 @@ export class SFASApplication extends BaseModel {
    */
   @Column({
     name: "extracted_at",
+    type: "timestamptz",
     nullable: false,
   })
   extractedAt: Date;

--- a/sources/packages/api/src/database/entities/sfas-part-time-application.model.ts
+++ b/sources/packages/api/src/database/entities/sfas-part-time-application.model.ts
@@ -4,7 +4,7 @@ import { TableNames } from "../constant";
 import { dateOnlyTransformer } from "../transformers/date-only.transformer";
 
 /**
- * Data related to a Student Application on SFAS Part Time.
+ * Data related to a Part Time Student Application on SFAS that came from SAIL
  */
 @Entity({ name: TableNames.SFASPartTimeApplications })
 export class SFASPartTimeApplications extends BaseModel {
@@ -46,7 +46,7 @@ export class SFASPartTimeApplications extends BaseModel {
    */
   @Column({
     name: "csgp_award",
-    nullable: false,
+    nullable: true,
   })
   CSGPAward: number;
   /**
@@ -54,7 +54,7 @@ export class SFASPartTimeApplications extends BaseModel {
    */
   @Column({
     name: "sbsd_award",
-    nullable: false,
+    nullable: true,
   })
   SBSDAward: number;
   /**
@@ -62,6 +62,7 @@ export class SFASPartTimeApplications extends BaseModel {
    */
   @Column({
     name: "extracted_at",
+    type: "timestamptz",
     nullable: false,
   })
   extractedAt: Date;

--- a/sources/packages/api/src/database/entities/sfas-part-time-application.model.ts
+++ b/sources/packages/api/src/database/entities/sfas-part-time-application.model.ts
@@ -1,0 +1,68 @@
+import { Column, Entity, PrimaryColumn } from "typeorm";
+import { BaseModel } from ".";
+import { TableNames } from "../constant";
+import { dateOnlyTransformer } from "../transformers/date-only.transformer";
+
+/**
+ * Data related to a Student Application on SFAS Part Time.
+ */
+@Entity({ name: TableNames.SFASPartTimeApplications })
+export class SFASPartTimeApplications extends BaseModel {
+  /**
+   * The unique key/number used in SFAS to identify this application (Sail_extract_data.sail_application_no).
+   */
+  @PrimaryColumn()
+  id: string;
+  /**
+   * The unique key/number used in SFAS to identify this individual (Sail_extract_data.individual_idx).
+   */
+  @Column({
+    name: "individual_id",
+    nullable: false,
+  })
+  individualId: number;
+  /**
+   * Educational program start date (Sail_extract_data.educ_start_dte).
+   */
+  @Column({
+    name: "start_date",
+    type: "date",
+    nullable: true,
+    transformer: dateOnlyTransformer,
+  })
+  startDate?: Date;
+  /**
+   * Educational Program End date (Sail_extract_data.educ_end_dte).
+   */
+  @Column({
+    name: "end_date",
+    type: "date",
+    nullable: true,
+    transformer: dateOnlyTransformer,
+  })
+  endDate?: Date;
+  /**
+   * CSGP Award Amount (sail_extract_data.sail_csgp_award_amt).
+   */
+  @Column({
+    name: "csgp_award",
+    nullable: false,
+  })
+  CSGPAward: number;
+  /**
+   * SBSD Award Amount (sail_extract_data.sail_bcsl_sbsd_award_amt ).
+   */
+  @Column({
+    name: "sbsd_award",
+    nullable: false,
+  })
+  SBSDAward: number;
+  /**
+   * Date that the record was extracted from SFAS.
+   */
+  @Column({
+    name: "extracted_at",
+    nullable: false,
+  })
+  extractedAt: Date;
+}

--- a/sources/packages/api/src/database/migrations/1642195310361-CreatePartTimeSAILApplicationRecords.ts
+++ b/sources/packages/api/src/database/migrations/1642195310361-CreatePartTimeSAILApplicationRecords.ts
@@ -1,0 +1,24 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+import { getSQLFileData } from "../../utilities";
+
+export class CreatePartTimeSAILApplicationRecords1642195310361
+  implements MigrationInterface
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      getSQLFileData(
+        "Create-part-time-sfas-application-records.sql",
+        "SFASPartTimeApplications",
+      ),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      getSQLFileData(
+        "Drop-part-time-sfas-application-records.sql",
+        "SFASPartTimeApplications",
+      ),
+    );
+  }
+}

--- a/sources/packages/api/src/services/index.ts
+++ b/sources/packages/api/src/services/index.ts
@@ -39,3 +39,4 @@ export * from "./sfas/sfas-restriction.service";
 export * from "./disbursement-schedule-service/disbursement-schedule-service";
 export * from "./disbursement-schedule-errors/disbursement-schedule-errors.service";
 export * from "./restriction/institution-restriction.service";
+export * from "./sfas/sfas-part-time-application.service"

--- a/sources/packages/api/src/services/sfas/sfas-part-time-application.service.ts
+++ b/sources/packages/api/src/services/sfas/sfas-part-time-application.service.ts
@@ -1,0 +1,47 @@
+import { Inject, Injectable } from "@nestjs/common";
+import { Connection } from "typeorm";
+import { DataModelService } from "../../database/data.model.service";
+import { SFASPartTimeApplications } from "../../database/entities";
+import { InjectLogger } from "../../common";
+import { LoggerService } from "../../logger/logger.service";
+import { getUTC } from "../../utilities";
+import { SFASDataImporter } from "./sfas-data-importer";
+import { SFASRecordIdentification } from "../../sfas-integration/sfas-files/sfas-record-identification";
+import { SFASPartTimeApplicationRecord } from "../../sfas-integration/sfas-files/sfas-part-time-application-record";
+
+/**
+ * Manages the part time application data related to an individual/student in SFAS.
+ */
+@Injectable()
+export class SFASPartTimeApplicationsService
+  extends DataModelService<SFASPartTimeApplications>
+  implements SFASDataImporter
+{
+  constructor(@Inject("Connection") connection: Connection) {
+    super(connection.getRepository(SFASPartTimeApplications));
+  }
+
+  /**
+   * Import a record from SFAS. This method will be invoked by SFAS
+   * import processing service when the record type is detected as
+   * RecordTypeCodes.ApplicationDataRecord.
+   */
+  async importSFASRecord(
+    record: SFASRecordIdentification,
+    extractedDate: Date,
+  ): Promise<void> {
+    const sfasApplication = new SFASPartTimeApplicationRecord(record.line);
+    const application = new SFASPartTimeApplications();
+    application.individualId = sfasApplication.individualId;
+    application.id = sfasApplication.applicationId;
+    application.startDate = sfasApplication.startDate;
+    application.endDate = sfasApplication.endDate;
+    application.CSGPAward = sfasApplication.CSGPAward;
+    application.SBSDAward = sfasApplication.SBSDAward;
+    application.extractedAt = getUTC(extractedDate);
+    await this.repo.save(application, { reload: false, transaction: false });
+  }
+
+  @InjectLogger()
+  logger: LoggerService;
+}

--- a/sources/packages/api/src/services/sfas/sfas-part-time-application.service.ts
+++ b/sources/packages/api/src/services/sfas/sfas-part-time-application.service.ts
@@ -24,7 +24,11 @@ export class SFASPartTimeApplicationsService
   /**
    * Import a record from SFAS. This method will be invoked by SFAS
    * import processing service when the record type is detected as
-   * RecordTypeCodes.ApplicationDataRecord.
+   * RecordTypeCodes.PartTimeApplicationDataRecord.
+   * ! when this scenarios was tested with test data, it was
+   * ! having application id duplication with different
+   * ! individual id, which will not happen in production
+   * ! as confirmed from client.
    */
   async importSFASRecord(
     record: SFASRecordIdentification,

--- a/sources/packages/api/src/sfas-integration/sfas-files/sfas-application-record.ts
+++ b/sources/packages/api/src/sfas-integration/sfas-files/sfas-application-record.ts
@@ -42,7 +42,7 @@ export class SFASApplicationRecord extends SFASRecordIdentification {
   /**
    * Total BC Student Loan (award_disbursement.disbursement_amt).
    */
-  get bslAward(): number {
+  get bslAward(): number | null {
     return this.line.substring(47, 47 + 10).trim()
       ? parseDecimal(this.line.substring(47, 47 + 10))
       : null;
@@ -50,7 +50,7 @@ export class SFASApplicationRecord extends SFASRecordIdentification {
   /**
    * Total CSL Student Loan (award_disbursement.disbursement_amt).
    */
-  get cslAward(): number {
+  get cslAward(): number | null {
     return this.line.substring(57, 57 + 10).trim()
       ? parseDecimal(this.line.substring(57, 57 + 10))
       : null;
@@ -58,7 +58,7 @@ export class SFASApplicationRecord extends SFASRecordIdentification {
   /**
    * Total BC Access Grant award_disbursement.disbursement_amt.
    */
-  get bcagAward(): number {
+  get bcagAward(): number | null {
     return this.line.substring(67, 67 + 10).trim()
       ? parseDecimal(this.line.substring(67, 67 + 10))
       : null;
@@ -66,7 +66,7 @@ export class SFASApplicationRecord extends SFASRecordIdentification {
   /**
    * Total British Columbia Permanent Disability Grant (award_disbursement.disbursement_amt).
    */
-  get bgpdAward(): number {
+  get bgpdAward(): number | null {
     return this.line.substring(77, 77 + 10).trim()
       ? parseDecimal(this.line.substring(77, 77 + 10))
       : null;
@@ -74,7 +74,7 @@ export class SFASApplicationRecord extends SFASRecordIdentification {
   /**
    * Total Canada Student Grant for Students in Full Time Studies (award_disbursement.disbursement_amt).
    */
-  get csfgAward(): number {
+  get csfgAward(): number | null {
     return this.line.substring(87, 87 + 10).trim()
       ? parseDecimal(this.line.substring(87, 87 + 10))
       : null;
@@ -82,7 +82,7 @@ export class SFASApplicationRecord extends SFASRecordIdentification {
   /**
    * Total Canada Student Top-Up Grant for Adult Learners (award_disbursement.disbursement_amt).
    */
-  get csgtAward(): number {
+  get csgtAward(): number | null {
     return this.line.substring(97, 97 + 10).trim()
       ? parseDecimal(this.line.substring(97, 97 + 10))
       : null;
@@ -90,7 +90,7 @@ export class SFASApplicationRecord extends SFASRecordIdentification {
   /**
    * Total Canada Grant – Full-Time with Dependent (award_disbursement.disbursement_amt).
    */
-  get csgdAward(): number {
+  get csgdAward(): number | null {
     return this.line.substring(107, 107 + 10).trim()
       ? parseDecimal(this.line.substring(107, 107 + 10))
       : null;
@@ -98,7 +98,7 @@ export class SFASApplicationRecord extends SFASRecordIdentification {
   /**
    * Total Canada Student Grant for Students with Permanent Disabilities (award_disbursement.disbursement_amt).
    */
-  get csgpAward(): number {
+  get csgpAward(): number | null {
     return this.line.substring(117, 117 + 10).trim()
       ? parseDecimal(this.line.substring(117, 117 + 10))
       : null;
@@ -106,7 +106,7 @@ export class SFASApplicationRecord extends SFASRecordIdentification {
   /**
    * Total Supplemental Bursary for Students with Disabilities (award_disbursement.disbursement_amt).
    */
-  get sbsdAward(): number {
+  get sbsdAward(): number | null {
     return this.line.substring(127, 127 + 10).trim()
       ? parseDecimal(this.line.substring(127, 127 + 10))
       : null;

--- a/sources/packages/api/src/sfas-integration/sfas-files/sfas-application-record.ts
+++ b/sources/packages/api/src/sfas-integration/sfas-files/sfas-application-record.ts
@@ -12,91 +12,109 @@ export class SFASApplicationRecord extends SFASRecordIdentification {
    * The unique key/number used in SFAS to identify this individual (individual.individual_idx).
    */
   get individualId(): number {
-    return +this.line.substr(3, 10);
+    return +this.line.substring(3, 3 + 10);
   }
   /**
    * The unique key/number used in SFAS to identify this application (application.application_idx).
    */
   get applicationId(): number {
-    return +this.line.substr(13, 10);
+    return +this.line.substring(13, 13 + 10);
   }
   /**
    * Educational program start date (application_assessment.educ_period_start_dte).
    */
   get startDate(): Date | null {
-    return parseDate(this.line.substr(23, 8));
+    return parseDate(this.line.substring(23, 23 + 8));
   }
   /**
    * Educational Program End date (application_assessment.educ_period_end_dte).
    */
   get endDate(): Date | null {
-    return parseDate(this.line.substr(31, 8));
+    return parseDate(this.line.substring(31, 31 + 8));
   }
   /**
    * Program year (Application.program_yr_id).
    * Example: 20202021.
    */
   get programYearId(): number | null {
-    return +this.line.substr(39, 8) || null;
+    return +this.line.substring(39, 39 + 8) || null;
   }
   /**
    * Total BC Student Loan (award_disbursement.disbursement_amt).
    */
   get bslAward(): number {
-    return parseDecimal(this.line.substr(47, 10));
+    return this.line.substring(47, 47 + 10).trim()
+      ? parseDecimal(this.line.substring(47, 47 + 10))
+      : null;
   }
   /**
    * Total CSL Student Loan (award_disbursement.disbursement_amt).
    */
   get cslAward(): number {
-    return parseDecimal(this.line.substr(57, 10));
+    return this.line.substring(57, 57 + 10).trim()
+      ? parseDecimal(this.line.substring(57, 57 + 10))
+      : null;
   }
   /**
    * Total BC Access Grant award_disbursement.disbursement_amt.
    */
   get bcagAward(): number {
-    return parseDecimal(this.line.substr(67, 10));
+    return this.line.substring(67, 67 + 10).trim()
+      ? parseDecimal(this.line.substring(67, 67 + 10))
+      : null;
   }
   /**
    * Total British Columbia Permanent Disability Grant (award_disbursement.disbursement_amt).
    */
   get bgpdAward(): number {
-    return parseDecimal(this.line.substr(77, 10));
+    return this.line.substring(77, 77 + 10).trim()
+      ? parseDecimal(this.line.substring(77, 77 + 10))
+      : null;
   }
   /**
    * Total Canada Student Grant for Students in Full Time Studies (award_disbursement.disbursement_amt).
    */
   get csfgAward(): number {
-    return parseDecimal(this.line.substr(87, 10));
+    return this.line.substring(87, 87 + 10).trim()
+      ? parseDecimal(this.line.substring(87, 87 + 10))
+      : null;
   }
   /**
    * Total Canada Student Top-Up Grant for Adult Learners (award_disbursement.disbursement_amt).
    */
   get csgtAward(): number {
-    return parseDecimal(this.line.substr(97, 10));
+    return this.line.substring(97, 97 + 10).trim()
+      ? parseDecimal(this.line.substring(97, 97 + 10))
+      : null;
   }
   /**
    * Total Canada Grant – Full-Time with Dependent (award_disbursement.disbursement_amt).
    */
   get csgdAward(): number {
-    return parseDecimal(this.line.substr(107, 10));
+    return this.line.substring(107, 107 + 10).trim()
+      ? parseDecimal(this.line.substring(107, 107 + 10))
+      : null;
   }
   /**
    * Total Canada Student Grant for Students with Permanent Disabilities (award_disbursement.disbursement_amt).
    */
   get csgpAward(): number {
-    return parseDecimal(this.line.substr(117, 10));
+    return this.line.substring(117, 117 + 10).trim()
+      ? parseDecimal(this.line.substring(117, 117 + 10))
+      : null;
   }
   /**
    * Total Supplemental Bursary for Students with Disabilities (award_disbursement.disbursement_amt).
    */
   get sbsdAward(): number {
-    return parseDecimal(this.line.substr(127, 10));
+    return this.line.substring(127, 127 + 10).trim()
+      ? parseDecimal(this.line.substring(127, 127 + 10))
+      : null;
   }
   /**
    * Date that this application was cancelled (application.cancel_dte).
    */
   get applicationCancelDate(): Date | null {
-    return parseDate(this.line.substr(137, 8));
+    return parseDate(this.line.substring(137, 137 + 8));
   }
 }

--- a/sources/packages/api/src/sfas-integration/sfas-files/sfas-part-time-application-record.ts
+++ b/sources/packages/api/src/sfas-integration/sfas-files/sfas-part-time-application-record.ts
@@ -1,0 +1,47 @@
+import { parseDate } from "./sfas-parse-utils";
+import { SFASRecordIdentification } from "./sfas-record-identification";
+
+/**
+ * This record contain data related to an Student part time Application on SFAS.
+ */
+export class SFASPartTimeApplicationRecord extends SFASRecordIdentification {
+  constructor(line: string) {
+    super(line);
+  }
+  /**
+   * The unique key/number used in SFAS to identify this individual (Sail_extract_data.individual_idx).
+   */
+  get individualId(): number {
+    return +this.line.substring(3, 3 + 10);
+  }
+  /**
+   * The unique key/number used in SFAS to identify this application (Sail_extract_data.sail_application_no).
+   */
+  get applicationId(): string {
+    return this.line.substring(13, 13 + 10);
+  }
+  /**
+   * Educational program start date (Sail_extract_data.educ_start_dte).
+   */
+  get startDate(): Date | null {
+    return parseDate(this.line.substring(23, 23 + 8));
+  }
+  /**
+   * Educational Program End date (Sail_extract_data.educ_end_dte).
+   */
+  get endDate(): Date | null {
+    return parseDate(this.line.substring(31, 31 + 8));
+  }
+  /**
+   * CSGP Award Amount (sail_extract_data.sail_csgp_award_amt).
+   */
+  get CSGPAward(): number {
+    return +this.line.substring(39, 39 + 10);
+  }
+  /**
+   * SBSD Award Amount (sail_extract_data.sail_bcsl_sbsd_award_amt ).
+   */
+  get SBSDAward(): number {
+    return +this.line.substring(49, 49 + 10);
+  }
+}

--- a/sources/packages/api/src/sfas-integration/sfas-files/sfas-part-time-application-record.ts
+++ b/sources/packages/api/src/sfas-integration/sfas-files/sfas-part-time-application-record.ts
@@ -35,13 +35,17 @@ export class SFASPartTimeApplicationRecord extends SFASRecordIdentification {
   /**
    * CSGP Award Amount (sail_extract_data.sail_csgp_award_amt).
    */
-  get CSGPAward(): number {
-    return +this.line.substring(39, 39 + 10);
+  get CSGPAward(): number | null {
+    return this.line.substring(39, 39 + 10).trim()
+      ? +this.line.substring(39, 39 + 10).trim()
+      : null;
   }
   /**
    * SBSD Award Amount (sail_extract_data.sail_bcsl_sbsd_award_amt ).
    */
-  get SBSDAward(): number {
-    return +this.line.substring(49, 49 + 10);
+  get SBSDAward(): number | null {
+    return this.line.substring(49, 49 + 10).trim()
+      ? +this.line.substring(49, 49 + 10).trim()
+      : null;
   }
 }

--- a/sources/packages/api/src/sfas-integration/sfas-integration-processing.service.ts
+++ b/sources/packages/api/src/sfas-integration/sfas-integration-processing.service.ts
@@ -13,6 +13,7 @@ import {
   SFASDataImporter,
   SFASIndividualService,
   SFASRestrictionService,
+  SFASPartTimeApplicationsService,
 } from "../services";
 import { SFAS_IMPORT_RECORDS_PROGRESS_REPORT_PACE } from "../utilities";
 import * as os from "os";
@@ -25,6 +26,7 @@ export class SFASIntegrationProcessingService {
     private readonly sfasIndividualService: SFASIndividualService,
     private readonly sfasApplicationService: SFASApplicationService,
     private readonly sfasRestrictionService: SFASRestrictionService,
+    private readonly sfasPartTimeApplicationsService: SFASPartTimeApplicationsService,
     config: ConfigService,
   ) {
     this.ftpReceiveFolder =
@@ -182,6 +184,9 @@ export class SFASIntegrationProcessingService {
         break;
       case RecordTypeCodes.RestrictionDataRecord:
         dataImporter = this.sfasRestrictionService;
+        break;
+      case RecordTypeCodes.PartTimeApplicationDataRecord:
+        dataImporter = this.sfasPartTimeApplicationsService;
         break;
     }
     return dataImporter;

--- a/sources/packages/api/src/sfas-integration/sfas-integration.models.ts
+++ b/sources/packages/api/src/sfas-integration/sfas-integration.models.ts
@@ -5,6 +5,7 @@ export enum RecordTypeCodes {
   Header = "100",
   IndividualDataRecord = "200",
   ApplicationDataRecord = "300",
+  PartTimeApplicationDataRecord = "301",
   RestrictionDataRecord = "400",
 }
 

--- a/sources/packages/api/src/sfas-integration/sfas-integration.module.ts
+++ b/sources/packages/api/src/sfas-integration/sfas-integration.module.ts
@@ -6,6 +6,7 @@ import {
   SFASIndividualService,
   SFASApplicationService,
   SFASRestrictionService,
+  SFASPartTimeApplicationsService,
 } from "../services";
 import { SFASIntegrationProcessingService } from "./sfas-integration-processing.service";
 import { SFASIntegrationService } from "./sfas-integration.service";
@@ -20,6 +21,7 @@ import { SFASIntegrationService } from "./sfas-integration.service";
     SFASIndividualService,
     SFASApplicationService,
     SFASRestrictionService,
+    SFASPartTimeApplicationsService,
   ],
   exports: [
     SFASIntegrationService,
@@ -27,6 +29,7 @@ import { SFASIntegrationService } from "./sfas-integration.service";
     SFASIndividualService,
     SFASApplicationService,
     SFASRestrictionService,
+    SFASPartTimeApplicationsService,
   ],
 })
 export class SFASIntegrationModule {}


### PR DESCRIPTION
-  Created table and insert records for SAIL APPLICATION DATA RECORDS
-  since  `substr` is deprecated i have used `substring`
![image](https://user-images.githubusercontent.com/77353155/150028576-911dbafa-db62-4037-9370-3ccabcbed3e5.png)
- primary id is varchar because we are saving the application id coming from the file as the primary key and in part-time case its like `2019P40086`