### PR TITLE
Fix watch for reactive data

### DIFF
--- a/sources/packages/web/src/components/generic/formio.vue
+++ b/sources/packages/web/src/components/generic/formio.vue
@@ -113,6 +113,7 @@ export default {
       () => {
         updateFormSubmissionData();
       },
+      { deep: true },
     );
 
     watch(


### PR DESCRIPTION
Fixed a cache issue when the form.io was not refreshing after the data was updated in a reactive object.
The issue was not noticed while in development because the form.io definition cache was disabled, forcing the request of the form every time and allowing the API data to be retrieve first.

"watch is shallow by default: the callback will only trigger when the watched property has been assigned a new value - it won't trigger on nested property changes. If you want the callback to fire on all nested mutations, you need to use a deep watcher."
Source: https://vuejs.org/guide/essentials/watchers.html#deep-watchers