### PR TITLE
[Bug][SIMS-#1184]Bugs in MSFAA and ECert Receive and File generation

### DIFF
--- a/sources/packages/api/src/esdc-integration/e-cert-integration/e-cert-file-handler.ts
+++ b/sources/packages/api/src/esdc-integration/e-cert-integration/e-cert-file-handler.ts
@@ -160,7 +160,7 @@ export class ECertFileHandler extends ESDCFileHandler {
 
           // Create the request filename with the file path for the e-Cert File.
           const fileInfo = await this.createRequestFileName(
-            `${fileCode}`,
+            fileCode,
             nextSequenceNumber,
           );
 

--- a/sources/packages/api/src/esdc-integration/e-cert-integration/e-cert-file-handler.ts
+++ b/sources/packages/api/src/esdc-integration/e-cert-integration/e-cert-file-handler.ts
@@ -15,7 +15,6 @@ import {
   ECERT_PART_TIME_FILE_CODE,
   ECERT_FULL_TIME_FEEDBACK_FILE_CODE,
   ECERT_PART_TIME_FEEDBACK_FILE_CODE,
-  getDayOfTheYear,
   getFieldOfStudyFromCIPCode,
   getISODateOnlyString,
 } from "../../utilities";
@@ -147,7 +146,6 @@ export class ECertFileHandler extends ESDCFileHandler {
     //Create records and create the unique file sequence number.
     let uploadResult: ECertUploadResult;
     const now = new Date();
-    const dayOfTheYear = getDayOfTheYear(now);
     await this.sequenceService.consumeNextSequence(
       `${sequenceGroup}_${getISODateOnlyString(new Date())}`,
       async (nextSequenceNumber: number, entityManager: EntityManager) => {
@@ -162,7 +160,7 @@ export class ECertFileHandler extends ESDCFileHandler {
 
           // Create the request filename with the file path for the e-Cert File.
           const fileInfo = await this.createRequestFileName(
-            `${fileCode}${now.getFullYear()}${dayOfTheYear}`,
+            `${fileCode}`,
             nextSequenceNumber,
           );
 

--- a/sources/packages/api/src/esdc-integration/msfaa-integration/msfaa-integration.service.ts
+++ b/sources/packages/api/src/esdc-integration/msfaa-integration/msfaa-integration.service.ts
@@ -149,7 +149,7 @@ export class MSFAAIntegrationService {
       filesToProcess = await client.list(
         `${this.esdcConfig.ftpResponseFolder}`,
         new RegExp(
-          `^${this.esdcConfig.environmentCode}EDU.PBC.MSFA.REC.*\\.DAT`,
+          `^${this.esdcConfig.environmentCode}EDU.PBC.MSFA.REC.*`,
           "i",
         ),
       );

--- a/sources/packages/api/src/utilities/system-configurations-constants.ts
+++ b/sources/packages/api/src/utilities/system-configurations-constants.ts
@@ -50,7 +50,7 @@ export const FEDERAL_RESTRICTIONS_UNIDENTIFIED_DESCRIPTION =
  * These constants are used to specify the filename code
  * created for Full-Time/ Part-Time files while ECert request file is generated.
  */
-export const ECERT_FULL_TIME_FILE_CODE = "PBC.EDU.ECERTS.";
+export const ECERT_FULL_TIME_FILE_CODE = "PBC.EDU.FTECERTS.";
 export const ECERT_PART_TIME_FILE_CODE = "PBC.EDU.PTCERTS.";
 
 /**

--- a/sources/packages/api/src/utilities/system-configurations-constants.ts
+++ b/sources/packages/api/src/utilities/system-configurations-constants.ts
@@ -51,7 +51,7 @@ export const FEDERAL_RESTRICTIONS_UNIDENTIFIED_DESCRIPTION =
  * created for Full-Time/ Part-Time files while ECert request file is generated.
  */
 export const ECERT_FULL_TIME_FILE_CODE = "PBC.EDU.FTECERTS.";
-export const ECERT_PART_TIME_FILE_CODE = "PBC.EDU.PTCERTS.";
+export const ECERT_PART_TIME_FILE_CODE = "PBC.EDU.PTCERTS.D";
 
 /**
  * These constants are used to specify the filename code

--- a/sources/packages/api/src/utilities/system-configurations-constants.ts
+++ b/sources/packages/api/src/utilities/system-configurations-constants.ts
@@ -64,8 +64,8 @@ export const MSFAA_PART_TIME_FILE_CODE = "PBC.EDU.MSFA.SENT.PT.";
  * These constants are used to specify the filename code
  * created for Full-Time/ Part-Time feedback file.
  */
-export const ECERT_FULL_TIME_FEEDBACK_FILE_CODE = "EDU.PBC.CERTSFB.*\\.DAT";
-export const ECERT_PART_TIME_FEEDBACK_FILE_CODE = "EDU.PBC.ECERTSFB.PT.*\\.DAT";
+export const ECERT_FULL_TIME_FEEDBACK_FILE_CODE = "EDU.PBC.CERTSFB.*";
+export const ECERT_PART_TIME_FEEDBACK_FILE_CODE = "EDU.PBC.ECERTSFB.PT.*";
 
 /**
  * These constants are used to specify the Template Id for email notification templates

--- a/sources/packages/api/src/utilities/system-configurations-constants.ts
+++ b/sources/packages/api/src/utilities/system-configurations-constants.ts
@@ -50,8 +50,8 @@ export const FEDERAL_RESTRICTIONS_UNIDENTIFIED_DESCRIPTION =
  * These constants are used to specify the filename code
  * created for Full-Time/ Part-Time files while ECert request file is generated.
  */
-export const ECERT_FULL_TIME_FILE_CODE = "PBC.EDU.ECERTS.D";
-export const ECERT_PART_TIME_FILE_CODE = "PBC.EDU.PTCERTS.D";
+export const ECERT_FULL_TIME_FILE_CODE = "PBC.EDU.ECERTS.";
+export const ECERT_PART_TIME_FILE_CODE = "PBC.EDU.PTCERTS.";
 
 /**
  * These constants are used to specify the filename code


### PR DESCRIPTION
- [x] REMOVE .DAT at end of file, not actually used in receive files of ESDC files (MSFAA and ECERT)
- [x] Correct file name is TPBC.EDU.FTECERTS.yyyymmdd.001    (not TPBC.EDU.FTECERTS.D202212220220502.001)