### PR TITLE
Date formatting using getISODateOnlyString  for disbursement list.

### DIFF
--- a/sources/packages/api/src/route-controllers/application/models/application.model.ts
+++ b/sources/packages/api/src/route-controllers/application/models/application.model.ts
@@ -168,7 +168,7 @@ export interface COESummaryDTO {
   coeStatus: COEStatus;
   fullName: string;
   disbursementScheduleId: number;
-  disbursementDate: Date;
+  disbursementDate: string;
 }
 
 export interface ProgramYearOfApplicationDto {

--- a/sources/packages/api/src/route-controllers/confirmation-of-enrollment/confirmation-of-enrollment.controller.ts
+++ b/sources/packages/api/src/route-controllers/confirmation-of-enrollment/confirmation-of-enrollment.controller.ts
@@ -43,6 +43,7 @@ import {
   DEFAULT_PAGE_LIMIT,
   FieldSortOrder,
   PaginatedResults,
+  getISODateOnlyString,
 } from "../../utilities";
 import {
   ApplicationDetailsForCOEDTO,
@@ -120,7 +121,9 @@ export class ConfirmationOfEnrollmentController {
             coeStatus: disbursement.coeStatus,
             fullName: getUserFullName(disbursement.application.student.user),
             disbursementScheduleId: disbursement.id,
-            disbursementDate: disbursement.disbursementDate,
+            disbursementDate: getISODateOnlyString(
+              disbursement.disbursementDate,
+            ),
           };
         },
       ) as COESummaryDTO[],


### PR DESCRIPTION
API Call to COE Summary using getISODateOnlyString  for disbursement date to ignore timestamp and timezone getting appended.