### PR TITLE
[API][Web][SIMS #978] Create pending offering PR 1

### DIFF
--- a/sources/packages/api/src-sql/EducationPrograms/Alter-assessed_date.sql
+++ b/sources/packages/api/src-sql/EducationPrograms/Alter-assessed_date.sql
@@ -1,0 +1,7 @@
+--Drop the NOT NULL and DEFAULT constraint on assessed_date.
+ALTER TABLE
+    sims.education_programs
+ALTER COLUMN
+    assessed_date DROP NOT NULL,
+ALTER COLUMN
+    assessed_date DROP DEFAULT;

--- a/sources/packages/api/src-sql/EducationPrograms/Alter-program-status.sql
+++ b/sources/packages/api/src-sql/EducationPrograms/Alter-program-status.sql
@@ -4,7 +4,7 @@ ALTER TABLE
 ALTER COLUMN
     program_status TYPE sims.program_status USING CASE
         WHEN program_status = 'approved' then 'Approved'
-        WHEN program_status = 'declined' then 'Declined'
+        WHEN program_status = 'denied' then 'Declined'
         WHEN program_status = 'pending' then 'Pending'
         ELSE 'Pending' :: sims.program_status
     END;

--- a/sources/packages/api/src-sql/EducationPrograms/Alter-program-status.sql
+++ b/sources/packages/api/src-sql/EducationPrograms/Alter-program-status.sql
@@ -1,0 +1,10 @@
+--Alter the column program status to use Enum from varchar.
+ALTER TABLE
+    sims.education_programs
+ALTER COLUMN
+    program_status TYPE sims.program_status USING CASE
+        WHEN program_status = 'approved' then 'Approved'
+        WHEN program_status = 'declined' then 'Declined'
+        WHEN program_status = 'pending' then 'Pending'
+        ELSE 'Pending' :: sims.program_status
+    END;

--- a/sources/packages/api/src-sql/EducationPrograms/Rename-approval-columns.sql
+++ b/sources/packages/api/src-sql/EducationPrograms/Rename-approval-columns.sql
@@ -1,0 +1,15 @@
+--Renaming the approval columns to be in sync with other entities.
+ALTER TABLE
+    sims.education_programs RENAME COLUMN approval_status TO program_status;
+
+COMMENT ON COLUMN sims.education_programs.program_status IS 'Indicates the current status of the program.';
+
+ALTER TABLE
+    sims.education_programs RENAME COLUMN status_updated_by TO assessed_by;
+
+COMMENT ON COLUMN sims.education_programs.assessed_by IS 'User who assessed the program and updated the status.';
+
+ALTER TABLE
+    sims.education_programs RENAME COLUMN status_updated_on TO assessed_date;
+
+COMMENT ON COLUMN sims.education_programs.assessed_date IS 'Date-time when the program was assessed.';

--- a/sources/packages/api/src-sql/EducationPrograms/Rollback-approval-column-names.sql
+++ b/sources/packages/api/src-sql/EducationPrograms/Rollback-approval-column-names.sql
@@ -1,0 +1,9 @@
+--Renaming the approval columns to rollback.
+ALTER TABLE
+    sims.education_programs RENAME COLUMN program_status TO approval_status;
+
+ALTER TABLE
+    sims.education_programs RENAME COLUMN assessed_by TO status_updated_by;
+
+ALTER TABLE
+    sims.education_programs RENAME COLUMN assessed_date TO status_updated_on;

--- a/sources/packages/api/src-sql/EducationPrograms/Rollback-assessed-date-constraint.sql
+++ b/sources/packages/api/src-sql/EducationPrograms/Rollback-assessed-date-constraint.sql
@@ -1,0 +1,19 @@
+--Update value of assessed date before setting NOT NULL.
+UPDATE
+    sims.education_programs
+SET
+    assessed_date = now()
+WHERE
+    assessed_date IS NULL;
+
+--Set NOT NULL constraint on assessed_date.
+ALTER TABLE
+    sims.education_programs
+ALTER COLUMN
+    assessed_date
+SET
+    NOT NULL,
+ALTER COLUMN
+    assessed_date
+SET
+    DEFAULT now();

--- a/sources/packages/api/src-sql/EducationPrograms/Rollback-program-status-type.sql
+++ b/sources/packages/api/src-sql/EducationPrograms/Rollback-program-status-type.sql
@@ -1,0 +1,5 @@
+-- Rollback program status type to varchar
+ALTER TABLE
+    sims.education_programs
+ALTER COLUMN
+    program_status TYPE VARCHAR(50);

--- a/sources/packages/api/src-sql/EducationProgramsOfferings/Add-approval-columns.sql
+++ b/sources/packages/api/src-sql/EducationProgramsOfferings/Add-approval-columns.sql
@@ -12,7 +12,7 @@ COMMENT ON COLUMN sims.education_programs_offerings.assessed_by IS 'User who ass
 ALTER TABLE
     sims.education_programs_offerings
 ADD
-    COLUMN IF NOT EXISTS assessed_date TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now();
+    COLUMN IF NOT EXISTS assessed_date TIMESTAMP WITH TIME ZONE;
 
 COMMENT ON COLUMN sims.education_programs_offerings.assessed_date IS 'Date-time when the offering was assessed.';
 

--- a/sources/packages/api/src-sql/EducationProgramsOfferings/Add-approval-columns.sql
+++ b/sources/packages/api/src-sql/EducationProgramsOfferings/Add-approval-columns.sql
@@ -1,0 +1,25 @@
+--Add column assessed_by to sims.education_programs_offerings.
+ALTER TABLE
+    sims.education_programs_offerings
+ADD
+    COLUMN IF NOT EXISTS assessed_by INT NULL DEFAULT NULL REFERENCES sims.users(id) ON DELETE
+SET
+    NULL;
+
+COMMENT ON COLUMN sims.education_programs_offerings.assessed_by IS 'User who assessed the offering and updated the status.';
+
+--Add column assessed_date to sims.education_programs_offerings.
+ALTER TABLE
+    sims.education_programs_offerings
+ADD
+    COLUMN IF NOT EXISTS assessed_date TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now();
+
+COMMENT ON COLUMN sims.education_programs_offerings.assessed_date IS 'Date-time when the offering was assessed.';
+
+--Add column submitted_date to sims.education_programs_offerings.
+ALTER TABLE
+    sims.education_programs_offerings
+ADD
+    COLUMN IF NOT EXISTS submitted_date TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now();
+
+COMMENT ON COLUMN sims.education_programs_offerings.submitted_date IS 'Date-time when the offering was submitted.';

--- a/sources/packages/api/src-sql/EducationProgramsOfferings/Add-offering-status.sql
+++ b/sources/packages/api/src-sql/EducationProgramsOfferings/Add-offering-status.sql
@@ -1,0 +1,13 @@
+--Add column offering_status to sims.education_programs_offerings.
+ALTER TABLE
+    sims.education_programs_offerings
+ADD
+    COLUMN IF NOT EXISTS offering_status sims.offering_status NOT NULL DEFAULT 'Approved';
+
+COMMENT ON COLUMN sims.education_programs_offerings.offering_status IS 'Status of the offering.';
+
+--Drop the default value after adding the column.
+ALTER TABLE
+    sims.education_programs_offerings
+ALTER COLUMN
+    offering_status DROP DEFAULT;

--- a/sources/packages/api/src-sql/EducationProgramsOfferings/Drop-approval-columns.sql
+++ b/sources/packages/api/src-sql/EducationProgramsOfferings/Drop-approval-columns.sql
@@ -1,0 +1,11 @@
+-- Drop assessed_by from sims.education_programs_offerings. 
+ALTER TABLE
+    sims.education_programs_offerings DROP COLUMN IF EXISTS assessed_by;
+
+-- Drop assessed_date from sims.education_programs_offerings. 
+ALTER TABLE
+    sims.education_programs_offerings DROP COLUMN IF EXISTS assessed_date;
+
+-- Drop submitted_date from sims.education_programs_offerings. 
+ALTER TABLE
+    sims.education_programs_offerings DROP COLUMN IF EXISTS submitted_date;

--- a/sources/packages/api/src-sql/EducationProgramsOfferings/Drop-offering-status.sql
+++ b/sources/packages/api/src-sql/EducationProgramsOfferings/Drop-offering-status.sql
@@ -1,0 +1,3 @@
+-- Drop offering_status from sims.education_programs_offerings. 
+ALTER TABLE
+    sims.education_programs_offerings DROP COLUMN IF EXISTS offering_status;

--- a/sources/packages/api/src-sql/Types/Add-offering-type-scholastic-standing.sql
+++ b/sources/packages/api/src-sql/Types/Add-offering-type-scholastic-standing.sql
@@ -1,0 +1,6 @@
+-- Add Scholastic Standing to sims.offering_types.
+ALTER TYPE sims.offering_types
+ADD
+    VALUE 'Scholastic Standing'
+AFTER
+    'Private';

--- a/sources/packages/api/src-sql/Types/Add-offering-type-scholastic-standing.sql
+++ b/sources/packages/api/src-sql/Types/Add-offering-type-scholastic-standing.sql
@@ -1,6 +1,6 @@
 -- Add Scholastic Standing to sims.offering_types.
 ALTER TYPE sims.offering_types
 ADD
-    VALUE 'Scholastic Standing'
+    VALUE 'Scholastic standing'
 AFTER
     'Private';

--- a/sources/packages/api/src-sql/Types/Create-offering-status.sql
+++ b/sources/packages/api/src-sql/Types/Create-offering-status.sql
@@ -1,0 +1,2 @@
+--Create an enum for offering status.
+CREATE TYPE sims.offering_status AS ENUM ('Pending', 'Approved', 'Declined');

--- a/sources/packages/api/src-sql/Types/Create-program-status.sql
+++ b/sources/packages/api/src-sql/Types/Create-program-status.sql
@@ -1,0 +1,2 @@
+--Create an enum for program status.
+CREATE TYPE sims.program_status AS ENUM ('Pending', 'Approved', 'Declined');

--- a/sources/packages/api/src-sql/Types/Drop-offering-status.sql
+++ b/sources/packages/api/src-sql/Types/Drop-offering-status.sql
@@ -1,0 +1,2 @@
+--Drop offering status to rollback.
+DROP TYPE IF EXISTS sims.offering_status;

--- a/sources/packages/api/src-sql/Types/Drop-offering-type-scholastic-standing.sql
+++ b/sources/packages/api/src-sql/Types/Drop-offering-type-scholastic-standing.sql
@@ -1,0 +1,15 @@
+--Removing the value Scholastic Standing from sims.offering_types.
+--As postgres does not support removal of an Enum Value, We create a temporary enum and rename it.
+CREATE TYPE sims.offering_types_to_rollback AS ENUM ('Public', 'Private');
+
+ALTER TABLE
+    sims.education_programs_offerings
+ALTER COLUMN
+    offering_type TYPE sims.offering_types_to_rollback USING CASE
+        WHEN offering_type = 'Scholastic Standing' then 'Private'
+        else 'Public' :: sims.offering_types_to_rollback
+    END;
+
+DROP TYPE sims.offering_types;
+
+ALTER TYPE sims.offering_types_to_rollback RENAME TO offering_types;

--- a/sources/packages/api/src-sql/Types/Drop-offering-type-scholastic-standing.sql
+++ b/sources/packages/api/src-sql/Types/Drop-offering-type-scholastic-standing.sql
@@ -6,7 +6,7 @@ ALTER TABLE
     sims.education_programs_offerings
 ALTER COLUMN
     offering_type TYPE sims.offering_types_to_rollback USING CASE
-        WHEN offering_type = 'Scholastic Standing' then 'Private'
+        WHEN offering_type = 'Scholastic standing' then 'Private'
         else 'Public' :: sims.offering_types_to_rollback
     END;
 

--- a/sources/packages/api/src-sql/Types/Drop-program-status.sql
+++ b/sources/packages/api/src-sql/Types/Drop-program-status.sql
@@ -1,0 +1,2 @@
+--Drop program status to rollback.
+DROP TYPE IF EXISTS sims.program_status;

--- a/sources/packages/api/src-sql/Types/Modify-offering-type-application-specific.sql
+++ b/sources/packages/api/src-sql/Types/Modify-offering-type-application-specific.sql
@@ -1,0 +1,2 @@
+--Alter the enum value of sims.offering_types Application Specific.
+ALTER TYPE sims.offering_types RENAME VALUE 'Application Specific' TO 'Private';

--- a/sources/packages/api/src-sql/Types/Rollback-to-offering-type-application-specific.sql
+++ b/sources/packages/api/src-sql/Types/Rollback-to-offering-type-application-specific.sql
@@ -1,0 +1,2 @@
+--Rollback the enum value to Application Specific.
+ALTER TYPE sims.offering_types RENAME VALUE 'Private' TO 'Application Specific';

--- a/sources/packages/api/src/database/entities/education-program-offering.model.ts
+++ b/sources/packages/api/src/database/entities/education-program-offering.model.ts
@@ -10,18 +10,9 @@ import { ColumnNames, TableNames } from "../constant";
 import { RecordDataModel } from "./record.model";
 import { EducationProgram } from "./education-program.model";
 import { InstitutionLocation } from "./institution-location.model";
-import { OfferingTypes, User } from ".";
+import { OfferingTypes, User, OfferingStatus } from ".";
 import { OfferingIntensity } from "./offering-intensity.type";
 import { dateOnlyTransformer } from "../transformers/date-only.transformer";
-
-/**
- * Represents the status of an offering.
- */
-export enum OfferingStatus {
-  Approved = "Approved",
-  Pending = "Pending",
-  Declined = "Declined",
-}
 
 /**
  * The main resource table to store education programs offerings related information.
@@ -159,6 +150,7 @@ export class EducationProgramOffering extends RecordDataModel {
    */
   @Column({
     name: "offering_type",
+    nullable: false,
     type: "enum",
     enum: OfferingTypes,
     enumName: "OfferingTypes",

--- a/sources/packages/api/src/database/entities/education-program-offering.model.ts
+++ b/sources/packages/api/src/database/entities/education-program-offering.model.ts
@@ -2,6 +2,7 @@ import {
   Column,
   Entity,
   JoinColumn,
+  ManyToOne,
   OneToOne,
   PrimaryGeneratedColumn,
 } from "typeorm";
@@ -9,9 +10,18 @@ import { ColumnNames, TableNames } from "../constant";
 import { RecordDataModel } from "./record.model";
 import { EducationProgram } from "./education-program.model";
 import { InstitutionLocation } from "./institution-location.model";
-import { OfferingTypes } from ".";
+import { OfferingTypes, User } from ".";
 import { OfferingIntensity } from "./offering-intensity.type";
 import { dateOnlyTransformer } from "../transformers/date-only.transformer";
+
+/**
+ * Represents the status of an offering.
+ */
+export enum OfferingStatus {
+  Approved = "Approved",
+  Pending = "Pending",
+  Declined = "Declined",
+}
 
 /**
  * The main resource table to store education programs offerings related information.
@@ -211,6 +221,47 @@ export class EducationProgramOffering extends RecordDataModel {
     name: "offering_declaration",
   })
   offeringDeclaration: boolean;
+
+  /**
+   * User who assessed the offering.
+   */
+  @ManyToOne(() => User, { eager: false, nullable: true })
+  @JoinColumn({
+    name: "assessed_by",
+    referencedColumnName: "id",
+  })
+  assessedBy?: User;
+
+  /**
+   * Date-time at which the offering was assessed.
+   */
+  @Column({
+    name: "assessed_date",
+    type: "timestamptz",
+    nullable: true,
+  })
+  assessedDate?: Date;
+
+  /**
+   * Education program offering submitted date.
+   */
+  @Column({
+    name: "submitted_date",
+    type: "timestamptz",
+    nullable: false,
+  })
+  submittedDate: Date;
+
+  /**
+   * Represents the current status of an offering.
+   */
+  @Column({
+    name: "program_status",
+    type: "enum",
+    enum: OfferingStatus,
+    enumName: "OfferingStatus",
+  })
+  offeringStatus: OfferingStatus;
 }
 
 /**

--- a/sources/packages/api/src/database/entities/education-program-offering.model.ts
+++ b/sources/packages/api/src/database/entities/education-program-offering.model.ts
@@ -256,7 +256,7 @@ export class EducationProgramOffering extends RecordDataModel {
    * Represents the current status of an offering.
    */
   @Column({
-    name: "program_status",
+    name: "offering_status",
     type: "enum",
     enum: OfferingStatus,
     enumName: "OfferingStatus",

--- a/sources/packages/api/src/database/entities/education-program.model.ts
+++ b/sources/packages/api/src/database/entities/education-program.model.ts
@@ -327,9 +327,9 @@ export class EducationProgram extends RecordDataModel {
   @Column({
     name: "assessed_date",
     type: "timestamptz",
-    nullable: false,
+    nullable: true,
   })
-  assessedDate: Date;
+  assessedDate?: Date;
 
   /**
    * Effective End date of the approved Education program.

--- a/sources/packages/api/src/database/entities/education-program.model.ts
+++ b/sources/packages/api/src/database/entities/education-program.model.ts
@@ -9,19 +9,9 @@ import {
 } from "typeorm";
 import { ColumnNames, TableNames } from "../constant";
 import { RecordDataModel } from "./record.model";
-import { Institution, Note, User } from ".";
+import { Institution, Note, User, ProgramStatus } from ".";
 import { ProgramIntensity } from "./program-intensity.type";
 import { dateOnlyTransformer } from "../transformers/date-only.transformer";
-
-/**
- * Represents the approval status for a program also stored
- * on column approval_status on table education_programs.
- */
-export enum ProgramStatus {
-  Approved = "Approved",
-  Pending = "Pending",
-  Declined = "Declined",
-}
 
 /**
  * The main resource table to store education programs related information.

--- a/sources/packages/api/src/database/entities/education-program.model.ts
+++ b/sources/packages/api/src/database/entities/education-program.model.ts
@@ -315,7 +315,7 @@ export class EducationProgram extends RecordDataModel {
     type: "timestamptz",
     nullable: false,
   })
-  submittedOn: Date;
+  submittedDate: Date;
 
   /**
    * Education program assessed date.
@@ -383,7 +383,7 @@ export class EducationProgram extends RecordDataModel {
  * on column approval_status on table education_programs.
  */
 export enum ProgramStatus {
-  Approved = "approved",
-  Pending = "pending",
-  Denied = "denied",
+  Approved = "Approved",
+  Pending = "Pending",
+  Declined = "Declined",
 }

--- a/sources/packages/api/src/database/entities/education-program.model.ts
+++ b/sources/packages/api/src/database/entities/education-program.model.ts
@@ -11,7 +11,6 @@ import { ColumnNames, TableNames } from "../constant";
 import { RecordDataModel } from "./record.model";
 import { Institution, Note, User } from ".";
 import { ProgramIntensity } from "./program-intensity.type";
-import { ApprovalStatus } from "../../services/education-program/constants";
 import { dateOnlyTransformer } from "../transformers/date-only.transformer";
 
 /**
@@ -159,9 +158,9 @@ export class EducationProgram extends RecordDataModel {
    * Approval status of the program like pending or approved.
    */
   @Column({
-    name: "approval_status",
+    name: "program_status",
   })
-  approvalStatus: ApprovalStatus;
+  programStatus: ProgramStatus;
   /**
    * Related institution.
    */
@@ -319,14 +318,14 @@ export class EducationProgram extends RecordDataModel {
   submittedOn: Date;
 
   /**
-   * Education program status updated on.
+   * Education program assessed date.
    */
   @Column({
-    name: "status_updated_on",
+    name: "assessed_date",
     type: "timestamptz",
     nullable: false,
   })
-  statusUpdatedOn: Date;
+  assessedDate: Date;
 
   /**
    * Effective End date of the approved Education program.
@@ -353,17 +352,17 @@ export class EducationProgram extends RecordDataModel {
   programNote?: Note;
 
   /**
-   * Education program status updated by.
+   * Education program assessed by.
    */
-  @RelationId((program: EducationProgram) => program.statusUpdatedBy)
-  statusUpdatedById?: number;
+  @RelationId((program: EducationProgram) => program.assessedBy)
+  assessedById?: number;
 
-  @ManyToOne((type) => User, { eager: false, nullable: true })
+  @ManyToOne(() => User, { eager: false, nullable: true })
   @JoinColumn({
-    name: "status_updated_by",
+    name: "assessed_by",
     referencedColumnName: "id",
   })
-  statusUpdatedBy?: User;
+  assessedBy?: User;
 
   /**
    * Education program submitted by.
@@ -377,4 +376,14 @@ export class EducationProgram extends RecordDataModel {
     referencedColumnName: "id",
   })
   submittedBy: User;
+}
+
+/**
+ * Represents the approval status for a program also stored
+ * on column approval_status on table education_programs.
+ */
+export enum ProgramStatus {
+  Approved = "approved",
+  Pending = "pending",
+  Denied = "denied",
 }

--- a/sources/packages/api/src/database/entities/education-program.model.ts
+++ b/sources/packages/api/src/database/entities/education-program.model.ts
@@ -14,6 +14,16 @@ import { ProgramIntensity } from "./program-intensity.type";
 import { dateOnlyTransformer } from "../transformers/date-only.transformer";
 
 /**
+ * Represents the approval status for a program also stored
+ * on column approval_status on table education_programs.
+ */
+export enum ProgramStatus {
+  Approved = "Approved",
+  Pending = "Pending",
+  Declined = "Declined",
+}
+
+/**
  * The main resource table to store education programs related information.
  * Tombstone information to education programs shared across institution locations.
  */
@@ -159,6 +169,10 @@ export class EducationProgram extends RecordDataModel {
    */
   @Column({
     name: "program_status",
+    nullable: false,
+    type: "enum",
+    enum: ProgramStatus,
+    enumName: "ProgramStatus",
   })
   programStatus: ProgramStatus;
   /**
@@ -376,14 +390,4 @@ export class EducationProgram extends RecordDataModel {
     referencedColumnName: "id",
   })
   submittedBy: User;
-}
-
-/**
- * Represents the approval status for a program also stored
- * on column approval_status on table education_programs.
- */
-export enum ProgramStatus {
-  Approved = "Approved",
-  Pending = "Pending",
-  Declined = "Declined",
 }

--- a/sources/packages/api/src/database/entities/index.ts
+++ b/sources/packages/api/src/database/entities/index.ts
@@ -56,3 +56,5 @@ export * from "./scholastic-standing-status.type";
 export * from "./student-appeal-status.type";
 export * from "./student-appeal-requests.model";
 export * from "./assessment-trigger.type";
+export * from "./program-status.type";
+export * from "./offering-status.type";

--- a/sources/packages/api/src/database/entities/offering-status.type.ts
+++ b/sources/packages/api/src/database/entities/offering-status.type.ts
@@ -1,0 +1,8 @@
+/**
+ * Represents the status of an offering.
+ */
+export enum OfferingStatus {
+  Approved = "Approved",
+  Pending = "Pending",
+  Declined = "Declined",
+}

--- a/sources/packages/api/src/database/entities/offering.type.ts
+++ b/sources/packages/api/src/database/entities/offering.type.ts
@@ -8,7 +8,11 @@ export enum OfferingTypes {
   public = "Public",
   /**
    * Offering was created to fulfill the need of
-   * a particular student application.
+   * a particular student/application.
    */
-  applicationSpecific = "Application Specific",
+  Private = "Private",
+  /**
+   * Offering created for change in scholastic standing.
+   */
+  ScholasticStanding = "Scholastic Standing",
 }

--- a/sources/packages/api/src/database/entities/offering.type.ts
+++ b/sources/packages/api/src/database/entities/offering.type.ts
@@ -12,7 +12,7 @@ export enum OfferingTypes {
    */
   Private = "Private",
   /**
-   * Offering created for change in scholastic standing.
+   * Offering created for a change in scholastic standing reported by institution.
    */
   ScholasticStanding = "Scholastic Standing",
 }

--- a/sources/packages/api/src/database/entities/offering.type.ts
+++ b/sources/packages/api/src/database/entities/offering.type.ts
@@ -5,7 +5,7 @@ export enum OfferingTypes {
   /**
    * Offering is available for all the students.
    */
-  public = "Public",
+  Public = "Public",
   /**
    * Offering was created to fulfill the need of
    * a particular student/application.
@@ -14,5 +14,5 @@ export enum OfferingTypes {
   /**
    * Offering created for a change in scholastic standing reported by institution.
    */
-  ScholasticStanding = "Scholastic Standing",
+  ScholasticStanding = "Scholastic standing",
 }

--- a/sources/packages/api/src/database/entities/program-status.type.ts
+++ b/sources/packages/api/src/database/entities/program-status.type.ts
@@ -1,0 +1,9 @@
+/**
+ * Represents the approval status for a program also stored
+ * on column approval_status on table education_programs.
+ */
+export enum ProgramStatus {
+  Approved = "Approved",
+  Pending = "Pending",
+  Declined = "Declined",
+}

--- a/sources/packages/api/src/database/migrations/1650655597471-AddOfferingStatusType.ts
+++ b/sources/packages/api/src/database/migrations/1650655597471-AddOfferingStatusType.ts
@@ -1,0 +1,16 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+import { getSQLFileData } from "../../utilities";
+
+export class AddOfferingStatusType1650655597471 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      getSQLFileData("Create-offering-status.sql", "Types"),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      getSQLFileData("Drop-offering-status.sql", "Types"),
+    );
+  }
+}

--- a/sources/packages/api/src/database/migrations/1650663208421-RenameOfferingTypeApplicationSpecific.ts
+++ b/sources/packages/api/src/database/migrations/1650663208421-RenameOfferingTypeApplicationSpecific.ts
@@ -1,0 +1,21 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+import { getSQLFileData } from "../../utilities";
+
+export class RenameOfferingTypeApplicationSpecific1650663208421
+  implements MigrationInterface
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      getSQLFileData("Modify-offering-type-application-specific.sql", "Types"),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      getSQLFileData(
+        "Rollback-to-offering-type-application-specific.sql",
+        "Types",
+      ),
+    );
+  }
+}

--- a/sources/packages/api/src/database/migrations/1650663373899-AddOfferingTypeScholasticStanding.ts
+++ b/sources/packages/api/src/database/migrations/1650663373899-AddOfferingTypeScholasticStanding.ts
@@ -1,0 +1,18 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+import { getSQLFileData } from "../../utilities";
+
+export class AddOfferingTypeScholasticStanding1650663373899
+  implements MigrationInterface
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      getSQLFileData("Add-offering-type-scholastic-standing.sql", "Types"),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      getSQLFileData("Drop-offering-type-scholastic-standing.sql", "Types"),
+    );
+  }
+}

--- a/sources/packages/api/src/database/migrations/1650670114801-AddOfferingStatusColumn.ts
+++ b/sources/packages/api/src/database/migrations/1650670114801-AddOfferingStatusColumn.ts
@@ -1,0 +1,18 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+import { getSQLFileData } from "../../utilities";
+
+export class AddOfferingStatusColumn1650670114801
+  implements MigrationInterface
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      getSQLFileData("Add-offering-status.sql", "EducationProgramsOfferings"),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      getSQLFileData("Drop-offering-status.sql", "EducationProgramsOfferings"),
+    );
+  }
+}

--- a/sources/packages/api/src/database/migrations/1650670243386-AddOfferingApprovalColumns.ts
+++ b/sources/packages/api/src/database/migrations/1650670243386-AddOfferingApprovalColumns.ts
@@ -1,0 +1,18 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+import { getSQLFileData } from "../../utilities";
+
+export class AddOfferingApprovalColumns1650670243386
+  implements MigrationInterface
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      getSQLFileData("Add-approval-columns.sql", "EducationProgramsOfferings"),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      getSQLFileData("Drop-approval-columns.sql", "EducationProgramsOfferings"),
+    );
+  }
+}

--- a/sources/packages/api/src/database/migrations/1650911871247-CreateProgramStatusType.ts
+++ b/sources/packages/api/src/database/migrations/1650911871247-CreateProgramStatusType.ts
@@ -1,0 +1,16 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+import { getSQLFileData } from "../../utilities";
+
+export class CreateProgramStatusType1650911871247
+  implements MigrationInterface
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      getSQLFileData("Create-program-status.sql", "Types"),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(getSQLFileData("Drop-program-status.sql", "Types"));
+  }
+}

--- a/sources/packages/api/src/database/migrations/1650913625695-RenameProgramApprovalColumns.ts
+++ b/sources/packages/api/src/database/migrations/1650913625695-RenameProgramApprovalColumns.ts
@@ -1,0 +1,18 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+import { getSQLFileData } from "../../utilities";
+
+export class RenameProgramApprovalColumns1650913625695
+  implements MigrationInterface
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      getSQLFileData("Rename-approval-columns.sql", "EducationPrograms"),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      getSQLFileData("Rollback-approval-column-names.sql", "EducationPrograms"),
+    );
+  }
+}

--- a/sources/packages/api/src/database/migrations/1650932727759-AlterProgramStatusColumnType.ts
+++ b/sources/packages/api/src/database/migrations/1650932727759-AlterProgramStatusColumnType.ts
@@ -1,0 +1,18 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+import { getSQLFileData } from "../../utilities";
+
+export class AlterProgramStatusColumnType1650932727759
+  implements MigrationInterface
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      getSQLFileData("Alter-program-status.sql", "EducationPrograms"),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      getSQLFileData("Rollback-program-status-type.sql", "EducationPrograms"),
+    );
+  }
+}

--- a/sources/packages/api/src/database/migrations/1651185866874-RemoveAssessedDateConstraint.ts
+++ b/sources/packages/api/src/database/migrations/1651185866874-RemoveAssessedDateConstraint.ts
@@ -1,0 +1,20 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+import { getSQLFileData } from "../../utilities";
+export class RemoveAssessedDateConstraint1651185866874
+  implements MigrationInterface
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      getSQLFileData("Alter-assessed_date.sql", "EducationPrograms"),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      getSQLFileData(
+        "Rollback-assessed-date-constraint.sql",
+        "EducationPrograms",
+      ),
+    );
+  }
+}

--- a/sources/packages/api/src/route-controllers/application/application.controller.service.ts
+++ b/sources/packages/api/src/route-controllers/application/application.controller.service.ts
@@ -17,11 +17,11 @@ import {
   getOfferingNameAndPeriod,
   getPIRDeniedReason,
 } from "../../utilities";
-import { ApprovalStatus } from "../../services/education-program/constants";
 import {
   Application,
   ApplicationData,
   DisbursementSchedule,
+  ProgramStatus,
 } from "../../database/entities";
 
 /**
@@ -87,7 +87,7 @@ export class ApplicationControllerService {
           id: selectedProgram.id,
           name: selectedProgram.name,
         };
-        if (selectedProgram.approvalStatus !== ApprovalStatus.approved) {
+        if (selectedProgram.programStatus !== ProgramStatus.Approved) {
           data.selectedProgram = null;
         }
       } else {

--- a/sources/packages/api/src/route-controllers/education-program-offering/education-program-offering.controller.ts
+++ b/sources/packages/api/src/route-controllers/education-program-offering/education-program-offering.controller.ts
@@ -133,7 +133,7 @@ export class EducationProgramOfferingController extends BaseController {
         page: page,
         pageLimit: pageLimit,
       },
-      [OfferingTypes.public, OfferingTypes.Private],
+      [OfferingTypes.Public, OfferingTypes.Private],
     );
   }
 
@@ -346,7 +346,7 @@ export class EducationProgramOfferingController extends BaseController {
         page: page,
         pageLimit: pageLimit,
       },
-      [OfferingTypes.public, OfferingTypes.Private],
+      [OfferingTypes.Public, OfferingTypes.Private],
     );
   }
 

--- a/sources/packages/api/src/route-controllers/education-program-offering/education-program-offering.controller.ts
+++ b/sources/packages/api/src/route-controllers/education-program-offering/education-program-offering.controller.ts
@@ -18,7 +18,7 @@ import {
   Groups,
 } from "../../auth/decorators";
 import {
-  ProgramOfferingBaseDTO,
+  SaveOfferingDTO,
   ProgramOfferingDto,
   ProgramOfferingDetailsDto,
   transformToProgramOfferingDto,
@@ -60,7 +60,7 @@ export class EducationProgramOfferingController extends BaseController {
   @HasLocationAccess("locationId")
   @Post("location/:locationId/education-program/:programId")
   async create(
-    @Body() payload: ProgramOfferingBaseDTO,
+    @Body() payload: SaveOfferingDTO,
     @Param("locationId") locationId: number,
     @Param("programId") programId: number,
     @UserToken() userToken: IInstitutionUserToken,
@@ -87,7 +87,6 @@ export class EducationProgramOfferingController extends BaseController {
       await this.programOfferingService.createEducationProgramOffering(
         locationId,
         programId,
-        userToken.userId,
         submissionResult.data.data,
       );
     return { id: createdProgramOffering.id };
@@ -165,7 +164,7 @@ export class EducationProgramOfferingController extends BaseController {
     "location/:locationId/education-program/:programId/offering/:offeringId",
   )
   async updateProgramOffering(
-    @Body() payload: ProgramOfferingBaseDTO,
+    @Body() payload: SaveOfferingDTO,
     @UserToken() userToken: IInstitutionUserToken,
     @Param("locationId") locationId: number,
     @Param("programId") programId?: number,
@@ -203,7 +202,6 @@ export class EducationProgramOfferingController extends BaseController {
         locationId,
         programId,
         offeringId,
-        userToken.userId,
         updatingResult.data.data,
       );
     return updateProgramOffering.affected;

--- a/sources/packages/api/src/route-controllers/education-program-offering/education-program-offering.controller.ts
+++ b/sources/packages/api/src/route-controllers/education-program-offering/education-program-offering.controller.ts
@@ -18,7 +18,7 @@ import {
   Groups,
 } from "../../auth/decorators";
 import {
-  SaveEducationProgramOfferingDto,
+  ProgramOfferingBaseDTO,
   ProgramOfferingDto,
   ProgramOfferingDetailsDto,
   transformToProgramOfferingDto,
@@ -60,7 +60,7 @@ export class EducationProgramOfferingController extends BaseController {
   @HasLocationAccess("locationId")
   @Post("location/:locationId/education-program/:programId")
   async create(
-    @Body() payload: SaveEducationProgramOfferingDto,
+    @Body() payload: ProgramOfferingBaseDTO,
     @Param("locationId") locationId: number,
     @Param("programId") programId: number,
     @UserToken() userToken: IInstitutionUserToken,
@@ -87,7 +87,8 @@ export class EducationProgramOfferingController extends BaseController {
       await this.programOfferingService.createEducationProgramOffering(
         locationId,
         programId,
-        submissionResult.data,
+        userToken.userId,
+        submissionResult.data.data,
       );
     return { id: createdProgramOffering.id };
   }
@@ -132,7 +133,7 @@ export class EducationProgramOfferingController extends BaseController {
         page: page,
         pageLimit: pageLimit,
       },
-      [OfferingTypes.public],
+      [OfferingTypes.public, OfferingTypes.Private],
     );
   }
 
@@ -164,7 +165,7 @@ export class EducationProgramOfferingController extends BaseController {
     "location/:locationId/education-program/:programId/offering/:offeringId",
   )
   async updateProgramOffering(
-    @Body() payload: SaveEducationProgramOfferingDto,
+    @Body() payload: ProgramOfferingBaseDTO,
     @UserToken() userToken: IInstitutionUserToken,
     @Param("locationId") locationId: number,
     @Param("programId") programId?: number,
@@ -202,7 +203,8 @@ export class EducationProgramOfferingController extends BaseController {
         locationId,
         programId,
         offeringId,
-        payload,
+        userToken.userId,
+        updatingResult.data.data,
       );
     return updateProgramOffering.affected;
   }
@@ -344,7 +346,7 @@ export class EducationProgramOfferingController extends BaseController {
         page: page,
         pageLimit: pageLimit,
       },
-      [OfferingTypes.public],
+      [OfferingTypes.public, OfferingTypes.Private],
     );
   }
 

--- a/sources/packages/api/src/route-controllers/education-program-offering/education-program-offering.controller.ts
+++ b/sources/packages/api/src/route-controllers/education-program-offering/education-program-offering.controller.ts
@@ -43,6 +43,7 @@ import { UserGroups } from "../../auth/user-groups.enum";
 import { EducationProgramOfferingModel } from "../../services/education-program-offering/education-program-offering.service.models";
 import { ApiTags } from "@nestjs/swagger";
 import BaseController from "../BaseController";
+import { PrimaryIdentifierAPIOutDTO } from "../models/primary.identifier.dto";
 
 @Controller("institution/offering")
 @ApiTags("institution")
@@ -63,7 +64,7 @@ export class EducationProgramOfferingController extends BaseController {
     @Param("locationId") locationId: number,
     @Param("programId") programId: number,
     @UserToken() userToken: IInstitutionUserToken,
-  ): Promise<number> {
+  ): Promise<PrimaryIdentifierAPIOutDTO> {
     const requestProgram = await this.programService.getInstitutionProgram(
       programId,
       userToken.authorizations.institutionId,
@@ -86,9 +87,9 @@ export class EducationProgramOfferingController extends BaseController {
       await this.programOfferingService.createEducationProgramOffering(
         locationId,
         programId,
-        payload,
+        submissionResult.data,
       );
-    return createdProgramOffering.id;
+    return { id: createdProgramOffering.id };
   }
 
   /**

--- a/sources/packages/api/src/route-controllers/education-program-offering/models/education-program-offering.dto.ts
+++ b/sources/packages/api/src/route-controllers/education-program-offering/models/education-program-offering.dto.ts
@@ -1,4 +1,4 @@
-import { OfferingTypes } from "../../../database/entities";
+import { OfferingTypes, OfferingStatus } from "../../../database/entities";
 import { OfferingIntensity } from "../../../database/entities/offering-intensity.type";
 import { StudyBreak } from "../../../database/entities/education-program-offering.model";
 import { ProgramOfferingModel } from "../../../services/education-program-offering/education-program-offering.service.models";
@@ -24,6 +24,10 @@ export interface ProgramOfferingBaseDTO {
   offeringWILType?: string;
   studyBreaks?: StudyBreak[];
   offeringDeclaration: boolean;
+  assessedBy?: string;
+  assessedDate?: Date;
+  submittedDate: Date;
+  offeringStatus: OfferingStatus;
 }
 /**
  * DTO for persisting program offering.
@@ -84,5 +88,7 @@ export const transformToProgramOfferingDto = (
     offeringWILType: offering.offeringWILType,
     studyBreaks: offering.studyBreaks,
     offeringDeclaration: offering.offeringDeclaration,
+    submittedDate: offering.submittedDate,
+    offeringStatus: offering.offeringStatus,
   };
 };

--- a/sources/packages/api/src/route-controllers/education-program-offering/models/education-program-offering.dto.ts
+++ b/sources/packages/api/src/route-controllers/education-program-offering/models/education-program-offering.dto.ts
@@ -3,7 +3,7 @@ import { OfferingIntensity } from "../../../database/entities/offering-intensity
 import { StudyBreak } from "../../../database/entities/education-program-offering.model";
 import { ProgramOfferingModel } from "../../../services/education-program-offering/education-program-offering.service.models";
 
-export interface ProgramOfferingBaseDTO {
+export interface SaveOfferingDTO {
   offeringName: string;
   studyStartDate: Date;
   studyEndDate: Date;
@@ -26,7 +26,6 @@ export interface ProgramOfferingBaseDTO {
   offeringDeclaration: boolean;
   assessedBy?: string;
   assessedDate?: Date;
-  submittedDate?: Date;
   offeringStatus: OfferingStatus;
   offeringType: OfferingTypes;
 }
@@ -45,8 +44,33 @@ export class EducationProgramOfferingDto {
 /**
  * View only DTO for program offering.
  */
-export interface ProgramOfferingDto extends ProgramOfferingBaseDTO {
+export interface ProgramOfferingDto {
   id: number;
+  offeringName: string;
+  studyStartDate: Date;
+  studyEndDate: Date;
+  actualTuitionCosts: number;
+  programRelatedCosts: number;
+  mandatoryFees: number;
+  exceptionalExpenses: number;
+  tuitionRemittanceRequestedAmount: number;
+  offeringDelivered: string;
+  lacksStudyDates: boolean;
+  lacksStudyBreaks: boolean;
+  lacksFixedCosts: boolean;
+  tuitionRemittanceRequested: string;
+  offeringIntensity: OfferingIntensity;
+  yearOfStudy: number;
+  showYearOfStudy?: boolean;
+  hasOfferingWILComponent: string;
+  offeringWILType?: string;
+  studyBreaks?: StudyBreak[];
+  offeringDeclaration: boolean;
+  assessedBy?: string;
+  assessedDate?: Date;
+  submittedDate: Date;
+  offeringStatus: OfferingStatus;
+  offeringType: OfferingTypes;
 }
 
 export interface ProgramOfferingDetailsDto {

--- a/sources/packages/api/src/route-controllers/education-program-offering/models/education-program-offering.dto.ts
+++ b/sources/packages/api/src/route-controllers/education-program-offering/models/education-program-offering.dto.ts
@@ -26,16 +26,11 @@ export interface ProgramOfferingBaseDTO {
   offeringDeclaration: boolean;
   assessedBy?: string;
   assessedDate?: Date;
-  submittedDate: Date;
+  submittedDate?: Date;
   offeringStatus: OfferingStatus;
+  offeringType: OfferingTypes;
 }
-/**
- * DTO for persisting program offering.
- */
-export interface SaveEducationProgramOfferingDto
-  extends ProgramOfferingBaseDTO {
-  offeringType?: OfferingTypes;
-}
+
 /**
  * Summary DTO of program offering.
  */
@@ -90,5 +85,6 @@ export const transformToProgramOfferingDto = (
     offeringDeclaration: offering.offeringDeclaration,
     submittedDate: offering.submittedDate,
     offeringStatus: offering.offeringStatus,
+    offeringType: offering.offeringType,
   };
 };

--- a/sources/packages/api/src/route-controllers/education-program/education-program.controller.ts
+++ b/sources/packages/api/src/route-controllers/education-program/education-program.controller.ts
@@ -204,13 +204,6 @@ export class EducationProgramController extends BaseController {
       submittedBy: getUserFullName(educationProgram.submittedBy),
       effectiveEndDate: getISODateOnlyString(educationProgram.effectiveEndDate),
       assessedDate: educationProgram.assessedDate,
-      // TODO: for now - program.effectiveEndDate is added by the ministry user
-      // so, if program.effectiveEndDate is null/undefined, then
-      // the program was auto approved, when institution submitted the
-      // program, else the program was approved by ministry user.
-      // ministry user uses IDIR. Program will always denied by
-      // ministry user (i.e IDIR). Will need to update in future as
-      // proper decision is taken
       assessedBy: getUserFullName(educationProgram.assessedBy),
     };
 

--- a/sources/packages/api/src/route-controllers/education-program/education-program.controller.ts
+++ b/sources/packages/api/src/route-controllers/education-program/education-program.controller.ts
@@ -97,7 +97,7 @@ export class EducationProgramController extends BaseController {
     return this.programService.getSummaryForLocation(
       userToken.authorizations.institutionId,
       locationId,
-      [OfferingTypes.public],
+      [OfferingTypes.public, OfferingTypes.Private],
       {
         searchCriteria: searchCriteria,
         sortField: sortField,
@@ -396,7 +396,7 @@ export class EducationProgramController extends BaseController {
   ): Promise<PaginatedResults<ProgramsSummary>> {
     return this.programService.getPaginatedProgramsForAEST(
       institutionId,
-      [OfferingTypes.public],
+      [OfferingTypes.public, OfferingTypes.Private],
       {
         searchCriteria: searchCriteria,
         sortField: sortColumn,

--- a/sources/packages/api/src/route-controllers/education-program/education-program.controller.ts
+++ b/sources/packages/api/src/route-controllers/education-program/education-program.controller.ts
@@ -97,7 +97,7 @@ export class EducationProgramController extends BaseController {
     return this.programService.getSummaryForLocation(
       userToken.authorizations.institutionId,
       locationId,
-      [OfferingTypes.public, OfferingTypes.Private],
+      [OfferingTypes.Public, OfferingTypes.Private],
       {
         searchCriteria: searchCriteria,
         sortField: sortField,
@@ -396,7 +396,7 @@ export class EducationProgramController extends BaseController {
   ): Promise<PaginatedResults<ProgramsSummary>> {
     return this.programService.getPaginatedProgramsForAEST(
       institutionId,
-      [OfferingTypes.public, OfferingTypes.Private],
+      [OfferingTypes.Public, OfferingTypes.Private],
       {
         searchCriteria: searchCriteria,
         sortField: sortColumn,

--- a/sources/packages/api/src/route-controllers/education-program/education-program.controller.ts
+++ b/sources/packages/api/src/route-controllers/education-program/education-program.controller.ts
@@ -205,7 +205,7 @@ export class EducationProgramController extends BaseController {
       programStatus: educationProgram.programStatus,
       programIntensity: educationProgram.programIntensity,
       institutionProgramCode: educationProgram.institutionProgramCode,
-      submittedOn: educationProgram.submittedOn,
+      submittedOn: educationProgram.submittedDate,
       submittedBy: getUserFullName(educationProgram.submittedBy),
       effectiveEndDate: getISODateOnlyString(educationProgram.effectiveEndDate),
       assessedDate: educationProgram.assessedDate,
@@ -218,7 +218,7 @@ export class EducationProgramController extends BaseController {
       // proper decision is taken
       assessedBy:
         educationProgram.effectiveEndDate ||
-        educationProgram.programStatus === ProgramStatus.Denied
+        educationProgram.programStatus === ProgramStatus.Declined
           ? getIDIRUserFullName(educationProgram.assessedBy)
           : getUserFullName(educationProgram.assessedBy),
     };

--- a/sources/packages/api/src/route-controllers/education-program/education-program.controller.ts
+++ b/sources/packages/api/src/route-controllers/education-program/education-program.controller.ts
@@ -36,7 +36,11 @@ import {
   EducationProgramsSummary,
 } from "../../services/education-program/education-program.service.models";
 import { SubsetEducationProgramDto } from "./models/summary-education-program.dto";
-import { EducationProgram, OfferingTypes } from "../../database/entities";
+import {
+  EducationProgram,
+  OfferingTypes,
+  ProgramStatus,
+} from "../../database/entities";
 import { OptionItem } from "../../types";
 import { UserGroups } from "../../auth/user-groups.enum";
 import {
@@ -49,7 +53,6 @@ import {
   getIDIRUserFullName,
   getUserFullName,
 } from "../../utilities";
-import { ApprovalStatus } from "../../services/education-program/constants";
 import { ApiTags } from "@nestjs/swagger";
 import BaseController from "../BaseController";
 
@@ -199,13 +202,13 @@ export class EducationProgramController extends BaseController {
       cipCode: educationProgram.cipCode,
       nocCode: educationProgram.nocCode,
       sabcCode: educationProgram.sabcCode,
-      approvalStatus: educationProgram.approvalStatus,
+      programStatus: educationProgram.programStatus,
       programIntensity: educationProgram.programIntensity,
       institutionProgramCode: educationProgram.institutionProgramCode,
       submittedOn: educationProgram.submittedOn,
       submittedBy: getUserFullName(educationProgram.submittedBy),
       effectiveEndDate: getISODateOnlyString(educationProgram.effectiveEndDate),
-      statusUpdatedOn: educationProgram.statusUpdatedOn,
+      assessedDate: educationProgram.assessedDate,
       // TODO: for now - program.effectiveEndDate is added by the ministry user
       // so, if program.effectiveEndDate is null/undefined, then
       // the program was auto approved, when institution submitted the
@@ -213,11 +216,11 @@ export class EducationProgramController extends BaseController {
       // ministry user uses IDIR. Program will always denied by
       // ministry user (i.e IDIR). Will need to update in future as
       // proper decision is taken
-      statusUpdatedBy:
+      assessedBy:
         educationProgram.effectiveEndDate ||
-        educationProgram.approvalStatus === ApprovalStatus.denied
-          ? getIDIRUserFullName(educationProgram.statusUpdatedBy)
-          : getUserFullName(educationProgram.statusUpdatedBy),
+        educationProgram.programStatus === ProgramStatus.Denied
+          ? getIDIRUserFullName(educationProgram.assessedBy)
+          : getUserFullName(educationProgram.assessedBy),
     };
 
     return programDetails;

--- a/sources/packages/api/src/route-controllers/education-program/education-program.controller.ts
+++ b/sources/packages/api/src/route-controllers/education-program/education-program.controller.ts
@@ -36,11 +36,7 @@ import {
   EducationProgramsSummary,
 } from "../../services/education-program/education-program.service.models";
 import { SubsetEducationProgramDto } from "./models/summary-education-program.dto";
-import {
-  EducationProgram,
-  OfferingTypes,
-  ProgramStatus,
-} from "../../database/entities";
+import { EducationProgram, OfferingTypes } from "../../database/entities";
 import { OptionItem } from "../../types";
 import { UserGroups } from "../../auth/user-groups.enum";
 import {
@@ -50,7 +46,6 @@ import {
   DEFAULT_PAGE_LIMIT,
   PaginatedResults,
   getISODateOnlyString,
-  getIDIRUserFullName,
   getUserFullName,
 } from "../../utilities";
 import { ApiTags } from "@nestjs/swagger";
@@ -216,11 +211,7 @@ export class EducationProgramController extends BaseController {
       // ministry user uses IDIR. Program will always denied by
       // ministry user (i.e IDIR). Will need to update in future as
       // proper decision is taken
-      assessedBy:
-        educationProgram.effectiveEndDate ||
-        educationProgram.programStatus === ProgramStatus.Declined
-          ? getIDIRUserFullName(educationProgram.assessedBy)
-          : getUserFullName(educationProgram.assessedBy),
+      assessedBy: getUserFullName(educationProgram.assessedBy),
     };
 
     return programDetails;

--- a/sources/packages/api/src/route-controllers/education-program/models/save-education-program.dto.ts
+++ b/sources/packages/api/src/route-controllers/education-program/models/save-education-program.dto.ts
@@ -1,5 +1,8 @@
-import { ApprovalStatus } from "../../../services/education-program/constants";
-import { EducationProgram, ProgramIntensity } from "../../../database/entities";
+import {
+  EducationProgram,
+  ProgramIntensity,
+  ProgramStatus,
+} from "../../../database/entities";
 import {
   credentialTypeToDisplay,
   getIDIRUserFullName,
@@ -44,14 +47,14 @@ export interface EducationProgramDto {
 
 export interface EducationProgramDataDto extends EducationProgramDto {
   credentialTypeToDisplay: string;
-  approvalStatus: ApprovalStatus;
+  programStatus: ProgramStatus;
   institutionId: number;
   id: number;
   institutionName: string;
   submittedOn: Date;
   submittedBy: string;
-  statusUpdatedOn?: Date;
-  statusUpdatedBy?: string;
+  assessedDate?: Date;
+  assessedBy?: string;
   effectiveEndDate: string;
 }
 
@@ -76,7 +79,7 @@ export const transformToEducationProgramData = (
 ): EducationProgramDataDto => {
   const programDetails: EducationProgramDataDto = {
     id: program.id,
-    approvalStatus: program.approvalStatus,
+    programStatus: program.programStatus,
     name: program.name,
     description: program.description,
     credentialType: program.credentialType,
@@ -122,7 +125,7 @@ export const transformToEducationProgramData = (
     submittedOn: program.submittedOn,
     submittedBy: getUserFullName(program.submittedBy),
     effectiveEndDate: getISODateOnlyString(program.effectiveEndDate),
-    statusUpdatedOn: program.statusUpdatedOn,
+    assessedDate: program.assessedDate,
     // TODO: for now - program.effectiveEndDate is added by the ministry user
     // so, if program.effectiveEndDate is null/undefined, then
     // the program was auto approved, when institution submitted the
@@ -130,11 +133,10 @@ export const transformToEducationProgramData = (
     // ministry user uses IDIR. Program will always denied by
     // ministry user (i.e IDIR). Will need to update in future as
     // proper decision is taken
-    statusUpdatedBy:
-      program.effectiveEndDate ||
-      program.approvalStatus === ApprovalStatus.denied
-        ? getIDIRUserFullName(program.statusUpdatedBy)
-        : getUserFullName(program.statusUpdatedBy),
+    assessedBy:
+      program.effectiveEndDate || program.programStatus === ProgramStatus.Denied
+        ? getIDIRUserFullName(program.assessedBy)
+        : getUserFullName(program.assessedBy),
   };
 
   return programDetails;
@@ -147,7 +149,7 @@ export class ProgramsSummary {
   formattedSubmittedDate: string;
   locationName: string;
   locationId: number;
-  programStatus: ApprovalStatus;
+  programStatus: ProgramStatus;
   totalOfferings: number;
 }
 

--- a/sources/packages/api/src/route-controllers/education-program/models/save-education-program.dto.ts
+++ b/sources/packages/api/src/route-controllers/education-program/models/save-education-program.dto.ts
@@ -122,7 +122,7 @@ export const transformToEducationProgramData = (
     credentialTypeToDisplay: credentialTypeToDisplay(program.credentialType),
     institutionId: program.institution.id,
     institutionName: program.institution.legalOperatingName,
-    submittedOn: program.submittedOn,
+    submittedOn: program.submittedDate,
     submittedBy: getUserFullName(program.submittedBy),
     effectiveEndDate: getISODateOnlyString(program.effectiveEndDate),
     assessedDate: program.assessedDate,
@@ -134,7 +134,8 @@ export const transformToEducationProgramData = (
     // ministry user (i.e IDIR). Will need to update in future as
     // proper decision is taken
     assessedBy:
-      program.effectiveEndDate || program.programStatus === ProgramStatus.Denied
+      program.effectiveEndDate ||
+      program.programStatus === ProgramStatus.Declined
         ? getIDIRUserFullName(program.assessedBy)
         : getUserFullName(program.assessedBy),
   };

--- a/sources/packages/api/src/route-controllers/education-program/models/save-education-program.dto.ts
+++ b/sources/packages/api/src/route-controllers/education-program/models/save-education-program.dto.ts
@@ -125,13 +125,6 @@ export const transformToEducationProgramData = (
     submittedBy: getUserFullName(program.submittedBy),
     effectiveEndDate: getISODateOnlyString(program.effectiveEndDate),
     assessedDate: program.assessedDate,
-    // TODO: for now - program.effectiveEndDate is added by the ministry user
-    // so, if program.effectiveEndDate is null/undefined, then
-    // the program was auto approved, when institution submitted the
-    // program, else the program was approved by ministry user.
-    // ministry user uses IDIR. Program will always denied by
-    // ministry user (i.e IDIR). Will need to update in future as
-    // proper decision is taken
     assessedBy: getUserFullName(program.assessedBy),
   };
 

--- a/sources/packages/api/src/route-controllers/education-program/models/save-education-program.dto.ts
+++ b/sources/packages/api/src/route-controllers/education-program/models/save-education-program.dto.ts
@@ -5,7 +5,6 @@ import {
 } from "../../../database/entities";
 import {
   credentialTypeToDisplay,
-  getIDIRUserFullName,
   getISODateOnlyString,
   getUserFullName,
 } from "../../../utilities";
@@ -133,11 +132,7 @@ export const transformToEducationProgramData = (
     // ministry user uses IDIR. Program will always denied by
     // ministry user (i.e IDIR). Will need to update in future as
     // proper decision is taken
-    assessedBy:
-      program.effectiveEndDate ||
-      program.programStatus === ProgramStatus.Declined
-        ? getIDIRUserFullName(program.assessedBy)
-        : getUserFullName(program.assessedBy),
+    assessedBy: getUserFullName(program.assessedBy),
   };
 
   return programDetails;

--- a/sources/packages/api/src/route-controllers/education-program/models/summary-education-program.dto.ts
+++ b/sources/packages/api/src/route-controllers/education-program/models/summary-education-program.dto.ts
@@ -9,12 +9,12 @@ export interface SubsetEducationProgramDto {
   cipCode: string;
   nocCode: string;
   sabcCode: string;
-  approvalStatus: string;
+  programStatus: string;
   programIntensity: ProgramIntensity;
   institutionProgramCode?: string;
   submittedOn: Date;
   submittedBy: string;
-  statusUpdatedOn?: Date;
-  statusUpdatedBy?: string;
+  assessedDate?: Date;
+  assessedBy?: string;
   effectiveEndDate: string;
 }

--- a/sources/packages/api/src/route-controllers/program-info-request/models/program-info-request.dto.ts
+++ b/sources/packages/api/src/route-controllers/program-info-request/models/program-info-request.dto.ts
@@ -1,9 +1,9 @@
 import { IsNotEmpty, IsInt, Min, IsOptional } from "class-validator";
-import { ProgramOfferingBaseDTO } from "../../education-program-offering/models/education-program-offering.dto";
+import { SaveOfferingDTO } from "../../education-program-offering/models/education-program-offering.dto";
 import { ProgramInfoStatus } from "../../../database/entities";
 import { OfferingIntensity } from "../../../database/entities/offering-intensity.type";
 
-export interface CompleteProgramInfoRequestDto extends ProgramOfferingBaseDTO {
+export interface CompleteProgramInfoRequestDto extends SaveOfferingDTO {
   selectedProgram?: number;
   selectedOffering?: number;
 }

--- a/sources/packages/api/src/route-controllers/program-info-request/models/program-info-request.dto.ts
+++ b/sources/packages/api/src/route-controllers/program-info-request/models/program-info-request.dto.ts
@@ -1,10 +1,9 @@
 import { IsNotEmpty, IsInt, Min, IsOptional } from "class-validator";
-import { SaveEducationProgramOfferingDto } from "../../education-program-offering/models/education-program-offering.dto";
+import { ProgramOfferingBaseDTO } from "../../education-program-offering/models/education-program-offering.dto";
 import { ProgramInfoStatus } from "../../../database/entities";
 import { OfferingIntensity } from "../../../database/entities/offering-intensity.type";
 
-export interface CompleteProgramInfoRequestDto
-  extends SaveEducationProgramOfferingDto {
+export interface CompleteProgramInfoRequestDto extends ProgramOfferingBaseDTO {
   selectedProgram?: number;
   selectedOffering?: number;
 }

--- a/sources/packages/api/src/services/education-program-offering/education-program-offering.service.models.ts
+++ b/sources/packages/api/src/services/education-program-offering/education-program-offering.service.models.ts
@@ -68,5 +68,5 @@ export interface SaveOfferingModel {
   assessedDate?: Date;
   submittedDate?: Date;
   offeringStatus: OfferingStatus;
-  offeringType?: OfferingTypes;
+  offeringType: OfferingTypes;
 }

--- a/sources/packages/api/src/services/education-program-offering/education-program-offering.service.models.ts
+++ b/sources/packages/api/src/services/education-program-offering/education-program-offering.service.models.ts
@@ -12,6 +12,8 @@ export class EducationProgramOfferingModel {
   studyEndDate: string;
   offeringDelivered: string;
   offeringIntensity: OfferingIntensity;
+  offeringType: OfferingTypes;
+  offeringStatus: OfferingStatus;
 }
 
 export interface ProgramOfferingModel {
@@ -38,9 +40,10 @@ export interface ProgramOfferingModel {
   offeringDeclaration: boolean;
   submittedDate: Date;
   offeringStatus: OfferingStatus;
+  offeringType: OfferingTypes;
 }
 
-export interface CreateOfferingModel {
+export interface SaveOfferingModel {
   offeringName: string;
   studyStartDate: Date;
   studyEndDate: Date;
@@ -63,7 +66,7 @@ export interface CreateOfferingModel {
   offeringDeclaration: boolean;
   assessedBy?: string;
   assessedDate?: Date;
-  submittedDate: Date;
+  submittedDate?: Date;
   offeringStatus: OfferingStatus;
   offeringType?: OfferingTypes;
 }

--- a/sources/packages/api/src/services/education-program-offering/education-program-offering.service.models.ts
+++ b/sources/packages/api/src/services/education-program-offering/education-program-offering.service.models.ts
@@ -1,4 +1,9 @@
-import { OfferingIntensity, StudyBreak } from "../../database/entities";
+import {
+  OfferingIntensity,
+  StudyBreak,
+  OfferingStatus,
+  OfferingTypes,
+} from "../../database/entities";
 
 export class EducationProgramOfferingModel {
   id: number;
@@ -31,4 +36,34 @@ export interface ProgramOfferingModel {
   offeringWILType?: string;
   studyBreaks?: StudyBreak[];
   offeringDeclaration: boolean;
+  submittedDate: Date;
+  offeringStatus: OfferingStatus;
+}
+
+export interface CreateOfferingModel {
+  offeringName: string;
+  studyStartDate: Date;
+  studyEndDate: Date;
+  actualTuitionCosts: number;
+  programRelatedCosts: number;
+  mandatoryFees: number;
+  exceptionalExpenses: number;
+  tuitionRemittanceRequestedAmount: number;
+  offeringDelivered: string;
+  lacksStudyDates: boolean;
+  lacksStudyBreaks: boolean;
+  lacksFixedCosts: boolean;
+  tuitionRemittanceRequested: string;
+  offeringIntensity: OfferingIntensity;
+  yearOfStudy: number;
+  showYearOfStudy?: boolean;
+  hasOfferingWILComponent: string;
+  offeringWILType?: string;
+  studyBreaks?: StudyBreak[];
+  offeringDeclaration: boolean;
+  assessedBy?: string;
+  assessedDate?: Date;
+  submittedDate: Date;
+  offeringStatus: OfferingStatus;
+  offeringType?: OfferingTypes;
 }

--- a/sources/packages/api/src/services/education-program-offering/education-program-offering.service.ts
+++ b/sources/packages/api/src/services/education-program-offering/education-program-offering.service.ts
@@ -9,10 +9,10 @@ import {
 } from "../../database/entities";
 import { RecordDataModelService } from "../../database/data.model.service";
 import { Connection, UpdateResult } from "typeorm";
-import { SaveEducationProgramOfferingDto } from "../../route-controllers/education-program-offering/models/education-program-offering.dto";
 import {
   EducationProgramOfferingModel,
   ProgramOfferingModel,
+  CreateOfferingModel,
 } from "./education-program-offering.service.models";
 import { ProgramYear } from "../../database/entities/program-year.model";
 import {
@@ -38,7 +38,7 @@ export class EducationProgramOfferingService extends RecordDataModelService<Educ
   async createEducationProgramOffering(
     locationId: number,
     programId: number,
-    educationProgramOffering: SaveEducationProgramOfferingDto,
+    educationProgramOffering: CreateOfferingModel,
   ): Promise<EducationProgramOffering> {
     const programOffering = this.populateProgramOffering(
       locationId,
@@ -191,7 +191,7 @@ export class EducationProgramOfferingService extends RecordDataModelService<Educ
     locationId: number,
     programId: number,
     offeringId: number,
-    educationProgramOffering: SaveEducationProgramOfferingDto,
+    educationProgramOffering: CreateOfferingModel,
   ): Promise<UpdateResult> {
     const programOffering = this.populateProgramOffering(
       locationId,
@@ -201,10 +201,10 @@ export class EducationProgramOfferingService extends RecordDataModelService<Educ
     return this.repo.update(offeringId, programOffering);
   }
 
-  populateProgramOffering(
+  private populateProgramOffering(
     locationId: number,
     programId: number,
-    educationProgramOffering: SaveEducationProgramOfferingDto,
+    educationProgramOffering: CreateOfferingModel,
   ): EducationProgramOffering {
     const programOffering = new EducationProgramOffering();
     programOffering.name = educationProgramOffering.offeringName;

--- a/sources/packages/api/src/services/education-program-offering/education-program-offering.service.ts
+++ b/sources/packages/api/src/services/education-program-offering/education-program-offering.service.ts
@@ -6,7 +6,6 @@ import {
   OfferingTypes,
   OfferingIntensity,
   ProgramStatus,
-  User,
 } from "../../database/entities";
 import { RecordDataModelService } from "../../database/data.model.service";
 import { Connection, UpdateResult } from "typeorm";
@@ -39,13 +38,11 @@ export class EducationProgramOfferingService extends RecordDataModelService<Educ
   async createEducationProgramOffering(
     locationId: number,
     programId: number,
-    userId: number,
     educationProgramOffering: SaveOfferingModel,
   ): Promise<EducationProgramOffering> {
     const programOffering = this.populateProgramOffering(
       locationId,
       programId,
-      userId,
       educationProgramOffering,
     );
     return this.repo.save(programOffering);
@@ -204,13 +201,11 @@ export class EducationProgramOfferingService extends RecordDataModelService<Educ
     locationId: number,
     programId: number,
     offeringId: number,
-    userId: number,
     educationProgramOffering: SaveOfferingModel,
   ): Promise<UpdateResult> {
     const programOffering = this.populateProgramOffering(
       locationId,
       programId,
-      userId,
       educationProgramOffering,
     );
     return this.repo.update(offeringId, programOffering);
@@ -219,7 +214,6 @@ export class EducationProgramOfferingService extends RecordDataModelService<Educ
   private populateProgramOffering(
     locationId: number,
     programId: number,
-    userId: number,
     educationProgramOffering: SaveOfferingModel,
   ): EducationProgramOffering {
     const programOffering = new EducationProgramOffering();
@@ -261,8 +255,6 @@ export class EducationProgramOfferingService extends RecordDataModelService<Educ
       educationProgramOffering.offeringDeclaration;
     programOffering.offeringType = educationProgramOffering.offeringType;
     programOffering.offeringStatus = educationProgramOffering.offeringStatus;
-    programOffering.assessedBy = { id: userId } as User;
-    programOffering.assessedDate = new Date();
     return programOffering;
   }
 

--- a/sources/packages/api/src/services/education-program-offering/education-program-offering.service.ts
+++ b/sources/packages/api/src/services/education-program-offering/education-program-offering.service.ts
@@ -244,7 +244,7 @@ export class EducationProgramOfferingService extends RecordDataModelService<Educ
     programOffering.tuitionRemittanceRequested =
       educationProgramOffering.tuitionRemittanceRequested;
     programOffering.offeringType =
-      educationProgramOffering.offeringType ?? OfferingTypes.public;
+      educationProgramOffering.offeringType ?? OfferingTypes.Public;
     programOffering.educationProgram = { id: programId } as EducationProgram;
     programOffering.institutionLocation = {
       id: locationId,
@@ -304,7 +304,7 @@ export class EducationProgramOfferingService extends RecordDataModelService<Educ
         locationId,
       })
       .andWhere("offerings.offeringType = :offeringType", {
-        offeringType: OfferingTypes.public,
+        offeringType: OfferingTypes.Public,
       })
       .andWhere(
         "offerings.studyStartDate BETWEEN programYear.startDate AND programYear.endDate",

--- a/sources/packages/api/src/services/education-program-offering/education-program-offering.service.ts
+++ b/sources/packages/api/src/services/education-program-offering/education-program-offering.service.ts
@@ -5,6 +5,7 @@ import {
   InstitutionLocation,
   OfferingTypes,
   OfferingIntensity,
+  ProgramStatus,
 } from "../../database/entities";
 import { RecordDataModelService } from "../../database/data.model.service";
 import { Connection, UpdateResult } from "typeorm";
@@ -13,7 +14,6 @@ import {
   EducationProgramOfferingModel,
   ProgramOfferingModel,
 } from "./education-program-offering.service.models";
-import { ApprovalStatus } from "../education-program/constants";
 import { ProgramYear } from "../../database/entities/program-year.model";
 import {
   FieldSortOrder,
@@ -277,8 +277,8 @@ export class EducationProgramOfferingService extends RecordDataModelService<Educ
       .addSelect("offerings.yearOfStudy")
       .addSelect("offerings.showYearOfStudy")
       .where("offerings.educationProgram.id = :programId", { programId })
-      .andWhere("programs.approvalStatus = :approvalStatus", {
-        approvalStatus: ApprovalStatus.approved,
+      .andWhere("programs.programStatus = :programStatus", {
+        programStatus: ProgramStatus.Approved,
       })
       .andWhere("offerings.institutionLocation.id = :locationId", {
         locationId,

--- a/sources/packages/api/src/services/education-program/constants.ts
+++ b/sources/packages/api/src/services/education-program/constants.ts
@@ -1,9 +1,0 @@
-/**
- * Represents the approval status for a program also stored
- * on column approval_status on table education_programs.
- */
-export enum ApprovalStatus {
-  approved = "approved",
-  pending = "pending",
-  denied = "denied",
-}

--- a/sources/packages/api/src/services/education-program/education-program.service.models.ts
+++ b/sources/packages/api/src/services/education-program/education-program.service.models.ts
@@ -1,12 +1,12 @@
 import { EducationProgramDto } from "../../route-controllers/education-program/models/save-education-program.dto";
-import { ApprovalStatus } from "../../services/education-program/constants";
+import { ProgramStatus } from "../../database/entities";
 /**
  * DTO that is used to persist the eduction programs form data.
  */
 export interface SaveEducationProgram extends EducationProgramDto {
   id?: number;
   institutionId: number;
-  approvalStatus: ApprovalStatus;
+  programStatus: ProgramStatus;
   userId: number;
 }
 
@@ -15,7 +15,7 @@ export class EducationProgramsSummary {
   programName: string;
   cipCode: string;
   credentialType: string;
-  approvalStatus: string;
+  programStatus: string;
   totalOfferings: number;
   credentialTypeToDisplay: string;
 }

--- a/sources/packages/api/src/services/education-program/education-program.service.ts
+++ b/sources/packages/api/src/services/education-program/education-program.service.ts
@@ -220,7 +220,7 @@ export class EducationProgramService extends RecordDataModelService<EducationPro
         `CASE programs.programStatus
                 WHEN '${ProgramStatus.Pending}' THEN ${SortPriority.Priority1}
                 WHEN '${ProgramStatus.Approved}' THEN ${SortPriority.Priority2}
-                WHEN '${ProgramStatus.Denied}' THEN ${SortPriority.Priority3}
+                WHEN '${ProgramStatus.Declined}' THEN ${SortPriority.Priority3}
                 ELSE ${SortPriority.Priority4}
               END`,
       );
@@ -330,7 +330,7 @@ export class EducationProgramService extends RecordDataModelService<EducationPro
         `CASE programs.programStatus
                 WHEN '${ProgramStatus.Pending}' THEN ${SortPriority.Priority1}
                 WHEN '${ProgramStatus.Approved}' THEN ${SortPriority.Priority2}
-                WHEN '${ProgramStatus.Denied}' THEN ${SortPriority.Priority3}
+                WHEN '${ProgramStatus.Declined}' THEN ${SortPriority.Priority3}
                 ELSE ${SortPriority.Priority4}
               END`,
       );
@@ -388,7 +388,7 @@ export class EducationProgramService extends RecordDataModelService<EducationPro
         "programs.institution",
         "institution.id",
         "institution.legalOperatingName",
-        "programs.submittedOn",
+        "programs.submittedDate",
         "submittedBy.firstName",
         "submittedBy.lastName",
         "assessedBy.firstName",
@@ -609,7 +609,7 @@ export class EducationProgramService extends RecordDataModelService<EducationPro
       // update program
       const program = new EducationProgram();
       program.id = programId;
-      program.programStatus = ProgramStatus.Denied;
+      program.programStatus = ProgramStatus.Declined;
       program.assessedDate = new Date();
       program.assessedBy = { id: userId } as User;
       program.programNote = noteObj;

--- a/sources/packages/api/src/services/student-scholastic-standings/student-scholastic-standings.service.ts
+++ b/sources/packages/api/src/services/student-scholastic-standings/student-scholastic-standings.service.ts
@@ -144,8 +144,7 @@ export class StudentScholasticStandingsService extends RecordDataModelService<St
         scholasticStandingData.exceptionalCosts ??
         existingOffering.exceptionalExpenses;
 
-      // TODO: When new offering type is added for report a change/ scholastic standing, update this.
-      offering.offeringType = OfferingTypes.applicationSpecific;
+      offering.offeringType = OfferingTypes.ScholasticStanding;
 
       // Save new offering.
       const savedOffering = await transactionalEntityManager

--- a/sources/packages/api/src/testHelpers/fake-entities/education-program-fake.ts
+++ b/sources/packages/api/src/testHelpers/fake-entities/education-program-fake.ts
@@ -1,8 +1,12 @@
 import * as faker from "faker";
-import { EducationProgram, Institution, User } from "../../database/entities";
+import {
+  EducationProgram,
+  Institution,
+  User,
+  ProgramStatus,
+} from "../../database/entities";
 import { createFakeInstitution } from "./institution-fake";
 import { ProgramIntensity } from "../../database/entities/program-intensity.type";
-import { ApprovalStatus } from "../../services/education-program/constants";
 
 export function createFakeEducationProgram(
   institution?: Institution,
@@ -23,7 +27,7 @@ export function createFakeEducationProgram(
   program.eslEligibility = "eslEligibility";
   program.hasJointInstitution = "hasJointInstitution";
   program.hasJointDesignatedInstitution = "hasJointDesignatedInstitution";
-  program.approvalStatus = ApprovalStatus.approved;
+  program.programStatus = ProgramStatus.Approved;
   program.hasWILComponent = "yes";
   program.hasTravel = "yes";
   program.hasIntlExchange = "yes";

--- a/sources/packages/api/src/testHelpers/fake-entities/education-program-offering-fake.ts
+++ b/sources/packages/api/src/testHelpers/fake-entities/education-program-offering-fake.ts
@@ -28,7 +28,7 @@ export function createFakeEducationProgramOffering(
   offering.educationProgram = program ?? createFakeEducationProgram();
   offering.institutionLocation = institutionLocation ?? createFakeLocation();
   offering.offeringIntensity = OfferingIntensity.fullTime;
-  offering.offeringType = OfferingTypes.public;
+  offering.offeringType = OfferingTypes.Public;
   offering.yearOfStudy = 1;
   offering.hasOfferingWILComponent = "no";
   offering.offeringDeclaration = true;

--- a/sources/packages/forms/src/form-definitions/educationprogram.json
+++ b/sources/packages/forms/src/form-definitions/educationprogram.json
@@ -82,7 +82,8 @@
       "showCharCount": false,
       "showWordCount": false,
       "allowMultipleMasks": false,
-      "id": "ekheeqdg"
+      "id": "ekheeqdg",
+      "addons": []
     },
     {
       "label": "HTML",
@@ -161,7 +162,8 @@
       "showCharCount": false,
       "showWordCount": false,
       "allowMultipleMasks": false,
-      "id": "elkbtok"
+      "id": "elkbtok",
+      "addons": []
     },
     {
       "label": "HTML",
@@ -240,7 +242,8 @@
       "showCharCount": false,
       "showWordCount": false,
       "allowMultipleMasks": false,
-      "id": "ee9wfci"
+      "id": "ee9wfci",
+      "addons": []
     },
     {
       "title": "Panel",
@@ -351,7 +354,10 @@
           "inputFormat": "plain",
           "inputMask": "",
           "spellcheck": true,
-          "id": "ee0f6le"
+          "id": "ee0f6le",
+          "addons": [],
+          "displayMask": "",
+          "truncateMultipleSpaces": false
         },
         {
           "label": "Program description",
@@ -433,7 +439,10 @@
           "wysiwyg": false,
           "editor": "",
           "fixedSize": true,
-          "id": "ev0808"
+          "id": "ev0808",
+          "addons": [],
+          "displayMask": "",
+          "truncateMultipleSpaces": false
         },
         {
           "label": "Credential type",
@@ -574,7 +583,9 @@
             "threshold": 0.3
           },
           "id": "e3cqf5c",
-          "defaultValue": ""
+          "defaultValue": "",
+          "addons": [],
+          "searchDebounce": 0.3
         },
         {
           "label": "CIP code",
@@ -648,7 +659,10 @@
           "inputFormat": "plain",
           "inputMask": "",
           "spellcheck": true,
-          "id": "e428vwr"
+          "id": "e428vwr",
+          "addons": [],
+          "displayMask": "",
+          "truncateMultipleSpaces": false
         },
         {
           "label": "National Occupational Classifcation (NOC)",
@@ -723,7 +737,10 @@
           "inputFormat": "plain",
           "inputMask": "",
           "spellcheck": true,
-          "id": "epeke7s"
+          "id": "epeke7s",
+          "addons": [],
+          "displayMask": "",
+          "truncateMultipleSpaces": false
         },
         {
           "label": "SABC program code, if this program has been approved for SABC funding before",
@@ -806,7 +823,10 @@
           "dataGridLabel": false,
           "inputType": "text",
           "id": "e9wg9zb",
-          "defaultValue": ""
+          "defaultValue": "",
+          "addons": [],
+          "displayMask": "",
+          "truncateMultipleSpaces": false
         },
         {
           "label": "Institution Program Code",
@@ -880,7 +900,10 @@
           "inputFormat": "plain",
           "inputMask": "",
           "spellcheck": true,
-          "id": "ezavw7e"
+          "id": "ezavw7e",
+          "addons": [],
+          "displayMask": "",
+          "truncateMultipleSpaces": false
         }
       ],
       "placeholder": "",
@@ -919,7 +942,9 @@
       "showWordCount": false,
       "allowMultipleMasks": false,
       "tree": false,
-      "id": "egrd3p"
+      "id": "egrd3p",
+      "addons": [],
+      "lazyLoad": false
     },
     {
       "label": "Program eligibility",
@@ -998,7 +1023,8 @@
       "showCharCount": false,
       "showWordCount": false,
       "allowMultipleMasks": false,
-      "id": "ek6kyv"
+      "id": "ek6kyv",
+      "addons": []
     },
     {
       "title": "Panel",
@@ -1076,6 +1102,8 @@
         {
           "label": "Are students able to take this on a part time basis?",
           "labelPosition": "top",
+          "labelWidth": "",
+          "labelMargin": "",
           "optionsLabelPosition": "right",
           "description": "",
           "tooltip": "A part-time program has a course load between 20 and 59%. A full-time program must have a course load of: 60% or greater or Between 40 and 60% for students with a permanent disability.",
@@ -1123,6 +1151,7 @@
             "unique": false
           },
           "errorLabel": "",
+          "errors": "",
           "key": "programIntensity",
           "tags": [],
           "properties": {},
@@ -1157,9 +1186,10 @@
           "showCharCount": false,
           "showWordCount": false,
           "allowMultipleMasks": false,
+          "addons": [],
           "inputType": "radio",
           "fieldSet": false,
-          "id": "e19ahea",
+          "id": "en95iv",
           "defaultValue": ""
         },
         {
@@ -1256,7 +1286,8 @@
           "showWordCount": false,
           "allowMultipleMasks": false,
           "fieldSet": false,
-          "id": "ehyzwln"
+          "id": "ehyzwln",
+          "addons": []
         },
         {
           "label": "Will the program also be offered and delivered at 100% course load on site?",
@@ -1345,7 +1376,8 @@
           "inputType": "radio",
           "fieldSet": false,
           "id": "esholy9",
-          "defaultValue": ""
+          "defaultValue": "",
+          "addons": []
         },
         {
           "label": "Will the students earn the same number of credits in the same time period as students in other StudentAid BC eligible programs delivered on site?",
@@ -1434,7 +1466,8 @@
           "inputType": "radio",
           "fieldSet": false,
           "id": "elcdcu6",
-          "defaultValue": ""
+          "defaultValue": "",
+          "addons": []
         },
         {
           "label": "Will they earn academic credits that are recognized at another designated institution listed in the BC Transfer Guide or other acceptable articulation agreements from other jurisdictions?",
@@ -1523,7 +1556,8 @@
           "inputType": "radio",
           "fieldSet": false,
           "id": "eplb04q",
-          "defaultValue": ""
+          "defaultValue": "",
+          "addons": []
         },
         {
           "label": "HTML",
@@ -1602,7 +1636,8 @@
           "showCharCount": false,
           "showWordCount": false,
           "allowMultipleMasks": false,
-          "id": "ex017l"
+          "id": "ex017l",
+          "addons": []
         },
         {
           "label": "HTML",
@@ -1681,12 +1716,15 @@
           "showCharCount": false,
           "showWordCount": false,
           "allowMultipleMasks": false,
-          "id": "eytg6z"
+          "id": "eytg6z",
+          "addons": []
         },
         {
           "label": "Program length",
           "labelPosition": "top",
           "widget": "html5",
+          "labelWidth": "",
+          "labelMargin": "",
           "placeholder": "",
           "description": "",
           "tooltip": "",
@@ -1736,6 +1774,7 @@
           "dataType": "",
           "idPath": "id",
           "valueProperty": "",
+          "limit": 100,
           "template": "<span>{{ item.label }}</span>",
           "refreshOn": "",
           "refreshOnBlur": "",
@@ -1768,6 +1807,7 @@
           },
           "unique": false,
           "errorLabel": "",
+          "errors": "",
           "key": "completionYears",
           "tags": [],
           "properties": {},
@@ -1794,26 +1834,27 @@
           },
           "selectFields": "",
           "searchField": "",
+          "searchDebounce": 0.3,
           "minSearch": 0,
           "filter": "",
-          "limit": 100,
           "redrawOn": "",
           "input": true,
+          "searchThreshold": 0.3,
           "prefix": "",
           "suffix": "",
           "dataGridLabel": false,
           "showCharCount": false,
           "showWordCount": false,
           "allowMultipleMasks": false,
+          "addons": [],
           "lazyLoad": true,
           "authenticate": false,
           "ignoreCache": false,
-          "searchThreshold": 0.3,
           "fuseOptions": {
             "include": "score",
             "threshold": 0.3
           },
-          "id": "e2u2n1o",
+          "id": "e746zrh",
           "defaultValue": ""
         },
         {
@@ -1903,7 +1944,8 @@
           "inputType": "radio",
           "fieldSet": false,
           "id": "elx192",
-          "defaultValue": ""
+          "defaultValue": "",
+          "addons": []
         },
         {
           "label": "Does this program include a minimum of 20 instructional hours per week?",
@@ -1992,7 +2034,8 @@
           "inputType": "radio",
           "fieldSet": false,
           "id": "e9emf5g",
-          "defaultValue": ""
+          "defaultValue": "",
+          "addons": []
         },
         {
           "label": "Is this an aviation program?",
@@ -2081,7 +2124,8 @@
           "inputType": "radio",
           "fieldSet": false,
           "id": "ekqcvci",
-          "defaultValue": ""
+          "defaultValue": "",
+          "addons": []
         },
         {
           "label": "HTML",
@@ -2160,7 +2204,8 @@
           "showCharCount": false,
           "showWordCount": false,
           "allowMultipleMasks": false,
-          "id": "e2uo9e5"
+          "id": "e2uo9e5",
+          "addons": []
         },
         {
           "label": "Does this program include a minimum of 15 instructional hours per week",
@@ -2249,7 +2294,8 @@
           "inputType": "radio",
           "fieldSet": false,
           "id": "ei8tl3n",
-          "defaultValue": ""
+          "defaultValue": "",
+          "addons": []
         },
         {
           "label": "HTML",
@@ -2328,7 +2374,8 @@
           "showCharCount": false,
           "showWordCount": false,
           "allowMultipleMasks": false,
-          "id": "exumj84"
+          "id": "exumj84",
+          "addons": []
         },
         {
           "label": "HTML",
@@ -2407,7 +2454,8 @@
           "showCharCount": false,
           "showWordCount": false,
           "allowMultipleMasks": false,
-          "id": "exthyjo"
+          "id": "exthyjo",
+          "addons": []
         },
         {
           "label": "Which regulatory body does this program belong to?",
@@ -2536,10 +2584,14 @@
             "threshold": 0.3
           },
           "id": "escw5nj",
-          "defaultValue": null
+          "defaultValue": null,
+          "addons": [],
+          "searchDebounce": 0.3
         }
       ],
-      "id": "e7ab3si"
+      "id": "e7ab3si",
+      "addons": [],
+      "lazyLoad": false
     },
     {
       "label": "HTML",
@@ -2618,7 +2670,8 @@
       "showCharCount": false,
       "showWordCount": false,
       "allowMultipleMasks": false,
-      "id": "e1z1fry"
+      "id": "e1z1fry",
+      "addons": []
     },
     {
       "title": "Panel",
@@ -2803,10 +2856,13 @@
           "showWordCount": false,
           "allowMultipleMasks": false,
           "fieldSet": false,
-          "id": "eaxt08"
+          "id": "eaxt08",
+          "addons": []
         }
       ],
-      "id": "e5zhra4"
+      "id": "e5zhra4",
+      "addons": [],
+      "lazyLoad": false
     },
     {
       "label": "HTML",
@@ -2885,7 +2941,8 @@
       "showCharCount": false,
       "showWordCount": false,
       "allowMultipleMasks": false,
-      "id": "ee1r44"
+      "id": "ee1r44",
+      "addons": []
     },
     {
       "title": "Panel",
@@ -3047,7 +3104,8 @@
           "inputType": "radio",
           "fieldSet": false,
           "id": "esmuskn",
-          "defaultValue": ""
+          "defaultValue": "",
+          "addons": []
         },
         {
           "label": "ESL Error",
@@ -3126,10 +3184,13 @@
           "showCharCount": false,
           "showWordCount": false,
           "allowMultipleMasks": false,
-          "id": "exiqgg3"
+          "id": "exiqgg3",
+          "addons": []
         }
       ],
-      "id": "elp3zbo"
+      "id": "elp3zbo",
+      "addons": [],
+      "lazyLoad": false
     },
     {
       "label": "Program partnerships",
@@ -3208,7 +3269,8 @@
       "showCharCount": false,
       "showWordCount": false,
       "allowMultipleMasks": false,
-      "id": "esxe4ld"
+      "id": "esxe4ld",
+      "addons": []
     },
     {
       "label": "HTML",
@@ -3287,7 +3349,8 @@
       "showCharCount": false,
       "showWordCount": false,
       "allowMultipleMasks": false,
-      "id": "ea288xg"
+      "id": "ea288xg",
+      "addons": []
     },
     {
       "title": "Panel",
@@ -3449,7 +3512,8 @@
           "inputType": "radio",
           "fieldSet": false,
           "id": "e1rl8gr",
-          "defaultValue": ""
+          "defaultValue": "",
+          "addons": []
         },
         {
           "label": "Are all institutions you partner with for this program designated by Student Aid BC?",
@@ -3538,7 +3602,8 @@
           "inputType": "radio",
           "fieldSet": false,
           "id": "eaa8y48",
-          "defaultValue": ""
+          "defaultValue": "",
+          "addons": []
         },
         {
           "label": "Join Program Error",
@@ -3612,10 +3677,13 @@
           "properties": {},
           "allowMultipleMasks": false,
           "tag": "p",
-          "id": "evafnlo"
+          "id": "evafnlo",
+          "addons": []
         }
       ],
-      "id": "e13hxz09"
+      "id": "e13hxz09",
+      "addons": [],
+      "lazyLoad": false
     },
     {
       "label": "HTML",
@@ -3694,7 +3762,8 @@
       "showCharCount": false,
       "showWordCount": false,
       "allowMultipleMasks": false,
-      "id": "eh5vqst"
+      "id": "eh5vqst",
+      "addons": []
     },
     {
       "title": "Panel",
@@ -3856,7 +3925,8 @@
           "inputType": "radio",
           "fieldSet": false,
           "id": "exfol75",
-          "defaultValue": ""
+          "defaultValue": "",
+          "addons": []
         },
         {
           "label": "Is the WIL approved by your regulator or oversight body?",
@@ -3945,7 +4015,8 @@
           "inputType": "radio",
           "fieldSet": false,
           "id": "etm9ggd",
-          "defaultValue": ""
+          "defaultValue": "",
+          "addons": []
         },
         {
           "label": "HTML",
@@ -4024,7 +4095,8 @@
           "showCharCount": false,
           "showWordCount": false,
           "allowMultipleMasks": false,
-          "id": "e6l2ag"
+          "id": "e6l2ag",
+          "addons": []
         },
         {
           "label": "Does the WIL meet the program eligibility requirements according to StudentAid BC policy?",
@@ -4113,7 +4185,8 @@
           "inputType": "radio",
           "fieldSet": false,
           "id": "ecvd00d",
-          "defaultValue": ""
+          "defaultValue": "",
+          "addons": []
         },
         {
           "label": "HTML",
@@ -4192,10 +4265,13 @@
           "showCharCount": false,
           "showWordCount": false,
           "allowMultipleMasks": false,
-          "id": "ezpggmh"
+          "id": "ezpggmh",
+          "addons": []
         }
       ],
-      "id": "eibwfjp"
+      "id": "eibwfjp",
+      "addons": [],
+      "lazyLoad": false
     },
     {
       "label": "HTML",
@@ -4274,7 +4350,8 @@
       "showCharCount": false,
       "showWordCount": false,
       "allowMultipleMasks": false,
-      "id": "e4hde4o"
+      "id": "e4hde4o",
+      "addons": []
     },
     {
       "title": "Panel",
@@ -4436,7 +4513,8 @@
           "inputType": "radio",
           "fieldSet": false,
           "id": "e6e6rtk",
-          "defaultValue": ""
+          "defaultValue": "",
+          "addons": []
         },
         {
           "label": "Does the field trip, field placement, or travel meet the program eligibility requirements according to StudentAid BC policy?",
@@ -4525,7 +4603,8 @@
           "inputType": "radio",
           "fieldSet": false,
           "id": "e7spkqj",
-          "defaultValue": ""
+          "defaultValue": "",
+          "addons": []
         },
         {
           "label": "HTML",
@@ -4604,10 +4683,13 @@
           "showCharCount": false,
           "showWordCount": false,
           "allowMultipleMasks": false,
-          "id": "e151ayq"
+          "id": "e151ayq",
+          "addons": []
         }
       ],
-      "id": "e2vc9tm"
+      "id": "e2vc9tm",
+      "addons": [],
+      "lazyLoad": false
     },
     {
       "label": "HTML",
@@ -4686,7 +4768,8 @@
       "showCharCount": false,
       "showWordCount": false,
       "allowMultipleMasks": false,
-      "id": "ekoiavph"
+      "id": "ekoiavph",
+      "addons": []
     },
     {
       "title": "Panel",
@@ -4848,7 +4931,8 @@
           "inputType": "radio",
           "fieldSet": false,
           "id": "eoapr4",
-          "defaultValue": ""
+          "defaultValue": "",
+          "addons": []
         },
         {
           "label": "Does the international exchange meet the program eligibility requirements according to StudentAid BC policy?",
@@ -4937,7 +5021,8 @@
           "inputType": "radio",
           "fieldSet": false,
           "id": "evzt5g8",
-          "defaultValue": ""
+          "defaultValue": "",
+          "addons": []
         },
         {
           "label": "HTML",
@@ -5016,10 +5101,13 @@
           "showCharCount": false,
           "showWordCount": false,
           "allowMultipleMasks": false,
-          "id": "e5pmzo"
+          "id": "e5pmzo",
+          "addons": []
         }
       ],
-      "id": "estalv"
+      "id": "estalv",
+      "addons": [],
+      "lazyLoad": false
     },
     {
       "label": "Declaration",
@@ -5098,7 +5186,8 @@
       "showCharCount": false,
       "showWordCount": false,
       "allowMultipleMasks": false,
-      "id": "e2jup75"
+      "id": "e2jup75",
+      "addons": []
     },
     {
       "title": "Panel",
@@ -5250,7 +5339,8 @@
           "showCharCount": false,
           "showWordCount": false,
           "allowMultipleMasks": false,
-          "id": "ebfilaf"
+          "id": "ebfilaf",
+          "addons": []
         },
         {
           "label": "HTML",
@@ -5329,7 +5419,8 @@
           "showCharCount": false,
           "showWordCount": false,
           "allowMultipleMasks": false,
-          "id": "es0rufl"
+          "id": "es0rufl",
+          "addons": []
         },
         {
           "label": "I confirm this program meets the policies outlined in the StudentAid BC policy manual.",
@@ -5404,10 +5495,13 @@
           "showCharCount": false,
           "showWordCount": false,
           "allowMultipleMasks": false,
-          "id": "ed13vad"
+          "id": "ed13vad",
+          "addons": []
         }
       ],
-      "id": "e7oaook"
+      "id": "e7oaook",
+      "addons": [],
+      "lazyLoad": false
     },
     {
       "label": "Submit",
@@ -5487,7 +5581,8 @@
       "showWordCount": false,
       "allowMultipleMasks": false,
       "dataGridLabel": true,
-      "id": "eept44e"
+      "id": "eept44e",
+      "addons": []
     },
     {
       "label": "isBCPrivate",
@@ -5557,10 +5652,13 @@
       "showWordCount": false,
       "allowMultipleMasks": false,
       "inputType": "hidden",
-      "id": "egqexmm"
+      "id": "egqexmm",
+      "addons": []
     },
     {
-      "label": "Approval Status",
+      "label": "Program Status",
+      "labelWidth": "",
+      "labelMargin": "",
       "customClass": "",
       "modalEdit": false,
       "defaultValue": null,
@@ -5570,9 +5668,9 @@
       "encrypted": false,
       "redrawOn": "",
       "customDefaultValue": "",
-      "calculateValue": "if (data.hasJointDesignatedInstitution === \"no\" || data.eslEligibility === \"20OrMore\" || \r\n(data.deliveredOnlineAlsoOnsite === \"no\" && data.sameOnlineCreditsEarned === \"no\" && earnAcademicCreditsOtherInstitution === \"no\") \r\n|| (data.courseLoadCalculation === \"hours\" && data.minHoursWeek === \"no\" && data.isAviationProgram === \"no\") || (data.courseLoadCalculation === \"hours\" && data.minHoursWeek === \"no\" && data.isAviationProgram === \"yes\" && data.minHoursWeekAvi === \"no\") \r\n|| (data.hasWILComponent === \"yes\" && data.isWILApproved === \"no\") || (data.hasWILComponent === \"yes\" && data.isWILApproved === \"yes\" && data.wilProgramEligibility === \"no\") \r\n|| (data.hasTravel === \"yes\" && data.travelProgramEligibility === \"no\") || (data.hasIntlExchange === \"yes\" && data.intlExchangeProgramEligibility === \"no\")) {\r\n  value = \"pending\";\r\n}\r\nelse {\r\n  value = \"approved\";\r\n}",
+      "calculateValue": "if (data.hasJointDesignatedInstitution === \"no\" || data.eslEligibility === \"20OrMore\" || \r\n(data.deliveredOnlineAlsoOnsite === \"no\" && data.sameOnlineCreditsEarned === \"no\" && earnAcademicCreditsOtherInstitution === \"no\") \r\n|| (data.courseLoadCalculation === \"hours\" && data.minHoursWeek === \"no\" && data.isAviationProgram === \"no\") || (data.courseLoadCalculation === \"hours\" && data.minHoursWeek === \"no\" && data.isAviationProgram === \"yes\" && data.minHoursWeekAvi === \"no\") \r\n|| (data.hasWILComponent === \"yes\" && data.isWILApproved === \"no\") || (data.hasWILComponent === \"yes\" && data.isWILApproved === \"yes\" && data.wilProgramEligibility === \"no\") \r\n|| (data.hasTravel === \"yes\" && data.travelProgramEligibility === \"no\") || (data.hasIntlExchange === \"yes\" && data.intlExchangeProgramEligibility === \"no\")) {\r\n  value = \"Pending\";\r\n}\r\nelse {\r\n  value = \"Approved\";\r\n}",
       "calculateServer": true,
-      "key": "approvalStatus",
+      "key": "programStatus",
       "tags": [],
       "properties": {},
       "logic": [],
@@ -5626,8 +5724,9 @@
       "showCharCount": false,
       "showWordCount": false,
       "allowMultipleMasks": false,
+      "addons": [],
       "inputType": "hidden",
-      "id": "e54szw"
+      "id": "edkeirb"
     },
     {
       "label": "applicationId",
@@ -5697,7 +5796,79 @@
       "inputType": "hidden",
       "id": "em1y8gd",
       "defaultValue": "",
-      "dataGridLabel": false
+      "dataGridLabel": false,
+      "addons": []
+    },
+    {
+      "label": "applicationStatus",
+      "customClass": "",
+      "modalEdit": false,
+      "defaultValue": null,
+      "persistent": true,
+      "protected": false,
+      "dbIndex": false,
+      "encrypted": false,
+      "redrawOn": "",
+      "customDefaultValue": "",
+      "calculateValue": "",
+      "calculateServer": false,
+      "key": "applicationStatus",
+      "tags": [],
+      "properties": {},
+      "logic": [],
+      "attributes": {},
+      "overlay": {
+        "style": "",
+        "page": "",
+        "left": "",
+        "top": "",
+        "width": "",
+        "height": ""
+      },
+      "type": "hidden",
+      "input": true,
+      "tableView": false,
+      "placeholder": "",
+      "prefix": "",
+      "suffix": "",
+      "multiple": false,
+      "unique": false,
+      "hidden": false,
+      "clearOnHide": true,
+      "refreshOn": "",
+      "dataGridLabel": false,
+      "labelPosition": "top",
+      "description": "",
+      "errorLabel": "",
+      "tooltip": "",
+      "hideLabel": false,
+      "tabindex": "",
+      "disabled": false,
+      "autofocus": false,
+      "widget": {
+        "type": "input"
+      },
+      "validateOn": "change",
+      "validate": {
+        "required": false,
+        "custom": "",
+        "customPrivate": false,
+        "strictDateValidation": false,
+        "multiple": false,
+        "unique": false
+      },
+      "conditional": {
+        "show": null,
+        "when": null,
+        "eq": ""
+      },
+      "allowCalculateOverride": false,
+      "showCharCount": false,
+      "showWordCount": false,
+      "allowMultipleMasks": false,
+      "inputType": "hidden",
+      "id": "e6z1qd9",
+      "addons": []
     }
   ],
   "display": "form",
@@ -5706,5 +5877,5 @@
   "path": "educationprogram",
   "machineName": "educationProgram",
   "created": "2021-08-05T18:32:10.610Z",
-  "modified": "2022-02-01T20:48:58.401Z"
+  "modified": "2022-04-26T19:59:04.423Z"
 }

--- a/sources/packages/forms/src/form-definitions/educationprogramoffering.json
+++ b/sources/packages/forms/src/form-definitions/educationprogramoffering.json
@@ -82,7 +82,8 @@
       "showCharCount": false,
       "showWordCount": false,
       "allowMultipleMasks": false,
-      "id": "e7v3zsj"
+      "id": "e7v3zsj",
+      "addons": []
     },
     {
       "label": "HTML",
@@ -161,7 +162,8 @@
       "showCharCount": false,
       "showWordCount": false,
       "allowMultipleMasks": false,
-      "id": "eju28h2"
+      "id": "eju28h2",
+      "addons": []
     },
     {
       "title": "Panel",
@@ -317,7 +319,10 @@
           "dataGridLabel": false,
           "inputType": "text",
           "id": "e0u54c",
-          "defaultValue": ""
+          "defaultValue": "",
+          "addons": [],
+          "displayMask": "",
+          "truncateMultipleSpaces": false
         },
         {
           "label": "Year of study",
@@ -462,7 +467,9 @@
             "threshold": 0.3
           },
           "id": "eny9x4v",
-          "defaultValue": ""
+          "defaultValue": "",
+          "addons": [],
+          "searchDebounce": 0.3
         },
         {
           "label": "Display this to students",
@@ -537,10 +544,13 @@
           "showCharCount": false,
           "showWordCount": false,
           "allowMultipleMasks": false,
-          "id": "ebim1"
+          "id": "ebim1",
+          "addons": []
         },
         {
           "label": "HTML",
+          "labelWidth": "",
+          "labelMargin": "",
           "tag": "p",
           "className": "alert alert-info fa fa-info-circle",
           "attrs": [
@@ -549,7 +559,7 @@
               "value": ""
             }
           ],
-          "content": "<strong> Here’s an example of what students will see.</strong>\n<br>e.g. 2022 Winter co-op (Jan 15 2022 - Mar 20 2022) - Year 1",
+          "content": "<strong class=\"ml-2\"> Here’s an example of what students will see.</strong>\n<br>e.g. 2022 Winter co-op (Jan 15 2022 - Mar 20 2022) - Year 1",
           "refreshOnChange": false,
           "customClass": "banner-info",
           "hidden": false,
@@ -616,11 +626,14 @@
           "showCharCount": false,
           "showWordCount": false,
           "allowMultipleMasks": false,
-          "id": "e9zes5n"
+          "addons": [],
+          "id": "eg6mj9j"
         },
         {
           "label": "How will this be offered?",
           "labelPosition": "top",
+          "labelWidth": "",
+          "labelMargin": "",
           "optionsLabelPosition": "right",
           "description": "",
           "tooltip": "",
@@ -660,7 +673,7 @@
             "required": true,
             "onlyAvailableItems": true,
             "customMessage": "",
-            "custom": "valid = (data.programIntensity.includes(input)) ? true : 'The program you have selected has only ' + data.programIntensity + ' offering';",
+            "custom": "",
             "customPrivate": false,
             "json": "",
             "strictDateValidation": false,
@@ -668,6 +681,7 @@
             "unique": false
           },
           "errorLabel": "",
+          "errors": "",
           "key": "offeringIntensity",
           "tags": [],
           "properties": {},
@@ -702,14 +716,172 @@
           "showCharCount": false,
           "showWordCount": false,
           "allowMultipleMasks": false,
+          "addons": [],
           "inputType": "radio",
           "fieldSet": false,
-          "id": "ev71tr",
+          "id": "ecva51o",
           "defaultValue": ""
+        },
+        {
+          "label": "Program Offering Intensity Mismatch",
+          "labelWidth": "",
+          "labelMargin": "",
+          "customClass": "",
+          "modalEdit": false,
+          "defaultValue": "false",
+          "persistent": true,
+          "protected": false,
+          "dbIndex": false,
+          "encrypted": false,
+          "redrawOn": "offeringIntensity",
+          "customDefaultValue": "",
+          "calculateValue": "value = (data.programIntensity !== data.offeringIntensity);",
+          "calculateServer": true,
+          "key": "programOfferingIntensityMismatch",
+          "tags": [],
+          "properties": {},
+          "logic": [],
+          "attributes": {},
+          "overlay": {
+            "style": "",
+            "page": "",
+            "left": "",
+            "top": "",
+            "width": "",
+            "height": ""
+          },
+          "type": "hidden",
+          "input": true,
+          "tableView": false,
+          "placeholder": "",
+          "prefix": "",
+          "suffix": "",
+          "multiple": false,
+          "unique": false,
+          "hidden": false,
+          "clearOnHide": true,
+          "refreshOn": "",
+          "dataGridLabel": false,
+          "labelPosition": "top",
+          "description": "",
+          "errorLabel": "",
+          "tooltip": "",
+          "hideLabel": false,
+          "tabindex": "",
+          "disabled": false,
+          "autofocus": false,
+          "widget": {
+            "type": "input"
+          },
+          "validateOn": "change",
+          "validate": {
+            "required": false,
+            "custom": "",
+            "customPrivate": false,
+            "strictDateValidation": false,
+            "multiple": false,
+            "unique": false
+          },
+          "conditional": {
+            "show": null,
+            "when": null,
+            "eq": ""
+          },
+          "allowCalculateOverride": false,
+          "showCharCount": false,
+          "showWordCount": false,
+          "allowMultipleMasks": false,
+          "addons": [],
+          "inputType": "hidden",
+          "id": "e6rovne"
+        },
+        {
+          "label": "Study period intensity popup",
+          "labelWidth": "",
+          "labelMargin": "",
+          "tag": "p",
+          "className": "alert alert-warning fa fa-exclamation-triangle",
+          "attrs": [
+            {
+              "attr": "",
+              "value": ""
+            }
+          ],
+          "content": "<strong class=\"ml-2\">The study period intensity is dependent on the program intensity</strong>\n<br>\n<span>Your program must have the correct program intensity to be able to select the offering intensity here.</span>",
+          "refreshOnChange": true,
+          "customClass": "banner-warning",
+          "hidden": false,
+          "modalEdit": false,
+          "key": "studyPeriodIntensityPopup",
+          "tags": [],
+          "properties": {},
+          "conditional": {
+            "show": true,
+            "when": "programOfferingIntensityMismatch",
+            "eq": "true",
+            "json": ""
+          },
+          "customConditional": "",
+          "logic": [],
+          "attributes": {},
+          "overlay": {
+            "style": "",
+            "page": "",
+            "left": "",
+            "top": "",
+            "width": "",
+            "height": ""
+          },
+          "type": "htmlelement",
+          "input": false,
+          "tableView": false,
+          "placeholder": "",
+          "prefix": "",
+          "suffix": "",
+          "multiple": false,
+          "defaultValue": null,
+          "protected": false,
+          "unique": false,
+          "persistent": false,
+          "clearOnHide": true,
+          "refreshOn": "",
+          "redrawOn": "",
+          "dataGridLabel": false,
+          "labelPosition": "top",
+          "description": "",
+          "errorLabel": "",
+          "tooltip": "",
+          "hideLabel": false,
+          "tabindex": "",
+          "disabled": false,
+          "autofocus": false,
+          "dbIndex": false,
+          "customDefaultValue": "",
+          "calculateValue": "",
+          "calculateServer": false,
+          "widget": null,
+          "validateOn": "change",
+          "validate": {
+            "required": false,
+            "custom": "",
+            "customPrivate": false,
+            "strictDateValidation": false,
+            "multiple": false,
+            "unique": false
+          },
+          "allowCalculateOverride": false,
+          "encrypted": false,
+          "showCharCount": false,
+          "showWordCount": false,
+          "allowMultipleMasks": false,
+          "addons": [],
+          "id": "e3bpgd8"
         },
         {
           "label": "How will this offering be delivered?",
           "labelPosition": "top",
+          "labelWidth": "",
+          "labelMargin": "",
           "optionsLabelPosition": "right",
           "description": "",
           "tooltip": "",
@@ -754,7 +926,7 @@
             "required": true,
             "onlyAvailableItems": true,
             "customMessage": "",
-            "custom": "valid =\n  (data.programDeliveryTypes.deliveredOnSite &&\n    !data.programDeliveryTypes.deliveredOnline &&\n    input === \"onsite\") ||\n  (!data.programDeliveryTypes.deliveredOnSite &&\n    data.programDeliveryTypes.deliveredOnline &&\n    input === \"online\") ||\n  (data.programDeliveryTypes.deliveredOnSite &&\n    data.programDeliveryTypes.deliveredOnline &&\n    (input === \"online\" || input === \"onsite\" || input === \"blended\"))\n    ? true\n    : \"Please ensure the study delivery aligns with program eligibility. To fix this, go back to your program and edit the delivery method.\";\n\n",
+            "custom": "",
             "customPrivate": false,
             "json": "",
             "strictDateValidation": false,
@@ -762,6 +934,7 @@
             "unique": false
           },
           "errorLabel": "",
+          "errors": "",
           "key": "offeringDelivered",
           "tags": [],
           "properties": {},
@@ -797,14 +970,172 @@
           "showCharCount": false,
           "showWordCount": false,
           "allowMultipleMasks": false,
+          "addons": [],
           "inputType": "radio",
           "fieldSet": false,
-          "id": "eqelas",
+          "id": "efieb9",
           "defaultValue": ""
+        },
+        {
+          "label": "Program Offering Delivery Mismatch",
+          "labelWidth": "",
+          "labelMargin": "",
+          "customClass": "",
+          "modalEdit": false,
+          "defaultValue": "false",
+          "persistent": true,
+          "protected": false,
+          "dbIndex": false,
+          "encrypted": false,
+          "redrawOn": "offeringDelivered",
+          "customDefaultValue": "",
+          "calculateValue": "value = !(data.programDeliveryTypes.deliveredOnSite &&\r\n    !data.programDeliveryTypes.deliveredOnline &&\r\n    data.offeringDelivered === \"onsite\") ||\r\n  (!data.programDeliveryTypes.deliveredOnSite &&\r\n    data.programDeliveryTypes.deliveredOnline &&\r\n    data.offeringDelivered === \"online\") ||\r\n  (data.programDeliveryTypes.deliveredOnSite &&\r\n    data.programDeliveryTypes.deliveredOnline &&\r\n    (data.offeringDelivered === \"online\" || data.offeringDelivered === \"onsite\" || data.offeringDelivered === \"blended\"));",
+          "calculateServer": true,
+          "key": "programOfferingDeliveryMismatch",
+          "tags": [],
+          "properties": {},
+          "logic": [],
+          "attributes": {},
+          "overlay": {
+            "style": "",
+            "page": "",
+            "left": "",
+            "top": "",
+            "width": "",
+            "height": ""
+          },
+          "type": "hidden",
+          "input": true,
+          "tableView": false,
+          "placeholder": "",
+          "prefix": "",
+          "suffix": "",
+          "multiple": false,
+          "unique": false,
+          "hidden": false,
+          "clearOnHide": true,
+          "refreshOn": "",
+          "dataGridLabel": false,
+          "labelPosition": "top",
+          "description": "",
+          "errorLabel": "",
+          "tooltip": "",
+          "hideLabel": false,
+          "tabindex": "",
+          "disabled": false,
+          "autofocus": false,
+          "widget": {
+            "type": "input"
+          },
+          "validateOn": "change",
+          "validate": {
+            "required": false,
+            "custom": "",
+            "customPrivate": false,
+            "strictDateValidation": false,
+            "multiple": false,
+            "unique": false
+          },
+          "conditional": {
+            "show": null,
+            "when": null,
+            "eq": ""
+          },
+          "allowCalculateOverride": false,
+          "showCharCount": false,
+          "showWordCount": false,
+          "allowMultipleMasks": false,
+          "addons": [],
+          "inputType": "hidden",
+          "id": "e4fjmqe"
+        },
+        {
+          "label": "HTML",
+          "labelWidth": "",
+          "labelMargin": "",
+          "tag": "p",
+          "className": "alert alert-warning fa fa-exclamation-triangle",
+          "attrs": [
+            {
+              "attr": "",
+              "value": ""
+            }
+          ],
+          "content": "<strong class=\"ml-2\">The study period delivery is dependent on the program delivery</strong>\n<br>\n<span>Your program must have the correct delivery method(s) to be able to select the offering delivery here.</span>",
+          "refreshOnChange": true,
+          "customClass": "banner-warning",
+          "hidden": false,
+          "modalEdit": false,
+          "key": "html9",
+          "tags": [],
+          "properties": {},
+          "conditional": {
+            "show": true,
+            "when": "programOfferingDeliveryMismatch",
+            "eq": "true",
+            "json": ""
+          },
+          "customConditional": "",
+          "logic": [],
+          "attributes": {},
+          "overlay": {
+            "style": "",
+            "page": "",
+            "left": "",
+            "top": "",
+            "width": "",
+            "height": ""
+          },
+          "type": "htmlelement",
+          "input": false,
+          "tableView": false,
+          "placeholder": "",
+          "prefix": "",
+          "suffix": "",
+          "multiple": false,
+          "defaultValue": null,
+          "protected": false,
+          "unique": false,
+          "persistent": false,
+          "clearOnHide": true,
+          "refreshOn": "",
+          "redrawOn": "",
+          "dataGridLabel": false,
+          "labelPosition": "top",
+          "description": "",
+          "errorLabel": "",
+          "tooltip": "",
+          "hideLabel": false,
+          "tabindex": "",
+          "disabled": false,
+          "autofocus": false,
+          "dbIndex": false,
+          "customDefaultValue": "",
+          "calculateValue": "",
+          "calculateServer": false,
+          "widget": null,
+          "validateOn": "change",
+          "validate": {
+            "required": false,
+            "custom": "",
+            "customPrivate": false,
+            "strictDateValidation": false,
+            "multiple": false,
+            "unique": false
+          },
+          "allowCalculateOverride": false,
+          "encrypted": false,
+          "showCharCount": false,
+          "showWordCount": false,
+          "allowMultipleMasks": false,
+          "addons": [],
+          "id": "eex713"
         },
         {
           "label": "Does this contain a work-integrated learning component?",
           "labelPosition": "top",
+          "labelWidth": "",
+          "labelMargin": "",
           "optionsLabelPosition": "right",
           "description": "",
           "tooltip": "",
@@ -842,9 +1173,9 @@
           "allowCalculateOverride": false,
           "validate": {
             "required": true,
-            "onlyAvailableItems": false,
+            "onlyAvailableItems": true,
             "customMessage": "",
-            "custom": "valid = (data.hasOfferingWILComponent === \"no\" || data.hasWILComponent ===\"yes\") ? true : \"This study period can’t contain a WIL component. Your program must be approved with a WIL component.\";  ",
+            "custom": "",
             "customPrivate": false,
             "json": "",
             "strictDateValidation": false,
@@ -852,6 +1183,7 @@
             "unique": false
           },
           "errorLabel": "",
+          "errors": "",
           "key": "hasOfferingWILComponent",
           "tags": [],
           "properties": {},
@@ -886,10 +1218,166 @@
           "showCharCount": false,
           "showWordCount": false,
           "allowMultipleMasks": false,
+          "addons": [],
           "inputType": "radio",
           "fieldSet": false,
-          "id": "evhzrlx",
+          "id": "epn7nqw",
           "defaultValue": ""
+        },
+        {
+          "label": "Program Offering WIL Mismatch",
+          "labelWidth": "",
+          "labelMargin": "",
+          "customClass": "",
+          "modalEdit": false,
+          "defaultValue": "false",
+          "persistent": true,
+          "protected": false,
+          "dbIndex": false,
+          "encrypted": false,
+          "redrawOn": "",
+          "customDefaultValue": "",
+          "calculateValue": "value = !(data.hasOfferingWILComponent === \"no\" || data.hasWILComponent === \"yes\");",
+          "calculateServer": true,
+          "key": "programOfferingWILMismatch",
+          "tags": [],
+          "properties": {},
+          "logic": [],
+          "attributes": {},
+          "overlay": {
+            "style": "",
+            "page": "",
+            "left": "",
+            "top": "",
+            "width": "",
+            "height": ""
+          },
+          "type": "hidden",
+          "input": true,
+          "tableView": false,
+          "placeholder": "",
+          "prefix": "",
+          "suffix": "",
+          "multiple": false,
+          "unique": false,
+          "hidden": false,
+          "clearOnHide": true,
+          "refreshOn": "",
+          "dataGridLabel": false,
+          "labelPosition": "top",
+          "description": "",
+          "errorLabel": "",
+          "tooltip": "",
+          "hideLabel": false,
+          "tabindex": "",
+          "disabled": false,
+          "autofocus": false,
+          "widget": {
+            "type": "input"
+          },
+          "validateOn": "change",
+          "validate": {
+            "required": false,
+            "custom": "",
+            "customPrivate": false,
+            "strictDateValidation": false,
+            "multiple": false,
+            "unique": false
+          },
+          "conditional": {
+            "show": null,
+            "when": null,
+            "eq": ""
+          },
+          "allowCalculateOverride": false,
+          "showCharCount": false,
+          "showWordCount": false,
+          "allowMultipleMasks": false,
+          "addons": [],
+          "inputType": "hidden",
+          "id": "eunqmim"
+        },
+        {
+          "label": "HTML",
+          "labelWidth": "",
+          "labelMargin": "",
+          "tag": "p",
+          "className": "alert alert-warning fa fa-exclamation-triangle",
+          "attrs": [
+            {
+              "attr": "",
+              "value": ""
+            }
+          ],
+          "content": "<strong class=\"ml-2\">This study period can’t contain a work-integrated component</strong>\n<br>\n<span>Your program must be approved with a work-integrated component first.</span>",
+          "refreshOnChange": false,
+          "customClass": "banner-warning",
+          "hidden": false,
+          "modalEdit": false,
+          "key": "html10",
+          "tags": [],
+          "properties": {},
+          "conditional": {
+            "show": true,
+            "when": "programOfferingWILMismatch",
+            "eq": "true",
+            "json": ""
+          },
+          "customConditional": "",
+          "logic": [],
+          "attributes": {},
+          "overlay": {
+            "style": "",
+            "page": "",
+            "left": "",
+            "top": "",
+            "width": "",
+            "height": ""
+          },
+          "type": "htmlelement",
+          "input": false,
+          "tableView": false,
+          "placeholder": "",
+          "prefix": "",
+          "suffix": "",
+          "multiple": false,
+          "defaultValue": null,
+          "protected": false,
+          "unique": false,
+          "persistent": false,
+          "clearOnHide": true,
+          "refreshOn": "",
+          "redrawOn": "",
+          "dataGridLabel": false,
+          "labelPosition": "top",
+          "description": "",
+          "errorLabel": "",
+          "tooltip": "",
+          "hideLabel": false,
+          "tabindex": "",
+          "disabled": false,
+          "autofocus": false,
+          "dbIndex": false,
+          "customDefaultValue": "",
+          "calculateValue": "",
+          "calculateServer": false,
+          "widget": null,
+          "validateOn": "change",
+          "validate": {
+            "required": false,
+            "custom": "",
+            "customPrivate": false,
+            "strictDateValidation": false,
+            "multiple": false,
+            "unique": false
+          },
+          "allowCalculateOverride": false,
+          "encrypted": false,
+          "showCharCount": false,
+          "showWordCount": false,
+          "allowMultipleMasks": false,
+          "addons": [],
+          "id": "e1kpvfl"
         },
         {
           "title": "Panel",
@@ -1009,7 +1497,10 @@
               "dataGridLabel": false,
               "inputType": "text",
               "id": "e2tfsl",
-              "defaultValue": ""
+              "defaultValue": "",
+              "addons": [],
+              "displayMask": "",
+              "truncateMultipleSpaces": false
             }
           ],
           "placeholder": "",
@@ -1048,7 +1539,9 @@
           "showWordCount": false,
           "allowMultipleMasks": false,
           "tree": false,
-          "id": "exvznu9"
+          "id": "exvznu9",
+          "addons": [],
+          "lazyLoad": false
         },
         {
           "label": "HTML",
@@ -1127,7 +1620,8 @@
           "showCharCount": false,
           "showWordCount": false,
           "allowMultipleMasks": false,
-          "id": "eedc4d8"
+          "id": "eedc4d8",
+          "addons": []
         },
         {
           "label": "Columns",
@@ -1259,14 +1753,16 @@
                   "showWordCount": false,
                   "allowMultipleMasks": false,
                   "datepickerMode": "day",
-                  "id": "eryjb2i"
+                  "id": "eryjb2i",
+                  "addons": []
                 }
               ],
               "width": 6,
               "offset": 0,
               "push": 0,
               "pull": 0,
-              "size": "md"
+              "size": "md",
+              "currentWidth": 6
             },
             {
               "components": [
@@ -1395,14 +1891,16 @@
                   "showWordCount": false,
                   "allowMultipleMasks": false,
                   "datepickerMode": "day",
-                  "id": "ebqtys"
+                  "id": "ebqtys",
+                  "addons": []
                 }
               ],
               "width": 6,
               "offset": 0,
               "push": 0,
               "pull": 0,
-              "size": "md"
+              "size": "md",
+              "currentWidth": 6
             }
           ],
           "autoAdjust": false,
@@ -1473,7 +1971,9 @@
           "allowMultipleMasks": false,
           "tree": false,
           "id": "etobky",
-          "dataGridLabel": false
+          "dataGridLabel": false,
+          "addons": [],
+          "lazyLoad": false
         },
         {
           "label": "No offering dates (for continuous entry)",
@@ -1548,7 +2048,163 @@
           "showCharCount": false,
           "showWordCount": false,
           "allowMultipleMasks": false,
-          "id": "e54dtsg"
+          "id": "e54dtsg",
+          "addons": []
+        },
+        {
+          "label": "Invalid Study Dates",
+          "labelWidth": "",
+          "labelMargin": "",
+          "customClass": "",
+          "modalEdit": false,
+          "defaultValue": "false",
+          "persistent": true,
+          "protected": false,
+          "dbIndex": false,
+          "encrypted": false,
+          "redrawOn": "data",
+          "customDefaultValue": "",
+          "calculateValue": "// To calculate the time difference of two dates\nconst differenceInTime =\n  new Date(data.studyEndDate).getTime() -\n  new Date(data.studyStartDate).getTime();\n  \n// To calculate the no. of days between two dates\nconst differenceInDays = differenceInTime / (1000 * 3600 * 24);\n\nvalue = !(differenceInDays >= 42 && differenceInDays <= 365);",
+          "calculateServer": true,
+          "key": "invalidStudyDates",
+          "tags": [],
+          "properties": {},
+          "logic": [],
+          "attributes": {},
+          "overlay": {
+            "style": "",
+            "page": "",
+            "left": "",
+            "top": "",
+            "width": "",
+            "height": ""
+          },
+          "type": "hidden",
+          "input": true,
+          "tableView": false,
+          "placeholder": "",
+          "prefix": "",
+          "suffix": "",
+          "multiple": false,
+          "unique": false,
+          "hidden": false,
+          "clearOnHide": true,
+          "refreshOn": "",
+          "dataGridLabel": false,
+          "labelPosition": "top",
+          "description": "",
+          "errorLabel": "",
+          "tooltip": "",
+          "hideLabel": false,
+          "tabindex": "",
+          "disabled": false,
+          "autofocus": false,
+          "widget": {
+            "type": "input"
+          },
+          "validateOn": "change",
+          "validate": {
+            "required": false,
+            "custom": "",
+            "customPrivate": false,
+            "strictDateValidation": false,
+            "multiple": false,
+            "unique": false
+          },
+          "conditional": {
+            "show": null,
+            "when": null,
+            "eq": ""
+          },
+          "allowCalculateOverride": false,
+          "showCharCount": false,
+          "showWordCount": false,
+          "allowMultipleMasks": false,
+          "addons": [],
+          "inputType": "hidden",
+          "id": "ee4814m"
+        },
+        {
+          "label": "Invalid study dates popup",
+          "labelWidth": "",
+          "labelMargin": "",
+          "tag": "p",
+          "className": "alert alert-warning fa fa-exclamation-triangle",
+          "attrs": [
+            {
+              "attr": "",
+              "value": ""
+            }
+          ],
+          "content": "<strong class=\"ml-2\">This study period is ineligible for StudentAid BC funding</strong>\n<br>\n<span>Please provide Study Start dateInvalid Study Period, Dates must be between 42 and 365 days.</span>",
+          "refreshOnChange": true,
+          "customClass": "banner-warning",
+          "hidden": false,
+          "modalEdit": false,
+          "key": "invalidStudyDatesPopup",
+          "tags": [],
+          "properties": {},
+          "conditional": {
+            "show": true,
+            "when": "invalidStudyDates",
+            "eq": "true",
+            "json": ""
+          },
+          "customConditional": "",
+          "logic": [],
+          "attributes": {},
+          "overlay": {
+            "style": "",
+            "page": "",
+            "left": "",
+            "top": "",
+            "width": "",
+            "height": ""
+          },
+          "type": "htmlelement",
+          "input": false,
+          "tableView": false,
+          "placeholder": "",
+          "prefix": "",
+          "suffix": "",
+          "multiple": false,
+          "defaultValue": null,
+          "protected": false,
+          "unique": false,
+          "persistent": false,
+          "clearOnHide": true,
+          "refreshOn": "",
+          "redrawOn": "",
+          "dataGridLabel": false,
+          "labelPosition": "top",
+          "description": "",
+          "errorLabel": "",
+          "tooltip": "",
+          "hideLabel": false,
+          "tabindex": "",
+          "disabled": false,
+          "autofocus": false,
+          "dbIndex": false,
+          "customDefaultValue": "",
+          "calculateValue": "",
+          "calculateServer": false,
+          "widget": null,
+          "validateOn": "change",
+          "validate": {
+            "required": false,
+            "custom": "",
+            "customPrivate": false,
+            "strictDateValidation": false,
+            "multiple": false,
+            "unique": false
+          },
+          "allowCalculateOverride": false,
+          "encrypted": false,
+          "showCharCount": false,
+          "showWordCount": false,
+          "allowMultipleMasks": false,
+          "addons": [],
+          "id": "eac16cn"
         },
         {
           "label": "HTML",
@@ -1627,7 +2283,8 @@
           "showCharCount": false,
           "showWordCount": false,
           "allowMultipleMasks": false,
-          "id": "egoblfc"
+          "id": "egoblfc",
+          "addons": []
         },
         {
           "label": "HTML",
@@ -1706,7 +2363,8 @@
           "showCharCount": false,
           "showWordCount": false,
           "allowMultipleMasks": false,
-          "id": "e0zx7sl"
+          "id": "e0zx7sl",
+          "addons": []
         },
         {
           "label": "Study Breaks",
@@ -1838,7 +2496,7 @@
                 "maxDate": null
               },
               "hideOnChildrenHidden": false,
-              "id": "e4xdqvr000000000000000000000000000000000000",
+              "id": "e4xdqvr00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
               "prefix": "",
               "customClass": "",
               "suffix": "",
@@ -1896,11 +2554,14 @@
                 "arrowkeys": true
               },
               "customOptions": {},
-              "shortcutButtons": []
+              "shortcutButtons": [],
+              "addons": []
             },
             {
               "label": "Break end date",
               "labelPosition": "top",
+              "labelWidth": "",
+              "labelMargin": "",
               "displayInTimezone": "viewer",
               "useLocaleSettings": false,
               "allowInput": true,
@@ -1938,9 +2599,9 @@
               "enableMaxDateInput": false,
               "enableTime": false,
               "timePicker": {
-                "showMeridian": true,
                 "hourStep": 1,
                 "minuteStep": 1,
+                "showMeridian": true,
                 "readonlyInput": false,
                 "mousewheel": true,
                 "arrowkeys": true
@@ -1962,7 +2623,7 @@
               "validate": {
                 "required": true,
                 "customMessage": "",
-                "custom": "var isEndDateValid = (row.breakStartDate && row.breakStartDate<row.breakEndDate);\r\nif(isEndDateValid){\r\n    var days = Date.parse(data.studyEndDate) - Date.parse(data.studyStartDate);\r\n    var studyDays = Math.round((days/(1000*60*60*24)));\r\n    var studyBreakDays = 0;\r\n    var errorMessage;\r\n    if(data.studyBreaks && data.studyBreaks.length>0){\r\n        for(let i=0;i<data.studyBreaks.length;i++){\r\n          var days = Date.parse(data.studyBreaks[i].breakEndDate) - Date.parse(data.studyBreaks[i].breakStartDate);\r\n          studyBreakDays = studyBreakDays + Math.round((days/(1000*60*60*24)));\r\n        }\r\n    }\r\n    var ifBreakExceedsMaxPercentage = (studyBreakDays > (studyDays * 0.1));\r\n    var ifBreakExceedMaxDays = (studyBreakDays > 21);\r\n\r\n    if(ifBreakExceedsMaxPercentage){\r\n        errorMessage = \"Your break(s) can’t exceed 10% of study dates.\";\r\n    }\r\n\r\n    if(ifBreakExceedMaxDays) {\r\n        errorMessage = errorMessage ? \"Your break(s) can’t exceed 10% of study dates and exceed 21 days.\" :\"Your break(s) can’t exceed 21 days.\";\r\n    }\r\n    valid = !errorMessage ? true : \"This program is ineligible for StudentAid BC funding. \" + errorMessage;\r\n\r\n}\r\nelse{\r\n    valid=(row.breakStartDate) ? (row.breakStartDate<row.breakEndDate) ? true : 'End Date must be after Break Start Date' : 'Please provide Break Start date';\r\n}",
+                "custom": "valid = row.breakStartDate\r\n  ? row.breakStartDate < row.breakEndDate\r\n    ? true\r\n    : \"Break End Date must be after Break Start Date\"\r\n  : \"Please provide Break Start date\";",
                 "customPrivate": false,
                 "json": "",
                 "strictDateValidation": false,
@@ -1972,6 +2633,7 @@
               "unique": false,
               "validateOn": "change",
               "errorLabel": "",
+              "errors": "",
               "key": "breakEndDate",
               "tags": [],
               "properties": {},
@@ -2022,8 +2684,9 @@
               "showCharCount": false,
               "showWordCount": false,
               "allowMultipleMasks": false,
+              "addons": [],
               "datepickerMode": "day",
-              "id": "ex3qj3m000000000000000000000000000000000000"
+              "id": "eaij81n0000000000000000000000000000000000000000000000000000000000"
             }
           ],
           "placeholder": "",
@@ -2038,7 +2701,9 @@
           "showWordCount": false,
           "allowMultipleMasks": false,
           "tree": true,
-          "id": "eo6zf9m"
+          "id": "eo6zf9m",
+          "addons": [],
+          "lazyLoad": false
         },
         {
           "label": "No study breaks",
@@ -2113,7 +2778,318 @@
           "showWordCount": false,
           "allowMultipleMasks": false,
           "dataGridLabel": true,
-          "id": "e087s16"
+          "id": "e087s16",
+          "addons": []
+        },
+        {
+          "label": "Invalid Study Break Message",
+          "labelWidth": "",
+          "labelMargin": "",
+          "customClass": "",
+          "modalEdit": false,
+          "defaultValue": null,
+          "persistent": "client-only",
+          "protected": false,
+          "dbIndex": false,
+          "encrypted": false,
+          "redrawOn": "invalidStudyBreaks",
+          "customDefaultValue": "",
+          "calculateValue": "//This variable will be populated by the calculated value logic in Invalid Study Breaks hidden component.",
+          "calculateServer": false,
+          "key": "invalidStudyBreakMessage",
+          "tags": [],
+          "properties": {},
+          "logic": [],
+          "attributes": {},
+          "overlay": {
+            "style": "",
+            "page": "",
+            "left": "",
+            "top": "",
+            "width": "",
+            "height": ""
+          },
+          "type": "hidden",
+          "input": true,
+          "tableView": false,
+          "placeholder": "",
+          "prefix": "",
+          "suffix": "",
+          "multiple": false,
+          "unique": false,
+          "hidden": false,
+          "clearOnHide": true,
+          "refreshOn": "",
+          "dataGridLabel": false,
+          "labelPosition": "top",
+          "description": "",
+          "errorLabel": "",
+          "tooltip": "",
+          "hideLabel": false,
+          "tabindex": "",
+          "disabled": false,
+          "autofocus": false,
+          "widget": {
+            "type": "input"
+          },
+          "validateOn": "change",
+          "validate": {
+            "required": false,
+            "custom": "",
+            "customPrivate": false,
+            "strictDateValidation": false,
+            "multiple": false,
+            "unique": false
+          },
+          "conditional": {
+            "show": null,
+            "when": null,
+            "eq": ""
+          },
+          "allowCalculateOverride": false,
+          "showCharCount": false,
+          "showWordCount": false,
+          "allowMultipleMasks": false,
+          "addons": [],
+          "inputType": "hidden",
+          "id": "e9uxqqc"
+        },
+        {
+          "label": "Invalid Study Breaks",
+          "labelWidth": "",
+          "labelMargin": "",
+          "customClass": "",
+          "modalEdit": false,
+          "defaultValue": "false",
+          "persistent": true,
+          "protected": false,
+          "dbIndex": false,
+          "encrypted": false,
+          "redrawOn": "data",
+          "customDefaultValue": "",
+          "calculateValue": "var days = Date.parse(data.studyEndDate) - Date.parse(data.studyStartDate);\r\nvar studyDays = Math.round(days / (1000 * 60 * 60 * 24));\r\nvar studyBreakDays = 0;\r\nvar errorMessage;\r\n\r\nif (data.studyBreaks && data.studyBreaks.length > 0) {\r\n    for (let i = 0; i < data.studyBreaks.length; i++) {\r\n      var days =\r\n        Date.parse(data.studyBreaks[i].breakEndDate) -\r\n        Date.parse(data.studyBreaks[i].breakStartDate);\r\n      studyBreakDays =\r\n        studyBreakDays + Math.round(days / (1000 * 60 * 60 * 24));\r\n    }\r\n}\r\n  \r\nvar ifBreakExceedsMaxPercentage = studyBreakDays > studyDays * 0.1;\r\nvar ifBreakExceedMaxDays = studyBreakDays > 21;\r\n\r\nif (ifBreakExceedsMaxPercentage) {\r\n  errorMessage = \"Your break(s) can't exceed 10% of study dates.\";\r\n}\r\n\r\nif (ifBreakExceedMaxDays) {\r\n  errorMessage = \"Your break(s) can't exceed 21 days.\";\r\n}\r\n\r\nif(ifBreakExceedsMaxPercentage && ifBreakExceedMaxDays){\r\n  errorMessage = \"Your break(s) can't exceed 10% of study dates and exceed 21 days.\";\r\n}\r\n\r\ndata.invalidStudyBreakMessage = errorMessage;\r\nvalue = !!errorMessage;",
+          "calculateServer": true,
+          "key": "invalidStudyBreaks",
+          "tags": [],
+          "properties": {},
+          "logic": [],
+          "attributes": {},
+          "overlay": {
+            "style": "",
+            "page": "",
+            "left": "",
+            "top": "",
+            "width": "",
+            "height": ""
+          },
+          "type": "hidden",
+          "input": true,
+          "tableView": false,
+          "placeholder": "",
+          "prefix": "",
+          "suffix": "",
+          "multiple": false,
+          "unique": false,
+          "hidden": false,
+          "clearOnHide": true,
+          "refreshOn": "",
+          "dataGridLabel": false,
+          "labelPosition": "top",
+          "description": "",
+          "errorLabel": "",
+          "tooltip": "",
+          "hideLabel": false,
+          "tabindex": "",
+          "disabled": false,
+          "autofocus": false,
+          "widget": {
+            "type": "input"
+          },
+          "validateOn": "change",
+          "validate": {
+            "required": false,
+            "custom": "",
+            "customPrivate": false,
+            "strictDateValidation": false,
+            "multiple": false,
+            "unique": false
+          },
+          "conditional": {
+            "show": null,
+            "when": null,
+            "eq": ""
+          },
+          "allowCalculateOverride": false,
+          "showCharCount": false,
+          "showWordCount": false,
+          "allowMultipleMasks": false,
+          "addons": [],
+          "inputType": "hidden",
+          "id": "eqfwgj"
+        },
+        {
+          "label": "HTML",
+          "labelWidth": "",
+          "labelMargin": "",
+          "tag": "p",
+          "className": "alert alert-warning fa fa-exclamation-triangle",
+          "attrs": [
+            {
+              "attr": "",
+              "value": ""
+            }
+          ],
+          "content": "<strong class=\"ml-2\">This study period is ineligible for StudentAid BC funding</strong>\n<br>\n<span>{{data.invalidStudyBreakMessage}}</span>",
+          "refreshOnChange": true,
+          "customClass": "banner-warning",
+          "hidden": false,
+          "modalEdit": false,
+          "key": "html11",
+          "tags": [],
+          "properties": {},
+          "conditional": {
+            "show": true,
+            "when": "invalidStudyBreaks",
+            "eq": "true",
+            "json": ""
+          },
+          "customConditional": "",
+          "logic": [],
+          "attributes": {},
+          "overlay": {
+            "style": "",
+            "page": "",
+            "left": "",
+            "top": "",
+            "width": "",
+            "height": ""
+          },
+          "type": "htmlelement",
+          "input": false,
+          "tableView": false,
+          "placeholder": "",
+          "prefix": "",
+          "suffix": "",
+          "multiple": false,
+          "defaultValue": null,
+          "protected": false,
+          "unique": false,
+          "persistent": false,
+          "clearOnHide": true,
+          "refreshOn": "",
+          "redrawOn": "",
+          "dataGridLabel": false,
+          "labelPosition": "top",
+          "description": "",
+          "errorLabel": "",
+          "tooltip": "",
+          "hideLabel": false,
+          "tabindex": "",
+          "disabled": false,
+          "autofocus": false,
+          "dbIndex": false,
+          "customDefaultValue": "",
+          "calculateValue": "",
+          "calculateServer": false,
+          "widget": null,
+          "validateOn": "change",
+          "validate": {
+            "required": false,
+            "custom": "",
+            "customPrivate": false,
+            "strictDateValidation": false,
+            "multiple": false,
+            "unique": false
+          },
+          "allowCalculateOverride": false,
+          "encrypted": false,
+          "showCharCount": false,
+          "showWordCount": false,
+          "allowMultipleMasks": false,
+          "addons": [],
+          "id": "e7p983tc"
+        },
+        {
+          "label": "HTML",
+          "labelWidth": "",
+          "labelMargin": "",
+          "tag": "p",
+          "className": "",
+          "attrs": [
+            {
+              "attr": "",
+              "value": ""
+            }
+          ],
+          "content": "Study breaks validation {{data.invalidStudyBreaks}}",
+          "refreshOnChange": false,
+          "customClass": "",
+          "hidden": false,
+          "modalEdit": false,
+          "key": "html12",
+          "tags": [],
+          "properties": {},
+          "conditional": {
+            "show": null,
+            "when": null,
+            "eq": "",
+            "json": ""
+          },
+          "customConditional": "",
+          "logic": [],
+          "attributes": {},
+          "overlay": {
+            "style": "",
+            "page": "",
+            "left": "",
+            "top": "",
+            "width": "",
+            "height": ""
+          },
+          "type": "htmlelement",
+          "input": false,
+          "placeholder": "",
+          "prefix": "",
+          "suffix": "",
+          "multiple": false,
+          "defaultValue": null,
+          "protected": false,
+          "unique": false,
+          "persistent": false,
+          "clearOnHide": true,
+          "refreshOn": "",
+          "redrawOn": "",
+          "tableView": false,
+          "dataGridLabel": false,
+          "labelPosition": "top",
+          "description": "",
+          "errorLabel": "",
+          "tooltip": "",
+          "hideLabel": false,
+          "tabindex": "",
+          "disabled": false,
+          "autofocus": false,
+          "dbIndex": false,
+          "customDefaultValue": "",
+          "calculateValue": "",
+          "calculateServer": false,
+          "widget": null,
+          "validateOn": "change",
+          "validate": {
+            "required": false,
+            "custom": "",
+            "customPrivate": false,
+            "strictDateValidation": false,
+            "multiple": false,
+            "unique": false
+          },
+          "allowCalculateOverride": false,
+          "encrypted": false,
+          "showCharCount": false,
+          "showWordCount": false,
+          "allowMultipleMasks": false,
+          "addons": [],
+          "id": "em3jrqp"
         },
         {
           "label": "HTML",
@@ -2192,7 +3168,8 @@
           "showCharCount": false,
           "showWordCount": false,
           "allowMultipleMasks": false,
-          "id": "es9d0f4"
+          "id": "es9d0f4",
+          "addons": []
         },
         {
           "label": "HTML",
@@ -2271,7 +3248,8 @@
           "showCharCount": false,
           "showWordCount": false,
           "allowMultipleMasks": false,
-          "id": "ejpj3l"
+          "id": "ejpj3l",
+          "addons": []
         },
         {
           "label": "Columns",
@@ -2361,14 +3339,16 @@
                   "showWordCount": false,
                   "allowMultipleMasks": false,
                   "id": "e3iuupj",
-                  "defaultValue": null
+                  "defaultValue": null,
+                  "addons": []
                 }
               ],
               "width": 3,
               "offset": 0,
               "push": 0,
               "pull": 0,
-              "size": "md"
+              "size": "md",
+              "currentWidth": 3
             },
             {
               "components": [
@@ -2455,14 +3435,16 @@
                   "showWordCount": false,
                   "allowMultipleMasks": false,
                   "id": "edg8oot",
-                  "defaultValue": null
+                  "defaultValue": null,
+                  "addons": []
                 }
               ],
               "width": 3,
               "offset": 0,
               "push": 0,
               "pull": 0,
-              "size": "md"
+              "size": "md",
+              "currentWidth": 3
             },
             {
               "components": [
@@ -2549,14 +3531,16 @@
                   "showWordCount": false,
                   "allowMultipleMasks": false,
                   "id": "expot7k",
-                  "defaultValue": null
+                  "defaultValue": null,
+                  "addons": []
                 }
               ],
               "size": "md",
               "width": 3,
               "offset": 0,
               "push": 0,
-              "pull": 0
+              "pull": 0,
+              "currentWidth": 3
             },
             {
               "components": [
@@ -2643,14 +3627,16 @@
                   "showWordCount": false,
                   "allowMultipleMasks": false,
                   "id": "e3mdxgr",
-                  "defaultValue": null
+                  "defaultValue": null,
+                  "addons": []
                 }
               ],
               "size": "md",
               "width": 3,
               "offset": 0,
               "push": 0,
-              "pull": 0
+              "pull": 0,
+              "currentWidth": 3
             }
           ],
           "key": "columns3",
@@ -2716,7 +3702,9 @@
           "autoAdjust": false,
           "hideOnChildrenHidden": false,
           "id": "ew5imr",
-          "dataGridLabel": false
+          "dataGridLabel": false,
+          "addons": [],
+          "lazyLoad": false
         },
         {
           "label": "No fixed costs",
@@ -2791,11 +3779,14 @@
           "showCharCount": false,
           "showWordCount": false,
           "allowMultipleMasks": false,
-          "id": "ejtd92t"
+          "id": "ejtd92t",
+          "addons": []
         },
         {
           "label": "Is tuition remittance requested?",
           "labelPosition": "top",
+          "labelWidth": "",
+          "labelMargin": "",
           "optionsLabelPosition": "right",
           "description": "",
           "tooltip": "",
@@ -2833,6 +3824,7 @@
           "allowCalculateOverride": false,
           "validate": {
             "required": true,
+            "onlyAvailableItems": true,
             "customMessage": "",
             "custom": "",
             "customPrivate": false,
@@ -2842,6 +3834,7 @@
             "unique": false
           },
           "errorLabel": "",
+          "errors": "",
           "key": "tuitionRemittanceRequested",
           "tags": [],
           "properties": {},
@@ -2872,16 +3865,17 @@
           "multiple": false,
           "unique": false,
           "refreshOn": "",
+          "dataGridLabel": false,
           "widget": null,
           "validateOn": "change",
           "showCharCount": false,
           "showWordCount": false,
           "allowMultipleMasks": false,
+          "addons": [],
           "inputType": "radio",
           "fieldSet": false,
-          "id": "ed973vq",
-          "defaultValue": "",
-          "dataGridLabel": false
+          "id": "esfouv8",
+          "defaultValue": ""
         },
         {
           "label": "Amount requested",
@@ -2965,7 +3959,263 @@
           "showWordCount": false,
           "allowMultipleMasks": false,
           "id": "eim5ou",
-          "defaultValue": null
+          "defaultValue": null,
+          "addons": []
+        },
+        {
+          "label": "Study period availability",
+          "labelWidth": "",
+          "labelMargin": "",
+          "tag": "p",
+          "className": "",
+          "attrs": [
+            {
+              "attr": "",
+              "value": ""
+            }
+          ],
+          "content": "Study period availability",
+          "refreshOnChange": false,
+          "customClass": "category-header-medium primary-color ",
+          "hidden": false,
+          "modalEdit": false,
+          "key": "studyPeriodAvailability",
+          "tags": [],
+          "properties": {},
+          "conditional": {
+            "show": null,
+            "when": null,
+            "eq": "",
+            "json": ""
+          },
+          "customConditional": "",
+          "logic": [],
+          "attributes": {},
+          "overlay": {
+            "style": "",
+            "page": "",
+            "left": "",
+            "top": "",
+            "width": "",
+            "height": ""
+          },
+          "type": "htmlelement",
+          "input": false,
+          "placeholder": "",
+          "prefix": "",
+          "suffix": "",
+          "multiple": false,
+          "defaultValue": null,
+          "protected": false,
+          "unique": false,
+          "persistent": false,
+          "clearOnHide": true,
+          "refreshOn": "",
+          "redrawOn": "",
+          "tableView": false,
+          "dataGridLabel": false,
+          "labelPosition": "top",
+          "description": "",
+          "errorLabel": "",
+          "tooltip": "",
+          "hideLabel": false,
+          "tabindex": "",
+          "disabled": false,
+          "autofocus": false,
+          "dbIndex": false,
+          "customDefaultValue": "",
+          "calculateValue": "",
+          "calculateServer": false,
+          "widget": null,
+          "validateOn": "change",
+          "validate": {
+            "required": false,
+            "custom": "",
+            "customPrivate": false,
+            "strictDateValidation": false,
+            "multiple": false,
+            "unique": false
+          },
+          "allowCalculateOverride": false,
+          "encrypted": false,
+          "showCharCount": false,
+          "showWordCount": false,
+          "allowMultipleMasks": false,
+          "addons": [],
+          "id": "ew8iax"
+        },
+        {
+          "title": "Offering type panel",
+          "labelWidth": "",
+          "labelMargin": "",
+          "theme": "default",
+          "tooltip": "",
+          "customClass": "",
+          "collapsible": false,
+          "hidden": false,
+          "hideLabel": true,
+          "disabled": false,
+          "modalEdit": false,
+          "key": "offeringTypePanel",
+          "tags": [],
+          "properties": {},
+          "customConditional": "",
+          "conditional": {
+            "json": "",
+            "show": null,
+            "when": null,
+            "eq": ""
+          },
+          "logic": [],
+          "attributes": {},
+          "overlay": {
+            "style": "",
+            "page": "",
+            "left": "",
+            "top": "",
+            "width": "",
+            "height": ""
+          },
+          "type": "panel",
+          "label": "Panel",
+          "breadcrumb": "default",
+          "tabindex": "",
+          "input": false,
+          "placeholder": "",
+          "prefix": "",
+          "suffix": "",
+          "multiple": false,
+          "defaultValue": null,
+          "protected": false,
+          "unique": false,
+          "persistent": false,
+          "clearOnHide": false,
+          "refreshOn": "",
+          "redrawOn": "",
+          "tableView": false,
+          "dataGridLabel": false,
+          "labelPosition": "top",
+          "description": "",
+          "errorLabel": "",
+          "autofocus": false,
+          "dbIndex": false,
+          "customDefaultValue": "",
+          "calculateValue": "",
+          "calculateServer": false,
+          "widget": null,
+          "validateOn": "change",
+          "validate": {
+            "required": false,
+            "custom": "",
+            "customPrivate": false,
+            "strictDateValidation": false,
+            "multiple": false,
+            "unique": false
+          },
+          "allowCalculateOverride": false,
+          "encrypted": false,
+          "showCharCount": false,
+          "showWordCount": false,
+          "allowMultipleMasks": false,
+          "addons": [],
+          "tree": false,
+          "lazyLoad": false,
+          "components": [
+            {
+              "label": "Do you want to add this study period for all students to select?",
+              "labelPosition": "top",
+              "labelWidth": "",
+              "labelMargin": "",
+              "optionsLabelPosition": "right",
+              "description": "",
+              "tooltip": "",
+              "customClass": "",
+              "tabindex": "",
+              "inline": false,
+              "hidden": false,
+              "hideLabel": false,
+              "autofocus": false,
+              "disabled": false,
+              "tableView": false,
+              "modalEdit": false,
+              "defaultValue": null,
+              "values": [
+                {
+                  "label": "Yes, this offering is for all students",
+                  "value": "Public",
+                  "shortcut": ""
+                },
+                {
+                  "label": "No, this offering is for a specific student",
+                  "value": "Private",
+                  "shortcut": ""
+                }
+              ],
+              "dataType": "",
+              "persistent": true,
+              "protected": false,
+              "dbIndex": false,
+              "encrypted": false,
+              "redrawOn": "",
+              "clearOnHide": true,
+              "customDefaultValue": "",
+              "calculateValue": "",
+              "calculateServer": false,
+              "allowCalculateOverride": false,
+              "validate": {
+                "required": true,
+                "onlyAvailableItems": true,
+                "customMessage": "",
+                "custom": "",
+                "customPrivate": false,
+                "json": "",
+                "strictDateValidation": false,
+                "multiple": false,
+                "unique": false
+              },
+              "errorLabel": "",
+              "errors": "",
+              "key": "offeringType",
+              "tags": [],
+              "properties": {},
+              "conditional": {
+                "show": null,
+                "when": null,
+                "eq": "",
+                "json": ""
+              },
+              "customConditional": "",
+              "logic": [],
+              "attributes": {},
+              "overlay": {
+                "style": "",
+                "page": "",
+                "left": "",
+                "top": "",
+                "width": "",
+                "height": ""
+              },
+              "type": "radio",
+              "input": true,
+              "placeholder": "",
+              "prefix": "",
+              "suffix": "",
+              "multiple": false,
+              "unique": false,
+              "refreshOn": "",
+              "dataGridLabel": false,
+              "widget": null,
+              "validateOn": "change",
+              "showCharCount": false,
+              "showWordCount": false,
+              "allowMultipleMasks": false,
+              "addons": [],
+              "inputType": "radio",
+              "fieldSet": false,
+              "id": "e66yqcm"
+            }
+          ],
+          "id": "ejutvc3"
         },
         {
           "label": "Declaration",
@@ -3044,7 +4294,8 @@
           "showCharCount": false,
           "showWordCount": false,
           "allowMultipleMasks": false,
-          "id": "ejh2mx3"
+          "id": "ejh2mx3",
+          "addons": []
         },
         {
           "title": "Panel",
@@ -3196,7 +4447,8 @@
               "showCharCount": false,
               "showWordCount": false,
               "allowMultipleMasks": false,
-              "id": "eicz0e"
+              "id": "eicz0e",
+              "addons": []
             },
             {
               "label": "I confirm this study period offering meets the policies outlined in the StudentAid BC policy manual.",
@@ -3271,13 +4523,18 @@
               "showCharCount": false,
               "showWordCount": false,
               "allowMultipleMasks": false,
-              "id": "epek39t"
+              "id": "epek39t",
+              "addons": []
             }
           ],
-          "id": "elah0n"
+          "id": "elah0n",
+          "addons": [],
+          "lazyLoad": false
         }
       ],
-      "id": "eia4y5n"
+      "id": "eia4y5n",
+      "addons": [],
+      "lazyLoad": false
     },
     {
       "label": "Submit",
@@ -3358,7 +4615,8 @@
       "allowMultipleMasks": false,
       "dataGridLabel": true,
       "id": "e673e1",
-      "hideOnChildrenHidden": false
+      "hideOnChildrenHidden": false,
+      "addons": []
     },
     {
       "label": "applicationId",
@@ -3428,7 +4686,152 @@
       "inputType": "hidden",
       "id": "em1y8gd",
       "defaultValue": "",
-      "dataGridLabel": false
+      "dataGridLabel": false,
+      "addons": []
+    },
+    {
+      "label": "applicationStatus",
+      "customClass": "",
+      "modalEdit": false,
+      "defaultValue": null,
+      "persistent": true,
+      "protected": false,
+      "dbIndex": false,
+      "encrypted": false,
+      "redrawOn": "",
+      "customDefaultValue": "",
+      "calculateValue": "",
+      "calculateServer": false,
+      "key": "applicationStatus",
+      "tags": [],
+      "properties": {},
+      "logic": [],
+      "attributes": {},
+      "overlay": {
+        "style": "",
+        "page": "",
+        "left": "",
+        "top": "",
+        "width": "",
+        "height": ""
+      },
+      "type": "hidden",
+      "input": true,
+      "tableView": false,
+      "placeholder": "",
+      "prefix": "",
+      "suffix": "",
+      "multiple": false,
+      "unique": false,
+      "hidden": false,
+      "clearOnHide": true,
+      "refreshOn": "",
+      "dataGridLabel": false,
+      "labelPosition": "top",
+      "description": "",
+      "errorLabel": "",
+      "tooltip": "",
+      "hideLabel": false,
+      "tabindex": "",
+      "disabled": false,
+      "autofocus": false,
+      "widget": {
+        "type": "input"
+      },
+      "validateOn": "change",
+      "validate": {
+        "required": false,
+        "custom": "",
+        "customPrivate": false,
+        "strictDateValidation": false,
+        "multiple": false,
+        "unique": false
+      },
+      "conditional": {
+        "show": null,
+        "when": null,
+        "eq": ""
+      },
+      "allowCalculateOverride": false,
+      "showCharCount": false,
+      "showWordCount": false,
+      "allowMultipleMasks": false,
+      "inputType": "hidden",
+      "id": "e6z1qd9",
+      "addons": []
+    },
+    {
+      "label": "Offering Status",
+      "labelWidth": "",
+      "labelMargin": "",
+      "customClass": "",
+      "modalEdit": false,
+      "defaultValue": null,
+      "persistent": true,
+      "protected": false,
+      "dbIndex": false,
+      "encrypted": false,
+      "redrawOn": "data",
+      "customDefaultValue": "",
+      "calculateValue": "value =\r\n  data.programOfferingIntensityMismatch ||\r\n  data.programOfferingDeliveryMismatch ||\r\n  data.programOfferingWILMismatch ||\r\n  data.invalidStudyDates ||\r\n  data.invalidStudyBreaks\r\n    ? \"Pending\"\r\n    : \"Approved\";",
+      "calculateServer": true,
+      "key": "offeringStatus",
+      "tags": [],
+      "properties": {},
+      "logic": [],
+      "attributes": {},
+      "overlay": {
+        "style": "",
+        "page": "",
+        "left": "",
+        "top": "",
+        "width": "",
+        "height": ""
+      },
+      "type": "hidden",
+      "input": true,
+      "tableView": false,
+      "placeholder": "",
+      "prefix": "",
+      "suffix": "",
+      "multiple": false,
+      "unique": false,
+      "hidden": false,
+      "clearOnHide": true,
+      "refreshOn": "",
+      "dataGridLabel": false,
+      "labelPosition": "top",
+      "description": "",
+      "errorLabel": "",
+      "tooltip": "",
+      "hideLabel": false,
+      "tabindex": "",
+      "disabled": false,
+      "autofocus": false,
+      "widget": {
+        "type": "input"
+      },
+      "validateOn": "change",
+      "validate": {
+        "required": false,
+        "custom": "",
+        "customPrivate": false,
+        "strictDateValidation": false,
+        "multiple": false,
+        "unique": false
+      },
+      "conditional": {
+        "show": null,
+        "when": null,
+        "eq": ""
+      },
+      "allowCalculateOverride": false,
+      "showCharCount": false,
+      "showWordCount": false,
+      "allowMultipleMasks": false,
+      "addons": [],
+      "inputType": "hidden",
+      "id": "eawojtn"
     }
   ],
   "display": "form",
@@ -3437,5 +4840,5 @@
   "path": "educationprogramoffering",
   "machineName": "educationProgramOffering",
   "created": "2021-06-28T22:04:18.848Z",
-  "modified": "2021-11-23T17:51:38.655Z"
+  "modified": "2022-04-28T00:03:40.096Z"
 }

--- a/sources/packages/web/src/components/common/ProgramDetailHeader.vue
+++ b/sources/packages/web/src/components/common/ProgramDetailHeader.vue
@@ -34,7 +34,7 @@
       />
       <div
         class="mx-2 vertical-divider"
-        v-if="educationProgram.assessedBy"
+        v-if="educationProgram.assessedDate"
       ></div>
       <header-title-value
         title="Approved"

--- a/sources/packages/web/src/components/common/ProgramDetailHeader.vue
+++ b/sources/packages/web/src/components/common/ProgramDetailHeader.vue
@@ -25,23 +25,23 @@
     </div>
     <div
       class="row mt-1"
-      v-if="ApprovalStatus.approved === educationProgram.approvalStatus"
+      v-if="ProgramStatus.Approved === educationProgram.programStatus"
     >
       <header-title-value
         title="Approved by"
-        :value="educationProgram.statusUpdatedBy ?? '-'"
-        v-if="educationProgram.statusUpdatedBy"
+        :value="educationProgram.assessedBy ?? '-'"
+        v-if="educationProgram.assessedBy"
       />
       <div
         class="mx-2 vertical-divider"
-        v-if="educationProgram.statusUpdatedBy"
+        v-if="educationProgram.assessedBy"
       ></div>
       <header-title-value
         title="Approved"
-        v-if="educationProgram.statusUpdatedOn"
+        v-if="educationProgram.assessedDate"
         :value="
-          educationProgram.statusUpdatedOn
-            ? dateOnlyLongString(educationProgram.statusUpdatedOn)
+          educationProgram.assessedDate
+            ? dateOnlyLongString(educationProgram.assessedDate)
             : '-'
         "
       />
@@ -61,18 +61,18 @@
     </div>
     <div
       class="row mt-1"
-      v-if="ApprovalStatus.denied === educationProgram.approvalStatus"
+      v-if="ProgramStatus.Denied === educationProgram.programStatus"
     >
       <header-title-value
         title="Denied by"
-        :value="educationProgram.statusUpdatedBy"
+        :value="educationProgram.assessedBy"
       />
       <div class="mx-2 vertical-divider"></div>
       <header-title-value
         title="Denied"
         :value="
-          educationProgram.statusUpdatedOn
-            ? dateOnlyLongString(educationProgram.statusUpdatedOn)
+          educationProgram.assessedDate
+            ? dateOnlyLongString(educationProgram.assessedDate)
             : '-'
         "
       />
@@ -81,7 +81,7 @@
 </template>
 
 <script lang="ts">
-import { EducationProgramData, ApprovalStatus, ClientIdType } from "@/types";
+import { EducationProgramData, ProgramStatus, ClientIdType } from "@/types";
 import HeaderTitleValue from "@/components/generic/HeaderTitleValue.vue";
 import { useFormatters } from "@/composables";
 import { computed } from "vue";
@@ -124,7 +124,7 @@ export default {
         });
     };
     return {
-      ApprovalStatus,
+      ProgramStatus,
       goToInstitution,
       dateOnlyLongString,
       institutionName,

--- a/sources/packages/web/src/components/common/ProgramDetailHeader.vue
+++ b/sources/packages/web/src/components/common/ProgramDetailHeader.vue
@@ -61,7 +61,7 @@
     </div>
     <div
       class="row mt-1"
-      v-if="ProgramStatus.Denied === educationProgram.programStatus"
+      v-if="ProgramStatus.Declined === educationProgram.programStatus"
     >
       <header-title-value
         title="Denied by"

--- a/sources/packages/web/src/components/common/ProgramDetails.vue
+++ b/sources/packages/web/src/components/common/ProgramDetails.vue
@@ -5,7 +5,7 @@
     </span>
     <program-status-chip
       class="ml-2"
-      :status="educationProgram.approvalStatus"
+      :status="educationProgram.programStatus"
     ></program-status-chip>
     <v-btn
       class="float-right"

--- a/sources/packages/web/src/components/generic/ProgramStatusChip.vue
+++ b/sources/packages/web/src/components/generic/ProgramStatusChip.vue
@@ -15,7 +15,7 @@ status Badge
 </template>
 <script lang="ts">
 import { computed } from "vue";
-import { ApprovalStatus } from "@/types";
+import { ProgramStatus } from "@/types";
 import {
   COLOR_BLACK,
   COLOR_WHITE,
@@ -34,17 +34,17 @@ export default {
   setup(props: any) {
     const iconColor = computed(() => {
       switch (props.status) {
-        case ApprovalStatus.approved:
+        case ProgramStatus.Approved:
           /**
            * Education Program is approved.
            */
           return COLOR_BANNER_SUCCESS;
-        case ApprovalStatus.pending:
+        case ProgramStatus.Pending:
           /**
            * Education Program is pending.
            */
           return COLOR_BANNER_WARNING;
-        case ApprovalStatus.denied:
+        case ProgramStatus.Denied:
           /**
            * Education Program is denied.
            */
@@ -64,17 +64,17 @@ export default {
 
     const badgeClass = computed(() => {
       switch (props.status) {
-        case ApprovalStatus.approved:
+        case ProgramStatus.Approved:
           /**
            * Education Program is approved.
            */
           return "status-badge-success";
-        case ApprovalStatus.pending:
+        case ProgramStatus.Pending:
           /**
            * Education Program is pending.
            */
           return "status-badge-warning";
-        case ApprovalStatus.denied:
+        case ProgramStatus.Denied:
           /**
            * Education Program is denied.
            */

--- a/sources/packages/web/src/components/generic/ProgramStatusChip.vue
+++ b/sources/packages/web/src/components/generic/ProgramStatusChip.vue
@@ -44,7 +44,7 @@ export default {
            * Education Program is pending.
            */
           return COLOR_BANNER_WARNING;
-        case ProgramStatus.Denied:
+        case ProgramStatus.Declined:
           /**
            * Education Program is denied.
            */
@@ -74,7 +74,7 @@ export default {
            * Education Program is pending.
            */
           return "status-badge-warning";
-        case ProgramStatus.Denied:
+        case ProgramStatus.Declined:
           /**
            * Education Program is denied.
            */

--- a/sources/packages/web/src/types/contracts/DataTableContract.ts
+++ b/sources/packages/web/src/types/contracts/DataTableContract.ts
@@ -64,7 +64,7 @@ export enum ProgramSummaryFields {
   CipCode = "cipCode",
   CredentialType = "credentialType",
   TotalOfferings = "totalOfferings",
-  ApprovalStatus = "approvalStatus",
+  ProgramStatus = "programStatus",
   IsActive = "isActive",
 }
 

--- a/sources/packages/web/src/types/contracts/InstituteContract.ts
+++ b/sources/packages/web/src/types/contracts/InstituteContract.ts
@@ -1,4 +1,4 @@
-import { ApprovalStatus } from "..";
+import { ProgramStatus } from "..";
 
 export interface Institute {
   name: string;
@@ -10,7 +10,7 @@ export interface AESTInstitutionProgramsSummaryDto {
   programName: string;
   submittedDate: Date;
   locationName: string;
-  programStatus: ApprovalStatus;
+  programStatus: ProgramStatus;
   totalOfferings: number;
   formattedSubmittedDate: string;
   locationId: number;

--- a/sources/packages/web/src/types/contracts/institution/EducationProgramDto.ts
+++ b/sources/packages/web/src/types/contracts/institution/EducationProgramDto.ts
@@ -22,7 +22,7 @@ export interface EducationProgramBaseDto {
   cipCode: string;
   nocCode: string;
   sabcCode: string;
-  approvalStatus: ApprovalStatus;
+  programStatus: ProgramStatus;
   programIntensity: ProgramIntensity;
   institutionProgramCode?: string;
 }
@@ -33,7 +33,7 @@ export interface SummaryEducationProgramDto {
   credentialType: string;
   cipCode: string;
   totalOfferings: number;
-  approvalStatus: ApprovalStatus;
+  programStatus: ProgramStatus;
   credentialTypeToDisplay: string;
 }
 
@@ -76,15 +76,15 @@ export interface EducationProgramDetails {
 
 export interface EducationProgramData extends EducationProgramDetails {
   credentialTypeToDisplay: string;
-  approvalStatus: ApprovalStatus;
+  programStatus: ProgramStatus;
   institutionId?: number;
   id: number;
   institutionName?: string;
   submittedOn: Date;
   submittedBy: string;
-  statusUpdatedOn?: Date;
-  statusUpdatedByFirstName?: string;
-  statusUpdatedByLastName?: string;
+  assessedDate?: Date;
+  assessedByFirstName?: string;
+  assessedByLastName?: string;
   effectiveEndDate: Date;
 }
 
@@ -97,19 +97,19 @@ export interface StudentEducationProgramDto {
   deliveryMethod: string;
 }
 
-export enum ApprovalStatus {
+export enum ProgramStatus {
   /**
    * Education Program is approved.
    */
-  approved = "approved",
+  Approved = "approved",
   /**
    * Education Program is pending.
    */
-  pending = "pending",
+  Pending = "pending",
   /**
    * Education Program is denied.
    */
-  denied = "denied",
+  Denied = "denied",
 }
 
 /**

--- a/sources/packages/web/src/types/contracts/institution/EducationProgramDto.ts
+++ b/sources/packages/web/src/types/contracts/institution/EducationProgramDto.ts
@@ -101,15 +101,15 @@ export enum ProgramStatus {
   /**
    * Education Program is approved.
    */
-  Approved = "approved",
+  Approved = "Approved",
   /**
    * Education Program is pending.
    */
-  Pending = "pending",
+  Pending = "Pending",
   /**
-   * Education Program is denied.
+   * Education Program is Declined.
    */
-  Denied = "denied",
+  Declined = "Declined",
 }
 
 /**

--- a/sources/packages/web/src/views/aest/institution/ProgramDetails.vue
+++ b/sources/packages/web/src/views/aest/institution/ProgramDetails.vue
@@ -42,9 +42,9 @@ import ManageProgramAndOfferingSummary from "@/components/common/ManageProgramAn
 import { ref, onMounted, computed } from "vue";
 import {
   EducationProgramData,
-  ApprovalStatus,
   ApproveProgram,
   DeclineProgram,
+  ProgramStatus,
 } from "@/types";
 import { EducationProgramService } from "@/services/EducationProgramService";
 import HeaderNavigator from "@/components/generic/HeaderNavigator.vue";
@@ -92,7 +92,7 @@ export default {
     };
 
     const isPendingProgram = computed(
-      () => educationProgram.value.approvalStatus === ApprovalStatus.pending,
+      () => educationProgram.value.programStatus === ProgramStatus.Pending,
     );
 
     const submitApproveProgram = async (approveProgramData: ApproveProgram) => {

--- a/sources/packages/web/src/views/aest/institution/Programs.vue
+++ b/sources/packages/web/src/views/aest/institution/Programs.vue
@@ -67,7 +67,7 @@
             header="Study periods"
           >
           </Column>
-          <Column :field="ProgramSummaryFields.ApprovalStatus" header="Status"
+          <Column :field="ProgramSummaryFields.ProgramStatus" header="Status"
             ><template #body="slotProps">
               <program-status-chip
                 :status="slotProps.data.programStatus"

--- a/sources/packages/web/src/views/institution/locations/programs/LocationPrograms.vue
+++ b/sources/packages/web/src/views/institution/locations/programs/LocationPrograms.vue
@@ -66,12 +66,12 @@
               header="Offerings"
             ></Column>
             <Column
-              :field="ProgramSummaryFields.ApprovalStatus"
+              :field="ProgramSummaryFields.ProgramStatus"
               header="Status"
               :sortable="true"
               ><template #body="slotProps">
                 <program-status-chip
-                  :status="slotProps.data.approvalStatus"
+                  :status="slotProps.data.programStatus"
                 ></program-status-chip></template
             ></Column>
             <Column>


### PR DESCRIPTION
## Following items fall under the scope of the PR

### For the offerings.

- [x] Added columns offering_status, assessed_by, assessed_date and submitted_date to education_programs_offerings table.
- [x] The Offering types enum updated to have Public | Private | Scholastic Standing for offerings.
- [x] Created offering status enum to have values Pending | Approved | Declined
- [x] Updated the form.io for the offerings to have popup in validation failures and calculate the offering status.
- [x] Added the Question to choose offering type from the form(This question was previously in PIR)
- [x] APIs in offering controller updated to persist/return newly added fields.
- [x] Service methods for offering using DTOs refactored.
- [x] APIs refactored to use dry-run submission data to create/update instead of API payload.

### The approval related columns were renamed in education_programs to be in sync with offerings.

- [x] The columns approval_status, status_updated_by and status_updated_on has been renamed to program_status, assessed_by and assessed_date.
- [x] The program_status(previously approval_status) values updated to [Pending | Approved | Declined] from [pending|approved|denied]
- [x] The program_status column type changed to enum from varchar.
- [x] The form.io of program updated to return new status values.