### PR TITLE
[Web][SIMS #397] Remove actions on completed and declined CoE

### DIFF
--- a/sources/packages/web/src/views/institution/locations/confirmation-of-enrollment/ApplicationDetailsForCOE.vue
+++ b/sources/packages/web/src/views/institution/locations/confirmation-of-enrollment/ApplicationDetailsForCOE.vue
@@ -91,7 +91,6 @@ export default {
     const showModal = ref(false);
     const editCOEModal = ref({} as ModalDialog<boolean>);
     const denyCOEModal = ref({} as ModalDialog<void>);
-
     const showHideConfirmCOE = () => {
       showModal.value = !showModal.value;
     };

--- a/sources/packages/web/src/views/institution/locations/confirmation-of-enrollment/ApplicationDetailsForCOE.vue
+++ b/sources/packages/web/src/views/institution/locations/confirmation-of-enrollment/ApplicationDetailsForCOE.vue
@@ -1,11 +1,14 @@
 <template>
   <div class="p-m-4">
     <HeaderNavigator
-      title="Back to Programs"
+      title="Confirmation of enrolment"
       :routeLocation="{ name: InstitutionRoutesConst.COE_SUMMARY }"
       subTitle="View Financial Aid Application"
       ><template #buttons>
-        <v-btn color="primary" @click="toggle"
+        <v-btn
+          v-if="initialData.applicationCOEStatus === COEStatus.required"
+          color="primary"
+          @click="toggle"
           ><v-icon size="25">mdi-arrow-down-bold-circle</v-icon>Application
           Actions
         </v-btn>
@@ -48,7 +51,7 @@ import Information from "@/components/institutions/confirmation-of-enrollment/in
 import HeaderNavigator from "@/components/generic/HeaderNavigator.vue";
 /**
  * added MenuType interface for prime vue component menu,
- *  remove it when vuetify componnt is used
+ *  remove it when vuetify component is used
  */
 
 export interface MenuType {
@@ -88,6 +91,7 @@ export default {
     const showModal = ref(false);
     const editCOEModal = ref({} as ModalDialog<boolean>);
     const denyCOEModal = ref({} as ModalDialog<void>);
+
     const showHideConfirmCOE = () => {
       showModal.value = !showModal.value;
     };


### PR DESCRIPTION
I implemented functionality to hide the Application Actions button when CoE is completed or Declined.
I also changed the navigation label to "Confirmation of enrolment".
Fixed a typo.

![coe-required](https://user-images.githubusercontent.com/72251620/156760465-c7bbcf64-e7e6-4e16-aa23-e516faa51377.jpg)
![coe-completed](https://user-images.githubusercontent.com/72251620/156760478-e176e28f-3b70-425b-bcc4-973bf342962d.jpg)
![coe-declined](https://user-images.githubusercontent.com/72251620/156760490-09119fb6-4248-4bae-aaaa-deba314f61ce.jpg)
![coe-label](https://user-images.githubusercontent.com/72251620/156760502-c86c0b2b-5073-437b-a8c7-6162dbc98afb.jpg)
