### PR TITLE
[API][SIMS #419] - Restrict CORS on all non-local-development environment

### DIFF
--- a/sources/packages/api/src/main.ts
+++ b/sources/packages/api/src/main.ts
@@ -48,9 +48,16 @@ async function bootstrap() {
   // Getting application port
   const port = process.env.PORT || 3000;
 
-  // TODO: Configure CORS to be as much restrictive as possible.
+  // Only for the development environment, the CORS setting allows
+  // any domain. Otherwise all the web origins(except the same domain where API is hosted)
+  // are restricted.
+  const allowAnyOrigin = process.env.NODE_ENV !== "production";
+
   //TODO: Check for potential security threats in exposing the content-disposition header.
-  app.enableCors({ exposedHeaders: "Content-Disposition" });
+  app.enableCors({
+    exposedHeaders: "Content-Disposition",
+    origin: allowAnyOrigin,
+  });
 
   // Setting express middleware for req
   app.use(LoggerService.apiLogger);

--- a/sources/packages/api/src/utilities/system-configurations-constants.ts
+++ b/sources/packages/api/src/utilities/system-configurations-constants.ts
@@ -99,7 +99,9 @@ export const MAX_UPLOAD_FILES = 1;
  * For multipart forms, the max number of parts (fields + files).
  * 3 means 'the file' + uniqueFileName + group.
  */
-export const MAX_UPLOAD_PARTS = 3;
+// TODO: The value has been set to 4 from 3 to fix the ongoing file upload issue.
+// TODO: On further investigation re-evaluate accordingly.
+export const MAX_UPLOAD_PARTS = 4;
 
 /**
  * Group name associated with the files uploaded by the Ministry


### PR DESCRIPTION
Defined a variable to allow cors request based on environment variable NODE_ENV.

- [x] CORS is restricted on all openshift environments.
- [x] CORS is allowed on local environment as our API(http://localhost:3000) and Web(http://localhost:8080) run on different domain.
- [x] The value of MAX_UPLOAD_PARTS has been updated to 4 from 3. Since with file interceptor is rejecting file with 3 parts if the maximum parts is set to 3. 