### PR TITLE
[api][SIM #28]Fixes after reassessments changes

### DIFF
--- a/sources/packages/api/src/database/entities/application.model.ts
+++ b/sources/packages/api/src/database/entities/application.model.ts
@@ -57,7 +57,7 @@ export class Application extends RecordDataModel {
   /**
    * Student associated with this application.
    */
-  @OneToOne(() => Student, { eager: false, cascade: true })
+  @OneToOne(() => Student, { eager: false, cascade: false })
   @JoinColumn({
     name: "student_id",
     referencedColumnName: ColumnNames.ID,

--- a/sources/packages/api/src/route-controllers/application/application.system.controller.ts
+++ b/sources/packages/api/src/route-controllers/application/application.system.controller.ts
@@ -24,10 +24,14 @@ import {
   CreateSupportingUsersDto,
   CreateIncomeVerificationDto,
   CRAVerificationIncomeDetailsDto,
-  UpdateOfferingIntensity,
 } from "./models/application.system.model";
 import { IConfig } from "../../types";
-import { ApiTags } from "@nestjs/swagger";
+import {
+  ApiNotFoundResponse,
+  ApiOkResponse,
+  ApiTags,
+  ApiUnprocessableEntityResponse,
+} from "@nestjs/swagger";
 import BaseController from "../BaseController";
 
 /**
@@ -78,20 +82,24 @@ export class ApplicationSystemController extends BaseController {
   /**
    * Associates an MSFAA number to the application checking
    * whatever is needed to create a new MSFAA or use an
-   * existing one instead.
+   * existing one instead. The MSFAA are individually associated
+   * considering the offering intensity full-time/part-time.
    * @param applicationId application id to receive an MSFAA.
-   * @param payload Offering Intensity of the student
    */
+  @ApiOkResponse({
+    description: "The application was successfully associated with an MSFAA.",
+  })
+  @ApiNotFoundResponse({
+    description:
+      "Student Application is not in the expected status. Applications status must the 'assessment' in order to have an MSFAA associated.",
+  })
+  @ApiUnprocessableEntityResponse({})
   @Patch(":applicationId/msfaa-number")
   async associateMSFAANumber(
     @Param("applicationId") applicationId: number,
-    @Body() payload: UpdateOfferingIntensity,
   ): Promise<void> {
     try {
-      await this.applicationService.associateMSFAANumber(
-        applicationId,
-        payload.offeringIntensity,
-      );
+      await this.applicationService.associateMSFAANumber(applicationId);
     } catch (error) {
       switch (error.name) {
         case APPLICATION_NOT_FOUND:

--- a/sources/packages/api/src/services/application/application.service.e2e-spec.ts
+++ b/sources/packages/api/src/services/application/application.service.e2e-spec.ts
@@ -29,7 +29,7 @@ import {
   createFakeMSFAANumber,
   createFakeStudent,
 } from "../../testHelpers/fake-entities";
-import { MAX_MFSAA_VALID_DAYS } from "../../utilities/system-configurations-constants";
+import { MAX_MSFAA_VALID_DAYS } from "../../utilities/system-configurations-constants";
 import * as dayjs from "dayjs";
 
 const createFakeApplicationInAssessment = (student: Student): Application => {
@@ -42,7 +42,7 @@ const createFakeApplicationInAssessment = (student: Student): Application => {
 
 const createDateInMSFAAValidPeriod = (increment: number): Date => {
   return dayjs()
-    .subtract(MAX_MFSAA_VALID_DAYS + increment, "days")
+    .subtract(MAX_MSFAA_VALID_DAYS + increment, "days")
     .toDate();
 };
 

--- a/sources/packages/api/src/services/disbursement-schedule-service/disbursement-schedule-service.ts
+++ b/sources/packages/api/src/services/disbursement-schedule-service/disbursement-schedule-service.ts
@@ -428,6 +428,7 @@ export class DisbursementScheduleService extends RecordDataModelService<Disburse
         "student.id",
         "user.firstName",
         "user.lastName",
+        "offering.name",
         "offering.offeringIntensity",
         "offering.studyStartDate",
         "offering.studyEndDate",

--- a/sources/packages/api/src/services/msfaa-number/msfaa-number.service.spec.ts
+++ b/sources/packages/api/src/services/msfaa-number/msfaa-number.service.spec.ts
@@ -5,7 +5,7 @@ import { MSFAANumberService } from "../../services/msfaa-number/msfaa-number.ser
 import { DatabaseModule } from "../../database/database.module";
 import { DatabaseService } from "../../database/database.service";
 import * as dayjs from "dayjs";
-import { MAX_MFSAA_VALID_DAYS } from "../../utilities";
+import { MAX_MSFAA_VALID_DAYS } from "../../utilities";
 
 describe("MSFAANumberService", () => {
   let service: MSFAANumberService;
@@ -32,7 +32,7 @@ describe("MSFAANumberService", () => {
   describe("isMSFAANumberValid", () => {
     it("should return true when start date is still valid", () => {
       // Arrange
-      const validPeriod = MAX_MFSAA_VALID_DAYS - 1;
+      const validPeriod = MAX_MSFAA_VALID_DAYS - 1;
       const startDate = new Date();
       const endDate = dayjs(startDate).add(validPeriod, "days").toDate();
       // Act
@@ -45,7 +45,7 @@ describe("MSFAANumberService", () => {
       // Arrange
       const startDate = new Date();
       const endDate = dayjs(startDate)
-        .add(MAX_MFSAA_VALID_DAYS, "days")
+        .add(MAX_MSFAA_VALID_DAYS, "days")
         .toDate();
       // Act
       const result = service.isMSFAANumberValid(startDate, endDate);
@@ -56,7 +56,7 @@ describe("MSFAANumberService", () => {
     it("should return false when start date is null", () => {
       // Arrange
       const startDate = null;
-      const validPeriod = MAX_MFSAA_VALID_DAYS - 1;
+      const validPeriod = MAX_MSFAA_VALID_DAYS - 1;
       const endDate = dayjs(new Date()).add(validPeriod, "days").toDate();
       // Act
       const result = service.isMSFAANumberValid(startDate, endDate);

--- a/sources/packages/api/src/services/msfaa-number/msfaa-number.service.ts
+++ b/sources/packages/api/src/services/msfaa-number/msfaa-number.service.ts
@@ -15,7 +15,7 @@ import {
   OfferingIntensity,
 } from "../../database/entities";
 import * as dayjs from "dayjs";
-import { MAX_MFSAA_VALID_DAYS } from "../../utilities";
+import { MAX_MSFAA_VALID_DAYS } from "../../utilities";
 import { SequenceControlService } from "../sequence-control/sequence-control.service";
 
 /**
@@ -79,6 +79,8 @@ export class MSFAANumberService extends RecordDataModelService<MSFAANumber> {
    * As per the current assumption, once the MSFAA is created on
    * ESDC it will not expire and can be reused.
    * @param studentId student id to filter.
+   * @param offeringIntensity MSFAA are generated individually for full-time/part-time
+   * applications. The offering intensity is used to differentiate between them.
    * @returns current valid MSFAA record.
    */
   async getCurrentValidMSFAANumber(
@@ -86,14 +88,14 @@ export class MSFAANumberService extends RecordDataModelService<MSFAANumber> {
     offeringIntensity: OfferingIntensity,
   ): Promise<MSFAANumber> {
     const minimumValidDate = dayjs()
-      .subtract(MAX_MFSAA_VALID_DAYS, "days")
+      .subtract(MAX_MSFAA_VALID_DAYS, "days")
       .toDate();
     return this.repo
       .createQueryBuilder("msfaaNumber")
       .innerJoin("msfaaNumber.student", "students")
       .where("students.id = :studentId", { studentId })
       .andWhere("msfaaNumber.referenceApplication is not null")
-      .andWhere("msfaaNumber.offeringIntensity= :offeringIntensity", {
+      .andWhere("msfaaNumber.offeringIntensity = :offeringIntensity", {
         offeringIntensity,
       })
       .andWhere("msfaaNumber.cancelledDate is null")
@@ -122,13 +124,13 @@ export class MSFAANumberService extends RecordDataModelService<MSFAANumber> {
     return (
       !!startDate &&
       !!endDate &&
-      dayjs(endDate).diff(startDate, "days") < MAX_MFSAA_VALID_DAYS
+      dayjs(endDate).diff(startDate, "days") < MAX_MSFAA_VALID_DAYS
     );
   }
 
   /**
    * Fetches the MSFAA number records which are not sent for request.
-   * This can be retrived by checking for date_requested column as null
+   * This can be retrieved by checking for date_requested column as null
    * in the MSFAANumber table.
    * @returns the records of the MSFAANumber table.
    */

--- a/sources/packages/api/src/services/student-assessment/student-assessment.service.ts
+++ b/sources/packages/api/src/services/student-assessment/student-assessment.service.ts
@@ -42,6 +42,7 @@ export class StudentAssessmentService extends RecordDataModelService<StudentAsse
       .createQueryBuilder("assessment")
       .select([
         "assessment.id",
+        "assessment.triggerType",
         "application.data",
         "programYear.programYear",
         "programYear.startDate",

--- a/sources/packages/api/src/testHelpers/fake-entities/application-fake.ts
+++ b/sources/packages/api/src/testHelpers/fake-entities/application-fake.ts
@@ -2,10 +2,10 @@ import {
   Application,
   ApplicationData,
   ApplicationStatus,
-  EducationProgramOffering,
   ProgramYear,
   RelationshipStatus,
   Student,
+  StudentAssessment,
 } from "../../database/entities";
 import { createFakeProgramYear } from "./program-year-fake";
 import { createFakeStudent } from "./student-fake";
@@ -13,8 +13,8 @@ import { getUTCNow } from "../../utilities/date-utils";
 
 export function createFakeApplication(
   student?: Student,
-  offering?: EducationProgramOffering,
   programYear?: ProgramYear,
+  currentStudentAssessment?: StudentAssessment,
 ): Application {
   const application = new Application();
   application.data = {} as ApplicationData;
@@ -23,5 +23,6 @@ export function createFakeApplication(
   application.applicationStatusUpdatedOn = getUTCNow();
   application.applicationStatus = ApplicationStatus.submitted;
   application.relationshipStatus = RelationshipStatus.Single;
+  application.currentAssessment = currentStudentAssessment;
   return application;
 }

--- a/sources/packages/api/src/testHelpers/fake-entities/index.ts
+++ b/sources/packages/api/src/testHelpers/fake-entities/index.ts
@@ -6,3 +6,4 @@ export * from "./student-fake";
 export * from "./user-fake";
 export * from "./education-program-offering-fake";
 export * from "./msfaa-number-fake";
+export * from "./student-assessment-fake";

--- a/sources/packages/api/src/testHelpers/fake-entities/student-assessment-fake.ts
+++ b/sources/packages/api/src/testHelpers/fake-entities/student-assessment-fake.ts
@@ -1,0 +1,22 @@
+import {
+  Application,
+  AssessmentTriggerType,
+  EducationProgramOffering,
+  StudentAssessment,
+  User,
+} from "../../database/entities";
+import { createFakeUser } from "./user-fake";
+
+export function createFakeStudentAssessment(
+  application?: Application,
+  user?: User,
+  offering?: EducationProgramOffering,
+): StudentAssessment {
+  const assessment = new StudentAssessment();
+  assessment.offering = offering;
+  assessment.application = application;
+  assessment.submittedDate = new Date();
+  assessment.submittedBy = user ?? createFakeUser();
+  assessment.triggerType = AssessmentTriggerType.OriginalAssessment;
+  return assessment;
+}

--- a/sources/packages/api/src/utilities/system-configurations-constants.ts
+++ b/sources/packages/api/src/utilities/system-configurations-constants.ts
@@ -13,7 +13,7 @@ export const COE_WINDOW = 21;
  * application (with a signed MSFAA) and the offering start date of a new
  * Student Application being submitted is inside the allowed period.
  */
-export const MAX_MFSAA_VALID_DAYS = 730;
+export const MAX_MSFAA_VALID_DAYS = 730;
 // Timeout to handle the worst-case scenario where the commit/rollback
 // was not executed due to a possible catastrophic failure.
 export const SUPPORTING_USERS_TRANSACTION_IDLE_TIMEOUT_SECONDS = 10;


### PR DESCRIPTION
- Reintroduce the missing trigger type that was preventing the application to move to "In Progress" after submission;
- Fixed MSFAA that was still relying on the offering from the _sims.applications_ table;
- Adjusted the MSFAA endpoint removing the offering intensity that is now retrieved from the application itself;
- Fixed the MSFAA query that was not considering the offering intensity type;
- Refactor a typo on the constant MAX_MSFAA_VALID_DAYS.
- Small change is needed (not critical) in the assessment_gateway workflow but it will be part of an upcoming PR.