### PR TITLE
[workflow][SIMS #1007]Using JSON.stringify to pass set variables

### DIFF
--- a/sources/packages/workflow/BPMN/disbursement-schedule-gateway.bpmn
+++ b/sources/packages/workflow/BPMN/disbursement-schedule-gateway.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_0cjijbh" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.11.1" modeler:executionPlatform="Camunda Platform" modeler:executionPlatformVersion="7.15.0">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_0cjijbh" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.0.0" modeler:executionPlatform="Camunda Platform" modeler:executionPlatformVersion="7.15.0">
   <bpmn:process id="disbursement-schedule-gateway" name="Disbursement Schedule Gateway" isExecutable="true">
     <bpmn:startEvent id="StartEvent_1">
       <bpmn:outgoing>Flow_1bh2hll</bpmn:outgoing>
@@ -18,10 +18,10 @@
 
 execution.setVariable(
   "schedulesJsonString",
-  JSON.stringify(disbursementSchedulesPayload)
+  disbursementSchedulesPayload
 );
 
-JSON.stringify(disbursementSchedulesPayload);</camunda:script>
+disbursementSchedulesPayload;</camunda:script>
             </camunda:inputParameter>
             <camunda:inputParameter name="headers">
               <camunda:map>
@@ -123,18 +123,18 @@ if (weeks &gt;= 17) {
       <bpmn:script>var firstDisbursementDate = execution.getVariable("firstDisbursementDate");
 var secondDisbursementDate = execution.getVariable("secondDisbursementDate");
 
-var CSPTPayload = execution.getVariable("CSPTPayload");
-var CSGPPayload = execution.getVariable("CSGPPayload");
-var CSGDPayload = execution.getVariable("CSGDPayload");
-var CSGFPayload = execution.getVariable("CSGFPayload");
-var CSGTPayload = execution.getVariable("CSGTPayload");
-var SBSDPayload = execution.getVariable("SBSDPayload");
-var BGPDPayload = execution.getVariable("BGPDPayload");
-var BCAGPayload = execution.getVariable("BCAGPayload");
-var BCSGPayload = execution.getVariable("BCSGPayload");
-var BCSLPayload = execution.getVariable("BCSLPayload");
-var CSLPayload = execution.getVariable("CSLPayload");
-var CSLPPayload = execution.getVariable("CSLPPayload");
+var CSPTPayload = JSON.parse(execution.getVariable("CSPTPayload") || null);
+var CSGPPayload = JSON.parse(execution.getVariable("CSGPPayload") || null);
+var CSGDPayload = JSON.parse(execution.getVariable("CSGDPayload") || null);
+var CSGFPayload = JSON.parse(execution.getVariable("CSGFPayload") || null);
+var CSGTPayload = JSON.parse(execution.getVariable("CSGTPayload") || null);
+var SBSDPayload = JSON.parse(execution.getVariable("SBSDPayload") || null);
+var BGPDPayload = JSON.parse(execution.getVariable("BGPDPayload") || null);
+var BCAGPayload = JSON.parse(execution.getVariable("BCAGPayload") || null);
+var BCSGPayload = JSON.parse(execution.getVariable("BCSGPayload") || null);
+var BCSLPayload = JSON.parse(execution.getVariable("BCSLPayload") || null);
+var CSLPayload = JSON.parse(execution.getVariable("CSLPayload") || null);
+var CSLPPayload = JSON.parse(execution.getVariable("CSLPPayload") || null);
 
 var schedulesJson = {};
 var disbursements = [];
@@ -288,7 +288,11 @@ if (firstDisbursementDate &amp;&amp; secondDisbursementDate) {
     };
   }
 }
-execution.setVariable("disbursementSchedulesPayload", schedulesJson);</bpmn:script>
+execution.setVariable(
+  "disbursementSchedulesPayload",
+  JSON.stringify(schedulesJson)
+);
+</bpmn:script>
     </bpmn:scriptTask>
     <bpmn:exclusiveGateway id="Gateway_1tnmx63">
       <bpmn:incoming>Flow_1pzqmu4</bpmn:incoming>

--- a/sources/packages/workflow/BPMN/ft-disbursement-calculation.bpmn
+++ b/sources/packages/workflow/BPMN/ft-disbursement-calculation.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_1y0piek" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.6.0">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_1y0piek" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.0.0">
   <bpmn:process id="ft-disbursement-calculation" name="Full Time Disbursement Calculation" isExecutable="true">
     <bpmn:startEvent id="StartEvent_1">
       <bpmn:outgoing>Flow_1rm93u5</bpmn:outgoing>
@@ -45,7 +45,7 @@ var CSLPayload = {
     : 0,
 };
 
-execution.setVariable("CSLPayload", CSLPayload);</bpmn:script>
+execution.setVariable("CSLPayload", JSON.stringify(CSLPayload));</bpmn:script>
     </bpmn:scriptTask>
     <bpmn:scriptTask id="CSGDPayload" name="Prepare CSGD Payload" scriptFormat="javascript">
       <bpmn:incoming>Flow_0tpy1p4</bpmn:incoming>
@@ -68,7 +68,7 @@ if (CSGDEligibility === "yes") {
   }
 }
 
-execution.setVariable("CSGDPayload", CSGDPayload);</bpmn:script>
+execution.setVariable("CSGDPayload", JSON.stringify(CSGDPayload));</bpmn:script>
     </bpmn:scriptTask>
     <bpmn:scriptTask id="CSGFPayload" name="Prepare CSGF Payload" scriptFormat="javascript">
       <bpmn:incoming>Flow_0nobrwh</bpmn:incoming>
@@ -91,7 +91,7 @@ if (CSGFEligibility === "yes") {
   }
 }
 
-execution.setVariable("CSGFPayload", CSGFPayload);</bpmn:script>
+execution.setVariable("CSGFPayload", JSON.stringify(CSGFPayload));</bpmn:script>
     </bpmn:scriptTask>
     <bpmn:scriptTask id="CSGTPayload" name="Prepare CSGT Payload" scriptFormat="javascript">
       <bpmn:incoming>Flow_1s5s2r9</bpmn:incoming>
@@ -114,7 +114,7 @@ if (CSGTEligibility === "yes") {
   }
 }
 
-execution.setVariable("CSGTPayload", CSGTPayload);</bpmn:script>
+execution.setVariable("CSGTPayload", JSON.stringify(CSGTPayload));</bpmn:script>
     </bpmn:scriptTask>
     <bpmn:scriptTask id="SBSDPayload" name="Prepare SBSD Payload" scriptFormat="javascript">
       <bpmn:incoming>Flow_0mkuwm5</bpmn:incoming>
@@ -137,7 +137,7 @@ if (SBSDEligibility === "yes") {
   }
 }
 
-execution.setVariable("SBSDPayload", SBSDPayload);</bpmn:script>
+execution.setVariable("SBSDPayload", JSON.stringify(SBSDPayload));</bpmn:script>
     </bpmn:scriptTask>
     <bpmn:scriptTask id="BGPDPayload" name="Prepare BGPD Payload" scriptFormat="javascript">
       <bpmn:incoming>Flow_0ayamtp</bpmn:incoming>
@@ -160,7 +160,7 @@ if (BGPDEligibility === "yes") {
   }
 }
 
-execution.setVariable("BGPDPayload", BGPDPayload);</bpmn:script>
+execution.setVariable("BGPDPayload", JSON.stringify(BGPDPayload));</bpmn:script>
     </bpmn:scriptTask>
     <bpmn:scriptTask id="BCAGPayload" name="Prepare BCAG Payload" scriptFormat="javascript">
       <bpmn:incoming>Flow_10i9h8g</bpmn:incoming>
@@ -186,7 +186,7 @@ if (BCAGEligibility === "yes" || BCAG2YearEligibility === "yes") {
   }
 }
 
-execution.setVariable("BCAGPayload", BCAGPayload);</bpmn:script>
+execution.setVariable("BCAGPayload", JSON.stringify(BCAGPayload));</bpmn:script>
     </bpmn:scriptTask>
     <bpmn:scriptTask id="BCSLPayload" name="Prepare BCSL Payload" scriptFormat="javascript">
       <bpmn:incoming>Flow_1n6cnps</bpmn:incoming>
@@ -201,7 +201,7 @@ var BCSLPayload = {
   valueAmount: parseFloat(provincialBCSLAmount) ? Math.round(parseFloat(provincialBCSLAmount) * 100) / 100 : 0,
 };
 
-execution.setVariable("BCSLPayload", BCSLPayload);</bpmn:script>
+execution.setVariable("BCSLPayload", JSON.stringify(BCSLPayload));</bpmn:script>
     </bpmn:scriptTask>
     <bpmn:scriptTask id="BCSGPayload" name="Prepare BCSG Payload" scriptFormat="javascript">
       <bpmn:incoming>Flow_11szlye</bpmn:incoming>
@@ -251,7 +251,7 @@ if (
   }
 }
 
-execution.setVariable("BCSGPayload", BCSGPayload);</bpmn:script>
+execution.setVariable("BCSGPayload", JSON.stringify(BCSGPayload));</bpmn:script>
     </bpmn:scriptTask>
     <bpmn:sequenceFlow id="Flow_1rm93u5" sourceRef="StartEvent_1" targetRef="ft-disbursement-split" />
     <bpmn:endEvent id="Event_1uh4i7c">
@@ -290,7 +290,7 @@ if (CSGPEligibility === "yes") {
   }
 }
 
-execution.setVariable("CSGPPayload", CSGPPayload);</bpmn:script>
+execution.setVariable("CSGPPayload", JSON.stringify(CSGPPayload));</bpmn:script>
     </bpmn:scriptTask>
     <bpmn:sequenceFlow id="Flow_1dz6dpg" sourceRef="CSGPPayload" targetRef="ft-disbursement-join" />
     <bpmn:sequenceFlow id="Flow_17tbprb" sourceRef="CSGDPayload" targetRef="ft-disbursement-join" />

--- a/sources/packages/workflow/BPMN/pt-disbursement-calculation.bpmn
+++ b/sources/packages/workflow/BPMN/pt-disbursement-calculation.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_08hvmk9" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.12.0">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_08hvmk9" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.0.0">
   <bpmn:process id="pt-disbursement-calculation" name="Part Time Disbursement Calculation" isExecutable="true">
     <bpmn:startEvent id="Event_00zpz0m">
       <bpmn:outgoing>Flow_05xex8s</bpmn:outgoing>
@@ -41,7 +41,7 @@ var CSLPPayload = {
     : 0,
 };
 
-execution.setVariable("CSLPPayload", CSLPPayload);</bpmn:script>
+execution.setVariable("CSLPPayload", JSON.stringify(CSLPPayload));</bpmn:script>
     </bpmn:scriptTask>
     <bpmn:scriptTask id="CSGP-PDPayload" name="Prepare CSGP-PD Payload" scriptFormat="javascript">
       <bpmn:incoming>Flow_0hi9h6k</bpmn:incoming>
@@ -61,7 +61,7 @@ var secondDisbursementDate = execution.getVariable("secondDisbursementDate");
     CSGPPayload["valueAmount"] = parseFloat(csgppdGrant) ? Math.round(parseFloat(csgppdGrant) * 100) / 100 : 0;
   }
 
-execution.setVariable("CSGPPayload", CSGPPayload);</bpmn:script>
+execution.setVariable("CSGPPayload", JSON.stringify(CSGPPayload));</bpmn:script>
     </bpmn:scriptTask>
     <bpmn:scriptTask id="CSG-PTDEPPayload" name="Prepare CSG-PTDEP Payload" scriptFormat="javascript">
       <bpmn:incoming>Flow_0xt0x2u</bpmn:incoming>
@@ -81,7 +81,7 @@ var secondDisbursementDate = execution.getVariable("secondDisbursementDate");
     CSGDPayload["valueAmount"] = parseFloat(csgptdepGrant) ? Math.round(parseFloat(csgptdepGrant) * 100) / 100 : 0;
   }
 
-execution.setVariable("CSGDPayload", CSGDPayload);</bpmn:script>
+execution.setVariable("CSGDPayload", JSON.stringify(CSGDPayload));</bpmn:script>
     </bpmn:scriptTask>
     <bpmn:scriptTask id="CSG-PTPayload" name="Prepare CSG-PT Payload" scriptFormat="javascript">
       <bpmn:incoming>Flow_13u518c</bpmn:incoming>
@@ -101,7 +101,7 @@ var secondDisbursementDate = execution.getVariable("secondDisbursementDate");
     CSPTPayload["valueAmount"] = parseFloat(csgptGrant) ? Math.round(parseFloat(csgptGrant) * 100) / 100 : 0;
   }
 
-execution.setVariable("CSPTPayload", CSPTPayload);</bpmn:script>
+execution.setVariable("CSPTPayload", JSON.stringify(CSPTPayload));</bpmn:script>
     </bpmn:scriptTask>
     <bpmn:scriptTask id="BCAG-PTPayload" name="Prepare BCAG-PT Payload" scriptFormat="javascript">
       <bpmn:incoming>Flow_0tdbdhh</bpmn:incoming>
@@ -121,7 +121,7 @@ var secondDisbursementDate = execution.getVariable("secondDisbursementDate");
     BCAGPayload["valueAmount"] = parseFloat(bcagptGrant) ? Math.round(parseFloat(bcagptGrant) * 100) / 100 : 0;
   }
 
-execution.setVariable("BCAGPayload", BCAGPayload);</bpmn:script>
+execution.setVariable("BCAGPayload", JSON.stringify(BCAGPayload));</bpmn:script>
     </bpmn:scriptTask>
     <bpmn:scriptTask id="SBSDPayload" name="Prepare SBSD Payload" scriptFormat="javascript">
       <bpmn:incoming>Flow_0imib5p</bpmn:incoming>
@@ -141,7 +141,7 @@ var secondDisbursementDate = execution.getVariable("secondDisbursementDate");
     SBSDPayload["valueAmount"] = parseFloat(sbsdGrant) ? Math.round(parseFloat(sbsdGrant) * 100) / 100 : 0;
   }
 
-execution.setVariable("SBSDPayload", SBSDPayload);</bpmn:script>
+execution.setVariable("SBSDPayload", JSON.stringify(SBSDPayload));</bpmn:script>
     </bpmn:scriptTask>
     <bpmn:sequenceFlow id="Flow_05xex8s" sourceRef="Event_00zpz0m" targetRef="pt-disbursement-split" />
     <bpmn:sequenceFlow id="Flow_19h2m8h" sourceRef="CSL-PTPayload" targetRef="pt-disbursement-join" />
@@ -176,7 +176,7 @@ var secondDisbursementDate = execution.getVariable("secondDisbursementDate");
     BCSGPayload["valueAmount"] = parseFloat(sbsdGrant + bcagptGrant) ? Math.round((parseFloat(sbsdGrant + bcagptGrant)) * 100) / 100 : 0;
   }
 
-execution.setVariable("BCSGPayload", BCSGPayload);</bpmn:script>
+execution.setVariable("BCSGPayload", JSON.stringify(BCSGPayload));</bpmn:script>
     </bpmn:scriptTask>
     <bpmn:sequenceFlow id="Flow_0ba1h8f" sourceRef="pt-disbursement-split" targetRef="Activity_0ye9hqh" />
     <bpmn:sequenceFlow id="Flow_16x3fbf" sourceRef="Activity_0ye9hqh" targetRef="pt-disbursement-join" />


### PR DESCRIPTION
While executing the workflow there were some errors like below when a JavaScript object was assigned to a Camunda variable.

![image](https://user-images.githubusercontent.com/61259237/173427016-4ef8ec96-d853-42ff-b701-4ed1c0953763.png)

The error was usually intermittent and even sometimes was resolved just by restarting the Openshift POD (what is not ideal).
The solution was to serialize the object to JSON and parse it back where it is consumed.
The workflow was tested for Full-time and Part-time and both worked as expected.