### PR TITLE
[api][SIMS #451] Source code update for NEST upgrade

### DIFF
--- a/sources/packages/api/ormconfig.js
+++ b/sources/packages/api/ormconfig.js
@@ -24,5 +24,4 @@ module.exports = {
     entitiesDir: "src/database/entities",
   },
   entities,
-  schema: process.env.DB_SCHEMA || "sims",
 };

--- a/sources/packages/api/ormconfig.js
+++ b/sources/packages/api/ormconfig.js
@@ -1,9 +1,13 @@
+const directLoad =
+  process.env.ENVIRONMENT === "test" || process.env.NODE_ENV === "cmd";
 
-const directLoad = (process.env.ENVIRONMENT === "test" || process.env.NODE_ENV === "cmd")
+const entities = directLoad
+  ? ["src/database/entities/*.model{.ts,.js}"]
+  : ["dist/database/entities/*.model{.ts,.js}"];
 
-const entities = directLoad ? ["src/database/entities/*.model{.ts,.js}"] : ["dist/database/entities/*.model{.ts,.js}"];
-
-const migrations = directLoad ? ["src/database/migrations/*{.ts,.js}"] : ["dist/database/migrations/*{.ts,.js}"];
+const migrations = directLoad
+  ? ["src/database/migrations/*{.ts,.js}"]
+  : ["dist/database/migrations/*{.ts,.js}"];
 
 module.exports = {
   type: "postgres",
@@ -12,11 +16,12 @@ module.exports = {
   database: process.env.POSTGRES_DB || "aest",
   username: process.env.POSTGRES_USER || "admin",
   password: process.env.POSTGRES_PASSWORD,
+  schema: process.env.DB_SCHEMA || "sims",
   synchronize: false,
   migrations,
   cli: {
     migrationsDir: "src/database/migrations",
-    entitiesDir: "src/database/entities"
+    entitiesDir: "src/database/entities",
   },
   entities,
   schema: process.env.DB_SCHEMA || "sims",

--- a/sources/packages/api/scripts/setupDB.ts
+++ b/sources/packages/api/scripts/setupDB.ts
@@ -9,7 +9,6 @@ const config = require("../ormconfig");
   try {
     // Create Connection
     console.log("**** Running setupDB ****");
-    delete config.entities;
     const connection = await createConnection({
       ...config,
       logging: ["error", "warn", "info"],

--- a/sources/packages/api/scripts/setupDB.ts
+++ b/sources/packages/api/scripts/setupDB.ts
@@ -9,16 +9,14 @@ const config = require("../ormconfig");
   try {
     // Create Connection
     console.log("**** Running setupDB ****");
-    delete config.schema;
     delete config.entities;
     const connection = await createConnection({
       ...config,
       logging: ["error", "warn", "info"],
     });
-    const schema = process.env.DB_SCHEMA || "sims";
-    await connection.query(`CREATE SCHEMA IF NOT EXISTS ${schema};`);
-    await connection.query(`SET search_path TO ${schema}, public;`);
-    await connection.query(`SET SCHEMA '${schema}';`);
+    await connection.query(`CREATE SCHEMA IF NOT EXISTS ${config.schema};`);
+    await connection.query(`SET search_path TO ${config.schema}, public;`);
+    await connection.query(`SET SCHEMA '${config.schema}';`);
     console.log(`**** Running migration ****`);
     await connection.runMigrations();
     await connection.close();

--- a/sources/packages/api/src/auth/guards/groups.guard.ts
+++ b/sources/packages/api/src/auth/guards/groups.guard.ts
@@ -1,5 +1,6 @@
 import { Injectable, CanActivate, ExecutionContext } from "@nestjs/common";
 import { Reflector } from "@nestjs/core";
+import { AuthorizedParties } from "../authorized-parties.enum";
 import { GROUPS_KEY } from "../decorators";
 import { UserGroups } from "../user-groups.enum";
 import { IUserToken } from "../userToken.interface";
@@ -22,6 +23,14 @@ export class GroupsGuard implements CanActivate {
       return true;
     }
     const { user } = context.switchToHttp().getRequest();
+    /**
+     * When a controller is shared between more then one client type(e.g Institution and Ministry)
+     * Following logic ensures that group check is done only for ministry(AEST) user.
+     * For client types except AEST, this decorator will not validate anything.
+     */
+    if (user.authorizedParty !== AuthorizedParties.aest) {
+      return true;
+    }
     const userToken = user as IUserToken;
     // Check if the user has any of the groups required to have access to the resource.
     return requiredGroups.some((group: string) =>

--- a/sources/packages/api/src/auth/guards/institution-admin.guard.ts
+++ b/sources/packages/api/src/auth/guards/institution-admin.guard.ts
@@ -1,6 +1,7 @@
 import { Injectable, CanActivate, ExecutionContext } from "@nestjs/common";
 import { Reflector } from "@nestjs/core";
 import { InstitutionUserAuthorizations } from "../../services/institution-user-auth/institution-user-auth.models";
+import { AuthorizedParties } from "../authorized-parties.enum";
 import { IS_INSTITUTION_ADMIN_KEY } from "../decorators/institution-admin.decorator";
 import { InstitutionUserRoles } from "../user-types.enum";
 
@@ -21,6 +22,14 @@ export class InstitutionAdminGuard implements CanActivate {
     }
 
     const { user } = context.switchToHttp().getRequest();
+    /**
+     * When a controller is shared between more then one client type(e.g Institution and Ministry)
+     * following logic ensures that admin role checked only for Institution user.
+     * For client types except Institution, this decorator will not validate anything.
+     */
+    if (user.authorizedParty !== AuthorizedParties.institution) {
+      return true;
+    }
     const authorizations = user.authorizations as InstitutionUserAuthorizations;
 
     if (!authorizations.isAdmin()) {

--- a/sources/packages/api/src/auth/guards/institution-location.guard.spec.ts
+++ b/sources/packages/api/src/auth/guards/institution-location.guard.spec.ts
@@ -7,6 +7,7 @@ import { HasLocationAccessParam } from "../decorators";
 import { IInstitutionUserToken } from "../userToken.interface";
 import { InstitutionLocationGuard } from "./institution-location.guard";
 import { InstitutionUserTypes } from "../user-types.enum";
+import { AuthorizedParties } from "../authorized-parties.enum";
 
 const activateGuard = async (
   locationId: number,
@@ -21,6 +22,7 @@ const activateGuard = async (
   const guard = new InstitutionLocationGuard(reflector);
   const user = {} as IInstitutionUserToken;
   user.authorizations = authorizations;
+  user.authorizedParty = AuthorizedParties.institution;
 
   const httpRequest = { user, params: { [locationIdParamName]: locationId } };
   const httpContext = createFakeHttpContext(httpRequest);

--- a/sources/packages/api/src/auth/guards/institution-location.guard.ts
+++ b/sources/packages/api/src/auth/guards/institution-location.guard.ts
@@ -1,6 +1,7 @@
 import { Injectable, CanActivate, ExecutionContext } from "@nestjs/common";
 import { Reflector } from "@nestjs/core";
 import { InstitutionUserAuthorizations } from "../../services/institution-user-auth/institution-user-auth.models";
+import { AuthorizedParties } from "../authorized-parties.enum";
 import {
   HasLocationAccessParam,
   HAS_LOCATION_ACCESS_KEY,
@@ -22,6 +23,14 @@ export class InstitutionLocationGuard implements CanActivate {
     }
 
     const { user } = context.switchToHttp().getRequest();
+    /**
+     * When a controller is shared between more then one client type(e.g Institution and Ministry)
+     * following logic ensures that location access is checked only for Institution user.
+     * For client types except Institution, this decorator will not validate anything.
+     */
+    if (user.authorizedParty !== AuthorizedParties.institution) {
+      return true;
+    }
     const authorizations = user.authorizations as InstitutionUserAuthorizations;
 
     const request = context.switchToHttp().getRequest();

--- a/sources/packages/api/src/database/database.service.ts
+++ b/sources/packages/api/src/database/database.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Inject } from "@nestjs/common";
+import { Injectable } from "@nestjs/common";
 import { LoggerService } from "../logger/logger.service";
 import { Connection } from "typeorm";
 import { InjectLogger } from "../common";
@@ -8,7 +8,7 @@ export class DatabaseService {
   @InjectLogger()
   logger: LoggerService;
 
-  constructor(@Inject("Connection") public connection: Connection) {
+  constructor(public connection: Connection) {
     connection
       .query(`SET SCHEMA '${process.env.DB_SCHEMA || "sims"}';`)
       .then(() => {

--- a/sources/packages/api/src/database/entities/application.model.ts
+++ b/sources/packages/api/src/database/entities/application.model.ts
@@ -123,6 +123,7 @@ export class Application extends RecordDataModel {
   @Column({
     name: "pir_status",
     type: "enum",
+    enum: ProgramInfoStatus,
   })
   pirStatus: ProgramInfoStatus;
 
@@ -149,12 +150,14 @@ export class Application extends RecordDataModel {
   @Column({
     name: "application_status",
     type: "enum",
+    enum: ApplicationStatus,
   })
   applicationStatus: ApplicationStatus;
 
   @Column({
     name: "assessment_status",
     type: "enum",
+    enum: AssessmentStatus,
   })
   assessmentStatus: AssessmentStatus;
 

--- a/sources/packages/api/src/database/entities/disbursement-schedule.model.ts
+++ b/sources/packages/api/src/database/entities/disbursement-schedule.model.ts
@@ -89,6 +89,7 @@ export class DisbursementSchedule extends RecordDataModel {
   @Column({
     name: "coe_status",
     type: "enum",
+    enum: COEStatus,
   })
   coeStatus: COEStatus;
 

--- a/sources/packages/api/src/database/entities/disbursement-values.model.ts
+++ b/sources/packages/api/src/database/entities/disbursement-values.model.ts
@@ -26,6 +26,7 @@ export class DisbursementValue extends RecordDataModel {
   @Column({
     name: "value_type",
     type: "enum",
+    enum: DisbursementValueType,
     nullable: false,
   })
   valueType: DisbursementValueType;

--- a/sources/packages/api/src/database/entities/education-program-offering.model.ts
+++ b/sources/packages/api/src/database/entities/education-program-offering.model.ts
@@ -150,6 +150,7 @@ export class EducationProgramOffering extends RecordDataModel {
   @Column({
     name: "offering_type",
     type: "enum",
+    enum: OfferingTypes,
   })
   offeringType: OfferingTypes;
   /**

--- a/sources/packages/api/src/database/entities/education-program.model.ts
+++ b/sources/packages/api/src/database/entities/education-program.model.ts
@@ -183,6 +183,7 @@ export class EducationProgram extends RecordDataModel {
     name: "program_intensity",
     nullable: false,
     type: "enum",
+    enum: ProgramIntensity,
   })
   programIntensity: ProgramIntensity;
 

--- a/sources/packages/api/src/database/entities/note.model.ts
+++ b/sources/packages/api/src/database/entities/note.model.ts
@@ -16,6 +16,7 @@ export class Note extends RecordDataModel {
   @Column({
     name: "note_type",
     type: "enum",
+    enum: NoteType,
     nullable: false,
   })
   noteType: NoteType;

--- a/sources/packages/api/src/database/entities/restriction.model.ts
+++ b/sources/packages/api/src/database/entities/restriction.model.ts
@@ -16,6 +16,7 @@ export class Restriction extends RecordDataModel {
   @Column({
     name: "restriction_type",
     type: "enum",
+    enum: RestrictionType,
     nullable: false,
   })
   restrictionType: RestrictionType;

--- a/sources/packages/api/src/database/entities/supporting-user.model.ts
+++ b/sources/packages/api/src/database/entities/supporting-user.model.ts
@@ -76,6 +76,7 @@ export class SupportingUser extends RecordDataModel {
   @Column({
     name: "supporting_user_type",
     type: "enum",
+    enum: SupportingUserType,
     nullable: false,
   })
   supportingUserType: SupportingUserType;

--- a/sources/packages/api/src/esdc-integration/fed-restriction-integration/fed-restriction-processing.service.ts
+++ b/sources/packages/api/src/esdc-integration/fed-restriction-integration/fed-restriction-processing.service.ts
@@ -1,6 +1,6 @@
 import { InjectLogger } from "../../common";
 import { LoggerService } from "../../logger/logger.service";
-import { Inject, Injectable } from "@nestjs/common";
+import { Injectable } from "@nestjs/common";
 import {
   ConfigService,
   FederalRestrictionService,
@@ -25,7 +25,7 @@ import { ProcessSFTPResponseResult } from "./fed-restriction-integration.models"
 export class FedRestrictionProcessingService {
   private readonly esdcConfig: ESDCIntegrationConfig;
   constructor(
-    @Inject("Connection") private readonly connection: Connection,
+    private readonly connection: Connection,
     config: ConfigService,
     private readonly restrictionService: RestrictionService,
     private readonly federalRestrictionService: FederalRestrictionService,

--- a/sources/packages/api/src/services/application/application.service.ts
+++ b/sources/packages/api/src/services/application/application.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Inject } from "@nestjs/common";
+import { Injectable } from "@nestjs/common";
 import { RecordDataModelService } from "../../database/data.model.service";
 import { Connection, In, IsNull, Not, UpdateResult, Brackets } from "typeorm";
 import { LoggerService } from "../../logger/logger.service";
@@ -60,7 +60,7 @@ export class ApplicationService extends RecordDataModelService<Application> {
   logger: LoggerService;
 
   constructor(
-    @Inject("Connection") connection: Connection,
+    connection: Connection,
     private readonly sequenceService: SequenceControlService,
     private readonly fileService: StudentFileService,
     private readonly workflow: WorkflowActionsService,

--- a/sources/packages/api/src/services/coe-denied-reason/coe-denied-reason.service.ts
+++ b/sources/packages/api/src/services/coe-denied-reason/coe-denied-reason.service.ts
@@ -1,11 +1,11 @@
-import { Injectable, Inject } from "@nestjs/common";
+import { Injectable } from "@nestjs/common";
 import { RecordDataModelService } from "../../database/data.model.service";
 import { Connection } from "typeorm";
 import { COEDeniedReason } from "../../database/entities/coe-denied-reason.model";
 
 @Injectable()
 export class COEDeniedReasonService extends RecordDataModelService<COEDeniedReason> {
-  constructor(@Inject("Connection") connection: Connection) {
+  constructor(connection: Connection) {
     super(connection.getRepository(COEDeniedReason));
   }
 

--- a/sources/packages/api/src/services/cra-income-verification/cra-income-verification.service.ts
+++ b/sources/packages/api/src/services/cra-income-verification/cra-income-verification.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Inject } from "@nestjs/common";
+import { Injectable } from "@nestjs/common";
 import { Connection, In, IsNull, Repository, UpdateResult } from "typeorm";
 import { RecordDataModelService } from "../../database/data.model.service";
 import {
@@ -26,7 +26,7 @@ const RETRY_BYPASS_CRA_RECEIVED_FILE_TIME = 2000;
 @Injectable()
 export class CRAIncomeVerificationService extends RecordDataModelService<CRAIncomeVerification> {
   constructor(
-    @Inject("Connection") connection: Connection,
+    connection: Connection,
     private readonly workflowService: WorkflowActionsService,
   ) {
     super(connection.getRepository(CRAIncomeVerification));

--- a/sources/packages/api/src/services/disbursement-schedule-errors/disbursement-schedule-errors.service.ts
+++ b/sources/packages/api/src/services/disbursement-schedule-errors/disbursement-schedule-errors.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Inject } from "@nestjs/common";
+import { Injectable } from "@nestjs/common";
 import { Connection, InsertResult } from "typeorm";
 import { RecordDataModelService } from "../../database/data.model.service";
 import {
@@ -12,7 +12,7 @@ import {
  */
 @Injectable()
 export class DisbursementScheduleErrorsService extends RecordDataModelService<DisbursementFeedbackErrors> {
-  constructor(@Inject("Connection") connection: Connection) {
+  constructor(connection: Connection) {
     super(connection.getRepository(DisbursementFeedbackErrors));
   }
 

--- a/sources/packages/api/src/services/education-program-offering/education-program-offering.service.ts
+++ b/sources/packages/api/src/services/education-program-offering/education-program-offering.service.ts
@@ -1,4 +1,4 @@
-import { Inject, Injectable } from "@nestjs/common";
+import { Injectable } from "@nestjs/common";
 import {
   EducationProgramOffering,
   EducationProgram,
@@ -24,7 +24,7 @@ import {
 } from "../../utilities";
 @Injectable()
 export class EducationProgramOfferingService extends RecordDataModelService<EducationProgramOffering> {
-  constructor(@Inject("Connection") connection: Connection) {
+  constructor(connection: Connection) {
     super(connection.getRepository(EducationProgramOffering));
   }
 

--- a/sources/packages/api/src/services/education-program/education-program.service.ts
+++ b/sources/packages/api/src/services/education-program/education-program.service.ts
@@ -1,4 +1,4 @@
-import { Inject, Injectable } from "@nestjs/common";
+import { Injectable } from "@nestjs/common";
 import {
   EducationProgram,
   EducationProgramOffering,
@@ -34,7 +34,7 @@ import {
 @Injectable()
 export class EducationProgramService extends RecordDataModelService<EducationProgram> {
   private readonly offeringsRepo: Repository<EducationProgramOffering>;
-  constructor(@Inject("Connection") private readonly connection: Connection) {
+  constructor(private readonly connection: Connection) {
     super(connection.getRepository(EducationProgram));
     this.offeringsRepo = connection.getRepository(EducationProgramOffering);
   }

--- a/sources/packages/api/src/services/institution-location/institution-location.service.ts
+++ b/sources/packages/api/src/services/institution-location/institution-location.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Inject } from "@nestjs/common";
+import { Injectable } from "@nestjs/common";
 import { RecordDataModelService } from "../../database/data.model.service";
 import { InstitutionLocation } from "../../database/entities/institution-location.model";
 import { Connection, UpdateResult } from "typeorm";
@@ -6,7 +6,7 @@ import { ValidatedInstitutionLocation } from "../../types";
 import { InstitutionLocationTypeDto } from "../../route-controllers/institution-locations/models/institution-location.dto";
 @Injectable()
 export class InstitutionLocationService extends RecordDataModelService<InstitutionLocation> {
-  constructor(@Inject("Connection") connection: Connection) {
+  constructor(connection: Connection) {
     super(connection.getRepository(InstitutionLocation));
   }
 

--- a/sources/packages/api/src/services/institution-type/institution-type.service.ts
+++ b/sources/packages/api/src/services/institution-type/institution-type.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Inject } from "@nestjs/common";
+import { Injectable } from "@nestjs/common";
 import { RecordDataModelService } from "../../database/data.model.service";
 import { InstitutionType } from "../../database/entities/institution-type.model";
 import { Connection } from "typeorm";
@@ -8,7 +8,7 @@ import { Connection } from "typeorm";
  */
 @Injectable()
 export class InstitutionTypeService extends RecordDataModelService<InstitutionType> {
-  constructor(@Inject("Connection") private readonly connection: Connection) {
+  constructor(private readonly connection: Connection) {
     super(connection.getRepository(InstitutionType));
   }
 

--- a/sources/packages/api/src/services/institution-user-auth/institution-user-auth.service.ts
+++ b/sources/packages/api/src/services/institution-user-auth/institution-user-auth.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Inject } from "@nestjs/common";
+import { Injectable } from "@nestjs/common";
 import { RecordDataModelService } from "../../database/data.model.service";
 import { Connection } from "typeorm";
 import { InstitutionUserAuth } from "../../database/entities";
@@ -12,7 +12,7 @@ import { InstitutionLocationService } from "..";
 @Injectable()
 export class InstitutionUserAuthService extends RecordDataModelService<InstitutionUserAuth> {
   constructor(
-    @Inject("Connection") connection: Connection,
+    connection: Connection,
     private readonly locationService: InstitutionLocationService,
   ) {
     super(connection.getRepository(InstitutionUserAuth));

--- a/sources/packages/api/src/services/institution/institution.service.ts
+++ b/sources/packages/api/src/services/institution/institution.service.ts
@@ -1,8 +1,4 @@
-import {
-  Injectable,
-  Inject,
-  UnprocessableEntityException,
-} from "@nestjs/common";
+import { Injectable, UnprocessableEntityException } from "@nestjs/common";
 import { RecordDataModelService } from "../../database/data.model.service";
 import {
   Institution,
@@ -55,7 +51,7 @@ export class InstitutionService extends RecordDataModelService<Institution> {
   institutionUserTypeAndRoleRepo: Repository<InstitutionUserTypeAndRole>;
   institutionUserAuthRepo: Repository<InstitutionUserAuth>;
   constructor(
-    @Inject("Connection") connection: Connection,
+    connection: Connection,
     private readonly bceidService: BCeIDService,
     private readonly userService: UserService,
   ) {

--- a/sources/packages/api/src/services/msfaa-number/msfaa-number.service.ts
+++ b/sources/packages/api/src/services/msfaa-number/msfaa-number.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Inject } from "@nestjs/common";
+import { Injectable } from "@nestjs/common";
 import {
   Brackets,
   Connection,
@@ -25,7 +25,7 @@ import { SequenceControlService } from "../sequence-control/sequence-control.ser
 @Injectable()
 export class MSFAANumberService extends RecordDataModelService<MSFAANumber> {
   constructor(
-    @Inject("Connection") connection: Connection,
+    connection: Connection,
     private readonly sequenceService: SequenceControlService,
   ) {
     super(connection.getRepository(MSFAANumber));

--- a/sources/packages/api/src/services/pir-denied-reason/pir-denied-reason.service.ts
+++ b/sources/packages/api/src/services/pir-denied-reason/pir-denied-reason.service.ts
@@ -1,11 +1,11 @@
-import { Injectable, Inject } from "@nestjs/common";
+import { Injectable } from "@nestjs/common";
 import { RecordDataModelService } from "../../database/data.model.service";
 import { Connection } from "typeorm";
 import { PIRDeniedReason } from "../../database/entities/pir-denied-reason.model";
 
 @Injectable()
 export class PIRDeniedReasonService extends RecordDataModelService<PIRDeniedReason> {
-  constructor(@Inject("Connection") private readonly connection: Connection) {
+  constructor(private readonly connection: Connection) {
     super(connection.getRepository(PIRDeniedReason));
   }
 

--- a/sources/packages/api/src/services/program-year/program-year.service.ts
+++ b/sources/packages/api/src/services/program-year/program-year.service.ts
@@ -1,11 +1,11 @@
-import { Injectable, Inject } from "@nestjs/common";
+import { Injectable } from "@nestjs/common";
 import { RecordDataModelService } from "../../database/data.model.service";
 import { Connection } from "typeorm";
 import { ProgramYear } from "../../database/entities/program-year.model";
 
 @Injectable()
 export class ProgramYearService extends RecordDataModelService<ProgramYear> {
-  constructor(@Inject("Connection") private readonly connection: Connection) {
+  constructor(private readonly connection: Connection) {
     super(connection.getRepository(ProgramYear));
   }
 

--- a/sources/packages/api/src/services/restriction/institution-restriction.service.ts
+++ b/sources/packages/api/src/services/restriction/institution-restriction.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Inject } from "@nestjs/common";
+import { Injectable } from "@nestjs/common";
 import { RecordDataModelService } from "../../database/data.model.service";
 import { Connection } from "typeorm";
 import { RESTRICTION_NOT_ACTIVE } from "./student-restriction.service";
@@ -22,7 +22,7 @@ import { CustomNamedError } from "../../utilities";
  */
 @Injectable()
 export class InstitutionRestrictionService extends RecordDataModelService<InstitutionRestriction> {
-  constructor(@Inject("Connection") connection: Connection) {
+  constructor(connection: Connection) {
     super(connection.getRepository(InstitutionRestriction));
   }
 

--- a/sources/packages/api/src/services/restriction/restriction.service.ts
+++ b/sources/packages/api/src/services/restriction/restriction.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Inject } from "@nestjs/common";
+import { Injectable } from "@nestjs/common";
 import { RecordDataModelService } from "../../database/data.model.service";
 import { Restriction, RestrictionType } from "../../database/entities";
 import { Connection, Repository } from "typeorm";
@@ -10,7 +10,7 @@ import { EnsureFederalRestrictionResult } from "./models/federal-restriction.mod
  */
 @Injectable()
 export class RestrictionService extends RecordDataModelService<Restriction> {
-  constructor(@Inject("Connection") connection: Connection) {
+  constructor(connection: Connection) {
     super(connection.getRepository(Restriction));
   }
 

--- a/sources/packages/api/src/services/restriction/student-restriction.service.ts
+++ b/sources/packages/api/src/services/restriction/student-restriction.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Inject } from "@nestjs/common";
+import { Injectable } from "@nestjs/common";
 import { RecordDataModelService } from "../../database/data.model.service";
 import {
   StudentRestriction,
@@ -28,7 +28,7 @@ export const RESTRICTION_NOT_PROVINCIAL = "RESTRICTION_NOT_PROVINCIAL";
  */
 @Injectable()
 export class StudentRestrictionService extends RecordDataModelService<StudentRestriction> {
-  constructor(@Inject("Connection") connection: Connection) {
+  constructor(connection: Connection) {
     super(connection.getRepository(StudentRestriction));
   }
 

--- a/sources/packages/api/src/services/sequence-control/sequence-control.service.ts
+++ b/sources/packages/api/src/services/sequence-control/sequence-control.service.ts
@@ -1,4 +1,4 @@
-import { Inject, Injectable } from "@nestjs/common";
+import { Injectable } from "@nestjs/common";
 import { Connection, EntityManager } from "typeorm";
 import { RecordDataModelService } from "../../database/data.model.service";
 import { SequenceControl } from "../../database/entities";
@@ -20,7 +20,7 @@ const TRANSACTION_IDLE_TIMEOUT_SECONDS = 30;
  */
 @Injectable()
 export class SequenceControlService extends RecordDataModelService<SequenceControl> {
-  constructor(@Inject("Connection") private readonly connection: Connection) {
+  constructor(private readonly connection: Connection) {
     super(connection.getRepository(SequenceControl));
   }
 

--- a/sources/packages/api/src/services/sfas/sfas-application.service.ts
+++ b/sources/packages/api/src/services/sfas/sfas-application.service.ts
@@ -1,4 +1,4 @@
-import { Inject, Injectable } from "@nestjs/common";
+import { Injectable } from "@nestjs/common";
 import { Connection, Brackets } from "typeorm";
 import { DataModelService } from "../../database/data.model.service";
 import { SFASApplication } from "../../database/entities";
@@ -17,7 +17,7 @@ export class SFASApplicationService
   extends DataModelService<SFASApplication>
   implements SFASDataImporter
 {
-  constructor(@Inject("Connection") connection: Connection) {
+  constructor(connection: Connection) {
     super(connection.getRepository(SFASApplication));
   }
 

--- a/sources/packages/api/src/services/sfas/sfas-individual.service.ts
+++ b/sources/packages/api/src/services/sfas/sfas-individual.service.ts
@@ -1,4 +1,4 @@
-import { Inject, Injectable } from "@nestjs/common";
+import { Injectable } from "@nestjs/common";
 import { Connection } from "typeorm";
 import { DataModelService } from "../../database/data.model.service";
 import { SFASIndividual } from "../../database/entities";
@@ -15,7 +15,7 @@ export class SFASIndividualService
   extends DataModelService<SFASIndividual>
   implements SFASDataImporter
 {
-  constructor(@Inject("Connection") connection: Connection) {
+  constructor(connection: Connection) {
     super(connection.getRepository(SFASIndividual));
   }
 

--- a/sources/packages/api/src/services/sfas/sfas-part-time-application.service.ts
+++ b/sources/packages/api/src/services/sfas/sfas-part-time-application.service.ts
@@ -1,4 +1,4 @@
-import { Inject, Injectable } from "@nestjs/common";
+import { Injectable } from "@nestjs/common";
 import { Connection, Brackets } from "typeorm";
 import { DataModelService } from "../../database/data.model.service";
 import { SFASPartTimeApplications } from "../../database/entities";
@@ -17,7 +17,7 @@ export class SFASPartTimeApplicationsService
   extends DataModelService<SFASPartTimeApplications>
   implements SFASDataImporter
 {
-  constructor(@Inject("Connection") connection: Connection) {
+  constructor(connection: Connection) {
     super(connection.getRepository(SFASPartTimeApplications));
   }
 

--- a/sources/packages/api/src/services/sfas/sfas-restriction.service.ts
+++ b/sources/packages/api/src/services/sfas/sfas-restriction.service.ts
@@ -1,4 +1,4 @@
-import { Inject, Injectable } from "@nestjs/common";
+import { Injectable } from "@nestjs/common";
 import { Connection } from "typeorm";
 import { DataModelService } from "../../database/data.model.service";
 import { SFASRestriction } from "../../database/entities";
@@ -19,7 +19,7 @@ export class SFASRestrictionService
   extends DataModelService<SFASRestriction>
   implements SFASDataImporter
 {
-  constructor(@Inject("Connection") connection: Connection) {
+  constructor(connection: Connection) {
     super(connection.getRepository(SFASRestriction));
   }
 

--- a/sources/packages/api/src/services/student-file/student-file.service.ts
+++ b/sources/packages/api/src/services/student-file/student-file.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Inject } from "@nestjs/common";
+import { Injectable } from "@nestjs/common";
 import { RecordDataModelService } from "../../database/data.model.service";
 import { Connection } from "typeorm";
 import { LoggerService } from "../../logger/logger.service";
@@ -8,7 +8,7 @@ import { CreateFile } from "./student-file.model";
 
 @Injectable()
 export class StudentFileService extends RecordDataModelService<StudentFile> {
-  constructor(@Inject("Connection") connection: Connection) {
+  constructor(connection: Connection) {
     super(connection.getRepository(StudentFile));
   }
 

--- a/sources/packages/api/src/services/student/student.service.ts
+++ b/sources/packages/api/src/services/student/student.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Inject } from "@nestjs/common";
+import { Injectable } from "@nestjs/common";
 import { RecordDataModelService } from "../../database/data.model.service";
 import {
   Application,
@@ -21,7 +21,7 @@ import { SFASIndividualService } from "../sfas/sfas-individual.service";
 @Injectable()
 export class StudentService extends RecordDataModelService<Student> {
   constructor(
-    @Inject("Connection") connection: Connection,
+    connection: Connection,
     private readonly sfasIndividualService: SFASIndividualService,
   ) {
     super(connection.getRepository(Student));

--- a/sources/packages/api/src/services/supporting-user/supporting-user.service.ts
+++ b/sources/packages/api/src/services/supporting-user/supporting-user.service.ts
@@ -1,4 +1,4 @@
-import { Inject, Injectable } from "@nestjs/common";
+import { Injectable } from "@nestjs/common";
 import { Connection } from "typeorm";
 import { RecordDataModelService } from "../../database/data.model.service";
 import {
@@ -18,7 +18,7 @@ import { UpdateSupportingUserInfo } from "./supporting-user.models";
 
 @Injectable()
 export class SupportingUserService extends RecordDataModelService<SupportingUser> {
-  constructor(@Inject("Connection") private readonly connection: Connection) {
+  constructor(private readonly connection: Connection) {
     super(connection.getRepository(SupportingUser));
   }
 

--- a/sources/packages/api/src/services/user/user.service.ts
+++ b/sources/packages/api/src/services/user/user.service.ts
@@ -1,11 +1,11 @@
-import { Injectable, Inject } from "@nestjs/common";
+import { Injectable } from "@nestjs/common";
 import { Connection } from "typeorm";
 import { DataModelService } from "../../database/data.model.service";
 import { User } from "../../database/entities";
 
 @Injectable()
 export class UserService extends DataModelService<User> {
-  constructor(@Inject("Connection") connection: Connection) {
+  constructor(connection: Connection) {
     super(connection.getRepository(User));
   }
 


### PR DESCRIPTION
Following changes are made to have the code ready for NEST upgrade and fix the decorators which are identified to be possibly used between more the one client types(Student | Institution | AEST | Supporting users)

- [x] Update setupDB.ts removing the line which deletes the config property schema and uses local variable to pass to the setup
- [x] Adding the property enum to all entities which has an enum column.
- [x] Removing @Inject("Connection") from all the service constructors.
- [x] Updating InstitutionLocation, InstitutionAdmin and Groups guard to validate only their respective client type users.