### PR TITLE
[vue]Full page container improvements

### DIFF
--- a/sources/packages/api/src/route-controllers/student/models/student.dto.ts
+++ b/sources/packages/api/src/route-controllers/student/models/student.dto.ts
@@ -80,6 +80,7 @@ export interface StudentRestrictionDTO {
 export class StudentDetailAPIOutDTO {
   firstName: string;
   lastName: string;
+  fullName: string;
   email: string;
   gender: string;
   dateOfBirth: Date;

--- a/sources/packages/api/src/route-controllers/student/student.controller.ts
+++ b/sources/packages/api/src/route-controllers/student/student.controller.ts
@@ -58,6 +58,7 @@ import {
   DEFAULT_PAGE_NUMBER,
   DEFAULT_PAGE_LIMIT,
   transformToApplicationSummaryDTO,
+  getUserFullName,
 } from "../../utilities";
 import { UserGroups } from "../../auth/user-groups.enum";
 import { Groups } from "../../auth/decorators";
@@ -565,6 +566,7 @@ export class StudentController extends BaseController {
     return {
       firstName: student.user.firstName,
       lastName: student.user.lastName,
+      fullName: getUserFullName(student.user),
       email: student.user.email,
       gender: student.gender,
       dateOfBirth: student.birthDate,

--- a/sources/packages/web/src/components/aest/StudentApplications.vue
+++ b/sources/packages/web/src/components/aest/StudentApplications.vue
@@ -1,6 +1,5 @@
 <template>
   <!-- This component is shared between ministry and student users -->
-  <p class="category-header-large color-blue">Applications</p>
   <DataTable
     :value="applicationAndCount.applications"
     :lazy="true"

--- a/sources/packages/web/src/components/generic/HeaderNavigator.vue
+++ b/sources/packages/web/src/components/generic/HeaderNavigator.vue
@@ -12,11 +12,16 @@
   </slot>
   <v-row>
     <v-col>
-      <slot name="subTitle">
-        <div class="header-sub-title">
-          {{ subTitle }}
-        </div>
-      </slot>
+      <span class="float-left">
+        <slot name="subTitle">
+          <div class="header-sub-title">
+            {{ subTitle }}
+          </div>
+        </slot>
+      </span>
+      <span class="float-left">
+        <slot name="subTitleDetails"></slot>
+      </span>
     </v-col>
     <v-col>
       <div class="float-right ml-2 header-button">

--- a/sources/packages/web/src/components/generic/HeaderNavigator.vue
+++ b/sources/packages/web/src/components/generic/HeaderNavigator.vue
@@ -1,17 +1,17 @@
 <template>
-  <slot name="title">
-    <div v-if="routeLocation" class="header-title">
-      <a @click="goBack()">
-        <font-awesome-icon :icon="['fas', 'arrow-left']" class="mr-2" />
-        {{ title }}</a
-      >
-    </div>
-    <div v-else class="header-title">
-      {{ title }}
-    </div>
-  </slot>
-  <v-row>
+  <v-row align="end" class="mb-8">
     <v-col>
+      <slot name="title">
+        <div v-if="routeLocation" class="header-title">
+          <a @click="goBack()">
+            <font-awesome-icon :icon="['fas', 'arrow-left']" class="mr-2" />
+            {{ title }}</a
+          >
+        </div>
+        <div v-else class="header-title">
+          {{ title }}
+        </div>
+      </slot>
       <span class="float-left">
         <slot name="subTitle">
           <div class="header-sub-title">
@@ -24,7 +24,7 @@
       </span>
     </v-col>
     <v-col>
-      <div class="float-right ml-2 header-button">
+      <div class="float-right header-button">
         <slot name="buttons"> </slot>
       </div>
     </v-col>

--- a/sources/packages/web/src/components/generic/HeaderNavigator.vue
+++ b/sources/packages/web/src/components/generic/HeaderNavigator.vue
@@ -20,7 +20,7 @@
         </slot>
       </span>
       <span class="float-left">
-        <slot name="subTitleDetails"></slot>
+        <slot name="sub-title-details"></slot>
       </span>
     </v-col>
     <v-col>

--- a/sources/packages/web/src/components/layouts/FullPageContainer.vue
+++ b/sources/packages/web/src/components/layouts/FullPageContainer.vue
@@ -3,19 +3,14 @@
     <header class="mb-4">
       <slot name="header"></slot>
     </header>
-    <template v-if="layoutType === 'card'">
+    <template v-if="layoutTemplate === LayoutTemplates.CenteredCard">
       <v-row justify="center">
-        <v-card class="w-100 full-page-container-size">
+        <v-card class="p-4 w-100 full-page-container-size">
           <slot></slot>
         </v-card>
       </v-row>
     </template>
-    <template v-else-if="layoutType === 'full-wide'">
-      <div class="w-100">
-        <slot></slot>
-      </div>
-    </template>
-    <template v-else>
+    <template v-else-if="layoutTemplate === LayoutTemplates.Centered">
       <v-row justify="center">
         <div class="w-100 full-page-container-size">
           <slot></slot>
@@ -24,12 +19,24 @@
     </template>
   </v-container>
 </template>
+
 <script lang="ts">
+enum LayoutTemplates {
+  Centered = "Centered",
+  CenteredCard = "CenteredCard",
+}
+
 export default {
   props: {
-    layoutType: {
+    layoutTemplate: {
       type: String,
+      required: false,
+      default: LayoutTemplates.CenteredCard,
+      validator: (val: string) => val in LayoutTemplates,
     },
+  },
+  setup() {
+    return { LayoutTemplates };
   },
 };
 </script>

--- a/sources/packages/web/src/components/layouts/FullPageContainer.vue
+++ b/sources/packages/web/src/components/layouts/FullPageContainer.vue
@@ -1,9 +1,35 @@
 <template>
   <v-container>
-    <v-row justify="center">
-      <v-card class="p-4 w-100 full-page-container-size">
+    <header class="mb-4">
+      <slot name="header"></slot>
+    </header>
+    <template v-if="layoutType === 'card'">
+      <v-row justify="center">
+        <v-card class="w-100 full-page-container-size">
+          <slot></slot>
+        </v-card>
+      </v-row>
+    </template>
+    <template v-else-if="layoutType === 'full-wide'">
+      <div class="w-100">
         <slot></slot>
-      </v-card>
-    </v-row>
+      </div>
+    </template>
+    <template v-else>
+      <v-row justify="center">
+        <div class="w-100 full-page-container-size">
+          <slot></slot>
+        </div>
+      </v-row>
+    </template>
   </v-container>
 </template>
+<script lang="ts">
+export default {
+  props: {
+    layoutType: {
+      type: String,
+    },
+  },
+};
+</script>

--- a/sources/packages/web/src/components/layouts/FullPageContainer.vue
+++ b/sources/packages/web/src/components/layouts/FullPageContainer.vue
@@ -1,18 +1,19 @@
 <template>
-  <v-container>
+  <v-container :fluid="fullWidth">
     <header class="mb-4">
       <slot name="header"></slot>
     </header>
+    <slot name="alerts"></slot>
     <template v-if="layoutTemplate === LayoutTemplates.CenteredCard">
       <v-row justify="center">
-        <v-card class="p-4 w-100 full-page-container-size">
+        <v-card class="p-4 w-100" :class="widthClass">
           <slot></slot>
         </v-card>
       </v-row>
     </template>
     <template v-else-if="layoutTemplate === LayoutTemplates.Centered">
       <v-row justify="center">
-        <div class="w-100 full-page-container-size">
+        <div class="w-100" :class="widthClass">
           <slot></slot>
         </div>
       </v-row>
@@ -21,6 +22,8 @@
 </template>
 
 <script lang="ts">
+import { computed } from "vue";
+
 enum LayoutTemplates {
   Centered = "Centered",
   CenteredCard = "CenteredCard",
@@ -34,9 +37,17 @@ export default {
       default: LayoutTemplates.CenteredCard,
       validator: (val: string) => val in LayoutTemplates,
     },
+    fullWidth: {
+      type: Boolean,
+      required: false,
+      default: false,
+    },
   },
-  setup() {
-    return { LayoutTemplates };
+  setup(props: any) {
+    const widthClass = computed(() => {
+      return props.fullWidth ? "" : "full-page-container-size";
+    });
+    return { LayoutTemplates, widthClass };
   },
 };
 </script>

--- a/sources/packages/web/src/types/contracts/StudentContract.ts
+++ b/sources/packages/web/src/types/contracts/StudentContract.ts
@@ -84,6 +84,7 @@ export interface SearchStudentResp {
 export interface StudentDetail {
   firstName: string;
   lastName: string;
+  fullName: string;
   gender: string;
   email: string;
   dateOfBirth: Date;

--- a/sources/packages/web/src/views/aest/AssessmentsSummary.vue
+++ b/sources/packages/web/src/views/aest/AssessmentsSummary.vue
@@ -1,5 +1,5 @@
 <template>
-  <full-page-container layout-type="card">
+  <full-page-container layout-template="Centered">
     <template #header>
       <header-navigator
         title="Student applications"

--- a/sources/packages/web/src/views/aest/AssessmentsSummary.vue
+++ b/sources/packages/web/src/views/aest/AssessmentsSummary.vue
@@ -1,22 +1,27 @@
 <template>
-  <header-navigator
-    title="Student applications"
-    :routeLocation="{
-      name: AESTRoutesConst.STUDENT_APPLICATIONS,
-      params: { studentId },
-    }"
-    subTitle="Assessment"
-  />
-  <RequestAssessment
-    :applicationId="applicationId"
-    @viewStudentAppeal="goToStudentAppeal"
-  />
-  <HistoryAssessment
-    :applicationId="applicationId"
-    @viewStudentAppeal="goToStudentAppeal"
-    @viewAssessment="gotToViewAssessment"
-  />
+  <full-page-container layout-type="card">
+    <template #header>
+      <header-navigator
+        title="Student applications"
+        :routeLocation="{
+          name: AESTRoutesConst.STUDENT_APPLICATIONS,
+          params: { studentId },
+        }"
+        subTitle="Assessment"
+      />
+    </template>
+    <RequestAssessment
+      :applicationId="applicationId"
+      @viewStudentAppeal="goToStudentAppeal"
+    />
+    <HistoryAssessment
+      :applicationId="applicationId"
+      @viewStudentAppeal="goToStudentAppeal"
+      @viewAssessment="gotToViewAssessment"
+    />
+  </full-page-container>
 </template>
+
 <script lang="ts">
 import { AESTRoutesConst } from "@/constants/routes/RouteConstants";
 import { useRouter } from "vue-router";

--- a/sources/packages/web/src/views/aest/student/StudentDetails.vue
+++ b/sources/packages/web/src/views/aest/student/StudentDetails.vue
@@ -1,21 +1,26 @@
 <template>
-  <div class="mb-2">
-    <div class="muted-heading-text">Student Details</div>
-    <span class="heading-x-large mb-2">
-      {{ studentDetails.firstName }} {{ studentDetails.lastName }}
-      <designation-and-restriction-status-badge
-        class="mb-4 ml-4"
-        :status="
-          studentDetails.hasRestriction
-            ? DesignationAndRestrictionStatus.restriction
-            : DesignationAndRestrictionStatus.noRestriction
-        "
-      />
-    </span>
-  </div>
-  <!-- TODO:replace prime tabMenu with vuetify3-->
-  <TabMenu :model="items" />
-  <router-view />
+  <full-page-container>
+    <template #header>
+      <header-navigator
+        title="Student Details"
+        :subTitle="studentDetails.firstName"
+      >
+        <template #sub-title-details>
+          <designation-and-restriction-status-badge
+            class="mb-4 ml-4 mt-4"
+            :status="
+              studentDetails.hasRestriction
+                ? DesignationAndRestrictionStatus.restriction
+                : DesignationAndRestrictionStatus.noRestriction
+            "
+          />
+        </template>
+      </header-navigator>
+    </template>
+    <!-- TODO:replace prime tabMenu with vuetify3-->
+    <TabMenu :model="items" />
+    <router-view />
+  </full-page-container>
 </template>
 
 <script lang="ts">

--- a/sources/packages/web/src/views/aest/student/StudentDetails.vue
+++ b/sources/packages/web/src/views/aest/student/StudentDetails.vue
@@ -1,9 +1,9 @@
 <template>
-  <full-page-container>
+  <full-page-container layout-template="Centered">
     <template #header>
       <header-navigator
         title="Student Details"
-        :subTitle="studentDetails.firstName"
+        :subTitle="studentDetails.fullName"
       >
         <template #sub-title-details>
           <designation-and-restriction-status-badge

--- a/sources/packages/web/src/views/student/StudentApplicationSummary.vue
+++ b/sources/packages/web/src/views/student/StudentApplicationSummary.vue
@@ -1,19 +1,28 @@
 <template>
-  <div class="p-m-4">
-    <RestrictionBanner
-      v-if="hasRestriction"
-      :restrictionMessage="restrictionMessage"
-    />
-    <CheckValidSINBanner />
-    <HeaderNavigator subTitle="My Applications" />
+  <full-page-container :full-width="true">
+    <template #header>
+      <header-navigator title="Applications" subTitle="My Applications">
+        <template #buttons>
+          <StartApplication :hasRestriction="hasRestriction" />
+        </template>
+      </header-navigator>
+    </template>
+    <template #alerts>
+      <RestrictionBanner
+        v-if="hasRestriction"
+        :restrictionMessage="restrictionMessage"
+      />
+      <CheckValidSINBanner />
+    </template>
+    <body-header
+      title="Applications"
+      class="m-1"
+      subTitle="A list of your applications for funding, grants, and bursaries."
+    >
+    </body-header>
     <v-row>
-      <span class="p-m-4"
-        >A list of your applications for funding, grants, and busaries.</span
-      >
       <v-col cols="12">
-        <span class="float-right"
-          ><StartApplication :hasRestriction="hasRestriction"
-        /></span>
+        <span class="float-right"></span>
       </v-col>
       <v-col cols="12">
         <StudentApplications
@@ -25,7 +34,7 @@
         />
       </v-col>
     </v-row>
-  </div>
+  </full-page-container>
   <ConfirmEditApplication ref="editApplicationModal" />
   <CancelApplication
     :showModal="showModal"

--- a/sources/packages/web/src/views/student/StudentDashboard.vue
+++ b/sources/packages/web/src/views/student/StudentDashboard.vue
@@ -1,15 +1,17 @@
 <template>
-  <v-container>
-    <RestrictionBanner
-      v-if="hasRestriction"
-      :restrictionMessage="restrictionMessage"
-    />
-    <CheckValidSINBanner />
+  <full-page-container layout-template="Centered">
+    <template #alerts>
+      <RestrictionBanner
+        v-if="hasRestriction"
+        :restrictionMessage="restrictionMessage"
+      />
+      <CheckValidSINBanner />
+    </template>
     <formio
       formName="studentwelcomepage"
       @customEvent="goToStudentApplication"
     ></formio>
-  </v-container>
+  </full-page-container>
 </template>
 <script lang="ts">
 import { StudentRoutesConst } from "../../constants/routes/RouteConstants";


### PR DESCRIPTION
The main idea is to change the `full-page-container` to have a header slot and also allow it to have pre-defined "templates" that are supposed to be common between multiple pages. The idea in continue to improve the component. For now there are some examples of what would be possible.

- We can configure the container to fill the entire page width, as shown below.
![image](https://user-images.githubusercontent.com/61259237/169158132-bdce2c8d-2780-43d4-b7dd-52a8ed82eef8.png)

- We can configure the container to have centralized content without a default `v-card`, as shown below.
![image](https://user-images.githubusercontent.com/61259237/169158306-fd887811-fd52-49d7-a343-1e9e8dbd44c0.png)
![image](https://user-images.githubusercontent.com/61259237/169158534-53a7da60-5f9c-4b12-b7f0-89c7044bd791.png)


- We can configure the container to have centralized content with a default `v-card`, as shown below.



