### PR TITLE
[api][SIMS #1353]Basic BCeID Institution Authorization

### DIFF
--- a/sources/packages/api/src/route-controllers/institution-user/institution-user.aest.controller.ts
+++ b/sources/packages/api/src/route-controllers/institution-user/institution-user.aest.controller.ts
@@ -29,6 +29,7 @@ import { ClientTypeBaseRoute } from "../../types";
 import { IUserToken } from "../../auth/userToken.interface";
 import { PrimaryIdentifierAPIOutDTO } from "../models/primary.identifier.dto";
 import { InstitutionUserPaginationOptionsAPIInDTO } from "../models/pagination.dto";
+import { BCeIDAccountTypeCodes } from "../../services/bceid/bceid.models";
 
 /**
  * Institution user controller for AEST client.
@@ -89,6 +90,8 @@ export class InstitutionUserAESTController extends BaseController {
       institutionId,
       payload,
       token.userId,
+      BCeIDAccountTypeCodes.Individual,
+      BCeIDAccountTypeCodes.Business,
     );
   }
 

--- a/sources/packages/api/src/route-controllers/institution-user/institution-user.controller.service.ts
+++ b/sources/packages/api/src/route-controllers/institution-user/institution-user.controller.service.ts
@@ -107,7 +107,7 @@ export class InstitutionUserControllerService {
    * @param institutionId institution to have the user associated.
    * @param payload user and authorization information.
    * @param auditUserId user that should be considered the one that is causing the changes.
-   * @param allowedAccountTypes types of BCeID account that can be created. For instance,
+   * @param allowedAccountTypes types of BCeID accounts that can be created. For instance,
    * basic BCeID accounts are allowed to be created only by the Ministry users.
    * @returns created user id.
    */

--- a/sources/packages/api/src/route-controllers/institution-user/institution-user.institutions.controller.ts
+++ b/sources/packages/api/src/route-controllers/institution-user/institution-user.institutions.controller.ts
@@ -124,6 +124,10 @@ export class InstitutionUserInstitutionsController extends BaseController {
       "or the user already exists " +
       "or a second legal signing authority is trying to be set when one is already in place.",
   })
+  @ApiForbiddenResponse({
+    description:
+      "The user is not allowed to create the requested BCeID account type.",
+  })
   @IsInstitutionAdmin()
   @Post()
   async createInstitutionUserWithAuth(
@@ -134,6 +138,7 @@ export class InstitutionUserInstitutionsController extends BaseController {
       userToken.authorizations.institutionId,
       payload,
       userToken.userId,
+      BCeIDAccountTypeCodes.Business,
     );
   }
 


### PR DESCRIPTION
Fix the authorization to prevent a basic BCeID user to create a basic BCeID user under the institution.
The UI is hiding the option but the API would accept the request if called directly.