### PR TITLE
[API][SIMS #140] change common auditing fields

### DIFF
--- a/sources/packages/api/src-sql/AlterAuditColumns/Add-with-time-zone.sql
+++ b/sources/packages/api/src-sql/AlterAuditColumns/Add-with-time-zone.sql
@@ -1,0 +1,281 @@
+-- Alter created_at column in applications to include timestamp with time zone. --
+ALTER TABLE
+    sims.applications
+ALTER COLUMN
+    created_at TYPE TIMESTAMP WITH TIME ZONE;
+
+-- Alter updated_at column in applications to include timestamp with time zone. --
+ALTER TABLE
+    sims.applications
+ALTER COLUMN
+    updated_at TYPE TIMESTAMP WITH TIME ZONE;
+
+-- Alter created_at column in application_student_files to include timestamp with time zone. --
+ALTER TABLE
+    sims.application_student_files
+ALTER COLUMN
+    created_at TYPE TIMESTAMP WITH TIME ZONE;
+
+-- Alter updated_at column in application_student_files to include timestamp with time zone. --
+ALTER TABLE
+    sims.application_student_files
+ALTER COLUMN
+    updated_at TYPE TIMESTAMP WITH TIME ZONE;
+
+-- Alter created_at column in institution_user_type_roles to include timestamp with time zone. --
+ALTER TABLE
+    sims.institution_user_type_roles
+ALTER COLUMN
+    created_at TYPE TIMESTAMP WITH TIME ZONE;
+
+-- Alter updated_at column in institution_user_type_roles to include timestamp with time zone. --
+ALTER TABLE
+    sims.institution_user_type_roles
+ALTER COLUMN
+    updated_at TYPE TIMESTAMP WITH TIME ZONE;
+
+-- Alter created_at column in coe_denied_reasons to include timestamp with time zone. --
+ALTER TABLE
+    sims.coe_denied_reasons
+ALTER COLUMN
+    created_at TYPE TIMESTAMP WITH TIME ZONE;
+
+-- Alter updated_at column in coe_denied_reasons to include timestamp with time zone. --
+ALTER TABLE
+    sims.coe_denied_reasons
+ALTER COLUMN
+    updated_at TYPE TIMESTAMP WITH TIME ZONE;
+
+-- Alter created_at column in cra_income_verifications to include timestamp with time zone. --
+ALTER TABLE
+    sims.cra_income_verifications
+ALTER COLUMN
+    created_at TYPE TIMESTAMP WITH TIME ZONE;
+
+-- Alter updated_at column in cra_income_verifications to include timestamp with time zone. --
+ALTER TABLE
+    sims.cra_income_verifications
+ALTER COLUMN
+    updated_at TYPE TIMESTAMP WITH TIME ZONE;
+
+-- Alter created_at column in education_programs to include timestamp with time zone. --
+ALTER TABLE
+    sims.education_programs
+ALTER COLUMN
+    created_at TYPE TIMESTAMP WITH TIME ZONE;
+
+-- Alter updated_at column in education_programs to include timestamp with time zone. --
+ALTER TABLE
+    sims.education_programs
+ALTER COLUMN
+    updated_at TYPE TIMESTAMP WITH TIME ZONE;
+
+-- Alter created_at column in education_programs_offerings to include timestamp with time zone. --
+ALTER TABLE
+    sims.education_programs_offerings
+ALTER COLUMN
+    created_at TYPE TIMESTAMP WITH TIME ZONE;
+
+-- Alter updated_at column in education_programs_offerings to include timestamp with time zone. --
+ALTER TABLE
+    sims.education_programs_offerings
+ALTER COLUMN
+    updated_at TYPE TIMESTAMP WITH TIME ZONE;
+
+-- Alter created_at column in institutions to include timestamp with time zone. --
+ALTER TABLE
+    sims.institutions
+ALTER COLUMN
+    created_at TYPE TIMESTAMP WITH TIME ZONE;
+
+-- Alter updated_at column in institutions to include timestamp with time zone. --
+ALTER TABLE
+    sims.institutions
+ALTER COLUMN
+    updated_at TYPE TIMESTAMP WITH TIME ZONE;
+
+-- Alter created_at column in institution_users to include timestamp with time zone. --
+ALTER TABLE
+    sims.institution_users
+ALTER COLUMN
+    created_at TYPE TIMESTAMP WITH TIME ZONE;
+
+-- Alter updated_at column in institution_users to include timestamp with time zone. --
+ALTER TABLE
+    sims.institution_users
+ALTER COLUMN
+    updated_at TYPE TIMESTAMP WITH TIME ZONE;
+
+-- Alter created_at column in institution_user_auth to include timestamp with time zone. --
+ALTER TABLE
+    sims.institution_user_auth
+ALTER COLUMN
+    created_at TYPE TIMESTAMP WITH TIME ZONE;
+
+-- Alter updated_at column in institution_user_auth to include timestamp with time zone. --
+ALTER TABLE
+    sims.institution_user_auth
+ALTER COLUMN
+    updated_at TYPE TIMESTAMP WITH TIME ZONE;
+
+-- Alter created_at column in institution_locations to include timestamp with time zone. --
+ALTER TABLE
+    sims.institution_locations
+ALTER COLUMN
+    created_at TYPE TIMESTAMP WITH TIME ZONE;
+
+-- Alter updated_at column in institution_locations to include timestamp with time zone. --
+ALTER TABLE
+    sims.institution_locations
+ALTER COLUMN
+    updated_at TYPE TIMESTAMP WITH TIME ZONE;
+
+-- Alter created_at column in institution_type to include timestamp with time zone. --
+ALTER TABLE
+    sims.institution_type
+ALTER COLUMN
+    created_at TYPE TIMESTAMP WITH TIME ZONE;
+
+-- Alter updated_at column in institution_type to include timestamp with time zone. --
+ALTER TABLE
+    sims.institution_type
+ALTER COLUMN
+    updated_at TYPE TIMESTAMP WITH TIME ZONE;
+
+-- Alter created_at column in institution_users to include timestamp with time zone. --
+ALTER TABLE
+    sims.institution_users
+ALTER COLUMN
+    created_at TYPE TIMESTAMP WITH TIME ZONE;
+
+-- Alter updated_at column in institution_users to include timestamp with time zone. --
+ALTER TABLE
+    sims.institution_users
+ALTER COLUMN
+    updated_at TYPE TIMESTAMP WITH TIME ZONE;
+
+-- Alter created_at column in msfaa_numbers to include timestamp with time zone. --
+ALTER TABLE
+    sims.msfaa_numbers
+ALTER COLUMN
+    created_at TYPE TIMESTAMP WITH TIME ZONE;
+
+-- Alter updated_at column in msfaa_numbers to include timestamp with time zone. --
+ALTER TABLE
+    sims.msfaa_numbers
+ALTER COLUMN
+    updated_at TYPE TIMESTAMP WITH TIME ZONE;
+
+-- Alter created_at column in pir_denied_reason to include timestamp with time zone. --
+ALTER TABLE
+    sims.pir_denied_reason
+ALTER COLUMN
+    created_at TYPE TIMESTAMP WITH TIME ZONE;
+
+-- Alter updated_at column in pir_denied_reason to include timestamp with time zone. --
+ALTER TABLE
+    sims.pir_denied_reason
+ALTER COLUMN
+    updated_at TYPE TIMESTAMP WITH TIME ZONE;
+
+-- Alter created_at column in program_years to include timestamp with time zone. --
+ALTER TABLE
+    sims.program_years
+ALTER COLUMN
+    created_at TYPE TIMESTAMP WITH TIME ZONE;
+
+-- Alter updated_at column in program_years to include timestamp with time zone. --
+ALTER TABLE
+    sims.program_years
+ALTER COLUMN
+    updated_at TYPE TIMESTAMP WITH TIME ZONE;
+
+-- Alter created_at column in federal_restrictions to include timestamp with time zone. --
+ALTER TABLE
+    sims.federal_restrictions
+ALTER COLUMN
+    created_at TYPE TIMESTAMP WITH TIME ZONE;
+
+-- Alter created_at column in restrictions to include timestamp with time zone. --
+ALTER TABLE
+    sims.restrictions
+ALTER COLUMN
+    created_at TYPE TIMESTAMP WITH TIME ZONE;
+
+-- Alter updated_at column in restrictions to include timestamp with time zone. --
+ALTER TABLE
+    sims.restrictions
+ALTER COLUMN
+    updated_at TYPE TIMESTAMP WITH TIME ZONE;
+
+-- Alter created_at column in student_restrictions to include timestamp with time zone. --
+ALTER TABLE
+    sims.student_restrictions
+ALTER COLUMN
+    created_at TYPE TIMESTAMP WITH TIME ZONE;
+
+-- Alter updated_at column in student_restrictions to include timestamp with time zone. --
+ALTER TABLE
+    sims.student_restrictions
+ALTER COLUMN
+    updated_at TYPE TIMESTAMP WITH TIME ZONE;
+
+-- Alter created_at column in sequence_controls to include timestamp with time zone. --
+ALTER TABLE
+    sims.sequence_controls
+ALTER COLUMN
+    created_at TYPE TIMESTAMP WITH TIME ZONE;
+
+-- Alter updated_at column in sequence_controls to include timestamp with time zone. --
+ALTER TABLE
+    sims.sequence_controls
+ALTER COLUMN
+    updated_at TYPE TIMESTAMP WITH TIME ZONE;
+
+-- Alter created_at column in students to include timestamp with time zone. --
+ALTER TABLE
+    sims.students
+ALTER COLUMN
+    created_at TYPE TIMESTAMP WITH TIME ZONE;
+
+-- Alter updated_at column in students to include timestamp with time zone. --
+ALTER TABLE
+    sims.students
+ALTER COLUMN
+    updated_at TYPE TIMESTAMP WITH TIME ZONE;
+
+-- Alter created_at column in student_files to include timestamp with time zone. --
+ALTER TABLE
+    sims.student_files
+ALTER COLUMN
+    created_at TYPE TIMESTAMP WITH TIME ZONE;
+
+-- Alter updated_at column in student_files to include timestamp with time zone. --
+ALTER TABLE
+    sims.student_files
+ALTER COLUMN
+    updated_at TYPE TIMESTAMP WITH TIME ZONE;
+
+-- Alter created_at column in supporting_users to include timestamp with time zone. --
+ALTER TABLE
+    sims.supporting_users
+ALTER COLUMN
+    created_at TYPE TIMESTAMP WITH TIME ZONE;
+
+-- Alter updated_at column in supporting_users to include timestamp with time zone. --
+ALTER TABLE
+    sims.supporting_users
+ALTER COLUMN
+    updated_at TYPE TIMESTAMP WITH TIME ZONE;
+
+-- Alter created_at column in users to include timestamp with time zone. --
+ALTER TABLE
+    sims.users
+ALTER COLUMN
+    created_at TYPE TIMESTAMP WITH TIME ZONE;
+
+-- Alter updated_at column in users to include timestamp with time zone. --
+ALTER TABLE
+    sims.users
+ALTER COLUMN
+    updated_at TYPE TIMESTAMP WITH TIME ZONE;

--- a/sources/packages/api/src-sql/AlterAuditColumns/Rollback-without-time-zone.sql
+++ b/sources/packages/api/src-sql/AlterAuditColumns/Rollback-without-time-zone.sql
@@ -1,280 +1,280 @@
--- Alter created_at column in applications to include timestamp WITHOUT time zone. --
+-- Alter created_at column in applications to include timestamp without time zone. --
 ALTER TABLE
     sims.applications
 ALTER COLUMN
     created_at TYPE TIMESTAMP WITHOUT TIME ZONE;
 
--- Alter updated_at column in applications to include timestamp WITHOUT time zone. --
+-- Alter updated_at column in applications to include timestamp without time zone. --
 ALTER TABLE
     sims.applications
 ALTER COLUMN
     updated_at TYPE TIMESTAMP WITHOUT TIME ZONE;
 
--- Alter created_at column in application_student_files to include timestamp WITHOUT time zone. --
+-- Alter created_at column in application_student_files to include timestamp without time zone. --
 ALTER TABLE
     sims.application_student_files
 ALTER COLUMN
     created_at TYPE TIMESTAMP WITHOUT TIME ZONE;
 
--- Alter updated_at column in application_student_files to include timestamp WITHOUT time zone. --
+-- Alter updated_at column in application_student_files to include timestamp without time zone. --
 ALTER TABLE
     sims.application_student_files
 ALTER COLUMN
     updated_at TYPE TIMESTAMP WITHOUT TIME ZONE;
 
--- Alter created_at column in institution_user_type_roles to include timestamp WITHOUT time zone. --
+-- Alter created_at column in institution_user_type_roles to include timestamp without time zone. --
 ALTER TABLE
     sims.institution_user_type_roles
 ALTER COLUMN
     created_at TYPE TIMESTAMP WITHOUT TIME ZONE;
 
--- Alter updated_at column in institution_user_type_roles to include timestamp WITHOUT time zone. --
+-- Alter updated_at column in institution_user_type_roles to include timestamp without time zone. --
 ALTER TABLE
     sims.institution_user_type_roles
 ALTER COLUMN
     updated_at TYPE TIMESTAMP WITHOUT TIME ZONE;
 
--- Alter created_at column in coe_denied_reasons to include timestamp WITHOUT time zone. --
+-- Alter created_at column in coe_denied_reasons to include timestamp without time zone. --
 ALTER TABLE
     sims.coe_denied_reasons
 ALTER COLUMN
     created_at TYPE TIMESTAMP WITHOUT TIME ZONE;
 
--- Alter updated_at column in coe_denied_reasons to include timestamp WITHOUT time zone. --
+-- Alter updated_at column in coe_denied_reasons to include timestamp without time zone. --
 ALTER TABLE
     sims.coe_denied_reasons
 ALTER COLUMN
     updated_at TYPE TIMESTAMP WITHOUT TIME ZONE;
 
--- Alter created_at column in cra_income_verifications to include timestamp WITHOUT time zone. --
+-- Alter created_at column in cra_income_verifications to include timestamp without time zone. --
 ALTER TABLE
     sims.cra_income_verifications
 ALTER COLUMN
     created_at TYPE TIMESTAMP WITHOUT TIME ZONE;
 
--- Alter updated_at column in cra_income_verifications to include timestamp WITHOUT time zone. --
+-- Alter updated_at column in cra_income_verifications to include timestamp without time zone. --
 ALTER TABLE
     sims.cra_income_verifications
 ALTER COLUMN
     updated_at TYPE TIMESTAMP WITHOUT TIME ZONE;
 
--- Alter created_at column in education_programs to include timestamp WITHOUT time zone. --
+-- Alter created_at column in education_programs to include timestamp without time zone. --
 ALTER TABLE
     sims.education_programs
 ALTER COLUMN
     created_at TYPE TIMESTAMP WITHOUT TIME ZONE;
 
--- Alter updated_at column in education_programs to include timestamp WITHOUT time zone. --
+-- Alter updated_at column in education_programs to include timestamp without time zone. --
 ALTER TABLE
     sims.education_programs
 ALTER COLUMN
     updated_at TYPE TIMESTAMP WITHOUT TIME ZONE;
 
--- Alter created_at column in education_programs_offerings to include timestamp WITHOUT time zone. --
+-- Alter created_at column in education_programs_offerings to include timestamp without time zone. --
 ALTER TABLE
     sims.education_programs_offerings
 ALTER COLUMN
     created_at TYPE TIMESTAMP WITHOUT TIME ZONE;
 
--- Alter updated_at column in education_programs_offerings to include timestamp WITHOUT time zone. --
+-- Alter updated_at column in education_programs_offerings to include timestamp without time zone. --
 ALTER TABLE
     sims.education_programs_offerings
 ALTER COLUMN
     updated_at TYPE TIMESTAMP WITHOUT TIME ZONE;
 
--- Alter created_at column in institutions to include timestamp WITHOUT time zone. --
+-- Alter created_at column in institutions to include timestamp without time zone. --
 ALTER TABLE
     sims.institutions
 ALTER COLUMN
     created_at TYPE TIMESTAMP WITHOUT TIME ZONE;
 
--- Alter updated_at column in institutions to include timestamp WITHOUT time zone. --
+-- Alter updated_at column in institutions to include timestamp without time zone. --
 ALTER TABLE
     sims.institutions
 ALTER COLUMN
     updated_at TYPE TIMESTAMP WITHOUT TIME ZONE;
 
--- Alter created_at column in institution_users to include timestamp WITHOUT time zone. --
+-- Alter created_at column in institution_users to include timestamp without time zone. --
 ALTER TABLE
     sims.institution_users
 ALTER COLUMN
     created_at TYPE TIMESTAMP WITHOUT TIME ZONE;
 
--- Alter updated_at column in institution_users to include timestamp WITHOUT time zone. --
+-- Alter updated_at column in institution_users to include timestamp without time zone. --
 ALTER TABLE
     sims.institution_users
 ALTER COLUMN
     updated_at TYPE TIMESTAMP WITHOUT TIME ZONE;
 
--- Alter created_at column in institution_user_auth to include timestamp WITHOUT time zone. --
+-- Alter created_at column in institution_user_auth to include timestamp without time zone. --
 ALTER TABLE
     sims.institution_user_auth
 ALTER COLUMN
     created_at TYPE TIMESTAMP WITHOUT TIME ZONE;
 
--- Alter updated_at column in institution_user_auth to include timestamp WITHOUT time zone. --
+-- Alter updated_at column in institution_user_auth to include timestamp without time zone. --
 ALTER TABLE
     sims.institution_user_auth
 ALTER COLUMN
     updated_at TYPE TIMESTAMP WITHOUT TIME ZONE;
 
--- Alter created_at column in institution_locations to include timestamp WITHOUT time zone. --
+-- Alter created_at column in institution_locations to include timestamp without time zone. --
 ALTER TABLE
     sims.institution_locations
 ALTER COLUMN
     created_at TYPE TIMESTAMP WITHOUT TIME ZONE;
 
--- Alter updated_at column in institution_locations to include timestamp WITHOUT time zone. --
+-- Alter updated_at column in institution_locations to include timestamp without time zone. --
 ALTER TABLE
     sims.institution_locations
 ALTER COLUMN
     updated_at TYPE TIMESTAMP WITHOUT TIME ZONE;
 
--- Alter created_at column in institution_type to include timestamp WITHOUT time zone. --
+-- Alter created_at column in institution_type to include timestamp without time zone. --
 ALTER TABLE
     sims.institution_type
 ALTER COLUMN
     created_at TYPE TIMESTAMP WITHOUT TIME ZONE;
 
--- Alter updated_at column in institution_type to include timestamp WITHOUT time zone. --
+-- Alter updated_at column in institution_type to include timestamp without time zone. --
 ALTER TABLE
     sims.institution_type
 ALTER COLUMN
     updated_at TYPE TIMESTAMP WITHOUT TIME ZONE;
 
--- Alter created_at column in institution_users to include timestamp WITHOUT time zone. --
+-- Alter created_at column in institution_users to include timestamp without time zone. --
 ALTER TABLE
     sims.institution_users
 ALTER COLUMN
     created_at TYPE TIMESTAMP WITHOUT TIME ZONE;
 
--- Alter updated_at column in institution_users to include timestamp WITHOUT time zone. --
+-- Alter updated_at column in institution_users to include timestamp without time zone. --
 ALTER TABLE
     sims.institution_users
 ALTER COLUMN
     updated_at TYPE TIMESTAMP WITHOUT TIME ZONE;
 
--- Alter created_at column in msfaa_numbers to include timestamp WITHOUT time zone. --
+-- Alter created_at column in msfaa_numbers to include timestamp without time zone. --
 ALTER TABLE
     sims.msfaa_numbers
 ALTER COLUMN
     created_at TYPE TIMESTAMP WITHOUT TIME ZONE;
 
--- Alter updated_at column in msfaa_numbers to include timestamp WITHOUT time zone. --
+-- Alter updated_at column in msfaa_numbers to include timestamp without time zone. --
 ALTER TABLE
     sims.msfaa_numbers
 ALTER COLUMN
     updated_at TYPE TIMESTAMP WITHOUT TIME ZONE;
 
--- Alter created_at column in pir_denied_reason to include timestamp WITHOUT time zone. --
+-- Alter created_at column in pir_denied_reason to include timestamp without time zone. --
 ALTER TABLE
     sims.pir_denied_reason
 ALTER COLUMN
     created_at TYPE TIMESTAMP WITHOUT TIME ZONE;
 
--- Alter updated_at column in pir_denied_reason to include timestamp WITHOUT time zone. --
+-- Alter updated_at column in pir_denied_reason to include timestamp without time zone. --
 ALTER TABLE
     sims.pir_denied_reason
 ALTER COLUMN
     updated_at TYPE TIMESTAMP WITHOUT TIME ZONE;
 
--- Alter created_at column in program_years to include timestamp WITHOUT time zone. --
+-- Alter created_at column in program_years to include timestamp without time zone. --
 ALTER TABLE
     sims.program_years
 ALTER COLUMN
     created_at TYPE TIMESTAMP WITHOUT TIME ZONE;
 
--- Alter updated_at column in program_years to include timestamp WITHOUT time zone. --
+-- Alter updated_at column in program_years to include timestamp without time zone. --
 ALTER TABLE
     sims.program_years
 ALTER COLUMN
     updated_at TYPE TIMESTAMP WITHOUT TIME ZONE;
 
--- Alter created_at column in federal_restrictions to include timestamp WITHOUT time zone. --
+-- Alter created_at column in federal_restrictions to include timestamp without time zone. --
 ALTER TABLE
     sims.federal_restrictions
 ALTER COLUMN
     created_at TYPE TIMESTAMP WITHOUT TIME ZONE;
 
--- Alter created_at column in restrictions to include timestamp WITHOUT time zone. --
+-- Alter created_at column in restrictions to include timestamp without time zone. --
 ALTER TABLE
     sims.restrictions
 ALTER COLUMN
     created_at TYPE TIMESTAMP WITHOUT TIME ZONE;
 
--- Alter updated_at column in restrictions to include timestamp WITHOUT time zone. --
+-- Alter updated_at column in restrictions to include timestamp without time zone. --
 ALTER TABLE
     sims.restrictions
 ALTER COLUMN
     updated_at TYPE TIMESTAMP WITHOUT TIME ZONE;
 
--- Alter created_at column in student_restrictions to include timestamp WITHOUT time zone. --
+-- Alter created_at column in student_restrictions to include timestamp without time zone. --
 ALTER TABLE
     sims.student_restrictions
 ALTER COLUMN
     created_at TYPE TIMESTAMP WITHOUT TIME ZONE;
 
--- Alter updated_at column in student_restrictions to include timestamp WITHOUT time zone. --
+-- Alter updated_at column in student_restrictions to include timestamp without time zone. --
 ALTER TABLE
     sims.student_restrictions
 ALTER COLUMN
     updated_at TYPE TIMESTAMP WITHOUT TIME ZONE;
 
--- Alter created_at column in sequence_controls to include timestamp WITHOUT time zone. --
+-- Alter created_at column in sequence_controls to include timestamp without time zone. --
 ALTER TABLE
     sims.sequence_controls
 ALTER COLUMN
     created_at TYPE TIMESTAMP WITHOUT TIME ZONE;
 
--- Alter updated_at column in sequence_controls to include timestamp WITHOUT time zone. --
+-- Alter updated_at column in sequence_controls to include timestamp without time zone. --
 ALTER TABLE
     sims.sequence_controls
 ALTER COLUMN
     updated_at TYPE TIMESTAMP WITHOUT TIME ZONE;
 
--- Alter created_at column in students to include timestamp WITHOUT time zone. --
+-- Alter created_at column in students to include timestamp without time zone. --
 ALTER TABLE
     sims.students
 ALTER COLUMN
     created_at TYPE TIMESTAMP WITHOUT TIME ZONE;
 
--- Alter updated_at column in students to include timestamp WITHOUT time zone. --
+-- Alter updated_at column in students to include timestamp without time zone. --
 ALTER TABLE
     sims.students
 ALTER COLUMN
     updated_at TYPE TIMESTAMP WITHOUT TIME ZONE;
 
--- Alter created_at column in student_files to include timestamp WITHOUT time zone. --
+-- Alter created_at column in student_files to include timestamp without time zone. --
 ALTER TABLE
     sims.student_files
 ALTER COLUMN
     created_at TYPE TIMESTAMP WITHOUT TIME ZONE;
 
--- Alter updated_at column in student_files to include timestamp WITHOUT time zone. --
+-- Alter updated_at column in student_files to include timestamp without time zone. --
 ALTER TABLE
     sims.student_files
 ALTER COLUMN
     updated_at TYPE TIMESTAMP WITHOUT TIME ZONE;
 
--- Alter created_at column in supporting_users to include timestamp WITHOUT time zone. --
+-- Alter created_at column in supporting_users to include timestamp without time zone. --
 ALTER TABLE
     sims.supporting_users
 ALTER COLUMN
     created_at TYPE TIMESTAMP WITHOUT TIME ZONE;
 
--- Alter updated_at column in supporting_users to include timestamp WITHOUT time zone. --
+-- Alter updated_at column in supporting_users to include timestamp without time zone. --
 ALTER TABLE
     sims.supporting_users
 ALTER COLUMN
     updated_at TYPE TIMESTAMP WITHOUT TIME ZONE;
 
--- Alter created_at column in users to include timestamp WITHOUT time zone. --
+-- Alter created_at column in users to include timestamp without time zone. --
 ALTER TABLE
     sims.users
 ALTER COLUMN
     created_at TYPE TIMESTAMP WITHOUT TIME ZONE;
 
--- Alter updated_at column in users to include timestamp WITHOUT time zone. --
+-- Alter updated_at column in users to include timestamp without time zone. --
 ALTER TABLE
     sims.users
 ALTER COLUMN

--- a/sources/packages/api/src-sql/AlterAuditColumns/Rollback-without-time-zone.sql
+++ b/sources/packages/api/src-sql/AlterAuditColumns/Rollback-without-time-zone.sql
@@ -1,0 +1,281 @@
+-- Alter created_at column in applications to include timestamp WITHOUT time zone. --
+ALTER TABLE
+    sims.applications
+ALTER COLUMN
+    created_at TYPE TIMESTAMP WITHOUT TIME ZONE;
+
+-- Alter updated_at column in applications to include timestamp WITHOUT time zone. --
+ALTER TABLE
+    sims.applications
+ALTER COLUMN
+    updated_at TYPE TIMESTAMP WITHOUT TIME ZONE;
+
+-- Alter created_at column in application_student_files to include timestamp WITHOUT time zone. --
+ALTER TABLE
+    sims.application_student_files
+ALTER COLUMN
+    created_at TYPE TIMESTAMP WITHOUT TIME ZONE;
+
+-- Alter updated_at column in application_student_files to include timestamp WITHOUT time zone. --
+ALTER TABLE
+    sims.application_student_files
+ALTER COLUMN
+    updated_at TYPE TIMESTAMP WITHOUT TIME ZONE;
+
+-- Alter created_at column in institution_user_type_roles to include timestamp WITHOUT time zone. --
+ALTER TABLE
+    sims.institution_user_type_roles
+ALTER COLUMN
+    created_at TYPE TIMESTAMP WITHOUT TIME ZONE;
+
+-- Alter updated_at column in institution_user_type_roles to include timestamp WITHOUT time zone. --
+ALTER TABLE
+    sims.institution_user_type_roles
+ALTER COLUMN
+    updated_at TYPE TIMESTAMP WITHOUT TIME ZONE;
+
+-- Alter created_at column in coe_denied_reasons to include timestamp WITHOUT time zone. --
+ALTER TABLE
+    sims.coe_denied_reasons
+ALTER COLUMN
+    created_at TYPE TIMESTAMP WITHOUT TIME ZONE;
+
+-- Alter updated_at column in coe_denied_reasons to include timestamp WITHOUT time zone. --
+ALTER TABLE
+    sims.coe_denied_reasons
+ALTER COLUMN
+    updated_at TYPE TIMESTAMP WITHOUT TIME ZONE;
+
+-- Alter created_at column in cra_income_verifications to include timestamp WITHOUT time zone. --
+ALTER TABLE
+    sims.cra_income_verifications
+ALTER COLUMN
+    created_at TYPE TIMESTAMP WITHOUT TIME ZONE;
+
+-- Alter updated_at column in cra_income_verifications to include timestamp WITHOUT time zone. --
+ALTER TABLE
+    sims.cra_income_verifications
+ALTER COLUMN
+    updated_at TYPE TIMESTAMP WITHOUT TIME ZONE;
+
+-- Alter created_at column in education_programs to include timestamp WITHOUT time zone. --
+ALTER TABLE
+    sims.education_programs
+ALTER COLUMN
+    created_at TYPE TIMESTAMP WITHOUT TIME ZONE;
+
+-- Alter updated_at column in education_programs to include timestamp WITHOUT time zone. --
+ALTER TABLE
+    sims.education_programs
+ALTER COLUMN
+    updated_at TYPE TIMESTAMP WITHOUT TIME ZONE;
+
+-- Alter created_at column in education_programs_offerings to include timestamp WITHOUT time zone. --
+ALTER TABLE
+    sims.education_programs_offerings
+ALTER COLUMN
+    created_at TYPE TIMESTAMP WITHOUT TIME ZONE;
+
+-- Alter updated_at column in education_programs_offerings to include timestamp WITHOUT time zone. --
+ALTER TABLE
+    sims.education_programs_offerings
+ALTER COLUMN
+    updated_at TYPE TIMESTAMP WITHOUT TIME ZONE;
+
+-- Alter created_at column in institutions to include timestamp WITHOUT time zone. --
+ALTER TABLE
+    sims.institutions
+ALTER COLUMN
+    created_at TYPE TIMESTAMP WITHOUT TIME ZONE;
+
+-- Alter updated_at column in institutions to include timestamp WITHOUT time zone. --
+ALTER TABLE
+    sims.institutions
+ALTER COLUMN
+    updated_at TYPE TIMESTAMP WITHOUT TIME ZONE;
+
+-- Alter created_at column in institution_users to include timestamp WITHOUT time zone. --
+ALTER TABLE
+    sims.institution_users
+ALTER COLUMN
+    created_at TYPE TIMESTAMP WITHOUT TIME ZONE;
+
+-- Alter updated_at column in institution_users to include timestamp WITHOUT time zone. --
+ALTER TABLE
+    sims.institution_users
+ALTER COLUMN
+    updated_at TYPE TIMESTAMP WITHOUT TIME ZONE;
+
+-- Alter created_at column in institution_user_auth to include timestamp WITHOUT time zone. --
+ALTER TABLE
+    sims.institution_user_auth
+ALTER COLUMN
+    created_at TYPE TIMESTAMP WITHOUT TIME ZONE;
+
+-- Alter updated_at column in institution_user_auth to include timestamp WITHOUT time zone. --
+ALTER TABLE
+    sims.institution_user_auth
+ALTER COLUMN
+    updated_at TYPE TIMESTAMP WITHOUT TIME ZONE;
+
+-- Alter created_at column in institution_locations to include timestamp WITHOUT time zone. --
+ALTER TABLE
+    sims.institution_locations
+ALTER COLUMN
+    created_at TYPE TIMESTAMP WITHOUT TIME ZONE;
+
+-- Alter updated_at column in institution_locations to include timestamp WITHOUT time zone. --
+ALTER TABLE
+    sims.institution_locations
+ALTER COLUMN
+    updated_at TYPE TIMESTAMP WITHOUT TIME ZONE;
+
+-- Alter created_at column in institution_type to include timestamp WITHOUT time zone. --
+ALTER TABLE
+    sims.institution_type
+ALTER COLUMN
+    created_at TYPE TIMESTAMP WITHOUT TIME ZONE;
+
+-- Alter updated_at column in institution_type to include timestamp WITHOUT time zone. --
+ALTER TABLE
+    sims.institution_type
+ALTER COLUMN
+    updated_at TYPE TIMESTAMP WITHOUT TIME ZONE;
+
+-- Alter created_at column in institution_users to include timestamp WITHOUT time zone. --
+ALTER TABLE
+    sims.institution_users
+ALTER COLUMN
+    created_at TYPE TIMESTAMP WITHOUT TIME ZONE;
+
+-- Alter updated_at column in institution_users to include timestamp WITHOUT time zone. --
+ALTER TABLE
+    sims.institution_users
+ALTER COLUMN
+    updated_at TYPE TIMESTAMP WITHOUT TIME ZONE;
+
+-- Alter created_at column in msfaa_numbers to include timestamp WITHOUT time zone. --
+ALTER TABLE
+    sims.msfaa_numbers
+ALTER COLUMN
+    created_at TYPE TIMESTAMP WITHOUT TIME ZONE;
+
+-- Alter updated_at column in msfaa_numbers to include timestamp WITHOUT time zone. --
+ALTER TABLE
+    sims.msfaa_numbers
+ALTER COLUMN
+    updated_at TYPE TIMESTAMP WITHOUT TIME ZONE;
+
+-- Alter created_at column in pir_denied_reason to include timestamp WITHOUT time zone. --
+ALTER TABLE
+    sims.pir_denied_reason
+ALTER COLUMN
+    created_at TYPE TIMESTAMP WITHOUT TIME ZONE;
+
+-- Alter updated_at column in pir_denied_reason to include timestamp WITHOUT time zone. --
+ALTER TABLE
+    sims.pir_denied_reason
+ALTER COLUMN
+    updated_at TYPE TIMESTAMP WITHOUT TIME ZONE;
+
+-- Alter created_at column in program_years to include timestamp WITHOUT time zone. --
+ALTER TABLE
+    sims.program_years
+ALTER COLUMN
+    created_at TYPE TIMESTAMP WITHOUT TIME ZONE;
+
+-- Alter updated_at column in program_years to include timestamp WITHOUT time zone. --
+ALTER TABLE
+    sims.program_years
+ALTER COLUMN
+    updated_at TYPE TIMESTAMP WITHOUT TIME ZONE;
+
+-- Alter created_at column in federal_restrictions to include timestamp WITHOUT time zone. --
+ALTER TABLE
+    sims.federal_restrictions
+ALTER COLUMN
+    created_at TYPE TIMESTAMP WITHOUT TIME ZONE;
+
+-- Alter created_at column in restrictions to include timestamp WITHOUT time zone. --
+ALTER TABLE
+    sims.restrictions
+ALTER COLUMN
+    created_at TYPE TIMESTAMP WITHOUT TIME ZONE;
+
+-- Alter updated_at column in restrictions to include timestamp WITHOUT time zone. --
+ALTER TABLE
+    sims.restrictions
+ALTER COLUMN
+    updated_at TYPE TIMESTAMP WITHOUT TIME ZONE;
+
+-- Alter created_at column in student_restrictions to include timestamp WITHOUT time zone. --
+ALTER TABLE
+    sims.student_restrictions
+ALTER COLUMN
+    created_at TYPE TIMESTAMP WITHOUT TIME ZONE;
+
+-- Alter updated_at column in student_restrictions to include timestamp WITHOUT time zone. --
+ALTER TABLE
+    sims.student_restrictions
+ALTER COLUMN
+    updated_at TYPE TIMESTAMP WITHOUT TIME ZONE;
+
+-- Alter created_at column in sequence_controls to include timestamp WITHOUT time zone. --
+ALTER TABLE
+    sims.sequence_controls
+ALTER COLUMN
+    created_at TYPE TIMESTAMP WITHOUT TIME ZONE;
+
+-- Alter updated_at column in sequence_controls to include timestamp WITHOUT time zone. --
+ALTER TABLE
+    sims.sequence_controls
+ALTER COLUMN
+    updated_at TYPE TIMESTAMP WITHOUT TIME ZONE;
+
+-- Alter created_at column in students to include timestamp WITHOUT time zone. --
+ALTER TABLE
+    sims.students
+ALTER COLUMN
+    created_at TYPE TIMESTAMP WITHOUT TIME ZONE;
+
+-- Alter updated_at column in students to include timestamp WITHOUT time zone. --
+ALTER TABLE
+    sims.students
+ALTER COLUMN
+    updated_at TYPE TIMESTAMP WITHOUT TIME ZONE;
+
+-- Alter created_at column in student_files to include timestamp WITHOUT time zone. --
+ALTER TABLE
+    sims.student_files
+ALTER COLUMN
+    created_at TYPE TIMESTAMP WITHOUT TIME ZONE;
+
+-- Alter updated_at column in student_files to include timestamp WITHOUT time zone. --
+ALTER TABLE
+    sims.student_files
+ALTER COLUMN
+    updated_at TYPE TIMESTAMP WITHOUT TIME ZONE;
+
+-- Alter created_at column in supporting_users to include timestamp WITHOUT time zone. --
+ALTER TABLE
+    sims.supporting_users
+ALTER COLUMN
+    created_at TYPE TIMESTAMP WITHOUT TIME ZONE;
+
+-- Alter updated_at column in supporting_users to include timestamp WITHOUT time zone. --
+ALTER TABLE
+    sims.supporting_users
+ALTER COLUMN
+    updated_at TYPE TIMESTAMP WITHOUT TIME ZONE;
+
+-- Alter created_at column in users to include timestamp WITHOUT time zone. --
+ALTER TABLE
+    sims.users
+ALTER COLUMN
+    created_at TYPE TIMESTAMP WITHOUT TIME ZONE;
+
+-- Alter updated_at column in users to include timestamp WITHOUT time zone. --
+ALTER TABLE
+    sims.users
+ALTER COLUMN
+    updated_at TYPE TIMESTAMP WITHOUT TIME ZONE;

--- a/sources/packages/api/src/database/migrations/1662585116277-AlterAuditColumns.ts
+++ b/sources/packages/api/src/database/migrations/1662585116277-AlterAuditColumns.ts
@@ -1,0 +1,16 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+import { getSQLFileData } from "../../utilities";
+
+export class AlterAuditColumns1662585116277 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      getSQLFileData("Add-with-time-zone.sql", "AlterAuditColumns"),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      getSQLFileData("Rollback-without-time-zone.sql", "AlterAuditColumns"),
+    );
+  }
+}


### PR DESCRIPTION
- Created migration script to alter all common auditing fields (created_at and updated_at) to use the same date type "timestamp with time zone". 

- The script above applies only to tables where the auditing fields were created using timestamp without time zone.