### PR TITLE
[api]Removed IsInstitutionAdmin decorator

### DIFF
--- a/sources/packages/api/src/route-controllers/institution/institution.institutions.controller.ts
+++ b/sources/packages/api/src/route-controllers/institution/institution.institutions.controller.ts
@@ -152,7 +152,6 @@ export class InstitutionInstitutionsController extends BaseController {
    * Get institution details of given institution.
    * @returns Institution details.
    */
-  @IsInstitutionAdmin()
   @Get()
   async getInstitutionDetail(
     @UserToken() token: IInstitutionUserToken,


### PR DESCRIPTION
- The API endpoint to get the application details was restricted only for admin users but it is also needed during the login process for non-admin-users which leads to a wrong _Forbidden User_ error.

![image](https://user-images.githubusercontent.com/61259237/176529084-88f857fa-3958-4a17-8b45-3b7805a599af.png)
