### PR TITLE
[web][SIMS #406]Fix for Designation Agreement Links

### DIFF
--- a/sources/packages/web/src/components/generic/formio.vue
+++ b/sources/packages/web/src/components/generic/formio.vue
@@ -12,7 +12,7 @@ import FormUploadService from "../../services/FormUploadService";
 import { FormIOCustomEvent } from "@/types";
 
 export default {
-  emits: ["submitted", "loaded", "changed", "customEvent"],
+  emits: ["submitted", "loaded", "changed", "customEvent", "render"],
   props: {
     formName: {
       type: String,
@@ -34,7 +34,7 @@ export default {
     // Update the form submission data and triggers the form redraw.
     // Redrawing ensures that components like dropdowns are going to
     // display the correct label associated with the correct value
-    // that was loaded into the sumission data.
+    // that was loaded into the submission data.
     const updateFormSubmissionData = () => {
       if (form && props.data) {
         form.submission = {
@@ -99,12 +99,19 @@ export default {
         context.emit("changed", form, event);
       });
 
-      form.on("submit", (submision: any) => {
-        context.emit("submitted", submision.data, form);
+      form.on("submit", (submission: any) => {
+        context.emit("submitted", submission.data, form);
       });
 
       form.on("customEvent", (event: FormIOCustomEvent) => {
         context.emit("customEvent", form, event);
+      });
+
+      // The form is done rendering and has completed the attach phase.
+      // Happens, for instance, after the form has the 'redraw' method
+      // executed, for instance, after data property is changed.
+      form.on("render", (event: HTMLElement) => {
+        context.emit("render", form, event);
       });
     });
 

--- a/sources/packages/web/src/components/partial-view/DesignationAgreement/DesignationAgreementForm.vue
+++ b/sources/packages/web/src/components/partial-view/DesignationAgreement/DesignationAgreementForm.vue
@@ -35,7 +35,7 @@ export default {
     const MANAGE_LOCATIONS_LINK = "goToManageLocations";
     const MANAGE_USERS_LINK = "goToManageUsers";
 
-    const formRender = async () => {
+    const formRender = () => {
       RouteHelper.AssociateHyperlinkClick(MANAGE_LOCATIONS_LINK, () =>
         router.push({ name: InstitutionRoutesConst.MANAGE_LOCATIONS }),
       );

--- a/sources/packages/web/src/components/partial-view/DesignationAgreement/DesignationAgreementForm.vue
+++ b/sources/packages/web/src/components/partial-view/DesignationAgreement/DesignationAgreementForm.vue
@@ -4,7 +4,7 @@
     :data="model"
     :readOnly="readOnly"
     @submitted="submitDesignation"
-    @loaded="formLoaded"
+    @render="formRender"
   ></formio>
 </template>
 
@@ -35,7 +35,7 @@ export default {
     const MANAGE_LOCATIONS_LINK = "goToManageLocations";
     const MANAGE_USERS_LINK = "goToManageUsers";
 
-    const formLoaded = async () => {
+    const formRender = async () => {
       RouteHelper.AssociateHyperlinkClick(MANAGE_LOCATIONS_LINK, () =>
         router.push({ name: InstitutionRoutesConst.MANAGE_LOCATIONS }),
       );
@@ -52,7 +52,7 @@ export default {
       return props.model.viewMode === DesignationFormViewModes.viewOnly;
     });
 
-    return { formLoaded, submitDesignation, readOnly };
+    return { formRender, submitDesignation, readOnly };
   },
 };
 </script>


### PR DESCRIPTION
While executing the association of the hyperlinks with the form.io during the load event, after the form call a redraw due to a binding changing, the association with the hyperlinks was lost.
Exposed the event from form.io called render that will happen after a redraw, allowing us to attach the hyperlink events every time that the hyperlink is recreated due to a redraw.