### PR TITLE
[SIMS-#900][Forms]Relationship-status rename

### DIFF
--- a/sources/packages/forms/src/form-definitions/sfaa2021-22.json
+++ b/sources/packages/forms/src/form-definitions/sfaa2021-22.json
@@ -139,7 +139,8 @@
                                                     "showCharCount": false,
                                                     "showWordCount": false,
                                                     "allowMultipleMasks": false,
-                                                    "id": "e3nqat"
+                                                    "id": "e3nqat",
+                                                    "addons": []
                                                 },
                                                 {
                                                     "label": "HTML",
@@ -219,14 +220,16 @@
                                                     "showCharCount": false,
                                                     "showWordCount": false,
                                                     "allowMultipleMasks": false,
-                                                    "id": "ef68phe"
+                                                    "id": "ef68phe",
+                                                    "addons": []
                                                 }
                                             ],
                                             "offset": 0,
                                             "push": 0,
                                             "pull": 0,
                                             "size": "md",
-                                            "width": 6
+                                            "width": 6,
+                                            "currentWidth": 6
                                         },
                                         {
                                             "components": [
@@ -301,14 +304,16 @@
                                                     "properties": {},
                                                     "allowMultipleMasks": false,
                                                     "content": "",
-                                                    "id": "e7p34h"
+                                                    "id": "e7p34h",
+                                                    "addons": []
                                                 }
                                             ],
                                             "offset": 0,
                                             "push": 0,
                                             "pull": 0,
                                             "size": "md",
-                                            "width": 6
+                                            "width": 6,
+                                            "currentWidth": 6
                                         }
                                     ],
                                     "hideLabel": true,
@@ -374,14 +379,17 @@
                                     "allowMultipleMasks": false,
                                     "tree": false,
                                     "autoAdjust": false,
-                                    "id": "ego57u"
+                                    "id": "ego57u",
+                                    "addons": [],
+                                    "lazyLoad": false
                                 }
                             ],
                             "width": 12,
                             "offset": 0,
                             "push": 0,
                             "pull": 0,
-                            "size": "md"
+                            "size": "md",
+                            "currentWidth": 12
                         },
                         {
                             "components": [],
@@ -389,7 +397,8 @@
                             "offset": 0,
                             "push": 0,
                             "pull": 0,
-                            "size": "md"
+                            "size": "md",
+                            "currentWidth": 6
                         }
                     ],
                     "type": "columns",
@@ -452,7 +461,9 @@
                     "tree": false,
                     "autoAdjust": false,
                     "hideOnChildrenHidden": false,
-                    "id": "evh64v3"
+                    "id": "evh64v3",
+                    "addons": [],
+                    "lazyLoad": false
                 },
                 {
                     "label": "applicationId",
@@ -519,7 +530,8 @@
                     "properties": {},
                     "allowMultipleMasks": false,
                     "inputType": "hidden",
-                    "id": "elknlor"
+                    "id": "elknlor",
+                    "addons": []
                 },
                 {
                     "label": "workflowName",
@@ -586,7 +598,8 @@
                     "properties": {},
                     "allowMultipleMasks": false,
                     "inputType": "hidden",
-                    "id": "ebsh4es"
+                    "id": "ebsh4es",
+                    "addons": []
                 }
             ],
             "input": false,
@@ -627,7 +640,9 @@
             "showWordCount": false,
             "allowMultipleMasks": false,
             "tree": false,
-            "id": "eyx5cz"
+            "id": "eyx5cz",
+            "addons": [],
+            "lazyLoad": false
         },
         {
             "title": "Program",
@@ -749,7 +764,8 @@
                     "showCharCount": false,
                     "showWordCount": false,
                     "allowMultipleMasks": false,
-                    "id": "exz6y1"
+                    "id": "exz6y1",
+                    "addons": []
                 },
                 {
                     "label": "HTML",
@@ -828,7 +844,8 @@
                     "showCharCount": false,
                     "showWordCount": false,
                     "allowMultipleMasks": false,
-                    "id": "e5gyojf"
+                    "id": "e5gyojf",
+                    "addons": []
                 },
                 {
                     "label": "HTML",
@@ -907,7 +924,8 @@
                     "showCharCount": false,
                     "showWordCount": false,
                     "allowMultipleMasks": false,
-                    "id": "erdyicdr"
+                    "id": "erdyicdr",
+                    "addons": []
                 },
                 {
                     "label": "HTML",
@@ -986,7 +1004,8 @@
                     "showCharCount": false,
                     "showWordCount": false,
                     "allowMultipleMasks": false,
-                    "id": "egxu9ol"
+                    "id": "egxu9ol",
+                    "addons": []
                 },
                 {
                     "label": "The school I will be attending",
@@ -1100,7 +1119,9 @@
                         "threshold": 0.3
                     },
                     "id": "ef6vu8sg",
-                    "defaultValue": ""
+                    "defaultValue": "",
+                    "addons": [],
+                    "searchDebounce": 0.3
                 },
                 {
                     "label": "My school isn't listed",
@@ -1175,7 +1196,8 @@
                     "showCharCount": false,
                     "showWordCount": false,
                     "allowMultipleMasks": false,
-                    "id": "eydaew"
+                    "id": "eydaew",
+                    "addons": []
                 },
                 {
                     "label": "HTML",
@@ -1254,7 +1276,8 @@
                     "showCharCount": false,
                     "showWordCount": false,
                     "allowMultipleMasks": false,
-                    "id": "e4c1ao"
+                    "id": "e4c1ao",
+                    "addons": []
                 },
                 {
                     "label": "HTML",
@@ -1333,7 +1356,8 @@
                     "showCharCount": false,
                     "showWordCount": false,
                     "allowMultipleMasks": false,
-                    "id": "e4c39nw"
+                    "id": "e4c39nw",
+                    "addons": []
                 },
                 {
                     "label": "How will you be attending the program",
@@ -1412,7 +1436,8 @@
                     "showCharCount": false,
                     "showWordCount": false,
                     "allowMultipleMasks": false,
-                    "id": "e2avb6r"
+                    "id": "e2avb6r",
+                    "addons": []
                 },
                 {
                     "label": "HTML",
@@ -1491,7 +1516,8 @@
                     "showCharCount": false,
                     "showWordCount": false,
                     "allowMultipleMasks": false,
-                    "id": "e4vwl6"
+                    "id": "e4vwl6",
+                    "addons": []
                 },
                 {
                     "label": "How will you be attending the program",
@@ -1608,7 +1634,9 @@
                         "threshold": 0.3
                     },
                     "id": "el8m1c",
-                    "defaultValue": ""
+                    "defaultValue": "",
+                    "addons": [],
+                    "searchDebounce": 0.3
                 },
                 {
                     "label": "HTML",
@@ -1687,7 +1715,8 @@
                     "showCharCount": false,
                     "showWordCount": false,
                     "allowMultipleMasks": false,
-                    "id": "e1zogo"
+                    "id": "e1zogo",
+                    "addons": []
                 },
                 {
                     "label": "The program I will be attending:",
@@ -1803,7 +1832,9 @@
                         "threshold": 0.3
                     },
                     "id": "ehmxwzx",
-                    "defaultValue": ""
+                    "defaultValue": "",
+                    "addons": [],
+                    "searchDebounce": 0.3
                 },
                 {
                     "label": "My program is not listed",
@@ -1891,7 +1922,8 @@
                     "showWordCount": false,
                     "allowMultipleMasks": false,
                     "fieldSet": false,
-                    "id": "ewojohn"
+                    "id": "ewojohn",
+                    "addons": []
                 },
                 {
                     "label": "selectedProgramDesc",
@@ -1961,7 +1993,8 @@
                     "showWordCount": false,
                     "allowMultipleMasks": false,
                     "inputType": "hidden",
-                    "id": "ee3p2mc"
+                    "id": "ee3p2mc",
+                    "addons": []
                 },
                 {
                     "title": "programDesc",
@@ -2080,7 +2113,8 @@
                             "properties": {},
                             "allowMultipleMasks": false,
                             "tag": "p",
-                            "id": "erk6bs"
+                            "id": "erk6bs",
+                            "addons": []
                         },
                         {
                             "label": "HTML",
@@ -2154,7 +2188,8 @@
                             "properties": {},
                             "allowMultipleMasks": false,
                             "tag": "p",
-                            "id": "ebiw6ol"
+                            "id": "ebiw6ol",
+                            "addons": []
                         },
                         {
                             "label": "Columns",
@@ -2233,14 +2268,16 @@
                                             "properties": {},
                                             "allowMultipleMasks": false,
                                             "tag": "p",
-                                            "id": "e30454"
+                                            "id": "e30454",
+                                            "addons": []
                                         }
                                     ],
                                     "width": 6,
                                     "offset": 0,
                                     "push": 0,
                                     "pull": 0,
-                                    "size": "md"
+                                    "size": "md",
+                                    "currentWidth": 6
                                 },
                                 {
                                     "components": [
@@ -2316,14 +2353,16 @@
                                             "properties": {},
                                             "allowMultipleMasks": false,
                                             "tag": "p",
-                                            "id": "ezr7ntp"
+                                            "id": "ezr7ntp",
+                                            "addons": []
                                         }
                                     ],
                                     "width": 6,
                                     "offset": 0,
                                     "push": 0,
                                     "pull": 0,
-                                    "size": "md"
+                                    "size": "md",
+                                    "currentWidth": 6
                                 }
                             ],
                             "key": "columns4",
@@ -2389,7 +2428,9 @@
                             "tree": false,
                             "autoAdjust": false,
                             "hideOnChildrenHidden": false,
-                            "id": "e5gzydg"
+                            "id": "e5gzydg",
+                            "addons": [],
+                            "lazyLoad": false
                         },
                         {
                             "label": "Columns",
@@ -2468,14 +2509,16 @@
                                             "properties": {},
                                             "allowMultipleMasks": false,
                                             "tag": "p",
-                                            "id": "ex0yioh"
+                                            "id": "ex0yioh",
+                                            "addons": []
                                         }
                                     ],
                                     "width": 6,
                                     "offset": 0,
                                     "push": 0,
                                     "pull": 0,
-                                    "size": "md"
+                                    "size": "md",
+                                    "currentWidth": 6
                                 },
                                 {
                                     "components": [
@@ -2551,14 +2594,16 @@
                                             "properties": {},
                                             "allowMultipleMasks": false,
                                             "tag": "p",
-                                            "id": "ec7blool"
+                                            "id": "ec7blool",
+                                            "addons": []
                                         }
                                     ],
                                     "width": 6,
                                     "offset": 0,
                                     "push": 0,
                                     "pull": 0,
-                                    "size": "md"
+                                    "size": "md",
+                                    "currentWidth": 6
                                 }
                             ],
                             "key": "columns5",
@@ -2624,7 +2669,9 @@
                             "tree": false,
                             "autoAdjust": false,
                             "hideOnChildrenHidden": false,
-                            "id": "e3fdigo"
+                            "id": "e3fdigo",
+                            "addons": [],
+                            "lazyLoad": false
                         }
                     ],
                     "placeholder": "",
@@ -2663,7 +2710,9 @@
                     "showWordCount": false,
                     "allowMultipleMasks": false,
                     "tree": false,
-                    "id": "edsnvs8"
+                    "id": "edsnvs8",
+                    "addons": [],
+                    "lazyLoad": false
                 },
                 {
                     "label": "Select when you will be taking the program",
@@ -2776,7 +2825,9 @@
                         "threshold": 0.3
                     },
                     "id": "eb4inb",
-                    "defaultValue": ""
+                    "defaultValue": "",
+                    "addons": [],
+                    "searchDebounce": 0.3
                 },
                 {
                     "label": "My study period isn’t listed",
@@ -2863,7 +2914,8 @@
                     "id": "eoslne6",
                     "defaultValue": {
                         "offeringnotListed": false
-                    }
+                    },
+                    "addons": []
                 },
                 {
                     "label": "selectedOfferingDate",
@@ -2930,7 +2982,8 @@
                     "properties": {},
                     "allowMultipleMasks": false,
                     "inputType": "hidden",
-                    "id": "eh1q3is"
+                    "id": "eh1q3is",
+                    "addons": []
                 },
                 {
                     "title": "Custom program and offering",
@@ -3050,7 +3103,8 @@
                             "properties": {},
                             "allowMultipleMasks": false,
                             "tag": "p",
-                            "id": "e30m9b"
+                            "id": "e30m9b",
+                            "addons": []
                         },
                         {
                             "label": "HTML",
@@ -3123,7 +3177,8 @@
                             "properties": {},
                             "allowMultipleMasks": false,
                             "tag": "p",
-                            "id": "ei10j1p"
+                            "id": "ei10j1p",
+                            "addons": []
                         },
                         {
                             "label": "HTML",
@@ -3196,7 +3251,8 @@
                             "properties": {},
                             "allowMultipleMasks": false,
                             "tag": "p",
-                            "id": "em3zynlo"
+                            "id": "em3zynlo",
+                            "addons": []
                         },
                         {
                             "label": "Program name",
@@ -3270,7 +3326,10 @@
                             "inputFormat": "plain",
                             "inputMask": "",
                             "spellcheck": true,
-                            "id": "ek2u9li"
+                            "id": "ek2u9li",
+                            "addons": [],
+                            "displayMask": "",
+                            "truncateMultipleSpaces": false
                         },
                         {
                             "label": "Program description",
@@ -3351,7 +3410,10 @@
                             "wysiwyg": false,
                             "editor": "",
                             "fixedSize": true,
-                            "id": "e1w8o5a"
+                            "id": "e1w8o5a",
+                            "addons": [],
+                            "displayMask": "",
+                            "truncateMultipleSpaces": false
                         },
                         {
                             "label": "HTML",
@@ -3425,7 +3487,8 @@
                             "properties": {},
                             "allowMultipleMasks": false,
                             "tag": "p",
-                            "id": "eh3kz5a"
+                            "id": "eh3kz5a",
+                            "addons": []
                         },
                         {
                             "label": "HTML",
@@ -3499,7 +3562,8 @@
                             "properties": {},
                             "allowMultipleMasks": false,
                             "tag": "p",
-                            "id": "exnccd"
+                            "id": "exnccd",
+                            "addons": []
                         },
                         {
                             "label": "Columns",
@@ -3575,7 +3639,8 @@
                                             "showWordCount": false,
                                             "allowMultipleMasks": false,
                                             "inputType": "hidden",
-                                            "id": "e2qzxte"
+                                            "id": "e2qzxte",
+                                            "addons": []
                                         },
                                         {
                                             "label": "<strong>Start date</strong>",
@@ -3705,14 +3770,16 @@
                                             "showWordCount": false,
                                             "allowMultipleMasks": false,
                                             "datepickerMode": "day",
-                                            "id": "eqnahab"
+                                            "id": "eqnahab",
+                                            "addons": []
                                         }
                                     ],
                                     "width": 6,
                                     "offset": 0,
                                     "push": 0,
                                     "pull": 0,
-                                    "size": "md"
+                                    "size": "md",
+                                    "currentWidth": 6
                                 },
                                 {
                                     "components": [
@@ -3785,7 +3852,8 @@
                                             "allowMultipleMasks": false,
                                             "inputType": "hidden",
                                             "id": "e9jayo",
-                                            "hideOnChildrenHidden": false
+                                            "hideOnChildrenHidden": false,
+                                            "addons": []
                                         },
                                         {
                                             "label": "<strong>End date</strong>",
@@ -3915,14 +3983,16 @@
                                             "showWordCount": false,
                                             "allowMultipleMasks": false,
                                             "datepickerMode": "day",
-                                            "id": "eyw0exi"
+                                            "id": "eyw0exi",
+                                            "addons": []
                                         }
                                     ],
                                     "width": 6,
                                     "offset": 0,
                                     "push": 0,
                                     "pull": 0,
-                                    "size": "md"
+                                    "size": "md",
+                                    "currentWidth": 6
                                 }
                             ],
                             "key": "columns",
@@ -3988,7 +4058,9 @@
                             "tree": false,
                             "autoAdjust": false,
                             "hideOnChildrenHidden": false,
-                            "id": "ey5rt8h"
+                            "id": "ey5rt8h",
+                            "addons": [],
+                            "lazyLoad": false
                         }
                     ],
                     "allowPrevious": false,
@@ -4028,7 +4100,9 @@
                     "showWordCount": false,
                     "allowMultipleMasks": false,
                     "tree": false,
-                    "id": "ehvspueo"
+                    "id": "ehvspueo",
+                    "addons": [],
+                    "lazyLoad": false
                 },
                 {
                     "label": "HTML",
@@ -4108,7 +4182,8 @@
                     "showCharCount": false,
                     "showWordCount": false,
                     "allowMultipleMasks": false,
-                    "id": "eez5j5i"
+                    "id": "eez5j5i",
+                    "addons": []
                 },
                 {
                     "label": "Student number",
@@ -4191,7 +4266,10 @@
                     "dataGridLabel": false,
                     "inputType": "text",
                     "id": "ek8w4hn",
-                    "defaultValue": ""
+                    "defaultValue": "",
+                    "addons": [],
+                    "displayMask": "",
+                    "truncateMultipleSpaces": false
                 },
                 {
                     "label": "Data Grid",
@@ -4347,8 +4425,11 @@
                             "input": true,
                             "refreshOn": "",
                             "inputType": "text",
-                            "id": "ecrze1n0000000000000000000000000",
-                            "defaultValue": ""
+                            "id": "ecrze1n00000000000000000000000000",
+                            "defaultValue": "",
+                            "addons": [],
+                            "displayMask": "",
+                            "truncateMultipleSpaces": false
                         }
                     ],
                     "placeholder": "",
@@ -4363,7 +4444,9 @@
                     "showWordCount": false,
                     "allowMultipleMasks": false,
                     "tree": true,
-                    "id": "e36mr6f"
+                    "id": "e36mr6f",
+                    "addons": [],
+                    "lazyLoad": false
                 }
             ],
             "input": false,
@@ -4404,7 +4487,9 @@
             "showWordCount": false,
             "allowMultipleMasks": false,
             "tree": false,
-            "id": "eybfjx6"
+            "id": "eybfjx6",
+            "addons": [],
+            "lazyLoad": false
         },
         {
             "title": "Personal information",
@@ -4526,7 +4611,8 @@
                     "showCharCount": false,
                     "showWordCount": false,
                     "allowMultipleMasks": false,
-                    "id": "epmbrga"
+                    "id": "epmbrga",
+                    "addons": []
                 },
                 {
                     "label": "HTML",
@@ -4605,7 +4691,8 @@
                     "showCharCount": false,
                     "showWordCount": false,
                     "allowMultipleMasks": false,
-                    "id": "ew33yx"
+                    "id": "ew33yx",
+                    "addons": []
                 },
                 {
                     "title": "StudentAid BC personal info panel",
@@ -4701,7 +4788,8 @@
                             "showCharCount": false,
                             "showWordCount": false,
                             "allowMultipleMasks": false,
-                            "id": "ez8hvke"
+                            "id": "ez8hvke",
+                            "addons": []
                         },
                         {
                             "label": "Content",
@@ -4775,7 +4863,8 @@
                             "properties": {},
                             "allowMultipleMasks": false,
                             "tag": "p",
-                            "id": "eow3mur"
+                            "id": "eow3mur",
+                            "addons": []
                         },
                         {
                             "label": "Student profile",
@@ -4850,7 +4939,8 @@
                             "block": false,
                             "disableOnInvalid": false,
                             "theme": "primary",
-                            "id": "ewtrt5h"
+                            "id": "ewtrt5h",
+                            "addons": []
                         },
                         {
                             "label": "Columns",
@@ -4931,7 +5021,10 @@
                                             "inputFormat": "plain",
                                             "inputMask": "",
                                             "spellcheck": true,
-                                            "id": "eollo8c"
+                                            "id": "eollo8c",
+                                            "addons": [],
+                                            "displayMask": "",
+                                            "truncateMultipleSpaces": false
                                         },
                                         {
                                             "label": "Date of birth",
@@ -5007,7 +5100,10 @@
                                             "inputFormat": "plain",
                                             "inputMask": "",
                                             "spellcheck": true,
-                                            "id": "eiro1mh"
+                                            "id": "eiro1mh",
+                                            "addons": [],
+                                            "displayMask": "",
+                                            "truncateMultipleSpaces": false
                                         },
                                         {
                                             "label": "Home address",
@@ -5083,7 +5179,10 @@
                                             "inputFormat": "plain",
                                             "inputMask": "",
                                             "spellcheck": true,
-                                            "id": "eppxei"
+                                            "id": "eppxei",
+                                            "addons": [],
+                                            "displayMask": "",
+                                            "truncateMultipleSpaces": false
                                         },
                                         {
                                             "label": "Email",
@@ -5158,14 +5257,18 @@
                                             "inputFormat": "plain",
                                             "inputMask": "",
                                             "spellcheck": true,
-                                            "id": "ey8k2yp"
+                                            "id": "ey8k2yp",
+                                            "addons": [],
+                                            "displayMask": "",
+                                            "truncateMultipleSpaces": false
                                         }
                                     ],
                                     "width": 6,
                                     "offset": 0,
                                     "push": 0,
                                     "pull": 0,
-                                    "size": "md"
+                                    "size": "md",
+                                    "currentWidth": 6
                                 },
                                 {
                                     "components": [
@@ -5242,7 +5345,10 @@
                                             "inputFormat": "plain",
                                             "inputMask": "",
                                             "spellcheck": true,
-                                            "id": "eug619a"
+                                            "id": "eug619a",
+                                            "addons": [],
+                                            "displayMask": "",
+                                            "truncateMultipleSpaces": false
                                         },
                                         {
                                             "label": "Gender",
@@ -5318,7 +5424,10 @@
                                             "inputFormat": "plain",
                                             "inputMask": "",
                                             "spellcheck": true,
-                                            "id": "el67mt"
+                                            "id": "el67mt",
+                                            "addons": [],
+                                            "displayMask": "",
+                                            "truncateMultipleSpaces": false
                                         },
                                         {
                                             "label": "Phone number",
@@ -5394,7 +5503,10 @@
                                             "inputFormat": "plain",
                                             "inputMask": "",
                                             "spellcheck": true,
-                                            "id": "egglzja"
+                                            "id": "egglzja",
+                                            "addons": [],
+                                            "displayMask": "",
+                                            "truncateMultipleSpaces": false
                                         },
                                         {
                                             "label": "Permanent disability status",
@@ -5469,14 +5581,18 @@
                                             "inputFormat": "plain",
                                             "inputMask": "",
                                             "spellcheck": true,
-                                            "id": "eq3hnwv"
+                                            "id": "eq3hnwv",
+                                            "addons": [],
+                                            "displayMask": "",
+                                            "truncateMultipleSpaces": false
                                         }
                                     ],
                                     "width": 6,
                                     "offset": 0,
                                     "push": 0,
                                     "pull": 0,
-                                    "size": "md"
+                                    "size": "md",
+                                    "currentWidth": 6
                                 }
                             ],
                             "key": "columns1",
@@ -5542,7 +5658,9 @@
                             "tree": false,
                             "autoAdjust": false,
                             "hideOnChildrenHidden": false,
-                            "id": "ebg5117"
+                            "id": "ebg5117",
+                            "addons": [],
+                            "lazyLoad": false
                         },
                         {
                             "label": "I confirm my StudentAid BC Profile information shown is correct",
@@ -5611,7 +5729,8 @@
                             "inputType": "checkbox",
                             "value": "",
                             "name": "",
-                            "id": "ebth7m"
+                            "id": "ebth7m",
+                            "addons": []
                         }
                     ],
                     "allowPrevious": false,
@@ -5673,7 +5792,9 @@
                     "tree": false,
                     "theme": "default",
                     "breadcrumb": "default",
-                    "id": "e1llrtm"
+                    "id": "e1llrtm",
+                    "addons": [],
+                    "lazyLoad": false
                 },
                 {
                     "label": "<strong>What is your citizenship status?</strong>",
@@ -5704,7 +5825,8 @@
                         "customPrivate": false,
                         "strictDateValidation": false,
                         "multiple": false,
-                        "unique": false
+                        "unique": false,
+                        "onlyAvailableItems": false
                     },
                     "key": "citizenship",
                     "type": "radio",
@@ -5760,7 +5882,8 @@
                     "allowMultipleMasks": false,
                     "inputType": "radio",
                     "fieldSet": false,
-                    "id": "e8pmct9"
+                    "id": "e8pmct9",
+                    "addons": []
                 },
                 {
                     "title": "Citizenship proof panel",
@@ -5857,7 +5980,8 @@
                             "showCharCount": false,
                             "showWordCount": false,
                             "allowMultipleMasks": false,
-                            "id": "es70kak"
+                            "id": "es70kak",
+                            "addons": []
                         },
                         {
                             "label": "HTML",
@@ -5936,7 +6060,8 @@
                             "showCharCount": false,
                             "showWordCount": false,
                             "allowMultipleMasks": false,
-                            "id": "emtg9xk"
+                            "id": "emtg9xk",
+                            "addons": []
                         },
                         {
                             "label": "HTML",
@@ -6015,7 +6140,8 @@
                             "showCharCount": false,
                             "showWordCount": false,
                             "allowMultipleMasks": false,
-                            "id": "eddhwkl"
+                            "id": "eddhwkl",
+                            "addons": []
                         },
                         {
                             "label": "HTML",
@@ -6094,7 +6220,8 @@
                             "showCharCount": false,
                             "showWordCount": false,
                             "allowMultipleMasks": false,
-                            "id": "ea2ohue"
+                            "id": "ea2ohue",
+                            "addons": []
                         },
                         {
                             "label": "HTML",
@@ -6173,7 +6300,8 @@
                             "showCharCount": false,
                             "showWordCount": false,
                             "allowMultipleMasks": false,
-                            "id": "e917eb"
+                            "id": "e917eb",
+                            "addons": []
                         },
                         {
                             "label": "HTML",
@@ -6252,7 +6380,8 @@
                             "showCharCount": false,
                             "showWordCount": false,
                             "allowMultipleMasks": false,
-                            "id": "emigw5m"
+                            "id": "emigw5m",
+                            "addons": []
                         },
                         {
                             "label": "Upload proof of citizenship",
@@ -6343,7 +6472,8 @@
                             "privateDownload": false,
                             "id": "etkoqe",
                             "options": "",
-                            "fileKey": ""
+                            "fileKey": "",
+                            "addons": []
                         },
                         {
                             "label": "Columns",
@@ -6420,14 +6550,16 @@
                                             "showCharCount": false,
                                             "showWordCount": false,
                                             "allowMultipleMasks": false,
-                                            "id": "e9wutz8"
+                                            "id": "e9wutz8",
+                                            "addons": []
                                         }
                                     ],
                                     "width": 6,
                                     "offset": 0,
                                     "push": 0,
                                     "pull": 0,
-                                    "size": "md"
+                                    "size": "md",
+                                    "currentWidth": 6
                                 },
                                 {
                                     "components": [
@@ -6501,14 +6633,16 @@
                                             "showCharCount": false,
                                             "showWordCount": false,
                                             "allowMultipleMasks": false,
-                                            "id": "e5czcdd"
+                                            "id": "e5czcdd",
+                                            "addons": []
                                         }
                                     ],
                                     "width": 6,
                                     "offset": 0,
                                     "push": 0,
                                     "pull": 0,
-                                    "size": "md"
+                                    "size": "md",
+                                    "currentWidth": 6
                                 }
                             ],
                             "autoAdjust": false,
@@ -6579,7 +6713,9 @@
                             "showWordCount": false,
                             "allowMultipleMasks": false,
                             "tree": false,
-                            "id": "elv3ea8"
+                            "id": "elv3ea8",
+                            "addons": [],
+                            "lazyLoad": false
                         }
                     ],
                     "allowPrevious": false,
@@ -6641,7 +6777,9 @@
                     "tree": false,
                     "theme": "default",
                     "breadcrumb": "default",
-                    "id": "efawj5"
+                    "id": "efawj5",
+                    "addons": [],
+                    "lazyLoad": false
                 },
                 {
                     "label": "<strong>Are you a resident of B.C.?</strong>",
@@ -6731,7 +6869,8 @@
                     "inputType": "radio",
                     "fieldSet": false,
                     "id": "e8a3hql",
-                    "defaultValue": ""
+                    "defaultValue": "",
+                    "addons": []
                 },
                 {
                     "title": "Not a BC resident panel",
@@ -6832,7 +6971,8 @@
                             "showCharCount": false,
                             "showWordCount": false,
                             "allowMultipleMasks": false,
-                            "id": "ean88l9"
+                            "id": "ean88l9",
+                            "addons": []
                         },
                         {
                             "label": "HTML",
@@ -6911,7 +7051,8 @@
                             "showCharCount": false,
                             "showWordCount": false,
                             "allowMultipleMasks": false,
-                            "id": "eqmirkg"
+                            "id": "eqmirkg",
+                            "addons": []
                         },
                         {
                             "label": "<strong>Which of the following best describes your situation?</strong>",
@@ -7010,7 +7151,8 @@
                             "inputType": "radio",
                             "fieldSet": false,
                             "id": "ep66483",
-                            "defaultValue": ""
+                            "defaultValue": "",
+                            "addons": []
                         },
                         {
                             "label": "HTML",
@@ -7089,7 +7231,8 @@
                             "showCharCount": false,
                             "showWordCount": false,
                             "allowMultipleMasks": false,
-                            "id": "ehuecan"
+                            "id": "ehuecan",
+                            "addons": []
                         },
                         {
                             "label": "Please explain your sitution:",
@@ -7179,7 +7322,10 @@
                             "inputMask": "",
                             "fixedSize": true,
                             "id": "euh1cll",
-                            "defaultValue": ""
+                            "defaultValue": "",
+                            "addons": [],
+                            "displayMask": "",
+                            "truncateMultipleSpaces": false
                         },
                         {
                             "title": "Upload supporting documents",
@@ -7303,7 +7449,8 @@
                                     "showCharCount": false,
                                     "showWordCount": false,
                                     "allowMultipleMasks": false,
-                                    "id": "eezq1g"
+                                    "id": "eezq1g",
+                                    "addons": []
                                 },
                                 {
                                     "label": "HTML",
@@ -7382,7 +7529,8 @@
                                     "showCharCount": false,
                                     "showWordCount": false,
                                     "allowMultipleMasks": false,
-                                    "id": "esar0bi"
+                                    "id": "esar0bi",
+                                    "addons": []
                                 },
                                 {
                                     "label": "HTML",
@@ -7461,7 +7609,8 @@
                                     "showCharCount": false,
                                     "showWordCount": false,
                                     "allowMultipleMasks": false,
-                                    "id": "e18yipa"
+                                    "id": "e18yipa",
+                                    "addons": []
                                 },
                                 {
                                     "label": "Upload supporting documents (optional):",
@@ -7552,7 +7701,8 @@
                                     "privateDownload": false,
                                     "id": "etziji",
                                     "options": "",
-                                    "fileKey": ""
+                                    "fileKey": "",
+                                    "addons": []
                                 },
                                 {
                                     "label": "Columns",
@@ -7629,14 +7779,16 @@
                                                     "showWordCount": false,
                                                     "allowMultipleMasks": false,
                                                     "id": "e7t7n9i",
-                                                    "hideOnChildrenHidden": false
+                                                    "hideOnChildrenHidden": false,
+                                                    "addons": []
                                                 }
                                             ],
                                             "width": 6,
                                             "offset": 0,
                                             "push": 0,
                                             "pull": 0,
-                                            "size": "md"
+                                            "size": "md",
+                                            "currentWidth": 6
                                         },
                                         {
                                             "components": [
@@ -7710,14 +7862,16 @@
                                                     "showWordCount": false,
                                                     "allowMultipleMasks": false,
                                                     "id": "e4rlla",
-                                                    "hideOnChildrenHidden": false
+                                                    "hideOnChildrenHidden": false,
+                                                    "addons": []
                                                 }
                                             ],
                                             "width": 6,
                                             "offset": 0,
                                             "push": 0,
                                             "pull": 0,
-                                            "size": "md"
+                                            "size": "md",
+                                            "currentWidth": 6
                                         }
                                     ],
                                     "autoAdjust": false,
@@ -7788,7 +7942,9 @@
                                     "showWordCount": false,
                                     "allowMultipleMasks": false,
                                     "tree": false,
-                                    "id": "e47hyqa"
+                                    "id": "e47hyqa",
+                                    "addons": [],
+                                    "lazyLoad": false
                                 }
                             ],
                             "placeholder": "",
@@ -7827,7 +7983,9 @@
                             "showWordCount": false,
                             "allowMultipleMasks": false,
                             "tree": false,
-                            "id": "eruhydo"
+                            "id": "eruhydo",
+                            "addons": [],
+                            "lazyLoad": false
                         }
                     ],
                     "allowPrevious": false,
@@ -7884,7 +8042,9 @@
                     "tree": false,
                     "theme": "default",
                     "breadcrumb": "default",
-                    "id": "eo7yj4f"
+                    "id": "eo7yj4f",
+                    "addons": [],
+                    "lazyLoad": false
                 },
                 {
                     "label": "<strong>Do you identify as an Indigenous person?</strong>",
@@ -7909,7 +8069,8 @@
                         "customPrivate": false,
                         "strictDateValidation": false,
                         "multiple": false,
-                        "unique": false
+                        "unique": false,
+                        "onlyAvailableItems": false
                     },
                     "errorLabel": "Aboriginal Status",
                     "key": "indigenousStatus",
@@ -7965,7 +8126,8 @@
                     "allowMultipleMasks": false,
                     "inputType": "radio",
                     "fieldSet": false,
-                    "id": "e96uncs"
+                    "id": "e96uncs",
+                    "addons": []
                 },
                 {
                     "title": "Indigenous Panel",
@@ -8065,7 +8227,8 @@
                             "showCharCount": false,
                             "showWordCount": false,
                             "allowMultipleMasks": false,
-                            "id": "e2ag0zq"
+                            "id": "e2ag0zq",
+                            "addons": []
                         },
                         {
                             "label": "<strong>I am:</strong>",
@@ -8095,7 +8258,8 @@
                                 "customPrivate": false,
                                 "strictDateValidation": false,
                                 "multiple": false,
-                                "unique": false
+                                "unique": false,
+                                "onlyAvailableItems": false
                             },
                             "key": "aboriginalHeritage",
                             "conditional": {
@@ -8150,7 +8314,8 @@
                             "allowMultipleMasks": false,
                             "inputType": "radio",
                             "fieldSet": false,
-                            "id": "ezochjc"
+                            "id": "ezochjc",
+                            "addons": []
                         }
                     ],
                     "allowPrevious": false,
@@ -8207,7 +8372,9 @@
                     "tree": false,
                     "theme": "default",
                     "breadcrumb": "default",
-                    "id": "ef3gfa"
+                    "id": "ef3gfa",
+                    "addons": [],
+                    "lazyLoad": false
                 },
                 {
                     "label": "<strong>Were you ever a youth in continuing care or custody of a director of child welfare in BC (ward of the court – this means the provincial government is/was your legal guardian)? </strong>",
@@ -8232,7 +8399,8 @@
                         "customPrivate": false,
                         "strictDateValidation": false,
                         "multiple": false,
-                        "unique": false
+                        "unique": false,
+                        "onlyAvailableItems": false
                     },
                     "errorLabel": "Youth In Care",
                     "key": "youthInCare",
@@ -8288,7 +8456,8 @@
                     "allowMultipleMasks": false,
                     "inputType": "radio",
                     "fieldSet": false,
-                    "id": "ema6dci"
+                    "id": "ema6dci",
+                    "addons": []
                 },
                 {
                     "label": "HTML",
@@ -8367,7 +8536,8 @@
                     "showCharCount": false,
                     "showWordCount": false,
                     "allowMultipleMasks": false,
-                    "id": "enupmu"
+                    "id": "enupmu",
+                    "addons": []
                 },
                 {
                     "label": "<strong>At the time of your course study start date, will you have been out of high school for 4 years?</strong>",
@@ -8456,7 +8626,8 @@
                     "inputType": "radio",
                     "fieldSet": false,
                     "id": "eahh865",
-                    "defaultValue": ""
+                    "defaultValue": "",
+                    "addons": []
                 },
                 {
                     "label": "<strong>When did you graduate or leave high-school?</strong>",
@@ -8582,7 +8753,8 @@
                     "showWordCount": false,
                     "allowMultipleMasks": false,
                     "datepickerMode": "day",
-                    "id": "ei3rn5"
+                    "id": "ei3rn5",
+                    "addons": []
                 },
                 {
                     "label": "HTML",
@@ -8661,7 +8833,8 @@
                     "showCharCount": false,
                     "showWordCount": false,
                     "allowMultipleMasks": false,
-                    "id": "epzt48g"
+                    "id": "epzt48g",
+                    "addons": []
                 },
                 {
                     "label": "<strong>Will you be working a full-time job of 32 hours per week for more than half of your study period?</strong>",
@@ -8687,7 +8860,8 @@
                         "customPrivate": false,
                         "strictDateValidation": false,
                         "multiple": false,
-                        "unique": false
+                        "unique": false,
+                        "onlyAvailableItems": false
                     },
                     "errorLabel": "Employment Information",
                     "key": "fullTimeJob",
@@ -8742,7 +8916,8 @@
                     "allowMultipleMasks": false,
                     "inputType": "radio",
                     "fieldSet": false,
-                    "id": "ewa5mpb"
+                    "id": "ewa5mpb",
+                    "addons": []
                 },
                 {
                     "label": "HTML",
@@ -8821,7 +8996,8 @@
                     "showCharCount": false,
                     "showWordCount": false,
                     "allowMultipleMasks": false,
-                    "id": "ejad0c"
+                    "id": "ejad0c",
+                    "addons": []
                 },
                 {
                     "label": "<strong>In the time since you left high school to your first day of classes, have you spent two periods of 12 consecutive months each, in the full time labour force?</strong>",
@@ -8902,7 +9078,8 @@
                     "allowMultipleMasks": false,
                     "inputType": "radio",
                     "fieldSet": false,
-                    "id": "eqf8qus"
+                    "id": "eqf8qus",
+                    "addons": []
                 },
                 {
                     "label": "HTML",
@@ -8981,7 +9158,8 @@
                     "showCharCount": false,
                     "showWordCount": false,
                     "allowMultipleMasks": false,
-                    "id": "evos73h"
+                    "id": "evos73h",
+                    "addons": []
                 },
                 {
                     "label": "HTML",
@@ -9060,7 +9238,8 @@
                     "showCharCount": false,
                     "showWordCount": false,
                     "allowMultipleMasks": false,
-                    "id": "ef4mzqb"
+                    "id": "ef4mzqb",
+                    "addons": []
                 },
                 {
                     "label": "<strong>Do you want to allow a trusted contact to interact with StudentAid BC on your behalf?</strong>",
@@ -9141,7 +9320,8 @@
                     "allowMultipleMasks": false,
                     "inputType": "radio",
                     "fieldSet": false,
-                    "id": "ewr6dc9"
+                    "id": "ewr6dc9",
+                    "addons": []
                 },
                 {
                     "title": "Trusted contact panel",
@@ -9242,7 +9422,8 @@
                             "showCharCount": false,
                             "showWordCount": false,
                             "allowMultipleMasks": false,
-                            "id": "eu1qpne"
+                            "id": "eu1qpne",
+                            "addons": []
                         },
                         {
                             "label": "HTML",
@@ -9321,7 +9502,8 @@
                             "showCharCount": false,
                             "showWordCount": false,
                             "allowMultipleMasks": false,
-                            "id": "eaqymr"
+                            "id": "eaqymr",
+                            "addons": []
                         },
                         {
                             "label": "<strong>ROI information</strong>",
@@ -9376,7 +9558,7 @@
                                     "key": "firstName",
                                     "type": "textfield",
                                     "input": true,
-                                    "id": "el2qrn9000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+                                    "id": "el2qrn90000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
                                     "placeholder": "",
                                     "prefix": "",
                                     "suffix": "",
@@ -9430,7 +9612,10 @@
                                     "inputType": "text",
                                     "inputFormat": "plain",
                                     "inputMask": "",
-                                    "spellcheck": true
+                                    "spellcheck": true,
+                                    "addons": [],
+                                    "displayMask": "",
+                                    "truncateMultipleSpaces": false
                                 },
                                 {
                                     "label": "Last name",
@@ -9450,7 +9635,7 @@
                                     "key": "lastName",
                                     "type": "textfield",
                                     "input": true,
-                                    "id": "e618eci000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+                                    "id": "e618eci0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
                                     "placeholder": "",
                                     "prefix": "",
                                     "suffix": "",
@@ -9504,7 +9689,10 @@
                                     "inputType": "text",
                                     "inputFormat": "plain",
                                     "inputMask": "",
-                                    "spellcheck": true
+                                    "spellcheck": true,
+                                    "addons": [],
+                                    "displayMask": "",
+                                    "truncateMultipleSpaces": false
                                 },
                                 {
                                     "label": "<strong>What is your relationship with this contact?</strong>",
@@ -9602,8 +9790,9 @@
                                     "allowMultipleMasks": false,
                                     "inputType": "radio",
                                     "fieldSet": false,
-                                    "id": "ejv9syt00000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
-                                    "defaultValue": ""
+                                    "id": "ejv9syt000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+                                    "defaultValue": "",
+                                    "addons": []
                                 },
                                 {
                                     "label": "<strong>How long do you want to give this person access to your StudentAid BC account?</strong>",
@@ -9639,7 +9828,7 @@
                                     "key": "strongHowLongDoYouWantToGiveThisPersonAccessToYourStudentAidBcAccountStrong",
                                     "type": "radio",
                                     "input": true,
-                                    "id": "ejm9s3q000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+                                    "id": "ejm9s3q0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
                                     "placeholder": "",
                                     "prefix": "",
                                     "customClass": "",
@@ -9689,7 +9878,8 @@
                                     "properties": {},
                                     "allowMultipleMasks": false,
                                     "inputType": "radio",
-                                    "fieldSet": false
+                                    "fieldSet": false,
+                                    "addons": []
                                 },
                                 {
                                     "label": "Select the date you would like this person’s access to your StudentAidBC account to expire",
@@ -9745,7 +9935,7 @@
                                         "disableWeekdays": false,
                                         "maxDate": null
                                     },
-                                    "id": "earatq000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+                                    "id": "earatq0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
                                     "prefix": "",
                                     "suffix": "",
                                     "multiple": false,
@@ -9804,7 +9994,8 @@
                                         "arrowkeys": true
                                     },
                                     "customOptions": {},
-                                    "shortcutButtons": []
+                                    "shortcutButtons": [],
+                                    "addons": []
                                 }
                             ],
                             "placeholder": "",
@@ -9856,7 +10047,9 @@
                             "allowMultipleMasks": false,
                             "tree": true,
                             "disableAddingRemovingRows": false,
-                            "id": "eq7yod9"
+                            "id": "eq7yod9",
+                            "addons": [],
+                            "lazyLoad": false
                         },
                         {
                             "html": "<p>The &nbsp;Freedom of Information and Protection of Privacy Act &nbsp;prevents StudentAid BC and financial aid staff from releasing any information pertaining to this application to anyone other than you unless you provide written permission. Complete these questions if you want to authorize another person to obtain information on your behalf about this application, related appendices, or assessment details. If you authorize someone to access information on your behalf by completing these questions, they must provide your Social Insurance Number and date of birth to access any information from StudentAid BC or financial aid staff. Please ensure you have the designated person’s authorization to enter their information. Do not use a school staff member. &nbsp;</p><p>&nbsp;</p><p>Note: Information can be shared with the persons/organizations identified in the StudentAid BC declaration based on your signature, regardless of whether these questions are completed.</p>",
@@ -9922,7 +10115,8 @@
                             "showWordCount": false,
                             "properties": {},
                             "allowMultipleMasks": false,
-                            "id": "eopro5d"
+                            "id": "eopro5d",
+                            "addons": []
                         },
                         {
                             "label": "roiWell",
@@ -10002,7 +10196,8 @@
                                     "inputType": "checkbox",
                                     "value": "",
                                     "name": "",
-                                    "id": "eqmvldl"
+                                    "id": "eqmvldl",
+                                    "addons": []
                                 }
                             ],
                             "placeholder": "",
@@ -10056,7 +10251,9 @@
                             "properties": {},
                             "allowMultipleMasks": false,
                             "tree": false,
-                            "id": "eepuwb5h"
+                            "id": "eepuwb5h",
+                            "addons": [],
+                            "lazyLoad": false
                         }
                     ],
                     "allowPrevious": false,
@@ -10113,77 +10310,9 @@
                     "tree": false,
                     "theme": "default",
                     "breadcrumb": "default",
-                    "id": "elibgq9"
-                },
-                {
-                    "label": "Dependantstatus",
-                    "customClass": "",
-                    "modalEdit": false,
-                    "defaultValue": null,
-                    "persistent": true,
-                    "protected": false,
-                    "dbIndex": false,
-                    "encrypted": false,
-                    "redrawOn": "",
-                    "customDefaultValue": "",
-                    "calculateValue": "//alert (data.dependantstatus);\nif (data.hasDependents === 'no' && (data.relationshipStatus === 'single' || data.relationshipStatus === 'otherSingle') && data.outOfHighSchoolFor4Years === 'no' && data.howWillYouBeAttendingTheProgram === \"Full Time\") {\n  instance.setValue ('dependant');\n}\nelse {\n  instance.setValue ('independant');\n}",
-                    "calculateServer": true,
-                    "key": "dependantstatus",
-                    "tags": [],
-                    "properties": {},
-                    "logic": [],
-                    "attributes": {},
-                    "overlay": {
-                        "style": "",
-                        "page": "",
-                        "left": "",
-                        "top": "",
-                        "width": "",
-                        "height": ""
-                    },
-                    "type": "hidden",
-                    "input": true,
-                    "tableView": false,
-                    "placeholder": "",
-                    "prefix": "",
-                    "suffix": "",
-                    "multiple": false,
-                    "unique": false,
-                    "hidden": false,
-                    "clearOnHide": true,
-                    "refreshOn": "",
-                    "dataGridLabel": false,
-                    "labelPosition": "top",
-                    "description": "",
-                    "errorLabel": "",
-                    "tooltip": "",
-                    "hideLabel": false,
-                    "tabindex": "",
-                    "disabled": false,
-                    "autofocus": false,
-                    "widget": {
-                        "type": "input"
-                    },
-                    "validateOn": "change",
-                    "validate": {
-                        "required": false,
-                        "custom": "",
-                        "customPrivate": false,
-                        "strictDateValidation": false,
-                        "multiple": false,
-                        "unique": false
-                    },
-                    "conditional": {
-                        "show": null,
-                        "when": null,
-                        "eq": ""
-                    },
-                    "allowCalculateOverride": false,
-                    "showCharCount": false,
-                    "showWordCount": false,
-                    "allowMultipleMasks": false,
-                    "inputType": "hidden",
-                    "id": "erzqc6d"
+                    "id": "elibgq9",
+                    "addons": [],
+                    "lazyLoad": false
                 }
             ],
             "input": false,
@@ -10224,7 +10353,9 @@
             "showWordCount": false,
             "allowMultipleMasks": false,
             "tree": false,
-            "id": "e5im6qg"
+            "id": "e5im6qg",
+            "addons": [],
+            "lazyLoad": false
         },
         {
             "title": "Family information",
@@ -10348,7 +10479,8 @@
                     "showCharCount": false,
                     "showWordCount": false,
                     "allowMultipleMasks": false,
-                    "id": "e1pe2c"
+                    "id": "e1pe2c",
+                    "addons": []
                 },
                 {
                     "label": "HTML",
@@ -10427,11 +10559,14 @@
                     "showCharCount": false,
                     "showWordCount": false,
                     "allowMultipleMasks": false,
-                    "id": "ejh8pr"
+                    "id": "ejh8pr",
+                    "addons": []
                 },
                 {
                     "label": "<strong>On my first day of class, I'll be:</strong>",
                     "labelPosition": "top",
+                    "labelWidth": "",
+                    "labelMargin": "",
                     "optionsLabelPosition": "right",
                     "description": "",
                     "tooltip": "",
@@ -10452,11 +10587,11 @@
                         },
                         {
                             "label": "Separated/divorced/widowed",
-                            "value": "otherSingle",
+                            "value": "other",
                             "shortcut": ""
                         },
                         {
-                            "value": "marriedCommonLaw",
+                            "value": "married",
                             "label": "Married/common-law",
                             "shortcut": ""
                         }
@@ -10484,6 +10619,7 @@
                         "unique": false
                     },
                     "errorLabel": "Relationship Status",
+                    "errors": "",
                     "key": "relationshipStatus",
                     "tags": [],
                     "properties": {},
@@ -10521,9 +10657,10 @@
                     "showCharCount": false,
                     "showWordCount": false,
                     "allowMultipleMasks": false,
+                    "addons": [],
                     "inputType": "radio",
                     "fieldSet": false,
-                    "id": "eoh9dul",
+                    "id": "e6m25u",
                     "defaultValue": ""
                 },
                 {
@@ -10684,7 +10821,8 @@
                             },
                             "customOptions": {},
                             "id": "enmzn3",
-                            "shortcutButtons": []
+                            "shortcutButtons": [],
+                            "addons": []
                         }
                     ],
                     "allowPrevious": false,
@@ -10724,7 +10862,9 @@
                     "showWordCount": false,
                     "allowMultipleMasks": false,
                     "tree": false,
-                    "id": "e7huqp"
+                    "id": "e7huqp",
+                    "addons": [],
+                    "lazyLoad": false
                 },
                 {
                     "label": "<strong>Do you have any dependants?</strong>",
@@ -10816,7 +10956,8 @@
                     "inputType": "radio",
                     "fieldSet": false,
                     "id": "es6wpct",
-                    "defaultValue": ""
+                    "defaultValue": "",
+                    "addons": []
                 },
                 {
                     "title": "Add Dependants Panel",
@@ -10917,7 +11058,8 @@
                             "showCharCount": false,
                             "showWordCount": false,
                             "allowMultipleMasks": false,
-                            "id": "ew64jgs"
+                            "id": "ew64jgs",
+                            "addons": []
                         },
                         {
                             "label": "HTML",
@@ -10996,7 +11138,8 @@
                             "showCharCount": false,
                             "showWordCount": false,
                             "allowMultipleMasks": false,
-                            "id": "e7hw8pg"
+                            "id": "e7hw8pg",
+                            "addons": []
                         },
                         {
                             "label": "<strong>Dependants</strong>",
@@ -11122,14 +11265,18 @@
                                                             "inputFormat": "plain",
                                                             "inputMask": "",
                                                             "spellcheck": true,
-                                                            "id": "ex25e6h"
+                                                            "id": "ex25e6h",
+                                                            "addons": [],
+                                                            "displayMask": "",
+                                                            "truncateMultipleSpaces": false
                                                         }
                                                     ],
                                                     "width": 6,
                                                     "offset": 0,
                                                     "push": 0,
                                                     "pull": 0,
-                                                    "size": "md"
+                                                    "size": "md",
+                                                    "currentWidth": 6
                                                 },
                                                 {
                                                     "components": [
@@ -11247,14 +11394,16 @@
                                                             "datepickerMode": "day",
                                                             "customOptions": {},
                                                             "id": "es6kg2vr",
-                                                            "shortcutButtons": []
+                                                            "shortcutButtons": [],
+                                                            "addons": []
                                                         }
                                                     ],
                                                     "width": 4,
                                                     "offset": 0,
                                                     "push": 0,
                                                     "pull": 0,
-                                                    "size": "md"
+                                                    "size": "md",
+                                                    "currentWidth": 4
                                                 }
                                             ],
                                             "autoAdjust": false,
@@ -11325,7 +11474,9 @@
                                             "showWordCount": false,
                                             "allowMultipleMasks": false,
                                             "tree": false,
-                                            "id": "e8qthqh"
+                                            "id": "e8qthqh",
+                                            "addons": [],
+                                            "lazyLoad": false
                                         },
                                         {
                                             "label": "<strong>Attending post secondary school</strong>",
@@ -11414,7 +11565,8 @@
                                             "inputType": "radio",
                                             "fieldSet": false,
                                             "id": "et9tfpg",
-                                            "defaultValue": ""
+                                            "defaultValue": "",
+                                            "addons": []
                                         },
                                         {
                                             "label": "<strong>Declared on taxes due to a disability</strong>",
@@ -11503,7 +11655,8 @@
                                             "inputType": "radio",
                                             "fieldSet": false,
                                             "id": "eve72ba",
-                                            "defaultValue": ""
+                                            "defaultValue": "",
+                                            "addons": []
                                         },
                                         {
                                             "title": "Upload panel",
@@ -11621,7 +11774,8 @@
                                                     "properties": {},
                                                     "allowMultipleMasks": false,
                                                     "tag": "p",
-                                                    "id": "eqgudcj"
+                                                    "id": "eqgudcj",
+                                                    "addons": []
                                                 },
                                                 {
                                                     "label": "HTML",
@@ -11694,7 +11848,8 @@
                                                     "properties": {},
                                                     "allowMultipleMasks": false,
                                                     "tag": "p",
-                                                    "id": "ertgpw8"
+                                                    "id": "ertgpw8",
+                                                    "addons": []
                                                 },
                                                 {
                                                     "label": " PD dependant upload",
@@ -11776,7 +11931,8 @@
                                                     "imageSize": "200",
                                                     "fileMinSize": "0KB",
                                                     "uploadOnly": false,
-                                                    "id": "euaz6kp"
+                                                    "id": "euaz6kp",
+                                                    "addons": []
                                                 },
                                                 {
                                                     "input": false,
@@ -11852,14 +12008,16 @@
                                                                     "showWordCount": false,
                                                                     "properties": {},
                                                                     "allowMultipleMasks": false,
-                                                                    "id": "e6menor"
+                                                                    "id": "e6menor",
+                                                                    "addons": []
                                                                 }
                                                             ],
                                                             "width": 6,
                                                             "offset": 0,
                                                             "push": 0,
                                                             "pull": 0,
-                                                            "size": "md"
+                                                            "size": "md",
+                                                            "currentWidth": 6
                                                         },
                                                         {
                                                             "components": [
@@ -11928,14 +12086,16 @@
                                                                     "showWordCount": false,
                                                                     "properties": {},
                                                                     "allowMultipleMasks": false,
-                                                                    "id": "enqrbog"
+                                                                    "id": "enqrbog",
+                                                                    "addons": []
                                                                 }
                                                             ],
                                                             "width": 6,
                                                             "offset": 0,
                                                             "push": 0,
                                                             "pull": 0,
-                                                            "size": "md"
+                                                            "size": "md",
+                                                            "currentWidth": 6
                                                         }
                                                     ],
                                                     "placeholder": "",
@@ -11997,7 +12157,9 @@
                                                     "tree": false,
                                                     "autoAdjust": false,
                                                     "hideOnChildrenHidden": false,
-                                                    "id": "egbz7e2"
+                                                    "id": "egbz7e2",
+                                                    "addons": [],
+                                                    "lazyLoad": false
                                                 }
                                             ],
                                             "placeholder": "",
@@ -12036,7 +12198,9 @@
                                             "showWordCount": false,
                                             "allowMultipleMasks": false,
                                             "tree": false,
-                                            "id": "ecnquik"
+                                            "id": "ecnquik",
+                                            "addons": [],
+                                            "lazyLoad": false
                                         },
                                         {
                                             "label": "IsAValidDependant",
@@ -12103,7 +12267,8 @@
                                             "properties": {},
                                             "allowMultipleMasks": false,
                                             "inputType": "hidden",
-                                            "id": "e48zvv3"
+                                            "id": "e48zvv3",
+                                            "addons": []
                                         },
                                         {
                                             "label": "ValidDependent",
@@ -12170,10 +12335,11 @@
                                             "properties": {},
                                             "allowMultipleMasks": false,
                                             "inputType": "hidden",
-                                            "id": "e64vrxl"
+                                            "id": "e64vrxl",
+                                            "addons": []
                                         }
                                     ],
-                                    "id": "ecpkm9j0000000000000000000000000000000000000000000",
+                                    "id": "ecpkm9j0000000000000000000000000000000000000000000000000000000000000",
                                     "placeholder": "",
                                     "prefix": "",
                                     "customClass": "",
@@ -12231,7 +12397,9 @@
                                     "properties": {},
                                     "allowMultipleMasks": false,
                                     "tree": false,
-                                    "legend": ""
+                                    "legend": "",
+                                    "addons": [],
+                                    "lazyLoad": false
                                 }
                             ],
                             "placeholder": "",
@@ -12277,7 +12445,9 @@
                             "allowMultipleMasks": false,
                             "tree": true,
                             "disableAddingRemovingRows": false,
-                            "id": "etl1y0a"
+                            "id": "etl1y0a",
+                            "addons": [],
+                            "lazyLoad": false
                         }
                     ],
                     "placeholder": "",
@@ -12333,7 +12503,9 @@
                     "tree": false,
                     "theme": "default",
                     "breadcrumb": "default",
-                    "id": "egyz9uo"
+                    "id": "egyz9uo",
+                    "addons": [],
+                    "lazyLoad": false
                 },
                 {
                     "label": "<strong>Do you have any dependents that you support financially but do not have sole custody of?</strong>",
@@ -12414,7 +12586,8 @@
                     "allowMultipleMasks": false,
                     "inputType": "radio",
                     "fieldSet": false,
-                    "id": "e0fe8eh"
+                    "id": "e0fe8eh",
+                    "addons": []
                 },
                 {
                     "title": "Dependents that you support financially but do not have sole custody",
@@ -12515,7 +12688,8 @@
                             "showCharCount": false,
                             "showWordCount": false,
                             "allowMultipleMasks": false,
-                            "id": "erpezbu"
+                            "id": "erpezbu",
+                            "addons": []
                         },
                         {
                             "label": "HTML",
@@ -12594,7 +12768,8 @@
                             "showCharCount": false,
                             "showWordCount": false,
                             "allowMultipleMasks": false,
-                            "id": "e11wyqh"
+                            "id": "e11wyqh",
+                            "addons": []
                         },
                         {
                             "label": "HTML",
@@ -12673,7 +12848,8 @@
                             "showCharCount": false,
                             "showWordCount": false,
                             "allowMultipleMasks": false,
-                            "id": "ehrudvm"
+                            "id": "ehrudvm",
+                            "addons": []
                         },
                         {
                             "label": "HTML",
@@ -12752,7 +12928,8 @@
                             "showCharCount": false,
                             "showWordCount": false,
                             "allowMultipleMasks": false,
-                            "id": "e5eif08"
+                            "id": "e5eif08",
+                            "addons": []
                         },
                         {
                             "label": "Dependant custody file upload",
@@ -12843,7 +13020,8 @@
                             "privateDownload": false,
                             "id": "ebvl7sr",
                             "options": "",
-                            "fileKey": ""
+                            "fileKey": "",
+                            "addons": []
                         },
                         {
                             "label": "Columns",
@@ -12920,14 +13098,16 @@
                                             "showWordCount": false,
                                             "allowMultipleMasks": false,
                                             "id": "efz51n7m",
-                                            "hideOnChildrenHidden": false
+                                            "hideOnChildrenHidden": false,
+                                            "addons": []
                                         }
                                     ],
                                     "width": 6,
                                     "offset": 0,
                                     "push": 0,
                                     "pull": 0,
-                                    "size": "md"
+                                    "size": "md",
+                                    "currentWidth": 6
                                 },
                                 {
                                     "components": [
@@ -13001,14 +13181,16 @@
                                             "showCharCount": false,
                                             "showWordCount": false,
                                             "allowMultipleMasks": false,
-                                            "id": "etqorpe"
+                                            "id": "etqorpe",
+                                            "addons": []
                                         }
                                     ],
                                     "width": 6,
                                     "offset": 0,
                                     "push": 0,
                                     "pull": 0,
-                                    "size": "md"
+                                    "size": "md",
+                                    "currentWidth": 6
                                 }
                             ],
                             "autoAdjust": false,
@@ -13079,7 +13261,9 @@
                             "showWordCount": false,
                             "allowMultipleMasks": false,
                             "tree": false,
-                            "id": "ealp1ro"
+                            "id": "ealp1ro",
+                            "addons": [],
+                            "lazyLoad": false
                         }
                     ],
                     "placeholder": "",
@@ -13135,7 +13319,82 @@
                     "tree": false,
                     "theme": "default",
                     "breadcrumb": "default",
-                    "id": "eaitjan"
+                    "id": "eaitjan",
+                    "addons": [],
+                    "lazyLoad": false
+                },
+                {
+                    "label": "Dependantstatus",
+                    "labelWidth": "",
+                    "labelMargin": "",
+                    "customClass": "",
+                    "modalEdit": false,
+                    "defaultValue": null,
+                    "persistent": true,
+                    "protected": false,
+                    "dbIndex": false,
+                    "encrypted": false,
+                    "redrawOn": "data",
+                    "customDefaultValue": "",
+                    "calculateValue": "//alert (data.dependantstatus);\nif (data.hasDependents === 'no' && (data.relationshipStatus === 'single' || data.relationshipStatus === 'otherSingle') && data.outOfHighSchoolFor4Years === 'no' && data.howWillYouBeAttendingTheProgram === \"Full Time\") {\n  instance.setValue ('dependant');\n}\nelse {\n  instance.setValue ('independant');\n}",
+                    "calculateServer": true,
+                    "key": "dependantstatus",
+                    "tags": [],
+                    "properties": {},
+                    "logic": [],
+                    "attributes": {},
+                    "overlay": {
+                        "style": "",
+                        "page": "",
+                        "left": "",
+                        "top": "",
+                        "width": "",
+                        "height": ""
+                    },
+                    "type": "hidden",
+                    "input": true,
+                    "tableView": false,
+                    "placeholder": "",
+                    "prefix": "",
+                    "suffix": "",
+                    "multiple": false,
+                    "unique": false,
+                    "hidden": false,
+                    "clearOnHide": true,
+                    "refreshOn": "",
+                    "dataGridLabel": false,
+                    "labelPosition": "top",
+                    "description": "",
+                    "errorLabel": "",
+                    "tooltip": "",
+                    "hideLabel": false,
+                    "tabindex": "",
+                    "disabled": false,
+                    "autofocus": false,
+                    "widget": {
+                        "type": "input"
+                    },
+                    "validateOn": "change",
+                    "validate": {
+                        "required": false,
+                        "custom": "",
+                        "customPrivate": false,
+                        "strictDateValidation": false,
+                        "multiple": false,
+                        "unique": false
+                    },
+                    "conditional": {
+                        "show": null,
+                        "when": null,
+                        "eq": ""
+                    },
+                    "allowCalculateOverride": false,
+                    "showCharCount": false,
+                    "showWordCount": false,
+                    "allowMultipleMasks": false,
+                    "addons": [],
+                    "inputType": "hidden",
+                    "id": "eaahv2r"
                 }
             ],
             "placeholder": "",
@@ -13174,7 +13433,9 @@
             "showWordCount": false,
             "allowMultipleMasks": false,
             "tree": false,
-            "id": "etsbz9o"
+            "id": "etsbz9o",
+            "addons": [],
+            "lazyLoad": false
         },
         {
             "title": "Partner information",
@@ -13298,7 +13559,8 @@
                     "showCharCount": false,
                     "showWordCount": false,
                     "allowMultipleMasks": false,
-                    "id": "ezo3nq8"
+                    "id": "ezo3nq8",
+                    "addons": []
                 },
                 {
                     "label": "HTML",
@@ -13377,7 +13639,8 @@
                     "showCharCount": false,
                     "showWordCount": false,
                     "allowMultipleMasks": false,
-                    "id": "ew7qj9"
+                    "id": "ew7qj9",
+                    "addons": []
                 },
                 {
                     "label": "<strong>Does your partner have a valid Social Insurance Number?</strong>",
@@ -13466,7 +13729,8 @@
                     "inputType": "radio",
                     "fieldSet": false,
                     "id": "eolgirh",
-                    "defaultValue": ""
+                    "defaultValue": "",
+                    "addons": []
                 },
                 {
                     "label": "Additional information required",
@@ -13545,7 +13809,8 @@
                     "showCharCount": false,
                     "showWordCount": false,
                     "allowMultipleMasks": false,
-                    "id": "eqyaa8b"
+                    "id": "eqyaa8b",
+                    "addons": []
                 },
                 {
                     "label": "Spouse Estimation",
@@ -13624,7 +13889,8 @@
                     "showCharCount": false,
                     "showWordCount": false,
                     "allowMultipleMasks": false,
-                    "id": "eow2c2c"
+                    "id": "eow2c2c",
+                    "addons": []
                 },
                 {
                     "title": "Partner Income Panel",
@@ -13724,7 +13990,8 @@
                             "showCharCount": false,
                             "showWordCount": false,
                             "allowMultipleMasks": false,
-                            "id": "e3pwpa9"
+                            "id": "e3pwpa9",
+                            "addons": []
                         },
                         {
                             "label": "HTML",
@@ -13803,7 +14070,8 @@
                             "showCharCount": false,
                             "showWordCount": false,
                             "allowMultipleMasks": false,
-                            "id": "eedvdyj"
+                            "id": "eedvdyj",
+                            "addons": []
                         },
                         {
                             "label": "What was your partner’s income (as shown on line 15000 of previous year’s Canada Revenue Agency tax return)? If they didn’t file taxes, enter total income from all sources in and outside of Canada.",
@@ -13878,7 +14146,8 @@
                             "showWordCount": false,
                             "properties": {},
                             "allowMultipleMasks": false,
-                            "id": "e9mqj6h"
+                            "id": "e9mqj6h",
+                            "addons": []
                         },
                         {
                             "label": "<strong>Will your partner be employed full-time or part-time during your study period</strong>",
@@ -13959,7 +14228,8 @@
                             "allowMultipleMasks": false,
                             "inputType": "radio",
                             "fieldSet": false,
-                            "id": "erofrhb"
+                            "id": "erofrhb",
+                            "addons": []
                         },
                         {
                             "label": "<strong>Will  your partner be at home caring for eligible dependent children on a full-time basis during the your entire study period? </strong>",
@@ -14040,7 +14310,8 @@
                             "allowMultipleMasks": false,
                             "inputType": "radio",
                             "fieldSet": false,
-                            "id": "e1z6lyb"
+                            "id": "e1z6lyb",
+                            "addons": []
                         },
                         {
                             "label": "<strong>Will your partner be living with you during the your study period?</strong>",
@@ -14121,7 +14392,8 @@
                             "allowMultipleMasks": false,
                             "inputType": "radio",
                             "fieldSet": false,
-                            "id": "ehnyp6c"
+                            "id": "ehnyp6c",
+                            "addons": []
                         },
                         {
                             "label": "<strong>Will your partner be a full-time post-secondary student for some or all of your study period?</strong>",
@@ -14202,7 +14474,8 @@
                             "allowMultipleMasks": false,
                             "inputType": "radio",
                             "fieldSet": false,
-                            "id": "e4neun"
+                            "id": "e4neun",
+                            "addons": []
                         },
                         {
                             "title": "If your partner will be a full-time student, how many weeks of your study period will they also be in studies Panel",
@@ -14306,7 +14579,8 @@
                                     "showWordCount": false,
                                     "allowMultipleMasks": false,
                                     "id": "epdswoon",
-                                    "defaultValue": null
+                                    "defaultValue": null,
+                                    "addons": []
                                 }
                             ],
                             "allowPrevious": false,
@@ -14363,7 +14637,9 @@
                             "tree": false,
                             "theme": "default",
                             "breadcrumb": "default",
-                            "id": "ep5lg4"
+                            "id": "ep5lg4",
+                            "addons": [],
+                            "lazyLoad": false
                         },
                         {
                             "label": "<strong>Will your partner recieve income assistance/social assistance (welfare) and/or BC income assistance for persons with disabilities during the your study period?</strong>",
@@ -14452,7 +14728,8 @@
                             "inputType": "radio",
                             "fieldSet": false,
                             "id": "ealunos",
-                            "defaultValue": ""
+                            "defaultValue": "",
+                            "addons": []
                         },
                         {
                             "title": "Provide the total income assistance/social assistance (welfare) and/or BC income assistance for persons with disabilities that your partner will be receiving during your study period Panel",
@@ -14548,7 +14825,8 @@
                                     "showWordCount": false,
                                     "properties": {},
                                     "allowMultipleMasks": false,
-                                    "id": "e9k0k58"
+                                    "id": "e9k0k58",
+                                    "addons": []
                                 }
                             ],
                             "allowPrevious": false,
@@ -14605,7 +14883,9 @@
                             "tree": false,
                             "theme": "default",
                             "breadcrumb": "default",
-                            "id": "ey6jmc4b"
+                            "id": "ey6jmc4b",
+                            "addons": [],
+                            "lazyLoad": false
                         },
                         {
                             "label": "<strong>Will your partner be in receipt of Employment Insurance benefits during the your study period?</strong>",
@@ -14686,7 +14966,8 @@
                             "allowMultipleMasks": false,
                             "inputType": "radio",
                             "fieldSet": false,
-                            "id": "enklghw"
+                            "id": "enklghw",
+                            "addons": []
                         },
                         {
                             "title": "Will your partner be in receipt of Employment Insurance benefits during the your study period Panel",
@@ -14783,7 +15064,8 @@
                                     "showWordCount": false,
                                     "properties": {},
                                     "allowMultipleMasks": false,
-                                    "id": "ei87gnna"
+                                    "id": "ei87gnna",
+                                    "addons": []
                                 }
                             ],
                             "allowPrevious": false,
@@ -14840,7 +15122,9 @@
                             "tree": false,
                             "theme": "default",
                             "breadcrumb": "default",
-                            "id": "ei0vzm"
+                            "id": "ei0vzm",
+                            "addons": [],
+                            "lazyLoad": false
                         },
                         {
                             "label": "<strong>Will your partner be in receipt of federal or provincial permanent disability benefits during the your study period?</strong>",
@@ -14921,7 +15205,8 @@
                             "allowMultipleMasks": false,
                             "inputType": "radio",
                             "fieldSet": false,
-                            "id": "ef7th7s"
+                            "id": "ef7th7s",
+                            "addons": []
                         },
                         {
                             "title": "Will your partner be in receipt of federal or provincial permanent disability benefits during the your study period Panel",
@@ -15018,7 +15303,8 @@
                                     "showWordCount": false,
                                     "properties": {},
                                     "allowMultipleMasks": false,
-                                    "id": "ecbhi1"
+                                    "id": "ecbhi1",
+                                    "addons": []
                                 }
                             ],
                             "allowPrevious": false,
@@ -15075,7 +15361,9 @@
                             "tree": false,
                             "theme": "default",
                             "breadcrumb": "default",
-                            "id": "em80rob"
+                            "id": "em80rob",
+                            "addons": [],
+                            "lazyLoad": false
                         },
                         {
                             "label": "<strong>Will your partner be paying a Canada Student Loan and/or a provincial student loan regular scheduled payments during the your study period?</strong>",
@@ -15156,7 +15444,8 @@
                             "allowMultipleMasks": false,
                             "inputType": "radio",
                             "fieldSet": false,
-                            "id": "eoxznh4"
+                            "id": "eoxznh4",
+                            "addons": []
                         },
                         {
                             "title": "Will your partner be paying a Canada Student Loan and/or a provincial student loan regular scheduled payments during the your study period Panel",
@@ -15252,7 +15541,8 @@
                                     "showWordCount": false,
                                     "properties": {},
                                     "allowMultipleMasks": false,
-                                    "id": "exjd5dg"
+                                    "id": "exjd5dg",
+                                    "addons": []
                                 }
                             ],
                             "allowPrevious": false,
@@ -15309,7 +15599,9 @@
                             "tree": false,
                             "theme": "default",
                             "breadcrumb": "default",
-                            "id": "et3rj9"
+                            "id": "et3rj9",
+                            "addons": [],
+                            "lazyLoad": false
                         },
                         {
                             "label": "<strong>Will your partner be paying for child support and/or spousal support during the your study period?</strong>",
@@ -15390,7 +15682,8 @@
                             "allowMultipleMasks": false,
                             "inputType": "radio",
                             "fieldSet": false,
-                            "id": "eboa3up"
+                            "id": "eboa3up",
+                            "addons": []
                         },
                         {
                             "title": "Will your partner be paying for child support and/or spousal support during the your study period Panel",
@@ -15486,7 +15779,8 @@
                                     "showWordCount": false,
                                     "properties": {},
                                     "allowMultipleMasks": false,
-                                    "id": "epwpsk9"
+                                    "id": "epwpsk9",
+                                    "addons": []
                                 }
                             ],
                             "allowPrevious": false,
@@ -15543,7 +15837,9 @@
                             "tree": false,
                             "theme": "default",
                             "breadcrumb": "default",
-                            "id": "ei3r3id"
+                            "id": "ei3r3id",
+                            "addons": [],
+                            "lazyLoad": false
                         },
                         {
                             "label": "<strong>Durring your study period, will your partner be taking care of eligible dependants? </strong>",
@@ -15624,7 +15920,8 @@
                             "allowMultipleMasks": false,
                             "inputType": "radio",
                             "fieldSet": false,
-                            "id": "e887jy"
+                            "id": "e887jy",
+                            "addons": []
                         }
                     ],
                     "allowPrevious": false,
@@ -15681,7 +15978,9 @@
                     "tree": false,
                     "theme": "default",
                     "breadcrumb": "default",
-                    "id": "etvo8m"
+                    "id": "etvo8m",
+                    "addons": [],
+                    "lazyLoad": false
                 }
             ],
             "placeholder": "",
@@ -15720,19 +16019,15 @@
             "showWordCount": false,
             "allowMultipleMasks": false,
             "tree": false,
-            "id": "esudth"
+            "id": "esudth",
+            "addons": [],
+            "lazyLoad": false
         },
         {
             "title": "Parent information",
+            "labelWidth": "",
+            "labelMargin": "",
             "theme": "default",
-            "breadcrumb": "default",
-            "breadcrumbClickable": true,
-            "buttonSettings": {
-                "previous": false,
-                "cancel": false,
-                "next": false
-            },
-            "scrollToTop": true,
             "tooltip": "",
             "customClass": "",
             "collapsible": false,
@@ -15750,7 +16045,6 @@
                 "when": "dependantstatus",
                 "eq": "dependant"
             },
-            "nextPage": "",
             "logic": [],
             "attributes": {},
             "overlay": {
@@ -15763,14 +16057,20 @@
             },
             "type": "panel",
             "label": "Parental information",
+            "breadcrumb": "default",
+            "buttonSettings": {
+                "previous": false,
+                "cancel": false,
+                "next": false
+            },
             "tabindex": "",
+            "breadcrumbClickable": true,
+            "scrollToTop": true,
             "input": false,
             "tableView": false,
             "components": [
                 {
                     "label": "HTML",
-                    "tag": "p",
-                    "className": "",
                     "attrs": [
                         {
                             "attr": "",
@@ -15780,30 +16080,10 @@
                     "content": "Parent information",
                     "refreshOnChange": false,
                     "customClass": "header-lg",
-                    "hidden": false,
-                    "modalEdit": false,
                     "key": "html69",
-                    "tags": [],
-                    "properties": {},
-                    "conditional": {
-                        "show": null,
-                        "when": null,
-                        "eq": "",
-                        "json": ""
-                    },
-                    "customConditional": "",
-                    "logic": [],
-                    "attributes": {},
-                    "overlay": {
-                        "style": "",
-                        "page": "",
-                        "left": "",
-                        "top": "",
-                        "width": "",
-                        "height": ""
-                    },
                     "type": "htmlelement",
                     "input": false,
+                    "tableView": false,
                     "placeholder": "",
                     "prefix": "",
                     "suffix": "",
@@ -15812,10 +16092,11 @@
                     "protected": false,
                     "unique": false,
                     "persistent": false,
+                    "hidden": false,
                     "clearOnHide": true,
                     "refreshOn": "",
                     "redrawOn": "",
-                    "tableView": false,
+                    "modalEdit": false,
                     "dataGridLabel": false,
                     "labelPosition": "top",
                     "description": "",
@@ -15830,6 +16111,7 @@
                     "calculateValue": "",
                     "calculateServer": false,
                     "widget": null,
+                    "attributes": {},
                     "validateOn": "change",
                     "validate": {
                         "required": false,
@@ -15839,17 +16121,30 @@
                         "multiple": false,
                         "unique": false
                     },
+                    "conditional": {
+                        "show": null,
+                        "when": null,
+                        "eq": ""
+                    },
+                    "overlay": {
+                        "style": "",
+                        "left": "",
+                        "top": "",
+                        "width": "",
+                        "height": ""
+                    },
                     "allowCalculateOverride": false,
                     "encrypted": false,
                     "showCharCount": false,
                     "showWordCount": false,
+                    "properties": {},
                     "allowMultipleMasks": false,
-                    "id": "ez47c9l"
+                    "addons": [],
+                    "tag": "p",
+                    "id": "ea8bk45"
                 },
                 {
                     "label": "HTML",
-                    "tag": "p",
-                    "className": "",
                     "attrs": [
                         {
                             "attr": "",
@@ -15858,43 +16153,24 @@
                     ],
                     "content": "Help text about this section will be displayed here",
                     "refreshOnChange": false,
-                    "customClass": "",
-                    "hidden": false,
-                    "modalEdit": false,
                     "key": "html70",
-                    "tags": [],
-                    "properties": {},
-                    "conditional": {
-                        "show": null,
-                        "when": null,
-                        "eq": "",
-                        "json": ""
-                    },
-                    "customConditional": "",
-                    "logic": [],
-                    "attributes": {},
-                    "overlay": {
-                        "style": "",
-                        "page": "",
-                        "left": "",
-                        "top": "",
-                        "width": "",
-                        "height": ""
-                    },
                     "type": "htmlelement",
                     "input": false,
+                    "tableView": false,
                     "placeholder": "",
                     "prefix": "",
+                    "customClass": "",
                     "suffix": "",
                     "multiple": false,
                     "defaultValue": null,
                     "protected": false,
                     "unique": false,
                     "persistent": false,
+                    "hidden": false,
                     "clearOnHide": true,
                     "refreshOn": "",
                     "redrawOn": "",
-                    "tableView": false,
+                    "modalEdit": false,
                     "dataGridLabel": false,
                     "labelPosition": "top",
                     "description": "",
@@ -15909,6 +16185,7 @@
                     "calculateValue": "",
                     "calculateServer": false,
                     "widget": null,
+                    "attributes": {},
                     "validateOn": "change",
                     "validate": {
                         "required": false,
@@ -15918,28 +16195,33 @@
                         "multiple": false,
                         "unique": false
                     },
+                    "conditional": {
+                        "show": null,
+                        "when": null,
+                        "eq": ""
+                    },
+                    "overlay": {
+                        "style": "",
+                        "left": "",
+                        "top": "",
+                        "width": "",
+                        "height": ""
+                    },
                     "allowCalculateOverride": false,
                     "encrypted": false,
                     "showCharCount": false,
                     "showWordCount": false,
+                    "properties": {},
                     "allowMultipleMasks": false,
-                    "id": "e037i3r"
+                    "addons": [],
+                    "tag": "p",
+                    "id": "ebsmu9q"
                 },
                 {
                     "label": "<strong>Is your parent(s)/step-parent/sponsor/legal guardian a resident of B.C.?</strong>",
-                    "labelPosition": "top",
                     "optionsLabelPosition": "right",
-                    "description": "",
-                    "tooltip": "",
-                    "customClass": "",
-                    "tabindex": "",
                     "inline": false,
-                    "hidden": false,
-                    "hideLabel": false,
-                    "autofocus": false,
-                    "disabled": false,
                     "tableView": false,
-                    "modalEdit": false,
                     "values": [
                         {
                             "label": "Yes",
@@ -15962,83 +16244,76 @@
                             "shortcut": ""
                         }
                     ],
-                    "dataType": "",
-                    "persistent": true,
+                    "validate": {
+                        "required": true,
+                        "custom": "",
+                        "customPrivate": false,
+                        "strictDateValidation": false,
+                        "multiple": false,
+                        "unique": false,
+                        "onlyAvailableItems": false
+                    },
+                    "key": "parentbcResident",
+                    "type": "radio",
+                    "input": true,
+                    "placeholder": "",
+                    "prefix": "",
+                    "customClass": "",
+                    "suffix": "",
+                    "multiple": false,
+                    "defaultValue": null,
                     "protected": false,
-                    "dbIndex": false,
-                    "encrypted": false,
-                    "redrawOn": "",
+                    "unique": false,
+                    "persistent": true,
+                    "hidden": false,
                     "clearOnHide": true,
+                    "refreshOn": "",
+                    "redrawOn": "",
+                    "modalEdit": false,
+                    "dataGridLabel": false,
+                    "labelPosition": "top",
+                    "description": "",
+                    "errorLabel": "",
+                    "tooltip": "",
+                    "hideLabel": false,
+                    "tabindex": "",
+                    "disabled": false,
+                    "autofocus": false,
+                    "dbIndex": false,
                     "customDefaultValue": "",
                     "calculateValue": "",
                     "calculateServer": false,
-                    "allowCalculateOverride": false,
-                    "validate": {
-                        "required": true,
-                        "onlyAvailableItems": false,
-                        "customMessage": "",
-                        "custom": "",
-                        "customPrivate": false,
-                        "json": "",
-                        "strictDateValidation": false,
-                        "multiple": false,
-                        "unique": false
-                    },
-                    "errorLabel": "",
-                    "key": "parentbcResident",
-                    "tags": [],
-                    "properties": {},
+                    "widget": null,
+                    "attributes": {},
+                    "validateOn": "change",
                     "conditional": {
                         "show": null,
                         "when": null,
-                        "eq": "",
-                        "json": ""
+                        "eq": ""
                     },
-                    "customConditional": "",
-                    "logic": [],
-                    "attributes": {},
                     "overlay": {
                         "style": "",
-                        "page": "",
                         "left": "",
                         "top": "",
                         "width": "",
                         "height": ""
                     },
-                    "type": "radio",
-                    "input": true,
-                    "placeholder": "",
-                    "prefix": "",
-                    "suffix": "",
-                    "multiple": false,
-                    "unique": false,
-                    "refreshOn": "",
-                    "dataGridLabel": false,
-                    "widget": null,
-                    "validateOn": "change",
+                    "allowCalculateOverride": false,
+                    "encrypted": false,
                     "showCharCount": false,
                     "showWordCount": false,
+                    "properties": {},
                     "allowMultipleMasks": false,
+                    "addons": [],
                     "inputType": "radio",
                     "fieldSet": false,
-                    "id": "e12vr2m",
-                    "defaultValue": ""
+                    "id": "e9gfew"
                 },
                 {
                     "label": "<strong>Does your parent(s)/step-parent/sponsor/legal guardian have a valid Social Insurance Number?</strong>",
-                    "labelPosition": "top",
                     "optionsLabelPosition": "right",
-                    "description": "",
-                    "tooltip": "",
-                    "customClass": "",
-                    "tabindex": "",
                     "inline": false,
-                    "hidden": false,
-                    "hideLabel": false,
-                    "autofocus": false,
-                    "disabled": false,
                     "tableView": false,
-                    "modalEdit": false,
                     "values": [
                         {
                             "label": "Yes",
@@ -16051,83 +16326,77 @@
                             "shortcut": ""
                         }
                     ],
-                    "dataType": "",
-                    "persistent": true,
+                    "validate": {
+                        "required": true,
+                        "custom": "",
+                        "customPrivate": false,
+                        "strictDateValidation": false,
+                        "multiple": false,
+                        "unique": false,
+                        "onlyAvailableItems": false
+                    },
+                    "key": "doYourParentSStepParentSponsorLegalGuardianHaveAValidSinNumber",
+                    "customConditional": "show = (data.parentbcResident && (data.parentbcResident === \"yes\" || data.parentbcResident === \"no\"));",
+                    "type": "radio",
+                    "input": true,
+                    "placeholder": "",
+                    "prefix": "",
+                    "customClass": "",
+                    "suffix": "",
+                    "multiple": false,
+                    "defaultValue": null,
                     "protected": false,
-                    "dbIndex": false,
-                    "encrypted": false,
-                    "redrawOn": "",
+                    "unique": false,
+                    "persistent": true,
+                    "hidden": false,
                     "clearOnHide": true,
+                    "refreshOn": "",
+                    "redrawOn": "",
+                    "modalEdit": false,
+                    "dataGridLabel": false,
+                    "labelPosition": "top",
+                    "description": "",
+                    "errorLabel": "",
+                    "tooltip": "",
+                    "hideLabel": false,
+                    "tabindex": "",
+                    "disabled": false,
+                    "autofocus": false,
+                    "dbIndex": false,
                     "customDefaultValue": "",
                     "calculateValue": "",
                     "calculateServer": false,
-                    "allowCalculateOverride": false,
-                    "validate": {
-                        "required": true,
-                        "onlyAvailableItems": false,
-                        "customMessage": "",
-                        "custom": "",
-                        "customPrivate": false,
-                        "json": "",
-                        "strictDateValidation": false,
-                        "multiple": false,
-                        "unique": false
-                    },
-                    "errorLabel": "",
-                    "key": "doYourParentSStepParentSponsorLegalGuardianHaveAValidSinNumber",
-                    "tags": [],
-                    "properties": {},
+                    "widget": null,
+                    "attributes": {},
+                    "validateOn": "change",
                     "conditional": {
                         "show": null,
                         "when": null,
-                        "eq": "",
-                        "json": ""
+                        "eq": ""
                     },
-                    "customConditional": "show = (data.parentbcResident && (data.parentbcResident === \"yes\" || data.parentbcResident === \"no\"));",
-                    "logic": [],
-                    "attributes": {},
                     "overlay": {
                         "style": "",
-                        "page": "",
                         "left": "",
                         "top": "",
                         "width": "",
                         "height": ""
                     },
-                    "type": "radio",
-                    "input": true,
-                    "placeholder": "",
-                    "prefix": "",
-                    "suffix": "",
-                    "multiple": false,
-                    "unique": false,
-                    "refreshOn": "",
-                    "dataGridLabel": false,
-                    "widget": null,
-                    "validateOn": "change",
+                    "allowCalculateOverride": false,
+                    "encrypted": false,
                     "showCharCount": false,
                     "showWordCount": false,
+                    "properties": {},
                     "allowMultipleMasks": false,
+                    "addons": [],
                     "inputType": "radio",
                     "fieldSet": false,
-                    "id": "edhl0tsr",
-                    "defaultValue": ""
+                    "id": "edwpye"
                 },
                 {
                     "label": "<strong>How many parents do you live with?</strong>",
-                    "labelPosition": "top",
                     "optionsLabelPosition": "right",
-                    "description": "",
-                    "tooltip": "",
-                    "customClass": "",
-                    "tabindex": "",
                     "inline": false,
-                    "hidden": false,
-                    "hideLabel": false,
-                    "autofocus": false,
-                    "disabled": false,
                     "tableView": false,
-                    "modalEdit": false,
                     "values": [
                         {
                             "label": "1",
@@ -16140,71 +16409,73 @@
                             "shortcut": ""
                         }
                     ],
-                    "dataType": "",
-                    "persistent": true,
-                    "protected": false,
-                    "dbIndex": false,
-                    "encrypted": false,
-                    "redrawOn": "",
-                    "clearOnHide": true,
-                    "customDefaultValue": "",
-                    "calculateValue": "",
-                    "calculateServer": false,
-                    "allowCalculateOverride": false,
                     "validate": {
                         "required": true,
-                        "onlyAvailableItems": false,
-                        "customMessage": "",
                         "custom": "",
                         "customPrivate": false,
-                        "json": "",
                         "strictDateValidation": false,
                         "multiple": false,
-                        "unique": false
+                        "unique": false,
+                        "onlyAvailableItems": false
                     },
-                    "errorLabel": "",
                     "key": "numberOfParents",
-                    "tags": [],
-                    "properties": {},
                     "conditional": {
                         "show": true,
                         "when": "isYourSpouseACanadianCitizen",
-                        "eq": "yes",
-                        "json": ""
-                    },
-                    "customConditional": "",
-                    "logic": [],
-                    "attributes": {},
-                    "overlay": {
-                        "style": "",
-                        "page": "",
-                        "left": "",
-                        "top": "",
-                        "width": "",
-                        "height": ""
+                        "eq": "yes"
                     },
                     "type": "radio",
                     "input": true,
                     "placeholder": "",
                     "prefix": "",
+                    "customClass": "",
                     "suffix": "",
                     "multiple": false,
+                    "defaultValue": null,
+                    "protected": false,
                     "unique": false,
+                    "persistent": true,
+                    "hidden": false,
+                    "clearOnHide": true,
                     "refreshOn": "",
+                    "redrawOn": "",
+                    "modalEdit": false,
                     "dataGridLabel": false,
+                    "labelPosition": "top",
+                    "description": "",
+                    "errorLabel": "",
+                    "tooltip": "",
+                    "hideLabel": false,
+                    "tabindex": "",
+                    "disabled": false,
+                    "autofocus": false,
+                    "dbIndex": false,
+                    "customDefaultValue": "",
+                    "calculateValue": "",
+                    "calculateServer": false,
                     "widget": null,
+                    "attributes": {},
                     "validateOn": "change",
+                    "overlay": {
+                        "style": "",
+                        "left": "",
+                        "top": "",
+                        "width": "",
+                        "height": ""
+                    },
+                    "allowCalculateOverride": false,
+                    "encrypted": false,
                     "showCharCount": false,
                     "showWordCount": false,
+                    "properties": {},
                     "allowMultipleMasks": false,
+                    "addons": [],
                     "inputType": "radio",
                     "fieldSet": false,
-                    "id": "ejm2anl",
-                    "defaultValue": ""
+                    "id": "e5yic27"
                 },
                 {
                     "label": "HTML",
-                    "tag": "p",
                     "className": "alert alert-info fa fa-info-circle",
                     "attrs": [
                         {
@@ -16215,27 +16486,11 @@
                     "content": "<Strong> Please be advised that your parent(s) will need to sign in and provide additional information.</Strong>\r\n<br/> Please check your email after submitting your application. An email will be sent to you with instructions for your parent(s) to sign in. Your application can not proceed until this information is received.",
                     "refreshOnChange": false,
                     "customClass": "banner-info",
-                    "hidden": false,
-                    "modalEdit": false,
                     "key": "html11",
-                    "tags": [],
-                    "properties": {},
                     "conditional": {
                         "show": true,
                         "when": "doYourParentSStepParentSponsorLegalGuardianHaveAValidSinNumber",
-                        "eq": "yes",
-                        "json": ""
-                    },
-                    "customConditional": "",
-                    "logic": [],
-                    "attributes": {},
-                    "overlay": {
-                        "style": "",
-                        "page": "",
-                        "left": "",
-                        "top": "",
-                        "width": "",
-                        "height": ""
+                        "eq": "yes"
                     },
                     "type": "htmlelement",
                     "input": false,
@@ -16248,9 +16503,11 @@
                     "protected": false,
                     "unique": false,
                     "persistent": false,
+                    "hidden": false,
                     "clearOnHide": true,
                     "refreshOn": "",
                     "redrawOn": "",
+                    "modalEdit": false,
                     "dataGridLabel": false,
                     "labelPosition": "top",
                     "description": "",
@@ -16265,6 +16522,7 @@
                     "calculateValue": "",
                     "calculateServer": false,
                     "widget": null,
+                    "attributes": {},
                     "validateOn": "change",
                     "validate": {
                         "required": false,
@@ -16274,16 +16532,25 @@
                         "multiple": false,
                         "unique": false
                     },
+                    "overlay": {
+                        "style": "",
+                        "left": "",
+                        "top": "",
+                        "width": "",
+                        "height": ""
+                    },
                     "allowCalculateOverride": false,
                     "encrypted": false,
                     "showCharCount": false,
                     "showWordCount": false,
+                    "properties": {},
                     "allowMultipleMasks": false,
-                    "id": "egvhhzk"
+                    "addons": [],
+                    "tag": "p",
+                    "id": "ecjuts"
                 },
                 {
                     "label": "HTML",
-                    "tag": "p",
                     "className": "alert alert-warning fa fa-exclamation-circle",
                     "attrs": [
                         {
@@ -16294,27 +16561,11 @@
                     "content": "<strong> Please be advised this could delay your application </strong>\n<br>Since we’re unable to validate your partner’s information with Canada Revenue Agency (CRA), please estimate your parent(s) income.",
                     "refreshOnChange": false,
                     "customClass": "banner-warning",
-                    "hidden": false,
-                    "modalEdit": false,
                     "key": "html2",
-                    "tags": [],
-                    "properties": {},
                     "conditional": {
                         "show": true,
                         "when": "doYourParentSStepParentSponsorLegalGuardianHaveAValidSinNumber",
-                        "eq": "no",
-                        "json": ""
-                    },
-                    "customConditional": "",
-                    "logic": [],
-                    "attributes": {},
-                    "overlay": {
-                        "style": "",
-                        "page": "",
-                        "left": "",
-                        "top": "",
-                        "width": "",
-                        "height": ""
+                        "eq": "no"
                     },
                     "type": "htmlelement",
                     "input": false,
@@ -16327,9 +16578,11 @@
                     "protected": false,
                     "unique": false,
                     "persistent": false,
+                    "hidden": false,
                     "clearOnHide": true,
                     "refreshOn": "",
                     "redrawOn": "",
+                    "modalEdit": false,
                     "dataGridLabel": false,
                     "labelPosition": "top",
                     "description": "",
@@ -16344,6 +16597,7 @@
                     "calculateValue": "",
                     "calculateServer": false,
                     "widget": null,
+                    "attributes": {},
                     "validateOn": "change",
                     "validate": {
                         "required": false,
@@ -16353,12 +16607,22 @@
                         "multiple": false,
                         "unique": false
                     },
+                    "overlay": {
+                        "style": "",
+                        "left": "",
+                        "top": "",
+                        "width": "",
+                        "height": ""
+                    },
                     "allowCalculateOverride": false,
                     "encrypted": false,
                     "showCharCount": false,
                     "showWordCount": false,
+                    "properties": {},
                     "allowMultipleMasks": false,
-                    "id": "e13cki8"
+                    "addons": [],
+                    "tag": "p",
+                    "id": "eo6ye08"
                 },
                 {
                     "title": "Parental Info Request ",
@@ -16455,12 +16719,11 @@
                             "showWordCount": false,
                             "properties": {},
                             "allowMultipleMasks": false,
-                            "id": "e4e7fo9"
+                            "addons": [],
+                            "id": "en0bng"
                         },
                         {
                             "label": "HTML",
-                            "tag": "p",
-                            "className": "",
                             "attrs": [
                                 {
                                     "attr": "",
@@ -16470,30 +16733,10 @@
                             "content": "Your siblings and other parent dependents ",
                             "refreshOnChange": false,
                             "customClass": "header-md",
-                            "hidden": false,
-                            "modalEdit": false,
                             "key": "html71",
-                            "tags": [],
-                            "properties": {},
-                            "conditional": {
-                                "show": null,
-                                "when": null,
-                                "eq": "",
-                                "json": ""
-                            },
-                            "customConditional": "",
-                            "logic": [],
-                            "attributes": {},
-                            "overlay": {
-                                "style": "",
-                                "page": "",
-                                "left": "",
-                                "top": "",
-                                "width": "",
-                                "height": ""
-                            },
                             "type": "htmlelement",
                             "input": false,
+                            "tableView": false,
                             "placeholder": "",
                             "prefix": "",
                             "suffix": "",
@@ -16502,10 +16745,11 @@
                             "protected": false,
                             "unique": false,
                             "persistent": false,
+                            "hidden": false,
                             "clearOnHide": true,
                             "refreshOn": "",
                             "redrawOn": "",
-                            "tableView": false,
+                            "modalEdit": false,
                             "dataGridLabel": false,
                             "labelPosition": "top",
                             "description": "",
@@ -16520,6 +16764,7 @@
                             "calculateValue": "",
                             "calculateServer": false,
                             "widget": null,
+                            "attributes": {},
                             "validateOn": "change",
                             "validate": {
                                 "required": false,
@@ -16529,17 +16774,30 @@
                                 "multiple": false,
                                 "unique": false
                             },
+                            "conditional": {
+                                "show": null,
+                                "when": null,
+                                "eq": ""
+                            },
+                            "overlay": {
+                                "style": "",
+                                "left": "",
+                                "top": "",
+                                "width": "",
+                                "height": ""
+                            },
                             "allowCalculateOverride": false,
                             "encrypted": false,
                             "showCharCount": false,
                             "showWordCount": false,
+                            "properties": {},
                             "allowMultipleMasks": false,
-                            "id": "eaz6oxq"
+                            "addons": [],
+                            "tag": "p",
+                            "id": "el1pjy"
                         },
                         {
                             "label": "HTML",
-                            "tag": "p",
-                            "className": "",
                             "attrs": [
                                 {
                                     "attr": "",
@@ -16548,43 +16806,24 @@
                             ],
                             "content": "We use this information to ensure that we take into account your parent(s) responsibility to other dependants…",
                             "refreshOnChange": false,
-                            "customClass": "",
-                            "hidden": false,
-                            "modalEdit": false,
                             "key": "html72",
-                            "tags": [],
-                            "properties": {},
-                            "conditional": {
-                                "show": null,
-                                "when": null,
-                                "eq": "",
-                                "json": ""
-                            },
-                            "customConditional": "",
-                            "logic": [],
-                            "attributes": {},
-                            "overlay": {
-                                "style": "",
-                                "page": "",
-                                "left": "",
-                                "top": "",
-                                "width": "",
-                                "height": ""
-                            },
                             "type": "htmlelement",
                             "input": false,
+                            "tableView": false,
                             "placeholder": "",
                             "prefix": "",
+                            "customClass": "",
                             "suffix": "",
                             "multiple": false,
                             "defaultValue": null,
                             "protected": false,
                             "unique": false,
                             "persistent": false,
+                            "hidden": false,
                             "clearOnHide": true,
                             "refreshOn": "",
                             "redrawOn": "",
-                            "tableView": false,
+                            "modalEdit": false,
                             "dataGridLabel": false,
                             "labelPosition": "top",
                             "description": "",
@@ -16599,6 +16838,7 @@
                             "calculateValue": "",
                             "calculateServer": false,
                             "widget": null,
+                            "attributes": {},
                             "validateOn": "change",
                             "validate": {
                                 "required": false,
@@ -16608,12 +16848,27 @@
                                 "multiple": false,
                                 "unique": false
                             },
+                            "conditional": {
+                                "show": null,
+                                "when": null,
+                                "eq": ""
+                            },
+                            "overlay": {
+                                "style": "",
+                                "left": "",
+                                "top": "",
+                                "width": "",
+                                "height": ""
+                            },
                             "allowCalculateOverride": false,
                             "encrypted": false,
                             "showCharCount": false,
                             "showWordCount": false,
+                            "properties": {},
                             "allowMultipleMasks": false,
-                            "id": "ee95ppo"
+                            "addons": [],
+                            "tag": "p",
+                            "id": "enrjqhk"
                         },
                         {
                             "label": "Do your parents have dependants other than yourself?",
@@ -16635,12 +16890,12 @@
                             ],
                             "validate": {
                                 "required": true,
-                                "onlyAvailableItems": false,
                                 "custom": "",
                                 "customPrivate": false,
                                 "strictDateValidation": false,
                                 "multiple": false,
-                                "unique": false
+                                "unique": false,
+                                "onlyAvailableItems": false
                             },
                             "key": "doYourParentsHaveDependantsOtherThanYourself",
                             "conditional": {
@@ -16692,9 +16947,10 @@
                             "showWordCount": false,
                             "properties": {},
                             "allowMultipleMasks": false,
+                            "addons": [],
                             "inputType": "radio",
                             "fieldSet": false,
-                            "id": "eq2hrdb"
+                            "id": "eht9ih"
                         },
                         {
                             "title": "Your siblings and other dependents panel",
@@ -16720,8 +16976,6 @@
                             "components": [
                                 {
                                     "label": "HTML",
-                                    "tag": "p",
-                                    "className": "",
                                     "attrs": [
                                         {
                                             "attr": "",
@@ -16731,30 +16985,10 @@
                                     "content": "Your siblings and other dependents ",
                                     "refreshOnChange": false,
                                     "customClass": "header-md",
-                                    "hidden": false,
-                                    "modalEdit": false,
                                     "key": "html73",
-                                    "tags": [],
-                                    "properties": {},
-                                    "conditional": {
-                                        "show": null,
-                                        "when": null,
-                                        "eq": "",
-                                        "json": ""
-                                    },
-                                    "customConditional": "",
-                                    "logic": [],
-                                    "attributes": {},
-                                    "overlay": {
-                                        "style": "",
-                                        "page": "",
-                                        "left": "",
-                                        "top": "",
-                                        "width": "",
-                                        "height": ""
-                                    },
                                     "type": "htmlelement",
                                     "input": false,
+                                    "tableView": false,
                                     "placeholder": "",
                                     "prefix": "",
                                     "suffix": "",
@@ -16763,10 +16997,11 @@
                                     "protected": false,
                                     "unique": false,
                                     "persistent": false,
+                                    "hidden": false,
                                     "clearOnHide": true,
                                     "refreshOn": "",
                                     "redrawOn": "",
-                                    "tableView": false,
+                                    "modalEdit": false,
                                     "dataGridLabel": false,
                                     "labelPosition": "top",
                                     "description": "",
@@ -16781,6 +17016,7 @@
                                     "calculateValue": "",
                                     "calculateServer": false,
                                     "widget": null,
+                                    "attributes": {},
                                     "validateOn": "change",
                                     "validate": {
                                         "required": false,
@@ -16790,17 +17026,30 @@
                                         "multiple": false,
                                         "unique": false
                                     },
+                                    "conditional": {
+                                        "show": null,
+                                        "when": null,
+                                        "eq": ""
+                                    },
+                                    "overlay": {
+                                        "style": "",
+                                        "left": "",
+                                        "top": "",
+                                        "width": "",
+                                        "height": ""
+                                    },
                                     "allowCalculateOverride": false,
                                     "encrypted": false,
                                     "showCharCount": false,
                                     "showWordCount": false,
+                                    "properties": {},
                                     "allowMultipleMasks": false,
-                                    "id": "e0bgfy"
+                                    "addons": [],
+                                    "tag": "p",
+                                    "id": "e6y8kvm"
                                 },
                                 {
                                     "label": "HTML",
-                                    "tag": "p",
-                                    "className": "",
                                     "attrs": [
                                         {
                                             "attr": "",
@@ -16809,43 +17058,24 @@
                                     ],
                                     "content": "We use this information to ensure that we take into account your parent(s) responsibility to other dependents…",
                                     "refreshOnChange": false,
-                                    "customClass": "",
-                                    "hidden": false,
-                                    "modalEdit": false,
                                     "key": "html74",
-                                    "tags": [],
-                                    "properties": {},
-                                    "conditional": {
-                                        "show": null,
-                                        "when": null,
-                                        "eq": "",
-                                        "json": ""
-                                    },
-                                    "customConditional": "",
-                                    "logic": [],
-                                    "attributes": {},
-                                    "overlay": {
-                                        "style": "",
-                                        "page": "",
-                                        "left": "",
-                                        "top": "",
-                                        "width": "",
-                                        "height": ""
-                                    },
                                     "type": "htmlelement",
                                     "input": false,
+                                    "tableView": false,
                                     "placeholder": "",
                                     "prefix": "",
+                                    "customClass": "",
                                     "suffix": "",
                                     "multiple": false,
                                     "defaultValue": null,
                                     "protected": false,
                                     "unique": false,
                                     "persistent": false,
+                                    "hidden": false,
                                     "clearOnHide": true,
                                     "refreshOn": "",
                                     "redrawOn": "",
-                                    "tableView": false,
+                                    "modalEdit": false,
                                     "dataGridLabel": false,
                                     "labelPosition": "top",
                                     "description": "",
@@ -16860,6 +17090,7 @@
                                     "calculateValue": "",
                                     "calculateServer": false,
                                     "widget": null,
+                                    "attributes": {},
                                     "validateOn": "change",
                                     "validate": {
                                         "required": false,
@@ -16869,12 +17100,27 @@
                                         "multiple": false,
                                         "unique": false
                                     },
+                                    "conditional": {
+                                        "show": null,
+                                        "when": null,
+                                        "eq": ""
+                                    },
+                                    "overlay": {
+                                        "style": "",
+                                        "left": "",
+                                        "top": "",
+                                        "width": "",
+                                        "height": ""
+                                    },
                                     "allowCalculateOverride": false,
                                     "encrypted": false,
                                     "showCharCount": false,
                                     "showWordCount": false,
+                                    "properties": {},
                                     "allowMultipleMasks": false,
-                                    "id": "eguy7vn"
+                                    "addons": [],
+                                    "tag": "p",
+                                    "id": "en32v89f"
                                 },
                                 {
                                     "label": "<strong>Parent dependent table</strong>",
@@ -16924,7 +17170,7 @@
                                             "key": "ageAtStartOfYourStudyPeriod",
                                             "type": "number",
                                             "input": true,
-                                            "id": "ea6c5bs000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+                                            "id": "edl38cm",
                                             "placeholder": "",
                                             "prefix": "",
                                             "customClass": "",
@@ -16974,7 +17220,8 @@
                                             "showCharCount": false,
                                             "showWordCount": false,
                                             "properties": {},
-                                            "allowMultipleMasks": false
+                                            "allowMultipleMasks": false,
+                                            "addons": []
                                         },
                                         {
                                             "label": "<strong>Will this dependant be attending high school or full-time post-secondary school at the start of your study period?</strong>",
@@ -16999,12 +17246,13 @@
                                                 "customPrivate": false,
                                                 "strictDateValidation": false,
                                                 "multiple": false,
-                                                "unique": false
+                                                "unique": false,
+                                                "onlyAvailableItems": false
                                             },
                                             "key": "willThisDependantBeAttendingHighSchoolOrFullTimePostSecondarySchoolAtTheStartOfYourStudyPeriod",
                                             "type": "radio",
                                             "input": true,
-                                            "id": "eqnu34000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+                                            "id": "eromvng",
                                             "placeholder": "",
                                             "prefix": "",
                                             "customClass": "",
@@ -17053,6 +17301,7 @@
                                             "showWordCount": false,
                                             "properties": {},
                                             "allowMultipleMasks": false,
+                                            "addons": [],
                                             "inputType": "radio",
                                             "fieldSet": false
                                         },
@@ -17079,12 +17328,13 @@
                                                 "customPrivate": false,
                                                 "strictDateValidation": false,
                                                 "multiple": false,
-                                                "unique": false
+                                                "unique": false,
+                                                "onlyAvailableItems": false
                                             },
                                             "key": "didYouParentSClaimThisDependantOnTheir20XxIncomeTaxReturnDueToADisability",
                                             "type": "radio",
                                             "input": true,
-                                            "id": "eajzsj000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+                                            "id": "eg65qgr",
                                             "placeholder": "",
                                             "prefix": "",
                                             "customClass": "",
@@ -17133,6 +17383,7 @@
                                             "showWordCount": false,
                                             "properties": {},
                                             "allowMultipleMasks": false,
+                                            "addons": [],
                                             "inputType": "radio",
                                             "fieldSet": false
                                         }
@@ -17187,9 +17438,11 @@
                                     "showWordCount": false,
                                     "properties": {},
                                     "allowMultipleMasks": false,
+                                    "addons": [],
                                     "tree": true,
+                                    "lazyLoad": false,
                                     "disableAddingRemovingRows": false,
-                                    "id": "e1exjiw"
+                                    "id": "eb9vzaq"
                                 }
                             ],
                             "allowPrevious": false,
@@ -17243,10 +17496,12 @@
                             "showWordCount": false,
                             "properties": {},
                             "allowMultipleMasks": false,
+                            "addons": [],
                             "tree": false,
+                            "lazyLoad": false,
                             "theme": "default",
                             "breadcrumb": "default",
-                            "id": "e8tw6ni"
+                            "id": "etlf95"
                         }
                     ],
                     "allowPrevious": false,
@@ -17300,15 +17555,15 @@
                     "showWordCount": false,
                     "properties": {},
                     "allowMultipleMasks": false,
+                    "addons": [],
                     "tree": false,
+                    "lazyLoad": false,
                     "theme": "default",
                     "breadcrumb": "default",
-                    "id": "etv3h9q"
+                    "id": "ei7drfd"
                 },
                 {
                     "title": "Estranged details panel",
-                    "theme": "default",
-                    "breadcrumb": "default",
                     "breadcrumbClickable": false,
                     "buttonSettings": {
                         "previous": false,
@@ -17316,44 +17571,21 @@
                         "next": false
                     },
                     "scrollToTop": false,
-                    "tooltip": "",
-                    "customClass": "",
                     "collapsible": false,
-                    "hidden": false,
                     "hideLabel": true,
-                    "disabled": false,
-                    "modalEdit": false,
                     "key": "estrangedDetailsPanel",
-                    "tags": [],
-                    "properties": {},
-                    "customConditional": "",
                     "conditional": {
-                        "json": "",
                         "show": true,
                         "when": "parentbcResident",
                         "eq": "estranged"
                     },
-                    "nextPage": "",
-                    "logic": [],
-                    "attributes": {},
-                    "overlay": {
-                        "style": "",
-                        "page": "",
-                        "left": "",
-                        "top": "",
-                        "width": "",
-                        "height": ""
-                    },
                     "type": "panel",
                     "label": "Estranged details panel",
-                    "tabindex": "",
                     "input": false,
                     "tableView": false,
                     "components": [
                         {
                             "label": "HTML",
-                            "tag": "p",
-                            "className": "",
                             "attrs": [
                                 {
                                     "attr": "",
@@ -17363,30 +17595,10 @@
                             "content": "Please provide supporting information ",
                             "refreshOnChange": false,
                             "customClass": "header-md",
-                            "hidden": false,
-                            "modalEdit": false,
                             "key": "html75",
-                            "tags": [],
-                            "properties": {},
-                            "conditional": {
-                                "show": null,
-                                "when": null,
-                                "eq": "",
-                                "json": ""
-                            },
-                            "customConditional": "",
-                            "logic": [],
-                            "attributes": {},
-                            "overlay": {
-                                "style": "",
-                                "page": "",
-                                "left": "",
-                                "top": "",
-                                "width": "",
-                                "height": ""
-                            },
                             "type": "htmlelement",
                             "input": false,
+                            "tableView": false,
                             "placeholder": "",
                             "prefix": "",
                             "suffix": "",
@@ -17395,10 +17607,11 @@
                             "protected": false,
                             "unique": false,
                             "persistent": false,
+                            "hidden": false,
                             "clearOnHide": true,
                             "refreshOn": "",
                             "redrawOn": "",
-                            "tableView": false,
+                            "modalEdit": false,
                             "dataGridLabel": false,
                             "labelPosition": "top",
                             "description": "",
@@ -17413,6 +17626,7 @@
                             "calculateValue": "",
                             "calculateServer": false,
                             "widget": null,
+                            "attributes": {},
                             "validateOn": "change",
                             "validate": {
                                 "required": false,
@@ -17422,17 +17636,30 @@
                                 "multiple": false,
                                 "unique": false
                             },
+                            "conditional": {
+                                "show": null,
+                                "when": null,
+                                "eq": ""
+                            },
+                            "overlay": {
+                                "style": "",
+                                "left": "",
+                                "top": "",
+                                "width": "",
+                                "height": ""
+                            },
                             "allowCalculateOverride": false,
                             "encrypted": false,
                             "showCharCount": false,
                             "showWordCount": false,
+                            "properties": {},
                             "allowMultipleMasks": false,
-                            "id": "eor6sz"
+                            "addons": [],
+                            "tag": "p",
+                            "id": "eqr4148"
                         },
                         {
                             "label": "HTML",
-                            "tag": "p",
-                            "className": "",
                             "attrs": [
                                 {
                                     "attr": "",
@@ -17441,43 +17668,24 @@
                             ],
                             "content": "You may be assessed as an independent student if there has been a severe family breakdown that goes beyond the normal disagreements between parents and children.",
                             "refreshOnChange": false,
-                            "customClass": "",
-                            "hidden": false,
-                            "modalEdit": false,
                             "key": "html76",
-                            "tags": [],
-                            "properties": {},
-                            "conditional": {
-                                "show": null,
-                                "when": null,
-                                "eq": "",
-                                "json": ""
-                            },
-                            "customConditional": "",
-                            "logic": [],
-                            "attributes": {},
-                            "overlay": {
-                                "style": "",
-                                "page": "",
-                                "left": "",
-                                "top": "",
-                                "width": "",
-                                "height": ""
-                            },
                             "type": "htmlelement",
                             "input": false,
+                            "tableView": false,
                             "placeholder": "",
                             "prefix": "",
+                            "customClass": "",
                             "suffix": "",
                             "multiple": false,
                             "defaultValue": null,
                             "protected": false,
                             "unique": false,
                             "persistent": false,
+                            "hidden": false,
                             "clearOnHide": true,
                             "refreshOn": "",
                             "redrawOn": "",
-                            "tableView": false,
+                            "modalEdit": false,
                             "dataGridLabel": false,
                             "labelPosition": "top",
                             "description": "",
@@ -17492,6 +17700,7 @@
                             "calculateValue": "",
                             "calculateServer": false,
                             "widget": null,
+                            "attributes": {},
                             "validateOn": "change",
                             "validate": {
                                 "required": false,
@@ -17501,39 +17710,34 @@
                                 "multiple": false,
                                 "unique": false
                             },
+                            "conditional": {
+                                "show": null,
+                                "when": null,
+                                "eq": ""
+                            },
+                            "overlay": {
+                                "style": "",
+                                "left": "",
+                                "top": "",
+                                "width": "",
+                                "height": ""
+                            },
                             "allowCalculateOverride": false,
                             "encrypted": false,
                             "showCharCount": false,
                             "showWordCount": false,
+                            "properties": {},
                             "allowMultipleMasks": false,
-                            "id": "ec2zw4i"
+                            "addons": [],
+                            "tag": "p",
+                            "id": "e9zei5r"
                         },
                         {
                             "label": "<strong>Please select the date you were estranged from your parents</strong>",
-                            "labelPosition": "top",
-                            "displayInTimezone": "viewer",
-                            "useLocaleSettings": false,
-                            "allowInput": true,
                             "format": "yyyy-MM-dd",
-                            "placeholder": "",
-                            "description": "",
-                            "tooltip": "",
-                            "customClass": "",
-                            "tabindex": "",
-                            "hidden": false,
-                            "hideLabel": false,
-                            "autofocus": false,
-                            "disabled": false,
                             "tableView": false,
-                            "modalEdit": false,
-                            "shortcutButtons": [],
-                            "enableDate": true,
                             "enableMinDateInput": false,
                             "datePicker": {
-                                "minDate": null,
-                                "maxDate": null,
-                                "disable": "",
-                                "disableFunction": "",
                                 "disableWeekends": false,
                                 "disableWeekdays": false,
                                 "showWeeks": true,
@@ -17542,72 +17746,15 @@
                                 "minMode": "day",
                                 "maxMode": "year",
                                 "yearRows": 4,
-                                "yearColumns": 5
+                                "yearColumns": 5,
+                                "minDate": null,
+                                "maxDate": null
                             },
                             "enableMaxDateInput": false,
                             "enableTime": false,
-                            "timePicker": {
-                                "showMeridian": true,
-                                "hourStep": 1,
-                                "minuteStep": 1,
-                                "readonlyInput": false,
-                                "mousewheel": true,
-                                "arrowkeys": true
-                            },
-                            "multiple": false,
-                            "defaultValue": "",
-                            "defaultDate": "",
-                            "customOptions": {},
-                            "persistent": true,
-                            "protected": false,
-                            "dbIndex": false,
-                            "encrypted": false,
-                            "redrawOn": "",
-                            "clearOnHide": true,
-                            "customDefaultValue": "",
-                            "calculateValue": "",
-                            "calculateServer": false,
-                            "allowCalculateOverride": false,
-                            "validate": {
-                                "required": false,
-                                "customMessage": "",
-                                "custom": "",
-                                "customPrivate": false,
-                                "json": "",
-                                "strictDateValidation": false,
-                                "multiple": false,
-                                "unique": false
-                            },
-                            "unique": false,
-                            "validateOn": "change",
-                            "errorLabel": "",
                             "key": "estrangedDate",
-                            "tags": [],
-                            "properties": {},
-                            "conditional": {
-                                "show": null,
-                                "when": null,
-                                "eq": "",
-                                "json": ""
-                            },
-                            "customConditional": "",
-                            "logic": [],
-                            "attributes": {},
-                            "overlay": {
-                                "style": "",
-                                "page": "",
-                                "left": "",
-                                "top": "",
-                                "width": "",
-                                "height": ""
-                            },
                             "type": "datetime",
-                            "timezone": "",
                             "input": true,
-                            "prefix": "",
-                            "suffix": "",
-                            "refreshOn": "",
-                            "dataGridLabel": false,
                             "widget": {
                                 "type": "calendar",
                                 "displayInTimezone": "viewer",
@@ -17622,22 +17769,86 @@
                                 "minuteIncrement": 1,
                                 "time_24hr": false,
                                 "minDate": null,
-                                "disabledDates": "",
                                 "disableWeekends": false,
                                 "disableWeekdays": false,
-                                "disableFunction": "",
                                 "maxDate": null
                             },
+                            "placeholder": "",
+                            "prefix": "",
+                            "customClass": "",
+                            "suffix": "",
+                            "multiple": false,
+                            "defaultValue": "",
+                            "protected": false,
+                            "unique": false,
+                            "persistent": true,
+                            "hidden": false,
+                            "clearOnHide": true,
+                            "refreshOn": "",
+                            "redrawOn": "",
+                            "modalEdit": false,
+                            "dataGridLabel": false,
+                            "labelPosition": "top",
+                            "description": "",
+                            "errorLabel": "",
+                            "tooltip": "",
+                            "hideLabel": false,
+                            "tabindex": "",
+                            "disabled": false,
+                            "autofocus": false,
+                            "dbIndex": false,
+                            "customDefaultValue": "",
+                            "calculateValue": "",
+                            "calculateServer": false,
+                            "attributes": {},
+                            "validateOn": "change",
+                            "validate": {
+                                "required": false,
+                                "custom": "",
+                                "customPrivate": false,
+                                "strictDateValidation": false,
+                                "multiple": false,
+                                "unique": false
+                            },
+                            "conditional": {
+                                "show": null,
+                                "when": null,
+                                "eq": ""
+                            },
+                            "overlay": {
+                                "style": "",
+                                "left": "",
+                                "top": "",
+                                "width": "",
+                                "height": ""
+                            },
+                            "allowCalculateOverride": false,
+                            "encrypted": false,
                             "showCharCount": false,
                             "showWordCount": false,
+                            "properties": {},
                             "allowMultipleMasks": false,
+                            "addons": [],
+                            "useLocaleSettings": false,
+                            "allowInput": true,
+                            "enableDate": true,
+                            "defaultDate": "",
+                            "displayInTimezone": "viewer",
+                            "timezone": "",
                             "datepickerMode": "day",
-                            "id": "exab4vl"
+                            "timePicker": {
+                                "hourStep": 1,
+                                "minuteStep": 1,
+                                "showMeridian": true,
+                                "readonlyInput": false,
+                                "mousewheel": true,
+                                "arrowkeys": true
+                            },
+                            "customOptions": {},
+                            "id": "erry83l"
                         },
                         {
                             "label": "HTML",
-                            "tag": "p",
-                            "className": "",
                             "attrs": [
                                 {
                                     "attr": "",
@@ -17647,30 +17858,10 @@
                             "content": "Upload supporting documents",
                             "refreshOnChange": false,
                             "customClass": "header-sm",
-                            "hidden": false,
-                            "modalEdit": false,
                             "key": "html77",
-                            "tags": [],
-                            "properties": {},
-                            "conditional": {
-                                "show": null,
-                                "when": null,
-                                "eq": "",
-                                "json": ""
-                            },
-                            "customConditional": "",
-                            "logic": [],
-                            "attributes": {},
-                            "overlay": {
-                                "style": "",
-                                "page": "",
-                                "left": "",
-                                "top": "",
-                                "width": "",
-                                "height": ""
-                            },
                             "type": "htmlelement",
                             "input": false,
+                            "tableView": false,
                             "placeholder": "",
                             "prefix": "",
                             "suffix": "",
@@ -17679,10 +17870,11 @@
                             "protected": false,
                             "unique": false,
                             "persistent": false,
+                            "hidden": false,
                             "clearOnHide": true,
                             "refreshOn": "",
                             "redrawOn": "",
-                            "tableView": false,
+                            "modalEdit": false,
                             "dataGridLabel": false,
                             "labelPosition": "top",
                             "description": "",
@@ -17697,6 +17889,7 @@
                             "calculateValue": "",
                             "calculateServer": false,
                             "widget": null,
+                            "attributes": {},
                             "validateOn": "change",
                             "validate": {
                                 "required": false,
@@ -17706,17 +17899,30 @@
                                 "multiple": false,
                                 "unique": false
                             },
+                            "conditional": {
+                                "show": null,
+                                "when": null,
+                                "eq": ""
+                            },
+                            "overlay": {
+                                "style": "",
+                                "left": "",
+                                "top": "",
+                                "width": "",
+                                "height": ""
+                            },
                             "allowCalculateOverride": false,
                             "encrypted": false,
                             "showCharCount": false,
                             "showWordCount": false,
+                            "properties": {},
                             "allowMultipleMasks": false,
-                            "id": "e7le97c"
+                            "addons": [],
+                            "tag": "p",
+                            "id": "efwpcq"
                         },
                         {
                             "label": "HTML",
-                            "tag": "p",
-                            "className": "",
                             "attrs": [
                                 {
                                     "attr": "",
@@ -17726,28 +17932,7 @@
                             "content": "<strong>Documents Accepted</strong><br>\r\nA letter from a third party (a social service agency or other professional with direct knowledge of your situation) that includes the following information:\r\n<ul>\r\n  <li>Their relationship to you and your family</li>\r\n  <li>Their profession</li>\r\n  <li>Their statement confirming the nature of the breakdown</li>\r\n</ul>",
                             "refreshOnChange": false,
                             "customClass": "align-bullets",
-                            "hidden": false,
-                            "modalEdit": false,
                             "key": "html20",
-                            "tags": [],
-                            "properties": {},
-                            "conditional": {
-                                "show": null,
-                                "when": null,
-                                "eq": "",
-                                "json": ""
-                            },
-                            "customConditional": "",
-                            "logic": [],
-                            "attributes": {},
-                            "overlay": {
-                                "style": "",
-                                "page": "",
-                                "left": "",
-                                "top": "",
-                                "width": "",
-                                "height": ""
-                            },
                             "type": "htmlelement",
                             "input": false,
                             "tableView": false,
@@ -17759,9 +17944,11 @@
                             "protected": false,
                             "unique": false,
                             "persistent": false,
+                            "hidden": false,
                             "clearOnHide": true,
                             "refreshOn": "",
                             "redrawOn": "",
+                            "modalEdit": false,
                             "dataGridLabel": false,
                             "labelPosition": "top",
                             "description": "",
@@ -17776,6 +17963,7 @@
                             "calculateValue": "",
                             "calculateServer": false,
                             "widget": null,
+                            "attributes": {},
                             "validateOn": "change",
                             "validate": {
                                 "required": false,
@@ -17785,17 +17973,30 @@
                                 "multiple": false,
                                 "unique": false
                             },
+                            "conditional": {
+                                "show": null,
+                                "when": null,
+                                "eq": ""
+                            },
+                            "overlay": {
+                                "style": "",
+                                "left": "",
+                                "top": "",
+                                "width": "",
+                                "height": ""
+                            },
                             "allowCalculateOverride": false,
                             "encrypted": false,
                             "showCharCount": false,
                             "showWordCount": false,
+                            "properties": {},
                             "allowMultipleMasks": false,
-                            "id": "eoxk0rq"
+                            "addons": [],
+                            "tag": "p",
+                            "id": "etawusr"
                         },
                         {
                             "label": "HTML",
-                            "tag": "p",
-                            "className": "",
                             "attrs": [
                                 {
                                     "attr": "",
@@ -17805,28 +18006,7 @@
                             "content": "<strong>Instructions</strong><br>\r\n<ul>\r\n  <li>Please upload a photo or scanned copy of your documentation</li>\r\n  <li>Rename your document to \"<strong>FirstnameLastName_Parents</strong>\" before uploading</li>\r\n  (e.g. JessieLee_Parents)\r\n</ul>",
                             "refreshOnChange": false,
                             "customClass": "align-bullets",
-                            "hidden": false,
-                            "modalEdit": false,
                             "key": "html21",
-                            "tags": [],
-                            "properties": {},
-                            "conditional": {
-                                "show": null,
-                                "when": null,
-                                "eq": "",
-                                "json": ""
-                            },
-                            "customConditional": "",
-                            "logic": [],
-                            "attributes": {},
-                            "overlay": {
-                                "style": "",
-                                "page": "",
-                                "left": "",
-                                "top": "",
-                                "width": "",
-                                "height": ""
-                            },
                             "type": "htmlelement",
                             "input": false,
                             "tableView": false,
@@ -17838,9 +18018,11 @@
                             "protected": false,
                             "unique": false,
                             "persistent": false,
+                            "hidden": false,
                             "clearOnHide": true,
                             "refreshOn": "",
                             "redrawOn": "",
+                            "modalEdit": false,
                             "dataGridLabel": false,
                             "labelPosition": "top",
                             "description": "",
@@ -17855,6 +18037,7 @@
                             "calculateValue": "",
                             "calculateServer": false,
                             "widget": null,
+                            "attributes": {},
                             "validateOn": "change",
                             "validate": {
                                 "required": false,
@@ -17864,31 +18047,35 @@
                                 "multiple": false,
                                 "unique": false
                             },
+                            "conditional": {
+                                "show": null,
+                                "when": null,
+                                "eq": ""
+                            },
+                            "overlay": {
+                                "style": "",
+                                "left": "",
+                                "top": "",
+                                "width": "",
+                                "height": ""
+                            },
                             "allowCalculateOverride": false,
                             "encrypted": false,
                             "showCharCount": false,
                             "showWordCount": false,
+                            "properties": {},
                             "allowMultipleMasks": false,
-                            "id": "et811p"
+                            "addons": [],
+                            "tag": "p",
+                            "id": "eo217d9"
                         },
                         {
                             "label": "Upload supporting documents (optional):",
-                            "labelPosition": "top",
-                            "description": "",
-                            "tooltip": "",
                             "customClass": "font-weight-bold",
-                            "tabindex": "",
-                            "hidden": false,
                             "hideLabel": true,
-                            "autofocus": false,
-                            "disabled": false,
                             "tableView": false,
-                            "modalEdit": false,
                             "storage": "url",
                             "dir": "Estranged Details",
-                            "fileNameTemplate": "",
-                            "image": false,
-                            "uploadOnly": false,
                             "webcam": false,
                             "fileTypes": [
                                 {
@@ -17897,70 +18084,72 @@
                                 }
                             ],
                             "filePattern": ".pdf,.doc,.docx,.jpg,.png,.txt",
-                            "fileMinSize": "0KB",
                             "fileMaxSize": "4MB",
                             "multiple": true,
-                            "persistent": true,
-                            "protected": false,
-                            "dbIndex": false,
-                            "encrypted": false,
-                            "redrawOn": "",
-                            "clearOnHide": true,
-                            "customDefaultValue": "",
-                            "calculateValue": "",
-                            "calculateServer": false,
-                            "allowCalculateOverride": false,
-                            "validate": {
-                                "required": false,
-                                "customMessage": "",
-                                "custom": "",
-                                "customPrivate": false,
-                                "json": "",
-                                "strictDateValidation": false,
-                                "multiple": false,
-                                "unique": false
-                            },
-                            "errorLabel": "",
                             "key": "estrangedFileUpload",
-                            "tags": [],
-                            "properties": {},
                             "conditional": {
                                 "show": true,
                                 "when": "parentbcResident",
-                                "eq": "estranged",
-                                "json": ""
-                            },
-                            "customConditional": "",
-                            "logic": [],
-                            "attributes": {},
-                            "overlay": {
-                                "style": "",
-                                "page": "",
-                                "left": "",
-                                "top": "",
-                                "width": "",
-                                "height": ""
+                                "eq": "estranged"
                             },
                             "type": "file",
                             "url": "students/files",
-                            "imageSize": "200",
                             "input": true,
                             "placeholder": "",
                             "prefix": "",
                             "suffix": "",
                             "defaultValue": null,
+                            "protected": false,
                             "unique": false,
+                            "persistent": true,
+                            "hidden": false,
+                            "clearOnHide": true,
                             "refreshOn": "",
+                            "redrawOn": "",
+                            "modalEdit": false,
                             "dataGridLabel": false,
+                            "labelPosition": "top",
+                            "description": "",
+                            "errorLabel": "",
+                            "tooltip": "",
+                            "tabindex": "",
+                            "disabled": false,
+                            "autofocus": false,
+                            "dbIndex": false,
+                            "customDefaultValue": "",
+                            "calculateValue": "",
+                            "calculateServer": false,
                             "widget": null,
+                            "attributes": {},
                             "validateOn": "change",
+                            "validate": {
+                                "required": false,
+                                "custom": "",
+                                "customPrivate": false,
+                                "strictDateValidation": false,
+                                "multiple": false,
+                                "unique": false
+                            },
+                            "overlay": {
+                                "style": "",
+                                "left": "",
+                                "top": "",
+                                "width": "",
+                                "height": ""
+                            },
+                            "allowCalculateOverride": false,
+                            "encrypted": false,
                             "showCharCount": false,
                             "showWordCount": false,
+                            "properties": {},
                             "allowMultipleMasks": false,
+                            "addons": [],
+                            "image": false,
                             "privateDownload": false,
-                            "id": "ez8n6sa",
-                            "options": "",
-                            "fileKey": ""
+                            "imageSize": "200",
+                            "fileMinSize": "0KB",
+                            "uploadOnly": false,
+                            "id": "esa19l"
                         },
                         {
                             "label": "Columns",
@@ -17970,126 +18159,26 @@
                                         {
                                             "html": "<p>We accept <strong>JPG, PNG, DOC, DOCX, PDF, TXT</strong></p>",
                                             "label": "Content",
-                                            "customClass": "",
                                             "refreshOnChange": false,
-                                            "hidden": false,
-                                            "modalEdit": false,
                                             "key": "content50",
-                                            "tags": [],
-                                            "properties": {},
-                                            "conditional": {
-                                                "show": null,
-                                                "when": null,
-                                                "eq": "",
-                                                "json": ""
-                                            },
-                                            "customConditional": "",
-                                            "logic": [],
-                                            "attributes": {},
-                                            "overlay": {
-                                                "style": "",
-                                                "page": "",
-                                                "left": "",
-                                                "top": "",
-                                                "width": "",
-                                                "height": ""
-                                            },
-                                            "type": "content",
-                                            "input": false,
-                                            "placeholder": "",
-                                            "prefix": "",
-                                            "suffix": "",
-                                            "multiple": false,
-                                            "defaultValue": null,
-                                            "protected": false,
-                                            "unique": false,
-                                            "persistent": true,
-                                            "clearOnHide": true,
-                                            "refreshOn": "",
-                                            "redrawOn": "",
-                                            "tableView": false,
-                                            "dataGridLabel": false,
-                                            "labelPosition": "top",
-                                            "description": "",
-                                            "errorLabel": "",
-                                            "tooltip": "",
-                                            "hideLabel": false,
-                                            "tabindex": "",
-                                            "disabled": false,
-                                            "autofocus": false,
-                                            "dbIndex": false,
-                                            "customDefaultValue": "",
-                                            "calculateValue": "",
-                                            "calculateServer": false,
-                                            "widget": null,
-                                            "validateOn": "change",
-                                            "validate": {
-                                                "required": false,
-                                                "custom": "",
-                                                "customPrivate": false,
-                                                "strictDateValidation": false,
-                                                "multiple": false,
-                                                "unique": false
-                                            },
-                                            "allowCalculateOverride": false,
-                                            "encrypted": false,
-                                            "showCharCount": false,
-                                            "showWordCount": false,
-                                            "allowMultipleMasks": false,
-                                            "id": "e78yx82",
-                                            "hideOnChildrenHidden": false
-                                        }
-                                    ],
-                                    "width": 6,
-                                    "offset": 0,
-                                    "push": 0,
-                                    "pull": 0,
-                                    "size": "md"
-                                },
-                                {
-                                    "components": [
-                                        {
-                                            "html": "<p style=\"text-align:right;\">4MB file limit each</p>",
-                                            "label": "Content",
-                                            "customClass": "",
-                                            "refreshOnChange": false,
-                                            "hidden": false,
-                                            "modalEdit": false,
-                                            "key": "content51",
-                                            "tags": [],
-                                            "properties": {},
-                                            "conditional": {
-                                                "show": null,
-                                                "when": null,
-                                                "eq": "",
-                                                "json": ""
-                                            },
-                                            "customConditional": "",
-                                            "logic": [],
-                                            "attributes": {},
-                                            "overlay": {
-                                                "style": "",
-                                                "page": "",
-                                                "left": "",
-                                                "top": "",
-                                                "width": "",
-                                                "height": ""
-                                            },
                                             "type": "content",
                                             "input": false,
                                             "tableView": false,
                                             "hideOnChildrenHidden": false,
                                             "placeholder": "",
                                             "prefix": "",
+                                            "customClass": "",
                                             "suffix": "",
                                             "multiple": false,
                                             "defaultValue": null,
                                             "protected": false,
                                             "unique": false,
                                             "persistent": true,
+                                            "hidden": false,
                                             "clearOnHide": true,
                                             "refreshOn": "",
                                             "redrawOn": "",
+                                            "modalEdit": false,
                                             "dataGridLabel": false,
                                             "labelPosition": "top",
                                             "description": "",
@@ -18104,6 +18193,7 @@
                                             "calculateValue": "",
                                             "calculateServer": false,
                                             "widget": null,
+                                            "attributes": {},
                                             "validateOn": "change",
                                             "validate": {
                                                 "required": false,
@@ -18113,66 +18203,139 @@
                                                 "multiple": false,
                                                 "unique": false
                                             },
+                                            "conditional": {
+                                                "show": null,
+                                                "when": null,
+                                                "eq": ""
+                                            },
+                                            "overlay": {
+                                                "style": "",
+                                                "left": "",
+                                                "top": "",
+                                                "width": "",
+                                                "height": ""
+                                            },
                                             "allowCalculateOverride": false,
                                             "encrypted": false,
                                             "showCharCount": false,
                                             "showWordCount": false,
+                                            "properties": {},
                                             "allowMultipleMasks": false,
-                                            "id": "erwolbi"
+                                            "addons": [],
+                                            "id": "efdt3wr"
                                         }
                                     ],
                                     "width": 6,
                                     "offset": 0,
                                     "push": 0,
                                     "pull": 0,
-                                    "size": "md"
+                                    "size": "md",
+                                    "currentWidth": 6
+                                },
+                                {
+                                    "components": [
+                                        {
+                                            "html": "<p style=\"text-align:right;\">4MB file limit each</p>",
+                                            "label": "Content",
+                                            "refreshOnChange": false,
+                                            "key": "content51",
+                                            "type": "content",
+                                            "input": false,
+                                            "tableView": false,
+                                            "hideOnChildrenHidden": false,
+                                            "placeholder": "",
+                                            "prefix": "",
+                                            "customClass": "",
+                                            "suffix": "",
+                                            "multiple": false,
+                                            "defaultValue": null,
+                                            "protected": false,
+                                            "unique": false,
+                                            "persistent": true,
+                                            "hidden": false,
+                                            "clearOnHide": true,
+                                            "refreshOn": "",
+                                            "redrawOn": "",
+                                            "modalEdit": false,
+                                            "dataGridLabel": false,
+                                            "labelPosition": "top",
+                                            "description": "",
+                                            "errorLabel": "",
+                                            "tooltip": "",
+                                            "hideLabel": false,
+                                            "tabindex": "",
+                                            "disabled": false,
+                                            "autofocus": false,
+                                            "dbIndex": false,
+                                            "customDefaultValue": "",
+                                            "calculateValue": "",
+                                            "calculateServer": false,
+                                            "widget": null,
+                                            "attributes": {},
+                                            "validateOn": "change",
+                                            "validate": {
+                                                "required": false,
+                                                "custom": "",
+                                                "customPrivate": false,
+                                                "strictDateValidation": false,
+                                                "multiple": false,
+                                                "unique": false
+                                            },
+                                            "conditional": {
+                                                "show": null,
+                                                "when": null,
+                                                "eq": ""
+                                            },
+                                            "overlay": {
+                                                "style": "",
+                                                "left": "",
+                                                "top": "",
+                                                "width": "",
+                                                "height": ""
+                                            },
+                                            "allowCalculateOverride": false,
+                                            "encrypted": false,
+                                            "showCharCount": false,
+                                            "showWordCount": false,
+                                            "properties": {},
+                                            "allowMultipleMasks": false,
+                                            "addons": [],
+                                            "id": "ef6c50a"
+                                        }
+                                    ],
+                                    "width": 6,
+                                    "offset": 0,
+                                    "push": 0,
+                                    "pull": 0,
+                                    "size": "md",
+                                    "currentWidth": 6
                                 }
                             ],
-                            "autoAdjust": false,
                             "hideOnChildrenHidden": false,
-                            "customClass": "",
-                            "hidden": false,
-                            "hideLabel": false,
-                            "modalEdit": false,
                             "key": "columns9",
-                            "tags": [],
-                            "properties": {},
-                            "conditional": {
-                                "show": null,
-                                "when": null,
-                                "eq": "",
-                                "json": ""
-                            },
-                            "customConditional": "",
-                            "logic": [],
-                            "attributes": {},
-                            "overlay": {
-                                "style": "",
-                                "page": "",
-                                "left": "",
-                                "top": "",
-                                "width": "",
-                                "height": ""
-                            },
                             "type": "columns",
                             "input": false,
+                            "tableView": false,
                             "placeholder": "",
                             "prefix": "",
+                            "customClass": "",
                             "suffix": "",
                             "multiple": false,
                             "defaultValue": null,
                             "protected": false,
                             "unique": false,
                             "persistent": false,
+                            "hidden": false,
                             "clearOnHide": false,
                             "refreshOn": "",
                             "redrawOn": "",
-                            "tableView": false,
+                            "modalEdit": false,
                             "dataGridLabel": false,
                             "labelPosition": "top",
                             "description": "",
                             "errorLabel": "",
                             "tooltip": "",
+                            "hideLabel": false,
                             "tabindex": "",
                             "disabled": false,
                             "autofocus": false,
@@ -18181,6 +18344,7 @@
                             "calculateValue": "",
                             "calculateServer": false,
                             "widget": null,
+                            "attributes": {},
                             "validateOn": "change",
                             "validate": {
                                 "required": false,
@@ -18190,37 +18354,60 @@
                                 "multiple": false,
                                 "unique": false
                             },
+                            "conditional": {
+                                "show": null,
+                                "when": null,
+                                "eq": ""
+                            },
+                            "overlay": {
+                                "style": "",
+                                "left": "",
+                                "top": "",
+                                "width": "",
+                                "height": ""
+                            },
                             "allowCalculateOverride": false,
                             "encrypted": false,
                             "showCharCount": false,
                             "showWordCount": false,
+                            "properties": {},
                             "allowMultipleMasks": false,
+                            "addons": [],
                             "tree": false,
-                            "id": "eoq6zle"
+                            "lazyLoad": false,
+                            "autoAdjust": false,
+                            "id": "eb17cap"
                         }
                     ],
                     "allowPrevious": false,
                     "placeholder": "",
                     "prefix": "",
+                    "customClass": "",
                     "suffix": "",
                     "multiple": false,
                     "defaultValue": null,
                     "protected": false,
                     "unique": false,
                     "persistent": false,
+                    "hidden": false,
                     "clearOnHide": false,
                     "refreshOn": "",
                     "redrawOn": "",
+                    "modalEdit": false,
                     "dataGridLabel": false,
                     "labelPosition": "top",
                     "description": "",
                     "errorLabel": "",
+                    "tooltip": "",
+                    "tabindex": "",
+                    "disabled": false,
                     "autofocus": false,
                     "dbIndex": false,
                     "customDefaultValue": "",
                     "calculateValue": "",
                     "calculateServer": false,
                     "widget": null,
+                    "attributes": {},
                     "validateOn": "change",
                     "validate": {
                         "required": false,
@@ -18230,18 +18417,28 @@
                         "multiple": false,
                         "unique": false
                     },
+                    "overlay": {
+                        "style": "",
+                        "left": "",
+                        "top": "",
+                        "width": "",
+                        "height": ""
+                    },
                     "allowCalculateOverride": false,
                     "encrypted": false,
                     "showCharCount": false,
                     "showWordCount": false,
+                    "properties": {},
                     "allowMultipleMasks": false,
+                    "addons": [],
                     "tree": false,
-                    "id": "ewxfwx"
+                    "lazyLoad": false,
+                    "theme": "default",
+                    "breadcrumb": "default",
+                    "id": "egztvc"
                 },
                 {
                     "title": "Parent is not a BC Resident",
-                    "theme": "default",
-                    "breadcrumb": "default",
                     "breadcrumbClickable": true,
                     "buttonSettings": {
                         "previous": true,
@@ -18249,44 +18446,21 @@
                         "next": true
                     },
                     "scrollToTop": false,
-                    "tooltip": "",
-                    "customClass": "",
                     "collapsible": false,
-                    "hidden": false,
                     "hideLabel": true,
-                    "disabled": false,
-                    "modalEdit": false,
                     "key": "parentIsNotABcResident",
-                    "tags": [],
-                    "properties": {},
-                    "customConditional": "",
                     "conditional": {
-                        "json": "",
                         "show": true,
                         "when": "parentbcResident",
                         "eq": "no"
                     },
-                    "nextPage": "",
-                    "logic": [],
-                    "attributes": {},
-                    "overlay": {
-                        "style": "",
-                        "page": "",
-                        "left": "",
-                        "top": "",
-                        "width": "",
-                        "height": ""
-                    },
                     "type": "panel",
                     "label": "Parent is not a BC Resident",
-                    "tabindex": "",
                     "input": false,
                     "tableView": false,
                     "components": [
                         {
                             "label": "HTML",
-                            "tag": "p",
-                            "className": "",
                             "attrs": [
                                 {
                                     "attr": "",
@@ -18296,30 +18470,10 @@
                             "content": "Please provide supporting information ",
                             "refreshOnChange": false,
                             "customClass": "header-md",
-                            "hidden": false,
-                            "modalEdit": false,
                             "key": "html78",
-                            "tags": [],
-                            "properties": {},
-                            "conditional": {
-                                "show": null,
-                                "when": null,
-                                "eq": "",
-                                "json": ""
-                            },
-                            "customConditional": "",
-                            "logic": [],
-                            "attributes": {},
-                            "overlay": {
-                                "style": "",
-                                "page": "",
-                                "left": "",
-                                "top": "",
-                                "width": "",
-                                "height": ""
-                            },
                             "type": "htmlelement",
                             "input": false,
+                            "tableView": false,
                             "placeholder": "",
                             "prefix": "",
                             "suffix": "",
@@ -18328,10 +18482,11 @@
                             "protected": false,
                             "unique": false,
                             "persistent": false,
+                            "hidden": false,
                             "clearOnHide": true,
                             "refreshOn": "",
                             "redrawOn": "",
-                            "tableView": false,
+                            "modalEdit": false,
                             "dataGridLabel": false,
                             "labelPosition": "top",
                             "description": "",
@@ -18346,6 +18501,7 @@
                             "calculateValue": "",
                             "calculateServer": false,
                             "widget": null,
+                            "attributes": {},
                             "validateOn": "change",
                             "validate": {
                                 "required": false,
@@ -18355,16 +18511,30 @@
                                 "multiple": false,
                                 "unique": false
                             },
+                            "conditional": {
+                                "show": null,
+                                "when": null,
+                                "eq": ""
+                            },
+                            "overlay": {
+                                "style": "",
+                                "left": "",
+                                "top": "",
+                                "width": "",
+                                "height": ""
+                            },
                             "allowCalculateOverride": false,
                             "encrypted": false,
                             "showCharCount": false,
                             "showWordCount": false,
+                            "properties": {},
                             "allowMultipleMasks": false,
-                            "id": "ebltkge"
+                            "addons": [],
+                            "tag": "p",
+                            "id": "e8ls0m"
                         },
                         {
                             "label": "HTML",
-                            "tag": "p",
                             "className": "alert alert-warning fa fa-exclamation-circle",
                             "attrs": [
                                 {
@@ -18375,28 +18545,7 @@
                             "content": "<strong> You indicated that your parent(s) are not B.C. residents</strong>\n<br> If any of the following circumstances apply, you may still be eligible for StudentAid BC funding.",
                             "refreshOnChange": false,
                             "customClass": "banner-warning",
-                            "hidden": false,
-                            "modalEdit": false,
                             "key": "html4",
-                            "tags": [],
-                            "properties": {},
-                            "conditional": {
-                                "show": null,
-                                "when": null,
-                                "eq": "",
-                                "json": ""
-                            },
-                            "customConditional": "",
-                            "logic": [],
-                            "attributes": {},
-                            "overlay": {
-                                "style": "",
-                                "page": "",
-                                "left": "",
-                                "top": "",
-                                "width": "",
-                                "height": ""
-                            },
                             "type": "htmlelement",
                             "input": false,
                             "tableView": false,
@@ -18408,9 +18557,11 @@
                             "protected": false,
                             "unique": false,
                             "persistent": false,
+                            "hidden": false,
                             "clearOnHide": true,
                             "refreshOn": "",
                             "redrawOn": "",
+                            "modalEdit": false,
                             "dataGridLabel": false,
                             "labelPosition": "top",
                             "description": "",
@@ -18425,6 +18576,7 @@
                             "calculateValue": "",
                             "calculateServer": false,
                             "widget": null,
+                            "attributes": {},
                             "validateOn": "change",
                             "validate": {
                                 "required": false,
@@ -18434,12 +18586,27 @@
                                 "multiple": false,
                                 "unique": false
                             },
+                            "conditional": {
+                                "show": null,
+                                "when": null,
+                                "eq": ""
+                            },
+                            "overlay": {
+                                "style": "",
+                                "left": "",
+                                "top": "",
+                                "width": "",
+                                "height": ""
+                            },
                             "allowCalculateOverride": false,
                             "encrypted": false,
                             "showCharCount": false,
                             "showWordCount": false,
+                            "properties": {},
                             "allowMultipleMasks": false,
-                            "id": "e9f4txe"
+                            "addons": [],
+                            "tag": "p",
+                            "id": "e9k29ch"
                         },
                         {
                             "label": "<strong>Which of the following best describes your situation?</strong>",
@@ -18485,12 +18652,12 @@
                             ],
                             "validate": {
                                 "required": true,
-                                "onlyAvailableItems": false,
                                 "custom": "",
                                 "customPrivate": false,
                                 "strictDateValidation": false,
                                 "multiple": false,
-                                "unique": false
+                                "unique": false,
+                                "onlyAvailableItems": false
                             },
                             "key": "parentSituation",
                             "conditional": {
@@ -18543,104 +18710,97 @@
                             "showWordCount": false,
                             "properties": {},
                             "allowMultipleMasks": false,
+                            "addons": [],
                             "inputType": "radio",
                             "fieldSet": false,
-                            "id": "ex5hv1e"
+                            "id": "eqzldh9"
                         },
                         {
                             "label": "<strong>Please explain your situation:</strong> <br><li>Why you should be considered a resident for StudentAid BC purposes <strong>and</strong></li><li>Why you haven't applied to your parent(s)' province of residency</li>",
-                            "labelPosition": "top",
-                            "placeholder": "",
-                            "description": "",
-                            "tooltip": "",
-                            "prefix": "",
-                            "suffix": "",
-                            "widget": {
-                                "type": "input"
-                            },
-                            "editor": "",
                             "autoExpand": false,
-                            "customClass": "",
-                            "tabindex": "",
-                            "autocomplete": "",
-                            "hidden": false,
-                            "hideLabel": false,
-                            "showWordCount": false,
-                            "showCharCount": false,
-                            "autofocus": false,
-                            "spellcheck": true,
-                            "disabled": false,
                             "tableView": true,
-                            "modalEdit": false,
-                            "multiple": false,
-                            "persistent": true,
-                            "inputFormat": "html",
-                            "protected": false,
-                            "dbIndex": false,
-                            "case": "",
-                            "encrypted": false,
-                            "redrawOn": "",
-                            "clearOnHide": true,
-                            "customDefaultValue": "",
-                            "calculateValue": "",
-                            "calculateServer": false,
-                            "allowCalculateOverride": false,
-                            "validateOn": "change",
                             "validate": {
+                                "maxLength": 500,
                                 "required": false,
-                                "pattern": "",
-                                "customMessage": "",
                                 "custom": "",
                                 "customPrivate": false,
-                                "json": "",
-                                "minLength": "",
-                                "maxLength": 500,
-                                "minWords": "",
-                                "maxWords": "",
                                 "strictDateValidation": false,
                                 "multiple": false,
-                                "unique": false
+                                "unique": false,
+                                "minLength": "",
+                                "pattern": "",
+                                "minWords": "",
+                                "maxWords": ""
                             },
-                            "unique": false,
-                            "errorLabel": "",
                             "key": "bcResidentLongText",
-                            "tags": [],
-                            "properties": {},
                             "conditional": {
                                 "show": true,
                                 "when": "parentSituation",
-                                "eq": "noneOfTheAbove",
-                                "json": ""
+                                "eq": "noneOfTheAbove"
                             },
-                            "customConditional": "",
-                            "logic": [],
+                            "type": "textarea",
+                            "input": true,
+                            "placeholder": "",
+                            "prefix": "",
+                            "customClass": "",
+                            "suffix": "",
+                            "multiple": false,
+                            "defaultValue": null,
+                            "protected": false,
+                            "unique": false,
+                            "persistent": true,
+                            "hidden": false,
+                            "clearOnHide": true,
+                            "refreshOn": "",
+                            "redrawOn": "",
+                            "modalEdit": false,
+                            "dataGridLabel": false,
+                            "labelPosition": "top",
+                            "description": "",
+                            "errorLabel": "",
+                            "tooltip": "",
+                            "hideLabel": false,
+                            "tabindex": "",
+                            "disabled": false,
+                            "autofocus": false,
+                            "dbIndex": false,
+                            "customDefaultValue": "",
+                            "calculateValue": "",
+                            "calculateServer": false,
+                            "widget": {
+                                "type": "input"
+                            },
                             "attributes": {},
+                            "validateOn": "change",
                             "overlay": {
                                 "style": "",
-                                "page": "",
                                 "left": "",
                                 "top": "",
                                 "width": "",
                                 "height": ""
                             },
-                            "type": "textarea",
-                            "rows": 3,
-                            "wysiwyg": false,
-                            "input": true,
-                            "refreshOn": "",
-                            "dataGridLabel": false,
+                            "allowCalculateOverride": false,
+                            "encrypted": false,
+                            "showCharCount": false,
+                            "showWordCount": false,
+                            "properties": {},
                             "allowMultipleMasks": false,
+                            "addons": [],
                             "mask": false,
                             "inputType": "text",
+                            "inputFormat": "html",
                             "inputMask": "",
+                            "displayMask": "",
+                            "spellcheck": true,
+                            "truncateMultipleSpaces": false,
+                            "rows": 3,
+                            "wysiwyg": false,
+                            "editor": "",
                             "fixedSize": true,
-                            "id": "eec3nss",
-                            "defaultValue": ""
+                            "id": "e2s6jrp"
                         },
                         {
                             "label": "HTML",
-                            "tag": "p",
-                            "className": "",
                             "attrs": [
                                 {
                                     "attr": "",
@@ -18650,30 +18810,10 @@
                             "content": "Upload supporting documents",
                             "refreshOnChange": false,
                             "customClass": "header-sm",
-                            "hidden": false,
-                            "modalEdit": false,
                             "key": "html79",
-                            "tags": [],
-                            "properties": {},
-                            "conditional": {
-                                "show": null,
-                                "when": null,
-                                "eq": "",
-                                "json": ""
-                            },
-                            "customConditional": "",
-                            "logic": [],
-                            "attributes": {},
-                            "overlay": {
-                                "style": "",
-                                "page": "",
-                                "left": "",
-                                "top": "",
-                                "width": "",
-                                "height": ""
-                            },
                             "type": "htmlelement",
                             "input": false,
+                            "tableView": false,
                             "placeholder": "",
                             "prefix": "",
                             "suffix": "",
@@ -18682,10 +18822,11 @@
                             "protected": false,
                             "unique": false,
                             "persistent": false,
+                            "hidden": false,
                             "clearOnHide": true,
                             "refreshOn": "",
                             "redrawOn": "",
-                            "tableView": false,
+                            "modalEdit": false,
                             "dataGridLabel": false,
                             "labelPosition": "top",
                             "description": "",
@@ -18700,6 +18841,7 @@
                             "calculateValue": "",
                             "calculateServer": false,
                             "widget": null,
+                            "attributes": {},
                             "validateOn": "change",
                             "validate": {
                                 "required": false,
@@ -18709,17 +18851,30 @@
                                 "multiple": false,
                                 "unique": false
                             },
+                            "conditional": {
+                                "show": null,
+                                "when": null,
+                                "eq": ""
+                            },
+                            "overlay": {
+                                "style": "",
+                                "left": "",
+                                "top": "",
+                                "width": "",
+                                "height": ""
+                            },
                             "allowCalculateOverride": false,
                             "encrypted": false,
                             "showCharCount": false,
                             "showWordCount": false,
+                            "properties": {},
                             "allowMultipleMasks": false,
-                            "id": "ec0pw2p"
+                            "addons": [],
+                            "tag": "p",
+                            "id": "evy207m"
                         },
                         {
                             "label": "HTML",
-                            "tag": "p",
-                            "className": "",
                             "attrs": [
                                 {
                                     "attr": "",
@@ -18729,28 +18884,7 @@
                             "content": "<strong>Documents Required</strong><br>\r\n<ul>\r\n  <li>Proof of address (e.g. paid utility receipts), <strong>or</strong></li>\r\n  <li>Letter from a professional third party <strong>or</strong></li>\r\n  <li>Official post-secondary transcripts <strong>or</strong></li>\r\n  <li>Student financial assistance denial letter from your previous province of residency</li>\r\n</ul>",
                             "refreshOnChange": false,
                             "customClass": "align-bullets",
-                            "hidden": false,
-                            "modalEdit": false,
                             "key": "html22",
-                            "tags": [],
-                            "properties": {},
-                            "conditional": {
-                                "show": null,
-                                "when": null,
-                                "eq": "",
-                                "json": ""
-                            },
-                            "customConditional": "",
-                            "logic": [],
-                            "attributes": {},
-                            "overlay": {
-                                "style": "",
-                                "page": "",
-                                "left": "",
-                                "top": "",
-                                "width": "",
-                                "height": ""
-                            },
                             "type": "htmlelement",
                             "input": false,
                             "tableView": false,
@@ -18762,9 +18896,11 @@
                             "protected": false,
                             "unique": false,
                             "persistent": false,
+                            "hidden": false,
                             "clearOnHide": true,
                             "refreshOn": "",
                             "redrawOn": "",
+                            "modalEdit": false,
                             "dataGridLabel": false,
                             "labelPosition": "top",
                             "description": "",
@@ -18779,6 +18915,7 @@
                             "calculateValue": "",
                             "calculateServer": false,
                             "widget": null,
+                            "attributes": {},
                             "validateOn": "change",
                             "validate": {
                                 "required": false,
@@ -18788,17 +18925,30 @@
                                 "multiple": false,
                                 "unique": false
                             },
+                            "conditional": {
+                                "show": null,
+                                "when": null,
+                                "eq": ""
+                            },
+                            "overlay": {
+                                "style": "",
+                                "left": "",
+                                "top": "",
+                                "width": "",
+                                "height": ""
+                            },
                             "allowCalculateOverride": false,
                             "encrypted": false,
                             "showCharCount": false,
                             "showWordCount": false,
+                            "properties": {},
                             "allowMultipleMasks": false,
-                            "id": "esbrfgj"
+                            "addons": [],
+                            "tag": "p",
+                            "id": "eiuvxzg"
                         },
                         {
                             "label": "HTML",
-                            "tag": "p",
-                            "className": "",
                             "attrs": [
                                 {
                                     "attr": "",
@@ -18808,28 +18958,7 @@
                             "content": "<strong>Instructions</strong><br>\r\n<ul>\r\n  <li>Please upload a photo or scanned copy of your documentation</li>\r\n  <li>Rename your document to \"<strong>FirstnameLastName_ParentsResidency</strong>\" before uploading</li>\r\n  (e.g. JessieLee_ParentsResidency)\r\n</ul>",
                             "refreshOnChange": false,
                             "customClass": "align-bullets",
-                            "hidden": false,
-                            "modalEdit": false,
                             "key": "html23",
-                            "tags": [],
-                            "properties": {},
-                            "conditional": {
-                                "show": null,
-                                "when": null,
-                                "eq": "",
-                                "json": ""
-                            },
-                            "customConditional": "",
-                            "logic": [],
-                            "attributes": {},
-                            "overlay": {
-                                "style": "",
-                                "page": "",
-                                "left": "",
-                                "top": "",
-                                "width": "",
-                                "height": ""
-                            },
                             "type": "htmlelement",
                             "input": false,
                             "tableView": false,
@@ -18841,9 +18970,11 @@
                             "protected": false,
                             "unique": false,
                             "persistent": false,
+                            "hidden": false,
                             "clearOnHide": true,
                             "refreshOn": "",
                             "redrawOn": "",
+                            "modalEdit": false,
                             "dataGridLabel": false,
                             "labelPosition": "top",
                             "description": "",
@@ -18858,6 +18989,7 @@
                             "calculateValue": "",
                             "calculateServer": false,
                             "widget": null,
+                            "attributes": {},
                             "validateOn": "change",
                             "validate": {
                                 "required": false,
@@ -18867,31 +18999,33 @@
                                 "multiple": false,
                                 "unique": false
                             },
+                            "conditional": {
+                                "show": null,
+                                "when": null,
+                                "eq": ""
+                            },
+                            "overlay": {
+                                "style": "",
+                                "left": "",
+                                "top": "",
+                                "width": "",
+                                "height": ""
+                            },
                             "allowCalculateOverride": false,
                             "encrypted": false,
                             "showCharCount": false,
                             "showWordCount": false,
+                            "properties": {},
                             "allowMultipleMasks": false,
-                            "id": "ewghf5j"
+                            "addons": [],
+                            "tag": "p",
+                            "id": "eretcag"
                         },
                         {
                             "label": "Upload supporting documents",
-                            "labelPosition": "top",
-                            "description": "",
-                            "tooltip": "",
-                            "customClass": "",
-                            "tabindex": "",
-                            "hidden": false,
                             "hideLabel": true,
-                            "autofocus": false,
-                            "disabled": false,
                             "tableView": false,
-                            "modalEdit": false,
                             "storage": "base64",
-                            "dir": "",
-                            "fileNameTemplate": "",
-                            "image": false,
-                            "uploadOnly": false,
                             "webcam": false,
                             "fileTypes": [
                                 {
@@ -18900,67 +19034,72 @@
                                 }
                             ],
                             "filePattern": ".pdf,.doc,.docx,.jpg,.png,.txt",
-                            "fileMinSize": "0KB",
                             "fileMaxSize": "4MB",
+                            "key": "parentNotBCResidentFileUpload",
+                            "type": "file",
+                            "input": true,
+                            "placeholder": "",
+                            "prefix": "",
+                            "customClass": "",
+                            "suffix": "",
                             "multiple": false,
-                            "persistent": true,
+                            "defaultValue": null,
                             "protected": false,
-                            "dbIndex": false,
-                            "encrypted": false,
-                            "redrawOn": "",
+                            "unique": false,
+                            "persistent": true,
+                            "hidden": false,
                             "clearOnHide": true,
+                            "refreshOn": "",
+                            "redrawOn": "",
+                            "modalEdit": false,
+                            "dataGridLabel": false,
+                            "labelPosition": "top",
+                            "description": "",
+                            "errorLabel": "",
+                            "tooltip": "",
+                            "tabindex": "",
+                            "disabled": false,
+                            "autofocus": false,
+                            "dbIndex": false,
                             "customDefaultValue": "",
                             "calculateValue": "",
                             "calculateServer": false,
-                            "allowCalculateOverride": false,
+                            "widget": null,
+                            "attributes": {},
+                            "validateOn": "change",
                             "validate": {
                                 "required": false,
-                                "customMessage": "",
                                 "custom": "",
                                 "customPrivate": false,
-                                "json": "",
                                 "strictDateValidation": false,
                                 "multiple": false,
                                 "unique": false
                             },
-                            "errorLabel": "",
-                            "key": "parentNotBCResidentFileUpload",
-                            "tags": [],
-                            "properties": {},
                             "conditional": {
                                 "show": null,
                                 "when": null,
-                                "eq": "",
-                                "json": ""
+                                "eq": ""
                             },
-                            "customConditional": "",
-                            "logic": [],
-                            "attributes": {},
                             "overlay": {
                                 "style": "",
-                                "page": "",
                                 "left": "",
                                 "top": "",
                                 "width": "",
                                 "height": ""
                             },
-                            "type": "file",
-                            "imageSize": "200",
-                            "input": true,
-                            "placeholder": "",
-                            "prefix": "",
-                            "suffix": "",
-                            "defaultValue": null,
-                            "unique": false,
-                            "refreshOn": "",
-                            "dataGridLabel": false,
-                            "widget": null,
-                            "validateOn": "change",
+                            "allowCalculateOverride": false,
+                            "encrypted": false,
                             "showCharCount": false,
                             "showWordCount": false,
+                            "properties": {},
                             "allowMultipleMasks": false,
+                            "addons": [],
+                            "image": false,
                             "privateDownload": false,
-                            "id": "ej7jsv"
+                            "imageSize": "200",
+                            "fileMinSize": "0KB",
+                            "uploadOnly": false,
+                            "id": "egjvujk"
                         },
                         {
                             "label": "Columns",
@@ -18970,126 +19109,26 @@
                                         {
                                             "html": "<p>We accept <strong>JPG, PNG, DOC, DOCX, PDF, TXT</strong></p>",
                                             "label": "Content",
-                                            "customClass": "",
                                             "refreshOnChange": false,
-                                            "hidden": false,
-                                            "modalEdit": false,
                                             "key": "content52",
-                                            "tags": [],
-                                            "properties": {},
-                                            "conditional": {
-                                                "show": null,
-                                                "when": null,
-                                                "eq": "",
-                                                "json": ""
-                                            },
-                                            "customConditional": "",
-                                            "logic": [],
-                                            "attributes": {},
-                                            "overlay": {
-                                                "style": "",
-                                                "page": "",
-                                                "left": "",
-                                                "top": "",
-                                                "width": "",
-                                                "height": ""
-                                            },
-                                            "type": "content",
-                                            "input": false,
-                                            "placeholder": "",
-                                            "prefix": "",
-                                            "suffix": "",
-                                            "multiple": false,
-                                            "defaultValue": null,
-                                            "protected": false,
-                                            "unique": false,
-                                            "persistent": true,
-                                            "clearOnHide": true,
-                                            "refreshOn": "",
-                                            "redrawOn": "",
-                                            "tableView": false,
-                                            "dataGridLabel": false,
-                                            "labelPosition": "top",
-                                            "description": "",
-                                            "errorLabel": "",
-                                            "tooltip": "",
-                                            "hideLabel": false,
-                                            "tabindex": "",
-                                            "disabled": false,
-                                            "autofocus": false,
-                                            "dbIndex": false,
-                                            "customDefaultValue": "",
-                                            "calculateValue": "",
-                                            "calculateServer": false,
-                                            "widget": null,
-                                            "validateOn": "change",
-                                            "validate": {
-                                                "required": false,
-                                                "custom": "",
-                                                "customPrivate": false,
-                                                "strictDateValidation": false,
-                                                "multiple": false,
-                                                "unique": false
-                                            },
-                                            "allowCalculateOverride": false,
-                                            "encrypted": false,
-                                            "showCharCount": false,
-                                            "showWordCount": false,
-                                            "allowMultipleMasks": false,
-                                            "id": "er6vb",
-                                            "hideOnChildrenHidden": false
-                                        }
-                                    ],
-                                    "width": 6,
-                                    "offset": 0,
-                                    "push": 0,
-                                    "pull": 0,
-                                    "size": "md"
-                                },
-                                {
-                                    "components": [
-                                        {
-                                            "html": "<p style=\"text-align:right;\">4MB file limit each</p>",
-                                            "label": "Content",
-                                            "customClass": "",
-                                            "refreshOnChange": false,
-                                            "hidden": false,
-                                            "modalEdit": false,
-                                            "key": "content53",
-                                            "tags": [],
-                                            "properties": {},
-                                            "conditional": {
-                                                "show": null,
-                                                "when": null,
-                                                "eq": "",
-                                                "json": ""
-                                            },
-                                            "customConditional": "",
-                                            "logic": [],
-                                            "attributes": {},
-                                            "overlay": {
-                                                "style": "",
-                                                "page": "",
-                                                "left": "",
-                                                "top": "",
-                                                "width": "",
-                                                "height": ""
-                                            },
                                             "type": "content",
                                             "input": false,
                                             "tableView": false,
                                             "hideOnChildrenHidden": false,
                                             "placeholder": "",
                                             "prefix": "",
+                                            "customClass": "",
                                             "suffix": "",
                                             "multiple": false,
                                             "defaultValue": null,
                                             "protected": false,
                                             "unique": false,
                                             "persistent": true,
+                                            "hidden": false,
                                             "clearOnHide": true,
                                             "refreshOn": "",
                                             "redrawOn": "",
+                                            "modalEdit": false,
                                             "dataGridLabel": false,
                                             "labelPosition": "top",
                                             "description": "",
@@ -19104,6 +19143,7 @@
                                             "calculateValue": "",
                                             "calculateServer": false,
                                             "widget": null,
+                                            "attributes": {},
                                             "validateOn": "change",
                                             "validate": {
                                                 "required": false,
@@ -19113,66 +19153,139 @@
                                                 "multiple": false,
                                                 "unique": false
                                             },
+                                            "conditional": {
+                                                "show": null,
+                                                "when": null,
+                                                "eq": ""
+                                            },
+                                            "overlay": {
+                                                "style": "",
+                                                "left": "",
+                                                "top": "",
+                                                "width": "",
+                                                "height": ""
+                                            },
                                             "allowCalculateOverride": false,
                                             "encrypted": false,
                                             "showCharCount": false,
                                             "showWordCount": false,
+                                            "properties": {},
                                             "allowMultipleMasks": false,
-                                            "id": "e9psih"
+                                            "addons": [],
+                                            "id": "eb410r"
                                         }
                                     ],
                                     "width": 6,
                                     "offset": 0,
                                     "push": 0,
                                     "pull": 0,
-                                    "size": "md"
+                                    "size": "md",
+                                    "currentWidth": 6
+                                },
+                                {
+                                    "components": [
+                                        {
+                                            "html": "<p style=\"text-align:right;\">4MB file limit each</p>",
+                                            "label": "Content",
+                                            "refreshOnChange": false,
+                                            "key": "content53",
+                                            "type": "content",
+                                            "input": false,
+                                            "tableView": false,
+                                            "hideOnChildrenHidden": false,
+                                            "placeholder": "",
+                                            "prefix": "",
+                                            "customClass": "",
+                                            "suffix": "",
+                                            "multiple": false,
+                                            "defaultValue": null,
+                                            "protected": false,
+                                            "unique": false,
+                                            "persistent": true,
+                                            "hidden": false,
+                                            "clearOnHide": true,
+                                            "refreshOn": "",
+                                            "redrawOn": "",
+                                            "modalEdit": false,
+                                            "dataGridLabel": false,
+                                            "labelPosition": "top",
+                                            "description": "",
+                                            "errorLabel": "",
+                                            "tooltip": "",
+                                            "hideLabel": false,
+                                            "tabindex": "",
+                                            "disabled": false,
+                                            "autofocus": false,
+                                            "dbIndex": false,
+                                            "customDefaultValue": "",
+                                            "calculateValue": "",
+                                            "calculateServer": false,
+                                            "widget": null,
+                                            "attributes": {},
+                                            "validateOn": "change",
+                                            "validate": {
+                                                "required": false,
+                                                "custom": "",
+                                                "customPrivate": false,
+                                                "strictDateValidation": false,
+                                                "multiple": false,
+                                                "unique": false
+                                            },
+                                            "conditional": {
+                                                "show": null,
+                                                "when": null,
+                                                "eq": ""
+                                            },
+                                            "overlay": {
+                                                "style": "",
+                                                "left": "",
+                                                "top": "",
+                                                "width": "",
+                                                "height": ""
+                                            },
+                                            "allowCalculateOverride": false,
+                                            "encrypted": false,
+                                            "showCharCount": false,
+                                            "showWordCount": false,
+                                            "properties": {},
+                                            "allowMultipleMasks": false,
+                                            "addons": [],
+                                            "id": "e0aaiai"
+                                        }
+                                    ],
+                                    "width": 6,
+                                    "offset": 0,
+                                    "push": 0,
+                                    "pull": 0,
+                                    "size": "md",
+                                    "currentWidth": 6
                                 }
                             ],
-                            "autoAdjust": false,
                             "hideOnChildrenHidden": false,
-                            "customClass": "",
-                            "hidden": false,
-                            "hideLabel": false,
-                            "modalEdit": false,
                             "key": "columns10",
-                            "tags": [],
-                            "properties": {},
-                            "conditional": {
-                                "show": null,
-                                "when": null,
-                                "eq": "",
-                                "json": ""
-                            },
-                            "customConditional": "",
-                            "logic": [],
-                            "attributes": {},
-                            "overlay": {
-                                "style": "",
-                                "page": "",
-                                "left": "",
-                                "top": "",
-                                "width": "",
-                                "height": ""
-                            },
                             "type": "columns",
                             "input": false,
+                            "tableView": false,
                             "placeholder": "",
                             "prefix": "",
+                            "customClass": "",
                             "suffix": "",
                             "multiple": false,
                             "defaultValue": null,
                             "protected": false,
                             "unique": false,
                             "persistent": false,
+                            "hidden": false,
                             "clearOnHide": false,
                             "refreshOn": "",
                             "redrawOn": "",
-                            "tableView": false,
+                            "modalEdit": false,
                             "dataGridLabel": false,
                             "labelPosition": "top",
                             "description": "",
                             "errorLabel": "",
                             "tooltip": "",
+                            "hideLabel": false,
                             "tabindex": "",
                             "disabled": false,
                             "autofocus": false,
@@ -19181,6 +19294,7 @@
                             "calculateValue": "",
                             "calculateServer": false,
                             "widget": null,
+                            "attributes": {},
                             "validateOn": "change",
                             "validate": {
                                 "required": false,
@@ -19190,36 +19304,59 @@
                                 "multiple": false,
                                 "unique": false
                             },
+                            "conditional": {
+                                "show": null,
+                                "when": null,
+                                "eq": ""
+                            },
+                            "overlay": {
+                                "style": "",
+                                "left": "",
+                                "top": "",
+                                "width": "",
+                                "height": ""
+                            },
                             "allowCalculateOverride": false,
                             "encrypted": false,
                             "showCharCount": false,
                             "showWordCount": false,
+                            "properties": {},
                             "allowMultipleMasks": false,
+                            "addons": [],
                             "tree": false,
-                            "id": "eblbijh"
+                            "lazyLoad": false,
+                            "autoAdjust": false,
+                            "id": "elphaz"
                         }
                     ],
                     "placeholder": "",
                     "prefix": "",
+                    "customClass": "",
                     "suffix": "",
                     "multiple": false,
                     "defaultValue": null,
                     "protected": false,
                     "unique": false,
                     "persistent": false,
+                    "hidden": false,
                     "clearOnHide": false,
                     "refreshOn": "",
                     "redrawOn": "",
+                    "modalEdit": false,
                     "dataGridLabel": false,
                     "labelPosition": "top",
                     "description": "",
                     "errorLabel": "",
+                    "tooltip": "",
+                    "tabindex": "",
+                    "disabled": false,
                     "autofocus": false,
                     "dbIndex": false,
                     "customDefaultValue": "",
                     "calculateValue": "",
                     "calculateServer": false,
                     "widget": null,
+                    "attributes": {},
                     "validateOn": "change",
                     "validate": {
                         "required": false,
@@ -19229,13 +19366,25 @@
                         "multiple": false,
                         "unique": false
                     },
+                    "overlay": {
+                        "style": "",
+                        "left": "",
+                        "top": "",
+                        "width": "",
+                        "height": ""
+                    },
                     "allowCalculateOverride": false,
                     "encrypted": false,
                     "showCharCount": false,
                     "showWordCount": false,
+                    "properties": {},
                     "allowMultipleMasks": false,
+                    "addons": [],
                     "tree": false,
-                    "id": "e64qs3"
+                    "lazyLoad": false,
+                    "theme": "default",
+                    "breadcrumb": "default",
+                    "id": "edpdb4q"
                 }
             ],
             "placeholder": "",
@@ -19273,8 +19422,10 @@
             "showCharCount": false,
             "showWordCount": false,
             "allowMultipleMasks": false,
+            "addons": [],
             "tree": false,
-            "id": "e73iekm"
+            "lazyLoad": false,
+            "id": "ekw5h2l"
         },
         {
             "title": "Financial information",
@@ -27465,6 +27616,76 @@
             "inputType": "hidden",
             "id": "em1y8gd",
             "defaultValue": ""
+        },
+        {
+            "label": "applicationStatus",
+            "customClass": "",
+            "modalEdit": false,
+            "defaultValue": null,
+            "persistent": true,
+            "protected": false,
+            "dbIndex": false,
+            "encrypted": false,
+            "redrawOn": "",
+            "customDefaultValue": "",
+            "calculateValue": "",
+            "calculateServer": false,
+            "key": "applicationStatus",
+            "tags": [],
+            "properties": {},
+            "logic": [],
+            "attributes": {},
+            "overlay": {
+                "style": "",
+                "page": "",
+                "left": "",
+                "top": "",
+                "width": "",
+                "height": ""
+            },
+            "type": "hidden",
+            "input": true,
+            "tableView": false,
+            "placeholder": "",
+            "prefix": "",
+            "suffix": "",
+            "multiple": false,
+            "unique": false,
+            "hidden": false,
+            "clearOnHide": true,
+            "refreshOn": "",
+            "dataGridLabel": false,
+            "labelPosition": "top",
+            "description": "",
+            "errorLabel": "",
+            "tooltip": "",
+            "hideLabel": false,
+            "tabindex": "",
+            "disabled": false,
+            "autofocus": false,
+            "widget": {
+                "type": "input"
+            },
+            "validateOn": "change",
+            "validate": {
+                "required": false,
+                "custom": "",
+                "customPrivate": false,
+                "strictDateValidation": false,
+                "multiple": false,
+                "unique": false
+            },
+            "conditional": {
+                "show": null,
+                "when": null,
+                "eq": ""
+            },
+            "allowCalculateOverride": false,
+            "showCharCount": false,
+            "showWordCount": false,
+            "allowMultipleMasks": false,
+            "inputType": "hidden",
+            "id": "e6z1qd9"
         }
     ],
     "display": "wizard",
@@ -27473,5 +27694,5 @@
     "name": "SFAA2021-22",
     "machineName": "SFAA2021-22",
     "created": "2021-07-12T19:51:16.443Z",
-    "modified": "2022-01-13T22:54:54.431Z"
+    "modified": "2022-02-16T23:04:04.742Z"
 }

--- a/sources/packages/forms/src/form-definitions/sfaa2021-22.json
+++ b/sources/packages/forms/src/form-definitions/sfaa2021-22.json
@@ -9558,7 +9558,7 @@
                                     "key": "firstName",
                                     "type": "textfield",
                                     "input": true,
-                                    "id": "el2qrn90000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+                                    "id": "el2qrn900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
                                     "placeholder": "",
                                     "prefix": "",
                                     "suffix": "",
@@ -9635,7 +9635,7 @@
                                     "key": "lastName",
                                     "type": "textfield",
                                     "input": true,
-                                    "id": "e618eci0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+                                    "id": "e618eci00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
                                     "placeholder": "",
                                     "prefix": "",
                                     "suffix": "",
@@ -9790,7 +9790,7 @@
                                     "allowMultipleMasks": false,
                                     "inputType": "radio",
                                     "fieldSet": false,
-                                    "id": "ejv9syt000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+                                    "id": "ejv9syt0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
                                     "defaultValue": "",
                                     "addons": []
                                 },
@@ -9828,7 +9828,7 @@
                                     "key": "strongHowLongDoYouWantToGiveThisPersonAccessToYourStudentAidBcAccountStrong",
                                     "type": "radio",
                                     "input": true,
-                                    "id": "ejm9s3q0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+                                    "id": "ejm9s3q00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
                                     "placeholder": "",
                                     "prefix": "",
                                     "customClass": "",
@@ -9935,7 +9935,7 @@
                                         "disableWeekdays": false,
                                         "maxDate": null
                                     },
-                                    "id": "earatq0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+                                    "id": "earatq00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
                                     "prefix": "",
                                     "suffix": "",
                                     "multiple": false,
@@ -10609,7 +10609,7 @@
                     "allowCalculateOverride": false,
                     "validate": {
                         "required": true,
-                        "onlyAvailableItems": false,
+                        "onlyAvailableItems": true,
                         "customMessage": "",
                         "custom": "",
                         "customPrivate": false,
@@ -10660,7 +10660,7 @@
                     "addons": [],
                     "inputType": "radio",
                     "fieldSet": false,
-                    "id": "e6m25u",
+                    "id": "e8hszx",
                     "defaultValue": ""
                 },
                 {
@@ -12354,7 +12354,7 @@
                                             "addons": []
                                         }
                                     ],
-                                    "id": "ecpkm9j00000000000000000000000000000000000000000000000000000000000000000",
+                                    "id": "ecpkm9j000000000000000000000000000000000000000000000000000000000000000000000",
                                     "placeholder": "",
                                     "prefix": "",
                                     "customClass": "",
@@ -13351,7 +13351,7 @@
                     "encrypted": false,
                     "redrawOn": "data",
                     "customDefaultValue": "",
-                    "calculateValue": "//alert (data.dependantstatus);\nif (data.hasDependents === 'no' && (data.relationshipStatus === 'single' || data.relationshipStatus === 'other') && data.outOfHighSchoolFor4Years === 'no' && data.howWillYouBeAttendingTheProgram === \"Full Time\") {\n  instance.setValue ('dependant');\n}\nelse {\n  instance.setValue ('independant');\n}",
+                    "calculateValue": "if (data.hasDependents === 'no' && (data.relationshipStatus === 'single' || data.relationshipStatus === 'other') && data.outOfHighSchoolFor4Years === 'no' && data.howWillYouBeAttendingTheProgram === \"Full Time\") {\n  instance.setValue ('dependant');\n}\nelse {\n  instance.setValue ('independant');\n}",
                     "calculateServer": true,
                     "key": "dependantstatus",
                     "tags": [],
@@ -13409,7 +13409,7 @@
                     "allowMultipleMasks": false,
                     "addons": [],
                     "inputType": "hidden",
-                    "id": "e6gw2r"
+                    "id": "essfav"
                 }
             ],
             "placeholder": "",
@@ -27652,5 +27652,5 @@
     "name": "SFAA2021-22",
     "machineName": "SFAA2021-22",
     "created": "2021-07-12T19:51:16.443Z",
-    "modified": "2022-02-16T23:25:07.343Z"
+    "modified": "2022-02-17T17:05:00.347Z"
 }

--- a/sources/packages/forms/src/form-definitions/sfaa2021-22.json
+++ b/sources/packages/forms/src/form-definitions/sfaa2021-22.json
@@ -10665,15 +10665,9 @@
                 },
                 {
                     "title": "Married/common law Panel",
+                    "labelWidth": "",
+                    "labelMargin": "",
                     "theme": "default",
-                    "breadcrumb": "default",
-                    "breadcrumbClickable": false,
-                    "buttonSettings": {
-                        "previous": false,
-                        "cancel": false,
-                        "next": false
-                    },
-                    "scrollToTop": false,
                     "tooltip": "",
                     "customClass": "",
                     "collapsible": false,
@@ -10681,7 +10675,7 @@
                     "hideLabel": true,
                     "disabled": false,
                     "modalEdit": false,
-                    "key": "marriedCommonLawPanel",
+                    "key": "marriedPanel",
                     "tags": [],
                     "properties": {},
                     "customConditional": "",
@@ -10689,9 +10683,8 @@
                         "json": "",
                         "show": true,
                         "when": "relationshipStatus",
-                        "eq": "marriedCommonLaw"
+                        "eq": "married"
                     },
-                    "nextPage": "",
                     "logic": [],
                     "attributes": {},
                     "overlay": {
@@ -10704,17 +10697,46 @@
                     },
                     "type": "panel",
                     "label": "Married/Common law Panel",
+                    "breadcrumb": "default",
+                    "buttonSettings": {
+                        "previous": false,
+                        "cancel": false,
+                        "next": false
+                    },
                     "tabindex": "",
+                    "breadcrumbClickable": false,
+                    "scrollToTop": false,
                     "input": false,
                     "tableView": false,
                     "components": [
                         {
                             "label": "Date of marriage or date of start of living together in a marriage-like relationship",
+                            "labelPosition": "top",
+                            "labelWidth": "",
+                            "labelMargin": "",
+                            "displayInTimezone": "viewer",
+                            "useLocaleSettings": false,
+                            "allowInput": true,
                             "format": "yyyy-MM-dd",
+                            "placeholder": "",
+                            "description": "",
+                            "tooltip": "",
                             "customClass": "font-weight-bold",
+                            "tabindex": "",
+                            "hidden": false,
+                            "hideLabel": false,
+                            "autofocus": false,
+                            "disabled": false,
                             "tableView": false,
+                            "modalEdit": false,
+                            "shortcutButtons": [],
+                            "enableDate": true,
                             "enableMinDateInput": false,
                             "datePicker": {
+                                "minDate": null,
+                                "maxDate": null,
+                                "disable": "",
+                                "disableFunction": "",
                                 "disableWeekends": false,
                                 "disableWeekdays": false,
                                 "showWeeks": true,
@@ -10723,27 +10745,68 @@
                                 "minMode": "day",
                                 "maxMode": "year",
                                 "yearRows": 4,
-                                "yearColumns": 5,
-                                "minDate": null,
-                                "maxDate": null
+                                "yearColumns": 5
                             },
                             "enableMaxDateInput": false,
                             "enableTime": false,
+                            "timePicker": {
+                                "hourStep": 1,
+                                "minuteStep": 1,
+                                "showMeridian": true,
+                                "readonlyInput": false,
+                                "mousewheel": true,
+                                "arrowkeys": true
+                            },
+                            "multiple": false,
+                            "defaultValue": "",
+                            "defaultDate": "",
+                            "customOptions": {},
+                            "persistent": true,
+                            "protected": false,
+                            "dbIndex": false,
+                            "encrypted": false,
+                            "redrawOn": "",
+                            "clearOnHide": true,
+                            "customDefaultValue": "",
+                            "calculateValue": "",
+                            "calculateServer": false,
+                            "allowCalculateOverride": false,
                             "validate": {
                                 "required": true,
+                                "customMessage": "",
                                 "custom": "",
                                 "customPrivate": false,
+                                "json": "",
                                 "strictDateValidation": false,
                                 "multiple": false,
                                 "unique": false
                             },
+                            "unique": false,
+                            "validateOn": "change",
+                            "errorLabel": "",
+                            "errors": "",
                             "key": "dateOfMarriageOrDateOfStartOfLivingTogetherInAMarriageLikeRelationship",
+                            "tags": [],
+                            "properties": {},
                             "conditional": {
                                 "show": true,
                                 "when": "relationshipStatus",
-                                "eq": "marriedCommonLaw"
+                                "eq": "married",
+                                "json": ""
+                            },
+                            "customConditional": "",
+                            "logic": [],
+                            "attributes": {},
+                            "overlay": {
+                                "style": "",
+                                "page": "",
+                                "left": "",
+                                "top": "",
+                                "width": "",
+                                "height": ""
                             },
                             "type": "datetime",
+                            "timezone": "",
                             "input": true,
                             "widget": {
                                 "type": "calendar",
@@ -10759,70 +10822,22 @@
                                 "minuteIncrement": 1,
                                 "time_24hr": false,
                                 "minDate": null,
+                                "disabledDates": "",
                                 "disableWeekends": false,
                                 "disableWeekdays": false,
+                                "disableFunction": "",
                                 "maxDate": null
                             },
-                            "placeholder": "",
                             "prefix": "",
                             "suffix": "",
-                            "multiple": false,
-                            "defaultValue": "",
-                            "protected": false,
-                            "unique": false,
-                            "persistent": true,
-                            "hidden": false,
-                            "clearOnHide": true,
                             "refreshOn": "",
-                            "redrawOn": "",
-                            "modalEdit": false,
                             "dataGridLabel": false,
-                            "labelPosition": "top",
-                            "description": "",
-                            "errorLabel": "",
-                            "tooltip": "",
-                            "hideLabel": false,
-                            "tabindex": "",
-                            "disabled": false,
-                            "autofocus": false,
-                            "dbIndex": false,
-                            "customDefaultValue": "",
-                            "calculateValue": "",
-                            "calculateServer": false,
-                            "attributes": {},
-                            "validateOn": "change",
-                            "overlay": {
-                                "style": "",
-                                "left": "",
-                                "top": "",
-                                "width": "",
-                                "height": ""
-                            },
-                            "allowCalculateOverride": false,
-                            "encrypted": false,
                             "showCharCount": false,
                             "showWordCount": false,
-                            "properties": {},
                             "allowMultipleMasks": false,
-                            "useLocaleSettings": false,
-                            "allowInput": true,
-                            "enableDate": true,
-                            "defaultDate": "",
-                            "displayInTimezone": "viewer",
-                            "timezone": "",
+                            "addons": [],
                             "datepickerMode": "day",
-                            "timePicker": {
-                                "hourStep": 1,
-                                "minuteStep": 1,
-                                "showMeridian": true,
-                                "readonlyInput": false,
-                                "mousewheel": true,
-                                "arrowkeys": true
-                            },
-                            "customOptions": {},
-                            "id": "enmzn3",
-                            "shortcutButtons": [],
-                            "addons": []
+                            "id": "e46qohj"
                         }
                     ],
                     "allowPrevious": false,
@@ -10861,10 +10876,10 @@
                     "showCharCount": false,
                     "showWordCount": false,
                     "allowMultipleMasks": false,
-                    "tree": false,
-                    "id": "e7huqp",
                     "addons": [],
-                    "lazyLoad": false
+                    "tree": false,
+                    "lazyLoad": false,
+                    "id": "e28wi9s"
                 },
                 {
                     "label": "<strong>Do you have any dependants?</strong>",
@@ -12339,7 +12354,7 @@
                                             "addons": []
                                         }
                                     ],
-                                    "id": "ecpkm9j0000000000000000000000000000000000000000000000000000000000000",
+                                    "id": "ecpkm9j00000000000000000000000000000000000000000000000000000000000000000",
                                     "placeholder": "",
                                     "prefix": "",
                                     "customClass": "",
@@ -13336,7 +13351,7 @@
                     "encrypted": false,
                     "redrawOn": "data",
                     "customDefaultValue": "",
-                    "calculateValue": "//alert (data.dependantstatus);\nif (data.hasDependents === 'no' && (data.relationshipStatus === 'single' || data.relationshipStatus === 'otherSingle') && data.outOfHighSchoolFor4Years === 'no' && data.howWillYouBeAttendingTheProgram === \"Full Time\") {\n  instance.setValue ('dependant');\n}\nelse {\n  instance.setValue ('independant');\n}",
+                    "calculateValue": "//alert (data.dependantstatus);\nif (data.hasDependents === 'no' && (data.relationshipStatus === 'single' || data.relationshipStatus === 'other') && data.outOfHighSchoolFor4Years === 'no' && data.howWillYouBeAttendingTheProgram === \"Full Time\") {\n  instance.setValue ('dependant');\n}\nelse {\n  instance.setValue ('independant');\n}",
                     "calculateServer": true,
                     "key": "dependantstatus",
                     "tags": [],
@@ -13394,7 +13409,7 @@
                     "allowMultipleMasks": false,
                     "addons": [],
                     "inputType": "hidden",
-                    "id": "eaahv2r"
+                    "id": "e6gw2r"
                 }
             ],
             "placeholder": "",
@@ -13439,15 +13454,9 @@
         },
         {
             "title": "Partner information",
+            "labelWidth": "",
+            "labelMargin": "",
             "theme": "default",
-            "breadcrumb": "default",
-            "breadcrumbClickable": true,
-            "buttonSettings": {
-                "previous": false,
-                "cancel": false,
-                "next": false
-            },
-            "scrollToTop": true,
             "tooltip": "",
             "customClass": "",
             "collapsible": false,
@@ -13463,9 +13472,8 @@
                 "json": "",
                 "show": true,
                 "when": "relationshipStatus",
-                "eq": "marriedCommonLaw"
+                "eq": "married"
             },
-            "nextPage": "",
             "logic": [],
             "attributes": {},
             "overlay": {
@@ -13478,14 +13486,20 @@
             },
             "type": "panel",
             "label": "Partner Information",
+            "breadcrumb": "default",
+            "buttonSettings": {
+                "previous": false,
+                "cancel": false,
+                "next": false
+            },
             "tabindex": "",
+            "breadcrumbClickable": true,
+            "scrollToTop": true,
             "input": false,
             "tableView": false,
             "components": [
                 {
                     "label": "HTML",
-                    "tag": "p",
-                    "className": "",
                     "attrs": [
                         {
                             "attr": "",
@@ -13495,30 +13509,10 @@
                     "content": "Partner information",
                     "refreshOnChange": false,
                     "customClass": "header-lg",
-                    "hidden": false,
-                    "modalEdit": false,
                     "key": "html65",
-                    "tags": [],
-                    "properties": {},
-                    "conditional": {
-                        "show": null,
-                        "when": null,
-                        "eq": "",
-                        "json": ""
-                    },
-                    "customConditional": "",
-                    "logic": [],
-                    "attributes": {},
-                    "overlay": {
-                        "style": "",
-                        "page": "",
-                        "left": "",
-                        "top": "",
-                        "width": "",
-                        "height": ""
-                    },
                     "type": "htmlelement",
                     "input": false,
+                    "tableView": false,
                     "placeholder": "",
                     "prefix": "",
                     "suffix": "",
@@ -13527,10 +13521,11 @@
                     "protected": false,
                     "unique": false,
                     "persistent": false,
+                    "hidden": false,
                     "clearOnHide": true,
                     "refreshOn": "",
                     "redrawOn": "",
-                    "tableView": false,
+                    "modalEdit": false,
                     "dataGridLabel": false,
                     "labelPosition": "top",
                     "description": "",
@@ -13545,6 +13540,7 @@
                     "calculateValue": "",
                     "calculateServer": false,
                     "widget": null,
+                    "attributes": {},
                     "validateOn": "change",
                     "validate": {
                         "required": false,
@@ -13554,18 +13550,30 @@
                         "multiple": false,
                         "unique": false
                     },
+                    "conditional": {
+                        "show": null,
+                        "when": null,
+                        "eq": ""
+                    },
+                    "overlay": {
+                        "style": "",
+                        "left": "",
+                        "top": "",
+                        "width": "",
+                        "height": ""
+                    },
                     "allowCalculateOverride": false,
                     "encrypted": false,
                     "showCharCount": false,
                     "showWordCount": false,
+                    "properties": {},
                     "allowMultipleMasks": false,
-                    "id": "ezo3nq8",
-                    "addons": []
+                    "addons": [],
+                    "tag": "p",
+                    "id": "elr03a"
                 },
                 {
                     "label": "HTML",
-                    "tag": "p",
-                    "className": "",
                     "attrs": [
                         {
                             "attr": "",
@@ -13574,43 +13582,24 @@
                     ],
                     "content": "Help text about this section will be displayed here",
                     "refreshOnChange": false,
-                    "customClass": "",
-                    "hidden": false,
-                    "modalEdit": false,
                     "key": "html66",
-                    "tags": [],
-                    "properties": {},
-                    "conditional": {
-                        "show": null,
-                        "when": null,
-                        "eq": "",
-                        "json": ""
-                    },
-                    "customConditional": "",
-                    "logic": [],
-                    "attributes": {},
-                    "overlay": {
-                        "style": "",
-                        "page": "",
-                        "left": "",
-                        "top": "",
-                        "width": "",
-                        "height": ""
-                    },
                     "type": "htmlelement",
                     "input": false,
+                    "tableView": false,
                     "placeholder": "",
                     "prefix": "",
+                    "customClass": "",
                     "suffix": "",
                     "multiple": false,
                     "defaultValue": null,
                     "protected": false,
                     "unique": false,
                     "persistent": false,
+                    "hidden": false,
                     "clearOnHide": true,
                     "refreshOn": "",
                     "redrawOn": "",
-                    "tableView": false,
+                    "modalEdit": false,
                     "dataGridLabel": false,
                     "labelPosition": "top",
                     "description": "",
@@ -13625,6 +13614,7 @@
                     "calculateValue": "",
                     "calculateServer": false,
                     "widget": null,
+                    "attributes": {},
                     "validateOn": "change",
                     "validate": {
                         "required": false,
@@ -13634,29 +13624,33 @@
                         "multiple": false,
                         "unique": false
                     },
+                    "conditional": {
+                        "show": null,
+                        "when": null,
+                        "eq": ""
+                    },
+                    "overlay": {
+                        "style": "",
+                        "left": "",
+                        "top": "",
+                        "width": "",
+                        "height": ""
+                    },
                     "allowCalculateOverride": false,
                     "encrypted": false,
                     "showCharCount": false,
                     "showWordCount": false,
+                    "properties": {},
                     "allowMultipleMasks": false,
-                    "id": "ew7qj9",
-                    "addons": []
+                    "addons": [],
+                    "tag": "p",
+                    "id": "e7kl6pb"
                 },
                 {
                     "label": "<strong>Does your partner have a valid Social Insurance Number?</strong>",
-                    "labelPosition": "top",
                     "optionsLabelPosition": "right",
-                    "description": "",
-                    "tooltip": "",
-                    "customClass": "",
-                    "tabindex": "",
                     "inline": false,
-                    "hidden": false,
-                    "hideLabel": false,
-                    "autofocus": false,
-                    "disabled": false,
                     "tableView": false,
-                    "modalEdit": false,
                     "values": [
                         {
                             "label": "Yes",
@@ -13669,72 +13663,73 @@
                             "shortcut": ""
                         }
                     ],
-                    "dataType": "",
-                    "persistent": true,
+                    "validate": {
+                        "required": true,
+                        "custom": "",
+                        "customPrivate": false,
+                        "strictDateValidation": false,
+                        "multiple": false,
+                        "unique": false,
+                        "onlyAvailableItems": false
+                    },
+                    "key": "isYourSpouseACanadianCitizen",
+                    "type": "radio",
+                    "input": true,
+                    "placeholder": "",
+                    "prefix": "",
+                    "customClass": "",
+                    "suffix": "",
+                    "multiple": false,
+                    "defaultValue": null,
                     "protected": false,
-                    "dbIndex": false,
-                    "encrypted": false,
-                    "redrawOn": "",
+                    "unique": false,
+                    "persistent": true,
+                    "hidden": false,
                     "clearOnHide": true,
+                    "refreshOn": "",
+                    "redrawOn": "",
+                    "modalEdit": false,
+                    "dataGridLabel": false,
+                    "labelPosition": "top",
+                    "description": "",
+                    "errorLabel": "",
+                    "tooltip": "",
+                    "hideLabel": false,
+                    "tabindex": "",
+                    "disabled": false,
+                    "autofocus": false,
+                    "dbIndex": false,
                     "customDefaultValue": "",
                     "calculateValue": "",
                     "calculateServer": false,
-                    "allowCalculateOverride": false,
-                    "validate": {
-                        "required": true,
-                        "onlyAvailableItems": false,
-                        "customMessage": "",
-                        "custom": "",
-                        "customPrivate": false,
-                        "json": "",
-                        "strictDateValidation": false,
-                        "multiple": false,
-                        "unique": false
-                    },
-                    "errorLabel": "",
-                    "key": "isYourSpouseACanadianCitizen",
-                    "tags": [],
-                    "properties": {},
+                    "widget": null,
+                    "attributes": {},
+                    "validateOn": "change",
                     "conditional": {
                         "show": null,
                         "when": null,
-                        "eq": "",
-                        "json": ""
+                        "eq": ""
                     },
-                    "customConditional": "",
-                    "logic": [],
-                    "attributes": {},
                     "overlay": {
                         "style": "",
-                        "page": "",
                         "left": "",
                         "top": "",
                         "width": "",
                         "height": ""
                     },
-                    "type": "radio",
-                    "input": true,
-                    "placeholder": "",
-                    "prefix": "",
-                    "suffix": "",
-                    "multiple": false,
-                    "unique": false,
-                    "refreshOn": "",
-                    "dataGridLabel": false,
-                    "widget": null,
-                    "validateOn": "change",
+                    "allowCalculateOverride": false,
+                    "encrypted": false,
                     "showCharCount": false,
                     "showWordCount": false,
+                    "properties": {},
                     "allowMultipleMasks": false,
+                    "addons": [],
                     "inputType": "radio",
                     "fieldSet": false,
-                    "id": "eolgirh",
-                    "defaultValue": "",
-                    "addons": []
+                    "id": "e818yqc"
                 },
                 {
                     "label": "Additional information required",
-                    "tag": "p",
                     "className": "alert alert-info  fa fa-info-circle",
                     "attrs": [
                         {
@@ -13745,27 +13740,11 @@
                     "content": "<Strong> Please be advised your partner will need to sign in to StudentAid BC and provide additional information.</Strong><br/> \r\nPlease check your email after submitting your application. An email will be sent to you with instructions for your partner to sign in. Your application cannot proceed until this information is received.\r\n<br />",
                     "refreshOnChange": false,
                     "customClass": "banner-info",
-                    "hidden": false,
-                    "modalEdit": false,
                     "key": "additionalInformationRequired",
-                    "tags": [],
-                    "properties": {},
                     "conditional": {
                         "show": true,
                         "when": "isYourSpouseACanadianCitizen",
-                        "eq": "yes",
-                        "json": ""
-                    },
-                    "customConditional": "",
-                    "logic": [],
-                    "attributes": {},
-                    "overlay": {
-                        "style": "",
-                        "page": "",
-                        "left": "",
-                        "top": "",
-                        "width": "",
-                        "height": ""
+                        "eq": "yes"
                     },
                     "type": "htmlelement",
                     "input": false,
@@ -13778,9 +13757,11 @@
                     "protected": false,
                     "unique": false,
                     "persistent": false,
+                    "hidden": false,
                     "clearOnHide": true,
                     "refreshOn": "",
                     "redrawOn": "",
+                    "modalEdit": false,
                     "dataGridLabel": false,
                     "labelPosition": "top",
                     "description": "",
@@ -13795,6 +13776,7 @@
                     "calculateValue": "",
                     "calculateServer": false,
                     "widget": null,
+                    "attributes": {},
                     "validateOn": "change",
                     "validate": {
                         "required": false,
@@ -13804,17 +13786,25 @@
                         "multiple": false,
                         "unique": false
                     },
+                    "overlay": {
+                        "style": "",
+                        "left": "",
+                        "top": "",
+                        "width": "",
+                        "height": ""
+                    },
                     "allowCalculateOverride": false,
                     "encrypted": false,
                     "showCharCount": false,
                     "showWordCount": false,
+                    "properties": {},
                     "allowMultipleMasks": false,
-                    "id": "eqyaa8b",
-                    "addons": []
+                    "addons": [],
+                    "tag": "p",
+                    "id": "ekld1xh"
                 },
                 {
                     "label": "Spouse Estimation",
-                    "tag": "p",
                     "className": "alert alert-warning fa fa-exclamation-circle",
                     "attrs": [
                         {
@@ -13825,27 +13815,11 @@
                     "content": "<strong> Please be advised this could delay your application</strong> \n<br />\nSince we’re unable to validate your partner’s information with Canada Revenue Agency (CRA), please estimate your partner’s income.",
                     "refreshOnChange": false,
                     "customClass": "banner-warning",
-                    "hidden": false,
-                    "modalEdit": false,
                     "key": "spouseEstimation",
-                    "tags": [],
-                    "properties": {},
                     "conditional": {
                         "show": true,
                         "when": "isYourSpouseACanadianCitizen",
-                        "eq": "no",
-                        "json": ""
-                    },
-                    "customConditional": "",
-                    "logic": [],
-                    "attributes": {},
-                    "overlay": {
-                        "style": "",
-                        "page": "",
-                        "left": "",
-                        "top": "",
-                        "width": "",
-                        "height": ""
+                        "eq": "no"
                     },
                     "type": "htmlelement",
                     "input": false,
@@ -13858,9 +13832,11 @@
                     "protected": false,
                     "unique": false,
                     "persistent": false,
+                    "hidden": false,
                     "clearOnHide": true,
                     "refreshOn": "",
                     "redrawOn": "",
+                    "modalEdit": false,
                     "dataGridLabel": false,
                     "labelPosition": "top",
                     "description": "",
@@ -13875,6 +13851,7 @@
                     "calculateValue": "",
                     "calculateServer": false,
                     "widget": null,
+                    "attributes": {},
                     "validateOn": "change",
                     "validate": {
                         "required": false,
@@ -13884,13 +13861,22 @@
                         "multiple": false,
                         "unique": false
                     },
+                    "overlay": {
+                        "style": "",
+                        "left": "",
+                        "top": "",
+                        "width": "",
+                        "height": ""
+                    },
                     "allowCalculateOverride": false,
                     "encrypted": false,
                     "showCharCount": false,
                     "showWordCount": false,
+                    "properties": {},
                     "allowMultipleMasks": false,
-                    "id": "eow2c2c",
-                    "addons": []
+                    "addons": [],
+                    "tag": "p",
+                    "id": "eljkpgs"
                 },
                 {
                     "title": "Partner Income Panel",
@@ -13915,8 +13901,6 @@
                     "components": [
                         {
                             "label": "HTML",
-                            "tag": "p",
-                            "className": "",
                             "attrs": [
                                 {
                                     "attr": "",
@@ -13926,30 +13910,10 @@
                             "content": "Partner income",
                             "refreshOnChange": false,
                             "customClass": "header-md",
-                            "hidden": false,
-                            "modalEdit": false,
                             "key": "html67",
-                            "tags": [],
-                            "properties": {},
-                            "conditional": {
-                                "show": null,
-                                "when": null,
-                                "eq": "",
-                                "json": ""
-                            },
-                            "customConditional": "",
-                            "logic": [],
-                            "attributes": {},
-                            "overlay": {
-                                "style": "",
-                                "page": "",
-                                "left": "",
-                                "top": "",
-                                "width": "",
-                                "height": ""
-                            },
                             "type": "htmlelement",
                             "input": false,
+                            "tableView": false,
                             "placeholder": "",
                             "prefix": "",
                             "suffix": "",
@@ -13958,10 +13922,11 @@
                             "protected": false,
                             "unique": false,
                             "persistent": false,
+                            "hidden": false,
                             "clearOnHide": true,
                             "refreshOn": "",
                             "redrawOn": "",
-                            "tableView": false,
+                            "modalEdit": false,
                             "dataGridLabel": false,
                             "labelPosition": "top",
                             "description": "",
@@ -13976,6 +13941,7 @@
                             "calculateValue": "",
                             "calculateServer": false,
                             "widget": null,
+                            "attributes": {},
                             "validateOn": "change",
                             "validate": {
                                 "required": false,
@@ -13985,18 +13951,30 @@
                                 "multiple": false,
                                 "unique": false
                             },
+                            "conditional": {
+                                "show": null,
+                                "when": null,
+                                "eq": ""
+                            },
+                            "overlay": {
+                                "style": "",
+                                "left": "",
+                                "top": "",
+                                "width": "",
+                                "height": ""
+                            },
                             "allowCalculateOverride": false,
                             "encrypted": false,
                             "showCharCount": false,
                             "showWordCount": false,
+                            "properties": {},
                             "allowMultipleMasks": false,
-                            "id": "e3pwpa9",
-                            "addons": []
+                            "addons": [],
+                            "tag": "p",
+                            "id": "eqe2r5r"
                         },
                         {
                             "label": "HTML",
-                            "tag": "p",
-                            "className": "",
                             "attrs": [
                                 {
                                     "attr": "",
@@ -14005,43 +13983,24 @@
                             ],
                             "content": "Help text about this section will be displayed here",
                             "refreshOnChange": false,
-                            "customClass": "",
-                            "hidden": false,
-                            "modalEdit": false,
                             "key": "html68",
-                            "tags": [],
-                            "properties": {},
-                            "conditional": {
-                                "show": null,
-                                "when": null,
-                                "eq": "",
-                                "json": ""
-                            },
-                            "customConditional": "",
-                            "logic": [],
-                            "attributes": {},
-                            "overlay": {
-                                "style": "",
-                                "page": "",
-                                "left": "",
-                                "top": "",
-                                "width": "",
-                                "height": ""
-                            },
                             "type": "htmlelement",
                             "input": false,
+                            "tableView": false,
                             "placeholder": "",
                             "prefix": "",
+                            "customClass": "",
                             "suffix": "",
                             "multiple": false,
                             "defaultValue": null,
                             "protected": false,
                             "unique": false,
                             "persistent": false,
+                            "hidden": false,
                             "clearOnHide": true,
                             "refreshOn": "",
                             "redrawOn": "",
-                            "tableView": false,
+                            "modalEdit": false,
                             "dataGridLabel": false,
                             "labelPosition": "top",
                             "description": "",
@@ -14056,6 +14015,7 @@
                             "calculateValue": "",
                             "calculateServer": false,
                             "widget": null,
+                            "attributes": {},
                             "validateOn": "change",
                             "validate": {
                                 "required": false,
@@ -14065,13 +14025,27 @@
                                 "multiple": false,
                                 "unique": false
                             },
+                            "conditional": {
+                                "show": null,
+                                "when": null,
+                                "eq": ""
+                            },
+                            "overlay": {
+                                "style": "",
+                                "left": "",
+                                "top": "",
+                                "width": "",
+                                "height": ""
+                            },
                             "allowCalculateOverride": false,
                             "encrypted": false,
                             "showCharCount": false,
                             "showWordCount": false,
+                            "properties": {},
                             "allowMultipleMasks": false,
-                            "id": "eedvdyj",
-                            "addons": []
+                            "addons": [],
+                            "tag": "p",
+                            "id": "e0xtk8"
                         },
                         {
                             "label": "What was your partner’s income (as shown on line 15000 of previous year’s Canada Revenue Agency tax return)? If they didn’t file taxes, enter total income from all sources in and outside of Canada.",
@@ -14146,8 +14120,8 @@
                             "showWordCount": false,
                             "properties": {},
                             "allowMultipleMasks": false,
-                            "id": "e9mqj6h",
-                            "addons": []
+                            "addons": [],
+                            "id": "e9yrlbn"
                         },
                         {
                             "label": "<strong>Will your partner be employed full-time or part-time during your study period</strong>",
@@ -14168,12 +14142,12 @@
                             ],
                             "validate": {
                                 "required": true,
-                                "onlyAvailableItems": false,
                                 "custom": "",
                                 "customPrivate": false,
                                 "strictDateValidation": false,
                                 "multiple": false,
-                                "unique": false
+                                "unique": false,
+                                "onlyAvailableItems": false
                             },
                             "key": "partnerEmployed",
                             "type": "radio",
@@ -14226,10 +14200,10 @@
                             "showWordCount": false,
                             "properties": {},
                             "allowMultipleMasks": false,
+                            "addons": [],
                             "inputType": "radio",
                             "fieldSet": false,
-                            "id": "erofrhb",
-                            "addons": []
+                            "id": "et8sctn"
                         },
                         {
                             "label": "<strong>Will  your partner be at home caring for eligible dependent children on a full-time basis during the your entire study period? </strong>",
@@ -14250,12 +14224,12 @@
                             ],
                             "validate": {
                                 "required": true,
-                                "onlyAvailableItems": false,
                                 "custom": "",
                                 "customPrivate": false,
                                 "strictDateValidation": false,
                                 "multiple": false,
-                                "unique": false
+                                "unique": false,
+                                "onlyAvailableItems": false
                             },
                             "key": "partnercaringforeligibleDependent",
                             "type": "radio",
@@ -14308,10 +14282,10 @@
                             "showWordCount": false,
                             "properties": {},
                             "allowMultipleMasks": false,
+                            "addons": [],
                             "inputType": "radio",
                             "fieldSet": false,
-                            "id": "e1z6lyb",
-                            "addons": []
+                            "id": "e10dqnd"
                         },
                         {
                             "label": "<strong>Will your partner be living with you during the your study period?</strong>",
@@ -14332,12 +14306,12 @@
                             ],
                             "validate": {
                                 "required": true,
-                                "onlyAvailableItems": false,
                                 "custom": "",
                                 "customPrivate": false,
                                 "strictDateValidation": false,
                                 "multiple": false,
-                                "unique": false
+                                "unique": false,
+                                "onlyAvailableItems": false
                             },
                             "key": "partnerlivingwithYou",
                             "type": "radio",
@@ -14390,10 +14364,10 @@
                             "showWordCount": false,
                             "properties": {},
                             "allowMultipleMasks": false,
+                            "addons": [],
                             "inputType": "radio",
                             "fieldSet": false,
-                            "id": "ehnyp6c",
-                            "addons": []
+                            "id": "eqks5039"
                         },
                         {
                             "label": "<strong>Will your partner be a full-time post-secondary student for some or all of your study period?</strong>",
@@ -14414,12 +14388,12 @@
                             ],
                             "validate": {
                                 "required": true,
-                                "onlyAvailableItems": false,
                                 "custom": "",
                                 "customPrivate": false,
                                 "strictDateValidation": false,
                                 "multiple": false,
-                                "unique": false
+                                "unique": false,
+                                "onlyAvailableItems": false
                             },
                             "key": "partnerfulltimeStudent",
                             "type": "radio",
@@ -14472,10 +14446,10 @@
                             "showWordCount": false,
                             "properties": {},
                             "allowMultipleMasks": false,
+                            "addons": [],
                             "inputType": "radio",
                             "fieldSet": false,
-                            "id": "e4neun",
-                            "addons": []
+                            "id": "e9fol1q"
                         },
                         {
                             "title": "If your partner will be a full-time student, how many weeks of your study period will they also be in studies Panel",
@@ -14500,87 +14474,79 @@
                             "components": [
                                 {
                                     "label": "<strong>If your partner will be a full-time student, how many weeks of your study period will they also be in studies?</strong>",
-                                    "labelPosition": "top",
-                                    "placeholder": "",
-                                    "description": "",
-                                    "tooltip": "",
                                     "prefix": "Number of Weeks",
-                                    "suffix": "",
-                                    "widget": {
-                                        "type": "input"
-                                    },
-                                    "customClass": "",
-                                    "tabindex": "",
-                                    "autocomplete": "",
-                                    "hidden": false,
-                                    "hideLabel": false,
                                     "mask": false,
-                                    "autofocus": false,
                                     "spellcheck": true,
-                                    "disabled": false,
                                     "tableView": false,
-                                    "modalEdit": false,
-                                    "multiple": false,
-                                    "persistent": true,
                                     "delimiter": false,
                                     "requireDecimal": false,
                                     "inputFormat": "plain",
-                                    "protected": false,
-                                    "dbIndex": false,
-                                    "encrypted": false,
-                                    "redrawOn": "",
-                                    "clearOnHide": true,
-                                    "customDefaultValue": "",
-                                    "calculateValue": "",
-                                    "calculateServer": false,
-                                    "allowCalculateOverride": false,
-                                    "validateOn": "change",
                                     "validate": {
                                         "required": true,
-                                        "customMessage": "",
                                         "custom": "const studyStartTime = new Date(data.studystartDate).getTime();\r\nconst studyEndTime= new Date(row.studyendDate).getTime();\r\nconst difference = (studyEndTime - studyStartTime);\r\nconst studyWeek = difference/(1000 * 60 * 60 * 24 * 7);\r\n// valid = parseInt(week);\r\n// vaild = (data.ifYourPartnerWillBeAFullTimeStudentHowManyWeeksOfYourStudyPeriodWillTheyAlsoBeInStudies <= studyWeek) ? true : \"Must be Equal to or less than Student Applicants study period\";\r\nvaildweek = (data.ifYourPartnerWillBeAFullTimeStudentHowManyWeeksOfYourStudyPeriodWillTheyAlsoBeInStudies <= studyWeek);\r\nvalid = vaildweek ? true : 'Must be Equal to or less than Student Applicants study period';\r\n",
                                         "customPrivate": false,
-                                        "json": "",
-                                        "min": "",
-                                        "max": "",
                                         "strictDateValidation": false,
                                         "multiple": false,
                                         "unique": false,
+                                        "min": "",
+                                        "max": "",
                                         "step": "any",
                                         "integer": ""
                                     },
-                                    "errorLabel": "",
                                     "key": "ifYourPartnerWillBeAFullTimeStudentHowManyWeeksOfYourStudyPeriodWillTheyAlsoBeInStudies",
-                                    "tags": [],
-                                    "properties": {},
                                     "conditional": {
                                         "show": true,
                                         "when": "partnerfulltimeStudent",
-                                        "eq": "yes",
-                                        "json": ""
+                                        "eq": "yes"
                                     },
-                                    "customConditional": "",
-                                    "logic": [],
+                                    "type": "number",
+                                    "input": true,
+                                    "placeholder": "",
+                                    "customClass": "",
+                                    "suffix": "",
+                                    "multiple": false,
+                                    "defaultValue": null,
+                                    "protected": false,
+                                    "unique": false,
+                                    "persistent": true,
+                                    "hidden": false,
+                                    "clearOnHide": true,
+                                    "refreshOn": "",
+                                    "redrawOn": "",
+                                    "modalEdit": false,
+                                    "dataGridLabel": false,
+                                    "labelPosition": "top",
+                                    "description": "",
+                                    "errorLabel": "",
+                                    "tooltip": "",
+                                    "hideLabel": false,
+                                    "tabindex": "",
+                                    "disabled": false,
+                                    "autofocus": false,
+                                    "dbIndex": false,
+                                    "customDefaultValue": "",
+                                    "calculateValue": "",
+                                    "calculateServer": false,
+                                    "widget": {
+                                        "type": "input"
+                                    },
                                     "attributes": {},
+                                    "validateOn": "change",
                                     "overlay": {
                                         "style": "",
-                                        "page": "",
                                         "left": "",
                                         "top": "",
                                         "width": "",
                                         "height": ""
                                     },
-                                    "type": "number",
-                                    "input": true,
-                                    "unique": false,
-                                    "refreshOn": "",
-                                    "dataGridLabel": false,
+                                    "allowCalculateOverride": false,
+                                    "encrypted": false,
                                     "showCharCount": false,
                                     "showWordCount": false,
+                                    "properties": {},
                                     "allowMultipleMasks": false,
-                                    "id": "epdswoon",
-                                    "defaultValue": null,
-                                    "addons": []
+                                    "addons": [],
+                                    "id": "eogukl"
                                 }
                             ],
                             "allowPrevious": false,
@@ -14634,28 +14600,18 @@
                             "showWordCount": false,
                             "properties": {},
                             "allowMultipleMasks": false,
+                            "addons": [],
                             "tree": false,
+                            "lazyLoad": false,
                             "theme": "default",
                             "breadcrumb": "default",
-                            "id": "ep5lg4",
-                            "addons": [],
-                            "lazyLoad": false
+                            "id": "eum6wts"
                         },
                         {
                             "label": "<strong>Will your partner recieve income assistance/social assistance (welfare) and/or BC income assistance for persons with disabilities during the your study period?</strong>",
-                            "labelPosition": "top",
                             "optionsLabelPosition": "right",
-                            "description": "",
-                            "tooltip": "",
-                            "customClass": "",
-                            "tabindex": "",
                             "inline": false,
-                            "hidden": false,
-                            "hideLabel": false,
-                            "autofocus": false,
-                            "disabled": false,
                             "tableView": false,
-                            "modalEdit": false,
                             "values": [
                                 {
                                     "label": "Yes",
@@ -14668,68 +14624,70 @@
                                     "shortcut": ""
                                 }
                             ],
-                            "dataType": "",
-                            "persistent": true,
+                            "validate": {
+                                "required": true,
+                                "custom": "",
+                                "customPrivate": false,
+                                "strictDateValidation": false,
+                                "multiple": false,
+                                "unique": false,
+                                "onlyAvailableItems": false
+                            },
+                            "key": "partnerrecieveIncomeAssistance",
+                            "type": "radio",
+                            "input": true,
+                            "placeholder": "",
+                            "prefix": "",
+                            "customClass": "",
+                            "suffix": "",
+                            "multiple": false,
+                            "defaultValue": null,
                             "protected": false,
-                            "dbIndex": false,
-                            "encrypted": false,
-                            "redrawOn": "",
+                            "unique": false,
+                            "persistent": true,
+                            "hidden": false,
                             "clearOnHide": true,
+                            "refreshOn": "",
+                            "redrawOn": "",
+                            "modalEdit": false,
+                            "dataGridLabel": false,
+                            "labelPosition": "top",
+                            "description": "",
+                            "errorLabel": "",
+                            "tooltip": "",
+                            "hideLabel": false,
+                            "tabindex": "",
+                            "disabled": false,
+                            "autofocus": false,
+                            "dbIndex": false,
                             "customDefaultValue": "",
                             "calculateValue": "",
                             "calculateServer": false,
-                            "allowCalculateOverride": false,
-                            "validate": {
-                                "required": true,
-                                "onlyAvailableItems": false,
-                                "customMessage": "",
-                                "custom": "",
-                                "customPrivate": false,
-                                "json": "",
-                                "strictDateValidation": false,
-                                "multiple": false,
-                                "unique": false
-                            },
-                            "errorLabel": "",
-                            "key": "partnerrecieveIncomeAssistance",
-                            "tags": [],
-                            "properties": {},
+                            "widget": null,
+                            "attributes": {},
+                            "validateOn": "change",
                             "conditional": {
                                 "show": null,
                                 "when": null,
-                                "eq": "",
-                                "json": ""
+                                "eq": ""
                             },
-                            "customConditional": "",
-                            "logic": [],
-                            "attributes": {},
                             "overlay": {
                                 "style": "",
-                                "page": "",
                                 "left": "",
                                 "top": "",
                                 "width": "",
                                 "height": ""
                             },
-                            "type": "radio",
-                            "input": true,
-                            "placeholder": "",
-                            "prefix": "",
-                            "suffix": "",
-                            "multiple": false,
-                            "unique": false,
-                            "refreshOn": "",
-                            "dataGridLabel": false,
-                            "widget": null,
-                            "validateOn": "change",
+                            "allowCalculateOverride": false,
+                            "encrypted": false,
                             "showCharCount": false,
                             "showWordCount": false,
+                            "properties": {},
                             "allowMultipleMasks": false,
+                            "addons": [],
                             "inputType": "radio",
                             "fieldSet": false,
-                            "id": "ealunos",
-                            "defaultValue": "",
-                            "addons": []
+                            "id": "exr8j58"
                         },
                         {
                             "title": "Provide the total income assistance/social assistance (welfare) and/or BC income assistance for persons with disabilities that your partner will be receiving during your study period Panel",
@@ -14825,8 +14783,8 @@
                                     "showWordCount": false,
                                     "properties": {},
                                     "allowMultipleMasks": false,
-                                    "id": "e9k0k58",
-                                    "addons": []
+                                    "addons": [],
+                                    "id": "eyn3uvta"
                                 }
                             ],
                             "allowPrevious": false,
@@ -14880,12 +14838,12 @@
                             "showWordCount": false,
                             "properties": {},
                             "allowMultipleMasks": false,
+                            "addons": [],
                             "tree": false,
+                            "lazyLoad": false,
                             "theme": "default",
                             "breadcrumb": "default",
-                            "id": "ey6jmc4b",
-                            "addons": [],
-                            "lazyLoad": false
+                            "id": "e1rvvnw"
                         },
                         {
                             "label": "<strong>Will your partner be in receipt of Employment Insurance benefits during the your study period?</strong>",
@@ -14906,12 +14864,12 @@
                             ],
                             "validate": {
                                 "required": true,
-                                "onlyAvailableItems": false,
                                 "custom": "",
                                 "customPrivate": false,
                                 "strictDateValidation": false,
                                 "multiple": false,
-                                "unique": false
+                                "unique": false,
+                                "onlyAvailableItems": false
                             },
                             "key": "partneremploymentInsurance",
                             "type": "radio",
@@ -14964,10 +14922,10 @@
                             "showWordCount": false,
                             "properties": {},
                             "allowMultipleMasks": false,
+                            "addons": [],
                             "inputType": "radio",
                             "fieldSet": false,
-                            "id": "enklghw",
-                            "addons": []
+                            "id": "e0ecn2s"
                         },
                         {
                             "title": "Will your partner be in receipt of Employment Insurance benefits during the your study period Panel",
@@ -15064,8 +15022,8 @@
                                     "showWordCount": false,
                                     "properties": {},
                                     "allowMultipleMasks": false,
-                                    "id": "ei87gnna",
-                                    "addons": []
+                                    "addons": [],
+                                    "id": "et1ybcb"
                                 }
                             ],
                             "allowPrevious": false,
@@ -15119,12 +15077,12 @@
                             "showWordCount": false,
                             "properties": {},
                             "allowMultipleMasks": false,
+                            "addons": [],
                             "tree": false,
+                            "lazyLoad": false,
                             "theme": "default",
                             "breadcrumb": "default",
-                            "id": "ei0vzm",
-                            "addons": [],
-                            "lazyLoad": false
+                            "id": "e4idhzf"
                         },
                         {
                             "label": "<strong>Will your partner be in receipt of federal or provincial permanent disability benefits during the your study period?</strong>",
@@ -15145,12 +15103,12 @@
                             ],
                             "validate": {
                                 "required": true,
-                                "onlyAvailableItems": false,
                                 "custom": "",
                                 "customPrivate": false,
                                 "strictDateValidation": false,
                                 "multiple": false,
-                                "unique": false
+                                "unique": false,
+                                "onlyAvailableItems": false
                             },
                             "key": "partnerpermanentdisabilityBenefits",
                             "type": "radio",
@@ -15203,10 +15161,10 @@
                             "showWordCount": false,
                             "properties": {},
                             "allowMultipleMasks": false,
+                            "addons": [],
                             "inputType": "radio",
                             "fieldSet": false,
-                            "id": "ef7th7s",
-                            "addons": []
+                            "id": "eo5sdra"
                         },
                         {
                             "title": "Will your partner be in receipt of federal or provincial permanent disability benefits during the your study period Panel",
@@ -15303,8 +15261,8 @@
                                     "showWordCount": false,
                                     "properties": {},
                                     "allowMultipleMasks": false,
-                                    "id": "ecbhi1",
-                                    "addons": []
+                                    "addons": [],
+                                    "id": "epl4y3b"
                                 }
                             ],
                             "allowPrevious": false,
@@ -15358,12 +15316,12 @@
                             "showWordCount": false,
                             "properties": {},
                             "allowMultipleMasks": false,
+                            "addons": [],
                             "tree": false,
+                            "lazyLoad": false,
                             "theme": "default",
                             "breadcrumb": "default",
-                            "id": "em80rob",
-                            "addons": [],
-                            "lazyLoad": false
+                            "id": "eh2gbg4"
                         },
                         {
                             "label": "<strong>Will your partner be paying a Canada Student Loan and/or a provincial student loan regular scheduled payments during the your study period?</strong>",
@@ -15384,12 +15342,12 @@
                             ],
                             "validate": {
                                 "required": true,
-                                "onlyAvailableItems": false,
                                 "custom": "",
                                 "customPrivate": false,
                                 "strictDateValidation": false,
                                 "multiple": false,
-                                "unique": false
+                                "unique": false,
+                                "onlyAvailableItems": false
                             },
                             "key": "partnerstudentLoan",
                             "type": "radio",
@@ -15442,10 +15400,10 @@
                             "showWordCount": false,
                             "properties": {},
                             "allowMultipleMasks": false,
+                            "addons": [],
                             "inputType": "radio",
                             "fieldSet": false,
-                            "id": "eoxznh4",
-                            "addons": []
+                            "id": "ej0kui"
                         },
                         {
                             "title": "Will your partner be paying a Canada Student Loan and/or a provincial student loan regular scheduled payments during the your study period Panel",
@@ -15541,8 +15499,8 @@
                                     "showWordCount": false,
                                     "properties": {},
                                     "allowMultipleMasks": false,
-                                    "id": "exjd5dg",
-                                    "addons": []
+                                    "addons": [],
+                                    "id": "epa8hyi"
                                 }
                             ],
                             "allowPrevious": false,
@@ -15596,12 +15554,12 @@
                             "showWordCount": false,
                             "properties": {},
                             "allowMultipleMasks": false,
+                            "addons": [],
                             "tree": false,
+                            "lazyLoad": false,
                             "theme": "default",
                             "breadcrumb": "default",
-                            "id": "et3rj9",
-                            "addons": [],
-                            "lazyLoad": false
+                            "id": "e5j24i"
                         },
                         {
                             "label": "<strong>Will your partner be paying for child support and/or spousal support during the your study period?</strong>",
@@ -15622,12 +15580,12 @@
                             ],
                             "validate": {
                                 "required": true,
-                                "onlyAvailableItems": false,
                                 "custom": "",
                                 "customPrivate": false,
                                 "strictDateValidation": false,
                                 "multiple": false,
-                                "unique": false
+                                "unique": false,
+                                "onlyAvailableItems": false
                             },
                             "key": "partnerchildSupport",
                             "type": "radio",
@@ -15680,10 +15638,10 @@
                             "showWordCount": false,
                             "properties": {},
                             "allowMultipleMasks": false,
+                            "addons": [],
                             "inputType": "radio",
                             "fieldSet": false,
-                            "id": "eboa3up",
-                            "addons": []
+                            "id": "ei0psd8"
                         },
                         {
                             "title": "Will your partner be paying for child support and/or spousal support during the your study period Panel",
@@ -15779,8 +15737,8 @@
                                     "showWordCount": false,
                                     "properties": {},
                                     "allowMultipleMasks": false,
-                                    "id": "epwpsk9",
-                                    "addons": []
+                                    "addons": [],
+                                    "id": "ecc8w6j"
                                 }
                             ],
                             "allowPrevious": false,
@@ -15834,12 +15792,12 @@
                             "showWordCount": false,
                             "properties": {},
                             "allowMultipleMasks": false,
+                            "addons": [],
                             "tree": false,
+                            "lazyLoad": false,
                             "theme": "default",
                             "breadcrumb": "default",
-                            "id": "ei3r3id",
-                            "addons": [],
-                            "lazyLoad": false
+                            "id": "ei7pb6"
                         },
                         {
                             "label": "<strong>Durring your study period, will your partner be taking care of eligible dependants? </strong>",
@@ -15860,12 +15818,12 @@
                             ],
                             "validate": {
                                 "required": true,
-                                "onlyAvailableItems": false,
                                 "custom": "",
                                 "customPrivate": false,
                                 "strictDateValidation": false,
                                 "multiple": false,
-                                "unique": false
+                                "unique": false,
+                                "onlyAvailableItems": false
                             },
                             "key": "durringYourStudyPeriodWillYourPartnerBeTakingCareOfEligibleDependants",
                             "type": "radio",
@@ -15918,10 +15876,10 @@
                             "showWordCount": false,
                             "properties": {},
                             "allowMultipleMasks": false,
+                            "addons": [],
                             "inputType": "radio",
                             "fieldSet": false,
-                            "id": "e887jy",
-                            "addons": []
+                            "id": "esm1hcg"
                         }
                     ],
                     "allowPrevious": false,
@@ -15975,12 +15933,12 @@
                     "showWordCount": false,
                     "properties": {},
                     "allowMultipleMasks": false,
+                    "addons": [],
                     "tree": false,
+                    "lazyLoad": false,
                     "theme": "default",
                     "breadcrumb": "default",
-                    "id": "etvo8m",
-                    "addons": [],
-                    "lazyLoad": false
+                    "id": "erae6ji"
                 }
             ],
             "placeholder": "",
@@ -16018,10 +15976,10 @@
             "showCharCount": false,
             "showWordCount": false,
             "allowMultipleMasks": false,
-            "tree": false,
-            "id": "esudth",
             "addons": [],
-            "lazyLoad": false
+            "tree": false,
+            "lazyLoad": false,
+            "id": "eo39uv9"
         },
         {
             "title": "Parent information",
@@ -27694,5 +27652,5 @@
     "name": "SFAA2021-22",
     "machineName": "SFAA2021-22",
     "created": "2021-07-12T19:51:16.443Z",
-    "modified": "2022-02-16T23:04:04.742Z"
+    "modified": "2022-02-16T23:25:07.343Z"
 }

--- a/sources/packages/forms/src/form-definitions/sfaa2022-23.json
+++ b/sources/packages/forms/src/form-definitions/sfaa2022-23.json
@@ -10665,15 +10665,9 @@
                 },
                 {
                     "title": "Married/common law Panel",
+                    "labelWidth": "",
+                    "labelMargin": "",
                     "theme": "default",
-                    "breadcrumb": "default",
-                    "breadcrumbClickable": false,
-                    "buttonSettings": {
-                        "previous": false,
-                        "cancel": false,
-                        "next": false
-                    },
-                    "scrollToTop": false,
                     "tooltip": "",
                     "customClass": "",
                     "collapsible": false,
@@ -10681,7 +10675,7 @@
                     "hideLabel": true,
                     "disabled": false,
                     "modalEdit": false,
-                    "key": "marriedCommonLawPanel",
+                    "key": "marriedPanel",
                     "tags": [],
                     "properties": {},
                     "customConditional": "",
@@ -10689,9 +10683,8 @@
                         "json": "",
                         "show": true,
                         "when": "relationshipStatus",
-                        "eq": "marriedCommonLaw"
+                        "eq": "married"
                     },
-                    "nextPage": "",
                     "logic": [],
                     "attributes": {},
                     "overlay": {
@@ -10704,7 +10697,15 @@
                     },
                     "type": "panel",
                     "label": "Married/Common law Panel",
+                    "breadcrumb": "default",
+                    "buttonSettings": {
+                        "previous": false,
+                        "cancel": false,
+                        "next": false
+                    },
                     "tabindex": "",
+                    "breadcrumbClickable": false,
+                    "scrollToTop": false,
                     "input": false,
                     "tableView": false,
                     "components": [
@@ -10741,7 +10742,7 @@
                             "conditional": {
                                 "show": true,
                                 "when": "relationshipStatus",
-                                "eq": "marriedCommonLaw"
+                                "eq": "married"
                             },
                             "type": "datetime",
                             "input": true,
@@ -10804,6 +10805,7 @@
                             "showWordCount": false,
                             "properties": {},
                             "allowMultipleMasks": false,
+                            "addons": [],
                             "useLocaleSettings": false,
                             "allowInput": true,
                             "enableDate": true,
@@ -10820,9 +10822,7 @@
                                 "arrowkeys": true
                             },
                             "customOptions": {},
-                            "id": "enmzn3",
-                            "shortcutButtons": [],
-                            "addons": []
+                            "id": "enx99y"
                         }
                     ],
                     "allowPrevious": false,
@@ -10861,10 +10861,10 @@
                     "showCharCount": false,
                     "showWordCount": false,
                     "allowMultipleMasks": false,
-                    "tree": false,
-                    "id": "e7huqp",
                     "addons": [],
-                    "lazyLoad": false
+                    "tree": false,
+                    "lazyLoad": false,
+                    "id": "eowsewn"
                 },
                 {
                     "label": "<strong>Do you have any dependants?</strong>",
@@ -12339,7 +12339,7 @@
                                             "addons": []
                                         }
                                     ],
-                                    "id": "ecpkm9j000000000000000000000000000000000000000000000000000000000000",
+                                    "id": "ecpkm9j00000000000000000000000000000000000000000000000000000000000000000",
                                     "placeholder": "",
                                     "prefix": "",
                                     "customClass": "",
@@ -13336,7 +13336,7 @@
                     "encrypted": false,
                     "redrawOn": "data",
                     "customDefaultValue": "",
-                    "calculateValue": "//alert (data.dependantstatus);\nif (data.hasDependents === 'no' && (data.relationshipStatus === 'single' || data.relationshipStatus === 'otherSingle') && data.outOfHighSchoolFor4Years === 'no' && data.howWillYouBeAttendingTheProgram === \"Full Time\") {\n  instance.setValue ('dependant');\n}\nelse {\n  instance.setValue ('independant');\n}",
+                    "calculateValue": "//alert (data.dependantstatus);\nif (data.hasDependents === 'no' && (data.relationshipStatus === 'single' || data.relationshipStatus === 'other') && data.outOfHighSchoolFor4Years === 'no' && data.howWillYouBeAttendingTheProgram === \"Full Time\") {\n  instance.setValue ('dependant');\n}\nelse {\n  instance.setValue ('independant');\n}",
                     "calculateServer": true,
                     "key": "dependantstatus",
                     "tags": [],
@@ -13394,7 +13394,7 @@
                     "allowMultipleMasks": false,
                     "addons": [],
                     "inputType": "hidden",
-                    "id": "ewwbcc9"
+                    "id": "egb193"
                 }
             ],
             "placeholder": "",
@@ -13439,15 +13439,9 @@
         },
         {
             "title": "Partner information",
+            "labelWidth": "",
+            "labelMargin": "",
             "theme": "default",
-            "breadcrumb": "default",
-            "breadcrumbClickable": true,
-            "buttonSettings": {
-                "previous": false,
-                "cancel": false,
-                "next": false
-            },
-            "scrollToTop": true,
             "tooltip": "",
             "customClass": "",
             "collapsible": false,
@@ -13463,9 +13457,8 @@
                 "json": "",
                 "show": true,
                 "when": "relationshipStatus",
-                "eq": "marriedCommonLaw"
+                "eq": "married"
             },
-            "nextPage": "",
             "logic": [],
             "attributes": {},
             "overlay": {
@@ -13478,14 +13471,20 @@
             },
             "type": "panel",
             "label": "Partner Information",
+            "breadcrumb": "default",
+            "buttonSettings": {
+                "previous": false,
+                "cancel": false,
+                "next": false
+            },
             "tabindex": "",
+            "breadcrumbClickable": true,
+            "scrollToTop": true,
             "input": false,
             "tableView": false,
             "components": [
                 {
                     "label": "HTML",
-                    "tag": "p",
-                    "className": "",
                     "attrs": [
                         {
                             "attr": "",
@@ -13495,30 +13494,10 @@
                     "content": "Partner information",
                     "refreshOnChange": false,
                     "customClass": "header-lg",
-                    "hidden": false,
-                    "modalEdit": false,
                     "key": "html65",
-                    "tags": [],
-                    "properties": {},
-                    "conditional": {
-                        "show": null,
-                        "when": null,
-                        "eq": "",
-                        "json": ""
-                    },
-                    "customConditional": "",
-                    "logic": [],
-                    "attributes": {},
-                    "overlay": {
-                        "style": "",
-                        "page": "",
-                        "left": "",
-                        "top": "",
-                        "width": "",
-                        "height": ""
-                    },
                     "type": "htmlelement",
                     "input": false,
+                    "tableView": false,
                     "placeholder": "",
                     "prefix": "",
                     "suffix": "",
@@ -13527,10 +13506,11 @@
                     "protected": false,
                     "unique": false,
                     "persistent": false,
+                    "hidden": false,
                     "clearOnHide": true,
                     "refreshOn": "",
                     "redrawOn": "",
-                    "tableView": false,
+                    "modalEdit": false,
                     "dataGridLabel": false,
                     "labelPosition": "top",
                     "description": "",
@@ -13545,6 +13525,7 @@
                     "calculateValue": "",
                     "calculateServer": false,
                     "widget": null,
+                    "attributes": {},
                     "validateOn": "change",
                     "validate": {
                         "required": false,
@@ -13554,18 +13535,30 @@
                         "multiple": false,
                         "unique": false
                     },
+                    "conditional": {
+                        "show": null,
+                        "when": null,
+                        "eq": ""
+                    },
+                    "overlay": {
+                        "style": "",
+                        "left": "",
+                        "top": "",
+                        "width": "",
+                        "height": ""
+                    },
                     "allowCalculateOverride": false,
                     "encrypted": false,
                     "showCharCount": false,
                     "showWordCount": false,
+                    "properties": {},
                     "allowMultipleMasks": false,
-                    "id": "ezo3nq8",
-                    "addons": []
+                    "addons": [],
+                    "tag": "p",
+                    "id": "en3rdtp"
                 },
                 {
                     "label": "HTML",
-                    "tag": "p",
-                    "className": "",
                     "attrs": [
                         {
                             "attr": "",
@@ -13574,43 +13567,24 @@
                     ],
                     "content": "Help text about this section will be displayed here",
                     "refreshOnChange": false,
-                    "customClass": "",
-                    "hidden": false,
-                    "modalEdit": false,
                     "key": "html66",
-                    "tags": [],
-                    "properties": {},
-                    "conditional": {
-                        "show": null,
-                        "when": null,
-                        "eq": "",
-                        "json": ""
-                    },
-                    "customConditional": "",
-                    "logic": [],
-                    "attributes": {},
-                    "overlay": {
-                        "style": "",
-                        "page": "",
-                        "left": "",
-                        "top": "",
-                        "width": "",
-                        "height": ""
-                    },
                     "type": "htmlelement",
                     "input": false,
+                    "tableView": false,
                     "placeholder": "",
                     "prefix": "",
+                    "customClass": "",
                     "suffix": "",
                     "multiple": false,
                     "defaultValue": null,
                     "protected": false,
                     "unique": false,
                     "persistent": false,
+                    "hidden": false,
                     "clearOnHide": true,
                     "refreshOn": "",
                     "redrawOn": "",
-                    "tableView": false,
+                    "modalEdit": false,
                     "dataGridLabel": false,
                     "labelPosition": "top",
                     "description": "",
@@ -13625,6 +13599,7 @@
                     "calculateValue": "",
                     "calculateServer": false,
                     "widget": null,
+                    "attributes": {},
                     "validateOn": "change",
                     "validate": {
                         "required": false,
@@ -13634,29 +13609,33 @@
                         "multiple": false,
                         "unique": false
                     },
+                    "conditional": {
+                        "show": null,
+                        "when": null,
+                        "eq": ""
+                    },
+                    "overlay": {
+                        "style": "",
+                        "left": "",
+                        "top": "",
+                        "width": "",
+                        "height": ""
+                    },
                     "allowCalculateOverride": false,
                     "encrypted": false,
                     "showCharCount": false,
                     "showWordCount": false,
+                    "properties": {},
                     "allowMultipleMasks": false,
-                    "id": "ew7qj9",
-                    "addons": []
+                    "addons": [],
+                    "tag": "p",
+                    "id": "elvfuof"
                 },
                 {
                     "label": "<strong>Does your partner have a valid Social Insurance Number?</strong>",
-                    "labelPosition": "top",
                     "optionsLabelPosition": "right",
-                    "description": "",
-                    "tooltip": "",
-                    "customClass": "",
-                    "tabindex": "",
                     "inline": false,
-                    "hidden": false,
-                    "hideLabel": false,
-                    "autofocus": false,
-                    "disabled": false,
                     "tableView": false,
-                    "modalEdit": false,
                     "values": [
                         {
                             "label": "Yes",
@@ -13669,72 +13648,73 @@
                             "shortcut": ""
                         }
                     ],
-                    "dataType": "",
-                    "persistent": true,
+                    "validate": {
+                        "required": true,
+                        "custom": "",
+                        "customPrivate": false,
+                        "strictDateValidation": false,
+                        "multiple": false,
+                        "unique": false,
+                        "onlyAvailableItems": false
+                    },
+                    "key": "isYourSpouseACanadianCitizen",
+                    "type": "radio",
+                    "input": true,
+                    "placeholder": "",
+                    "prefix": "",
+                    "customClass": "",
+                    "suffix": "",
+                    "multiple": false,
+                    "defaultValue": null,
                     "protected": false,
-                    "dbIndex": false,
-                    "encrypted": false,
-                    "redrawOn": "",
+                    "unique": false,
+                    "persistent": true,
+                    "hidden": false,
                     "clearOnHide": true,
+                    "refreshOn": "",
+                    "redrawOn": "",
+                    "modalEdit": false,
+                    "dataGridLabel": false,
+                    "labelPosition": "top",
+                    "description": "",
+                    "errorLabel": "",
+                    "tooltip": "",
+                    "hideLabel": false,
+                    "tabindex": "",
+                    "disabled": false,
+                    "autofocus": false,
+                    "dbIndex": false,
                     "customDefaultValue": "",
                     "calculateValue": "",
                     "calculateServer": false,
-                    "allowCalculateOverride": false,
-                    "validate": {
-                        "required": true,
-                        "onlyAvailableItems": false,
-                        "customMessage": "",
-                        "custom": "",
-                        "customPrivate": false,
-                        "json": "",
-                        "strictDateValidation": false,
-                        "multiple": false,
-                        "unique": false
-                    },
-                    "errorLabel": "",
-                    "key": "isYourSpouseACanadianCitizen",
-                    "tags": [],
-                    "properties": {},
+                    "widget": null,
+                    "attributes": {},
+                    "validateOn": "change",
                     "conditional": {
                         "show": null,
                         "when": null,
-                        "eq": "",
-                        "json": ""
+                        "eq": ""
                     },
-                    "customConditional": "",
-                    "logic": [],
-                    "attributes": {},
                     "overlay": {
                         "style": "",
-                        "page": "",
                         "left": "",
                         "top": "",
                         "width": "",
                         "height": ""
                     },
-                    "type": "radio",
-                    "input": true,
-                    "placeholder": "",
-                    "prefix": "",
-                    "suffix": "",
-                    "multiple": false,
-                    "unique": false,
-                    "refreshOn": "",
-                    "dataGridLabel": false,
-                    "widget": null,
-                    "validateOn": "change",
+                    "allowCalculateOverride": false,
+                    "encrypted": false,
                     "showCharCount": false,
                     "showWordCount": false,
+                    "properties": {},
                     "allowMultipleMasks": false,
+                    "addons": [],
                     "inputType": "radio",
                     "fieldSet": false,
-                    "id": "eolgirh",
-                    "defaultValue": "",
-                    "addons": []
+                    "id": "ej6ywpp"
                 },
                 {
                     "label": "Additional information required",
-                    "tag": "p",
                     "className": "alert alert-info  fa fa-info-circle",
                     "attrs": [
                         {
@@ -13745,27 +13725,11 @@
                     "content": "<Strong> Please be advised your partner will need to sign in to StudentAid BC and provide additional information.</Strong><br/> \r\nPlease check your email after submitting your application. An email will be sent to you with instructions for your partner to sign in. Your application cannot proceed until this information is received.\r\n<br />",
                     "refreshOnChange": false,
                     "customClass": "banner-info",
-                    "hidden": false,
-                    "modalEdit": false,
                     "key": "additionalInformationRequired",
-                    "tags": [],
-                    "properties": {},
                     "conditional": {
                         "show": true,
                         "when": "isYourSpouseACanadianCitizen",
-                        "eq": "yes",
-                        "json": ""
-                    },
-                    "customConditional": "",
-                    "logic": [],
-                    "attributes": {},
-                    "overlay": {
-                        "style": "",
-                        "page": "",
-                        "left": "",
-                        "top": "",
-                        "width": "",
-                        "height": ""
+                        "eq": "yes"
                     },
                     "type": "htmlelement",
                     "input": false,
@@ -13778,9 +13742,11 @@
                     "protected": false,
                     "unique": false,
                     "persistent": false,
+                    "hidden": false,
                     "clearOnHide": true,
                     "refreshOn": "",
                     "redrawOn": "",
+                    "modalEdit": false,
                     "dataGridLabel": false,
                     "labelPosition": "top",
                     "description": "",
@@ -13795,6 +13761,7 @@
                     "calculateValue": "",
                     "calculateServer": false,
                     "widget": null,
+                    "attributes": {},
                     "validateOn": "change",
                     "validate": {
                         "required": false,
@@ -13804,17 +13771,25 @@
                         "multiple": false,
                         "unique": false
                     },
+                    "overlay": {
+                        "style": "",
+                        "left": "",
+                        "top": "",
+                        "width": "",
+                        "height": ""
+                    },
                     "allowCalculateOverride": false,
                     "encrypted": false,
                     "showCharCount": false,
                     "showWordCount": false,
+                    "properties": {},
                     "allowMultipleMasks": false,
-                    "id": "eqyaa8b",
-                    "addons": []
+                    "addons": [],
+                    "tag": "p",
+                    "id": "efqr3g"
                 },
                 {
                     "label": "Spouse Estimation",
-                    "tag": "p",
                     "className": "alert alert-warning fa fa-exclamation-circle",
                     "attrs": [
                         {
@@ -13825,27 +13800,11 @@
                     "content": "<strong> Please be advised this could delay your application</strong> \n<br />\nSince we’re unable to validate your partner’s information with Canada Revenue Agency (CRA), please estimate your partner’s income.",
                     "refreshOnChange": false,
                     "customClass": "banner-warning",
-                    "hidden": false,
-                    "modalEdit": false,
                     "key": "spouseEstimation",
-                    "tags": [],
-                    "properties": {},
                     "conditional": {
                         "show": true,
                         "when": "isYourSpouseACanadianCitizen",
-                        "eq": "no",
-                        "json": ""
-                    },
-                    "customConditional": "",
-                    "logic": [],
-                    "attributes": {},
-                    "overlay": {
-                        "style": "",
-                        "page": "",
-                        "left": "",
-                        "top": "",
-                        "width": "",
-                        "height": ""
+                        "eq": "no"
                     },
                     "type": "htmlelement",
                     "input": false,
@@ -13858,9 +13817,11 @@
                     "protected": false,
                     "unique": false,
                     "persistent": false,
+                    "hidden": false,
                     "clearOnHide": true,
                     "refreshOn": "",
                     "redrawOn": "",
+                    "modalEdit": false,
                     "dataGridLabel": false,
                     "labelPosition": "top",
                     "description": "",
@@ -13875,6 +13836,7 @@
                     "calculateValue": "",
                     "calculateServer": false,
                     "widget": null,
+                    "attributes": {},
                     "validateOn": "change",
                     "validate": {
                         "required": false,
@@ -13884,13 +13846,22 @@
                         "multiple": false,
                         "unique": false
                     },
+                    "overlay": {
+                        "style": "",
+                        "left": "",
+                        "top": "",
+                        "width": "",
+                        "height": ""
+                    },
                     "allowCalculateOverride": false,
                     "encrypted": false,
                     "showCharCount": false,
                     "showWordCount": false,
+                    "properties": {},
                     "allowMultipleMasks": false,
-                    "id": "eow2c2c",
-                    "addons": []
+                    "addons": [],
+                    "tag": "p",
+                    "id": "enke0qu"
                 },
                 {
                     "title": "Partner Income Panel",
@@ -13915,8 +13886,6 @@
                     "components": [
                         {
                             "label": "HTML",
-                            "tag": "p",
-                            "className": "",
                             "attrs": [
                                 {
                                     "attr": "",
@@ -13926,30 +13895,10 @@
                             "content": "Partner income",
                             "refreshOnChange": false,
                             "customClass": "header-md",
-                            "hidden": false,
-                            "modalEdit": false,
                             "key": "html67",
-                            "tags": [],
-                            "properties": {},
-                            "conditional": {
-                                "show": null,
-                                "when": null,
-                                "eq": "",
-                                "json": ""
-                            },
-                            "customConditional": "",
-                            "logic": [],
-                            "attributes": {},
-                            "overlay": {
-                                "style": "",
-                                "page": "",
-                                "left": "",
-                                "top": "",
-                                "width": "",
-                                "height": ""
-                            },
                             "type": "htmlelement",
                             "input": false,
+                            "tableView": false,
                             "placeholder": "",
                             "prefix": "",
                             "suffix": "",
@@ -13958,10 +13907,11 @@
                             "protected": false,
                             "unique": false,
                             "persistent": false,
+                            "hidden": false,
                             "clearOnHide": true,
                             "refreshOn": "",
                             "redrawOn": "",
-                            "tableView": false,
+                            "modalEdit": false,
                             "dataGridLabel": false,
                             "labelPosition": "top",
                             "description": "",
@@ -13976,6 +13926,7 @@
                             "calculateValue": "",
                             "calculateServer": false,
                             "widget": null,
+                            "attributes": {},
                             "validateOn": "change",
                             "validate": {
                                 "required": false,
@@ -13985,18 +13936,30 @@
                                 "multiple": false,
                                 "unique": false
                             },
+                            "conditional": {
+                                "show": null,
+                                "when": null,
+                                "eq": ""
+                            },
+                            "overlay": {
+                                "style": "",
+                                "left": "",
+                                "top": "",
+                                "width": "",
+                                "height": ""
+                            },
                             "allowCalculateOverride": false,
                             "encrypted": false,
                             "showCharCount": false,
                             "showWordCount": false,
+                            "properties": {},
                             "allowMultipleMasks": false,
-                            "id": "e3pwpa9",
-                            "addons": []
+                            "addons": [],
+                            "tag": "p",
+                            "id": "evz2md"
                         },
                         {
                             "label": "HTML",
-                            "tag": "p",
-                            "className": "",
                             "attrs": [
                                 {
                                     "attr": "",
@@ -14005,43 +13968,24 @@
                             ],
                             "content": "Help text about this section will be displayed here",
                             "refreshOnChange": false,
-                            "customClass": "",
-                            "hidden": false,
-                            "modalEdit": false,
                             "key": "html68",
-                            "tags": [],
-                            "properties": {},
-                            "conditional": {
-                                "show": null,
-                                "when": null,
-                                "eq": "",
-                                "json": ""
-                            },
-                            "customConditional": "",
-                            "logic": [],
-                            "attributes": {},
-                            "overlay": {
-                                "style": "",
-                                "page": "",
-                                "left": "",
-                                "top": "",
-                                "width": "",
-                                "height": ""
-                            },
                             "type": "htmlelement",
                             "input": false,
+                            "tableView": false,
                             "placeholder": "",
                             "prefix": "",
+                            "customClass": "",
                             "suffix": "",
                             "multiple": false,
                             "defaultValue": null,
                             "protected": false,
                             "unique": false,
                             "persistent": false,
+                            "hidden": false,
                             "clearOnHide": true,
                             "refreshOn": "",
                             "redrawOn": "",
-                            "tableView": false,
+                            "modalEdit": false,
                             "dataGridLabel": false,
                             "labelPosition": "top",
                             "description": "",
@@ -14056,6 +14000,7 @@
                             "calculateValue": "",
                             "calculateServer": false,
                             "widget": null,
+                            "attributes": {},
                             "validateOn": "change",
                             "validate": {
                                 "required": false,
@@ -14065,13 +14010,27 @@
                                 "multiple": false,
                                 "unique": false
                             },
+                            "conditional": {
+                                "show": null,
+                                "when": null,
+                                "eq": ""
+                            },
+                            "overlay": {
+                                "style": "",
+                                "left": "",
+                                "top": "",
+                                "width": "",
+                                "height": ""
+                            },
                             "allowCalculateOverride": false,
                             "encrypted": false,
                             "showCharCount": false,
                             "showWordCount": false,
+                            "properties": {},
                             "allowMultipleMasks": false,
-                            "id": "eedvdyj",
-                            "addons": []
+                            "addons": [],
+                            "tag": "p",
+                            "id": "e9e67m6"
                         },
                         {
                             "label": "What was your partner’s income (as shown on line 15000 of previous year’s Canada Revenue Agency tax return)? If they didn’t file taxes, enter total income from all sources in and outside of Canada.",
@@ -14146,8 +14105,8 @@
                             "showWordCount": false,
                             "properties": {},
                             "allowMultipleMasks": false,
-                            "id": "e9mqj6h",
-                            "addons": []
+                            "addons": [],
+                            "id": "evzgb9g"
                         },
                         {
                             "label": "<strong>Will your partner be employed full-time or part-time during your study period</strong>",
@@ -14168,12 +14127,12 @@
                             ],
                             "validate": {
                                 "required": true,
-                                "onlyAvailableItems": false,
                                 "custom": "",
                                 "customPrivate": false,
                                 "strictDateValidation": false,
                                 "multiple": false,
-                                "unique": false
+                                "unique": false,
+                                "onlyAvailableItems": false
                             },
                             "key": "partnerEmployed",
                             "type": "radio",
@@ -14226,10 +14185,10 @@
                             "showWordCount": false,
                             "properties": {},
                             "allowMultipleMasks": false,
+                            "addons": [],
                             "inputType": "radio",
                             "fieldSet": false,
-                            "id": "erofrhb",
-                            "addons": []
+                            "id": "ew6uez"
                         },
                         {
                             "label": "<strong>Will  your partner be at home caring for eligible dependent children on a full-time basis during the your entire study period? </strong>",
@@ -14250,12 +14209,12 @@
                             ],
                             "validate": {
                                 "required": true,
-                                "onlyAvailableItems": false,
                                 "custom": "",
                                 "customPrivate": false,
                                 "strictDateValidation": false,
                                 "multiple": false,
-                                "unique": false
+                                "unique": false,
+                                "onlyAvailableItems": false
                             },
                             "key": "partnercaringforeligibleDependent",
                             "type": "radio",
@@ -14308,10 +14267,10 @@
                             "showWordCount": false,
                             "properties": {},
                             "allowMultipleMasks": false,
+                            "addons": [],
                             "inputType": "radio",
                             "fieldSet": false,
-                            "id": "e1z6lyb",
-                            "addons": []
+                            "id": "eb8ngb"
                         },
                         {
                             "label": "<strong>Will your partner be living with you during the your study period?</strong>",
@@ -14332,12 +14291,12 @@
                             ],
                             "validate": {
                                 "required": true,
-                                "onlyAvailableItems": false,
                                 "custom": "",
                                 "customPrivate": false,
                                 "strictDateValidation": false,
                                 "multiple": false,
-                                "unique": false
+                                "unique": false,
+                                "onlyAvailableItems": false
                             },
                             "key": "partnerlivingwithYou",
                             "type": "radio",
@@ -14390,10 +14349,10 @@
                             "showWordCount": false,
                             "properties": {},
                             "allowMultipleMasks": false,
+                            "addons": [],
                             "inputType": "radio",
                             "fieldSet": false,
-                            "id": "ehnyp6c",
-                            "addons": []
+                            "id": "ezlp9vt"
                         },
                         {
                             "label": "<strong>Will your partner be a full-time post-secondary student for some or all of your study period?</strong>",
@@ -14414,12 +14373,12 @@
                             ],
                             "validate": {
                                 "required": true,
-                                "onlyAvailableItems": false,
                                 "custom": "",
                                 "customPrivate": false,
                                 "strictDateValidation": false,
                                 "multiple": false,
-                                "unique": false
+                                "unique": false,
+                                "onlyAvailableItems": false
                             },
                             "key": "partnerfulltimeStudent",
                             "type": "radio",
@@ -14472,10 +14431,10 @@
                             "showWordCount": false,
                             "properties": {},
                             "allowMultipleMasks": false,
+                            "addons": [],
                             "inputType": "radio",
                             "fieldSet": false,
-                            "id": "e4neun",
-                            "addons": []
+                            "id": "el8q4e"
                         },
                         {
                             "title": "If your partner will be a full-time student, how many weeks of your study period will they also be in studies Panel",
@@ -14500,87 +14459,79 @@
                             "components": [
                                 {
                                     "label": "<strong>If your partner will be a full-time student, how many weeks of your study period will they also be in studies?</strong>",
-                                    "labelPosition": "top",
-                                    "placeholder": "",
-                                    "description": "",
-                                    "tooltip": "",
                                     "prefix": "Number of Weeks",
-                                    "suffix": "",
-                                    "widget": {
-                                        "type": "input"
-                                    },
-                                    "customClass": "",
-                                    "tabindex": "",
-                                    "autocomplete": "",
-                                    "hidden": false,
-                                    "hideLabel": false,
                                     "mask": false,
-                                    "autofocus": false,
                                     "spellcheck": true,
-                                    "disabled": false,
                                     "tableView": false,
-                                    "modalEdit": false,
-                                    "multiple": false,
-                                    "persistent": true,
                                     "delimiter": false,
                                     "requireDecimal": false,
                                     "inputFormat": "plain",
-                                    "protected": false,
-                                    "dbIndex": false,
-                                    "encrypted": false,
-                                    "redrawOn": "",
-                                    "clearOnHide": true,
-                                    "customDefaultValue": "",
-                                    "calculateValue": "",
-                                    "calculateServer": false,
-                                    "allowCalculateOverride": false,
-                                    "validateOn": "change",
                                     "validate": {
                                         "required": true,
-                                        "customMessage": "",
                                         "custom": "const studyStartTime = new Date(data.studystartDate).getTime();\r\nconst studyEndTime= new Date(row.studyendDate).getTime();\r\nconst difference = (studyEndTime - studyStartTime);\r\nconst studyWeek = difference/(1000 * 60 * 60 * 24 * 7);\r\n// valid = parseInt(week);\r\n// vaild = (data.ifYourPartnerWillBeAFullTimeStudentHowManyWeeksOfYourStudyPeriodWillTheyAlsoBeInStudies <= studyWeek) ? true : \"Must be Equal to or less than Student Applicants study period\";\r\nvaildweek = (data.ifYourPartnerWillBeAFullTimeStudentHowManyWeeksOfYourStudyPeriodWillTheyAlsoBeInStudies <= studyWeek);\r\nvalid = vaildweek ? true : 'Must be Equal to or less than Student Applicants study period';\r\n",
                                         "customPrivate": false,
-                                        "json": "",
-                                        "min": "",
-                                        "max": "",
                                         "strictDateValidation": false,
                                         "multiple": false,
                                         "unique": false,
+                                        "min": "",
+                                        "max": "",
                                         "step": "any",
                                         "integer": ""
                                     },
-                                    "errorLabel": "",
                                     "key": "ifYourPartnerWillBeAFullTimeStudentHowManyWeeksOfYourStudyPeriodWillTheyAlsoBeInStudies",
-                                    "tags": [],
-                                    "properties": {},
                                     "conditional": {
                                         "show": true,
                                         "when": "partnerfulltimeStudent",
-                                        "eq": "yes",
-                                        "json": ""
+                                        "eq": "yes"
                                     },
-                                    "customConditional": "",
-                                    "logic": [],
+                                    "type": "number",
+                                    "input": true,
+                                    "placeholder": "",
+                                    "customClass": "",
+                                    "suffix": "",
+                                    "multiple": false,
+                                    "defaultValue": null,
+                                    "protected": false,
+                                    "unique": false,
+                                    "persistent": true,
+                                    "hidden": false,
+                                    "clearOnHide": true,
+                                    "refreshOn": "",
+                                    "redrawOn": "",
+                                    "modalEdit": false,
+                                    "dataGridLabel": false,
+                                    "labelPosition": "top",
+                                    "description": "",
+                                    "errorLabel": "",
+                                    "tooltip": "",
+                                    "hideLabel": false,
+                                    "tabindex": "",
+                                    "disabled": false,
+                                    "autofocus": false,
+                                    "dbIndex": false,
+                                    "customDefaultValue": "",
+                                    "calculateValue": "",
+                                    "calculateServer": false,
+                                    "widget": {
+                                        "type": "input"
+                                    },
                                     "attributes": {},
+                                    "validateOn": "change",
                                     "overlay": {
                                         "style": "",
-                                        "page": "",
                                         "left": "",
                                         "top": "",
                                         "width": "",
                                         "height": ""
                                     },
-                                    "type": "number",
-                                    "input": true,
-                                    "unique": false,
-                                    "refreshOn": "",
-                                    "dataGridLabel": false,
+                                    "allowCalculateOverride": false,
+                                    "encrypted": false,
                                     "showCharCount": false,
                                     "showWordCount": false,
+                                    "properties": {},
                                     "allowMultipleMasks": false,
-                                    "id": "epdswoon",
-                                    "defaultValue": null,
-                                    "addons": []
+                                    "addons": [],
+                                    "id": "evhapmn"
                                 }
                             ],
                             "allowPrevious": false,
@@ -14634,28 +14585,18 @@
                             "showWordCount": false,
                             "properties": {},
                             "allowMultipleMasks": false,
+                            "addons": [],
                             "tree": false,
+                            "lazyLoad": false,
                             "theme": "default",
                             "breadcrumb": "default",
-                            "id": "ep5lg4",
-                            "addons": [],
-                            "lazyLoad": false
+                            "id": "eq38b6a"
                         },
                         {
                             "label": "<strong>Will your partner recieve income assistance/social assistance (welfare) and/or BC income assistance for persons with disabilities during the your study period?</strong>",
-                            "labelPosition": "top",
                             "optionsLabelPosition": "right",
-                            "description": "",
-                            "tooltip": "",
-                            "customClass": "",
-                            "tabindex": "",
                             "inline": false,
-                            "hidden": false,
-                            "hideLabel": false,
-                            "autofocus": false,
-                            "disabled": false,
                             "tableView": false,
-                            "modalEdit": false,
                             "values": [
                                 {
                                     "label": "Yes",
@@ -14668,68 +14609,70 @@
                                     "shortcut": ""
                                 }
                             ],
-                            "dataType": "",
-                            "persistent": true,
+                            "validate": {
+                                "required": true,
+                                "custom": "",
+                                "customPrivate": false,
+                                "strictDateValidation": false,
+                                "multiple": false,
+                                "unique": false,
+                                "onlyAvailableItems": false
+                            },
+                            "key": "partnerrecieveIncomeAssistance",
+                            "type": "radio",
+                            "input": true,
+                            "placeholder": "",
+                            "prefix": "",
+                            "customClass": "",
+                            "suffix": "",
+                            "multiple": false,
+                            "defaultValue": null,
                             "protected": false,
-                            "dbIndex": false,
-                            "encrypted": false,
-                            "redrawOn": "",
+                            "unique": false,
+                            "persistent": true,
+                            "hidden": false,
                             "clearOnHide": true,
+                            "refreshOn": "",
+                            "redrawOn": "",
+                            "modalEdit": false,
+                            "dataGridLabel": false,
+                            "labelPosition": "top",
+                            "description": "",
+                            "errorLabel": "",
+                            "tooltip": "",
+                            "hideLabel": false,
+                            "tabindex": "",
+                            "disabled": false,
+                            "autofocus": false,
+                            "dbIndex": false,
                             "customDefaultValue": "",
                             "calculateValue": "",
                             "calculateServer": false,
-                            "allowCalculateOverride": false,
-                            "validate": {
-                                "required": true,
-                                "onlyAvailableItems": false,
-                                "customMessage": "",
-                                "custom": "",
-                                "customPrivate": false,
-                                "json": "",
-                                "strictDateValidation": false,
-                                "multiple": false,
-                                "unique": false
-                            },
-                            "errorLabel": "",
-                            "key": "partnerrecieveIncomeAssistance",
-                            "tags": [],
-                            "properties": {},
+                            "widget": null,
+                            "attributes": {},
+                            "validateOn": "change",
                             "conditional": {
                                 "show": null,
                                 "when": null,
-                                "eq": "",
-                                "json": ""
+                                "eq": ""
                             },
-                            "customConditional": "",
-                            "logic": [],
-                            "attributes": {},
                             "overlay": {
                                 "style": "",
-                                "page": "",
                                 "left": "",
                                 "top": "",
                                 "width": "",
                                 "height": ""
                             },
-                            "type": "radio",
-                            "input": true,
-                            "placeholder": "",
-                            "prefix": "",
-                            "suffix": "",
-                            "multiple": false,
-                            "unique": false,
-                            "refreshOn": "",
-                            "dataGridLabel": false,
-                            "widget": null,
-                            "validateOn": "change",
+                            "allowCalculateOverride": false,
+                            "encrypted": false,
                             "showCharCount": false,
                             "showWordCount": false,
+                            "properties": {},
                             "allowMultipleMasks": false,
+                            "addons": [],
                             "inputType": "radio",
                             "fieldSet": false,
-                            "id": "ealunos",
-                            "defaultValue": "",
-                            "addons": []
+                            "id": "e4x2ul"
                         },
                         {
                             "title": "Provide the total income assistance/social assistance (welfare) and/or BC income assistance for persons with disabilities that your partner will be receiving during your study period Panel",
@@ -14825,8 +14768,8 @@
                                     "showWordCount": false,
                                     "properties": {},
                                     "allowMultipleMasks": false,
-                                    "id": "e9k0k58",
-                                    "addons": []
+                                    "addons": [],
+                                    "id": "eagmvc"
                                 }
                             ],
                             "allowPrevious": false,
@@ -14880,12 +14823,12 @@
                             "showWordCount": false,
                             "properties": {},
                             "allowMultipleMasks": false,
+                            "addons": [],
                             "tree": false,
+                            "lazyLoad": false,
                             "theme": "default",
                             "breadcrumb": "default",
-                            "id": "ey6jmc4b",
-                            "addons": [],
-                            "lazyLoad": false
+                            "id": "exyfgn"
                         },
                         {
                             "label": "<strong>Will your partner be in receipt of Employment Insurance benefits during the your study period?</strong>",
@@ -14906,12 +14849,12 @@
                             ],
                             "validate": {
                                 "required": true,
-                                "onlyAvailableItems": false,
                                 "custom": "",
                                 "customPrivate": false,
                                 "strictDateValidation": false,
                                 "multiple": false,
-                                "unique": false
+                                "unique": false,
+                                "onlyAvailableItems": false
                             },
                             "key": "partneremploymentInsurance",
                             "type": "radio",
@@ -14964,10 +14907,10 @@
                             "showWordCount": false,
                             "properties": {},
                             "allowMultipleMasks": false,
+                            "addons": [],
                             "inputType": "radio",
                             "fieldSet": false,
-                            "id": "enklghw",
-                            "addons": []
+                            "id": "e4eo1zj"
                         },
                         {
                             "title": "Will your partner be in receipt of Employment Insurance benefits during the your study period Panel",
@@ -15064,8 +15007,8 @@
                                     "showWordCount": false,
                                     "properties": {},
                                     "allowMultipleMasks": false,
-                                    "id": "ei87gnna",
-                                    "addons": []
+                                    "addons": [],
+                                    "id": "e34vso"
                                 }
                             ],
                             "allowPrevious": false,
@@ -15119,12 +15062,12 @@
                             "showWordCount": false,
                             "properties": {},
                             "allowMultipleMasks": false,
+                            "addons": [],
                             "tree": false,
+                            "lazyLoad": false,
                             "theme": "default",
                             "breadcrumb": "default",
-                            "id": "ei0vzm",
-                            "addons": [],
-                            "lazyLoad": false
+                            "id": "eeyu3mw"
                         },
                         {
                             "label": "<strong>Will your partner be in receipt of federal or provincial permanent disability benefits during the your study period?</strong>",
@@ -15145,12 +15088,12 @@
                             ],
                             "validate": {
                                 "required": true,
-                                "onlyAvailableItems": false,
                                 "custom": "",
                                 "customPrivate": false,
                                 "strictDateValidation": false,
                                 "multiple": false,
-                                "unique": false
+                                "unique": false,
+                                "onlyAvailableItems": false
                             },
                             "key": "partnerpermanentdisabilityBenefits",
                             "type": "radio",
@@ -15203,10 +15146,10 @@
                             "showWordCount": false,
                             "properties": {},
                             "allowMultipleMasks": false,
+                            "addons": [],
                             "inputType": "radio",
                             "fieldSet": false,
-                            "id": "ef7th7s",
-                            "addons": []
+                            "id": "edx8ai"
                         },
                         {
                             "title": "Will your partner be in receipt of federal or provincial permanent disability benefits during the your study period Panel",
@@ -15303,8 +15246,8 @@
                                     "showWordCount": false,
                                     "properties": {},
                                     "allowMultipleMasks": false,
-                                    "id": "ecbhi1",
-                                    "addons": []
+                                    "addons": [],
+                                    "id": "ezpa64"
                                 }
                             ],
                             "allowPrevious": false,
@@ -15358,12 +15301,12 @@
                             "showWordCount": false,
                             "properties": {},
                             "allowMultipleMasks": false,
+                            "addons": [],
                             "tree": false,
+                            "lazyLoad": false,
                             "theme": "default",
                             "breadcrumb": "default",
-                            "id": "em80rob",
-                            "addons": [],
-                            "lazyLoad": false
+                            "id": "e27eti7"
                         },
                         {
                             "label": "<strong>Will your partner be paying a Canada Student Loan and/or a provincial student loan regular scheduled payments during the your study period?</strong>",
@@ -15384,12 +15327,12 @@
                             ],
                             "validate": {
                                 "required": true,
-                                "onlyAvailableItems": false,
                                 "custom": "",
                                 "customPrivate": false,
                                 "strictDateValidation": false,
                                 "multiple": false,
-                                "unique": false
+                                "unique": false,
+                                "onlyAvailableItems": false
                             },
                             "key": "partnerstudentLoan",
                             "type": "radio",
@@ -15442,10 +15385,10 @@
                             "showWordCount": false,
                             "properties": {},
                             "allowMultipleMasks": false,
+                            "addons": [],
                             "inputType": "radio",
                             "fieldSet": false,
-                            "id": "eoxznh4",
-                            "addons": []
+                            "id": "e61fh5d"
                         },
                         {
                             "title": "Will your partner be paying a Canada Student Loan and/or a provincial student loan regular scheduled payments during the your study period Panel",
@@ -15541,8 +15484,8 @@
                                     "showWordCount": false,
                                     "properties": {},
                                     "allowMultipleMasks": false,
-                                    "id": "exjd5dg",
-                                    "addons": []
+                                    "addons": [],
+                                    "id": "elm4dbc"
                                 }
                             ],
                             "allowPrevious": false,
@@ -15596,12 +15539,12 @@
                             "showWordCount": false,
                             "properties": {},
                             "allowMultipleMasks": false,
+                            "addons": [],
                             "tree": false,
+                            "lazyLoad": false,
                             "theme": "default",
                             "breadcrumb": "default",
-                            "id": "et3rj9",
-                            "addons": [],
-                            "lazyLoad": false
+                            "id": "e2f623"
                         },
                         {
                             "label": "<strong>Will your partner be paying for child support and/or spousal support during the your study period?</strong>",
@@ -15622,12 +15565,12 @@
                             ],
                             "validate": {
                                 "required": true,
-                                "onlyAvailableItems": false,
                                 "custom": "",
                                 "customPrivate": false,
                                 "strictDateValidation": false,
                                 "multiple": false,
-                                "unique": false
+                                "unique": false,
+                                "onlyAvailableItems": false
                             },
                             "key": "partnerchildSupport",
                             "type": "radio",
@@ -15680,10 +15623,10 @@
                             "showWordCount": false,
                             "properties": {},
                             "allowMultipleMasks": false,
+                            "addons": [],
                             "inputType": "radio",
                             "fieldSet": false,
-                            "id": "eboa3up",
-                            "addons": []
+                            "id": "e7p57e"
                         },
                         {
                             "title": "Will your partner be paying for child support and/or spousal support during the your study period Panel",
@@ -15779,8 +15722,8 @@
                                     "showWordCount": false,
                                     "properties": {},
                                     "allowMultipleMasks": false,
-                                    "id": "epwpsk9",
-                                    "addons": []
+                                    "addons": [],
+                                    "id": "eik5h9f"
                                 }
                             ],
                             "allowPrevious": false,
@@ -15834,12 +15777,12 @@
                             "showWordCount": false,
                             "properties": {},
                             "allowMultipleMasks": false,
+                            "addons": [],
                             "tree": false,
+                            "lazyLoad": false,
                             "theme": "default",
                             "breadcrumb": "default",
-                            "id": "ei3r3id",
-                            "addons": [],
-                            "lazyLoad": false
+                            "id": "ea9vbp6"
                         },
                         {
                             "label": "<strong>Durring your study period, will your partner be taking care of eligible dependants? </strong>",
@@ -15860,12 +15803,12 @@
                             ],
                             "validate": {
                                 "required": true,
-                                "onlyAvailableItems": false,
                                 "custom": "",
                                 "customPrivate": false,
                                 "strictDateValidation": false,
                                 "multiple": false,
-                                "unique": false
+                                "unique": false,
+                                "onlyAvailableItems": false
                             },
                             "key": "durringYourStudyPeriodWillYourPartnerBeTakingCareOfEligibleDependants",
                             "type": "radio",
@@ -15918,10 +15861,10 @@
                             "showWordCount": false,
                             "properties": {},
                             "allowMultipleMasks": false,
+                            "addons": [],
                             "inputType": "radio",
                             "fieldSet": false,
-                            "id": "e887jy",
-                            "addons": []
+                            "id": "eee4uqa"
                         }
                     ],
                     "allowPrevious": false,
@@ -15975,12 +15918,12 @@
                     "showWordCount": false,
                     "properties": {},
                     "allowMultipleMasks": false,
+                    "addons": [],
                     "tree": false,
+                    "lazyLoad": false,
                     "theme": "default",
                     "breadcrumb": "default",
-                    "id": "etvo8m",
-                    "addons": [],
-                    "lazyLoad": false
+                    "id": "eq8pumq"
                 }
             ],
             "placeholder": "",
@@ -16018,10 +15961,10 @@
             "showCharCount": false,
             "showWordCount": false,
             "allowMultipleMasks": false,
-            "tree": false,
-            "id": "esudth",
             "addons": [],
-            "lazyLoad": false
+            "tree": false,
+            "lazyLoad": false,
+            "id": "e9pj66k"
         },
         {
             "title": "Parent information",
@@ -27844,5 +27787,5 @@
     "name": "SFAA2022-23",
     "machineName": "SFAA2022-23",
     "created": "2021-07-12T19:51:16.443Z",
-    "modified": "2022-02-16T23:04:31.333Z"
+    "modified": "2022-02-16T23:23:07.557Z"
 }

--- a/sources/packages/forms/src/form-definitions/sfaa2022-23.json
+++ b/sources/packages/forms/src/form-definitions/sfaa2022-23.json
@@ -139,7 +139,8 @@
                                                     "showCharCount": false,
                                                     "showWordCount": false,
                                                     "allowMultipleMasks": false,
-                                                    "id": "e0452mk"
+                                                    "id": "e0452mk",
+                                                    "addons": []
                                                 },
                                                 {
                                                     "label": "HTML",
@@ -219,14 +220,16 @@
                                                     "showCharCount": false,
                                                     "showWordCount": false,
                                                     "allowMultipleMasks": false,
-                                                    "id": "ef68phe"
+                                                    "id": "ef68phe",
+                                                    "addons": []
                                                 }
                                             ],
                                             "offset": 0,
                                             "push": 0,
                                             "pull": 0,
                                             "size": "md",
-                                            "width": 6
+                                            "width": 6,
+                                            "currentWidth": 6
                                         },
                                         {
                                             "components": [
@@ -301,14 +304,16 @@
                                                     "properties": {},
                                                     "allowMultipleMasks": false,
                                                     "content": "",
-                                                    "id": "e7p34h"
+                                                    "id": "e7p34h",
+                                                    "addons": []
                                                 }
                                             ],
                                             "offset": 0,
                                             "push": 0,
                                             "pull": 0,
                                             "size": "md",
-                                            "width": 6
+                                            "width": 6,
+                                            "currentWidth": 6
                                         }
                                     ],
                                     "hideLabel": true,
@@ -374,14 +379,17 @@
                                     "allowMultipleMasks": false,
                                     "tree": false,
                                     "autoAdjust": false,
-                                    "id": "ego57u"
+                                    "id": "ego57u",
+                                    "addons": [],
+                                    "lazyLoad": false
                                 }
                             ],
                             "width": 12,
                             "offset": 0,
                             "push": 0,
                             "pull": 0,
-                            "size": "md"
+                            "size": "md",
+                            "currentWidth": 12
                         },
                         {
                             "components": [],
@@ -389,7 +397,8 @@
                             "offset": 0,
                             "push": 0,
                             "pull": 0,
-                            "size": "md"
+                            "size": "md",
+                            "currentWidth": 6
                         }
                     ],
                     "type": "columns",
@@ -452,7 +461,9 @@
                     "tree": false,
                     "autoAdjust": false,
                     "hideOnChildrenHidden": false,
-                    "id": "evh64v3"
+                    "id": "evh64v3",
+                    "addons": [],
+                    "lazyLoad": false
                 },
                 {
                     "label": "applicationId",
@@ -519,7 +530,8 @@
                     "properties": {},
                     "allowMultipleMasks": false,
                     "inputType": "hidden",
-                    "id": "elknlor"
+                    "id": "elknlor",
+                    "addons": []
                 },
                 {
                     "label": "workflowName",
@@ -586,7 +598,8 @@
                     "properties": {},
                     "allowMultipleMasks": false,
                     "inputType": "hidden",
-                    "id": "ebsh4es"
+                    "id": "ebsh4es",
+                    "addons": []
                 }
             ],
             "input": false,
@@ -627,7 +640,9 @@
             "showWordCount": false,
             "allowMultipleMasks": false,
             "tree": false,
-            "id": "eyx5cz"
+            "id": "eyx5cz",
+            "addons": [],
+            "lazyLoad": false
         },
         {
             "title": "Program",
@@ -749,7 +764,8 @@
                     "showCharCount": false,
                     "showWordCount": false,
                     "allowMultipleMasks": false,
-                    "id": "exz6y1"
+                    "id": "exz6y1",
+                    "addons": []
                 },
                 {
                     "label": "HTML",
@@ -828,7 +844,8 @@
                     "showCharCount": false,
                     "showWordCount": false,
                     "allowMultipleMasks": false,
-                    "id": "e5gyojf"
+                    "id": "e5gyojf",
+                    "addons": []
                 },
                 {
                     "label": "HTML",
@@ -907,7 +924,8 @@
                     "showCharCount": false,
                     "showWordCount": false,
                     "allowMultipleMasks": false,
-                    "id": "erdyicdr"
+                    "id": "erdyicdr",
+                    "addons": []
                 },
                 {
                     "label": "HTML",
@@ -986,7 +1004,8 @@
                     "showCharCount": false,
                     "showWordCount": false,
                     "allowMultipleMasks": false,
-                    "id": "egxu9ol"
+                    "id": "egxu9ol",
+                    "addons": []
                 },
                 {
                     "label": "The school I will be attending",
@@ -1100,7 +1119,9 @@
                         "threshold": 0.3
                     },
                     "id": "ef6vu8sg",
-                    "defaultValue": ""
+                    "defaultValue": "",
+                    "addons": [],
+                    "searchDebounce": 0.3
                 },
                 {
                     "label": "My school isn't listed",
@@ -1175,7 +1196,8 @@
                     "showCharCount": false,
                     "showWordCount": false,
                     "allowMultipleMasks": false,
-                    "id": "eydaew"
+                    "id": "eydaew",
+                    "addons": []
                 },
                 {
                     "label": "HTML",
@@ -1254,7 +1276,8 @@
                     "showCharCount": false,
                     "showWordCount": false,
                     "allowMultipleMasks": false,
-                    "id": "e4c1ao"
+                    "id": "e4c1ao",
+                    "addons": []
                 },
                 {
                     "label": "HTML",
@@ -1333,7 +1356,8 @@
                     "showCharCount": false,
                     "showWordCount": false,
                     "allowMultipleMasks": false,
-                    "id": "e4c39nw"
+                    "id": "e4c39nw",
+                    "addons": []
                 },
                 {
                     "label": "How will you be attending the program",
@@ -1412,7 +1436,8 @@
                     "showCharCount": false,
                     "showWordCount": false,
                     "allowMultipleMasks": false,
-                    "id": "e2avb6r"
+                    "id": "e2avb6r",
+                    "addons": []
                 },
                 {
                     "label": "HTML",
@@ -1491,7 +1516,8 @@
                     "showCharCount": false,
                     "showWordCount": false,
                     "allowMultipleMasks": false,
-                    "id": "e4vwl6"
+                    "id": "e4vwl6",
+                    "addons": []
                 },
                 {
                     "label": "How will you be attending the program",
@@ -1608,7 +1634,9 @@
                         "threshold": 0.3
                     },
                     "id": "el8m1c",
-                    "defaultValue": ""
+                    "defaultValue": "",
+                    "addons": [],
+                    "searchDebounce": 0.3
                 },
                 {
                     "label": "HTML",
@@ -1687,7 +1715,8 @@
                     "showCharCount": false,
                     "showWordCount": false,
                     "allowMultipleMasks": false,
-                    "id": "e1zogo"
+                    "id": "e1zogo",
+                    "addons": []
                 },
                 {
                     "label": "The program I will be attending:",
@@ -1803,7 +1832,9 @@
                         "threshold": 0.3
                     },
                     "id": "ehmxwzx",
-                    "defaultValue": ""
+                    "defaultValue": "",
+                    "addons": [],
+                    "searchDebounce": 0.3
                 },
                 {
                     "label": "My program is not listed",
@@ -1891,7 +1922,8 @@
                     "showWordCount": false,
                     "allowMultipleMasks": false,
                     "fieldSet": false,
-                    "id": "ewojohn"
+                    "id": "ewojohn",
+                    "addons": []
                 },
                 {
                     "label": "selectedProgramDesc",
@@ -1961,7 +1993,8 @@
                     "showWordCount": false,
                     "allowMultipleMasks": false,
                     "inputType": "hidden",
-                    "id": "ee3p2mc"
+                    "id": "ee3p2mc",
+                    "addons": []
                 },
                 {
                     "title": "programDesc",
@@ -2080,7 +2113,8 @@
                             "properties": {},
                             "allowMultipleMasks": false,
                             "tag": "p",
-                            "id": "erk6bs"
+                            "id": "erk6bs",
+                            "addons": []
                         },
                         {
                             "label": "HTML",
@@ -2154,7 +2188,8 @@
                             "properties": {},
                             "allowMultipleMasks": false,
                             "tag": "p",
-                            "id": "ebiw6ol"
+                            "id": "ebiw6ol",
+                            "addons": []
                         },
                         {
                             "label": "Columns",
@@ -2233,14 +2268,16 @@
                                             "properties": {},
                                             "allowMultipleMasks": false,
                                             "tag": "p",
-                                            "id": "e30454"
+                                            "id": "e30454",
+                                            "addons": []
                                         }
                                     ],
                                     "width": 6,
                                     "offset": 0,
                                     "push": 0,
                                     "pull": 0,
-                                    "size": "md"
+                                    "size": "md",
+                                    "currentWidth": 6
                                 },
                                 {
                                     "components": [
@@ -2316,14 +2353,16 @@
                                             "properties": {},
                                             "allowMultipleMasks": false,
                                             "tag": "p",
-                                            "id": "ezr7ntp"
+                                            "id": "ezr7ntp",
+                                            "addons": []
                                         }
                                     ],
                                     "width": 6,
                                     "offset": 0,
                                     "push": 0,
                                     "pull": 0,
-                                    "size": "md"
+                                    "size": "md",
+                                    "currentWidth": 6
                                 }
                             ],
                             "key": "columns4",
@@ -2389,7 +2428,9 @@
                             "tree": false,
                             "autoAdjust": false,
                             "hideOnChildrenHidden": false,
-                            "id": "e5gzydg"
+                            "id": "e5gzydg",
+                            "addons": [],
+                            "lazyLoad": false
                         },
                         {
                             "label": "Columns",
@@ -2468,14 +2509,16 @@
                                             "properties": {},
                                             "allowMultipleMasks": false,
                                             "tag": "p",
-                                            "id": "ex0yioh"
+                                            "id": "ex0yioh",
+                                            "addons": []
                                         }
                                     ],
                                     "width": 6,
                                     "offset": 0,
                                     "push": 0,
                                     "pull": 0,
-                                    "size": "md"
+                                    "size": "md",
+                                    "currentWidth": 6
                                 },
                                 {
                                     "components": [
@@ -2551,14 +2594,16 @@
                                             "properties": {},
                                             "allowMultipleMasks": false,
                                             "tag": "p",
-                                            "id": "ec7blool"
+                                            "id": "ec7blool",
+                                            "addons": []
                                         }
                                     ],
                                     "width": 6,
                                     "offset": 0,
                                     "push": 0,
                                     "pull": 0,
-                                    "size": "md"
+                                    "size": "md",
+                                    "currentWidth": 6
                                 }
                             ],
                             "key": "columns5",
@@ -2624,7 +2669,9 @@
                             "tree": false,
                             "autoAdjust": false,
                             "hideOnChildrenHidden": false,
-                            "id": "e3fdigo"
+                            "id": "e3fdigo",
+                            "addons": [],
+                            "lazyLoad": false
                         }
                     ],
                     "placeholder": "",
@@ -2663,7 +2710,9 @@
                     "showWordCount": false,
                     "allowMultipleMasks": false,
                     "tree": false,
-                    "id": "edsnvs8"
+                    "id": "edsnvs8",
+                    "addons": [],
+                    "lazyLoad": false
                 },
                 {
                     "label": "Select when you will be taking the program",
@@ -2776,7 +2825,9 @@
                         "threshold": 0.3
                     },
                     "id": "eb4inb",
-                    "defaultValue": ""
+                    "defaultValue": "",
+                    "addons": [],
+                    "searchDebounce": 0.3
                 },
                 {
                     "label": "My study period isn’t listed",
@@ -2863,7 +2914,8 @@
                     "id": "eoslne6",
                     "defaultValue": {
                         "offeringnotListed": false
-                    }
+                    },
+                    "addons": []
                 },
                 {
                     "label": "selectedOfferingDate",
@@ -2930,7 +2982,8 @@
                     "properties": {},
                     "allowMultipleMasks": false,
                     "inputType": "hidden",
-                    "id": "eh1q3is"
+                    "id": "eh1q3is",
+                    "addons": []
                 },
                 {
                     "title": "Custom program and offering",
@@ -3050,7 +3103,8 @@
                             "properties": {},
                             "allowMultipleMasks": false,
                             "tag": "p",
-                            "id": "e30m9b"
+                            "id": "e30m9b",
+                            "addons": []
                         },
                         {
                             "label": "HTML",
@@ -3123,7 +3177,8 @@
                             "properties": {},
                             "allowMultipleMasks": false,
                             "tag": "p",
-                            "id": "ei10j1p"
+                            "id": "ei10j1p",
+                            "addons": []
                         },
                         {
                             "label": "HTML",
@@ -3196,7 +3251,8 @@
                             "properties": {},
                             "allowMultipleMasks": false,
                             "tag": "p",
-                            "id": "em3zynlo"
+                            "id": "em3zynlo",
+                            "addons": []
                         },
                         {
                             "label": "Program name",
@@ -3270,7 +3326,10 @@
                             "inputFormat": "plain",
                             "inputMask": "",
                             "spellcheck": true,
-                            "id": "ek2u9li"
+                            "id": "ek2u9li",
+                            "addons": [],
+                            "displayMask": "",
+                            "truncateMultipleSpaces": false
                         },
                         {
                             "label": "Program description",
@@ -3351,7 +3410,10 @@
                             "wysiwyg": false,
                             "editor": "",
                             "fixedSize": true,
-                            "id": "e1w8o5a"
+                            "id": "e1w8o5a",
+                            "addons": [],
+                            "displayMask": "",
+                            "truncateMultipleSpaces": false
                         },
                         {
                             "label": "HTML",
@@ -3425,7 +3487,8 @@
                             "properties": {},
                             "allowMultipleMasks": false,
                             "tag": "p",
-                            "id": "eh3kz5a"
+                            "id": "eh3kz5a",
+                            "addons": []
                         },
                         {
                             "label": "HTML",
@@ -3499,7 +3562,8 @@
                             "properties": {},
                             "allowMultipleMasks": false,
                             "tag": "p",
-                            "id": "exnccd"
+                            "id": "exnccd",
+                            "addons": []
                         },
                         {
                             "label": "Columns",
@@ -3575,7 +3639,8 @@
                                             "showWordCount": false,
                                             "allowMultipleMasks": false,
                                             "inputType": "hidden",
-                                            "id": "e2qzxte"
+                                            "id": "e2qzxte",
+                                            "addons": []
                                         },
                                         {
                                             "label": "<strong>Start date</strong>",
@@ -3705,14 +3770,16 @@
                                             "showWordCount": false,
                                             "allowMultipleMasks": false,
                                             "datepickerMode": "day",
-                                            "id": "eqnahab"
+                                            "id": "eqnahab",
+                                            "addons": []
                                         }
                                     ],
                                     "width": 6,
                                     "offset": 0,
                                     "push": 0,
                                     "pull": 0,
-                                    "size": "md"
+                                    "size": "md",
+                                    "currentWidth": 6
                                 },
                                 {
                                     "components": [
@@ -3785,7 +3852,8 @@
                                             "allowMultipleMasks": false,
                                             "inputType": "hidden",
                                             "id": "e9jayo",
-                                            "hideOnChildrenHidden": false
+                                            "hideOnChildrenHidden": false,
+                                            "addons": []
                                         },
                                         {
                                             "label": "<strong>End date</strong>",
@@ -3915,14 +3983,16 @@
                                             "showWordCount": false,
                                             "allowMultipleMasks": false,
                                             "datepickerMode": "day",
-                                            "id": "eyw0exi"
+                                            "id": "eyw0exi",
+                                            "addons": []
                                         }
                                     ],
                                     "width": 6,
                                     "offset": 0,
                                     "push": 0,
                                     "pull": 0,
-                                    "size": "md"
+                                    "size": "md",
+                                    "currentWidth": 6
                                 }
                             ],
                             "key": "columns",
@@ -3988,7 +4058,9 @@
                             "tree": false,
                             "autoAdjust": false,
                             "hideOnChildrenHidden": false,
-                            "id": "ey5rt8h"
+                            "id": "ey5rt8h",
+                            "addons": [],
+                            "lazyLoad": false
                         }
                     ],
                     "allowPrevious": false,
@@ -4028,7 +4100,9 @@
                     "showWordCount": false,
                     "allowMultipleMasks": false,
                     "tree": false,
-                    "id": "ehvspueo"
+                    "id": "ehvspueo",
+                    "addons": [],
+                    "lazyLoad": false
                 },
                 {
                     "label": "HTML",
@@ -4108,7 +4182,8 @@
                     "showCharCount": false,
                     "showWordCount": false,
                     "allowMultipleMasks": false,
-                    "id": "eez5j5i"
+                    "id": "eez5j5i",
+                    "addons": []
                 },
                 {
                     "label": "Student number",
@@ -4191,7 +4266,10 @@
                     "dataGridLabel": false,
                     "inputType": "text",
                     "id": "ek8w4hn",
-                    "defaultValue": ""
+                    "defaultValue": "",
+                    "addons": [],
+                    "displayMask": "",
+                    "truncateMultipleSpaces": false
                 },
                 {
                     "label": "Data Grid",
@@ -4347,8 +4425,11 @@
                             "input": true,
                             "refreshOn": "",
                             "inputType": "text",
-                            "id": "ecrze1n0000000000000000000000000",
-                            "defaultValue": ""
+                            "id": "ecrze1n00000000000000000000000000",
+                            "defaultValue": "",
+                            "addons": [],
+                            "displayMask": "",
+                            "truncateMultipleSpaces": false
                         }
                     ],
                     "placeholder": "",
@@ -4363,7 +4444,9 @@
                     "showWordCount": false,
                     "allowMultipleMasks": false,
                     "tree": true,
-                    "id": "e36mr6f"
+                    "id": "e36mr6f",
+                    "addons": [],
+                    "lazyLoad": false
                 }
             ],
             "input": false,
@@ -4404,7 +4487,9 @@
             "showWordCount": false,
             "allowMultipleMasks": false,
             "tree": false,
-            "id": "eybfjx6"
+            "id": "eybfjx6",
+            "addons": [],
+            "lazyLoad": false
         },
         {
             "title": "Personal information",
@@ -4526,7 +4611,8 @@
                     "showCharCount": false,
                     "showWordCount": false,
                     "allowMultipleMasks": false,
-                    "id": "epmbrga"
+                    "id": "epmbrga",
+                    "addons": []
                 },
                 {
                     "label": "HTML",
@@ -4605,7 +4691,8 @@
                     "showCharCount": false,
                     "showWordCount": false,
                     "allowMultipleMasks": false,
-                    "id": "ew33yx"
+                    "id": "ew33yx",
+                    "addons": []
                 },
                 {
                     "title": "StudentAid BC personal info panel",
@@ -4701,7 +4788,8 @@
                             "showCharCount": false,
                             "showWordCount": false,
                             "allowMultipleMasks": false,
-                            "id": "ez8hvke"
+                            "id": "ez8hvke",
+                            "addons": []
                         },
                         {
                             "label": "Content",
@@ -4775,7 +4863,8 @@
                             "properties": {},
                             "allowMultipleMasks": false,
                             "tag": "p",
-                            "id": "eow3mur"
+                            "id": "eow3mur",
+                            "addons": []
                         },
                         {
                             "label": "Student profile",
@@ -4850,7 +4939,8 @@
                             "block": false,
                             "disableOnInvalid": false,
                             "theme": "primary",
-                            "id": "ewtrt5h"
+                            "id": "ewtrt5h",
+                            "addons": []
                         },
                         {
                             "label": "Columns",
@@ -4931,7 +5021,10 @@
                                             "inputFormat": "plain",
                                             "inputMask": "",
                                             "spellcheck": true,
-                                            "id": "eollo8c"
+                                            "id": "eollo8c",
+                                            "addons": [],
+                                            "displayMask": "",
+                                            "truncateMultipleSpaces": false
                                         },
                                         {
                                             "label": "Date of birth",
@@ -5007,7 +5100,10 @@
                                             "inputFormat": "plain",
                                             "inputMask": "",
                                             "spellcheck": true,
-                                            "id": "eiro1mh"
+                                            "id": "eiro1mh",
+                                            "addons": [],
+                                            "displayMask": "",
+                                            "truncateMultipleSpaces": false
                                         },
                                         {
                                             "label": "Home address",
@@ -5083,7 +5179,10 @@
                                             "inputFormat": "plain",
                                             "inputMask": "",
                                             "spellcheck": true,
-                                            "id": "eppxei"
+                                            "id": "eppxei",
+                                            "addons": [],
+                                            "displayMask": "",
+                                            "truncateMultipleSpaces": false
                                         },
                                         {
                                             "label": "Email",
@@ -5158,14 +5257,18 @@
                                             "inputFormat": "plain",
                                             "inputMask": "",
                                             "spellcheck": true,
-                                            "id": "ey8k2yp"
+                                            "id": "ey8k2yp",
+                                            "addons": [],
+                                            "displayMask": "",
+                                            "truncateMultipleSpaces": false
                                         }
                                     ],
                                     "width": 6,
                                     "offset": 0,
                                     "push": 0,
                                     "pull": 0,
-                                    "size": "md"
+                                    "size": "md",
+                                    "currentWidth": 6
                                 },
                                 {
                                     "components": [
@@ -5242,7 +5345,10 @@
                                             "inputFormat": "plain",
                                             "inputMask": "",
                                             "spellcheck": true,
-                                            "id": "eug619a"
+                                            "id": "eug619a",
+                                            "addons": [],
+                                            "displayMask": "",
+                                            "truncateMultipleSpaces": false
                                         },
                                         {
                                             "label": "Gender",
@@ -5318,7 +5424,10 @@
                                             "inputFormat": "plain",
                                             "inputMask": "",
                                             "spellcheck": true,
-                                            "id": "el67mt"
+                                            "id": "el67mt",
+                                            "addons": [],
+                                            "displayMask": "",
+                                            "truncateMultipleSpaces": false
                                         },
                                         {
                                             "label": "Phone number",
@@ -5394,7 +5503,10 @@
                                             "inputFormat": "plain",
                                             "inputMask": "",
                                             "spellcheck": true,
-                                            "id": "egglzja"
+                                            "id": "egglzja",
+                                            "addons": [],
+                                            "displayMask": "",
+                                            "truncateMultipleSpaces": false
                                         },
                                         {
                                             "label": "Permanent disability status",
@@ -5469,14 +5581,18 @@
                                             "inputFormat": "plain",
                                             "inputMask": "",
                                             "spellcheck": true,
-                                            "id": "eq3hnwv"
+                                            "id": "eq3hnwv",
+                                            "addons": [],
+                                            "displayMask": "",
+                                            "truncateMultipleSpaces": false
                                         }
                                     ],
                                     "width": 6,
                                     "offset": 0,
                                     "push": 0,
                                     "pull": 0,
-                                    "size": "md"
+                                    "size": "md",
+                                    "currentWidth": 6
                                 }
                             ],
                             "key": "columns1",
@@ -5542,7 +5658,9 @@
                             "tree": false,
                             "autoAdjust": false,
                             "hideOnChildrenHidden": false,
-                            "id": "ebg5117"
+                            "id": "ebg5117",
+                            "addons": [],
+                            "lazyLoad": false
                         },
                         {
                             "label": "I confirm my StudentAid BC Profile information shown is correct",
@@ -5611,7 +5729,8 @@
                             "inputType": "checkbox",
                             "value": "",
                             "name": "",
-                            "id": "ebth7m"
+                            "id": "ebth7m",
+                            "addons": []
                         }
                     ],
                     "allowPrevious": false,
@@ -5673,7 +5792,9 @@
                     "tree": false,
                     "theme": "default",
                     "breadcrumb": "default",
-                    "id": "e1llrtm"
+                    "id": "e1llrtm",
+                    "addons": [],
+                    "lazyLoad": false
                 },
                 {
                     "label": "<strong>What is your citizenship status?</strong>",
@@ -5704,7 +5825,8 @@
                         "customPrivate": false,
                         "strictDateValidation": false,
                         "multiple": false,
-                        "unique": false
+                        "unique": false,
+                        "onlyAvailableItems": false
                     },
                     "key": "citizenship",
                     "type": "radio",
@@ -5760,7 +5882,8 @@
                     "allowMultipleMasks": false,
                     "inputType": "radio",
                     "fieldSet": false,
-                    "id": "e8pmct9"
+                    "id": "e8pmct9",
+                    "addons": []
                 },
                 {
                     "title": "Citizenship proof panel",
@@ -5857,7 +5980,8 @@
                             "showCharCount": false,
                             "showWordCount": false,
                             "allowMultipleMasks": false,
-                            "id": "es70kak"
+                            "id": "es70kak",
+                            "addons": []
                         },
                         {
                             "label": "HTML",
@@ -5936,7 +6060,8 @@
                             "showCharCount": false,
                             "showWordCount": false,
                             "allowMultipleMasks": false,
-                            "id": "emtg9xk"
+                            "id": "emtg9xk",
+                            "addons": []
                         },
                         {
                             "label": "HTML",
@@ -6015,7 +6140,8 @@
                             "showCharCount": false,
                             "showWordCount": false,
                             "allowMultipleMasks": false,
-                            "id": "eddhwkl"
+                            "id": "eddhwkl",
+                            "addons": []
                         },
                         {
                             "label": "HTML",
@@ -6094,7 +6220,8 @@
                             "showCharCount": false,
                             "showWordCount": false,
                             "allowMultipleMasks": false,
-                            "id": "ea2ohue"
+                            "id": "ea2ohue",
+                            "addons": []
                         },
                         {
                             "label": "HTML",
@@ -6173,7 +6300,8 @@
                             "showCharCount": false,
                             "showWordCount": false,
                             "allowMultipleMasks": false,
-                            "id": "e917eb"
+                            "id": "e917eb",
+                            "addons": []
                         },
                         {
                             "label": "HTML",
@@ -6252,7 +6380,8 @@
                             "showCharCount": false,
                             "showWordCount": false,
                             "allowMultipleMasks": false,
-                            "id": "emigw5m"
+                            "id": "emigw5m",
+                            "addons": []
                         },
                         {
                             "label": "Upload proof of citizenship",
@@ -6343,7 +6472,8 @@
                             "privateDownload": false,
                             "id": "etkoqe",
                             "options": "",
-                            "fileKey": ""
+                            "fileKey": "",
+                            "addons": []
                         },
                         {
                             "label": "Columns",
@@ -6420,14 +6550,16 @@
                                             "showCharCount": false,
                                             "showWordCount": false,
                                             "allowMultipleMasks": false,
-                                            "id": "e9wutz8"
+                                            "id": "e9wutz8",
+                                            "addons": []
                                         }
                                     ],
                                     "width": 6,
                                     "offset": 0,
                                     "push": 0,
                                     "pull": 0,
-                                    "size": "md"
+                                    "size": "md",
+                                    "currentWidth": 6
                                 },
                                 {
                                     "components": [
@@ -6501,14 +6633,16 @@
                                             "showCharCount": false,
                                             "showWordCount": false,
                                             "allowMultipleMasks": false,
-                                            "id": "e5czcdd"
+                                            "id": "e5czcdd",
+                                            "addons": []
                                         }
                                     ],
                                     "width": 6,
                                     "offset": 0,
                                     "push": 0,
                                     "pull": 0,
-                                    "size": "md"
+                                    "size": "md",
+                                    "currentWidth": 6
                                 }
                             ],
                             "autoAdjust": false,
@@ -6579,7 +6713,9 @@
                             "showWordCount": false,
                             "allowMultipleMasks": false,
                             "tree": false,
-                            "id": "elv3ea8"
+                            "id": "elv3ea8",
+                            "addons": [],
+                            "lazyLoad": false
                         }
                     ],
                     "allowPrevious": false,
@@ -6641,7 +6777,9 @@
                     "tree": false,
                     "theme": "default",
                     "breadcrumb": "default",
-                    "id": "efawj5"
+                    "id": "efawj5",
+                    "addons": [],
+                    "lazyLoad": false
                 },
                 {
                     "label": "<strong>Are you a resident of B.C.?</strong>",
@@ -6731,7 +6869,8 @@
                     "inputType": "radio",
                     "fieldSet": false,
                     "id": "e8a3hql",
-                    "defaultValue": ""
+                    "defaultValue": "",
+                    "addons": []
                 },
                 {
                     "title": "Not a BC resident panel",
@@ -6832,7 +6971,8 @@
                             "showCharCount": false,
                             "showWordCount": false,
                             "allowMultipleMasks": false,
-                            "id": "ean88l9"
+                            "id": "ean88l9",
+                            "addons": []
                         },
                         {
                             "label": "HTML",
@@ -6911,7 +7051,8 @@
                             "showCharCount": false,
                             "showWordCount": false,
                             "allowMultipleMasks": false,
-                            "id": "eqmirkg"
+                            "id": "eqmirkg",
+                            "addons": []
                         },
                         {
                             "label": "<strong>Which of the following best describes your situation?</strong>",
@@ -7010,7 +7151,8 @@
                             "inputType": "radio",
                             "fieldSet": false,
                             "id": "ep66483",
-                            "defaultValue": ""
+                            "defaultValue": "",
+                            "addons": []
                         },
                         {
                             "label": "HTML",
@@ -7089,7 +7231,8 @@
                             "showCharCount": false,
                             "showWordCount": false,
                             "allowMultipleMasks": false,
-                            "id": "ehuecan"
+                            "id": "ehuecan",
+                            "addons": []
                         },
                         {
                             "label": "Please explain your sitution:",
@@ -7179,7 +7322,10 @@
                             "inputMask": "",
                             "fixedSize": true,
                             "id": "euh1cll",
-                            "defaultValue": ""
+                            "defaultValue": "",
+                            "addons": [],
+                            "displayMask": "",
+                            "truncateMultipleSpaces": false
                         },
                         {
                             "title": "Upload supporting documents",
@@ -7303,7 +7449,8 @@
                                     "showCharCount": false,
                                     "showWordCount": false,
                                     "allowMultipleMasks": false,
-                                    "id": "eezq1g"
+                                    "id": "eezq1g",
+                                    "addons": []
                                 },
                                 {
                                     "label": "HTML",
@@ -7382,7 +7529,8 @@
                                     "showCharCount": false,
                                     "showWordCount": false,
                                     "allowMultipleMasks": false,
-                                    "id": "esar0bi"
+                                    "id": "esar0bi",
+                                    "addons": []
                                 },
                                 {
                                     "label": "HTML",
@@ -7461,7 +7609,8 @@
                                     "showCharCount": false,
                                     "showWordCount": false,
                                     "allowMultipleMasks": false,
-                                    "id": "e18yipa"
+                                    "id": "e18yipa",
+                                    "addons": []
                                 },
                                 {
                                     "label": "Upload supporting documents (optional):",
@@ -7552,7 +7701,8 @@
                                     "privateDownload": false,
                                     "id": "etziji",
                                     "options": "",
-                                    "fileKey": ""
+                                    "fileKey": "",
+                                    "addons": []
                                 },
                                 {
                                     "label": "Columns",
@@ -7629,14 +7779,16 @@
                                                     "showWordCount": false,
                                                     "allowMultipleMasks": false,
                                                     "id": "e7t7n9i",
-                                                    "hideOnChildrenHidden": false
+                                                    "hideOnChildrenHidden": false,
+                                                    "addons": []
                                                 }
                                             ],
                                             "width": 6,
                                             "offset": 0,
                                             "push": 0,
                                             "pull": 0,
-                                            "size": "md"
+                                            "size": "md",
+                                            "currentWidth": 6
                                         },
                                         {
                                             "components": [
@@ -7710,14 +7862,16 @@
                                                     "showWordCount": false,
                                                     "allowMultipleMasks": false,
                                                     "id": "e4rlla",
-                                                    "hideOnChildrenHidden": false
+                                                    "hideOnChildrenHidden": false,
+                                                    "addons": []
                                                 }
                                             ],
                                             "width": 6,
                                             "offset": 0,
                                             "push": 0,
                                             "pull": 0,
-                                            "size": "md"
+                                            "size": "md",
+                                            "currentWidth": 6
                                         }
                                     ],
                                     "autoAdjust": false,
@@ -7788,7 +7942,9 @@
                                     "showWordCount": false,
                                     "allowMultipleMasks": false,
                                     "tree": false,
-                                    "id": "e47hyqa"
+                                    "id": "e47hyqa",
+                                    "addons": [],
+                                    "lazyLoad": false
                                 }
                             ],
                             "placeholder": "",
@@ -7827,7 +7983,9 @@
                             "showWordCount": false,
                             "allowMultipleMasks": false,
                             "tree": false,
-                            "id": "eruhydo"
+                            "id": "eruhydo",
+                            "addons": [],
+                            "lazyLoad": false
                         }
                     ],
                     "allowPrevious": false,
@@ -7884,7 +8042,9 @@
                     "tree": false,
                     "theme": "default",
                     "breadcrumb": "default",
-                    "id": "eo7yj4f"
+                    "id": "eo7yj4f",
+                    "addons": [],
+                    "lazyLoad": false
                 },
                 {
                     "label": "<strong>Do you identify as an Indigenous person?</strong>",
@@ -7909,7 +8069,8 @@
                         "customPrivate": false,
                         "strictDateValidation": false,
                         "multiple": false,
-                        "unique": false
+                        "unique": false,
+                        "onlyAvailableItems": false
                     },
                     "errorLabel": "Aboriginal Status",
                     "key": "indigenousStatus",
@@ -7965,7 +8126,8 @@
                     "allowMultipleMasks": false,
                     "inputType": "radio",
                     "fieldSet": false,
-                    "id": "e96uncs"
+                    "id": "e96uncs",
+                    "addons": []
                 },
                 {
                     "title": "Indigenous Panel",
@@ -8065,7 +8227,8 @@
                             "showCharCount": false,
                             "showWordCount": false,
                             "allowMultipleMasks": false,
-                            "id": "e2ag0zq"
+                            "id": "e2ag0zq",
+                            "addons": []
                         },
                         {
                             "label": "<strong>I am:</strong>",
@@ -8095,7 +8258,8 @@
                                 "customPrivate": false,
                                 "strictDateValidation": false,
                                 "multiple": false,
-                                "unique": false
+                                "unique": false,
+                                "onlyAvailableItems": false
                             },
                             "key": "aboriginalHeritage",
                             "conditional": {
@@ -8150,7 +8314,8 @@
                             "allowMultipleMasks": false,
                             "inputType": "radio",
                             "fieldSet": false,
-                            "id": "ezochjc"
+                            "id": "ezochjc",
+                            "addons": []
                         }
                     ],
                     "allowPrevious": false,
@@ -8207,7 +8372,9 @@
                     "tree": false,
                     "theme": "default",
                     "breadcrumb": "default",
-                    "id": "ef3gfa"
+                    "id": "ef3gfa",
+                    "addons": [],
+                    "lazyLoad": false
                 },
                 {
                     "label": "<strong>Were you ever a youth in continuing care or custody of a director of child welfare in BC (ward of the court – this means the provincial government is/was your legal guardian)? </strong>",
@@ -8232,7 +8399,8 @@
                         "customPrivate": false,
                         "strictDateValidation": false,
                         "multiple": false,
-                        "unique": false
+                        "unique": false,
+                        "onlyAvailableItems": false
                     },
                     "errorLabel": "Youth In Care",
                     "key": "youthInCare",
@@ -8288,7 +8456,8 @@
                     "allowMultipleMasks": false,
                     "inputType": "radio",
                     "fieldSet": false,
-                    "id": "ema6dci"
+                    "id": "ema6dci",
+                    "addons": []
                 },
                 {
                     "label": "HTML",
@@ -8367,7 +8536,8 @@
                     "showCharCount": false,
                     "showWordCount": false,
                     "allowMultipleMasks": false,
-                    "id": "enupmu"
+                    "id": "enupmu",
+                    "addons": []
                 },
                 {
                     "label": "<strong>At the time of your course study start date, will you have been out of high school for 4 years?</strong>",
@@ -8456,7 +8626,8 @@
                     "inputType": "radio",
                     "fieldSet": false,
                     "id": "eahh865",
-                    "defaultValue": ""
+                    "defaultValue": "",
+                    "addons": []
                 },
                 {
                     "label": "<strong>When did you graduate or leave high-school?</strong>",
@@ -8582,7 +8753,8 @@
                     "showWordCount": false,
                     "allowMultipleMasks": false,
                     "datepickerMode": "day",
-                    "id": "ei3rn5"
+                    "id": "ei3rn5",
+                    "addons": []
                 },
                 {
                     "label": "HTML",
@@ -8661,7 +8833,8 @@
                     "showCharCount": false,
                     "showWordCount": false,
                     "allowMultipleMasks": false,
-                    "id": "epzt48g"
+                    "id": "epzt48g",
+                    "addons": []
                 },
                 {
                     "label": "<strong>Will you be working a full-time job of 32 hours per week for more than half of your study period?</strong>",
@@ -8687,7 +8860,8 @@
                         "customPrivate": false,
                         "strictDateValidation": false,
                         "multiple": false,
-                        "unique": false
+                        "unique": false,
+                        "onlyAvailableItems": false
                     },
                     "errorLabel": "Employment Information",
                     "key": "fullTimeJob",
@@ -8742,7 +8916,8 @@
                     "allowMultipleMasks": false,
                     "inputType": "radio",
                     "fieldSet": false,
-                    "id": "ewa5mpb"
+                    "id": "ewa5mpb",
+                    "addons": []
                 },
                 {
                     "label": "HTML",
@@ -8821,7 +8996,8 @@
                     "showCharCount": false,
                     "showWordCount": false,
                     "allowMultipleMasks": false,
-                    "id": "ejad0c"
+                    "id": "ejad0c",
+                    "addons": []
                 },
                 {
                     "label": "<strong>In the time since you left high school to your first day of classes, have you spent two periods of 12 consecutive months each, in the full time labour force?</strong>",
@@ -8902,7 +9078,8 @@
                     "allowMultipleMasks": false,
                     "inputType": "radio",
                     "fieldSet": false,
-                    "id": "eqf8qus"
+                    "id": "eqf8qus",
+                    "addons": []
                 },
                 {
                     "label": "HTML",
@@ -8981,7 +9158,8 @@
                     "showCharCount": false,
                     "showWordCount": false,
                     "allowMultipleMasks": false,
-                    "id": "evos73h"
+                    "id": "evos73h",
+                    "addons": []
                 },
                 {
                     "label": "HTML",
@@ -9060,7 +9238,8 @@
                     "showCharCount": false,
                     "showWordCount": false,
                     "allowMultipleMasks": false,
-                    "id": "ef4mzqb"
+                    "id": "ef4mzqb",
+                    "addons": []
                 },
                 {
                     "label": "<strong>Do you want to allow a trusted contact to interact with StudentAid BC on your behalf?</strong>",
@@ -9141,7 +9320,8 @@
                     "allowMultipleMasks": false,
                     "inputType": "radio",
                     "fieldSet": false,
-                    "id": "ewr6dc9"
+                    "id": "ewr6dc9",
+                    "addons": []
                 },
                 {
                     "title": "Trusted contact panel",
@@ -9242,7 +9422,8 @@
                             "showCharCount": false,
                             "showWordCount": false,
                             "allowMultipleMasks": false,
-                            "id": "eu1qpne"
+                            "id": "eu1qpne",
+                            "addons": []
                         },
                         {
                             "label": "HTML",
@@ -9321,7 +9502,8 @@
                             "showCharCount": false,
                             "showWordCount": false,
                             "allowMultipleMasks": false,
-                            "id": "eaqymr"
+                            "id": "eaqymr",
+                            "addons": []
                         },
                         {
                             "label": "<strong>ROI information</strong>",
@@ -9376,7 +9558,7 @@
                                     "key": "firstName",
                                     "type": "textfield",
                                     "input": true,
-                                    "id": "el2qrn9000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+                                    "id": "el2qrn90000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
                                     "placeholder": "",
                                     "prefix": "",
                                     "suffix": "",
@@ -9430,7 +9612,10 @@
                                     "inputType": "text",
                                     "inputFormat": "plain",
                                     "inputMask": "",
-                                    "spellcheck": true
+                                    "spellcheck": true,
+                                    "addons": [],
+                                    "displayMask": "",
+                                    "truncateMultipleSpaces": false
                                 },
                                 {
                                     "label": "Last name",
@@ -9450,7 +9635,7 @@
                                     "key": "lastName",
                                     "type": "textfield",
                                     "input": true,
-                                    "id": "e618eci000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+                                    "id": "e618eci0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
                                     "placeholder": "",
                                     "prefix": "",
                                     "suffix": "",
@@ -9504,7 +9689,10 @@
                                     "inputType": "text",
                                     "inputFormat": "plain",
                                     "inputMask": "",
-                                    "spellcheck": true
+                                    "spellcheck": true,
+                                    "addons": [],
+                                    "displayMask": "",
+                                    "truncateMultipleSpaces": false
                                 },
                                 {
                                     "label": "<strong>What is your relationship with this contact?</strong>",
@@ -9602,8 +9790,9 @@
                                     "allowMultipleMasks": false,
                                     "inputType": "radio",
                                     "fieldSet": false,
-                                    "id": "ejv9syt00000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
-                                    "defaultValue": ""
+                                    "id": "ejv9syt000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+                                    "defaultValue": "",
+                                    "addons": []
                                 },
                                 {
                                     "label": "<strong>How long do you want to give this person access to your StudentAid BC account?</strong>",
@@ -9639,7 +9828,7 @@
                                     "key": "strongHowLongDoYouWantToGiveThisPersonAccessToYourStudentAidBcAccountStrong",
                                     "type": "radio",
                                     "input": true,
-                                    "id": "ejm9s3q000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+                                    "id": "ejm9s3q0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
                                     "placeholder": "",
                                     "prefix": "",
                                     "customClass": "",
@@ -9689,7 +9878,8 @@
                                     "properties": {},
                                     "allowMultipleMasks": false,
                                     "inputType": "radio",
-                                    "fieldSet": false
+                                    "fieldSet": false,
+                                    "addons": []
                                 },
                                 {
                                     "label": "Select the date you would like this person’s access to your StudentAidBC account to expire",
@@ -9745,7 +9935,7 @@
                                         "disableWeekdays": false,
                                         "maxDate": null
                                     },
-                                    "id": "earatq000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+                                    "id": "earatq0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
                                     "prefix": "",
                                     "suffix": "",
                                     "multiple": false,
@@ -9804,7 +9994,8 @@
                                         "arrowkeys": true
                                     },
                                     "customOptions": {},
-                                    "shortcutButtons": []
+                                    "shortcutButtons": [],
+                                    "addons": []
                                 }
                             ],
                             "placeholder": "",
@@ -9856,7 +10047,9 @@
                             "allowMultipleMasks": false,
                             "tree": true,
                             "disableAddingRemovingRows": false,
-                            "id": "eq7yod9"
+                            "id": "eq7yod9",
+                            "addons": [],
+                            "lazyLoad": false
                         },
                         {
                             "html": "<p>The &nbsp;Freedom of Information and Protection of Privacy Act &nbsp;prevents StudentAid BC and financial aid staff from releasing any information pertaining to this application to anyone other than you unless you provide written permission. Complete these questions if you want to authorize another person to obtain information on your behalf about this application, related appendices, or assessment details. If you authorize someone to access information on your behalf by completing these questions, they must provide your Social Insurance Number and date of birth to access any information from StudentAid BC or financial aid staff. Please ensure you have the designated person’s authorization to enter their information. Do not use a school staff member. &nbsp;</p><p>&nbsp;</p><p>Note: Information can be shared with the persons/organizations identified in the StudentAid BC declaration based on your signature, regardless of whether these questions are completed.</p>",
@@ -9922,7 +10115,8 @@
                             "showWordCount": false,
                             "properties": {},
                             "allowMultipleMasks": false,
-                            "id": "eopro5d"
+                            "id": "eopro5d",
+                            "addons": []
                         },
                         {
                             "label": "roiWell",
@@ -10002,7 +10196,8 @@
                                     "inputType": "checkbox",
                                     "value": "",
                                     "name": "",
-                                    "id": "eqmvldl"
+                                    "id": "eqmvldl",
+                                    "addons": []
                                 }
                             ],
                             "placeholder": "",
@@ -10056,7 +10251,9 @@
                             "properties": {},
                             "allowMultipleMasks": false,
                             "tree": false,
-                            "id": "eepuwb5h"
+                            "id": "eepuwb5h",
+                            "addons": [],
+                            "lazyLoad": false
                         }
                     ],
                     "allowPrevious": false,
@@ -10113,77 +10310,9 @@
                     "tree": false,
                     "theme": "default",
                     "breadcrumb": "default",
-                    "id": "elibgq9"
-                },
-                {
-                    "label": "Dependantstatus",
-                    "customClass": "",
-                    "modalEdit": false,
-                    "defaultValue": null,
-                    "persistent": true,
-                    "protected": false,
-                    "dbIndex": false,
-                    "encrypted": false,
-                    "redrawOn": "",
-                    "customDefaultValue": "",
-                    "calculateValue": "//alert (data.dependantstatus);\nif (data.hasDependents === 'no' && (data.relationshipStatus === 'single' || data.relationshipStatus === 'otherSingle') && data.outOfHighSchoolFor4Years === 'no' && data.howWillYouBeAttendingTheProgram === \"Full Time\") {\n  instance.setValue ('dependant');\n}\nelse {\n  instance.setValue ('independant');\n}",
-                    "calculateServer": true,
-                    "key": "dependantstatus",
-                    "tags": [],
-                    "properties": {},
-                    "logic": [],
-                    "attributes": {},
-                    "overlay": {
-                        "style": "",
-                        "page": "",
-                        "left": "",
-                        "top": "",
-                        "width": "",
-                        "height": ""
-                    },
-                    "type": "hidden",
-                    "input": true,
-                    "tableView": false,
-                    "placeholder": "",
-                    "prefix": "",
-                    "suffix": "",
-                    "multiple": false,
-                    "unique": false,
-                    "hidden": false,
-                    "clearOnHide": true,
-                    "refreshOn": "",
-                    "dataGridLabel": false,
-                    "labelPosition": "top",
-                    "description": "",
-                    "errorLabel": "",
-                    "tooltip": "",
-                    "hideLabel": false,
-                    "tabindex": "",
-                    "disabled": false,
-                    "autofocus": false,
-                    "widget": {
-                        "type": "input"
-                    },
-                    "validateOn": "change",
-                    "validate": {
-                        "required": false,
-                        "custom": "",
-                        "customPrivate": false,
-                        "strictDateValidation": false,
-                        "multiple": false,
-                        "unique": false
-                    },
-                    "conditional": {
-                        "show": null,
-                        "when": null,
-                        "eq": ""
-                    },
-                    "allowCalculateOverride": false,
-                    "showCharCount": false,
-                    "showWordCount": false,
-                    "allowMultipleMasks": false,
-                    "inputType": "hidden",
-                    "id": "erzqc6d"
+                    "id": "elibgq9",
+                    "addons": [],
+                    "lazyLoad": false
                 }
             ],
             "input": false,
@@ -10224,7 +10353,9 @@
             "showWordCount": false,
             "allowMultipleMasks": false,
             "tree": false,
-            "id": "e5im6qg"
+            "id": "e5im6qg",
+            "addons": [],
+            "lazyLoad": false
         },
         {
             "title": "Family information",
@@ -10348,7 +10479,8 @@
                     "showCharCount": false,
                     "showWordCount": false,
                     "allowMultipleMasks": false,
-                    "id": "e1pe2c"
+                    "id": "e1pe2c",
+                    "addons": []
                 },
                 {
                     "label": "HTML",
@@ -10427,11 +10559,14 @@
                     "showCharCount": false,
                     "showWordCount": false,
                     "allowMultipleMasks": false,
-                    "id": "ejh8pr"
+                    "id": "ejh8pr",
+                    "addons": []
                 },
                 {
                     "label": "<strong>On my first day of class, I'll be:</strong>",
                     "labelPosition": "top",
+                    "labelWidth": "",
+                    "labelMargin": "",
                     "optionsLabelPosition": "right",
                     "description": "",
                     "tooltip": "",
@@ -10452,11 +10587,11 @@
                         },
                         {
                             "label": "Separated/divorced/widowed",
-                            "value": "otherSingle",
+                            "value": "other",
                             "shortcut": ""
                         },
                         {
-                            "value": "marriedCommonLaw",
+                            "value": "married",
                             "label": "Married/common-law",
                             "shortcut": ""
                         }
@@ -10484,6 +10619,7 @@
                         "unique": false
                     },
                     "errorLabel": "Relationship Status",
+                    "errors": "",
                     "key": "relationshipStatus",
                     "tags": [],
                     "properties": {},
@@ -10521,9 +10657,10 @@
                     "showCharCount": false,
                     "showWordCount": false,
                     "allowMultipleMasks": false,
+                    "addons": [],
                     "inputType": "radio",
                     "fieldSet": false,
-                    "id": "eoh9dul",
+                    "id": "e76zqu",
                     "defaultValue": ""
                 },
                 {
@@ -10684,7 +10821,8 @@
                             },
                             "customOptions": {},
                             "id": "enmzn3",
-                            "shortcutButtons": []
+                            "shortcutButtons": [],
+                            "addons": []
                         }
                     ],
                     "allowPrevious": false,
@@ -10724,7 +10862,9 @@
                     "showWordCount": false,
                     "allowMultipleMasks": false,
                     "tree": false,
-                    "id": "e7huqp"
+                    "id": "e7huqp",
+                    "addons": [],
+                    "lazyLoad": false
                 },
                 {
                     "label": "<strong>Do you have any dependants?</strong>",
@@ -10816,7 +10956,8 @@
                     "inputType": "radio",
                     "fieldSet": false,
                     "id": "es6wpct",
-                    "defaultValue": ""
+                    "defaultValue": "",
+                    "addons": []
                 },
                 {
                     "title": "Add Dependants Panel",
@@ -10917,7 +11058,8 @@
                             "showCharCount": false,
                             "showWordCount": false,
                             "allowMultipleMasks": false,
-                            "id": "ew64jgs"
+                            "id": "ew64jgs",
+                            "addons": []
                         },
                         {
                             "label": "HTML",
@@ -10996,7 +11138,8 @@
                             "showCharCount": false,
                             "showWordCount": false,
                             "allowMultipleMasks": false,
-                            "id": "e7hw8pg"
+                            "id": "e7hw8pg",
+                            "addons": []
                         },
                         {
                             "label": "<strong>Dependants</strong>",
@@ -11122,14 +11265,18 @@
                                                             "inputFormat": "plain",
                                                             "inputMask": "",
                                                             "spellcheck": true,
-                                                            "id": "ex25e6h"
+                                                            "id": "ex25e6h",
+                                                            "addons": [],
+                                                            "displayMask": "",
+                                                            "truncateMultipleSpaces": false
                                                         }
                                                     ],
                                                     "width": 6,
                                                     "offset": 0,
                                                     "push": 0,
                                                     "pull": 0,
-                                                    "size": "md"
+                                                    "size": "md",
+                                                    "currentWidth": 6
                                                 },
                                                 {
                                                     "components": [
@@ -11247,14 +11394,16 @@
                                                             "datepickerMode": "day",
                                                             "customOptions": {},
                                                             "id": "es6kg2vr",
-                                                            "shortcutButtons": []
+                                                            "shortcutButtons": [],
+                                                            "addons": []
                                                         }
                                                     ],
                                                     "width": 4,
                                                     "offset": 0,
                                                     "push": 0,
                                                     "pull": 0,
-                                                    "size": "md"
+                                                    "size": "md",
+                                                    "currentWidth": 4
                                                 }
                                             ],
                                             "autoAdjust": false,
@@ -11325,7 +11474,9 @@
                                             "showWordCount": false,
                                             "allowMultipleMasks": false,
                                             "tree": false,
-                                            "id": "e8qthqh"
+                                            "id": "e8qthqh",
+                                            "addons": [],
+                                            "lazyLoad": false
                                         },
                                         {
                                             "label": "<strong>Attending post secondary school</strong>",
@@ -11414,7 +11565,8 @@
                                             "inputType": "radio",
                                             "fieldSet": false,
                                             "id": "et9tfpg",
-                                            "defaultValue": ""
+                                            "defaultValue": "",
+                                            "addons": []
                                         },
                                         {
                                             "label": "<strong>Declared on taxes due to a disability</strong>",
@@ -11503,7 +11655,8 @@
                                             "inputType": "radio",
                                             "fieldSet": false,
                                             "id": "eve72ba",
-                                            "defaultValue": ""
+                                            "defaultValue": "",
+                                            "addons": []
                                         },
                                         {
                                             "title": "Upload panel",
@@ -11621,7 +11774,8 @@
                                                     "properties": {},
                                                     "allowMultipleMasks": false,
                                                     "tag": "p",
-                                                    "id": "eqgudcj"
+                                                    "id": "eqgudcj",
+                                                    "addons": []
                                                 },
                                                 {
                                                     "label": "HTML",
@@ -11694,7 +11848,8 @@
                                                     "properties": {},
                                                     "allowMultipleMasks": false,
                                                     "tag": "p",
-                                                    "id": "ertgpw8"
+                                                    "id": "ertgpw8",
+                                                    "addons": []
                                                 },
                                                 {
                                                     "label": " PD dependant upload",
@@ -11776,7 +11931,8 @@
                                                     "imageSize": "200",
                                                     "fileMinSize": "0KB",
                                                     "uploadOnly": false,
-                                                    "id": "euaz6kp"
+                                                    "id": "euaz6kp",
+                                                    "addons": []
                                                 },
                                                 {
                                                     "input": false,
@@ -11852,14 +12008,16 @@
                                                                     "showWordCount": false,
                                                                     "properties": {},
                                                                     "allowMultipleMasks": false,
-                                                                    "id": "e6menor"
+                                                                    "id": "e6menor",
+                                                                    "addons": []
                                                                 }
                                                             ],
                                                             "width": 6,
                                                             "offset": 0,
                                                             "push": 0,
                                                             "pull": 0,
-                                                            "size": "md"
+                                                            "size": "md",
+                                                            "currentWidth": 6
                                                         },
                                                         {
                                                             "components": [
@@ -11928,14 +12086,16 @@
                                                                     "showWordCount": false,
                                                                     "properties": {},
                                                                     "allowMultipleMasks": false,
-                                                                    "id": "enqrbog"
+                                                                    "id": "enqrbog",
+                                                                    "addons": []
                                                                 }
                                                             ],
                                                             "width": 6,
                                                             "offset": 0,
                                                             "push": 0,
                                                             "pull": 0,
-                                                            "size": "md"
+                                                            "size": "md",
+                                                            "currentWidth": 6
                                                         }
                                                     ],
                                                     "placeholder": "",
@@ -11997,7 +12157,9 @@
                                                     "tree": false,
                                                     "autoAdjust": false,
                                                     "hideOnChildrenHidden": false,
-                                                    "id": "egbz7e2"
+                                                    "id": "egbz7e2",
+                                                    "addons": [],
+                                                    "lazyLoad": false
                                                 }
                                             ],
                                             "placeholder": "",
@@ -12036,7 +12198,9 @@
                                             "showWordCount": false,
                                             "allowMultipleMasks": false,
                                             "tree": false,
-                                            "id": "ecnquik"
+                                            "id": "ecnquik",
+                                            "addons": [],
+                                            "lazyLoad": false
                                         },
                                         {
                                             "label": "IsAValidDependant",
@@ -12103,7 +12267,8 @@
                                             "properties": {},
                                             "allowMultipleMasks": false,
                                             "inputType": "hidden",
-                                            "id": "e48zvv3"
+                                            "id": "e48zvv3",
+                                            "addons": []
                                         },
                                         {
                                             "label": "ValidDependent",
@@ -12170,10 +12335,11 @@
                                             "properties": {},
                                             "allowMultipleMasks": false,
                                             "inputType": "hidden",
-                                            "id": "e64vrxl"
+                                            "id": "e64vrxl",
+                                            "addons": []
                                         }
                                     ],
-                                    "id": "ecpkm9j0000000000000000000000000000000000000000000",
+                                    "id": "ecpkm9j000000000000000000000000000000000000000000000000000000000000",
                                     "placeholder": "",
                                     "prefix": "",
                                     "customClass": "",
@@ -12231,7 +12397,9 @@
                                     "properties": {},
                                     "allowMultipleMasks": false,
                                     "tree": false,
-                                    "legend": ""
+                                    "legend": "",
+                                    "addons": [],
+                                    "lazyLoad": false
                                 }
                             ],
                             "placeholder": "",
@@ -12277,7 +12445,9 @@
                             "allowMultipleMasks": false,
                             "tree": true,
                             "disableAddingRemovingRows": false,
-                            "id": "etl1y0a"
+                            "id": "etl1y0a",
+                            "addons": [],
+                            "lazyLoad": false
                         }
                     ],
                     "placeholder": "",
@@ -12333,7 +12503,9 @@
                     "tree": false,
                     "theme": "default",
                     "breadcrumb": "default",
-                    "id": "egyz9uo"
+                    "id": "egyz9uo",
+                    "addons": [],
+                    "lazyLoad": false
                 },
                 {
                     "label": "<strong>Do you have any dependents that you support financially but do not have sole custody of?</strong>",
@@ -12414,7 +12586,8 @@
                     "allowMultipleMasks": false,
                     "inputType": "radio",
                     "fieldSet": false,
-                    "id": "e0fe8eh"
+                    "id": "e0fe8eh",
+                    "addons": []
                 },
                 {
                     "title": "Dependents that you support financially but do not have sole custody",
@@ -12515,7 +12688,8 @@
                             "showCharCount": false,
                             "showWordCount": false,
                             "allowMultipleMasks": false,
-                            "id": "erpezbu"
+                            "id": "erpezbu",
+                            "addons": []
                         },
                         {
                             "label": "HTML",
@@ -12594,7 +12768,8 @@
                             "showCharCount": false,
                             "showWordCount": false,
                             "allowMultipleMasks": false,
-                            "id": "e11wyqh"
+                            "id": "e11wyqh",
+                            "addons": []
                         },
                         {
                             "label": "HTML",
@@ -12673,7 +12848,8 @@
                             "showCharCount": false,
                             "showWordCount": false,
                             "allowMultipleMasks": false,
-                            "id": "ehrudvm"
+                            "id": "ehrudvm",
+                            "addons": []
                         },
                         {
                             "label": "HTML",
@@ -12752,7 +12928,8 @@
                             "showCharCount": false,
                             "showWordCount": false,
                             "allowMultipleMasks": false,
-                            "id": "e5eif08"
+                            "id": "e5eif08",
+                            "addons": []
                         },
                         {
                             "label": "Dependant custody file upload",
@@ -12843,7 +13020,8 @@
                             "privateDownload": false,
                             "id": "ebvl7sr",
                             "options": "",
-                            "fileKey": ""
+                            "fileKey": "",
+                            "addons": []
                         },
                         {
                             "label": "Columns",
@@ -12920,14 +13098,16 @@
                                             "showWordCount": false,
                                             "allowMultipleMasks": false,
                                             "id": "efz51n7m",
-                                            "hideOnChildrenHidden": false
+                                            "hideOnChildrenHidden": false,
+                                            "addons": []
                                         }
                                     ],
                                     "width": 6,
                                     "offset": 0,
                                     "push": 0,
                                     "pull": 0,
-                                    "size": "md"
+                                    "size": "md",
+                                    "currentWidth": 6
                                 },
                                 {
                                     "components": [
@@ -13001,14 +13181,16 @@
                                             "showCharCount": false,
                                             "showWordCount": false,
                                             "allowMultipleMasks": false,
-                                            "id": "etqorpe"
+                                            "id": "etqorpe",
+                                            "addons": []
                                         }
                                     ],
                                     "width": 6,
                                     "offset": 0,
                                     "push": 0,
                                     "pull": 0,
-                                    "size": "md"
+                                    "size": "md",
+                                    "currentWidth": 6
                                 }
                             ],
                             "autoAdjust": false,
@@ -13079,7 +13261,9 @@
                             "showWordCount": false,
                             "allowMultipleMasks": false,
                             "tree": false,
-                            "id": "ealp1ro"
+                            "id": "ealp1ro",
+                            "addons": [],
+                            "lazyLoad": false
                         }
                     ],
                     "placeholder": "",
@@ -13135,7 +13319,82 @@
                     "tree": false,
                     "theme": "default",
                     "breadcrumb": "default",
-                    "id": "eaitjan"
+                    "id": "eaitjan",
+                    "addons": [],
+                    "lazyLoad": false
+                },
+                {
+                    "label": "Dependantstatus",
+                    "labelWidth": "",
+                    "labelMargin": "",
+                    "customClass": "",
+                    "modalEdit": false,
+                    "defaultValue": null,
+                    "persistent": true,
+                    "protected": false,
+                    "dbIndex": false,
+                    "encrypted": false,
+                    "redrawOn": "data",
+                    "customDefaultValue": "",
+                    "calculateValue": "//alert (data.dependantstatus);\nif (data.hasDependents === 'no' && (data.relationshipStatus === 'single' || data.relationshipStatus === 'otherSingle') && data.outOfHighSchoolFor4Years === 'no' && data.howWillYouBeAttendingTheProgram === \"Full Time\") {\n  instance.setValue ('dependant');\n}\nelse {\n  instance.setValue ('independant');\n}",
+                    "calculateServer": true,
+                    "key": "dependantstatus",
+                    "tags": [],
+                    "properties": {},
+                    "logic": [],
+                    "attributes": {},
+                    "overlay": {
+                        "style": "",
+                        "page": "",
+                        "left": "",
+                        "top": "",
+                        "width": "",
+                        "height": ""
+                    },
+                    "type": "hidden",
+                    "input": true,
+                    "tableView": false,
+                    "placeholder": "",
+                    "prefix": "",
+                    "suffix": "",
+                    "multiple": false,
+                    "unique": false,
+                    "hidden": false,
+                    "clearOnHide": true,
+                    "refreshOn": "",
+                    "dataGridLabel": false,
+                    "labelPosition": "top",
+                    "description": "",
+                    "errorLabel": "",
+                    "tooltip": "",
+                    "hideLabel": false,
+                    "tabindex": "",
+                    "disabled": false,
+                    "autofocus": false,
+                    "widget": {
+                        "type": "input"
+                    },
+                    "validateOn": "change",
+                    "validate": {
+                        "required": false,
+                        "custom": "",
+                        "customPrivate": false,
+                        "strictDateValidation": false,
+                        "multiple": false,
+                        "unique": false
+                    },
+                    "conditional": {
+                        "show": null,
+                        "when": null,
+                        "eq": ""
+                    },
+                    "allowCalculateOverride": false,
+                    "showCharCount": false,
+                    "showWordCount": false,
+                    "allowMultipleMasks": false,
+                    "addons": [],
+                    "inputType": "hidden",
+                    "id": "ewwbcc9"
                 }
             ],
             "placeholder": "",
@@ -13174,7 +13433,9 @@
             "showWordCount": false,
             "allowMultipleMasks": false,
             "tree": false,
-            "id": "etsbz9o"
+            "id": "etsbz9o",
+            "addons": [],
+            "lazyLoad": false
         },
         {
             "title": "Partner information",
@@ -13298,7 +13559,8 @@
                     "showCharCount": false,
                     "showWordCount": false,
                     "allowMultipleMasks": false,
-                    "id": "ezo3nq8"
+                    "id": "ezo3nq8",
+                    "addons": []
                 },
                 {
                     "label": "HTML",
@@ -13377,7 +13639,8 @@
                     "showCharCount": false,
                     "showWordCount": false,
                     "allowMultipleMasks": false,
-                    "id": "ew7qj9"
+                    "id": "ew7qj9",
+                    "addons": []
                 },
                 {
                     "label": "<strong>Does your partner have a valid Social Insurance Number?</strong>",
@@ -13466,7 +13729,8 @@
                     "inputType": "radio",
                     "fieldSet": false,
                     "id": "eolgirh",
-                    "defaultValue": ""
+                    "defaultValue": "",
+                    "addons": []
                 },
                 {
                     "label": "Additional information required",
@@ -13545,7 +13809,8 @@
                     "showCharCount": false,
                     "showWordCount": false,
                     "allowMultipleMasks": false,
-                    "id": "eqyaa8b"
+                    "id": "eqyaa8b",
+                    "addons": []
                 },
                 {
                     "label": "Spouse Estimation",
@@ -13624,7 +13889,8 @@
                     "showCharCount": false,
                     "showWordCount": false,
                     "allowMultipleMasks": false,
-                    "id": "eow2c2c"
+                    "id": "eow2c2c",
+                    "addons": []
                 },
                 {
                     "title": "Partner Income Panel",
@@ -13724,7 +13990,8 @@
                             "showCharCount": false,
                             "showWordCount": false,
                             "allowMultipleMasks": false,
-                            "id": "e3pwpa9"
+                            "id": "e3pwpa9",
+                            "addons": []
                         },
                         {
                             "label": "HTML",
@@ -13803,7 +14070,8 @@
                             "showCharCount": false,
                             "showWordCount": false,
                             "allowMultipleMasks": false,
-                            "id": "eedvdyj"
+                            "id": "eedvdyj",
+                            "addons": []
                         },
                         {
                             "label": "What was your partner’s income (as shown on line 15000 of previous year’s Canada Revenue Agency tax return)? If they didn’t file taxes, enter total income from all sources in and outside of Canada.",
@@ -13878,7 +14146,8 @@
                             "showWordCount": false,
                             "properties": {},
                             "allowMultipleMasks": false,
-                            "id": "e9mqj6h"
+                            "id": "e9mqj6h",
+                            "addons": []
                         },
                         {
                             "label": "<strong>Will your partner be employed full-time or part-time during your study period</strong>",
@@ -13959,7 +14228,8 @@
                             "allowMultipleMasks": false,
                             "inputType": "radio",
                             "fieldSet": false,
-                            "id": "erofrhb"
+                            "id": "erofrhb",
+                            "addons": []
                         },
                         {
                             "label": "<strong>Will  your partner be at home caring for eligible dependent children on a full-time basis during the your entire study period? </strong>",
@@ -14040,7 +14310,8 @@
                             "allowMultipleMasks": false,
                             "inputType": "radio",
                             "fieldSet": false,
-                            "id": "e1z6lyb"
+                            "id": "e1z6lyb",
+                            "addons": []
                         },
                         {
                             "label": "<strong>Will your partner be living with you during the your study period?</strong>",
@@ -14121,7 +14392,8 @@
                             "allowMultipleMasks": false,
                             "inputType": "radio",
                             "fieldSet": false,
-                            "id": "ehnyp6c"
+                            "id": "ehnyp6c",
+                            "addons": []
                         },
                         {
                             "label": "<strong>Will your partner be a full-time post-secondary student for some or all of your study period?</strong>",
@@ -14202,7 +14474,8 @@
                             "allowMultipleMasks": false,
                             "inputType": "radio",
                             "fieldSet": false,
-                            "id": "e4neun"
+                            "id": "e4neun",
+                            "addons": []
                         },
                         {
                             "title": "If your partner will be a full-time student, how many weeks of your study period will they also be in studies Panel",
@@ -14306,7 +14579,8 @@
                                     "showWordCount": false,
                                     "allowMultipleMasks": false,
                                     "id": "epdswoon",
-                                    "defaultValue": null
+                                    "defaultValue": null,
+                                    "addons": []
                                 }
                             ],
                             "allowPrevious": false,
@@ -14363,7 +14637,9 @@
                             "tree": false,
                             "theme": "default",
                             "breadcrumb": "default",
-                            "id": "ep5lg4"
+                            "id": "ep5lg4",
+                            "addons": [],
+                            "lazyLoad": false
                         },
                         {
                             "label": "<strong>Will your partner recieve income assistance/social assistance (welfare) and/or BC income assistance for persons with disabilities during the your study period?</strong>",
@@ -14452,7 +14728,8 @@
                             "inputType": "radio",
                             "fieldSet": false,
                             "id": "ealunos",
-                            "defaultValue": ""
+                            "defaultValue": "",
+                            "addons": []
                         },
                         {
                             "title": "Provide the total income assistance/social assistance (welfare) and/or BC income assistance for persons with disabilities that your partner will be receiving during your study period Panel",
@@ -14548,7 +14825,8 @@
                                     "showWordCount": false,
                                     "properties": {},
                                     "allowMultipleMasks": false,
-                                    "id": "e9k0k58"
+                                    "id": "e9k0k58",
+                                    "addons": []
                                 }
                             ],
                             "allowPrevious": false,
@@ -14605,7 +14883,9 @@
                             "tree": false,
                             "theme": "default",
                             "breadcrumb": "default",
-                            "id": "ey6jmc4b"
+                            "id": "ey6jmc4b",
+                            "addons": [],
+                            "lazyLoad": false
                         },
                         {
                             "label": "<strong>Will your partner be in receipt of Employment Insurance benefits during the your study period?</strong>",
@@ -14686,7 +14966,8 @@
                             "allowMultipleMasks": false,
                             "inputType": "radio",
                             "fieldSet": false,
-                            "id": "enklghw"
+                            "id": "enklghw",
+                            "addons": []
                         },
                         {
                             "title": "Will your partner be in receipt of Employment Insurance benefits during the your study period Panel",
@@ -14783,7 +15064,8 @@
                                     "showWordCount": false,
                                     "properties": {},
                                     "allowMultipleMasks": false,
-                                    "id": "ei87gnna"
+                                    "id": "ei87gnna",
+                                    "addons": []
                                 }
                             ],
                             "allowPrevious": false,
@@ -14840,7 +15122,9 @@
                             "tree": false,
                             "theme": "default",
                             "breadcrumb": "default",
-                            "id": "ei0vzm"
+                            "id": "ei0vzm",
+                            "addons": [],
+                            "lazyLoad": false
                         },
                         {
                             "label": "<strong>Will your partner be in receipt of federal or provincial permanent disability benefits during the your study period?</strong>",
@@ -14921,7 +15205,8 @@
                             "allowMultipleMasks": false,
                             "inputType": "radio",
                             "fieldSet": false,
-                            "id": "ef7th7s"
+                            "id": "ef7th7s",
+                            "addons": []
                         },
                         {
                             "title": "Will your partner be in receipt of federal or provincial permanent disability benefits during the your study period Panel",
@@ -15018,7 +15303,8 @@
                                     "showWordCount": false,
                                     "properties": {},
                                     "allowMultipleMasks": false,
-                                    "id": "ecbhi1"
+                                    "id": "ecbhi1",
+                                    "addons": []
                                 }
                             ],
                             "allowPrevious": false,
@@ -15075,7 +15361,9 @@
                             "tree": false,
                             "theme": "default",
                             "breadcrumb": "default",
-                            "id": "em80rob"
+                            "id": "em80rob",
+                            "addons": [],
+                            "lazyLoad": false
                         },
                         {
                             "label": "<strong>Will your partner be paying a Canada Student Loan and/or a provincial student loan regular scheduled payments during the your study period?</strong>",
@@ -15156,7 +15444,8 @@
                             "allowMultipleMasks": false,
                             "inputType": "radio",
                             "fieldSet": false,
-                            "id": "eoxznh4"
+                            "id": "eoxznh4",
+                            "addons": []
                         },
                         {
                             "title": "Will your partner be paying a Canada Student Loan and/or a provincial student loan regular scheduled payments during the your study period Panel",
@@ -15252,7 +15541,8 @@
                                     "showWordCount": false,
                                     "properties": {},
                                     "allowMultipleMasks": false,
-                                    "id": "exjd5dg"
+                                    "id": "exjd5dg",
+                                    "addons": []
                                 }
                             ],
                             "allowPrevious": false,
@@ -15309,7 +15599,9 @@
                             "tree": false,
                             "theme": "default",
                             "breadcrumb": "default",
-                            "id": "et3rj9"
+                            "id": "et3rj9",
+                            "addons": [],
+                            "lazyLoad": false
                         },
                         {
                             "label": "<strong>Will your partner be paying for child support and/or spousal support during the your study period?</strong>",
@@ -15390,7 +15682,8 @@
                             "allowMultipleMasks": false,
                             "inputType": "radio",
                             "fieldSet": false,
-                            "id": "eboa3up"
+                            "id": "eboa3up",
+                            "addons": []
                         },
                         {
                             "title": "Will your partner be paying for child support and/or spousal support during the your study period Panel",
@@ -15486,7 +15779,8 @@
                                     "showWordCount": false,
                                     "properties": {},
                                     "allowMultipleMasks": false,
-                                    "id": "epwpsk9"
+                                    "id": "epwpsk9",
+                                    "addons": []
                                 }
                             ],
                             "allowPrevious": false,
@@ -15543,7 +15837,9 @@
                             "tree": false,
                             "theme": "default",
                             "breadcrumb": "default",
-                            "id": "ei3r3id"
+                            "id": "ei3r3id",
+                            "addons": [],
+                            "lazyLoad": false
                         },
                         {
                             "label": "<strong>Durring your study period, will your partner be taking care of eligible dependants? </strong>",
@@ -15624,7 +15920,8 @@
                             "allowMultipleMasks": false,
                             "inputType": "radio",
                             "fieldSet": false,
-                            "id": "e887jy"
+                            "id": "e887jy",
+                            "addons": []
                         }
                     ],
                     "allowPrevious": false,
@@ -15681,7 +15978,9 @@
                     "tree": false,
                     "theme": "default",
                     "breadcrumb": "default",
-                    "id": "etvo8m"
+                    "id": "etvo8m",
+                    "addons": [],
+                    "lazyLoad": false
                 }
             ],
             "placeholder": "",
@@ -15720,7 +16019,9 @@
             "showWordCount": false,
             "allowMultipleMasks": false,
             "tree": false,
-            "id": "esudth"
+            "id": "esudth",
+            "addons": [],
+            "lazyLoad": false
         },
         {
             "title": "Parent information",
@@ -27465,6 +27766,76 @@
             "inputType": "hidden",
             "id": "em1y8gd",
             "defaultValue": ""
+        },
+        {
+            "label": "applicationStatus",
+            "customClass": "",
+            "modalEdit": false,
+            "defaultValue": null,
+            "persistent": true,
+            "protected": false,
+            "dbIndex": false,
+            "encrypted": false,
+            "redrawOn": "",
+            "customDefaultValue": "",
+            "calculateValue": "",
+            "calculateServer": false,
+            "key": "applicationStatus",
+            "tags": [],
+            "properties": {},
+            "logic": [],
+            "attributes": {},
+            "overlay": {
+                "style": "",
+                "page": "",
+                "left": "",
+                "top": "",
+                "width": "",
+                "height": ""
+            },
+            "type": "hidden",
+            "input": true,
+            "tableView": false,
+            "placeholder": "",
+            "prefix": "",
+            "suffix": "",
+            "multiple": false,
+            "unique": false,
+            "hidden": false,
+            "clearOnHide": true,
+            "refreshOn": "",
+            "dataGridLabel": false,
+            "labelPosition": "top",
+            "description": "",
+            "errorLabel": "",
+            "tooltip": "",
+            "hideLabel": false,
+            "tabindex": "",
+            "disabled": false,
+            "autofocus": false,
+            "widget": {
+                "type": "input"
+            },
+            "validateOn": "change",
+            "validate": {
+                "required": false,
+                "custom": "",
+                "customPrivate": false,
+                "strictDateValidation": false,
+                "multiple": false,
+                "unique": false
+            },
+            "conditional": {
+                "show": null,
+                "when": null,
+                "eq": ""
+            },
+            "allowCalculateOverride": false,
+            "showCharCount": false,
+            "showWordCount": false,
+            "allowMultipleMasks": false,
+            "inputType": "hidden",
+            "id": "e6z1qd9"
         }
     ],
     "display": "wizard",
@@ -27473,5 +27844,5 @@
     "name": "SFAA2022-23",
     "machineName": "SFAA2022-23",
     "created": "2021-07-12T19:51:16.443Z",
-    "modified": "2022-01-13T22:00:05.107Z"
+    "modified": "2022-02-16T23:04:31.333Z"
 }

--- a/sources/packages/forms/src/form-definitions/sfaa2022-23.json
+++ b/sources/packages/forms/src/form-definitions/sfaa2022-23.json
@@ -10609,7 +10609,7 @@
                     "allowCalculateOverride": false,
                     "validate": {
                         "required": true,
-                        "onlyAvailableItems": false,
+                        "onlyAvailableItems": true,
                         "customMessage": "",
                         "custom": "",
                         "customPrivate": false,
@@ -10660,7 +10660,7 @@
                     "addons": [],
                     "inputType": "radio",
                     "fieldSet": false,
-                    "id": "e76zqu",
+                    "id": "epq5uo",
                     "defaultValue": ""
                 },
                 {
@@ -12339,7 +12339,7 @@
                                             "addons": []
                                         }
                                     ],
-                                    "id": "ecpkm9j00000000000000000000000000000000000000000000000000000000000000000",
+                                    "id": "ecpkm9j00000000000000000000000000000000000000000000000000000000000000000000",
                                     "placeholder": "",
                                     "prefix": "",
                                     "customClass": "",
@@ -13336,7 +13336,7 @@
                     "encrypted": false,
                     "redrawOn": "data",
                     "customDefaultValue": "",
-                    "calculateValue": "//alert (data.dependantstatus);\nif (data.hasDependents === 'no' && (data.relationshipStatus === 'single' || data.relationshipStatus === 'other') && data.outOfHighSchoolFor4Years === 'no' && data.howWillYouBeAttendingTheProgram === \"Full Time\") {\n  instance.setValue ('dependant');\n}\nelse {\n  instance.setValue ('independant');\n}",
+                    "calculateValue": "if (data.hasDependents === 'no' && (data.relationshipStatus === 'single' || data.relationshipStatus === 'other') && data.outOfHighSchoolFor4Years === 'no' && data.howWillYouBeAttendingTheProgram === \"Full Time\") {\n  instance.setValue ('dependant');\n}\nelse {\n  instance.setValue ('independant');\n}",
                     "calculateServer": true,
                     "key": "dependantstatus",
                     "tags": [],
@@ -13394,7 +13394,7 @@
                     "allowMultipleMasks": false,
                     "addons": [],
                     "inputType": "hidden",
-                    "id": "egb193"
+                    "id": "e18odfo"
                 }
             ],
             "placeholder": "",
@@ -27787,5 +27787,5 @@
     "name": "SFAA2022-23",
     "machineName": "SFAA2022-23",
     "created": "2021-07-12T19:51:16.443Z",
-    "modified": "2022-02-16T23:23:07.557Z"
+    "modified": "2022-02-17T17:05:30.826Z"
 }

--- a/sources/packages/forms/src/form-definitions/sfaa2023-24.json
+++ b/sources/packages/forms/src/form-definitions/sfaa2023-24.json
@@ -139,7 +139,8 @@
                                                     "showCharCount": false,
                                                     "showWordCount": false,
                                                     "allowMultipleMasks": false,
-                                                    "id": "eet78d9"
+                                                    "id": "eet78d9",
+                                                    "addons": []
                                                 },
                                                 {
                                                     "label": "HTML",
@@ -219,14 +220,16 @@
                                                     "showCharCount": false,
                                                     "showWordCount": false,
                                                     "allowMultipleMasks": false,
-                                                    "id": "ef68phe"
+                                                    "id": "ef68phe",
+                                                    "addons": []
                                                 }
                                             ],
                                             "offset": 0,
                                             "push": 0,
                                             "pull": 0,
                                             "size": "md",
-                                            "width": 6
+                                            "width": 6,
+                                            "currentWidth": 6
                                         },
                                         {
                                             "components": [
@@ -301,14 +304,16 @@
                                                     "properties": {},
                                                     "allowMultipleMasks": false,
                                                     "content": "",
-                                                    "id": "e7p34h"
+                                                    "id": "e7p34h",
+                                                    "addons": []
                                                 }
                                             ],
                                             "offset": 0,
                                             "push": 0,
                                             "pull": 0,
                                             "size": "md",
-                                            "width": 6
+                                            "width": 6,
+                                            "currentWidth": 6
                                         }
                                     ],
                                     "hideLabel": true,
@@ -374,14 +379,17 @@
                                     "allowMultipleMasks": false,
                                     "tree": false,
                                     "autoAdjust": false,
-                                    "id": "ego57u"
+                                    "id": "ego57u",
+                                    "addons": [],
+                                    "lazyLoad": false
                                 }
                             ],
                             "width": 12,
                             "offset": 0,
                             "push": 0,
                             "pull": 0,
-                            "size": "md"
+                            "size": "md",
+                            "currentWidth": 12
                         },
                         {
                             "components": [],
@@ -389,7 +397,8 @@
                             "offset": 0,
                             "push": 0,
                             "pull": 0,
-                            "size": "md"
+                            "size": "md",
+                            "currentWidth": 6
                         }
                     ],
                     "type": "columns",
@@ -452,7 +461,9 @@
                     "tree": false,
                     "autoAdjust": false,
                     "hideOnChildrenHidden": false,
-                    "id": "evh64v3"
+                    "id": "evh64v3",
+                    "addons": [],
+                    "lazyLoad": false
                 },
                 {
                     "label": "applicationId",
@@ -519,7 +530,8 @@
                     "properties": {},
                     "allowMultipleMasks": false,
                     "inputType": "hidden",
-                    "id": "elknlor"
+                    "id": "elknlor",
+                    "addons": []
                 },
                 {
                     "label": "workflowName",
@@ -586,7 +598,8 @@
                     "properties": {},
                     "allowMultipleMasks": false,
                     "inputType": "hidden",
-                    "id": "ebsh4es"
+                    "id": "ebsh4es",
+                    "addons": []
                 }
             ],
             "input": false,
@@ -627,7 +640,9 @@
             "showWordCount": false,
             "allowMultipleMasks": false,
             "tree": false,
-            "id": "eyx5cz"
+            "id": "eyx5cz",
+            "addons": [],
+            "lazyLoad": false
         },
         {
             "title": "Program",
@@ -4526,7 +4541,8 @@
                     "showCharCount": false,
                     "showWordCount": false,
                     "allowMultipleMasks": false,
-                    "id": "epmbrga"
+                    "id": "epmbrga",
+                    "addons": []
                 },
                 {
                     "label": "HTML",
@@ -4605,7 +4621,8 @@
                     "showCharCount": false,
                     "showWordCount": false,
                     "allowMultipleMasks": false,
-                    "id": "ew33yx"
+                    "id": "ew33yx",
+                    "addons": []
                 },
                 {
                     "title": "StudentAid BC personal info panel",
@@ -4701,7 +4718,8 @@
                             "showCharCount": false,
                             "showWordCount": false,
                             "allowMultipleMasks": false,
-                            "id": "ez8hvke"
+                            "id": "ez8hvke",
+                            "addons": []
                         },
                         {
                             "label": "Content",
@@ -4775,7 +4793,8 @@
                             "properties": {},
                             "allowMultipleMasks": false,
                             "tag": "p",
-                            "id": "eow3mur"
+                            "id": "eow3mur",
+                            "addons": []
                         },
                         {
                             "label": "Student profile",
@@ -4850,7 +4869,8 @@
                             "block": false,
                             "disableOnInvalid": false,
                             "theme": "primary",
-                            "id": "ewtrt5h"
+                            "id": "ewtrt5h",
+                            "addons": []
                         },
                         {
                             "label": "Columns",
@@ -4931,7 +4951,10 @@
                                             "inputFormat": "plain",
                                             "inputMask": "",
                                             "spellcheck": true,
-                                            "id": "eollo8c"
+                                            "id": "eollo8c",
+                                            "addons": [],
+                                            "displayMask": "",
+                                            "truncateMultipleSpaces": false
                                         },
                                         {
                                             "label": "Date of birth",
@@ -5007,7 +5030,10 @@
                                             "inputFormat": "plain",
                                             "inputMask": "",
                                             "spellcheck": true,
-                                            "id": "eiro1mh"
+                                            "id": "eiro1mh",
+                                            "addons": [],
+                                            "displayMask": "",
+                                            "truncateMultipleSpaces": false
                                         },
                                         {
                                             "label": "Home address",
@@ -5083,7 +5109,10 @@
                                             "inputFormat": "plain",
                                             "inputMask": "",
                                             "spellcheck": true,
-                                            "id": "eppxei"
+                                            "id": "eppxei",
+                                            "addons": [],
+                                            "displayMask": "",
+                                            "truncateMultipleSpaces": false
                                         },
                                         {
                                             "label": "Email",
@@ -5158,14 +5187,18 @@
                                             "inputFormat": "plain",
                                             "inputMask": "",
                                             "spellcheck": true,
-                                            "id": "ey8k2yp"
+                                            "id": "ey8k2yp",
+                                            "addons": [],
+                                            "displayMask": "",
+                                            "truncateMultipleSpaces": false
                                         }
                                     ],
                                     "width": 6,
                                     "offset": 0,
                                     "push": 0,
                                     "pull": 0,
-                                    "size": "md"
+                                    "size": "md",
+                                    "currentWidth": 6
                                 },
                                 {
                                     "components": [
@@ -5242,7 +5275,10 @@
                                             "inputFormat": "plain",
                                             "inputMask": "",
                                             "spellcheck": true,
-                                            "id": "eug619a"
+                                            "id": "eug619a",
+                                            "addons": [],
+                                            "displayMask": "",
+                                            "truncateMultipleSpaces": false
                                         },
                                         {
                                             "label": "Gender",
@@ -5318,7 +5354,10 @@
                                             "inputFormat": "plain",
                                             "inputMask": "",
                                             "spellcheck": true,
-                                            "id": "el67mt"
+                                            "id": "el67mt",
+                                            "addons": [],
+                                            "displayMask": "",
+                                            "truncateMultipleSpaces": false
                                         },
                                         {
                                             "label": "Phone number",
@@ -5394,7 +5433,10 @@
                                             "inputFormat": "plain",
                                             "inputMask": "",
                                             "spellcheck": true,
-                                            "id": "egglzja"
+                                            "id": "egglzja",
+                                            "addons": [],
+                                            "displayMask": "",
+                                            "truncateMultipleSpaces": false
                                         },
                                         {
                                             "label": "Permanent disability status",
@@ -5469,14 +5511,18 @@
                                             "inputFormat": "plain",
                                             "inputMask": "",
                                             "spellcheck": true,
-                                            "id": "eq3hnwv"
+                                            "id": "eq3hnwv",
+                                            "addons": [],
+                                            "displayMask": "",
+                                            "truncateMultipleSpaces": false
                                         }
                                     ],
                                     "width": 6,
                                     "offset": 0,
                                     "push": 0,
                                     "pull": 0,
-                                    "size": "md"
+                                    "size": "md",
+                                    "currentWidth": 6
                                 }
                             ],
                             "key": "columns1",
@@ -5542,7 +5588,9 @@
                             "tree": false,
                             "autoAdjust": false,
                             "hideOnChildrenHidden": false,
-                            "id": "ebg5117"
+                            "id": "ebg5117",
+                            "addons": [],
+                            "lazyLoad": false
                         },
                         {
                             "label": "I confirm my StudentAid BC Profile information shown is correct",
@@ -5611,7 +5659,8 @@
                             "inputType": "checkbox",
                             "value": "",
                             "name": "",
-                            "id": "ebth7m"
+                            "id": "ebth7m",
+                            "addons": []
                         }
                     ],
                     "allowPrevious": false,
@@ -5673,7 +5722,9 @@
                     "tree": false,
                     "theme": "default",
                     "breadcrumb": "default",
-                    "id": "e1llrtm"
+                    "id": "e1llrtm",
+                    "addons": [],
+                    "lazyLoad": false
                 },
                 {
                     "label": "<strong>What is your citizenship status?</strong>",
@@ -5704,7 +5755,8 @@
                         "customPrivate": false,
                         "strictDateValidation": false,
                         "multiple": false,
-                        "unique": false
+                        "unique": false,
+                        "onlyAvailableItems": false
                     },
                     "key": "citizenship",
                     "type": "radio",
@@ -5760,7 +5812,8 @@
                     "allowMultipleMasks": false,
                     "inputType": "radio",
                     "fieldSet": false,
-                    "id": "e8pmct9"
+                    "id": "e8pmct9",
+                    "addons": []
                 },
                 {
                     "title": "Citizenship proof panel",
@@ -5857,7 +5910,8 @@
                             "showCharCount": false,
                             "showWordCount": false,
                             "allowMultipleMasks": false,
-                            "id": "es70kak"
+                            "id": "es70kak",
+                            "addons": []
                         },
                         {
                             "label": "HTML",
@@ -5936,7 +5990,8 @@
                             "showCharCount": false,
                             "showWordCount": false,
                             "allowMultipleMasks": false,
-                            "id": "emtg9xk"
+                            "id": "emtg9xk",
+                            "addons": []
                         },
                         {
                             "label": "HTML",
@@ -6015,7 +6070,8 @@
                             "showCharCount": false,
                             "showWordCount": false,
                             "allowMultipleMasks": false,
-                            "id": "eddhwkl"
+                            "id": "eddhwkl",
+                            "addons": []
                         },
                         {
                             "label": "HTML",
@@ -6094,7 +6150,8 @@
                             "showCharCount": false,
                             "showWordCount": false,
                             "allowMultipleMasks": false,
-                            "id": "ea2ohue"
+                            "id": "ea2ohue",
+                            "addons": []
                         },
                         {
                             "label": "HTML",
@@ -6173,7 +6230,8 @@
                             "showCharCount": false,
                             "showWordCount": false,
                             "allowMultipleMasks": false,
-                            "id": "e917eb"
+                            "id": "e917eb",
+                            "addons": []
                         },
                         {
                             "label": "HTML",
@@ -6252,7 +6310,8 @@
                             "showCharCount": false,
                             "showWordCount": false,
                             "allowMultipleMasks": false,
-                            "id": "emigw5m"
+                            "id": "emigw5m",
+                            "addons": []
                         },
                         {
                             "label": "Upload proof of citizenship",
@@ -6343,7 +6402,8 @@
                             "privateDownload": false,
                             "id": "etkoqe",
                             "options": "",
-                            "fileKey": ""
+                            "fileKey": "",
+                            "addons": []
                         },
                         {
                             "label": "Columns",
@@ -6420,14 +6480,16 @@
                                             "showCharCount": false,
                                             "showWordCount": false,
                                             "allowMultipleMasks": false,
-                                            "id": "e9wutz8"
+                                            "id": "e9wutz8",
+                                            "addons": []
                                         }
                                     ],
                                     "width": 6,
                                     "offset": 0,
                                     "push": 0,
                                     "pull": 0,
-                                    "size": "md"
+                                    "size": "md",
+                                    "currentWidth": 6
                                 },
                                 {
                                     "components": [
@@ -6501,14 +6563,16 @@
                                             "showCharCount": false,
                                             "showWordCount": false,
                                             "allowMultipleMasks": false,
-                                            "id": "e5czcdd"
+                                            "id": "e5czcdd",
+                                            "addons": []
                                         }
                                     ],
                                     "width": 6,
                                     "offset": 0,
                                     "push": 0,
                                     "pull": 0,
-                                    "size": "md"
+                                    "size": "md",
+                                    "currentWidth": 6
                                 }
                             ],
                             "autoAdjust": false,
@@ -6579,7 +6643,9 @@
                             "showWordCount": false,
                             "allowMultipleMasks": false,
                             "tree": false,
-                            "id": "elv3ea8"
+                            "id": "elv3ea8",
+                            "addons": [],
+                            "lazyLoad": false
                         }
                     ],
                     "allowPrevious": false,
@@ -6641,7 +6707,9 @@
                     "tree": false,
                     "theme": "default",
                     "breadcrumb": "default",
-                    "id": "efawj5"
+                    "id": "efawj5",
+                    "addons": [],
+                    "lazyLoad": false
                 },
                 {
                     "label": "<strong>Are you a resident of B.C.?</strong>",
@@ -6731,7 +6799,8 @@
                     "inputType": "radio",
                     "fieldSet": false,
                     "id": "e8a3hql",
-                    "defaultValue": ""
+                    "defaultValue": "",
+                    "addons": []
                 },
                 {
                     "title": "Not a BC resident panel",
@@ -6832,7 +6901,8 @@
                             "showCharCount": false,
                             "showWordCount": false,
                             "allowMultipleMasks": false,
-                            "id": "ean88l9"
+                            "id": "ean88l9",
+                            "addons": []
                         },
                         {
                             "label": "HTML",
@@ -6911,7 +6981,8 @@
                             "showCharCount": false,
                             "showWordCount": false,
                             "allowMultipleMasks": false,
-                            "id": "eqmirkg"
+                            "id": "eqmirkg",
+                            "addons": []
                         },
                         {
                             "label": "<strong>Which of the following best describes your situation?</strong>",
@@ -7010,7 +7081,8 @@
                             "inputType": "radio",
                             "fieldSet": false,
                             "id": "ep66483",
-                            "defaultValue": ""
+                            "defaultValue": "",
+                            "addons": []
                         },
                         {
                             "label": "HTML",
@@ -7089,7 +7161,8 @@
                             "showCharCount": false,
                             "showWordCount": false,
                             "allowMultipleMasks": false,
-                            "id": "ehuecan"
+                            "id": "ehuecan",
+                            "addons": []
                         },
                         {
                             "label": "Please explain your sitution:",
@@ -7179,7 +7252,10 @@
                             "inputMask": "",
                             "fixedSize": true,
                             "id": "euh1cll",
-                            "defaultValue": ""
+                            "defaultValue": "",
+                            "addons": [],
+                            "displayMask": "",
+                            "truncateMultipleSpaces": false
                         },
                         {
                             "title": "Upload supporting documents",
@@ -7303,7 +7379,8 @@
                                     "showCharCount": false,
                                     "showWordCount": false,
                                     "allowMultipleMasks": false,
-                                    "id": "eezq1g"
+                                    "id": "eezq1g",
+                                    "addons": []
                                 },
                                 {
                                     "label": "HTML",
@@ -7382,7 +7459,8 @@
                                     "showCharCount": false,
                                     "showWordCount": false,
                                     "allowMultipleMasks": false,
-                                    "id": "esar0bi"
+                                    "id": "esar0bi",
+                                    "addons": []
                                 },
                                 {
                                     "label": "HTML",
@@ -7461,7 +7539,8 @@
                                     "showCharCount": false,
                                     "showWordCount": false,
                                     "allowMultipleMasks": false,
-                                    "id": "e18yipa"
+                                    "id": "e18yipa",
+                                    "addons": []
                                 },
                                 {
                                     "label": "Upload supporting documents (optional):",
@@ -7552,7 +7631,8 @@
                                     "privateDownload": false,
                                     "id": "etziji",
                                     "options": "",
-                                    "fileKey": ""
+                                    "fileKey": "",
+                                    "addons": []
                                 },
                                 {
                                     "label": "Columns",
@@ -7629,14 +7709,16 @@
                                                     "showWordCount": false,
                                                     "allowMultipleMasks": false,
                                                     "id": "e7t7n9i",
-                                                    "hideOnChildrenHidden": false
+                                                    "hideOnChildrenHidden": false,
+                                                    "addons": []
                                                 }
                                             ],
                                             "width": 6,
                                             "offset": 0,
                                             "push": 0,
                                             "pull": 0,
-                                            "size": "md"
+                                            "size": "md",
+                                            "currentWidth": 6
                                         },
                                         {
                                             "components": [
@@ -7710,14 +7792,16 @@
                                                     "showWordCount": false,
                                                     "allowMultipleMasks": false,
                                                     "id": "e4rlla",
-                                                    "hideOnChildrenHidden": false
+                                                    "hideOnChildrenHidden": false,
+                                                    "addons": []
                                                 }
                                             ],
                                             "width": 6,
                                             "offset": 0,
                                             "push": 0,
                                             "pull": 0,
-                                            "size": "md"
+                                            "size": "md",
+                                            "currentWidth": 6
                                         }
                                     ],
                                     "autoAdjust": false,
@@ -7788,7 +7872,9 @@
                                     "showWordCount": false,
                                     "allowMultipleMasks": false,
                                     "tree": false,
-                                    "id": "e47hyqa"
+                                    "id": "e47hyqa",
+                                    "addons": [],
+                                    "lazyLoad": false
                                 }
                             ],
                             "placeholder": "",
@@ -7827,7 +7913,9 @@
                             "showWordCount": false,
                             "allowMultipleMasks": false,
                             "tree": false,
-                            "id": "eruhydo"
+                            "id": "eruhydo",
+                            "addons": [],
+                            "lazyLoad": false
                         }
                     ],
                     "allowPrevious": false,
@@ -7884,7 +7972,9 @@
                     "tree": false,
                     "theme": "default",
                     "breadcrumb": "default",
-                    "id": "eo7yj4f"
+                    "id": "eo7yj4f",
+                    "addons": [],
+                    "lazyLoad": false
                 },
                 {
                     "label": "<strong>Do you identify as an Indigenous person?</strong>",
@@ -7909,7 +7999,8 @@
                         "customPrivate": false,
                         "strictDateValidation": false,
                         "multiple": false,
-                        "unique": false
+                        "unique": false,
+                        "onlyAvailableItems": false
                     },
                     "errorLabel": "Aboriginal Status",
                     "key": "indigenousStatus",
@@ -7965,7 +8056,8 @@
                     "allowMultipleMasks": false,
                     "inputType": "radio",
                     "fieldSet": false,
-                    "id": "e96uncs"
+                    "id": "e96uncs",
+                    "addons": []
                 },
                 {
                     "title": "Indigenous Panel",
@@ -8065,7 +8157,8 @@
                             "showCharCount": false,
                             "showWordCount": false,
                             "allowMultipleMasks": false,
-                            "id": "e2ag0zq"
+                            "id": "e2ag0zq",
+                            "addons": []
                         },
                         {
                             "label": "<strong>I am:</strong>",
@@ -8095,7 +8188,8 @@
                                 "customPrivate": false,
                                 "strictDateValidation": false,
                                 "multiple": false,
-                                "unique": false
+                                "unique": false,
+                                "onlyAvailableItems": false
                             },
                             "key": "aboriginalHeritage",
                             "conditional": {
@@ -8150,7 +8244,8 @@
                             "allowMultipleMasks": false,
                             "inputType": "radio",
                             "fieldSet": false,
-                            "id": "ezochjc"
+                            "id": "ezochjc",
+                            "addons": []
                         }
                     ],
                     "allowPrevious": false,
@@ -8207,7 +8302,9 @@
                     "tree": false,
                     "theme": "default",
                     "breadcrumb": "default",
-                    "id": "ef3gfa"
+                    "id": "ef3gfa",
+                    "addons": [],
+                    "lazyLoad": false
                 },
                 {
                     "label": "<strong>Were you ever a youth in continuing care or custody of a director of child welfare in BC (ward of the court – this means the provincial government is/was your legal guardian)? </strong>",
@@ -8232,7 +8329,8 @@
                         "customPrivate": false,
                         "strictDateValidation": false,
                         "multiple": false,
-                        "unique": false
+                        "unique": false,
+                        "onlyAvailableItems": false
                     },
                     "errorLabel": "Youth In Care",
                     "key": "youthInCare",
@@ -8288,7 +8386,8 @@
                     "allowMultipleMasks": false,
                     "inputType": "radio",
                     "fieldSet": false,
-                    "id": "ema6dci"
+                    "id": "ema6dci",
+                    "addons": []
                 },
                 {
                     "label": "HTML",
@@ -8367,7 +8466,8 @@
                     "showCharCount": false,
                     "showWordCount": false,
                     "allowMultipleMasks": false,
-                    "id": "enupmu"
+                    "id": "enupmu",
+                    "addons": []
                 },
                 {
                     "label": "<strong>At the time of your course study start date, will you have been out of high school for 4 years?</strong>",
@@ -8456,7 +8556,8 @@
                     "inputType": "radio",
                     "fieldSet": false,
                     "id": "eahh865",
-                    "defaultValue": ""
+                    "defaultValue": "",
+                    "addons": []
                 },
                 {
                     "label": "<strong>When did you graduate or leave high-school?</strong>",
@@ -8582,7 +8683,8 @@
                     "showWordCount": false,
                     "allowMultipleMasks": false,
                     "datepickerMode": "day",
-                    "id": "ei3rn5"
+                    "id": "ei3rn5",
+                    "addons": []
                 },
                 {
                     "label": "HTML",
@@ -8661,7 +8763,8 @@
                     "showCharCount": false,
                     "showWordCount": false,
                     "allowMultipleMasks": false,
-                    "id": "epzt48g"
+                    "id": "epzt48g",
+                    "addons": []
                 },
                 {
                     "label": "<strong>Will you be working a full-time job of 32 hours per week for more than half of your study period?</strong>",
@@ -8687,7 +8790,8 @@
                         "customPrivate": false,
                         "strictDateValidation": false,
                         "multiple": false,
-                        "unique": false
+                        "unique": false,
+                        "onlyAvailableItems": false
                     },
                     "errorLabel": "Employment Information",
                     "key": "fullTimeJob",
@@ -8742,7 +8846,8 @@
                     "allowMultipleMasks": false,
                     "inputType": "radio",
                     "fieldSet": false,
-                    "id": "ewa5mpb"
+                    "id": "ewa5mpb",
+                    "addons": []
                 },
                 {
                     "label": "HTML",
@@ -8821,7 +8926,8 @@
                     "showCharCount": false,
                     "showWordCount": false,
                     "allowMultipleMasks": false,
-                    "id": "ejad0c"
+                    "id": "ejad0c",
+                    "addons": []
                 },
                 {
                     "label": "<strong>In the time since you left high school to your first day of classes, have you spent two periods of 12 consecutive months each, in the full time labour force?</strong>",
@@ -8902,7 +9008,8 @@
                     "allowMultipleMasks": false,
                     "inputType": "radio",
                     "fieldSet": false,
-                    "id": "eqf8qus"
+                    "id": "eqf8qus",
+                    "addons": []
                 },
                 {
                     "label": "HTML",
@@ -8981,7 +9088,8 @@
                     "showCharCount": false,
                     "showWordCount": false,
                     "allowMultipleMasks": false,
-                    "id": "evos73h"
+                    "id": "evos73h",
+                    "addons": []
                 },
                 {
                     "label": "HTML",
@@ -9060,7 +9168,8 @@
                     "showCharCount": false,
                     "showWordCount": false,
                     "allowMultipleMasks": false,
-                    "id": "ef4mzqb"
+                    "id": "ef4mzqb",
+                    "addons": []
                 },
                 {
                     "label": "<strong>Do you want to allow a trusted contact to interact with StudentAid BC on your behalf?</strong>",
@@ -9141,7 +9250,8 @@
                     "allowMultipleMasks": false,
                     "inputType": "radio",
                     "fieldSet": false,
-                    "id": "ewr6dc9"
+                    "id": "ewr6dc9",
+                    "addons": []
                 },
                 {
                     "title": "Trusted contact panel",
@@ -9242,7 +9352,8 @@
                             "showCharCount": false,
                             "showWordCount": false,
                             "allowMultipleMasks": false,
-                            "id": "eu1qpne"
+                            "id": "eu1qpne",
+                            "addons": []
                         },
                         {
                             "label": "HTML",
@@ -9321,7 +9432,8 @@
                             "showCharCount": false,
                             "showWordCount": false,
                             "allowMultipleMasks": false,
-                            "id": "eaqymr"
+                            "id": "eaqymr",
+                            "addons": []
                         },
                         {
                             "label": "<strong>ROI information</strong>",
@@ -9376,7 +9488,7 @@
                                     "key": "firstName",
                                     "type": "textfield",
                                     "input": true,
-                                    "id": "el2qrn9000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+                                    "id": "el2qrn9000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
                                     "placeholder": "",
                                     "prefix": "",
                                     "suffix": "",
@@ -9430,7 +9542,10 @@
                                     "inputType": "text",
                                     "inputFormat": "plain",
                                     "inputMask": "",
-                                    "spellcheck": true
+                                    "spellcheck": true,
+                                    "addons": [],
+                                    "displayMask": "",
+                                    "truncateMultipleSpaces": false
                                 },
                                 {
                                     "label": "Last name",
@@ -9450,7 +9565,7 @@
                                     "key": "lastName",
                                     "type": "textfield",
                                     "input": true,
-                                    "id": "e618eci000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+                                    "id": "e618eci000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
                                     "placeholder": "",
                                     "prefix": "",
                                     "suffix": "",
@@ -9504,7 +9619,10 @@
                                     "inputType": "text",
                                     "inputFormat": "plain",
                                     "inputMask": "",
-                                    "spellcheck": true
+                                    "spellcheck": true,
+                                    "addons": [],
+                                    "displayMask": "",
+                                    "truncateMultipleSpaces": false
                                 },
                                 {
                                     "label": "<strong>What is your relationship with this contact?</strong>",
@@ -9602,8 +9720,9 @@
                                     "allowMultipleMasks": false,
                                     "inputType": "radio",
                                     "fieldSet": false,
-                                    "id": "ejv9syt00000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
-                                    "defaultValue": ""
+                                    "id": "ejv9syt00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+                                    "defaultValue": "",
+                                    "addons": []
                                 },
                                 {
                                     "label": "<strong>How long do you want to give this person access to your StudentAid BC account?</strong>",
@@ -9639,7 +9758,7 @@
                                     "key": "strongHowLongDoYouWantToGiveThisPersonAccessToYourStudentAidBcAccountStrong",
                                     "type": "radio",
                                     "input": true,
-                                    "id": "ejm9s3q000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+                                    "id": "ejm9s3q000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
                                     "placeholder": "",
                                     "prefix": "",
                                     "customClass": "",
@@ -9689,7 +9808,8 @@
                                     "properties": {},
                                     "allowMultipleMasks": false,
                                     "inputType": "radio",
-                                    "fieldSet": false
+                                    "fieldSet": false,
+                                    "addons": []
                                 },
                                 {
                                     "label": "Select the date you would like this person’s access to your StudentAidBC account to expire",
@@ -9745,7 +9865,7 @@
                                         "disableWeekdays": false,
                                         "maxDate": null
                                     },
-                                    "id": "earatq000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+                                    "id": "earatq000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
                                     "prefix": "",
                                     "suffix": "",
                                     "multiple": false,
@@ -9804,7 +9924,8 @@
                                         "arrowkeys": true
                                     },
                                     "customOptions": {},
-                                    "shortcutButtons": []
+                                    "shortcutButtons": [],
+                                    "addons": []
                                 }
                             ],
                             "placeholder": "",
@@ -9856,7 +9977,9 @@
                             "allowMultipleMasks": false,
                             "tree": true,
                             "disableAddingRemovingRows": false,
-                            "id": "eq7yod9"
+                            "id": "eq7yod9",
+                            "addons": [],
+                            "lazyLoad": false
                         },
                         {
                             "html": "<p>The &nbsp;Freedom of Information and Protection of Privacy Act &nbsp;prevents StudentAid BC and financial aid staff from releasing any information pertaining to this application to anyone other than you unless you provide written permission. Complete these questions if you want to authorize another person to obtain information on your behalf about this application, related appendices, or assessment details. If you authorize someone to access information on your behalf by completing these questions, they must provide your Social Insurance Number and date of birth to access any information from StudentAid BC or financial aid staff. Please ensure you have the designated person’s authorization to enter their information. Do not use a school staff member. &nbsp;</p><p>&nbsp;</p><p>Note: Information can be shared with the persons/organizations identified in the StudentAid BC declaration based on your signature, regardless of whether these questions are completed.</p>",
@@ -9922,7 +10045,8 @@
                             "showWordCount": false,
                             "properties": {},
                             "allowMultipleMasks": false,
-                            "id": "eopro5d"
+                            "id": "eopro5d",
+                            "addons": []
                         },
                         {
                             "label": "roiWell",
@@ -10002,7 +10126,8 @@
                                     "inputType": "checkbox",
                                     "value": "",
                                     "name": "",
-                                    "id": "eqmvldl"
+                                    "id": "eqmvldl",
+                                    "addons": []
                                 }
                             ],
                             "placeholder": "",
@@ -10056,7 +10181,9 @@
                             "properties": {},
                             "allowMultipleMasks": false,
                             "tree": false,
-                            "id": "eepuwb5h"
+                            "id": "eepuwb5h",
+                            "addons": [],
+                            "lazyLoad": false
                         }
                     ],
                     "allowPrevious": false,
@@ -10113,77 +10240,9 @@
                     "tree": false,
                     "theme": "default",
                     "breadcrumb": "default",
-                    "id": "elibgq9"
-                },
-                {
-                    "label": "Dependantstatus",
-                    "customClass": "",
-                    "modalEdit": false,
-                    "defaultValue": null,
-                    "persistent": true,
-                    "protected": false,
-                    "dbIndex": false,
-                    "encrypted": false,
-                    "redrawOn": "",
-                    "customDefaultValue": "",
-                    "calculateValue": "//alert (data.dependantstatus);\nif (data.hasDependents === 'no' && (data.relationshipStatus === 'single' || data.relationshipStatus === 'otherSingle') && data.outOfHighSchoolFor4Years === 'no' && data.howWillYouBeAttendingTheProgram === \"Full Time\") {\n  instance.setValue ('dependant');\n}\nelse {\n  instance.setValue ('independant');\n}",
-                    "calculateServer": true,
-                    "key": "dependantstatus",
-                    "tags": [],
-                    "properties": {},
-                    "logic": [],
-                    "attributes": {},
-                    "overlay": {
-                        "style": "",
-                        "page": "",
-                        "left": "",
-                        "top": "",
-                        "width": "",
-                        "height": ""
-                    },
-                    "type": "hidden",
-                    "input": true,
-                    "tableView": false,
-                    "placeholder": "",
-                    "prefix": "",
-                    "suffix": "",
-                    "multiple": false,
-                    "unique": false,
-                    "hidden": false,
-                    "clearOnHide": true,
-                    "refreshOn": "",
-                    "dataGridLabel": false,
-                    "labelPosition": "top",
-                    "description": "",
-                    "errorLabel": "",
-                    "tooltip": "",
-                    "hideLabel": false,
-                    "tabindex": "",
-                    "disabled": false,
-                    "autofocus": false,
-                    "widget": {
-                        "type": "input"
-                    },
-                    "validateOn": "change",
-                    "validate": {
-                        "required": false,
-                        "custom": "",
-                        "customPrivate": false,
-                        "strictDateValidation": false,
-                        "multiple": false,
-                        "unique": false
-                    },
-                    "conditional": {
-                        "show": null,
-                        "when": null,
-                        "eq": ""
-                    },
-                    "allowCalculateOverride": false,
-                    "showCharCount": false,
-                    "showWordCount": false,
-                    "allowMultipleMasks": false,
-                    "inputType": "hidden",
-                    "id": "erzqc6d"
+                    "id": "elibgq9",
+                    "addons": [],
+                    "lazyLoad": false
                 }
             ],
             "input": false,
@@ -10224,7 +10283,9 @@
             "showWordCount": false,
             "allowMultipleMasks": false,
             "tree": false,
-            "id": "e5im6qg"
+            "id": "e5im6qg",
+            "addons": [],
+            "lazyLoad": false
         },
         {
             "title": "Family information",
@@ -10348,7 +10409,8 @@
                     "showCharCount": false,
                     "showWordCount": false,
                     "allowMultipleMasks": false,
-                    "id": "e1pe2c"
+                    "id": "e1pe2c",
+                    "addons": []
                 },
                 {
                     "label": "HTML",
@@ -10427,11 +10489,14 @@
                     "showCharCount": false,
                     "showWordCount": false,
                     "allowMultipleMasks": false,
-                    "id": "ejh8pr"
+                    "id": "ejh8pr",
+                    "addons": []
                 },
                 {
                     "label": "<strong>On my first day of class, I'll be:</strong>",
                     "labelPosition": "top",
+                    "labelWidth": "",
+                    "labelMargin": "",
                     "optionsLabelPosition": "right",
                     "description": "",
                     "tooltip": "",
@@ -10452,11 +10517,11 @@
                         },
                         {
                             "label": "Separated/divorced/widowed",
-                            "value": "otherSingle",
+                            "value": "other",
                             "shortcut": ""
                         },
                         {
-                            "value": "marriedCommonLaw",
+                            "value": "married",
                             "label": "Married/common-law",
                             "shortcut": ""
                         }
@@ -10484,6 +10549,7 @@
                         "unique": false
                     },
                     "errorLabel": "Relationship Status",
+                    "errors": "",
                     "key": "relationshipStatus",
                     "tags": [],
                     "properties": {},
@@ -10521,9 +10587,10 @@
                     "showCharCount": false,
                     "showWordCount": false,
                     "allowMultipleMasks": false,
+                    "addons": [],
                     "inputType": "radio",
                     "fieldSet": false,
-                    "id": "eoh9dul",
+                    "id": "eolljxr",
                     "defaultValue": ""
                 },
                 {
@@ -10684,7 +10751,8 @@
                             },
                             "customOptions": {},
                             "id": "enmzn3",
-                            "shortcutButtons": []
+                            "shortcutButtons": [],
+                            "addons": []
                         }
                     ],
                     "allowPrevious": false,
@@ -10724,7 +10792,9 @@
                     "showWordCount": false,
                     "allowMultipleMasks": false,
                     "tree": false,
-                    "id": "e7huqp"
+                    "id": "e7huqp",
+                    "addons": [],
+                    "lazyLoad": false
                 },
                 {
                     "label": "<strong>Do you have any dependants?</strong>",
@@ -10816,7 +10886,8 @@
                     "inputType": "radio",
                     "fieldSet": false,
                     "id": "es6wpct",
-                    "defaultValue": ""
+                    "defaultValue": "",
+                    "addons": []
                 },
                 {
                     "title": "Add Dependants Panel",
@@ -10917,7 +10988,8 @@
                             "showCharCount": false,
                             "showWordCount": false,
                             "allowMultipleMasks": false,
-                            "id": "ew64jgs"
+                            "id": "ew64jgs",
+                            "addons": []
                         },
                         {
                             "label": "HTML",
@@ -10996,7 +11068,8 @@
                             "showCharCount": false,
                             "showWordCount": false,
                             "allowMultipleMasks": false,
-                            "id": "e7hw8pg"
+                            "id": "e7hw8pg",
+                            "addons": []
                         },
                         {
                             "label": "<strong>Dependants</strong>",
@@ -11122,14 +11195,18 @@
                                                             "inputFormat": "plain",
                                                             "inputMask": "",
                                                             "spellcheck": true,
-                                                            "id": "ex25e6h"
+                                                            "id": "ex25e6h",
+                                                            "addons": [],
+                                                            "displayMask": "",
+                                                            "truncateMultipleSpaces": false
                                                         }
                                                     ],
                                                     "width": 6,
                                                     "offset": 0,
                                                     "push": 0,
                                                     "pull": 0,
-                                                    "size": "md"
+                                                    "size": "md",
+                                                    "currentWidth": 6
                                                 },
                                                 {
                                                     "components": [
@@ -11247,14 +11324,16 @@
                                                             "datepickerMode": "day",
                                                             "customOptions": {},
                                                             "id": "es6kg2vr",
-                                                            "shortcutButtons": []
+                                                            "shortcutButtons": [],
+                                                            "addons": []
                                                         }
                                                     ],
                                                     "width": 4,
                                                     "offset": 0,
                                                     "push": 0,
                                                     "pull": 0,
-                                                    "size": "md"
+                                                    "size": "md",
+                                                    "currentWidth": 4
                                                 }
                                             ],
                                             "autoAdjust": false,
@@ -11325,7 +11404,9 @@
                                             "showWordCount": false,
                                             "allowMultipleMasks": false,
                                             "tree": false,
-                                            "id": "e8qthqh"
+                                            "id": "e8qthqh",
+                                            "addons": [],
+                                            "lazyLoad": false
                                         },
                                         {
                                             "label": "<strong>Attending post secondary school</strong>",
@@ -11414,7 +11495,8 @@
                                             "inputType": "radio",
                                             "fieldSet": false,
                                             "id": "et9tfpg",
-                                            "defaultValue": ""
+                                            "defaultValue": "",
+                                            "addons": []
                                         },
                                         {
                                             "label": "<strong>Declared on taxes due to a disability</strong>",
@@ -11503,7 +11585,8 @@
                                             "inputType": "radio",
                                             "fieldSet": false,
                                             "id": "eve72ba",
-                                            "defaultValue": ""
+                                            "defaultValue": "",
+                                            "addons": []
                                         },
                                         {
                                             "title": "Upload panel",
@@ -11621,7 +11704,8 @@
                                                     "properties": {},
                                                     "allowMultipleMasks": false,
                                                     "tag": "p",
-                                                    "id": "eqgudcj"
+                                                    "id": "eqgudcj",
+                                                    "addons": []
                                                 },
                                                 {
                                                     "label": "HTML",
@@ -11694,7 +11778,8 @@
                                                     "properties": {},
                                                     "allowMultipleMasks": false,
                                                     "tag": "p",
-                                                    "id": "ertgpw8"
+                                                    "id": "ertgpw8",
+                                                    "addons": []
                                                 },
                                                 {
                                                     "label": " PD dependant upload",
@@ -11776,7 +11861,8 @@
                                                     "imageSize": "200",
                                                     "fileMinSize": "0KB",
                                                     "uploadOnly": false,
-                                                    "id": "euaz6kp"
+                                                    "id": "euaz6kp",
+                                                    "addons": []
                                                 },
                                                 {
                                                     "input": false,
@@ -11852,14 +11938,16 @@
                                                                     "showWordCount": false,
                                                                     "properties": {},
                                                                     "allowMultipleMasks": false,
-                                                                    "id": "e6menor"
+                                                                    "id": "e6menor",
+                                                                    "addons": []
                                                                 }
                                                             ],
                                                             "width": 6,
                                                             "offset": 0,
                                                             "push": 0,
                                                             "pull": 0,
-                                                            "size": "md"
+                                                            "size": "md",
+                                                            "currentWidth": 6
                                                         },
                                                         {
                                                             "components": [
@@ -11928,14 +12016,16 @@
                                                                     "showWordCount": false,
                                                                     "properties": {},
                                                                     "allowMultipleMasks": false,
-                                                                    "id": "enqrbog"
+                                                                    "id": "enqrbog",
+                                                                    "addons": []
                                                                 }
                                                             ],
                                                             "width": 6,
                                                             "offset": 0,
                                                             "push": 0,
                                                             "pull": 0,
-                                                            "size": "md"
+                                                            "size": "md",
+                                                            "currentWidth": 6
                                                         }
                                                     ],
                                                     "placeholder": "",
@@ -11997,7 +12087,9 @@
                                                     "tree": false,
                                                     "autoAdjust": false,
                                                     "hideOnChildrenHidden": false,
-                                                    "id": "egbz7e2"
+                                                    "id": "egbz7e2",
+                                                    "addons": [],
+                                                    "lazyLoad": false
                                                 }
                                             ],
                                             "placeholder": "",
@@ -12036,7 +12128,9 @@
                                             "showWordCount": false,
                                             "allowMultipleMasks": false,
                                             "tree": false,
-                                            "id": "ecnquik"
+                                            "id": "ecnquik",
+                                            "addons": [],
+                                            "lazyLoad": false
                                         },
                                         {
                                             "label": "IsAValidDependant",
@@ -12103,7 +12197,8 @@
                                             "properties": {},
                                             "allowMultipleMasks": false,
                                             "inputType": "hidden",
-                                            "id": "e48zvv3"
+                                            "id": "e48zvv3",
+                                            "addons": []
                                         },
                                         {
                                             "label": "ValidDependent",
@@ -12170,10 +12265,11 @@
                                             "properties": {},
                                             "allowMultipleMasks": false,
                                             "inputType": "hidden",
-                                            "id": "e64vrxl"
+                                            "id": "e64vrxl",
+                                            "addons": []
                                         }
                                     ],
-                                    "id": "ecpkm9j0000000000000000000000000000000000000000000",
+                                    "id": "ecpkm9j0000000000000000000000000000000000000000000000000000000000",
                                     "placeholder": "",
                                     "prefix": "",
                                     "customClass": "",
@@ -12231,7 +12327,9 @@
                                     "properties": {},
                                     "allowMultipleMasks": false,
                                     "tree": false,
-                                    "legend": ""
+                                    "legend": "",
+                                    "addons": [],
+                                    "lazyLoad": false
                                 }
                             ],
                             "placeholder": "",
@@ -12277,7 +12375,9 @@
                             "allowMultipleMasks": false,
                             "tree": true,
                             "disableAddingRemovingRows": false,
-                            "id": "etl1y0a"
+                            "id": "etl1y0a",
+                            "addons": [],
+                            "lazyLoad": false
                         }
                     ],
                     "placeholder": "",
@@ -12333,7 +12433,9 @@
                     "tree": false,
                     "theme": "default",
                     "breadcrumb": "default",
-                    "id": "egyz9uo"
+                    "id": "egyz9uo",
+                    "addons": [],
+                    "lazyLoad": false
                 },
                 {
                     "label": "<strong>Do you have any dependents that you support financially but do not have sole custody of?</strong>",
@@ -12414,7 +12516,8 @@
                     "allowMultipleMasks": false,
                     "inputType": "radio",
                     "fieldSet": false,
-                    "id": "e0fe8eh"
+                    "id": "e0fe8eh",
+                    "addons": []
                 },
                 {
                     "title": "Dependents that you support financially but do not have sole custody",
@@ -12515,7 +12618,8 @@
                             "showCharCount": false,
                             "showWordCount": false,
                             "allowMultipleMasks": false,
-                            "id": "erpezbu"
+                            "id": "erpezbu",
+                            "addons": []
                         },
                         {
                             "label": "HTML",
@@ -12594,7 +12698,8 @@
                             "showCharCount": false,
                             "showWordCount": false,
                             "allowMultipleMasks": false,
-                            "id": "e11wyqh"
+                            "id": "e11wyqh",
+                            "addons": []
                         },
                         {
                             "label": "HTML",
@@ -12673,7 +12778,8 @@
                             "showCharCount": false,
                             "showWordCount": false,
                             "allowMultipleMasks": false,
-                            "id": "ehrudvm"
+                            "id": "ehrudvm",
+                            "addons": []
                         },
                         {
                             "label": "HTML",
@@ -12752,7 +12858,8 @@
                             "showCharCount": false,
                             "showWordCount": false,
                             "allowMultipleMasks": false,
-                            "id": "e5eif08"
+                            "id": "e5eif08",
+                            "addons": []
                         },
                         {
                             "label": "Dependant custody file upload",
@@ -12843,7 +12950,8 @@
                             "privateDownload": false,
                             "id": "ebvl7sr",
                             "options": "",
-                            "fileKey": ""
+                            "fileKey": "",
+                            "addons": []
                         },
                         {
                             "label": "Columns",
@@ -12920,14 +13028,16 @@
                                             "showWordCount": false,
                                             "allowMultipleMasks": false,
                                             "id": "efz51n7m",
-                                            "hideOnChildrenHidden": false
+                                            "hideOnChildrenHidden": false,
+                                            "addons": []
                                         }
                                     ],
                                     "width": 6,
                                     "offset": 0,
                                     "push": 0,
                                     "pull": 0,
-                                    "size": "md"
+                                    "size": "md",
+                                    "currentWidth": 6
                                 },
                                 {
                                     "components": [
@@ -13001,14 +13111,16 @@
                                             "showCharCount": false,
                                             "showWordCount": false,
                                             "allowMultipleMasks": false,
-                                            "id": "etqorpe"
+                                            "id": "etqorpe",
+                                            "addons": []
                                         }
                                     ],
                                     "width": 6,
                                     "offset": 0,
                                     "push": 0,
                                     "pull": 0,
-                                    "size": "md"
+                                    "size": "md",
+                                    "currentWidth": 6
                                 }
                             ],
                             "autoAdjust": false,
@@ -13079,7 +13191,9 @@
                             "showWordCount": false,
                             "allowMultipleMasks": false,
                             "tree": false,
-                            "id": "ealp1ro"
+                            "id": "ealp1ro",
+                            "addons": [],
+                            "lazyLoad": false
                         }
                     ],
                     "placeholder": "",
@@ -13135,7 +13249,82 @@
                     "tree": false,
                     "theme": "default",
                     "breadcrumb": "default",
-                    "id": "eaitjan"
+                    "id": "eaitjan",
+                    "addons": [],
+                    "lazyLoad": false
+                },
+                {
+                    "label": "Dependantstatus",
+                    "labelWidth": "",
+                    "labelMargin": "",
+                    "customClass": "",
+                    "modalEdit": false,
+                    "defaultValue": null,
+                    "persistent": true,
+                    "protected": false,
+                    "dbIndex": false,
+                    "encrypted": false,
+                    "redrawOn": "data",
+                    "customDefaultValue": "",
+                    "calculateValue": "//alert (data.dependantstatus);\nif (data.hasDependents === 'no' && (data.relationshipStatus === 'single' || data.relationshipStatus === 'otherSingle') && data.outOfHighSchoolFor4Years === 'no' && data.howWillYouBeAttendingTheProgram === \"Full Time\") {\n  instance.setValue ('dependant');\n}\nelse {\n  instance.setValue ('independant');\n}",
+                    "calculateServer": true,
+                    "key": "dependantstatus",
+                    "tags": [],
+                    "properties": {},
+                    "logic": [],
+                    "attributes": {},
+                    "overlay": {
+                        "style": "",
+                        "page": "",
+                        "left": "",
+                        "top": "",
+                        "width": "",
+                        "height": ""
+                    },
+                    "type": "hidden",
+                    "input": true,
+                    "tableView": false,
+                    "placeholder": "",
+                    "prefix": "",
+                    "suffix": "",
+                    "multiple": false,
+                    "unique": false,
+                    "hidden": false,
+                    "clearOnHide": true,
+                    "refreshOn": "",
+                    "dataGridLabel": false,
+                    "labelPosition": "top",
+                    "description": "",
+                    "errorLabel": "",
+                    "tooltip": "",
+                    "hideLabel": false,
+                    "tabindex": "",
+                    "disabled": false,
+                    "autofocus": false,
+                    "widget": {
+                        "type": "input"
+                    },
+                    "validateOn": "change",
+                    "validate": {
+                        "required": false,
+                        "custom": "",
+                        "customPrivate": false,
+                        "strictDateValidation": false,
+                        "multiple": false,
+                        "unique": false
+                    },
+                    "conditional": {
+                        "show": null,
+                        "when": null,
+                        "eq": ""
+                    },
+                    "allowCalculateOverride": false,
+                    "showCharCount": false,
+                    "showWordCount": false,
+                    "allowMultipleMasks": false,
+                    "addons": [],
+                    "inputType": "hidden",
+                    "id": "eqcc5ni"
                 }
             ],
             "placeholder": "",
@@ -13174,7 +13363,9 @@
             "showWordCount": false,
             "allowMultipleMasks": false,
             "tree": false,
-            "id": "etsbz9o"
+            "id": "etsbz9o",
+            "addons": [],
+            "lazyLoad": false
         },
         {
             "title": "Partner information",
@@ -27465,6 +27656,76 @@
             "inputType": "hidden",
             "id": "em1y8gd",
             "defaultValue": ""
+        },
+        {
+            "label": "applicationStatus",
+            "customClass": "",
+            "modalEdit": false,
+            "defaultValue": null,
+            "persistent": true,
+            "protected": false,
+            "dbIndex": false,
+            "encrypted": false,
+            "redrawOn": "",
+            "customDefaultValue": "",
+            "calculateValue": "",
+            "calculateServer": false,
+            "key": "applicationStatus",
+            "tags": [],
+            "properties": {},
+            "logic": [],
+            "attributes": {},
+            "overlay": {
+                "style": "",
+                "page": "",
+                "left": "",
+                "top": "",
+                "width": "",
+                "height": ""
+            },
+            "type": "hidden",
+            "input": true,
+            "tableView": false,
+            "placeholder": "",
+            "prefix": "",
+            "suffix": "",
+            "multiple": false,
+            "unique": false,
+            "hidden": false,
+            "clearOnHide": true,
+            "refreshOn": "",
+            "dataGridLabel": false,
+            "labelPosition": "top",
+            "description": "",
+            "errorLabel": "",
+            "tooltip": "",
+            "hideLabel": false,
+            "tabindex": "",
+            "disabled": false,
+            "autofocus": false,
+            "widget": {
+                "type": "input"
+            },
+            "validateOn": "change",
+            "validate": {
+                "required": false,
+                "custom": "",
+                "customPrivate": false,
+                "strictDateValidation": false,
+                "multiple": false,
+                "unique": false
+            },
+            "conditional": {
+                "show": null,
+                "when": null,
+                "eq": ""
+            },
+            "allowCalculateOverride": false,
+            "showCharCount": false,
+            "showWordCount": false,
+            "allowMultipleMasks": false,
+            "inputType": "hidden",
+            "id": "e6z1qd9"
         }
     ],
     "display": "wizard",
@@ -27473,5 +27734,5 @@
     "name": "SFAA2023-24",
     "machineName": "SFAA2023-24",
     "created": "2021-07-12T19:51:16.443Z",
-    "modified": "2022-01-13T22:51:39.299Z"
+    "modified": "2022-02-16T23:04:55.535Z"
 }

--- a/sources/packages/forms/src/form-definitions/sfaa2023-24.json
+++ b/sources/packages/forms/src/form-definitions/sfaa2023-24.json
@@ -10539,7 +10539,7 @@
                     "allowCalculateOverride": false,
                     "validate": {
                         "required": true,
-                        "onlyAvailableItems": false,
+                        "onlyAvailableItems": true,
                         "customMessage": "",
                         "custom": "",
                         "customPrivate": false,
@@ -10590,7 +10590,7 @@
                     "addons": [],
                     "inputType": "radio",
                     "fieldSet": false,
-                    "id": "eolljxr",
+                    "id": "e42reqi",
                     "defaultValue": ""
                 },
                 {
@@ -12269,7 +12269,7 @@
                                             "addons": []
                                         }
                                     ],
-                                    "id": "ecpkm9j0000000000000000000000000000000000000000000000000000000000000000",
+                                    "id": "ecpkm9j0000000000000000000000000000000000000000000000000000000000000000000",
                                     "placeholder": "",
                                     "prefix": "",
                                     "customClass": "",
@@ -13266,7 +13266,7 @@
                     "encrypted": false,
                     "redrawOn": "data",
                     "customDefaultValue": "",
-                    "calculateValue": "//alert (data.dependantstatus);\nif (data.hasDependents === 'no' && (data.relationshipStatus === 'single' || data.relationshipStatus === 'other') && data.outOfHighSchoolFor4Years === 'no' && data.howWillYouBeAttendingTheProgram === \"Full Time\") {\n  instance.setValue ('dependant');\n}\nelse {\n  instance.setValue ('independant');\n}",
+                    "calculateValue": "if (data.hasDependents === 'no' && (data.relationshipStatus === 'single' || data.relationshipStatus === 'other') && data.outOfHighSchoolFor4Years === 'no' && data.howWillYouBeAttendingTheProgram === \"Full Time\") {\n  instance.setValue ('dependant');\n}\nelse {\n  instance.setValue ('independant');\n}",
                     "calculateServer": true,
                     "key": "dependantstatus",
                     "tags": [],
@@ -13324,7 +13324,7 @@
                     "allowMultipleMasks": false,
                     "addons": [],
                     "inputType": "hidden",
-                    "id": "eknombl"
+                    "id": "en998k"
                 }
             ],
             "placeholder": "",
@@ -27717,5 +27717,5 @@
     "name": "SFAA2023-24",
     "machineName": "SFAA2023-24",
     "created": "2021-07-12T19:51:16.443Z",
-    "modified": "2022-02-16T23:19:03.226Z"
+    "modified": "2022-02-17T17:05:59.060Z"
 }

--- a/sources/packages/forms/src/form-definitions/sfaa2023-24.json
+++ b/sources/packages/forms/src/form-definitions/sfaa2023-24.json
@@ -10595,15 +10595,9 @@
                 },
                 {
                     "title": "Married/common law Panel",
+                    "labelWidth": "",
+                    "labelMargin": "",
                     "theme": "default",
-                    "breadcrumb": "default",
-                    "breadcrumbClickable": false,
-                    "buttonSettings": {
-                        "previous": false,
-                        "cancel": false,
-                        "next": false
-                    },
-                    "scrollToTop": false,
                     "tooltip": "",
                     "customClass": "",
                     "collapsible": false,
@@ -10611,7 +10605,7 @@
                     "hideLabel": true,
                     "disabled": false,
                     "modalEdit": false,
-                    "key": "marriedCommonLawPanel",
+                    "key": "marriedPanel",
                     "tags": [],
                     "properties": {},
                     "customConditional": "",
@@ -10619,9 +10613,8 @@
                         "json": "",
                         "show": true,
                         "when": "relationshipStatus",
-                        "eq": "marriedCommonLaw"
+                        "eq": "married"
                     },
-                    "nextPage": "",
                     "logic": [],
                     "attributes": {},
                     "overlay": {
@@ -10634,7 +10627,15 @@
                     },
                     "type": "panel",
                     "label": "Married/Common law Panel",
+                    "breadcrumb": "default",
+                    "buttonSettings": {
+                        "previous": false,
+                        "cancel": false,
+                        "next": false
+                    },
                     "tabindex": "",
+                    "breadcrumbClickable": false,
+                    "scrollToTop": false,
                     "input": false,
                     "tableView": false,
                     "components": [
@@ -10671,7 +10672,7 @@
                             "conditional": {
                                 "show": true,
                                 "when": "relationshipStatus",
-                                "eq": "marriedCommonLaw"
+                                "eq": "married"
                             },
                             "type": "datetime",
                             "input": true,
@@ -10734,6 +10735,7 @@
                             "showWordCount": false,
                             "properties": {},
                             "allowMultipleMasks": false,
+                            "addons": [],
                             "useLocaleSettings": false,
                             "allowInput": true,
                             "enableDate": true,
@@ -10750,9 +10752,7 @@
                                 "arrowkeys": true
                             },
                             "customOptions": {},
-                            "id": "enmzn3",
-                            "shortcutButtons": [],
-                            "addons": []
+                            "id": "ezu7c9n"
                         }
                     ],
                     "allowPrevious": false,
@@ -10791,10 +10791,10 @@
                     "showCharCount": false,
                     "showWordCount": false,
                     "allowMultipleMasks": false,
-                    "tree": false,
-                    "id": "e7huqp",
                     "addons": [],
-                    "lazyLoad": false
+                    "tree": false,
+                    "lazyLoad": false,
+                    "id": "ewbw0si"
                 },
                 {
                     "label": "<strong>Do you have any dependants?</strong>",
@@ -12269,7 +12269,7 @@
                                             "addons": []
                                         }
                                     ],
-                                    "id": "ecpkm9j0000000000000000000000000000000000000000000000000000000000",
+                                    "id": "ecpkm9j0000000000000000000000000000000000000000000000000000000000000000",
                                     "placeholder": "",
                                     "prefix": "",
                                     "customClass": "",
@@ -13266,7 +13266,7 @@
                     "encrypted": false,
                     "redrawOn": "data",
                     "customDefaultValue": "",
-                    "calculateValue": "//alert (data.dependantstatus);\nif (data.hasDependents === 'no' && (data.relationshipStatus === 'single' || data.relationshipStatus === 'otherSingle') && data.outOfHighSchoolFor4Years === 'no' && data.howWillYouBeAttendingTheProgram === \"Full Time\") {\n  instance.setValue ('dependant');\n}\nelse {\n  instance.setValue ('independant');\n}",
+                    "calculateValue": "//alert (data.dependantstatus);\nif (data.hasDependents === 'no' && (data.relationshipStatus === 'single' || data.relationshipStatus === 'other') && data.outOfHighSchoolFor4Years === 'no' && data.howWillYouBeAttendingTheProgram === \"Full Time\") {\n  instance.setValue ('dependant');\n}\nelse {\n  instance.setValue ('independant');\n}",
                     "calculateServer": true,
                     "key": "dependantstatus",
                     "tags": [],
@@ -13324,7 +13324,7 @@
                     "allowMultipleMasks": false,
                     "addons": [],
                     "inputType": "hidden",
-                    "id": "eqcc5ni"
+                    "id": "eknombl"
                 }
             ],
             "placeholder": "",
@@ -13369,15 +13369,9 @@
         },
         {
             "title": "Partner information",
+            "labelWidth": "",
+            "labelMargin": "",
             "theme": "default",
-            "breadcrumb": "default",
-            "breadcrumbClickable": true,
-            "buttonSettings": {
-                "previous": false,
-                "cancel": false,
-                "next": false
-            },
-            "scrollToTop": true,
             "tooltip": "",
             "customClass": "",
             "collapsible": false,
@@ -13393,9 +13387,8 @@
                 "json": "",
                 "show": true,
                 "when": "relationshipStatus",
-                "eq": "marriedCommonLaw"
+                "eq": "married"
             },
-            "nextPage": "",
             "logic": [],
             "attributes": {},
             "overlay": {
@@ -13408,14 +13401,20 @@
             },
             "type": "panel",
             "label": "Partner Information",
+            "breadcrumb": "default",
+            "buttonSettings": {
+                "previous": false,
+                "cancel": false,
+                "next": false
+            },
             "tabindex": "",
+            "breadcrumbClickable": true,
+            "scrollToTop": true,
             "input": false,
             "tableView": false,
             "components": [
                 {
                     "label": "HTML",
-                    "tag": "p",
-                    "className": "",
                     "attrs": [
                         {
                             "attr": "",
@@ -13425,30 +13424,10 @@
                     "content": "Partner information",
                     "refreshOnChange": false,
                     "customClass": "header-lg",
-                    "hidden": false,
-                    "modalEdit": false,
                     "key": "html65",
-                    "tags": [],
-                    "properties": {},
-                    "conditional": {
-                        "show": null,
-                        "when": null,
-                        "eq": "",
-                        "json": ""
-                    },
-                    "customConditional": "",
-                    "logic": [],
-                    "attributes": {},
-                    "overlay": {
-                        "style": "",
-                        "page": "",
-                        "left": "",
-                        "top": "",
-                        "width": "",
-                        "height": ""
-                    },
                     "type": "htmlelement",
                     "input": false,
+                    "tableView": false,
                     "placeholder": "",
                     "prefix": "",
                     "suffix": "",
@@ -13457,10 +13436,11 @@
                     "protected": false,
                     "unique": false,
                     "persistent": false,
+                    "hidden": false,
                     "clearOnHide": true,
                     "refreshOn": "",
                     "redrawOn": "",
-                    "tableView": false,
+                    "modalEdit": false,
                     "dataGridLabel": false,
                     "labelPosition": "top",
                     "description": "",
@@ -13475,6 +13455,7 @@
                     "calculateValue": "",
                     "calculateServer": false,
                     "widget": null,
+                    "attributes": {},
                     "validateOn": "change",
                     "validate": {
                         "required": false,
@@ -13484,17 +13465,30 @@
                         "multiple": false,
                         "unique": false
                     },
+                    "conditional": {
+                        "show": null,
+                        "when": null,
+                        "eq": ""
+                    },
+                    "overlay": {
+                        "style": "",
+                        "left": "",
+                        "top": "",
+                        "width": "",
+                        "height": ""
+                    },
                     "allowCalculateOverride": false,
                     "encrypted": false,
                     "showCharCount": false,
                     "showWordCount": false,
+                    "properties": {},
                     "allowMultipleMasks": false,
-                    "id": "ezo3nq8"
+                    "addons": [],
+                    "tag": "p",
+                    "id": "e7g4j5"
                 },
                 {
                     "label": "HTML",
-                    "tag": "p",
-                    "className": "",
                     "attrs": [
                         {
                             "attr": "",
@@ -13503,43 +13497,24 @@
                     ],
                     "content": "Help text about this section will be displayed here",
                     "refreshOnChange": false,
-                    "customClass": "",
-                    "hidden": false,
-                    "modalEdit": false,
                     "key": "html66",
-                    "tags": [],
-                    "properties": {},
-                    "conditional": {
-                        "show": null,
-                        "when": null,
-                        "eq": "",
-                        "json": ""
-                    },
-                    "customConditional": "",
-                    "logic": [],
-                    "attributes": {},
-                    "overlay": {
-                        "style": "",
-                        "page": "",
-                        "left": "",
-                        "top": "",
-                        "width": "",
-                        "height": ""
-                    },
                     "type": "htmlelement",
                     "input": false,
+                    "tableView": false,
                     "placeholder": "",
                     "prefix": "",
+                    "customClass": "",
                     "suffix": "",
                     "multiple": false,
                     "defaultValue": null,
                     "protected": false,
                     "unique": false,
                     "persistent": false,
+                    "hidden": false,
                     "clearOnHide": true,
                     "refreshOn": "",
                     "redrawOn": "",
-                    "tableView": false,
+                    "modalEdit": false,
                     "dataGridLabel": false,
                     "labelPosition": "top",
                     "description": "",
@@ -13554,6 +13529,7 @@
                     "calculateValue": "",
                     "calculateServer": false,
                     "widget": null,
+                    "attributes": {},
                     "validateOn": "change",
                     "validate": {
                         "required": false,
@@ -13563,28 +13539,33 @@
                         "multiple": false,
                         "unique": false
                     },
+                    "conditional": {
+                        "show": null,
+                        "when": null,
+                        "eq": ""
+                    },
+                    "overlay": {
+                        "style": "",
+                        "left": "",
+                        "top": "",
+                        "width": "",
+                        "height": ""
+                    },
                     "allowCalculateOverride": false,
                     "encrypted": false,
                     "showCharCount": false,
                     "showWordCount": false,
+                    "properties": {},
                     "allowMultipleMasks": false,
-                    "id": "ew7qj9"
+                    "addons": [],
+                    "tag": "p",
+                    "id": "e68yx8d"
                 },
                 {
                     "label": "<strong>Does your partner have a valid Social Insurance Number?</strong>",
-                    "labelPosition": "top",
                     "optionsLabelPosition": "right",
-                    "description": "",
-                    "tooltip": "",
-                    "customClass": "",
-                    "tabindex": "",
                     "inline": false,
-                    "hidden": false,
-                    "hideLabel": false,
-                    "autofocus": false,
-                    "disabled": false,
                     "tableView": false,
-                    "modalEdit": false,
                     "values": [
                         {
                             "label": "Yes",
@@ -13597,71 +13578,73 @@
                             "shortcut": ""
                         }
                     ],
-                    "dataType": "",
-                    "persistent": true,
+                    "validate": {
+                        "required": true,
+                        "custom": "",
+                        "customPrivate": false,
+                        "strictDateValidation": false,
+                        "multiple": false,
+                        "unique": false,
+                        "onlyAvailableItems": false
+                    },
+                    "key": "isYourSpouseACanadianCitizen",
+                    "type": "radio",
+                    "input": true,
+                    "placeholder": "",
+                    "prefix": "",
+                    "customClass": "",
+                    "suffix": "",
+                    "multiple": false,
+                    "defaultValue": null,
                     "protected": false,
-                    "dbIndex": false,
-                    "encrypted": false,
-                    "redrawOn": "",
+                    "unique": false,
+                    "persistent": true,
+                    "hidden": false,
                     "clearOnHide": true,
+                    "refreshOn": "",
+                    "redrawOn": "",
+                    "modalEdit": false,
+                    "dataGridLabel": false,
+                    "labelPosition": "top",
+                    "description": "",
+                    "errorLabel": "",
+                    "tooltip": "",
+                    "hideLabel": false,
+                    "tabindex": "",
+                    "disabled": false,
+                    "autofocus": false,
+                    "dbIndex": false,
                     "customDefaultValue": "",
                     "calculateValue": "",
                     "calculateServer": false,
-                    "allowCalculateOverride": false,
-                    "validate": {
-                        "required": true,
-                        "onlyAvailableItems": false,
-                        "customMessage": "",
-                        "custom": "",
-                        "customPrivate": false,
-                        "json": "",
-                        "strictDateValidation": false,
-                        "multiple": false,
-                        "unique": false
-                    },
-                    "errorLabel": "",
-                    "key": "isYourSpouseACanadianCitizen",
-                    "tags": [],
-                    "properties": {},
+                    "widget": null,
+                    "attributes": {},
+                    "validateOn": "change",
                     "conditional": {
                         "show": null,
                         "when": null,
-                        "eq": "",
-                        "json": ""
+                        "eq": ""
                     },
-                    "customConditional": "",
-                    "logic": [],
-                    "attributes": {},
                     "overlay": {
                         "style": "",
-                        "page": "",
                         "left": "",
                         "top": "",
                         "width": "",
                         "height": ""
                     },
-                    "type": "radio",
-                    "input": true,
-                    "placeholder": "",
-                    "prefix": "",
-                    "suffix": "",
-                    "multiple": false,
-                    "unique": false,
-                    "refreshOn": "",
-                    "dataGridLabel": false,
-                    "widget": null,
-                    "validateOn": "change",
+                    "allowCalculateOverride": false,
+                    "encrypted": false,
                     "showCharCount": false,
                     "showWordCount": false,
+                    "properties": {},
                     "allowMultipleMasks": false,
+                    "addons": [],
                     "inputType": "radio",
                     "fieldSet": false,
-                    "id": "eolgirh",
-                    "defaultValue": ""
+                    "id": "ef5lhtg"
                 },
                 {
                     "label": "Additional information required",
-                    "tag": "p",
                     "className": "alert alert-info  fa fa-info-circle",
                     "attrs": [
                         {
@@ -13672,27 +13655,11 @@
                     "content": "<Strong> Please be advised your partner will need to sign in to StudentAid BC and provide additional information.</Strong><br/> \r\nPlease check your email after submitting your application. An email will be sent to you with instructions for your partner to sign in. Your application cannot proceed until this information is received.\r\n<br />",
                     "refreshOnChange": false,
                     "customClass": "banner-info",
-                    "hidden": false,
-                    "modalEdit": false,
                     "key": "additionalInformationRequired",
-                    "tags": [],
-                    "properties": {},
                     "conditional": {
                         "show": true,
                         "when": "isYourSpouseACanadianCitizen",
-                        "eq": "yes",
-                        "json": ""
-                    },
-                    "customConditional": "",
-                    "logic": [],
-                    "attributes": {},
-                    "overlay": {
-                        "style": "",
-                        "page": "",
-                        "left": "",
-                        "top": "",
-                        "width": "",
-                        "height": ""
+                        "eq": "yes"
                     },
                     "type": "htmlelement",
                     "input": false,
@@ -13705,9 +13672,11 @@
                     "protected": false,
                     "unique": false,
                     "persistent": false,
+                    "hidden": false,
                     "clearOnHide": true,
                     "refreshOn": "",
                     "redrawOn": "",
+                    "modalEdit": false,
                     "dataGridLabel": false,
                     "labelPosition": "top",
                     "description": "",
@@ -13722,6 +13691,7 @@
                     "calculateValue": "",
                     "calculateServer": false,
                     "widget": null,
+                    "attributes": {},
                     "validateOn": "change",
                     "validate": {
                         "required": false,
@@ -13731,16 +13701,25 @@
                         "multiple": false,
                         "unique": false
                     },
+                    "overlay": {
+                        "style": "",
+                        "left": "",
+                        "top": "",
+                        "width": "",
+                        "height": ""
+                    },
                     "allowCalculateOverride": false,
                     "encrypted": false,
                     "showCharCount": false,
                     "showWordCount": false,
+                    "properties": {},
                     "allowMultipleMasks": false,
-                    "id": "eqyaa8b"
+                    "addons": [],
+                    "tag": "p",
+                    "id": "ebrp57"
                 },
                 {
                     "label": "Spouse Estimation",
-                    "tag": "p",
                     "className": "alert alert-warning fa fa-exclamation-circle",
                     "attrs": [
                         {
@@ -13751,27 +13730,11 @@
                     "content": "<strong> Please be advised this could delay your application</strong> \n<br />\nSince we’re unable to validate your partner’s information with Canada Revenue Agency (CRA), please estimate your partner’s income.",
                     "refreshOnChange": false,
                     "customClass": "banner-warning",
-                    "hidden": false,
-                    "modalEdit": false,
                     "key": "spouseEstimation",
-                    "tags": [],
-                    "properties": {},
                     "conditional": {
                         "show": true,
                         "when": "isYourSpouseACanadianCitizen",
-                        "eq": "no",
-                        "json": ""
-                    },
-                    "customConditional": "",
-                    "logic": [],
-                    "attributes": {},
-                    "overlay": {
-                        "style": "",
-                        "page": "",
-                        "left": "",
-                        "top": "",
-                        "width": "",
-                        "height": ""
+                        "eq": "no"
                     },
                     "type": "htmlelement",
                     "input": false,
@@ -13784,9 +13747,11 @@
                     "protected": false,
                     "unique": false,
                     "persistent": false,
+                    "hidden": false,
                     "clearOnHide": true,
                     "refreshOn": "",
                     "redrawOn": "",
+                    "modalEdit": false,
                     "dataGridLabel": false,
                     "labelPosition": "top",
                     "description": "",
@@ -13801,6 +13766,7 @@
                     "calculateValue": "",
                     "calculateServer": false,
                     "widget": null,
+                    "attributes": {},
                     "validateOn": "change",
                     "validate": {
                         "required": false,
@@ -13810,12 +13776,22 @@
                         "multiple": false,
                         "unique": false
                     },
+                    "overlay": {
+                        "style": "",
+                        "left": "",
+                        "top": "",
+                        "width": "",
+                        "height": ""
+                    },
                     "allowCalculateOverride": false,
                     "encrypted": false,
                     "showCharCount": false,
                     "showWordCount": false,
+                    "properties": {},
                     "allowMultipleMasks": false,
-                    "id": "eow2c2c"
+                    "addons": [],
+                    "tag": "p",
+                    "id": "eay47qm"
                 },
                 {
                     "title": "Partner Income Panel",
@@ -13840,8 +13816,6 @@
                     "components": [
                         {
                             "label": "HTML",
-                            "tag": "p",
-                            "className": "",
                             "attrs": [
                                 {
                                     "attr": "",
@@ -13851,30 +13825,10 @@
                             "content": "Partner income",
                             "refreshOnChange": false,
                             "customClass": "header-md",
-                            "hidden": false,
-                            "modalEdit": false,
                             "key": "html67",
-                            "tags": [],
-                            "properties": {},
-                            "conditional": {
-                                "show": null,
-                                "when": null,
-                                "eq": "",
-                                "json": ""
-                            },
-                            "customConditional": "",
-                            "logic": [],
-                            "attributes": {},
-                            "overlay": {
-                                "style": "",
-                                "page": "",
-                                "left": "",
-                                "top": "",
-                                "width": "",
-                                "height": ""
-                            },
                             "type": "htmlelement",
                             "input": false,
+                            "tableView": false,
                             "placeholder": "",
                             "prefix": "",
                             "suffix": "",
@@ -13883,10 +13837,11 @@
                             "protected": false,
                             "unique": false,
                             "persistent": false,
+                            "hidden": false,
                             "clearOnHide": true,
                             "refreshOn": "",
                             "redrawOn": "",
-                            "tableView": false,
+                            "modalEdit": false,
                             "dataGridLabel": false,
                             "labelPosition": "top",
                             "description": "",
@@ -13901,6 +13856,7 @@
                             "calculateValue": "",
                             "calculateServer": false,
                             "widget": null,
+                            "attributes": {},
                             "validateOn": "change",
                             "validate": {
                                 "required": false,
@@ -13910,17 +13866,30 @@
                                 "multiple": false,
                                 "unique": false
                             },
+                            "conditional": {
+                                "show": null,
+                                "when": null,
+                                "eq": ""
+                            },
+                            "overlay": {
+                                "style": "",
+                                "left": "",
+                                "top": "",
+                                "width": "",
+                                "height": ""
+                            },
                             "allowCalculateOverride": false,
                             "encrypted": false,
                             "showCharCount": false,
                             "showWordCount": false,
+                            "properties": {},
                             "allowMultipleMasks": false,
-                            "id": "e3pwpa9"
+                            "addons": [],
+                            "tag": "p",
+                            "id": "exhpges"
                         },
                         {
                             "label": "HTML",
-                            "tag": "p",
-                            "className": "",
                             "attrs": [
                                 {
                                     "attr": "",
@@ -13929,43 +13898,24 @@
                             ],
                             "content": "Help text about this section will be displayed here",
                             "refreshOnChange": false,
-                            "customClass": "",
-                            "hidden": false,
-                            "modalEdit": false,
                             "key": "html68",
-                            "tags": [],
-                            "properties": {},
-                            "conditional": {
-                                "show": null,
-                                "when": null,
-                                "eq": "",
-                                "json": ""
-                            },
-                            "customConditional": "",
-                            "logic": [],
-                            "attributes": {},
-                            "overlay": {
-                                "style": "",
-                                "page": "",
-                                "left": "",
-                                "top": "",
-                                "width": "",
-                                "height": ""
-                            },
                             "type": "htmlelement",
                             "input": false,
+                            "tableView": false,
                             "placeholder": "",
                             "prefix": "",
+                            "customClass": "",
                             "suffix": "",
                             "multiple": false,
                             "defaultValue": null,
                             "protected": false,
                             "unique": false,
                             "persistent": false,
+                            "hidden": false,
                             "clearOnHide": true,
                             "refreshOn": "",
                             "redrawOn": "",
-                            "tableView": false,
+                            "modalEdit": false,
                             "dataGridLabel": false,
                             "labelPosition": "top",
                             "description": "",
@@ -13980,6 +13930,7 @@
                             "calculateValue": "",
                             "calculateServer": false,
                             "widget": null,
+                            "attributes": {},
                             "validateOn": "change",
                             "validate": {
                                 "required": false,
@@ -13989,12 +13940,27 @@
                                 "multiple": false,
                                 "unique": false
                             },
+                            "conditional": {
+                                "show": null,
+                                "when": null,
+                                "eq": ""
+                            },
+                            "overlay": {
+                                "style": "",
+                                "left": "",
+                                "top": "",
+                                "width": "",
+                                "height": ""
+                            },
                             "allowCalculateOverride": false,
                             "encrypted": false,
                             "showCharCount": false,
                             "showWordCount": false,
+                            "properties": {},
                             "allowMultipleMasks": false,
-                            "id": "eedvdyj"
+                            "addons": [],
+                            "tag": "p",
+                            "id": "evpffp"
                         },
                         {
                             "label": "What was your partner’s income (as shown on line 15000 of previous year’s Canada Revenue Agency tax return)? If they didn’t file taxes, enter total income from all sources in and outside of Canada.",
@@ -14069,7 +14035,8 @@
                             "showWordCount": false,
                             "properties": {},
                             "allowMultipleMasks": false,
-                            "id": "e9mqj6h"
+                            "addons": [],
+                            "id": "eakjnu"
                         },
                         {
                             "label": "<strong>Will your partner be employed full-time or part-time during your study period</strong>",
@@ -14090,12 +14057,12 @@
                             ],
                             "validate": {
                                 "required": true,
-                                "onlyAvailableItems": false,
                                 "custom": "",
                                 "customPrivate": false,
                                 "strictDateValidation": false,
                                 "multiple": false,
-                                "unique": false
+                                "unique": false,
+                                "onlyAvailableItems": false
                             },
                             "key": "partnerEmployed",
                             "type": "radio",
@@ -14148,9 +14115,10 @@
                             "showWordCount": false,
                             "properties": {},
                             "allowMultipleMasks": false,
+                            "addons": [],
                             "inputType": "radio",
                             "fieldSet": false,
-                            "id": "erofrhb"
+                            "id": "enf43pg"
                         },
                         {
                             "label": "<strong>Will  your partner be at home caring for eligible dependent children on a full-time basis during the your entire study period? </strong>",
@@ -14171,12 +14139,12 @@
                             ],
                             "validate": {
                                 "required": true,
-                                "onlyAvailableItems": false,
                                 "custom": "",
                                 "customPrivate": false,
                                 "strictDateValidation": false,
                                 "multiple": false,
-                                "unique": false
+                                "unique": false,
+                                "onlyAvailableItems": false
                             },
                             "key": "partnercaringforeligibleDependent",
                             "type": "radio",
@@ -14229,9 +14197,10 @@
                             "showWordCount": false,
                             "properties": {},
                             "allowMultipleMasks": false,
+                            "addons": [],
                             "inputType": "radio",
                             "fieldSet": false,
-                            "id": "e1z6lyb"
+                            "id": "efeg6kc"
                         },
                         {
                             "label": "<strong>Will your partner be living with you during the your study period?</strong>",
@@ -14252,12 +14221,12 @@
                             ],
                             "validate": {
                                 "required": true,
-                                "onlyAvailableItems": false,
                                 "custom": "",
                                 "customPrivate": false,
                                 "strictDateValidation": false,
                                 "multiple": false,
-                                "unique": false
+                                "unique": false,
+                                "onlyAvailableItems": false
                             },
                             "key": "partnerlivingwithYou",
                             "type": "radio",
@@ -14310,9 +14279,10 @@
                             "showWordCount": false,
                             "properties": {},
                             "allowMultipleMasks": false,
+                            "addons": [],
                             "inputType": "radio",
                             "fieldSet": false,
-                            "id": "ehnyp6c"
+                            "id": "e6f8sq"
                         },
                         {
                             "label": "<strong>Will your partner be a full-time post-secondary student for some or all of your study period?</strong>",
@@ -14333,12 +14303,12 @@
                             ],
                             "validate": {
                                 "required": true,
-                                "onlyAvailableItems": false,
                                 "custom": "",
                                 "customPrivate": false,
                                 "strictDateValidation": false,
                                 "multiple": false,
-                                "unique": false
+                                "unique": false,
+                                "onlyAvailableItems": false
                             },
                             "key": "partnerfulltimeStudent",
                             "type": "radio",
@@ -14391,9 +14361,10 @@
                             "showWordCount": false,
                             "properties": {},
                             "allowMultipleMasks": false,
+                            "addons": [],
                             "inputType": "radio",
                             "fieldSet": false,
-                            "id": "e4neun"
+                            "id": "eeeyy3l"
                         },
                         {
                             "title": "If your partner will be a full-time student, how many weeks of your study period will they also be in studies Panel",
@@ -14418,86 +14389,79 @@
                             "components": [
                                 {
                                     "label": "<strong>If your partner will be a full-time student, how many weeks of your study period will they also be in studies?</strong>",
-                                    "labelPosition": "top",
-                                    "placeholder": "",
-                                    "description": "",
-                                    "tooltip": "",
                                     "prefix": "Number of Weeks",
-                                    "suffix": "",
-                                    "widget": {
-                                        "type": "input"
-                                    },
-                                    "customClass": "",
-                                    "tabindex": "",
-                                    "autocomplete": "",
-                                    "hidden": false,
-                                    "hideLabel": false,
                                     "mask": false,
-                                    "autofocus": false,
                                     "spellcheck": true,
-                                    "disabled": false,
                                     "tableView": false,
-                                    "modalEdit": false,
-                                    "multiple": false,
-                                    "persistent": true,
                                     "delimiter": false,
                                     "requireDecimal": false,
                                     "inputFormat": "plain",
-                                    "protected": false,
-                                    "dbIndex": false,
-                                    "encrypted": false,
-                                    "redrawOn": "",
-                                    "clearOnHide": true,
-                                    "customDefaultValue": "",
-                                    "calculateValue": "",
-                                    "calculateServer": false,
-                                    "allowCalculateOverride": false,
-                                    "validateOn": "change",
                                     "validate": {
                                         "required": true,
-                                        "customMessage": "",
                                         "custom": "const studyStartTime = new Date(data.studystartDate).getTime();\r\nconst studyEndTime= new Date(row.studyendDate).getTime();\r\nconst difference = (studyEndTime - studyStartTime);\r\nconst studyWeek = difference/(1000 * 60 * 60 * 24 * 7);\r\n// valid = parseInt(week);\r\n// vaild = (data.ifYourPartnerWillBeAFullTimeStudentHowManyWeeksOfYourStudyPeriodWillTheyAlsoBeInStudies <= studyWeek) ? true : \"Must be Equal to or less than Student Applicants study period\";\r\nvaildweek = (data.ifYourPartnerWillBeAFullTimeStudentHowManyWeeksOfYourStudyPeriodWillTheyAlsoBeInStudies <= studyWeek);\r\nvalid = vaildweek ? true : 'Must be Equal to or less than Student Applicants study period';\r\n",
                                         "customPrivate": false,
-                                        "json": "",
-                                        "min": "",
-                                        "max": "",
                                         "strictDateValidation": false,
                                         "multiple": false,
                                         "unique": false,
+                                        "min": "",
+                                        "max": "",
                                         "step": "any",
                                         "integer": ""
                                     },
-                                    "errorLabel": "",
                                     "key": "ifYourPartnerWillBeAFullTimeStudentHowManyWeeksOfYourStudyPeriodWillTheyAlsoBeInStudies",
-                                    "tags": [],
-                                    "properties": {},
                                     "conditional": {
                                         "show": true,
                                         "when": "partnerfulltimeStudent",
-                                        "eq": "yes",
-                                        "json": ""
+                                        "eq": "yes"
                                     },
-                                    "customConditional": "",
-                                    "logic": [],
+                                    "type": "number",
+                                    "input": true,
+                                    "placeholder": "",
+                                    "customClass": "",
+                                    "suffix": "",
+                                    "multiple": false,
+                                    "defaultValue": null,
+                                    "protected": false,
+                                    "unique": false,
+                                    "persistent": true,
+                                    "hidden": false,
+                                    "clearOnHide": true,
+                                    "refreshOn": "",
+                                    "redrawOn": "",
+                                    "modalEdit": false,
+                                    "dataGridLabel": false,
+                                    "labelPosition": "top",
+                                    "description": "",
+                                    "errorLabel": "",
+                                    "tooltip": "",
+                                    "hideLabel": false,
+                                    "tabindex": "",
+                                    "disabled": false,
+                                    "autofocus": false,
+                                    "dbIndex": false,
+                                    "customDefaultValue": "",
+                                    "calculateValue": "",
+                                    "calculateServer": false,
+                                    "widget": {
+                                        "type": "input"
+                                    },
                                     "attributes": {},
+                                    "validateOn": "change",
                                     "overlay": {
                                         "style": "",
-                                        "page": "",
                                         "left": "",
                                         "top": "",
                                         "width": "",
                                         "height": ""
                                     },
-                                    "type": "number",
-                                    "input": true,
-                                    "unique": false,
-                                    "refreshOn": "",
-                                    "dataGridLabel": false,
+                                    "allowCalculateOverride": false,
+                                    "encrypted": false,
                                     "showCharCount": false,
                                     "showWordCount": false,
+                                    "properties": {},
                                     "allowMultipleMasks": false,
-                                    "id": "epdswoon",
-                                    "defaultValue": null
+                                    "addons": [],
+                                    "id": "epd2l8"
                                 }
                             ],
                             "allowPrevious": false,
@@ -14551,26 +14515,18 @@
                             "showWordCount": false,
                             "properties": {},
                             "allowMultipleMasks": false,
+                            "addons": [],
                             "tree": false,
+                            "lazyLoad": false,
                             "theme": "default",
                             "breadcrumb": "default",
-                            "id": "ep5lg4"
+                            "id": "erpsflp"
                         },
                         {
                             "label": "<strong>Will your partner recieve income assistance/social assistance (welfare) and/or BC income assistance for persons with disabilities during the your study period?</strong>",
-                            "labelPosition": "top",
                             "optionsLabelPosition": "right",
-                            "description": "",
-                            "tooltip": "",
-                            "customClass": "",
-                            "tabindex": "",
                             "inline": false,
-                            "hidden": false,
-                            "hideLabel": false,
-                            "autofocus": false,
-                            "disabled": false,
                             "tableView": false,
-                            "modalEdit": false,
                             "values": [
                                 {
                                     "label": "Yes",
@@ -14583,67 +14539,70 @@
                                     "shortcut": ""
                                 }
                             ],
-                            "dataType": "",
-                            "persistent": true,
+                            "validate": {
+                                "required": true,
+                                "custom": "",
+                                "customPrivate": false,
+                                "strictDateValidation": false,
+                                "multiple": false,
+                                "unique": false,
+                                "onlyAvailableItems": false
+                            },
+                            "key": "partnerrecieveIncomeAssistance",
+                            "type": "radio",
+                            "input": true,
+                            "placeholder": "",
+                            "prefix": "",
+                            "customClass": "",
+                            "suffix": "",
+                            "multiple": false,
+                            "defaultValue": null,
                             "protected": false,
-                            "dbIndex": false,
-                            "encrypted": false,
-                            "redrawOn": "",
+                            "unique": false,
+                            "persistent": true,
+                            "hidden": false,
                             "clearOnHide": true,
+                            "refreshOn": "",
+                            "redrawOn": "",
+                            "modalEdit": false,
+                            "dataGridLabel": false,
+                            "labelPosition": "top",
+                            "description": "",
+                            "errorLabel": "",
+                            "tooltip": "",
+                            "hideLabel": false,
+                            "tabindex": "",
+                            "disabled": false,
+                            "autofocus": false,
+                            "dbIndex": false,
                             "customDefaultValue": "",
                             "calculateValue": "",
                             "calculateServer": false,
-                            "allowCalculateOverride": false,
-                            "validate": {
-                                "required": true,
-                                "onlyAvailableItems": false,
-                                "customMessage": "",
-                                "custom": "",
-                                "customPrivate": false,
-                                "json": "",
-                                "strictDateValidation": false,
-                                "multiple": false,
-                                "unique": false
-                            },
-                            "errorLabel": "",
-                            "key": "partnerrecieveIncomeAssistance",
-                            "tags": [],
-                            "properties": {},
+                            "widget": null,
+                            "attributes": {},
+                            "validateOn": "change",
                             "conditional": {
                                 "show": null,
                                 "when": null,
-                                "eq": "",
-                                "json": ""
+                                "eq": ""
                             },
-                            "customConditional": "",
-                            "logic": [],
-                            "attributes": {},
                             "overlay": {
                                 "style": "",
-                                "page": "",
                                 "left": "",
                                 "top": "",
                                 "width": "",
                                 "height": ""
                             },
-                            "type": "radio",
-                            "input": true,
-                            "placeholder": "",
-                            "prefix": "",
-                            "suffix": "",
-                            "multiple": false,
-                            "unique": false,
-                            "refreshOn": "",
-                            "dataGridLabel": false,
-                            "widget": null,
-                            "validateOn": "change",
+                            "allowCalculateOverride": false,
+                            "encrypted": false,
                             "showCharCount": false,
                             "showWordCount": false,
+                            "properties": {},
                             "allowMultipleMasks": false,
+                            "addons": [],
                             "inputType": "radio",
                             "fieldSet": false,
-                            "id": "ealunos",
-                            "defaultValue": ""
+                            "id": "erbduch"
                         },
                         {
                             "title": "Provide the total income assistance/social assistance (welfare) and/or BC income assistance for persons with disabilities that your partner will be receiving during your study period Panel",
@@ -14739,7 +14698,8 @@
                                     "showWordCount": false,
                                     "properties": {},
                                     "allowMultipleMasks": false,
-                                    "id": "e9k0k58"
+                                    "addons": [],
+                                    "id": "ec9ggzb"
                                 }
                             ],
                             "allowPrevious": false,
@@ -14793,10 +14753,12 @@
                             "showWordCount": false,
                             "properties": {},
                             "allowMultipleMasks": false,
+                            "addons": [],
                             "tree": false,
+                            "lazyLoad": false,
                             "theme": "default",
                             "breadcrumb": "default",
-                            "id": "ey6jmc4b"
+                            "id": "edkwdv"
                         },
                         {
                             "label": "<strong>Will your partner be in receipt of Employment Insurance benefits during the your study period?</strong>",
@@ -14817,12 +14779,12 @@
                             ],
                             "validate": {
                                 "required": true,
-                                "onlyAvailableItems": false,
                                 "custom": "",
                                 "customPrivate": false,
                                 "strictDateValidation": false,
                                 "multiple": false,
-                                "unique": false
+                                "unique": false,
+                                "onlyAvailableItems": false
                             },
                             "key": "partneremploymentInsurance",
                             "type": "radio",
@@ -14875,9 +14837,10 @@
                             "showWordCount": false,
                             "properties": {},
                             "allowMultipleMasks": false,
+                            "addons": [],
                             "inputType": "radio",
                             "fieldSet": false,
-                            "id": "enklghw"
+                            "id": "e31a1pa"
                         },
                         {
                             "title": "Will your partner be in receipt of Employment Insurance benefits during the your study period Panel",
@@ -14974,7 +14937,8 @@
                                     "showWordCount": false,
                                     "properties": {},
                                     "allowMultipleMasks": false,
-                                    "id": "ei87gnna"
+                                    "addons": [],
+                                    "id": "ei6mju"
                                 }
                             ],
                             "allowPrevious": false,
@@ -15028,10 +14992,12 @@
                             "showWordCount": false,
                             "properties": {},
                             "allowMultipleMasks": false,
+                            "addons": [],
                             "tree": false,
+                            "lazyLoad": false,
                             "theme": "default",
                             "breadcrumb": "default",
-                            "id": "ei0vzm"
+                            "id": "ew2mb4"
                         },
                         {
                             "label": "<strong>Will your partner be in receipt of federal or provincial permanent disability benefits during the your study period?</strong>",
@@ -15052,12 +15018,12 @@
                             ],
                             "validate": {
                                 "required": true,
-                                "onlyAvailableItems": false,
                                 "custom": "",
                                 "customPrivate": false,
                                 "strictDateValidation": false,
                                 "multiple": false,
-                                "unique": false
+                                "unique": false,
+                                "onlyAvailableItems": false
                             },
                             "key": "partnerpermanentdisabilityBenefits",
                             "type": "radio",
@@ -15110,9 +15076,10 @@
                             "showWordCount": false,
                             "properties": {},
                             "allowMultipleMasks": false,
+                            "addons": [],
                             "inputType": "radio",
                             "fieldSet": false,
-                            "id": "ef7th7s"
+                            "id": "en3em5g"
                         },
                         {
                             "title": "Will your partner be in receipt of federal or provincial permanent disability benefits during the your study period Panel",
@@ -15209,7 +15176,8 @@
                                     "showWordCount": false,
                                     "properties": {},
                                     "allowMultipleMasks": false,
-                                    "id": "ecbhi1"
+                                    "addons": [],
+                                    "id": "eitn5um"
                                 }
                             ],
                             "allowPrevious": false,
@@ -15263,10 +15231,12 @@
                             "showWordCount": false,
                             "properties": {},
                             "allowMultipleMasks": false,
+                            "addons": [],
                             "tree": false,
+                            "lazyLoad": false,
                             "theme": "default",
                             "breadcrumb": "default",
-                            "id": "em80rob"
+                            "id": "e827a1k"
                         },
                         {
                             "label": "<strong>Will your partner be paying a Canada Student Loan and/or a provincial student loan regular scheduled payments during the your study period?</strong>",
@@ -15287,12 +15257,12 @@
                             ],
                             "validate": {
                                 "required": true,
-                                "onlyAvailableItems": false,
                                 "custom": "",
                                 "customPrivate": false,
                                 "strictDateValidation": false,
                                 "multiple": false,
-                                "unique": false
+                                "unique": false,
+                                "onlyAvailableItems": false
                             },
                             "key": "partnerstudentLoan",
                             "type": "radio",
@@ -15345,9 +15315,10 @@
                             "showWordCount": false,
                             "properties": {},
                             "allowMultipleMasks": false,
+                            "addons": [],
                             "inputType": "radio",
                             "fieldSet": false,
-                            "id": "eoxznh4"
+                            "id": "eu8nr9s"
                         },
                         {
                             "title": "Will your partner be paying a Canada Student Loan and/or a provincial student loan regular scheduled payments during the your study period Panel",
@@ -15443,7 +15414,8 @@
                                     "showWordCount": false,
                                     "properties": {},
                                     "allowMultipleMasks": false,
-                                    "id": "exjd5dg"
+                                    "addons": [],
+                                    "id": "esoydt6"
                                 }
                             ],
                             "allowPrevious": false,
@@ -15497,10 +15469,12 @@
                             "showWordCount": false,
                             "properties": {},
                             "allowMultipleMasks": false,
+                            "addons": [],
                             "tree": false,
+                            "lazyLoad": false,
                             "theme": "default",
                             "breadcrumb": "default",
-                            "id": "et3rj9"
+                            "id": "ets4ead"
                         },
                         {
                             "label": "<strong>Will your partner be paying for child support and/or spousal support during the your study period?</strong>",
@@ -15521,12 +15495,12 @@
                             ],
                             "validate": {
                                 "required": true,
-                                "onlyAvailableItems": false,
                                 "custom": "",
                                 "customPrivate": false,
                                 "strictDateValidation": false,
                                 "multiple": false,
-                                "unique": false
+                                "unique": false,
+                                "onlyAvailableItems": false
                             },
                             "key": "partnerchildSupport",
                             "type": "radio",
@@ -15579,9 +15553,10 @@
                             "showWordCount": false,
                             "properties": {},
                             "allowMultipleMasks": false,
+                            "addons": [],
                             "inputType": "radio",
                             "fieldSet": false,
-                            "id": "eboa3up"
+                            "id": "e12r1qh"
                         },
                         {
                             "title": "Will your partner be paying for child support and/or spousal support during the your study period Panel",
@@ -15677,7 +15652,8 @@
                                     "showWordCount": false,
                                     "properties": {},
                                     "allowMultipleMasks": false,
-                                    "id": "epwpsk9"
+                                    "addons": [],
+                                    "id": "ehvnz5p"
                                 }
                             ],
                             "allowPrevious": false,
@@ -15731,10 +15707,12 @@
                             "showWordCount": false,
                             "properties": {},
                             "allowMultipleMasks": false,
+                            "addons": [],
                             "tree": false,
+                            "lazyLoad": false,
                             "theme": "default",
                             "breadcrumb": "default",
-                            "id": "ei3r3id"
+                            "id": "e7t47mk"
                         },
                         {
                             "label": "<strong>Durring your study period, will your partner be taking care of eligible dependants? </strong>",
@@ -15755,12 +15733,12 @@
                             ],
                             "validate": {
                                 "required": true,
-                                "onlyAvailableItems": false,
                                 "custom": "",
                                 "customPrivate": false,
                                 "strictDateValidation": false,
                                 "multiple": false,
-                                "unique": false
+                                "unique": false,
+                                "onlyAvailableItems": false
                             },
                             "key": "durringYourStudyPeriodWillYourPartnerBeTakingCareOfEligibleDependants",
                             "type": "radio",
@@ -15813,9 +15791,10 @@
                             "showWordCount": false,
                             "properties": {},
                             "allowMultipleMasks": false,
+                            "addons": [],
                             "inputType": "radio",
                             "fieldSet": false,
-                            "id": "e887jy"
+                            "id": "elmurep"
                         }
                     ],
                     "allowPrevious": false,
@@ -15869,10 +15848,12 @@
                     "showWordCount": false,
                     "properties": {},
                     "allowMultipleMasks": false,
+                    "addons": [],
                     "tree": false,
+                    "lazyLoad": false,
                     "theme": "default",
                     "breadcrumb": "default",
-                    "id": "etvo8m"
+                    "id": "evhpw5x"
                 }
             ],
             "placeholder": "",
@@ -15910,8 +15891,10 @@
             "showCharCount": false,
             "showWordCount": false,
             "allowMultipleMasks": false,
+            "addons": [],
             "tree": false,
-            "id": "esudth"
+            "lazyLoad": false,
+            "id": "ecc7kw"
         },
         {
             "title": "Parent information",
@@ -27734,5 +27717,5 @@
     "name": "SFAA2023-24",
     "machineName": "SFAA2023-24",
     "created": "2021-07-12T19:51:16.443Z",
-    "modified": "2022-02-16T23:04:55.535Z"
+    "modified": "2022-02-16T23:19:03.226Z"
 }


### PR DESCRIPTION
- Relationship status for marriedCommonLaw is renamed to married and otherSingle is renamed to other in all the workflow and the student application forms for the 3 years. This has been done to be in consistent with our code relationshipstatus.
- dependantStatus hidden variable event trigger has been updated to AnyChange to hide and show the partnerInformation tab, which was inconsistent. Also moved to the appropriate screen.