### PR TITLE
[vuetify]Upgrade beta 4

### DIFF
--- a/sources/packages/web/package-lock.json
+++ b/sources/packages/web/package-lock.json
@@ -34,7 +34,7 @@
         "vue": "^3.2.31",
         "vue-class-component": "^8.0.0-0",
         "vue-router": "^4.0.14",
-        "vuetify": "^3.0.0-beta.0",
+        "vuetify": "^3.0.0-beta.4",
         "vuex": "^4.0.2",
         "yup": "^0.32.11"
       },
@@ -16335,23 +16335,34 @@
       }
     },
     "node_modules/vuetify": {
-      "version": "3.0.0-beta.0",
-      "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-3.0.0-beta.0.tgz",
-      "integrity": "sha512-/xDoSTs1l/s9jkFwQ5uK9ok9py0TsImRENA7DrAJnsgx5cwH9yEvS3XJOUOsH3ra+VYt5xZP7Pfh8/HtBQaAlw==",
+      "version": "3.0.0-beta.4",
+      "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-3.0.0-beta.4.tgz",
+      "integrity": "sha512-saq44U5bDO5z7BNWVeBdyY37BTPOQTeuz7Tm3kyywMEDHhZKw9BhtCo/QodTndoofRSRWXfE7MI2/AEvG/1x+g==",
+      "engines": {
+        "node": "^12.20 || >=14.13"
+      },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/johnleider"
       },
       "peerDependencies": {
         "@formatjs/intl": "^1.0.0 || ^2.0.0",
-        "vue": "^3.2.19",
-        "vue-i18n": "^9.0.0"
+        "vite-plugin-vuetify": "1.0.0-alpha.12",
+        "vue": "^3.2.0",
+        "vue-i18n": "^9.0.0",
+        "webpack-plugin-vuetify": "2.0.0-alpha.11"
       },
       "peerDependenciesMeta": {
         "@formatjs/intl": {
           "optional": true
         },
+        "vite-plugin-vuetify": {
+          "optional": true
+        },
         "vue-i18n": {
+          "optional": true
+        },
+        "webpack-plugin-vuetify": {
           "optional": true
         }
       }
@@ -29340,9 +29351,9 @@
       }
     },
     "vuetify": {
-      "version": "3.0.0-beta.0",
-      "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-3.0.0-beta.0.tgz",
-      "integrity": "sha512-/xDoSTs1l/s9jkFwQ5uK9ok9py0TsImRENA7DrAJnsgx5cwH9yEvS3XJOUOsH3ra+VYt5xZP7Pfh8/HtBQaAlw==",
+      "version": "3.0.0-beta.4",
+      "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-3.0.0-beta.4.tgz",
+      "integrity": "sha512-saq44U5bDO5z7BNWVeBdyY37BTPOQTeuz7Tm3kyywMEDHhZKw9BhtCo/QodTndoofRSRWXfE7MI2/AEvG/1x+g==",
       "requires": {}
     },
     "vuex": {

--- a/sources/packages/web/package.json
+++ b/sources/packages/web/package.json
@@ -36,7 +36,7 @@
     "vue": "^3.2.31",
     "vue-class-component": "^8.0.0-0",
     "vue-router": "^4.0.14",
-    "vuetify": "^3.0.0-beta.0",
+    "vuetify": "^3.0.0-beta.4",
     "vuex": "^4.0.2",
     "yup": "^0.32.11"
   },

--- a/sources/packages/web/src/assets/css/base.scss
+++ b/sources/packages/web/src/assets/css/base.scss
@@ -59,29 +59,29 @@ html * {
   padding: 0.5rem !important;
 }
 
-/** Moving the dimension and position properties of status badge to common class **/
+// Specific styles for the outlined v-chip.
 .v-chip--variant-outlined {
   border: 2px solid !important;
   font-weight: 700 !important;
   background-color: white !important;
 }
 
-// success badge
+// Success v-chip.
 .v-chip--variant-outlined.status-chip-success {
   border-color: $badge-border-success !important;
 }
 
-// inactive badge
+// Inactive v-chip.
 .v-chip--variant-outlined.status-chip-inactive {
   border-color: $badge-border-inactive !important;
 }
 
-//warning badge
+// Warning v-chip.
 .v-chip--variant-outlined.status-chip-warning {
   border-color: $badge-border-warning !important;
 }
 
-//error badge
+// Error v-chip.
 .v-chip--variant-outlined.status-chip-error {
   border-color: $badge-border-error !important;
 }

--- a/sources/packages/web/src/assets/css/base.scss
+++ b/sources/packages/web/src/assets/css/base.scss
@@ -60,37 +60,30 @@ html * {
 }
 
 /** Moving the dimension and position properties of status badge to common class **/
-.status_badge {
-  border-width: 1px;
-  padding: 15px;
-  border-style: solid;
-  border-radius: 30px;
-  position: static;
-  font-weight: 700;
+.v-chip--variant-outlined {
+  border: 2px solid !important;
+  font-weight: 700 !important;
+  background-color: white !important;
 }
 
 // success badge
-.status-badge-success .v-badge__badge {
-  @extend .status_badge;
-  border-color: $badge-border-success;
+.v-chip--variant-outlined.status-chip-success {
+  border-color: $badge-border-success !important;
 }
 
 // inactive badge
-.status-badge-inactive .v-badge__badge {
-  @extend .status_badge;
-  border-color: $badge-border-inactive;
+.v-chip--variant-outlined.status-chip-inactive {
+  border-color: $badge-border-inactive !important;
 }
 
 //warning badge
-.status-badge-warning .v-badge__badge {
-  @extend .status_badge;
-  border-color: $badge-border-warning;
+.v-chip--variant-outlined.status-chip-warning {
+  border-color: $badge-border-warning !important;
 }
 
 //error badge
-.status-badge-error .v-badge__badge {
-  @extend .status_badge;
-  border-color: $badge-border-error;
+.v-chip--variant-outlined.status-chip-error {
+  border-color: $badge-border-error !important;
 }
 
 //Defining the height of rounded filter button

--- a/sources/packages/web/src/assets/css/base.scss
+++ b/sources/packages/web/src/assets/css/base.scss
@@ -63,7 +63,7 @@ html * {
 .v-chip--variant-outlined {
   border: 2px solid !important;
   font-weight: 700 !important;
-  background-color: white !important;
+  background-color: $badge-background-color !important;
 }
 
 // Success v-chip.

--- a/sources/packages/web/src/assets/css/global-style-variables.scss
+++ b/sources/packages/web/src/assets/css/global-style-variables.scss
@@ -56,6 +56,7 @@ $badge-border-warning: rgb(255, 122, 0, 0.2);
 $badge-border-error: rgb(228, 34, 46, 0.2);
 $badge-border-success: rgb(22, 201, 46, 0.2);
 $badge-border-inactive: rgb(51, 58, 71, 0.2);
+$badge-background-color: white;
 
 /** font weight **/
 $font-weight-bold: bold;

--- a/sources/packages/web/src/assets/css/vuetify.scss
+++ b/sources/packages/web/src/assets/css/vuetify.scss
@@ -27,6 +27,7 @@
   border: 3px solid $banner-color-error;
 }
 
+// Reducing the spacing to looks like more with the UI definitions.
 .v-list-item-icon--start {
   -webkit-margin-end: 10px !important;
   margin-inline-end: 10px !important;

--- a/sources/packages/web/src/assets/css/vuetify.scss
+++ b/sources/packages/web/src/assets/css/vuetify.scss
@@ -32,3 +32,8 @@
   -webkit-margin-end: 10px !important;
   margin-inline-end: 10px !important;
 }
+
+// Reducing the spacing to looks like more with the UI definitions.
+.v-list-group__items {
+  --indent-padding: 10px !important;
+}

--- a/sources/packages/web/src/assets/css/vuetify.scss
+++ b/sources/packages/web/src/assets/css/vuetify.scss
@@ -26,3 +26,8 @@
   background-color: $banner-background-error;
   border: 3px solid $banner-color-error;
 }
+
+.v-list-item-icon--start {
+  -webkit-margin-end: 10px !important;
+  margin-inline-end: 10px !important;
+}

--- a/sources/packages/web/src/components/generic/StatusChip.vue
+++ b/sources/packages/web/src/components/generic/StatusChip.vue
@@ -1,21 +1,14 @@
 <template>
-  <v-badge :color="backGroundColor" :text-color="textColor" :class="badgeClass">
-    <template v-slot:badge>
-      <font-awesome-icon
-        :icon="['fas', 'circle']"
-        class="mr-1"
-        :color="iconColor"
-      />
-      <span>{{ label ?? status }}</span>
-    </template>
-  </v-badge>
+  <v-chip :text-color="textColor" :class="chipClass" variant="outlined">
+    <v-icon start icon="fa:fa fa-circle" :color="iconColor" size="12" />
+    {{ label ?? status }}
+  </v-chip>
 </template>
 <script lang="ts">
 import { computed } from "vue";
 import { StatusChipTypes } from "@/components/generic/StatusChip.models";
 import {
   COLOR_BLACK,
-  COLOR_WHITE,
   COLOR_BANNER_SUCCESS,
   COLOR_BANNER_WARNING,
   COLOR_BANNER_ERROR,
@@ -46,21 +39,17 @@ export default {
       }
     });
 
-    const badgeClass = computed(() => {
+    const chipClass = computed(() => {
       switch (props.status) {
         case StatusChipTypes.Success:
-          return "status-badge-success";
+          return "status-chip-success";
         case StatusChipTypes.Warning:
-          return "status-badge-warning";
+          return "status-chip-warning";
         case StatusChipTypes.Error:
-          return "status-badge-error";
+          return "status-chip-error";
         default:
-          return "status-badge-inactive";
+          return "status-chip-inactive";
       }
-    });
-
-    const backGroundColor = computed(() => {
-      return COLOR_WHITE;
     });
 
     const textColor = computed(() => {
@@ -68,9 +57,8 @@ export default {
     });
 
     return {
-      badgeClass,
+      chipClass,
       textColor,
-      backGroundColor,
       iconColor,
     };
   },

--- a/sources/packages/web/src/components/layouts/Institution/sidebar/HomeSideBar.vue
+++ b/sources/packages/web/src/components/layouts/Institution/sidebar/HomeSideBar.vue
@@ -1,49 +1,35 @@
 <template>
-  <v-navigation-drawer app class="body-background">
-    <v-list dense nav>
+  <v-navigation-drawer app class="body-background" permanent>
+    <v-list density="compact" nav>
       <v-list-item
         v-for="item in items"
         :key="item.label"
         @click="item.command"
-      >
-        <v-list-item-icon>
-          <v-icon>{{ item.icon }}</v-icon>
-        </v-list-item-icon>
-        <v-list-item-content>
-          <v-list-item-title>{{ item.label }}</v-list-item-title>
-        </v-list-item-content>
-      </v-list-item>
-      <v-list-item>
-        <v-list-item-content>
-          <v-list-item-title class="spaced-text text-muted"
-            >LOCATIONS</v-list-item-title
-          >
-        </v-list-item-content>
-      </v-list-item>
-      <v-list-item
-        v-for="location in locationsMenu"
-        :key="location.label"
-        @click="location.command"
-      >
-        <v-list-item-content>
-          <v-list-item-title
-            ><v-icon>{{ location.icon }}</v-icon>
-            {{ location.label }}</v-list-item-title
-          >
-          <v-list-item
-            v-for="locationItem in location?.items"
-            :key="locationItem"
-            @click="locationItem.command"
-          >
-            <v-list-item-icon>
-              <v-icon>{{ locationItem.icon }}</v-icon>
-            </v-list-item-icon>
-            <v-list-item-content>
-              <v-list-item-title>{{ locationItem.label }}</v-list-item-title>
-            </v-list-item-content>
-          </v-list-item>
-        </v-list-item-content>
-      </v-list-item>
+        :prepend-icon="item.icon"
+        :title="item.label"
+      />
+      <v-list density="compact" nav>
+        <v-list-subheader>Locations</v-list-subheader>
+        <v-list-item
+          v-for="location in locationsMenu"
+          :key="location.label"
+          @click="location.command"
+        >
+          <v-list-item-content>
+            <v-list-item-title
+              ><v-icon>{{ location.icon }}</v-icon>
+              {{ location.label }}</v-list-item-title
+            >
+            <v-list-item
+              v-for="locationItem in location?.items"
+              :key="locationItem"
+              :prepend-icon="locationItem.icon"
+              :title="locationItem.label"
+              @click="locationItem.command"
+            />
+          </v-list-item-content>
+        </v-list-item>
+      </v-list>
     </v-list>
   </v-navigation-drawer>
 </template>
@@ -53,14 +39,10 @@ import { useStore } from "vuex";
 import { ref, onMounted, computed, watch } from "vue";
 import { InstitutionRoutesConst } from "@/constants/routes/RouteConstants";
 import { InstitutionUserAuthRolesAndLocation } from "@/types/contracts/institution/InstitutionUser";
-// TODO: SINCE USERS ARE NOT PART OF MVP, COMMENTING THE BELOW CODE,
-// TODO: PLEASE UNCOMMENT IT WHEN IT IS TAKEN FOR DEVELOPMENT
-// import { InstitutionUserTypes } from "@/types/contracts/InstitutionRouteMeta";
-import { useInstitutionAuth } from "../../../../composables/institution/useInstitutionAuth";
+import { useInstitutionAuth } from "@/composables/institution/useInstitutionAuth";
 import { MenuModel } from "@/types";
 
 export default {
-  components: {},
   setup() {
     const store = useStore();
     const router = useRouter();
@@ -154,33 +136,7 @@ export default {
               }
             : undefined;
 
-        // TODO: SINCE USERS ARE NOT PART OF MVP, COMMENTING THE BELOW CODE,
-        // TODO: PLEASE UNCOMMENT IT WHEN IT IS TAKEN FOR DEVELOPMENT
-        // const locationUserMenu =
-        //   isAdmin.value ||
-        //   userAuth.value?.some(
-        //     (el: InstitutionUserAuthRolesAndLocation) =>
-        //       el?.locationId === data?.id &&
-        //       el?.userType === InstitutionUserTypes.locationManager,
-        //   )
-        //     ? {
-        //         label: "Users",
-        //         icon: "mdi-account-multiple-outline",
-        //         command: () => {
-        //           router.push({
-        //             name: InstitutionRoutesConst.LOCATION_USERS,
-        //             params: {
-        //               locationId: data.id,
-        //               locationName: data.name,
-        //             },
-        //           });
-        //         },
-        //       }
-        //     : undefined;
-
         if (locationMenu) {
-          // TODO: SINCE USERS ARE NOT PART OF MVP, COMMENTING THE BELOW CODE,
-          // TODO: PLEASE UNCOMMENT IT WHEN IT IS TAKEN FOR DEVELOPMENT
           // if (locationUserMenu) locationMenu?.items?.push(locationUserMenu);
           locationsMenu.value.push(locationMenu);
         }

--- a/sources/packages/web/src/components/layouts/Institution/sidebar/HomeSideBar.vue
+++ b/sources/packages/web/src/components/layouts/Institution/sidebar/HomeSideBar.vue
@@ -137,7 +137,6 @@ export default {
             : undefined;
 
         if (locationMenu) {
-          // if (locationUserMenu) locationMenu?.items?.push(locationUserMenu);
           locationsMenu.value.push(locationMenu);
         }
       }

--- a/sources/packages/web/src/components/layouts/Institution/sidebar/HomeSideBar.vue
+++ b/sources/packages/web/src/components/layouts/Institution/sidebar/HomeSideBar.vue
@@ -8,28 +8,28 @@
         :prepend-icon="item.icon"
         :title="item.label"
       />
-      <v-list density="compact" nav>
-        <v-list-subheader>Locations</v-list-subheader>
+      <v-list-subheader>Locations</v-list-subheader>
+      <v-list-group
+        v-for="location in locationsMenu"
+        :key="location.label"
+        collapse-icon="mdi-chevron-up"
+        expand-icon="mdi-chevron-down"
+      >
+        <template #activator="{ props }">
+          <v-list-item
+            v-bind="props"
+            :title="location.label"
+            :prepend-icon="location.icon"
+          ></v-list-item>
+        </template>
         <v-list-item
-          v-for="location in locationsMenu"
-          :key="location.label"
-          @click="location.command"
-        >
-          <v-list-item-content>
-            <v-list-item-title
-              ><v-icon>{{ location.icon }}</v-icon>
-              {{ location.label }}</v-list-item-title
-            >
-            <v-list-item
-              v-for="locationItem in location?.items"
-              :key="locationItem"
-              :prepend-icon="locationItem.icon"
-              :title="locationItem.label"
-              @click="locationItem.command"
-            />
-          </v-list-item-content>
-        </v-list-item>
-      </v-list>
+          v-for="locationItem in location?.items"
+          :key="locationItem"
+          :prepend-icon="locationItem.icon"
+          :title="locationItem.label"
+          @click="locationItem.command"
+        />
+      </v-list-group>
     </v-list>
   </v-navigation-drawer>
 </template>

--- a/sources/packages/web/src/components/layouts/Institution/sidebar/ManageInstitutionSideBar.vue
+++ b/sources/packages/web/src/components/layouts/Institution/sidebar/ManageInstitutionSideBar.vue
@@ -1,18 +1,13 @@
 <template>
-  <v-navigation-drawer app class="body-background">
-    <v-list dense nav>
+  <v-navigation-drawer app class="body-background" permanent>
+    <v-list density="compact" nav>
       <v-list-item
         v-for="item in items"
         :key="item.label"
         @click="item.command"
-      >
-        <v-list-item-icon>
-          <v-icon>{{ item.icon }}</v-icon>
-        </v-list-item-icon>
-        <v-list-item-content>
-          <v-list-item-title>{{ item.label }}</v-list-item-title>
-        </v-list-item-content>
-      </v-list-item>
+        :prepend-icon="item.icon"
+        :title="item.label"
+      />
     </v-list>
   </v-navigation-drawer>
 </template>

--- a/sources/packages/web/src/components/layouts/aest/AESTApplicationSideBar.vue
+++ b/sources/packages/web/src/components/layouts/aest/AESTApplicationSideBar.vue
@@ -2,11 +2,13 @@
   <!-- TODO: need to use v-list-group and update code with vuetify is -->
   <v-navigation-drawer app class="body-background" permanent>
     <v-list-item
+      density="compact"
+      nav
       :prepend-icon="studentMenu.studentApplication.icon"
       :title="studentMenu.studentApplication.label"
       @click="studentMenu.studentApplication.command"
     />
-    <v-list density="compact" v-if="relatedParentPartners.length">
+    <v-list density="compact" v-if="relatedParentPartners.length" nav>
       <v-list-subheader>Supporting users</v-list-subheader>
       <v-list-item
         v-for="relatedParentPartner in relatedParentPartners"
@@ -17,6 +19,8 @@
       />
     </v-list>
     <v-list-item
+      density="compact"
+      nav
       :prepend-icon="studentMenu.assessments.icon"
       :title="studentMenu.assessments.label"
       @click="studentMenu.assessments.command"

--- a/sources/packages/web/src/components/layouts/aest/AESTApplicationSideBar.vue
+++ b/sources/packages/web/src/components/layouts/aest/AESTApplicationSideBar.vue
@@ -1,51 +1,26 @@
 <template>
   <!-- TODO: need to use v-list-group and update code with vuetify is -->
-  <v-navigation-drawer app class="body-background">
-    <v-list dense nav>
-      <v-list-item @click="studentMenu.studentApplication.command">
-        <v-list-item-icon>
-          <font-awesome-icon
-            :icon="studentMenu.studentApplication.icon"
-            class="mr-2"
-          />
-        </v-list-item-icon>
-        <v-list-item-content>
-          <v-list-item-title
-            >{{ studentMenu.studentApplication.label }}
-          </v-list-item-title>
-        </v-list-item-content>
-      </v-list-item>
+  <v-navigation-drawer app class="body-background" permanent>
+    <v-list-item
+      :prepend-icon="studentMenu.studentApplication.icon"
+      :title="studentMenu.studentApplication.label"
+      @click="studentMenu.studentApplication.command"
+    />
+    <v-list density="compact" v-if="relatedParentPartners.length">
+      <v-list-subheader>Supporting users</v-list-subheader>
       <v-list-item
         v-for="relatedParentPartner in relatedParentPartners"
         :key="relatedParentPartner.label"
+        :prepend-icon="relatedParentPartner.icon"
+        :title="relatedParentPartner.label"
         @click="relatedParentPartner.command"
-      >
-        <!-- TODO: remove the div when `v-list-item-group` is available and implemented -->
-        <div class="px-3">
-          <v-list-item-icon>
-            <font-awesome-icon :icon="relatedParentPartner.icon" class="mr-2" />
-          </v-list-item-icon>
-          <v-list-item-content>
-            <v-list-item-title>{{
-              relatedParentPartner.label
-            }}</v-list-item-title>
-          </v-list-item-content>
-        </div>
-      </v-list-item>
-      <v-list-item @click="studentMenu.assessments.command">
-        <v-list-item-icon>
-          <font-awesome-icon
-            :icon="studentMenu.assessments.icon"
-            class="mr-2"
-          />
-        </v-list-item-icon>
-        <v-list-item-content>
-          <v-list-item-title
-            >{{ studentMenu.assessments.label }}
-          </v-list-item-title>
-        </v-list-item-content>
-      </v-list-item>
+      />
     </v-list>
+    <v-list-item
+      :prepend-icon="studentMenu.assessments.icon"
+      :title="studentMenu.assessments.label"
+      @click="studentMenu.assessments.command"
+    />
   </v-navigation-drawer>
 </template>
 
@@ -78,8 +53,7 @@ export default {
     const studentMenu = ref<StudentApplicationMenu>({
       studentApplication: {
         label: "Student",
-        // TODO: in figma this icon is PRO version
-        icon: ["fas", "graduation-cap"],
+        icon: "mdi-school-outline",
         command: () => {
           router.push({
             name: AESTRoutesConst.APPLICATION_DETAILS,
@@ -92,7 +66,7 @@ export default {
       },
       assessments: {
         label: "Assessments",
-        icon: ["far", "check-square"],
+        icon: "mdi-checkbox-marked-outline",
         command: () => {
           router.push({
             name: AESTRoutesConst.ASSESSMENTS_SUMMARY,
@@ -104,6 +78,7 @@ export default {
         },
       },
     });
+
     const goToSupportingUser = (supportingUserId: number) => {
       router.push({
         name: AESTRoutesConst.SUPPORTING_USER_DETAILS,
@@ -114,6 +89,7 @@ export default {
         },
       });
     };
+
     onMounted(async () => {
       const supportingUsers =
         await SupportingUsersService.shared.getSupportingUsersForSideBar(
@@ -123,14 +99,14 @@ export default {
         if (supportingUser.supportingUserType === SupportingUserType.Parent) {
           relatedParentPartners.value.push({
             label: `Parent ${index + 1}`,
-            icon: ["far", "user"],
+            icon: "mdi-account-outline",
             command: () => goToSupportingUser(supportingUser.supportingUserId),
           });
         }
         if (supportingUser.supportingUserType === SupportingUserType.Partner) {
           relatedParentPartners.value.push({
             label: "Partner",
-            icon: ["far", "user"],
+            icon: "mdi-account-outline",
             command: () => goToSupportingUser(supportingUser.supportingUserId),
           });
         }

--- a/sources/packages/web/src/components/layouts/aest/AESTHomeSideBar.vue
+++ b/sources/packages/web/src/components/layouts/aest/AESTHomeSideBar.vue
@@ -1,6 +1,6 @@
 <template>
-  <v-navigation-drawer class="body-background" permanent>
-    <v-list density="compact">
+  <v-navigation-drawer app class="body-background" permanent>
+    <v-list density="compact" nav>
       <v-list-item
         v-for="topItem in topItems"
         :key="topItem.label"
@@ -9,7 +9,7 @@
         @click="topItem.command"
       />
     </v-list>
-    <v-list density="compact">
+    <v-list density="compact" nav>
       <v-list-subheader>Student requests</v-list-subheader>
       <v-list-item
         :prepend-icon="exceptionsItem.icon"
@@ -17,10 +17,8 @@
         @click="exceptionsItem.command"
       />
     </v-list>
-    <v-list density="compact">
-      <v-list-item-title class="text-muted ml-4"
-        >Institution requests</v-list-item-title
-      >
+    <v-list density="compact" nav>
+      <v-list-subheader>Institution requests</v-list-subheader>
       <v-list-item
         :title="pendingDesignationItem.label"
         :prepend-icon="pendingDesignationItem.icon"
@@ -28,7 +26,7 @@
       />
     </v-list>
     <template #append>
-      <v-list density="compact">
+      <v-list density="compact" nav>
         <v-list-item @click="reports.command" :title="reports.label">
         </v-list-item>
       </v-list>

--- a/sources/packages/web/src/components/layouts/aest/AESTHomeSideBar.vue
+++ b/sources/packages/web/src/components/layouts/aest/AESTHomeSideBar.vue
@@ -1,64 +1,35 @@
 <template>
-  <v-navigation-drawer app class="body-background">
-    <v-list dense nav>
+  <v-navigation-drawer class="body-background" permanent>
+    <v-list density="compact">
       <v-list-item
-        v-for="item in items"
-        :key="item.label"
-        @click="item.command"
-      >
-        <v-list-item-icon>
-          <font-awesome-icon :icon="item.icon" class="mr-2" />
-        </v-list-item-icon>
-        <v-list-item-content>
-          <v-list-item-title>{{ item.label }}</v-list-item-title>
-        </v-list-item-content>
-      </v-list-item>
+        v-for="topItem in topItems"
+        :key="topItem.label"
+        :prepend-icon="topItem.icon"
+        :title="topItem.label"
+        @click="topItem.command"
+      />
     </v-list>
-    <v-list dense nav>
-      <v-list-item-title class="text-muted ml-4"
-        >Student requests</v-list-item-title
-      >
-      <v-list-item @click="exceptionsItem.command">
-        <v-list-item-icon>
-          <font-awesome-icon :icon="exceptionsItem.icon" class="mr-2" />
-        </v-list-item-icon>
-        <v-list-item-content>
-          <v-list-item-title>{{ exceptionsItem.label }}</v-list-item-title>
-        </v-list-item-content>
-      </v-list-item>
-      <v-list-item>
-        <v-list-item-icon>
-          <font-awesome-icon :icon="['fas', 'folder-open']" class="mr-2" />
-        </v-list-item-icon>
-        <v-list-item-content>
-          <v-list-item-title>Pending applications</v-list-item-title>
-        </v-list-item-content>
-      </v-list-item>
+    <v-list density="compact">
+      <v-list-subheader>Student requests</v-list-subheader>
+      <v-list-item
+        :prepend-icon="exceptionsItem.icon"
+        :title="exceptionsItem.label"
+        @click="exceptionsItem.command"
+      />
     </v-list>
-    <v-list dense nav>
+    <v-list density="compact">
       <v-list-item-title class="text-muted ml-4"
         >Institution requests</v-list-item-title
       >
-      <v-list-item @click="pendingDesignationItem.command">
-        <v-list-item-icon>
-          <font-awesome-icon :icon="pendingDesignationItem.icon" class="mr-2" />
-        </v-list-item-icon>
-        <v-list-item-content>
-          <v-list-item-title>{{
-            pendingDesignationItem.label
-          }}</v-list-item-title>
-        </v-list-item-content>
-      </v-list-item>
+      <v-list-item
+        :title="pendingDesignationItem.label"
+        :prepend-icon="pendingDesignationItem.icon"
+        @click="pendingDesignationItem.command"
+      />
     </v-list>
     <template #append>
-      <v-list dense nav>
-        <v-list-item @click="reports.command">
-          <v-list-item-icon>
-            <font-awesome-icon :icon="reports.icon" class="mr-2" />
-          </v-list-item-icon>
-          <v-list-item-content>
-            <v-list-item-title>{{ reports.label }}</v-list-item-title>
-          </v-list-item-content>
+      <v-list density="compact">
+        <v-list-item @click="reports.command" :title="reports.label">
         </v-list-item>
       </v-list>
     </template>
@@ -73,10 +44,10 @@ import { MenuModel } from "@/types";
 export default {
   setup() {
     const router = useRouter();
-    const items = ref<MenuModel[]>([
+    const topItems = ref<MenuModel[]>([
       {
         label: "Dashboard",
-        icon: ["fas", "home"],
+        icon: "mdi-home-outline",
         command: () => {
           router.push({
             name: AESTRoutesConst.AEST_DASHBOARD,
@@ -85,7 +56,7 @@ export default {
       },
       {
         label: "Search Students",
-        icon: ["fas", "search"],
+        icon: "mdi-magnify",
         command: () => {
           router.push({
             name: AESTRoutesConst.SEARCH_STUDENTS,
@@ -94,22 +65,28 @@ export default {
       },
       {
         label: "Search Institutions",
-        icon: ["fas", "search"],
+        icon: "mdi-magnify",
         command: () => {
           router.push({
             name: AESTRoutesConst.SEARCH_INSTITUTIONS,
           });
         },
       },
-      {
-        label: "Settings",
-        icon: ["fas", "cog"],
-      },
     ]);
+
+    const exceptionsItem = ref({
+      label: "Exceptions",
+      icon: "mdi-alert-circle-outline",
+      command: () => {
+        router.push({
+          name: AESTRoutesConst.APPLICATION_EXCEPTIONS_PENDING,
+        });
+      },
+    } as MenuModel);
 
     const pendingDesignationItem = ref({
       label: "Pending designations",
-      icon: ["fas", "pen-nib"],
+      icon: "mdi-bookmark-outline",
       command: () => {
         router.push({
           name: AESTRoutesConst.PENDING_DESIGNATIONS,
@@ -119,7 +96,7 @@ export default {
 
     const reports = ref({
       label: "Reports",
-      icon: ["far", "copy"],
+      icon: "mdi-home-outline",
       command: () => {
         router.push({
           name: AESTRoutesConst.REPORTS,
@@ -127,21 +104,12 @@ export default {
       },
     } as MenuModel);
 
-    const exceptionsItem = ref({
-      label: "Exceptions",
-      icon: ["far", "check-circle"],
-      command: () => {
-        router.push({
-          name: AESTRoutesConst.APPLICATION_EXCEPTIONS_PENDING,
-        });
-      },
-    } as MenuModel);
-
     return {
-      items,
+      topItems,
       pendingDesignationItem,
       exceptionsItem,
       reports,
+      AESTRoutesConst,
     };
   },
 };

--- a/sources/packages/web/src/plugins/vuetify.ts
+++ b/sources/packages/web/src/plugins/vuetify.ts
@@ -1,4 +1,5 @@
 import "@mdi/font/css/materialdesignicons.css";
+import "@fortawesome/fontawesome-free/css/all.css";
 import "vuetify/lib/styles/main.sass";
 import { createVuetify } from "vuetify";
 import * as components from "vuetify/lib/components";
@@ -21,7 +22,7 @@ export default createVuetify({
     },
   },
   icons: {
-    defaultSet: "fa",
+    defaultSet: "mdi",
     aliases,
     sets: {
       fa,

--- a/sources/packages/web/src/views/aest/AppAEST.vue
+++ b/sources/packages/web/src/views/aest/AppAEST.vue
@@ -11,12 +11,12 @@
         @click="
           $router.push({ name: AESTRoutesConst.INSTITUTION_PROFILE_CREATE })
         "
-        ><v-icon icon="fa fa-edit"></v-icon>Create institution</v-btn
+        ><v-icon icon="fa:fa fa-edit"></v-icon>Create institution</v-btn
       >
       <v-btn
         v-if="isAuthenticated"
         class="mr-5"
-        icon="fa fa-user"
+        icon="fa:fa fa-user"
         variant="outlined"
         elevation="1"
         color="grey"

--- a/sources/packages/web/src/views/aest/Login.vue
+++ b/sources/packages/web/src/views/aest/Login.vue
@@ -10,19 +10,25 @@
     </v-card-header>
     <v-card-text
       >Please use your IDIR to authenticate. You must be previously authorized
-      by the system administrator in order to successfully login.</v-card-text
-    >
-    <v-row justify="center" class="m-3">
-      <v-btn color="primary" data-cy="loginWithIDIR" @click="login">
-        <v-icon size="25" class="mr-2">mdi-account-outline</v-icon>
-        Login with IDIR
-      </v-btn>
-    </v-row>
-    <Message severity="error" class="mx-2" v-if="showNotAllowedUser">
-      The user was validated successfully but is not currently allowed to have
-      access to this application. Please contact the Administrator for more
-      information.
-    </Message>
+      by the system administrator in order to successfully login.
+      <Message severity="error" v-if="showNotAllowedUser">
+        The user was validated successfully but is not currently allowed to have
+        access to this application. Please contact the Administrator for more
+        information.
+      </Message>
+    </v-card-text>
+    <v-card-actions>
+      <v-row justify="center">
+        <v-btn
+          class="primary-btn-background"
+          data-cy="loginWithIDIR"
+          @click="login"
+          prepend-icon="fa:fa fa-user"
+        >
+          Login with IDIR
+        </v-btn>
+      </v-row>
+    </v-card-actions>
   </v-card>
 </template>
 

--- a/sources/packages/web/src/views/institution/Login.vue
+++ b/sources/packages/web/src/views/institution/Login.vue
@@ -10,32 +10,40 @@
     </v-card-header>
     <v-card-text
       >We are using BCeID for Authentication. Please click on Login/Register
-      buttons below to start your sign in/sign up with your Business
-      BCeID.</v-card-text
-    >
-    <v-row justify="center" class="m-3">
-      <v-btn class="mr-2" color="primary" @click="login">
-        <v-icon size="25" class="mr-2">mdi-account-outline</v-icon>
-        Login with BCeID
-      </v-btn>
-      <v-btn color="primary" @click="login">
-        <v-icon size="25" class="mr-2">mdi-account-star-outline</v-icon>
-        Sign Up with BCeID
-      </v-btn>
-    </v-row>
-    <Message severity="error" class="mx-2" v-if="showBasicBCeIDMessage">
-      No such Business account has been found with BCeID. Please login with your
-      Business BCeId
-    </Message>
-    <Message severity="error" class="mx-2" v-if="showDisabledUserMessage">
-      Disabled User - you dont have access to the system. Please contact
-      Administrator for more informations.
-    </Message>
-    <Message severity="error" class="mx-2" v-if="showUnknownUserMessage">
-      The user was validated successfully but is not currently allowed to have
-      access to this application. Please contact the Administrator for more
-      information
-    </Message>
+      buttons below to start your sign in/sign up with your Business BCeID.
+      <Message severity="error" v-if="showBasicBCeIDMessage">
+        No such Business account has been found with BCeID. Please login with
+        your Business BCeId
+      </Message>
+      <Message severity="error" v-if="showDisabledUserMessage">
+        Disabled User - you don't have access to the system. Please contact
+        Administrator for more informations.
+      </Message>
+      <Message severity="error" v-if="showUnknownUserMessage">
+        The user was validated successfully but is not currently allowed to have
+        access to this application. Please contact the Administrator for more
+        information
+      </Message>
+    </v-card-text>
+    <v-card-actions>
+      <v-row justify="center" class="my-3">
+        <v-btn
+          class="primary-btn-background"
+          @click="login"
+          prepend-icon="fa:fa fa-user"
+        >
+          Login with BCeID
+        </v-btn>
+        <v-btn
+          class="primary-btn-background"
+          @click="login"
+          variant="outlined"
+          prepend-icon="fa:fa fa-user-plus"
+        >
+          Sign Up with BCeID
+        </v-btn>
+      </v-row>
+    </v-card-actions>
   </v-card>
 </template>
 

--- a/sources/packages/web/src/views/student/Login.vue
+++ b/sources/packages/web/src/views/student/Login.vue
@@ -12,16 +12,17 @@
       >We are using BCSC for authentication. Please click on Login/Register
       buttons below to start your sign in/sign up.</v-card-text
     >
-    <v-row justify="center" class="m-3">
-      <v-btn class="mr-2" color="primary" @click="login">
-        <v-icon size="25" class="mr-2">mdi-account-outline</v-icon>
-        Login with BCSC
-      </v-btn>
-      <v-btn color="primary" @click="login">
-        <v-icon size="25" class="mr-2">mdi-account-star-outline</v-icon>
-        Sign Up with BCSC
-      </v-btn>
-    </v-row>
+    <v-card-actions>
+      <v-row justify="center" class="m-3">
+        <v-btn
+          class="primary-btn-background"
+          @click="login"
+          prepend-icon="fa:fa fa-user"
+        >
+          Login / Sign up with BCSC
+        </v-btn>
+      </v-row>
+    </v-card-actions>
   </v-card>
 </template>
 


### PR DESCRIPTION
- Changed icon library to use mdi (Material Design Icons) as default to cause less impact during the transition to use `v-icon` that now supports Font Awesome and Material Design Icons.
- StatuChip component changed to stop using `v-badge` and use `v-chip`.
- Login pages adjusted.
- Left menus adjusted to use the properties instead of the contents

Before

![image](https://user-images.githubusercontent.com/61259237/176726956-8bfd0389-5d29-48d4-b6f6-dc9592a57a29.png)

After

![image](https://user-images.githubusercontent.com/61259237/176726821-f18e025e-0601-475b-95a2-e6f98e8fa6ac.png)

- Buttons have now the `prepend-icon` working, so we can use the property instead of setting the icon using the v-icon. Please notice also that the below icons are set using the Font Awesome `fa:` prefix.
![image](https://user-images.githubusercontent.com/61259237/176755685-535d9b1e-6ec2-4e82-ac44-408b27bc9474.png)

- There is a known issue with the alerts that cause the font to be different as shown below.
 
![image](https://user-images.githubusercontent.com/61259237/176759931-c8830da1-f679-4af9-ac85-ea9ebe231ed7.png)

The above issue affects the alerts when the body text is not defined between a span, like the below one that is working as expected.

![image](https://user-images.githubusercontent.com/61259237/176760040-7dd36c08-263a-4d03-a515-3a2a6c648e8b.png)

Since it is not a blocker right now the changes to fix the individual alerts will come later.