### PR TITLE
[Web][SIMS #467] Work around to fix the non-reactive nature of form.io readOnly property.

### DIFF
--- a/sources/packages/web/src/views/aest/institution/DesignationAESTView.vue
+++ b/sources/packages/web/src/views/aest/institution/DesignationAESTView.vue
@@ -22,7 +22,10 @@
       </template>
     </header-navigator>
     <full-page-container class="mt-4">
+      <!-- Form.io is not reactively binding the property readOnly. Hence loading the form only after API call is completed. -->
+      <!-- If the readOnly value change after DOM(form) is mounted, form does not respond to it.  -->
       <designation-agreement-form
+        v-if="modelLoaded"
         :model="designationFormModel"
       ></designation-agreement-form>
     </full-page-container>
@@ -102,6 +105,7 @@ export default {
     const navigationTitle = computed(() =>
       props.institutionId ? "Manage designations" : "Pending designations",
     );
+    const modelLoaded = ref(false);
 
     const loadDesignation = async () => {
       designationAgreement.value = await DesignationAgreementService.shared.getDesignationAgreement(
@@ -133,6 +137,7 @@ export default {
           }),
         }),
       );
+      modelLoaded.value = true;
     };
     onMounted(async () => {
       await loadDesignation();
@@ -211,6 +216,7 @@ export default {
       DesignationAgreementStatus,
       updateDesignation,
       showActionButtons,
+      modelLoaded,
     };
   },
 };

--- a/sources/packages/web/src/views/institution/designations/DesignationView.vue
+++ b/sources/packages/web/src/views/institution/designations/DesignationView.vue
@@ -8,7 +8,10 @@
       }"
     />
     <full-page-container class="mt-4">
+      <!-- Form.io is not reactively binding the property readOnly. Hence loading the form only after API call is completed. -->
+      <!-- If the readOnly value change after DOM(form) is mounted, form does not respond to it.  -->
       <designation-agreement-form
+        v-if="modelLoaded"
         :model="designationModel"
       ></designation-agreement-form>
     </full-page-container>
@@ -17,7 +20,7 @@
 
 <script lang="ts">
 import FullPageContainer from "@/components/layouts/FullPageContainer.vue";
-import { onMounted, reactive } from "vue";
+import { onMounted, reactive, ref } from "vue";
 import { useFormatters, useDesignationAgreement } from "@/composables";
 import DesignationAgreementForm from "@/components/partial-view/DesignationAgreement/DesignationAgreementForm.vue";
 import {
@@ -40,6 +43,7 @@ export default {
     const formatter = useFormatters();
     const { mapDesignationChipStatus } = useDesignationAgreement();
     const designationModel = reactive({} as DesignationModel);
+    const modelLoaded = ref(false);
 
     onMounted(async () => {
       const designation = await DesignationAgreementService.shared.getDesignationAgreement(
@@ -67,9 +71,10 @@ export default {
           }),
         }),
       );
+      modelLoaded.value = true;
     });
 
-    return { designationModel, InstitutionRoutesConst };
+    return { designationModel, InstitutionRoutesConst, modelLoaded };
   },
 };
 </script>


### PR DESCRIPTION
Form.io is not reactively binding the property readOnly. If the readOnly value change after DOM(form) is mounted, form does not respond to it.

Hence, the modelLoaded variable ensures that API is called and data is initialized before form is loaded.