### PR TITLE
[Web][UI Fix]Align tooltip icons to start slightly over the text

### DIFF
--- a/sources/packages/web/src/components/common/AssessmentAwardDetails.vue
+++ b/sources/packages/web/src/components/common/AssessmentAwardDetails.vue
@@ -111,7 +111,7 @@
               assessmentAwardData.estimatedAward.disbursement2TuitionRemittance
             "
           >
-            <status-info-label :data="{ status: StatusInfo.Completed }">
+            <status-info-label :status="StatusInfo.Completed">
               Tuition remittance applied
               <span class="label-bold"
                 >-${{

--- a/sources/packages/web/src/components/generic/TooltipIcon.vue
+++ b/sources/packages/web/src/components/generic/TooltipIcon.vue
@@ -3,7 +3,7 @@
     <template #activator="{ props }">
       <v-icon
         icon="fa:fas fa-circle-question"
-        class="mx-2"
+        class="mx-2 mt-n1"
         color="secondary"
         size="16"
         v-bind="props"


### PR DESCRIPTION
- [x] Align tooltip icons to start slightly over the text as per figma 
- [x] Fix the assignment value of status-info-label.