### PR TITLE
[api][SIMS #1341]Validation fixes.

### DIFF
--- a/sources/packages/api/src/services/education-program-offering/education-program-offering-import-csv.service.ts
+++ b/sources/packages/api/src/services/education-program-offering/education-program-offering-import-csv.service.ts
@@ -66,7 +66,10 @@ export class EducationProgramOfferingImportCSVService {
       studyStartDate: csvModel.studyStartDate,
       studyEndDate: csvModel.studyEndDate,
       lacksStudyBreaks: csvModel.hasStudyBreaks == YesNoOptions.No,
-      studyBreaks: csvModel.studyBreaks,
+      studyBreaks:
+        csvModel.hasStudyBreaks == YesNoOptions.Yes
+          ? csvModel.studyBreaks
+          : null,
       actualTuitionCosts: csvModel.actualTuitionCosts,
       programRelatedCosts: csvModel.programRelatedCosts,
       mandatoryFees: csvModel.mandatoryFees,
@@ -166,7 +169,7 @@ export class EducationProgramOfferingImportCSVService {
       offeringModels.push(offeringModel);
       offeringModel.institutionLocationCode = line[CSVHeaders.locationCode];
       offeringModel.sabcProgramCode = line[CSVHeaders.sabcProgramCode];
-      offeringModel.offeringName = line[CSVHeaders.offeringName];
+      offeringModel.offeringName = line[CSVHeaders.offeringName]?.trim();
       offeringModel.yearOfStudy = line[CSVHeaders.yearOfStudy];
       offeringModel.showYearOfStudy = line[CSVHeaders.showYearOfStudy];
       offeringModel.offeringIntensity = line[CSVHeaders.offeringIntensity];
@@ -174,7 +177,8 @@ export class EducationProgramOfferingImportCSVService {
       offeringModel.courseLoad = line[CSVHeaders.courseLoad];
       offeringModel.offeringDelivered = line[CSVHeaders.deliveredType];
       offeringModel.WILComponent = line[CSVHeaders.wilComponent];
-      offeringModel.WILComponentType = line[CSVHeaders.wilComponentType];
+      offeringModel.WILComponentType =
+        line[CSVHeaders.wilComponentType]?.trim();
       offeringModel.studyStartDate = line[CSVHeaders.studyStartDate];
       offeringModel.studyEndDate = line[CSVHeaders.studyEndDate];
       offeringModel.hasStudyBreaks = line[CSVHeaders.hasStudyBreaks];

--- a/sources/packages/api/src/services/education-program-offering/education-program-offering-import-csv.service.ts
+++ b/sources/packages/api/src/services/education-program-offering/education-program-offering-import-csv.service.ts
@@ -65,9 +65,9 @@ export class EducationProgramOfferingImportCSVService {
       offeringWILComponentType: csvModel.WILComponentType,
       studyStartDate: csvModel.studyStartDate,
       studyEndDate: csvModel.studyEndDate,
-      lacksStudyBreaks: csvModel.hasStudyBreaks == YesNoOptions.No,
+      lacksStudyBreaks: csvModel.hasStudyBreaks === YesNoOptions.No,
       studyBreaks:
-        csvModel.hasStudyBreaks == YesNoOptions.Yes
+        csvModel.hasStudyBreaks === YesNoOptions.Yes
           ? csvModel.studyBreaks
           : null,
       actualTuitionCosts: csvModel.actualTuitionCosts,

--- a/sources/packages/api/src/services/education-program-offering/education-program-offering-validation.models.ts
+++ b/sources/packages/api/src/services/education-program-offering/education-program-offering-validation.models.ts
@@ -32,6 +32,7 @@ import {
   PeriodsAreBetweenLimits,
   PeriodMinLength,
   PeriodMaxLength,
+  IsDateAfter,
 } from "../../utilities/class-validation";
 import { Type } from "class-transformer";
 import { ProgramAllowsOfferingIntensity } from "./custom-validators/program-allows-offering-intensity";
@@ -297,6 +298,7 @@ export class OfferingValidationModel {
   @IsDateString(undefined, {
     message: getDateFormatMessage(userFriendlyNames.studyEndDate),
   })
+  @IsDateAfter(studyStartDateProperty, userFriendlyNames.studyEndDate)
   @PeriodMinLength(
     studyStartDateProperty,
     OFFERING_STUDY_PERIOD_MIN_DAYS,

--- a/sources/packages/api/src/utilities/class-validation/custom-validators/is-date-after.ts
+++ b/sources/packages/api/src/utilities/class-validation/custom-validators/is-date-after.ts
@@ -1,0 +1,60 @@
+import {
+  ValidatorConstraintInterface,
+  ValidatorConstraint,
+  registerDecorator,
+  ValidationOptions,
+  ValidationArguments,
+} from "class-validator";
+import { getDateOnlyFormat, isAfter } from "../../date-utils";
+
+/**
+ * Checks if the date decorated is after the date provided as a reference in the
+ * parameter startDateProperty.
+ */
+@ValidatorConstraint()
+class IsDateAfterConstraint implements ValidatorConstraintInterface {
+  validate(value: Date | string, args: ValidationArguments): boolean {
+    const [startDateProperty] = args.constraints;
+    const periodStartDate = startDateProperty(args.object);
+    if (!periodStartDate) {
+      // The related property does not exists in the provided object to be compared.
+      return false;
+    }
+    return isAfter(periodStartDate, value);
+  }
+
+  defaultMessage(args: ValidationArguments) {
+    const [startDateProperty, propertyDisplayName] = args.constraints;
+    const startDate = getDateOnlyFormat(startDateProperty(args.object));
+    return `${
+      propertyDisplayName ?? args.property
+    } must be greater than ${startDate}.`;
+  }
+}
+
+/**
+ * Checks if the date decorated is after the date provided as a reference in the
+ * parameter startDateProperty.
+ * @param startDateProperty start date to be compared with the decorated one.
+ * @param propertyDisplayName user-friendly property name to be added to the
+ * validation message.
+ * @param validationOptions validations options.
+ * @returns true if the date property decorated is greater than the one
+ * provided as a reference in the parameter startDateProperty.
+ */
+export function IsDateAfter(
+  startDateProperty: (targetObject: unknown) => Date | string,
+  propertyDisplayName?: string,
+  validationOptions?: ValidationOptions,
+) {
+  return (object: unknown, propertyName: string) => {
+    registerDecorator({
+      name: "IsDateAfter",
+      target: object.constructor,
+      propertyName,
+      options: validationOptions,
+      constraints: [startDateProperty, propertyDisplayName],
+      validator: IsDateAfterConstraint,
+    });
+  };
+}

--- a/sources/packages/api/src/utilities/class-validation/custom-validators/period-max-length.ts
+++ b/sources/packages/api/src/utilities/class-validation/custom-validators/period-max-length.ts
@@ -5,7 +5,7 @@ import {
   ValidationOptions,
   ValidationArguments,
 } from "class-validator";
-import { dateDifference, getISODateOnlyString } from "../../date-utils";
+import { dateDifference, getDateOnlyFormat } from "../../date-utils";
 
 /**
  * Checks if the number of days between the property date decorated with this
@@ -27,8 +27,8 @@ class PeriodMaxLengthConstraint implements ValidatorConstraintInterface {
   defaultMessage(args: ValidationArguments) {
     const [startDateProperty, maxDaysAllowed, propertyDisplayName] =
       args.constraints;
-    const startDate = getISODateOnlyString(startDateProperty(args.object));
-    const endDate = getISODateOnlyString(args.value);
+    const startDate = getDateOnlyFormat(startDateProperty(args.object));
+    const endDate = getDateOnlyFormat(args.value);
     return `${
       propertyDisplayName ?? args.property
     }, the number of day(s) between ${startDate} and ${endDate} must not be greater than ${maxDaysAllowed}.`;

--- a/sources/packages/api/src/utilities/class-validation/custom-validators/period-min-length.ts
+++ b/sources/packages/api/src/utilities/class-validation/custom-validators/period-min-length.ts
@@ -5,7 +5,7 @@ import {
   ValidationOptions,
   ValidationArguments,
 } from "class-validator";
-import { dateDifference, getISODateOnlyString } from "../../date-utils";
+import { dateDifference, getDateOnlyFormat } from "../../date-utils";
 
 /**
  * Checks if the number of days between the property date decorated with this
@@ -27,8 +27,8 @@ class PeriodMinLengthConstraint implements ValidatorConstraintInterface {
   defaultMessage(args: ValidationArguments) {
     const [startDateProperty, minDaysAllowed, propertyDisplayName] =
       args.constraints;
-    const startDate = getISODateOnlyString(startDateProperty(args.object));
-    const endDate = getISODateOnlyString(args.value);
+    const startDate = getDateOnlyFormat(startDateProperty(args.object));
+    const endDate = getDateOnlyFormat(args.value);
     return `${
       propertyDisplayName ?? args.property
     }, the number of day(s) between ${startDate} and ${endDate} must be at least ${minDaysAllowed}.`;

--- a/sources/packages/api/src/utilities/class-validation/custom-validators/periods-are-between-limits.ts
+++ b/sources/packages/api/src/utilities/class-validation/custom-validators/periods-are-between-limits.ts
@@ -5,7 +5,7 @@ import {
   ValidationOptions,
   ValidationArguments,
 } from "class-validator";
-import { getISODateOnlyString, isBetweenPeriod, Period } from "../..";
+import { getDateOnlyFormat, isBetweenPeriod, Period } from "../..";
 import { getPeriodStartDateProperty, getPeriodEndDateProperty } from "..";
 
 /**
@@ -42,9 +42,9 @@ class PeriodsAreBetweenLimitsConstraint
     const period: Period = this.getPeriodFromArguments(args);
     return `${
       propertyDisplayName ?? args.property
-    } must have all dates between ${getISODateOnlyString(
+    } must have all dates between ${getDateOnlyFormat(
       period.startDate,
-    )} and ${getISODateOnlyString(period.endDate)}.`;
+    )} and ${getDateOnlyFormat(period.endDate)}.`;
   }
 
   private getPeriodFromArguments(args: ValidationArguments): Period {

--- a/sources/packages/api/src/utilities/class-validation/index.ts
+++ b/sources/packages/api/src/utilities/class-validation/index.ts
@@ -6,3 +6,4 @@ export * from "./custom-validators/periods-are-between-limits";
 export * from "./custom-validators/period-min-length";
 export * from "./custom-validators/period-max-length";
 export * from "./validation-utils";
+export * from "./custom-validators/is-date-after";

--- a/sources/packages/api/src/utilities/date-utils.ts
+++ b/sources/packages/api/src/utilities/date-utils.ts
@@ -37,6 +37,19 @@ export const getUTC = (localDate: Date): Date => {
 };
 
 /**
+ * Checks if the end date is after the start date.
+ * @param startDate start date.
+ * @param endDate end date.
+ * @returns true if end date is after start date, otherwise, false.
+ */
+export const isAfter = (
+  startDate: string | Date,
+  endDate: string | Date,
+): boolean => {
+  return dayjs(endDate).isAfter(startDate);
+};
+
+/**
  * Difference in days between endDate and startDate (endDate-startDate).
  * @param endDate end date.
  * @param startDate start date.


### PR DESCRIPTION
Fixes for offering bulk upload validation.
- A new validator was created to generate an error when the end date is not greater than the start state. It was not possible to reuse the period validation.
- Avoid creating study breaks when the property "has study breaks" is not set as `yes`.
- Changed the date format displayed to the user in the validation messages.

![image](https://user-images.githubusercontent.com/61259237/191368114-5a7f8059-38c5-4206-9992-b235cfd78d49.png)
