### PR TITLE
[api][SIMS #612]New decorator and new service account user

### DIFF
--- a/sources/packages/api/src/auth/auth.module.ts
+++ b/sources/packages/api/src/auth/auth.module.ts
@@ -26,6 +26,7 @@ import {
   GroupsGuard,
   RestrictionsGuard,
   SINValidationGuard,
+  RequiresStudentAccountGuard,
 } from "./guards";
 import { RolesGuard } from "./guards/roles.guard";
 
@@ -79,6 +80,10 @@ const jwtModule = JwtModule.register({
     {
       provide: APP_GUARD,
       useClass: RestrictionsGuard,
+    },
+    {
+      provide: APP_GUARD,
+      useClass: RequiresStudentAccountGuard,
     },
     {
       provide: APP_GUARD,

--- a/sources/packages/api/src/auth/decorators/index.ts
+++ b/sources/packages/api/src/auth/decorators/index.ts
@@ -8,3 +8,4 @@ export * from "./allow-inactive-user.decorator";
 export * from "./groups.decorator";
 export * from "./check-restrictions.decorator";
 export * from "./check-sin-status.decorator";
+export * from "./requires-student-account.decorator";

--- a/sources/packages/api/src/auth/decorators/requires-student-account.decorator.ts
+++ b/sources/packages/api/src/auth/decorators/requires-student-account.decorator.ts
@@ -1,0 +1,10 @@
+import { SetMetadata } from "@nestjs/common";
+
+export const REQUIRES_STUDENT_ACCOUNT_KEY = "requires-student-account-key";
+/**
+ * Specifies when a user requires a created student account to have access to a route.
+ * If the decorator is present it means that the student account will be required by default.
+ * @param required if true(default), the student account must be present.
+ */
+export const RequiresStudentAccount = (required = true) =>
+  SetMetadata(REQUIRES_STUDENT_ACCOUNT_KEY, required);

--- a/sources/packages/api/src/auth/guards/authorized-parties.guard.ts
+++ b/sources/packages/api/src/auth/guards/authorized-parties.guard.ts
@@ -68,6 +68,8 @@ export class AuthorizedPartiesGuard implements CanActivate {
         return idp === IdentityProviders.BCeID;
       case AuthorizedParties.aest:
         return idp === IdentityProviders.IDIR;
+      case AuthorizedParties.formsFlowBPM:
+        return true;
       default:
         return false;
     }

--- a/sources/packages/api/src/auth/guards/authorized-parties.guard.ts
+++ b/sources/packages/api/src/auth/guards/authorized-parties.guard.ts
@@ -1,7 +1,14 @@
-import { Injectable, CanActivate, ExecutionContext } from "@nestjs/common";
+import {
+  Injectable,
+  CanActivate,
+  ExecutionContext,
+  ForbiddenException,
+} from "@nestjs/common";
 import { Reflector } from "@nestjs/core";
 import { AuthorizedParties } from "../authorized-parties.enum";
 import { AUTHORIZED_PARTY_KEY } from "../decorators/authorized-party.decorator";
+import { IdentityProviders } from "../identity-providers.enum";
+import { IUserToken } from "../userToken.interface";
 
 /**
  * Inspect the token to check if the correct authorized party
@@ -19,9 +26,50 @@ export class AuthorizedPartiesGuard implements CanActivate {
       return true;
     }
     const { user } = context.switchToHttp().getRequest();
+    const userToken = user as IUserToken;
 
-    return authorizedParties.some(
-      (authorizedParty) => authorizedParty === user.authorizedParty,
+    const hasAuthorizedParty = authorizedParties.some(
+      (authorizedParty) => authorizedParty === userToken.authorizedParty,
     );
+    if (!hasAuthorizedParty) {
+      throw new ForbiddenException(
+        "Client is not authorized under the expected authorized party(azp).",
+      );
+    }
+
+    const isAllowedIDP = this.isAllowedIDP(
+      userToken.authorizedParty,
+      userToken.IDP,
+    );
+    if (!isAllowedIDP) {
+      throw new ForbiddenException(
+        "Client is not authorized under the expected identity provider(IDP).",
+      );
+    }
+
+    return true;
+  }
+
+  /**
+   * Determines if the client is authorized through the expected IDP.
+   * @param authorizedParty authorized party type to be checked.
+   * @param idp identity provider used for authentication on Keycloak.
+   * @returns true if IDP is allowed, otherwise, false.
+   */
+  private isAllowedIDP(
+    authorizedParty: AuthorizedParties,
+    idp: IdentityProviders,
+  ): boolean {
+    switch (authorizedParty) {
+      case AuthorizedParties.student:
+      case AuthorizedParties.supportingUsers:
+        return idp === IdentityProviders.BCSC;
+      case AuthorizedParties.institution:
+        return idp === IdentityProviders.BCeID;
+      case AuthorizedParties.aest:
+        return idp === IdentityProviders.IDIR;
+      default:
+        return false;
+    }
   }
 }

--- a/sources/packages/api/src/auth/guards/index.ts
+++ b/sources/packages/api/src/auth/guards/index.ts
@@ -6,3 +6,4 @@ export * from "./active-user.guard";
 export * from "./groups.guard";
 export * from "./restrictions.guard";
 export * from "./sin-validation.guard";
+export * from "./requires-student-account.guard";

--- a/sources/packages/api/src/auth/guards/requires-student-account.guard.ts
+++ b/sources/packages/api/src/auth/guards/requires-student-account.guard.ts
@@ -1,4 +1,9 @@
-import { Injectable, CanActivate, ExecutionContext } from "@nestjs/common";
+import {
+  Injectable,
+  CanActivate,
+  ExecutionContext,
+  UnauthorizedException,
+} from "@nestjs/common";
 import { Reflector } from "@nestjs/core";
 import { StudentUserToken } from "../userToken.interface";
 import { REQUIRES_STUDENT_ACCOUNT_KEY } from "../decorators";
@@ -23,6 +28,13 @@ export class RequiresStudentAccountGuard implements CanActivate {
 
     const { user } = context.switchToHttp().getRequest();
     const userToken = user as StudentUserToken;
-    return !!userToken?.studentId;
+
+    if (!userToken?.studentId) {
+      throw new UnauthorizedException(
+        "The user does not have a student account associated.",
+      );
+    }
+
+    return true;
   }
 }

--- a/sources/packages/api/src/auth/guards/requires-student-account.guard.ts
+++ b/sources/packages/api/src/auth/guards/requires-student-account.guard.ts
@@ -1,0 +1,28 @@
+import { Injectable, CanActivate, ExecutionContext } from "@nestjs/common";
+import { Reflector } from "@nestjs/core";
+import { StudentUserToken } from "../userToken.interface";
+import { REQUIRES_STUDENT_ACCOUNT_KEY } from "../decorators";
+
+/**
+ * Specifies when a student account must be already created in order to access a route.
+ */
+@Injectable()
+export class RequiresStudentAccountGuard implements CanActivate {
+  constructor(private readonly reflector: Reflector) {}
+
+  canActivate(context: ExecutionContext): boolean {
+    const requiresStudentAccount = this.reflector.getAllAndOverride<boolean>(
+      REQUIRES_STUDENT_ACCOUNT_KEY,
+      [context.getHandler(), context.getClass()],
+    );
+
+    // Checks if the decorator is present or it is false.
+    if (!requiresStudentAccount) {
+      return true;
+    }
+
+    const { user } = context.switchToHttp().getRequest();
+    const userToken = user as StudentUserToken;
+    return !!userToken?.studentId;
+  }
+}

--- a/sources/packages/api/src/auth/identity-providers.enum.ts
+++ b/sources/packages/api/src/auth/identity-providers.enum.ts
@@ -1,0 +1,9 @@
+/**
+ * Identity providers (IDPs) available on Keyclock
+ * and received as a token property named IDP.
+ */
+export enum IdentityProviders {
+  BCeID = "BCEID",
+  BCSC = "BCSC",
+  IDIR = "IDIR",
+}

--- a/sources/packages/api/src/auth/jwt.strategy.ts
+++ b/sources/packages/api/src/auth/jwt.strategy.ts
@@ -48,8 +48,7 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
       });
     }
 
-    // Check if it is expected that a user exists on DB for the
-    // specific authorized party (only Students and Institution for now).
+    // Check if it is expected that a user exists on DB for the specific authorized parties.
     const authorizedParties = [
       AuthorizedParties.institution,
       AuthorizedParties.student,
@@ -57,8 +56,7 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
       AuthorizedParties.formsFlowBPM,
     ];
     if (!authorizedParties.includes(userToken.authorizedParty)) {
-      // If not present in the list just return the received token
-      // without any further processing.
+      // If not present in the list just return the received token without any further processing.
       return userToken;
     }
 

--- a/sources/packages/api/src/auth/userToken.interface.ts
+++ b/sources/packages/api/src/auth/userToken.interface.ts
@@ -27,3 +27,7 @@ export interface IUserToken {
 export interface IInstitutionUserToken extends IUserToken {
   authorizations: InstitutionUserAuthorizations;
 }
+
+export interface StudentUserToken extends IUserToken {
+  studentId?: number;
+}

--- a/sources/packages/api/src/auth/userToken.interface.ts
+++ b/sources/packages/api/src/auth/userToken.interface.ts
@@ -1,5 +1,6 @@
 import { InstitutionUserAuthorizations } from "../services/institution-user-auth/institution-user-auth.models";
 import { AuthorizedParties } from "./authorized-parties.enum";
+import { IdentityProviders } from "./identity-providers.enum";
 
 /**
  * User information extracted from the token during the
@@ -21,6 +22,7 @@ export interface IUserToken {
   roles: string[];
   groups: string[];
   idp_user_name: string;
+  IDP: IdentityProviders;
   authorizedParty: AuthorizedParties;
 }
 

--- a/sources/packages/api/src/route-controllers/application/application.students.controller.ts
+++ b/sources/packages/api/src/route-controllers/application/application.students.controller.ts
@@ -41,6 +41,7 @@ import {
   UserToken,
   CheckRestrictions,
   CheckSinValidation,
+  RequiresStudentAccount,
 } from "../../auth/decorators";
 import { AuthorizedParties } from "../../auth/authorized-parties.enum";
 import { ApiProcessError, ClientTypeBaseRoute } from "../../types";
@@ -57,6 +58,7 @@ import {
 import { ApplicationControllerService } from "./application.controller.service";
 
 @AllowAuthorizedParty(AuthorizedParties.student)
+@RequiresStudentAccount()
 @Controller("application")
 @ApiTags(`${ClientTypeBaseRoute.Student}-application`)
 export class ApplicationStudentsController extends BaseController {

--- a/sources/packages/api/src/route-controllers/assessment/assessment.students.controller.ts
+++ b/sources/packages/api/src/route-controllers/assessment/assessment.students.controller.ts
@@ -10,6 +10,7 @@ import BaseController from "../BaseController";
 import {
   AllowAuthorizedParty,
   CheckRestrictions,
+  RequiresStudentAccount,
   UserToken,
 } from "../../auth/decorators";
 import { AuthorizedParties } from "../../auth/authorized-parties.enum";
@@ -25,16 +26,15 @@ import {
   ASSESSMENT_INVALID_OPERATION_IN_THE_CURRENT_STATE,
   ASSESSMENT_NOT_FOUND,
   StudentAssessmentService,
-  StudentService,
 } from "../../services";
-import { IUserToken } from "../../auth/userToken.interface";
+import { StudentUserToken } from "../../auth/userToken.interface";
 
 @AllowAuthorizedParty(AuthorizedParties.student)
+@RequiresStudentAccount()
 @Controller("assessment")
 @ApiTags(`${ClientTypeBaseRoute.Student}-assessment`)
 export class AssessmentStudentsController extends BaseController {
   constructor(
-    private readonly studentService: StudentService,
     private readonly studentAssessmentService: StudentAssessmentService,
     private readonly assessmentControllerService: AssessmentControllerService,
   ) {
@@ -55,11 +55,11 @@ export class AssessmentStudentsController extends BaseController {
   })
   async getAssessmentNOA(
     @Param("assessmentId") assessmentId: number,
-    @UserToken() userToken: IUserToken,
+    @UserToken() userToken: StudentUserToken,
   ): Promise<AssessmentNOAAPIOutDTO> {
     return this.assessmentControllerService.getAssessmentNOA(
       assessmentId,
-      userToken.userId,
+      userToken.studentId,
     );
   }
 
@@ -77,12 +77,12 @@ export class AssessmentStudentsController extends BaseController {
   @Patch(":assessmentId/confirm-assessment")
   async confirmAssessmentNOA(
     @Param("assessmentId") assessmentId: number,
-    @UserToken() userToken: IUserToken,
+    @UserToken() userToken: StudentUserToken,
   ): Promise<void> {
     try {
       await this.studentAssessmentService.studentConfirmAssessment(
         assessmentId,
-        userToken.userId,
+        userToken.studentId,
       );
     } catch (error) {
       switch (error.name) {

--- a/sources/packages/api/src/route-controllers/institution-locations/institution-location.students.controller.ts
+++ b/sources/packages/api/src/route-controllers/institution-locations/institution-location.students.controller.ts
@@ -1,7 +1,10 @@
 import { Controller, Get } from "@nestjs/common";
 import { ApiTags } from "@nestjs/swagger";
 import { AuthorizedParties } from "../../auth/authorized-parties.enum";
-import { AllowAuthorizedParty } from "../../auth/decorators";
+import {
+  AllowAuthorizedParty,
+  RequiresStudentAccount,
+} from "../../auth/decorators";
 import { InstitutionLocationService } from "../../services";
 import { ClientTypeBaseRoute } from "../../types";
 import BaseController from "../BaseController";
@@ -11,6 +14,7 @@ import { OptionItemAPIOutDTO } from "../models/common.dto";
  * Institution location controller for Students client.
  */
 @AllowAuthorizedParty(AuthorizedParties.student)
+@RequiresStudentAccount()
 @Controller("institution/location")
 @ApiTags(`${ClientTypeBaseRoute.Student}-institution/location`)
 export class InstitutionLocationStudentsController extends BaseController {

--- a/sources/packages/api/src/route-controllers/program-year/program-year.controller.ts
+++ b/sources/packages/api/src/route-controllers/program-year/program-year.controller.ts
@@ -6,7 +6,10 @@ import { AllowAuthorizedParty } from "../../auth/decorators/authorized-party.dec
 import { AuthorizedParties } from "../../auth/authorized-parties.enum";
 import { ProgramYearDto } from "./models/program-year.dto";
 import { ApiTags } from "@nestjs/swagger";
+import { RequiresStudentAccount } from "../../auth/decorators";
+
 @AllowAuthorizedParty(AuthorizedParties.student)
+@RequiresStudentAccount()
 @Controller("program-year")
 @ApiTags("program-year")
 export class ProgramYearController extends BaseController {

--- a/sources/packages/api/src/route-controllers/student-appeal/student-appeal.students.controller.ts
+++ b/sources/packages/api/src/route-controllers/student-appeal/student-appeal.students.controller.ts
@@ -16,7 +16,11 @@ import {
 import { StudentAppealAPIInDTO } from "./models/student-appeal.dto";
 import { PrimaryIdentifierAPIOutDTO } from "../models/primary.identifier.dto";
 import { AuthorizedParties } from "../../auth/authorized-parties.enum";
-import { AllowAuthorizedParty, UserToken } from "../../auth/decorators";
+import {
+  AllowAuthorizedParty,
+  RequiresStudentAccount,
+  UserToken,
+} from "../../auth/decorators";
 import { IUserToken } from "../../auth/userToken.interface";
 import {
   ApiTags,
@@ -34,6 +38,7 @@ import { INVALID_APPLICATION_NUMBER } from "../../constants";
 import { StudentAppealRequestModel } from "src/services/student-appeal/student-appeal.model";
 
 @AllowAuthorizedParty(AuthorizedParties.student)
+@RequiresStudentAccount()
 @Controller("appeal")
 @ApiTags(`${ClientTypeBaseRoute.Student}-appeal`)
 export class StudentAppealStudentsController extends BaseController {

--- a/sources/packages/api/src/route-controllers/student/student.students.controller.ts
+++ b/sources/packages/api/src/route-controllers/student/student.students.controller.ts
@@ -7,7 +7,7 @@ import {
   RequiresStudentAccount,
   UserToken,
 } from "../../auth/decorators";
-import { StudentFileService, StudentService } from "../../services";
+import { StudentFileService } from "../../services";
 import BaseController from "../BaseController";
 import { StudentUploadFileDTO } from "./models/student.dto";
 import { ClientTypeBaseRoute } from "../../types";
@@ -21,10 +21,7 @@ import { ClientTypeBaseRoute } from "../../types";
 @ApiTags(`${ClientTypeBaseRoute.Student}-students`)
 @Injectable()
 export class StudentStudentsController extends BaseController {
-  constructor(
-    private readonly studentService: StudentService,
-    private readonly fileService: StudentFileService,
-  ) {
+  constructor(private readonly fileService: StudentFileService) {
     super();
   }
 

--- a/sources/packages/api/src/route-controllers/student/student.students.controller.ts
+++ b/sources/packages/api/src/route-controllers/student/student.students.controller.ts
@@ -1,6 +1,6 @@
-import { Controller, Get, Injectable, NotFoundException } from "@nestjs/common";
+import { Controller, Get, Injectable } from "@nestjs/common";
 import { ApiNotFoundResponse, ApiTags } from "@nestjs/swagger";
-import { IUserToken, StudentUserToken } from "../../auth/userToken.interface";
+import { StudentUserToken } from "../../auth/userToken.interface";
 import { AuthorizedParties } from "../../auth/authorized-parties.enum";
 import {
   AllowAuthorizedParty,

--- a/sources/packages/api/src/services/student-assessment/student-assessment.service.ts
+++ b/sources/packages/api/src/services/student-assessment/student-assessment.service.ts
@@ -336,12 +336,12 @@ export class StudentAssessmentService extends RecordDataModelService<StudentAsse
    * Updates assessment and application statuses when
    * the student is confirming the NOA (Notice of Assessment).
    * @param assessmentId assessment id to be updated.
-   * @param userId user confirming the NOA.
+   * @param studentId student confirming the NOA.
    * @returns updated record.
    */
   async studentConfirmAssessment(
     assessmentId: number,
-    userId: number,
+    studentId: number,
   ): Promise<StudentAssessment> {
     const assessment = await this.repo
       .createQueryBuilder("assessment")
@@ -353,7 +353,7 @@ export class StudentAssessmentService extends RecordDataModelService<StudentAsse
       .innerJoin("assessment.application", "application")
       .innerJoin("application.student", "student")
       .where("assessment.id = :assessmentId", { assessmentId })
-      .andWhere("student.user.id = :userId", { userId })
+      .andWhere("student.id = :studentId", { studentId })
       .getOne();
 
     if (!assessment) {

--- a/sources/packages/api/src/services/user/user.model.ts
+++ b/sources/packages/api/src/services/user/user.model.ts
@@ -1,0 +1,5 @@
+export class UserLoginInfo {
+  id: number;
+  isActive: boolean;
+  studentId?: number;
+}

--- a/sources/packages/api/src/services/user/user.model.ts
+++ b/sources/packages/api/src/services/user/user.model.ts
@@ -1,4 +1,4 @@
-export class UserLoginInfo {
+export interface UserLoginInfo {
   id: number;
   isActive: boolean;
   studentId?: number;

--- a/sources/packages/api/src/services/user/user.service.ts
+++ b/sources/packages/api/src/services/user/user.service.ts
@@ -1,7 +1,9 @@
 import { Injectable } from "@nestjs/common";
+import { SERVICE_ACCOUNT_DEFAULT_USER_EMAIL } from "../../utilities";
 import { Connection } from "typeorm";
 import { DataModelService } from "../../database/data.model.service";
-import { User } from "../../database/entities";
+import { Student, User } from "../../database/entities";
+import { UserLoginInfo } from "./user.model";
 
 @Injectable()
 export class UserService extends DataModelService<User> {
@@ -20,25 +22,27 @@ export class UserService extends DataModelService<User> {
    * @param userName User name (same from Keycloak).
    * @returns User login info if the user was found, otherwise null.
    */
-  async getUserLoginInfo(
-    userName: string,
-  ): Promise<{ id: number; isActive: boolean }> {
+  async getUserLoginInfo(userName: string): Promise<UserLoginInfo> {
     const user = await this.repo
       .createQueryBuilder("user")
-      .where("user.user_name = :userName", { userName })
-      .select(["user.id", "user.is_active"])
+      .select("user.id", "id")
+      .addSelect("user.isActive", "isActive")
+      .addSelect("student.id", "studentId")
+      .leftJoin(Student, "student", "student.user.id = user.id")
+      .where("user.userName = :userName", { userName })
       .getRawOne();
 
     if (!user) {
-      // When Students and Institutions users logins for the first time
-      // there will no users records until the Institution Profile or
-      // Student Profile is finalized, and this is expected.
+      // When users logins for the first time there will be no users records.
+      // For instance, Students, Institutions Users and Supporting Users, must complete
+      // their profiles in oder to have the user persisted to the database.
       return null;
     }
 
     return {
-      id: user.user_id,
-      isActive: user.is_active,
+      id: user.id,
+      isActive: user.isActive,
+      studentId: user.studentId,
     };
   }
 
@@ -81,6 +85,20 @@ export class UserService extends DataModelService<User> {
     user.email = email;
     user.firstName = givenNames;
     user.lastName = lastName;
+    return this.repo.save(user);
+  }
+
+  /**
+   * Creates an user associated with the a service account.
+   * @param userName user name to create the user for the service account.
+   * @returns new user created.
+   */
+  async createServiceAccountUser(userName: string) {
+    const user = new User();
+    user.userName = userName;
+    user.email = SERVICE_ACCOUNT_DEFAULT_USER_EMAIL;
+    user.firstName = null;
+    user.lastName = userName;
     return this.repo.save(user);
   }
 }

--- a/sources/packages/api/src/services/user/user.service.ts
+++ b/sources/packages/api/src/services/user/user.service.ts
@@ -35,7 +35,7 @@ export class UserService extends DataModelService<User> {
     if (!user) {
       // When users logins for the first time there will be no users records.
       // For instance, Students, Institutions Users and Supporting Users, must complete
-      // their profiles in oder to have the user persisted to the database.
+      // their profiles in order to have the user persisted to the database.
       return null;
     }
 

--- a/sources/packages/api/src/utilities/system-configurations-constants.ts
+++ b/sources/packages/api/src/utilities/system-configurations-constants.ts
@@ -72,3 +72,10 @@ export const ECERT_PART_TIME_FEEDBACK_FILE_CODE = "EDU.PBC.ECERTSFB.PT.*";
  */
 export const STUDENT_FILE_UPLOAD_TEMPLATE_ID =
   "3b37994f-464f-4eb0-ad30-84739fa82377";
+
+/**
+ * Email used during service account creation. It is the same across all the
+ * environment and there is no actual use for it right now. Used because the email
+ * is an mandatory field while creating a new user.
+ */
+export const SERVICE_ACCOUNT_DEFAULT_USER_EMAIL = "dev_sabc@gov.bc.ca";


### PR DESCRIPTION
- Created a new user (when not already created) for the `forms-flow-bpm` that will allow saving the audit user also during workflow operations on the SIMS API.
- Added validation for the IDP used for authorization based on the authorized party. It will basically enforce that a user logged in to the Institution was authenticated using BCeID, a student was authenticated using BCSC, and so on. **THE SAME VALIDATION ALREADY EXISTS ON THE VUE APPLICATION BUT IS WAS MISSING ON THE API.**
- Created a new decorator `@RequiresStudentAccount()` that will ensure that there is a student account created and associated with the current user. The decorator can also be used as `@RequiresStudentAccount(false)` in methods that the student must access but the student account is not created yet, for instance, the POST to create the student account itself.
 
![image](https://user-images.githubusercontent.com/61259237/167517593-f0c4e2a8-5810-41db-8f3d-ca8d1b31a188.png)

- The endpoints that need to validate if a current student exists can now skip the validation. For instance, the below one

![image](https://user-images.githubusercontent.com/61259237/167517851-bcb71c4e-d18d-4f8d-bc79-7f4161faff47.png)

can be refactored as below

![image](https://user-images.githubusercontent.com/61259237/167517878-85d0881a-87df-4c7f-a063-0d62157131de.png)

- Included the audience (`audience: "sims-api"`) also in the token validation and added a new scope to necessary clients on DEV/TEST

![image](https://user-images.githubusercontent.com/61259237/167518178-6da8170e-c731-4b51-927a-3a31b1248c21.png)

![image](https://user-images.githubusercontent.com/61259237/167518263-dd3f274b-b718-412f-af03-c34cc4dfd332.png)
