### PR TITLE
[web][api][SIMS #1300]PIR moved to institutions API client

### DIFF
--- a/sources/packages/api/src/app.institutions.module.ts
+++ b/sources/packages/api/src/app.institutions.module.ts
@@ -27,6 +27,8 @@ import {
   DisbursementScheduleService,
   COEDeniedReasonService,
   InstitutionTypeService,
+  EducationProgramOfferingService,
+  PIRDeniedReasonService,
 } from "./services";
 import {
   DesignationAgreementInstitutionsController,
@@ -40,6 +42,7 @@ import {
   InstitutionUserInstitutionsController,
   InstitutionUserControllerService,
   ConfirmationOfEnrollmentInstitutionsController,
+  ProgramInfoRequestInstitutionsController,
 } from "./route-controllers";
 import { AuthModule } from "./auth/auth.module";
 import { LoggerModule } from "./logger/logger.module";
@@ -53,6 +56,7 @@ import { LoggerModule } from "./logger/logger.module";
     InstitutionLocationInstitutionsController,
     ScholasticStandingInstitutionsController,
     ConfirmationOfEnrollmentInstitutionsController,
+    ProgramInfoRequestInstitutionsController,
   ],
   providers: [
     FormService,
@@ -86,6 +90,8 @@ import { LoggerModule } from "./logger/logger.module";
     DisbursementScheduleService,
     COEDeniedReasonService,
     InstitutionTypeService,
+    EducationProgramOfferingService,
+    PIRDeniedReasonService,
   ],
 })
 export class AppInstitutionsModule {}

--- a/sources/packages/api/src/app.module.ts
+++ b/sources/packages/api/src/app.module.ts
@@ -39,7 +39,6 @@ import {
   EducationProgramController,
   EducationProgramOfferingController,
   ATBCController,
-  ProgramInfoRequestController,
   NotesController,
   RestrictionController,
 } from "./route-controllers";
@@ -106,7 +105,6 @@ import { AppSupportingUsersModule } from "./app.supporting-users.module";
     EducationProgramController,
     EducationProgramOfferingController,
     ATBCController,
-    ProgramInfoRequestController,
     NotesController,
     RestrictionController,
   ],
@@ -130,7 +128,6 @@ import { AppSupportingUsersModule } from "./app.supporting-users.module";
     ProgramYearService,
     SequenceControlService,
     InstitutionTypeService,
-    PIRDeniedReasonService,
     MSFAANumberService,
     StudentRestrictionService,
     RestrictionService,

--- a/sources/packages/api/src/app.module.ts
+++ b/sources/packages/api/src/app.module.ts
@@ -22,7 +22,6 @@ import {
   ProgramYearService,
   SequenceControlService,
   InstitutionTypeService,
-  PIRDeniedReasonService,
   MSFAANumberService,
   StudentRestrictionService,
   RestrictionService,

--- a/sources/packages/api/src/constants/error-code.constants.ts
+++ b/sources/packages/api/src/constants/error-code.constants.ts
@@ -41,3 +41,9 @@ export const INSTITUTION_MUST_HAVE_AN_ADMIN = "INSTITUTION_MUST_HAVE_AN_ADMIN";
  * The BCeID user id was not able to be retrieved from the BCeID Web Service.
  */
 export const BCEID_ACCOUNT_NOT_FOUND = "BCEID_ACCOUNT_NOT_FOUND";
+/**
+ * Program information request (PIR) errors.
+ */
+export const PIR_REQUEST_NOT_FOUND_ERROR = "PIR_REQUEST_NOT_FOUND_ERROR";
+export const PIR_DENIED_REASON_NOT_FOUND_ERROR =
+  "PIR_DENIED_REASON_NOT_FOUND_ERROR";

--- a/sources/packages/api/src/route-controllers/application/models/application.model.ts
+++ b/sources/packages/api/src/route-controllers/application/models/application.model.ts
@@ -93,15 +93,6 @@ export class GetApplicationDataDto extends GetApplicationBaseDTO {
   programYearEndDate: Date;
 }
 
-export interface PIRSummaryDTO {
-  applicationNumber: string;
-  studyStartPeriod: string;
-  studyEndPeriod: string;
-  applicationId: number;
-  pirStatus: string;
-  fullName: string;
-}
-
 export interface ApplicationStatusToBeUpdatedDto {
   applicationStatus: ApplicationStatus;
 }

--- a/sources/packages/api/src/route-controllers/index.ts
+++ b/sources/packages/api/src/route-controllers/index.ts
@@ -7,7 +7,7 @@ export * from "./education-program/education-program.controller";
 export * from "./education-program-offering/education-program-offering.controller";
 export * from "./application/application.system-access.controller";
 export * from "./atbc/atbc.system.controller";
-export * from "./program-info-request/program-info-request.controller";
+export * from "./program-info-request/program-info-request.institutions.controller";
 export * from "./confirmation-of-enrollment/confirmation-of-enrollment.institutions.controller";
 export * from "./supporting-user/supporting-user.supporting-users.controller";
 export * from "./esdc-integration/msfaa-integration.system-access.controller";

--- a/sources/packages/api/src/route-controllers/program-info-request/models/program-info-request.dto.ts
+++ b/sources/packages/api/src/route-controllers/program-info-request/models/program-info-request.dto.ts
@@ -1,10 +1,4 @@
-import {
-  IsNotEmpty,
-  IsInt,
-  Min,
-  IsOptional,
-  IsPositive,
-} from "class-validator";
+import { IsOptional, IsPositive } from "class-validator";
 import { OfferingTypes, ProgramInfoStatus } from "../../../database/entities";
 import { OfferingIntensity } from "../../../database/entities/offering-intensity.type";
 
@@ -44,15 +38,22 @@ export class CourseDetails {
   courseEndDate: string;
 }
 
-export interface GetPIRDeniedReasonDto {
+export class PIRDeniedReasonAPIOutDTO {
   id: number;
   description: string;
 }
 
-export class DenyProgramInfoRequestDto {
-  @IsNotEmpty()
-  @IsInt()
-  @Min(1)
+export class PIRSummaryAPIOutDTO {
+  applicationNumber: string;
+  studyStartPeriod: string;
+  studyEndPeriod: string;
+  applicationId: number;
+  pirStatus: string;
+  fullName: string;
+}
+
+export class DenyProgramInfoRequestAPIInDTO {
+  @IsPositive()
   pirDenyReasonId: number;
   @IsOptional()
   otherReasonDesc?: string;

--- a/sources/packages/api/src/route-controllers/program-info-request/program-info-request.institutions.controller.ts
+++ b/sources/packages/api/src/route-controllers/program-info-request/program-info-request.institutions.controller.ts
@@ -131,7 +131,7 @@ export class ProgramInfoRequestInstitutionsController extends BaseController {
     // from PIR (sims.applications table) will be used.
     result.selectedProgram =
       originalAssessmentOffering?.educationProgram.id ??
-      application.pirProgram?.id;
+      application.pirProgram.id;
     // Offering only available when PIR is completed.
     if (originalAssessmentOffering) {
       result.selectedOffering = originalAssessmentOffering.id;
@@ -232,7 +232,7 @@ export class ProgramInfoRequestInstitutionsController extends BaseController {
     }
 
     try {
-      // validate possible overlaps with exists applications.
+      // Validate possible overlaps with exists applications.
       await this.applicationService.validateOverlappingDatesAndPIR(
         applicationId,
         application.student.user.lastName,

--- a/sources/packages/api/src/services/application/application.service.ts
+++ b/sources/packages/api/src/services/application/application.service.ts
@@ -505,12 +505,17 @@ export class ApplicationService extends RecordDataModelService<Application> {
   }
 
   /**
-   * Get student application details with the application Id.
-   * @param applicationId student application id .
-   * @returns student Application Details.
+   * Get student application details for a Program Information Request(PIR).
+   * @param applicationId student application id.
+   * @param locationId associated location that has access to the
+   * Program Information Request.
+   * @returns student application details.
    */
-  async getApplicationById(applicationId: number): Promise<Application> {
-    return this.repo
+  async getApplicationForPIR(
+    applicationId: number,
+    locationId: number,
+  ): Promise<Application> {
+    const query = this.repo
       .createQueryBuilder("application")
       .select([
         "application.data",
@@ -523,10 +528,13 @@ export class ApplicationService extends RecordDataModelService<Application> {
       .innerJoin("application.student", "student")
       .innerJoin("student.sinValidation", "sinValidation")
       .innerJoin("student.user", "user")
-      .andWhere("application.id = :applicationId", {
+      .where("application.id = :applicationId", {
         applicationId,
-      })
-      .getOne();
+      });
+    if (locationId) {
+      query.andWhere("application.location.id = locationId:", { locationId });
+    }
+    return query.getOne();
   }
 
   /**

--- a/sources/packages/api/src/services/application/application.service.ts
+++ b/sources/packages/api/src/services/application/application.service.ts
@@ -53,10 +53,11 @@ import { SFASPartTimeApplicationsService } from "../sfas/sfas-part-time-applicat
 import { ConfigService } from "../config/config.service";
 import { IConfig } from "../../types";
 import { StudentRestrictionService } from "../restriction/student-restriction.service";
+import {
+  PIR_DENIED_REASON_NOT_FOUND_ERROR,
+  PIR_REQUEST_NOT_FOUND_ERROR,
+} from "../../constants";
 
-export const PIR_REQUEST_NOT_FOUND_ERROR = "PIR_REQUEST_NOT_FOUND_ERROR";
-export const PIR_DENIED_REASON_NOT_FOUND_ERROR =
-  "PIR_DENIED_REASON_NOT_FOUND_ERROR";
 export const APPLICATION_DRAFT_NOT_FOUND = "APPLICATION_DRAFT_NOT_FOUND";
 export const MORE_THAN_ONE_APPLICATION_DRAFT_ERROR =
   "ONLY_ONE_APPLICATION_DRAFT_PER_STUDENT_ALLOWED";
@@ -405,6 +406,8 @@ export class ApplicationService extends RecordDataModelService<Application> {
         "currentAssessment.triggerType",
         "location.name",
         "student.id",
+        "student.birthDate",
+        "user.id",
         "user.firstName",
         "user.lastName",
         "pirProgram.id",
@@ -428,10 +431,13 @@ export class ApplicationService extends RecordDataModelService<Application> {
         "programYear.active",
         "programYear.startDate",
         "programYear.endDate",
+        "sinValidation.id",
+        "sinValidation.sin",
       ])
       .innerJoin("application.programYear", "programYear")
       .leftJoin("application.pirProgram", "pirProgram")
       .innerJoin("application.student", "student")
+      .innerJoin("student.sinValidation", "sinValidation")
       .innerJoin("application.location", "location")
       .innerJoin("application.currentAssessment", "currentAssessment")
       .leftJoin("currentAssessment.offering", "offering")
@@ -502,39 +508,6 @@ export class ApplicationService extends RecordDataModelService<Application> {
       applicationQuery.andWhere("user.id = :userId", { userId });
     }
     return applicationQuery.getOne();
-  }
-
-  /**
-   * Get student application details for a Program Information Request(PIR).
-   * @param applicationId student application id.
-   * @param locationId associated location that has access to the
-   * Program Information Request.
-   * @returns student application details.
-   */
-  async getApplicationForPIR(
-    applicationId: number,
-    locationId: number,
-  ): Promise<Application> {
-    const query = this.repo
-      .createQueryBuilder("application")
-      .select([
-        "application.data",
-        "student.birthDate",
-        "sinValidation.id",
-        "sinValidation.sin",
-        "user.id",
-        "user.lastName",
-      ])
-      .innerJoin("application.student", "student")
-      .innerJoin("student.sinValidation", "sinValidation")
-      .innerJoin("student.user", "user")
-      .where("application.id = :applicationId", {
-        applicationId,
-      });
-    if (locationId) {
-      query.andWhere("application.location.id = locationId:", { locationId });
-    }
-    return query.getOne();
   }
 
   /**
@@ -660,7 +633,7 @@ export class ApplicationService extends RecordDataModelService<Application> {
    * Updates only applications that have the PIR status as required.
    * @param applicationId application id to be updated.
    * @param locationId location that is setting the offering.
-   * @param offering offering to be set in the assessment.
+   * @param offeringId offering to be set in the assessment.
    * @param auditUserId user that should be considered the one that is
    * causing the changes.
    * @returns updated application.
@@ -668,7 +641,7 @@ export class ApplicationService extends RecordDataModelService<Application> {
   async setOfferingForProgramInfoRequest(
     applicationId: number,
     locationId: number,
-    offering: EducationProgramOffering,
+    offeringId: number,
     auditUserId: number,
   ): Promise<Application> {
     return this.dataSource.transaction(async (transactionalEntityManager) => {
@@ -701,13 +674,15 @@ export class ApplicationService extends RecordDataModelService<Application> {
         );
       }
       const auditUser = { id: auditUserId } as User;
-      application.currentAssessment.offering = offering;
+      application.currentAssessment.offering = {
+        id: offeringId,
+      } as EducationProgramOffering;
       application.currentAssessment.modifier = auditUser;
       application.pirStatus = ProgramInfoStatus.completed;
       application.modifier = auditUser;
       await this.studentRestrictionService.assessSINRestrictionForOfferingId(
         application.student.id,
-        offering.id,
+        offeringId,
         applicationId,
         auditUserId,
         transactionalEntityManager,

--- a/sources/packages/api/src/services/application/application.service.ts
+++ b/sources/packages/api/src/services/application/application.service.ts
@@ -387,7 +387,7 @@ export class ApplicationService extends RecordDataModelService<Application> {
   /**
    * Gets the Program Information Requests (PIR) associated with the
    * application and the original assessment that contains the offering
-   * to be complete or that was completed during the PIR process.
+   * to be completed or that was completed during the PIR process.
    * @param locationId location id.
    * @param applicationId application id.
    * @returns student application with Program Information Request.

--- a/sources/packages/api/src/services/application/application.service.ts
+++ b/sources/packages/api/src/services/application/application.service.ts
@@ -385,8 +385,9 @@ export class ApplicationService extends RecordDataModelService<Application> {
   }
 
   /**
-   * Gets the Program Information Request
-   * associated with the application.
+   * Gets the Program Information Requests (PIR) associated with the
+   * application and the original assessment that contains the offering
+   * to be complete or that was completed during the PIR process.
    * @param locationId location id.
    * @param applicationId application id.
    * @returns student application with Program Information Request.
@@ -402,8 +403,6 @@ export class ApplicationService extends RecordDataModelService<Application> {
         "application.pirStatus",
         "application.data",
         "application.pirDeniedOtherDesc",
-        "currentAssessment.id",
-        "currentAssessment.triggerType",
         "location.name",
         "student.id",
         "student.birthDate",
@@ -433,14 +432,16 @@ export class ApplicationService extends RecordDataModelService<Application> {
         "programYear.endDate",
         "sinValidation.id",
         "sinValidation.sin",
+        "studentAssessments.id",
+        "studentAssessments.triggerType",
       ])
       .innerJoin("application.programYear", "programYear")
       .leftJoin("application.pirProgram", "pirProgram")
       .innerJoin("application.student", "student")
       .innerJoin("student.sinValidation", "sinValidation")
       .innerJoin("application.location", "location")
-      .innerJoin("application.currentAssessment", "currentAssessment")
-      .leftJoin("currentAssessment.offering", "offering")
+      .innerJoin("application.studentAssessments", "studentAssessments")
+      .leftJoin("studentAssessments.offering", "offering")
       .leftJoin("offering.educationProgram", "educationProgram")
       .innerJoin("student.user", "user")
       .leftJoin("application.pirDeniedReasonId", "PIRDeniedReason")
@@ -448,6 +449,12 @@ export class ApplicationService extends RecordDataModelService<Application> {
         applicationId,
       })
       .andWhere("location.id = :locationId", { locationId })
+      .andWhere("studentAssessments.triggerType = :triggerType", {
+        triggerType: AssessmentTriggerType.OriginalAssessment,
+      })
+      .andWhere("application.pirStatus != :pirStatus", {
+        pirStatus: ProgramInfoStatus.notRequired,
+      })
       .andWhere("application.applicationStatus != :overwrittenStatus", {
         overwrittenStatus: ApplicationStatus.overwritten,
       })

--- a/sources/packages/web/src/services/ProgramInfoRequestService.ts
+++ b/sources/packages/web/src/services/ProgramInfoRequestService.ts
@@ -1,59 +1,92 @@
-import {
-  CompleteProgramInfoRequestDto,
-  DenyProgramInfoRequestDto,
-  GetProgramInfoRequestDto,
-  PIRSummaryDTO,
-  GetPIRDeniedReasonDto,
-} from "@/types";
 import ApiClient from "./http/ApiClient";
+import {
+  CompleteProgramInfoRequestAPIInDTO,
+  DenyProgramInfoRequestAPIInDTO,
+  PIRDeniedReasonAPIOutDTO,
+  PIRSummaryAPIOutDTO,
+  ProgramInfoRequestAPIOutDTO,
+} from "@/services/http/dto";
 
 export class ProgramInfoRequestService {
-  // Share Instance
+  // Shared Instance
   private static instance: ProgramInfoRequestService;
 
-  public static get shared(): ProgramInfoRequestService {
+  static get shared(): ProgramInfoRequestService {
     return this.instance || (this.instance = new this());
   }
 
+  /**
+   * Gets the information to show a Program Information Request (PIR)
+   * with the data provided by the student, either when student select
+   * an existing program or not.
+   * @param locationId location id.
+   * @param applicationId application id.
+   * @returns program information request.
+   */
   async getProgramInfoRequest(
     locationId: number,
     applicationId: number,
-  ): Promise<GetProgramInfoRequestDto> {
+  ): Promise<ProgramInfoRequestAPIOutDTO> {
     return ApiClient.ProgramInfoRequest.getProgramInfoRequest(
       locationId,
       applicationId,
     );
   }
 
-  public async completeProgramInfoRequest(
+  /**
+   * Completes the Program Info Request (PIR), defining the
+   * PIR status as completed in the student application table.
+   * The PIR is completed by select an existing offering.
+   * @param locationId location that is completing the PIR.
+   * @param applicationId application id to be updated.
+   * @param payload offering to be updated in the student application.
+   */
+  async completeProgramInfoRequest(
     locationId: number,
     applicationId: number,
-    data: CompleteProgramInfoRequestDto,
+    payload: CompleteProgramInfoRequestAPIInDTO,
   ): Promise<void> {
     await ApiClient.ProgramInfoRequest.completeProgramInfoRequest(
       locationId,
       applicationId,
-      data,
+      payload,
     );
   }
 
-  public async denyProgramInfoRequest(
+  /**
+   * Deny the Program Info Request (PIR), defining the
+   * PIR status as Declined in the student application table.
+   * @param locationId location that is completing the PIR.
+   * @param applicationId application id to be updated.
+   * @param payload contains the denied reason of the student application.
+   */
+  async denyProgramInfoRequest(
     locationId: number,
     applicationId: number,
-    data: DenyProgramInfoRequestDto,
+    payload: DenyProgramInfoRequestAPIInDTO,
   ): Promise<void> {
     await ApiClient.ProgramInfoRequest.denyProgramInfoRequest(
       locationId,
       applicationId,
-      data,
+      payload,
     );
   }
 
-  public async getPIRSummary(locationId: number): Promise<PIRSummaryDTO[]> {
+  /**
+   * Get all applications of a location in an institution
+   * with Program Info Request (PIR) status completed and required
+   * @param locationId location that is completing the PIR.
+   * @returns student application list of an institution location.
+   */
+  async getPIRSummary(locationId: number): Promise<PIRSummaryAPIOutDTO[]> {
     return ApiClient.ProgramInfoRequest.getPIRSummary(locationId);
   }
 
-  public async getPIRDeniedReasonList(): Promise<GetPIRDeniedReasonDto[]> {
+  /**
+   * Get all PIR denied reasons, which are active.
+   * @returns PIR denied reason list.
+   */
+  async getPIRDeniedReasonList(): Promise<PIRDeniedReasonAPIOutDTO[]> {
     return ApiClient.ProgramInfoRequest.getPIRDeniedReasonList();
   }
 }

--- a/sources/packages/web/src/services/http/ProgramInfoRequestApi.ts
+++ b/sources/packages/web/src/services/http/ProgramInfoRequestApi.ts
@@ -1,74 +1,96 @@
+import HttpBaseClient from "@/services/http/common/HttpBaseClient";
 import {
-  CompleteProgramInfoRequestDto,
-  DenyProgramInfoRequestDto,
-  GetProgramInfoRequestDto,
-  PIRSummaryDTO,
-  GetPIRDeniedReasonDto,
-} from "@/types";
-import HttpBaseClient from "./common/HttpBaseClient";
+  CompleteProgramInfoRequestAPIInDTO,
+  DenyProgramInfoRequestAPIInDTO,
+  PIRDeniedReasonAPIOutDTO,
+  PIRSummaryAPIOutDTO,
+  ProgramInfoRequestAPIOutDTO,
+} from "@/services/http/dto";
 
 export class ProgramInfoRequestApi extends HttpBaseClient {
-  public async getProgramInfoRequest(
+  /**
+   * Gets the information to show a Program Information Request (PIR)
+   * with the data provided by the student, either when student select
+   * an existing program or not.
+   * @param locationId location id.
+   * @param applicationId application id.
+   * @returns program information request.
+   */
+  async getProgramInfoRequest(
     locationId: number,
     applicationId: number,
-  ): Promise<GetProgramInfoRequestDto> {
-    const response = await this.apiClient.get(
-      `institution/location/${locationId}/program-info-request/application/${applicationId}`,
-      this.addAuthHeader(),
+  ): Promise<ProgramInfoRequestAPIOutDTO> {
+    return this.getCallTyped(
+      this.addClientRoot(
+        `location/${locationId}/program-info-request/application/${applicationId}`,
+      ),
     );
-    return response.data;
   }
 
-  public async completeProgramInfoRequest(
+  /**
+   * Completes the Program Info Request (PIR), defining the
+   * PIR status as completed in the student application table.
+   * The PIR is completed by select an existing offering.
+   * @param locationId location that is completing the PIR.
+   * @param applicationId application id to be updated.
+   * @param payload offering to be updated in the student application.
+   */
+  async completeProgramInfoRequest(
     locationId: number,
     applicationId: number,
-    data: CompleteProgramInfoRequestDto,
+    payload: CompleteProgramInfoRequestAPIInDTO,
   ): Promise<void> {
     try {
       await this.patchCall(
-        `institution/location/${locationId}/program-info-request/application/${applicationId}/complete`,
-        { ...data },
+        this.addClientRoot(
+          `location/${locationId}/program-info-request/application/${applicationId}/complete`,
+        ),
+        payload,
       );
     } catch (error: unknown) {
       this.handleAPICustomError(error);
     }
   }
 
-  public async denyProgramInfoRequest(
+  /**
+   * Deny the Program Info Request (PIR), defining the
+   * PIR status as Declined in the student application table.
+   * @param locationId location that is completing the PIR.
+   * @param applicationId application id to be updated.
+   * @param payload contains the denied reason of the student application.
+   */
+  async denyProgramInfoRequest(
     locationId: number,
     applicationId: number,
-    data: DenyProgramInfoRequestDto,
+    payload: DenyProgramInfoRequestAPIInDTO,
   ): Promise<void> {
-    await this.apiClient.patch(
-      `institution/location/${locationId}/program-info-request/application/${applicationId}/deny`,
-      { ...data },
-      this.addAuthHeader(),
+    await this.patchCall(
+      this.addClientRoot(
+        `location/${locationId}/program-info-request/application/${applicationId}/deny`,
+      ),
+      payload,
     );
   }
 
-  public async getPIRSummary(locationId: number): Promise<PIRSummaryDTO[]> {
-    try {
-      const response = await this.apiClient.get(
-        `institution/location/${locationId}/program-info-request`,
-        this.addAuthHeader(),
-      );
-      return response.data;
-    } catch (error) {
-      this.handleRequestError(error);
-      throw error;
-    }
+  /**
+   * Get all applications of a location in an institution
+   * with Program Info Request (PIR) status completed and required
+   * @param locationId location that is completing the PIR.
+   * @returns student application list of an institution location.
+   */
+  async getPIRSummary(locationId: number): Promise<PIRSummaryAPIOutDTO[]> {
+    return this.getCallTyped<PIRSummaryAPIOutDTO[]>(
+      this.addClientRoot(`location/${locationId}/program-info-request`),
+    );
   }
 
-  public async getPIRDeniedReasonList(): Promise<GetPIRDeniedReasonDto[]> {
-    try {
-      const response = await this.apiClient.get(
-        `institution/location/program-info-request/denied-reason`,
-        this.addAuthHeader(),
-      );
-      return response.data;
-    } catch (error) {
-      this.handleRequestError(error);
-      throw error;
-    }
+  /**
+   * Get all PIR denied reasons, which are active.
+   * @returns PIR denied reason list.
+   */
+  async getPIRDeniedReasonList(): Promise<PIRDeniedReasonAPIOutDTO[]> {
+    return this.getCallTyped(
+      this.addClientRoot(`location/program-info-request/denied-reason`),
+    );
   }
 }

--- a/sources/packages/web/src/services/http/dto/ProgramInfoRequest.dto.ts
+++ b/sources/packages/web/src/services/http/dto/ProgramInfoRequest.dto.ts
@@ -1,10 +1,13 @@
 import {
   CourseDetails,
-  OfferingDTO,
   OfferingIntensity,
   OfferingTypes,
   ProgramInfoStatus,
 } from "@/types";
+
+export interface CompleteProgramInfoRequestAPIInDTO {
+  selectedOffering: number;
+}
 
 export interface ProgramInfoRequestAPIOutDTO {
   institutionLocationName: string;
@@ -28,21 +31,6 @@ export interface ProgramInfoRequestAPIOutDTO {
   courseDetails?: CourseDetails[];
   pirDenyReasonId?: number;
   otherReasonDesc?: string;
-}
-
-export interface PIRSummaryDTO {
-  applicationNumber: string;
-  studyStartPeriod: string;
-  studyEndPeriod: string;
-  applicationId: number;
-  pirStatus: ProgramInfoStatus;
-  fullName: string;
-}
-
-export interface CompleteProgramInfoRequestAPIInDTO extends OfferingDTO {
-  selectedProgram?: number;
-  selectedOffering?: number;
-  offeringType?: string;
 }
 
 export interface PIRDeniedReasonAPIOutDTO {

--- a/sources/packages/web/src/services/http/dto/ProgramInfoRequest.dto.ts
+++ b/sources/packages/web/src/services/http/dto/ProgramInfoRequest.dto.ts
@@ -1,0 +1,57 @@
+import { OfferingDTO, OfferingIntensity, ProgramInfoStatus } from "@/types";
+
+export interface ProgramInfoRequestAPIOutDTO
+  extends CompleteProgramInfoRequestAPIInDTO {
+  institutionLocationName: string;
+  applicationNumber: string;
+  studentFullName: string;
+  studentSelectedProgram: string;
+  studentCustomProgram: string;
+  studentCustomProgramDescription: string;
+  studentStudyStartDate: string;
+  studentStudyEndDate: string;
+  pirStatus: ProgramInfoStatus;
+  programYearId: number;
+  pirDenyReasonId?: number;
+  otherReasonDesc?: string;
+  // for `Deny program information request` checkbox
+  denyProgramInformationRequest: boolean;
+  isActiveProgramYear: boolean;
+  offeringIntensitySelectedByStudent: OfferingIntensity;
+  programYearStartDate: Date;
+  programYearEndDate: Date;
+}
+
+export interface PIRSummaryDTO {
+  applicationNumber: string;
+  studyStartPeriod: string;
+  studyEndPeriod: string;
+  applicationId: number;
+  pirStatus: ProgramInfoStatus;
+  fullName: string;
+}
+
+export interface CompleteProgramInfoRequestAPIInDTO extends OfferingDTO {
+  selectedProgram?: number;
+  selectedOffering?: number;
+  offeringType?: string;
+}
+
+export interface PIRDeniedReasonAPIOutDTO {
+  id: number;
+  description: string;
+}
+
+export interface PIRSummaryAPIOutDTO {
+  applicationNumber: string;
+  studyStartPeriod: string;
+  studyEndPeriod: string;
+  applicationId: number;
+  pirStatus: string;
+  fullName: string;
+}
+
+export interface DenyProgramInfoRequestAPIInDTO {
+  pirDenyReasonId: number;
+  otherReasonDesc?: string;
+}

--- a/sources/packages/web/src/services/http/dto/ProgramInfoRequest.dto.ts
+++ b/sources/packages/web/src/services/http/dto/ProgramInfoRequest.dto.ts
@@ -1,25 +1,33 @@
-import { OfferingDTO, OfferingIntensity, ProgramInfoStatus } from "@/types";
+import {
+  CourseDetails,
+  OfferingDTO,
+  OfferingIntensity,
+  OfferingTypes,
+  ProgramInfoStatus,
+} from "@/types";
 
-export interface ProgramInfoRequestAPIOutDTO
-  extends CompleteProgramInfoRequestAPIInDTO {
+export interface ProgramInfoRequestAPIOutDTO {
   institutionLocationName: string;
   applicationNumber: string;
   studentFullName: string;
   studentSelectedProgram: string;
+  selectedProgram?: number;
+  selectedOffering?: number;
+  pirStatus: ProgramInfoStatus;
   studentCustomProgram: string;
   studentCustomProgramDescription: string;
   studentStudyStartDate: string;
   studentStudyEndDate: string;
-  pirStatus: ProgramInfoStatus;
+  offeringIntensitySelectedByStudent: OfferingIntensity;
   programYearId: number;
+  isActiveProgramYear: boolean;
+  offeringName: string;
+  offeringDelivered: string;
+  offeringType: OfferingTypes;
+  offeringIntensity: OfferingIntensity;
+  courseDetails?: CourseDetails[];
   pirDenyReasonId?: number;
   otherReasonDesc?: string;
-  // for `Deny program information request` checkbox
-  denyProgramInformationRequest: boolean;
-  isActiveProgramYear: boolean;
-  offeringIntensitySelectedByStudent: OfferingIntensity;
-  programYearStartDate: Date;
-  programYearEndDate: Date;
 }
 
 export interface PIRSummaryDTO {

--- a/sources/packages/web/src/services/http/dto/index.ts
+++ b/sources/packages/web/src/services/http/dto/index.ts
@@ -11,3 +11,4 @@ export * from "@/services/http/dto/Pagination.dto";
 export * from "@/services/http/dto/ApplicationException.dto";
 export * from "@/services/http/dto/Institution-user.dto";
 export * from "@/services/http/dto/ConfirmationOfEnrolment.dto";
+export * from "@/services/http/dto/ProgramInfoRequest.dto";

--- a/sources/packages/web/src/types/contracts/institution/EducationProgramOfferingDto.ts
+++ b/sources/packages/web/src/types/contracts/institution/EducationProgramOfferingDto.ts
@@ -44,3 +44,10 @@ export enum OfferingTypes {
    */
   ScholasticStanding = "Scholastic standing",
 }
+
+export interface CourseDetails {
+  courseName: string;
+  courseCode: string;
+  courseStartDate: string;
+  courseEndDate: string;
+}

--- a/sources/packages/web/src/types/contracts/institution/ProgramInfoRequest.ts
+++ b/sources/packages/web/src/types/contracts/institution/ProgramInfoRequest.ts
@@ -1,5 +1,3 @@
-import { OfferingDTO, OfferingIntensity } from "@/types";
-
 /**
  * Possible status for a Program Information Request (PIR).
  */
@@ -27,50 +25,4 @@ export enum ProgramInfoStatus {
    * The PIR was declined by the institution.
    */
   declined = "Declined",
-}
-export interface PIRSummaryDTO {
-  applicationNumber: string;
-  studyStartPeriod: string;
-  studyEndPeriod: string;
-  applicationId: number;
-  pirStatus: ProgramInfoStatus;
-  fullName: string;
-}
-
-export interface CompleteProgramInfoRequestDto extends OfferingDTO {
-  selectedProgram?: number;
-  selectedOffering?: number;
-  offeringType?: string;
-}
-
-export interface GetProgramInfoRequestDto
-  extends CompleteProgramInfoRequestDto {
-  institutionLocationName: string;
-  applicationNumber: string;
-  studentFullName: string;
-  studentSelectedProgram: string;
-  studentCustomProgram: string;
-  studentCustomProgramDescription: string;
-  studentStudyStartDate: string;
-  studentStudyEndDate: string;
-  pirStatus: ProgramInfoStatus;
-  programYearId: number;
-  pirDenyReasonId?: number;
-  otherReasonDesc?: string;
-  // for `Deny program information request` checkbox
-  denyProgramInformationRequest: boolean;
-  isActiveProgramYear: boolean;
-  offeringIntensitySelectedByStudent: OfferingIntensity;
-  programYearStartDate: Date;
-  programYearEndDate: Date;
-}
-
-export interface GetPIRDeniedReasonDto {
-  id: number;
-  description: string;
-}
-
-export interface DenyProgramInfoRequestDto {
-  pirDenyReasonId: number;
-  otherReasonDesc?: string;
 }

--- a/sources/packages/web/src/views/institution/locations/program-info-request/LocationEditProgramInfoRequest.vue
+++ b/sources/packages/web/src/views/institution/locations/program-info-request/LocationEditProgramInfoRequest.vue
@@ -38,12 +38,12 @@ import {
   ApiProcessError,
   FormIOCustomEvent,
   FormIOCustomEventTypes,
-  GetProgramInfoRequestDto,
 } from "@/types";
 import {
   PIR_OR_DATE_OVERLAP_ERROR,
   OFFERING_INTENSITY_MISMATCH,
 } from "@/constants";
+import { ProgramInfoRequestAPIOutDTO } from "@/services/http/dto";
 
 export default {
   props: {
@@ -60,7 +60,7 @@ export default {
     const toast = useToastMessage();
     const router = useRouter();
     const { dateOnlyLongString } = useFormatters();
-    const initialData = ref({} as GetProgramInfoRequestDto);
+    const initialData = ref({} as ProgramInfoRequestAPIOutDTO);
     const formioUtils = useFormioUtils();
     const formioDataLoader = useFormioDropdownLoader();
     const programRequestData = ref();

--- a/sources/packages/web/src/views/institution/locations/program-info-request/LocationProgramInfoRequestSummary.vue
+++ b/sources/packages/web/src/views/institution/locations/program-info-request/LocationProgramInfoRequestSummary.vue
@@ -60,8 +60,9 @@ import { onMounted, ref, watch } from "vue";
 import { useRouter } from "vue-router";
 import { InstitutionRoutesConst } from "@/constants/routes/RouteConstants";
 import { ProgramInfoRequestService } from "@/services/ProgramInfoRequestService";
-import { PIRSummaryDTO, ProgramInfoStatus } from "@/types";
+import { ProgramInfoStatus } from "@/types";
 import { useFormatters } from "@/composables";
+import { PIRSummaryAPIOutDTO } from "@/services/http/dto";
 
 export default {
   props: {
@@ -77,7 +78,7 @@ export default {
   setup(props: any) {
     const router = useRouter();
     const { dateString } = useFormatters();
-    const applications = ref([] as PIRSummaryDTO[]);
+    const applications = ref([] as PIRSummaryAPIOutDTO[]);
 
     const goToViewApplication = (applicationId: number) => {
       router.push({


### PR DESCRIPTION
- Program information request related methods moved to a specific institution client controller.
- Changed PIR get data to rely always on the original assessment instead of the current assessment to ensure that every time that the PIR UI is shown the data will be coming from the original assessment record.