### PR TITLE
[API][SIMS #1379] Add custom validator for Query Param

### DIFF
--- a/sources/packages/backend/apps/api/src/route-controllers/application/application.aest.controller.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/application/application.aest.controller.ts
@@ -1,4 +1,10 @@
-import { Controller, Get, NotFoundException, Param } from "@nestjs/common";
+import {
+  Controller,
+  Get,
+  NotFoundException,
+  Param,
+  ParseIntPipe,
+} from "@nestjs/common";
 import { ApplicationService } from "../../services";
 import BaseController from "../BaseController";
 import { GetApplicationBaseDTO } from "./models/application.model";
@@ -31,7 +37,7 @@ export class ApplicationAESTController extends BaseController {
   @ApiOkResponse({ description: "Application details fetched." })
   @ApiNotFoundResponse({ description: "Application not found." })
   async getApplication(
-    @Param("applicationId") applicationId: number,
+    @Param("applicationId", ParseIntPipe) applicationId: number,
   ): Promise<GetApplicationBaseDTO> {
     const application = await this.applicationService.getApplicationByIdAndUser(
       applicationId,

--- a/sources/packages/backend/apps/api/src/route-controllers/application/application.students.controller.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/application/application.students.controller.ts
@@ -11,6 +11,8 @@ import {
   UnprocessableEntityException,
   Query,
   ParseIntPipe,
+  DefaultValuePipe,
+  ParseBoolPipe,
 } from "@nestjs/common";
 import {
   ApplicationService,
@@ -93,7 +95,7 @@ export class ApplicationStudentsController extends BaseController {
     description: "Application id not found.",
   })
   async getByApplicationId(
-    @Param("id") applicationId: number,
+    @Param("id", ParseIntPipe) applicationId: number,
     @UserToken() userToken: IUserToken,
   ): Promise<GetApplicationDataDto> {
     const application = await this.applicationService.getApplicationByIdAndUser(
@@ -154,7 +156,7 @@ export class ApplicationStudentsController extends BaseController {
   })
   async submitApplication(
     @Body() payload: SaveApplicationDto,
-    @Param("applicationId") applicationId: number,
+    @Param("applicationId", ParseIntPipe) applicationId: number,
     @UserToken() studentToken: StudentUserToken,
   ): Promise<void> {
     await this.applicationControllerService.offeringIntensityRestrictionCheck(
@@ -304,7 +306,7 @@ export class ApplicationStudentsController extends BaseController {
   @ApiNotFoundResponse({ description: "APPLICATION_DRAFT_NOT_FOUND." })
   async updateDraftApplication(
     @Body() payload: SaveApplicationDto,
-    @Param("applicationId") applicationId: number,
+    @Param("applicationId", ParseIntPipe) applicationId: number,
     @UserToken() studentToken: StudentUserToken,
   ): Promise<void> {
     try {
@@ -339,7 +341,7 @@ export class ApplicationStudentsController extends BaseController {
   @Patch(":applicationId/status")
   async updateStudentApplicationStatus(
     @UserToken() userToken: IUserToken,
-    @Param("applicationId") applicationId: number,
+    @Param("applicationId", ParseIntPipe) applicationId: number,
     @Body() payload: ApplicationStatusToBeUpdatedDto,
   ): Promise<void> {
     const studentApplication =
@@ -390,8 +392,9 @@ export class ApplicationStudentsController extends BaseController {
   @Get(":applicationId/program-year")
   async programYearOfApplication(
     @UserToken() userToken: IUserToken,
-    @Param("applicationId") applicationId: number,
-    @Query("includeInActivePY") includeInActivePY?: boolean,
+    @Param("applicationId", ParseIntPipe) applicationId: number,
+    @Query("includeInActivePY", new DefaultValuePipe(false), ParseBoolPipe)
+    includeInActivePY: boolean,
   ): Promise<ApplicationWithProgramYearDto> {
     const student = await this.studentService.getStudentByUserId(
       userToken.userId,

--- a/sources/packages/backend/apps/api/src/route-controllers/application/application.students.controller.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/application/application.students.controller.ts
@@ -39,6 +39,7 @@ import {
   ApplicationStatusToBeUpdatedDto,
   ApplicationWithProgramYearDto,
   ApplicationIdentifiersDTO,
+  ApplicationNumberParamAPIInDTO,
 } from "./models/application.model";
 import {
   AllowAuthorizedParty,
@@ -436,13 +437,13 @@ export class ApplicationStudentsController extends BaseController {
   })
   @Get(":applicationNumber/appeal")
   async getApplicationToRequestAppeal(
-    @Param("applicationNumber") applicationNumber: string,
+    @Param() applicationNumberParam: ApplicationNumberParamAPIInDTO,
     @UserToken() userToken: IUserToken,
   ): Promise<ApplicationIdentifiersDTO> {
     const application =
       await this.applicationService.getApplicationToRequestAppeal(
         userToken.userId,
-        applicationNumber,
+        applicationNumberParam.applicationNumber,
       );
     if (!application) {
       throw new NotFoundException(

--- a/sources/packages/backend/apps/api/src/route-controllers/application/models/application.model.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/application/models/application.model.ts
@@ -1,4 +1,4 @@
-import { IsObject, IsOptional, IsPositive } from "class-validator";
+import { IsObject, IsOptional, IsPositive, MaxLength } from "class-validator";
 import {
   ApplicationStatus,
   ProgramInfoStatus,
@@ -109,4 +109,9 @@ export interface ApplicationWithProgramYearDto {
 export enum SuccessWaitingStatus {
   Success = "Success",
   Waiting = "Waiting",
+}
+
+export class ApplicationNumberParamAPIInDTO {
+  @MaxLength(10)
+  applicationNumber: string;
 }

--- a/sources/packages/backend/apps/api/src/route-controllers/assessment/assessment.aest.controller.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/assessment/assessment.aest.controller.ts
@@ -116,7 +116,7 @@ export class AssessmentAESTController extends BaseController {
     description: "Notice of assessment data is not present.",
   })
   async getAssessmentNOA(
-    @Param("assessmentId") assessmentId: number,
+    @Param("assessmentId", ParseIntPipe) assessmentId: number,
   ): Promise<AssessmentNOAAPIOutDTO> {
     return this.assessmentControllerService.getAssessmentNOA(assessmentId);
   }

--- a/sources/packages/backend/apps/api/src/route-controllers/assessment/assessment.students.controller.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/assessment/assessment.students.controller.ts
@@ -59,7 +59,7 @@ export class AssessmentStudentsController extends BaseController {
     description: "Notice of assessment data is not present.",
   })
   async getAssessmentNOA(
-    @Param("assessmentId") assessmentId: number,
+    @Param("assessmentId", ParseIntPipe) assessmentId: number,
     @UserToken() userToken: StudentUserToken,
   ): Promise<AssessmentNOAAPIOutDTO> {
     return this.assessmentControllerService.getAssessmentNOA(
@@ -80,7 +80,7 @@ export class AssessmentStudentsController extends BaseController {
   })
   @Patch(":assessmentId/confirm-assessment")
   async confirmAssessmentNOA(
-    @Param("assessmentId") assessmentId: number,
+    @Param("assessmentId", ParseIntPipe) assessmentId: number,
     @UserToken() userToken: StudentUserToken,
   ): Promise<void> {
     try {

--- a/sources/packages/backend/apps/api/src/route-controllers/designation-agreement/designation-agreement.aest.controller.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/designation-agreement/designation-agreement.aest.controller.ts
@@ -8,6 +8,8 @@ import {
   Query,
   BadRequestException,
   UnprocessableEntityException,
+  ParseIntPipe,
+  ParseEnumPipe,
 } from "@nestjs/common";
 import {
   DesignationAgreementService,
@@ -59,7 +61,7 @@ export class DesignationAgreementAESTController extends BaseController {
    */
   @Get(":designationId")
   async getDesignationAgreement(
-    @Param("designationId") designationId: number,
+    @Param("designationId", ParseIntPipe) designationId: number,
   ): Promise<GetDesignationAgreementDto> {
     return this.designationAgreementControllerService.getDesignationAgreement(
       designationId,
@@ -75,7 +77,7 @@ export class DesignationAgreementAESTController extends BaseController {
    */
   @Get("institution/:institutionId")
   async getDesignationAgreements(
-    @Param("institutionId") institutionId: number,
+    @Param("institutionId", ParseIntPipe) institutionId: number,
   ): Promise<GetDesignationAgreementsDto[]> {
     return this.designationAgreementControllerService.getDesignationAgreements(
       institutionId,
@@ -90,14 +92,10 @@ export class DesignationAgreementAESTController extends BaseController {
    */
   @Get("status/:designationStatus")
   async getDesignationAgreementByStatus(
-    @Param("designationStatus") designationStatus: DesignationAgreementStatus,
+    @Param("designationStatus", new ParseEnumPipe(DesignationAgreementStatus))
+    designationStatus: DesignationAgreementStatus,
     @Query(PaginationParams.SearchCriteria) searchCriteria: string,
   ): Promise<PendingDesignationDto[]> {
-    if (
-      !Object.values(DesignationAgreementStatus).includes(designationStatus)
-    ) {
-      throw new NotFoundException("Invalid designation agreement status.");
-    }
     const pendingDesignations =
       await this.designationAgreementService.getDesignationAgreementsByStatus(
         designationStatus,
@@ -125,7 +123,7 @@ export class DesignationAgreementAESTController extends BaseController {
   @Roles(Role.InstitutionApproveDeclineDesignation)
   @Patch(":designationId")
   async updateDesignationAgreement(
-    @Param("designationId") designationId: number,
+    @Param("designationId", ParseIntPipe) designationId: number,
     @Body() payload: UpdateDesignationDto,
     @UserToken() userToken: IUserToken,
   ): Promise<void> {

--- a/sources/packages/backend/apps/api/src/route-controllers/designation-agreement/designation-agreement.institutions.controller.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/designation-agreement/designation-agreement.institutions.controller.ts
@@ -5,6 +5,7 @@ import {
   ForbiddenException,
   Get,
   Param,
+  ParseIntPipe,
   Post,
   UnprocessableEntityException,
 } from "@nestjs/common";
@@ -107,7 +108,7 @@ export class DesignationAgreementInstitutionsController extends BaseController {
   @Get(":designationId")
   async getDesignationAgreement(
     @UserToken() userToken: IInstitutionUserToken,
-    @Param("designationId") designationId: number,
+    @Param("designationId", ParseIntPipe) designationId: number,
   ): Promise<GetDesignationAgreementDto> {
     return this.designationAgreementControllerService.getDesignationAgreement(
       designationId,

--- a/sources/packages/backend/apps/api/src/route-controllers/dynamic-form/dynamic-form.controller.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/dynamic-form/dynamic-form.controller.ts
@@ -4,6 +4,12 @@ import { FormService } from "../../services";
 import { AllowAuthorizedParty } from "../../auth/decorators";
 import { AuthorizedParties } from "../../auth/authorized-parties.enum";
 import { ApiTags } from "@nestjs/swagger";
+import { MaxLength } from "class-validator";
+
+class FormNameParamAPIInDTO {
+  @MaxLength(200)
+  formName: string;
+}
 
 @AllowAuthorizedParty(
   AuthorizedParties.institution,
@@ -23,7 +29,7 @@ export class DynamicFormController extends BaseController {
     return this.formService.list();
   }
   @Get(":formName")
-  async getForm(@Param("formName") formName: string): Promise<any> {
-    return this.formService.fetch(formName);
+  async getForm(@Param() formNameParam: FormNameParamAPIInDTO): Promise<any> {
+    return this.formService.fetch(formNameParam.formName);
   }
 }

--- a/sources/packages/backend/apps/api/src/route-controllers/education-program-offering/education-program-offering.institutions.controller.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/education-program-offering/education-program-offering.institutions.controller.ts
@@ -274,7 +274,8 @@ export class EducationProgramOfferingInstitutionsController extends BaseControll
     @Param("locationId", ParseIntPipe) locationId: number,
     @Param("programId", ParseIntPipe) programId: number,
     @Param("programYearId", ParseIntPipe) programYearId: number,
-    @Query("includeInActivePY") includeInActivePY = false,
+    @Query("includeInActivePY", new DefaultValuePipe(false), ParseBoolPipe)
+    includeInActivePY: boolean,
     @Query("offeringIntensity") offeringIntensity?: OfferingIntensity,
   ): Promise<OptionItemAPIOutDTO[]> {
     return this.educationProgramOfferingControllerService.getProgramOfferingsOptionsList(

--- a/sources/packages/backend/apps/api/src/route-controllers/education-program-offering/education-program-offering.institutions.controller.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/education-program-offering/education-program-offering.institutions.controller.ts
@@ -56,6 +56,7 @@ import {
   OFFERING_BULK_UPLOAD_MAX_UPLOAD_PARTS,
   uploadLimits,
 } from "../../utilities";
+import { ParseEnumQueryPipe } from "../../utilities/class-validation";
 import { CustomNamedError } from "@sims/utilities";
 import { FileInterceptor } from "@nestjs/platform-express";
 import { EducationProgramOfferingImportCSVService } from "../../services/education-program-offering/education-program-offering-import-csv.service";
@@ -276,7 +277,8 @@ export class EducationProgramOfferingInstitutionsController extends BaseControll
     @Param("programYearId", ParseIntPipe) programYearId: number,
     @Query("includeInActivePY", new DefaultValuePipe(false), ParseBoolPipe)
     includeInActivePY: boolean,
-    @Query("offeringIntensity") offeringIntensity?: OfferingIntensity,
+    @Query("offeringIntensity", new ParseEnumQueryPipe(OfferingIntensity))
+    offeringIntensity?: OfferingIntensity,
   ): Promise<OptionItemAPIOutDTO[]> {
     return this.educationProgramOfferingControllerService.getProgramOfferingsOptionsList(
       locationId,

--- a/sources/packages/backend/apps/api/src/route-controllers/education-program-offering/education-program-offering.students.controller.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/education-program-offering/education-program-offering.students.controller.ts
@@ -1,7 +1,9 @@
 import {
   Controller,
+  DefaultValuePipe,
   Get,
   Param,
+  ParseBoolPipe,
   ParseIntPipe,
   Query,
   UnprocessableEntityException,
@@ -53,7 +55,8 @@ export class EducationProgramOfferingStudentsController extends BaseController {
     @Param("locationId", ParseIntPipe) locationId: number,
     @Param("programId", ParseIntPipe) programId: number,
     @Param("programYearId", ParseIntPipe) programYearId: number,
-    @Query("includeInActivePY") includeInActivePY = false,
+    @Query("includeInActivePY", new DefaultValuePipe(false), ParseBoolPipe)
+    includeInActivePY: boolean,
     @Query("offeringIntensity") offeringIntensity?: OfferingIntensity,
   ): Promise<OptionItemAPIOutDTO[]> {
     return this.educationProgramOfferingControllerService.getProgramOfferingsOptionsList(

--- a/sources/packages/backend/apps/api/src/route-controllers/education-program-offering/education-program-offering.students.controller.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/education-program-offering/education-program-offering.students.controller.ts
@@ -22,6 +22,7 @@ import BaseController from "../BaseController";
 import { OfferingStartDateAPIOutDTO } from "./models/education-program-offering.dto";
 import { OptionItemAPIOutDTO } from "../models/common.dto";
 import { EducationProgramOfferingControllerService } from "./education-program-offering.controller.service";
+import { ParseEnumQueryPipe } from "../../utilities/class-validation";
 
 @AllowAuthorizedParty(AuthorizedParties.student)
 @Controller("education-program-offering")
@@ -57,7 +58,8 @@ export class EducationProgramOfferingStudentsController extends BaseController {
     @Param("programYearId", ParseIntPipe) programYearId: number,
     @Query("includeInActivePY", new DefaultValuePipe(false), ParseBoolPipe)
     includeInActivePY: boolean,
-    @Query("offeringIntensity") offeringIntensity?: OfferingIntensity,
+    @Query("offeringIntensity", new ParseEnumQueryPipe(OfferingIntensity))
+    offeringIntensity?: OfferingIntensity,
   ): Promise<OptionItemAPIOutDTO[]> {
     return this.educationProgramOfferingControllerService.getProgramOfferingsOptionsList(
       locationId,

--- a/sources/packages/backend/apps/api/src/route-controllers/education-program/education-program.students.controller.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/education-program/education-program.students.controller.ts
@@ -73,7 +73,7 @@ export class EducationProgramStudentsController extends BaseController {
       new DefaultValuePipe(false),
       ParseBoolPipe,
     )
-    isIncludeInActiveProgramYear,
+    isIncludeInActiveProgramYear: boolean,
   ): Promise<OptionItemAPIOutDTO[]> {
     const programs = await this.programService.getProgramsForLocation(
       locationId,

--- a/sources/packages/backend/apps/api/src/route-controllers/institution-locations/institution-location.aest.controller.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/institution-locations/institution-location.aest.controller.ts
@@ -1,4 +1,11 @@
-import { Body, Controller, Get, Param, Patch } from "@nestjs/common";
+import {
+  Body,
+  Controller,
+  Get,
+  Param,
+  ParseIntPipe,
+  Patch,
+} from "@nestjs/common";
 import { ApiNotFoundResponse, ApiTags } from "@nestjs/swagger";
 import { InstitutionLocationService } from "../../services";
 import { AuthorizedParties } from "../../auth/authorized-parties.enum";
@@ -42,7 +49,7 @@ export class InstitutionLocationAESTController extends BaseController {
   @Get(":locationId")
   @ApiNotFoundResponse({ description: "Institution Location not found." })
   async getInstitutionLocation(
-    @Param("locationId") locationId: number,
+    @Param("locationId", ParseIntPipe) locationId: number,
   ): Promise<InstitutionLocationDetailsAPIOutDTO> {
     // Get particular institution location.
     return this.locationControllerService.getInstitutionLocation(locationId);
@@ -56,7 +63,7 @@ export class InstitutionLocationAESTController extends BaseController {
   @Roles(Role.InstitutionEditLocationDetails)
   @Patch(":locationId")
   async update(
-    @Param("locationId") locationId: number,
+    @Param("locationId", ParseIntPipe) locationId: number,
     @Body() payload: AESTInstitutionLocationAPIInDTO,
     @UserToken() userToken: IUserToken,
   ): Promise<void> {

--- a/sources/packages/backend/apps/api/src/route-controllers/institution-locations/institution-location.institutions.controller.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/institution-locations/institution-location.institutions.controller.ts
@@ -2,10 +2,12 @@ import {
   BadRequestException,
   Body,
   Controller,
+  DefaultValuePipe,
   Get,
   NotFoundException,
   Param,
   ParseBoolPipe,
+  ParseIntPipe,
   Patch,
   Post,
   Query,
@@ -110,7 +112,7 @@ export class InstitutionLocationInstitutionsController extends BaseController {
   @IsInstitutionAdmin()
   @Patch(":locationId")
   async update(
-    @Param("locationId") locationId: number,
+    @Param("locationId", ParseIntPipe) locationId: number,
     @Body() payload: InstitutionLocationPrimaryContactAPIInDTO,
     @UserToken() userToken: IInstitutionUserToken,
   ): Promise<void> {
@@ -132,9 +134,10 @@ export class InstitutionLocationInstitutionsController extends BaseController {
   @HasLocationAccess("locationId")
   @Get(":locationId/active-applications")
   async getActiveApplications(
-    @Param("locationId") locationId: number,
+    @Param("locationId", ParseIntPipe) locationId: number,
     @Query() pagination: ApplicationStatusPaginationOptionsAPIInDTO,
-    @Query("archived", ParseBoolPipe) archived: boolean,
+    @Query("archived", new DefaultValuePipe(false), ParseBoolPipe)
+    archived: boolean,
   ): Promise<PaginatedResultsAPIOutDTO<ActiveApplicationSummaryAPIOutDTO>> {
     const applications = await this.applicationService.getActiveApplications(
       locationId,
@@ -175,7 +178,7 @@ export class InstitutionLocationInstitutionsController extends BaseController {
   @Get(":locationId")
   @ApiNotFoundResponse({ description: "Institution Location not found." })
   async getInstitutionLocation(
-    @Param("locationId") locationId: number,
+    @Param("locationId", ParseIntPipe) locationId: number,
     @UserToken() userToken: IInstitutionUserToken,
   ): Promise<InstitutionLocationDetailsAPIOutDTO> {
     // Get particular institution location.
@@ -208,8 +211,8 @@ export class InstitutionLocationInstitutionsController extends BaseController {
   @HasLocationAccess("locationId")
   @Get(":locationId/active-application/:applicationId")
   async getActiveApplication(
-    @Param("locationId") locationId: number,
-    @Param("applicationId") applicationId: number,
+    @Param("locationId", ParseIntPipe) locationId: number,
+    @Param("applicationId", ParseIntPipe) applicationId: number,
   ): Promise<ActiveApplicationDataAPIOutDTO> {
     const application = await this.applicationService.getActiveApplication(
       applicationId,

--- a/sources/packages/backend/apps/api/src/route-controllers/institution-user/institution-user.aest.controller.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/institution-user/institution-user.aest.controller.ts
@@ -61,9 +61,9 @@ export class InstitutionUserAESTController extends BaseController {
    * when available.
    * @returns all filtered institution users.
    */
-  @Get()
+  @Get("institution/:institutionId")
   async getInstitutionUserSummary(
-    @Query("institutionId", ParseIntPipe) institutionId: number,
+    @Param("institutionId", ParseIntPipe) institutionId: number,
     @Query() paginationOptions: InstitutionUserPaginationOptionsAPIInDTO,
   ): Promise<PaginatedResults<InstitutionUserAPIOutDTO>> {
     return this.institutionUserControllerService.getInstitutionUsers(

--- a/sources/packages/backend/apps/api/src/route-controllers/institution/institution.aest.controller.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/institution/institution.aest.controller.ts
@@ -4,6 +4,7 @@ import {
   Get,
   NotFoundException,
   Param,
+  ParseIntPipe,
   Patch,
   Post,
   Query,
@@ -102,7 +103,7 @@ export class InstitutionAESTController extends BaseController {
    */
   @Get(":institutionId")
   async getInstitutionDetailById(
-    @Param("institutionId") institutionId: number,
+    @Param("institutionId", ParseIntPipe) institutionId: number,
   ): Promise<InstitutionDetailAPIOutDTO> {
     const institutionDetail =
       await this.institutionControllerService.getInstitutionDetail(
@@ -124,7 +125,7 @@ export class InstitutionAESTController extends BaseController {
   @Roles(Role.InstitutionEditProfile)
   @Patch(":institutionId")
   async updateInstitution(
-    @Param("institutionId") institutionId: number,
+    @Param("institutionId", ParseIntPipe) institutionId: number,
     @Body() payload: InstitutionProfileAPIInDTO,
     @UserToken() userToken: IUserToken,
   ): Promise<void> {
@@ -148,7 +149,7 @@ export class InstitutionAESTController extends BaseController {
    */
   @Get(":institutionId/basic-details")
   async getBasicInstitutionInfoById(
-    @Param("institutionId") institutionId: number,
+    @Param("institutionId", ParseIntPipe) institutionId: number,
   ): Promise<InstitutionBasicAPIOutDTO> {
     const institutionDetail =
       await this.institutionService.getBasicInstitutionDetailById(
@@ -172,7 +173,7 @@ export class InstitutionAESTController extends BaseController {
    */
   @Get(":institutionId/locations")
   async getAllInstitutionLocations(
-    @Param("institutionId") institutionId: number,
+    @Param("institutionId", ParseIntPipe) institutionId: number,
   ): Promise<InstitutionLocationAPIOutDTO[]> {
     // get all institution locations with designation statuses.
     return this.locationControllerService.getInstitutionLocations(

--- a/sources/packages/backend/apps/api/src/route-controllers/institution/institution.aest.controller.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/institution/institution.aest.controller.ts
@@ -26,6 +26,7 @@ import {
   SearchInstitutionAPIOutDTO,
   InstitutionBasicAPIOutDTO,
   AESTCreateInstitutionFormAPIInDTO,
+  SearchInstitutionQueryAPIInDTO,
 } from "./models/institution.dto";
 import BaseController from "../BaseController";
 import { InstitutionControllerService } from "./institution.controller.service";
@@ -64,17 +65,19 @@ export class InstitutionAESTController extends BaseController {
    */
   @Get("search")
   async searchInstitutions(
-    @Query("legalName") legalName: string,
-    @Query("operatingName") operatingName: string,
+    @Query() searchInstitutionQuery: SearchInstitutionQueryAPIInDTO,
   ): Promise<SearchInstitutionAPIOutDTO[]> {
-    if (!legalName && !operatingName) {
+    if (
+      !searchInstitutionQuery.legalName &&
+      !searchInstitutionQuery.operatingName
+    ) {
       throw new UnprocessableEntityException(
         "Search with at least one search criteria",
       );
     }
     const searchInstitutions = await this.institutionService.searchInstitution(
-      legalName,
-      operatingName,
+      searchInstitutionQuery.legalName,
+      searchInstitutionQuery.operatingName,
     );
     return searchInstitutions.map((eachInstitution: Institution) => {
       const mailingAddress =

--- a/sources/packages/backend/apps/api/src/route-controllers/institution/models/institution.dto.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/institution/models/institution.dto.ts
@@ -3,6 +3,7 @@ import {
   IsNotEmpty,
   IsOptional,
   IsPositive,
+  MaxLength,
   ValidateNested,
 } from "class-validator";
 import { OmitType } from "@nestjs/mapped-types";
@@ -140,4 +141,13 @@ export class SearchInstitutionAPIOutDTO {
   legalName: string;
   operatingName: string;
   address: AddressAPIOutDTO;
+}
+
+export class SearchInstitutionQueryAPIInDTO {
+  @IsOptional()
+  @MaxLength(64)
+  legalName?: string;
+  @IsOptional()
+  @MaxLength(64)
+  operatingName?: string;
 }

--- a/sources/packages/backend/apps/api/src/route-controllers/models/pagination.dto.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/models/pagination.dto.ts
@@ -1,4 +1,4 @@
-import { IsEnum, IsIn, IsOptional, Max, Min } from "class-validator";
+import { IsEnum, IsIn, IsOptional, Max, MaxLength, Min } from "class-validator";
 import { FieldSortOrder } from "../../utilities";
 
 /**
@@ -29,8 +29,12 @@ abstract class PaginationOptionsAPIInDTO {
   pageLimit: number;
   /**
    * Criteria to be used to filter the records.
+   ** Max length value is currently assumed from sum of
+   ** user first and last name in database which could be
+   ** largest possible search text.
    */
   @IsOptional()
+  @MaxLength(200)
   searchCriteria?: string;
 }
 

--- a/sources/packages/backend/apps/api/src/route-controllers/note/note.aest.controller.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/note/note.aest.controller.ts
@@ -29,6 +29,7 @@ import { ApiNotFoundResponse, ApiTags } from "@nestjs/swagger";
 import { Role } from "../../auth/roles.enum";
 import { ClientTypeBaseRoute } from "../../types";
 import { PrimaryIdentifierAPIOutDTO } from "../models/primary.identifier.dto";
+import { ParseEnumQueryPipe } from "../../utilities/class-validation";
 
 /**
  * Controller for Notes.
@@ -56,7 +57,7 @@ export class NoteAESTController extends BaseController {
   @Get("student/:studentId")
   async getStudentDetails(
     @Param("studentId", ParseIntPipe) studentId: number,
-    @Query("noteType") noteType: NoteType,
+    @Query("noteType", new ParseEnumQueryPipe(NoteType)) noteType: NoteType,
   ): Promise<NoteAPIOutDTO[]> {
     const student = await this.studentService.getStudentById(studentId);
     if (!student) {
@@ -79,7 +80,7 @@ export class NoteAESTController extends BaseController {
   @Get("institution/:institutionId")
   async getInstitutionDetails(
     @Param("institutionId", ParseIntPipe) institutionId: number,
-    @Query("noteType") noteType: NoteType,
+    @Query("noteType", new ParseEnumQueryPipe(NoteType)) noteType: NoteType,
   ): Promise<NoteAPIOutDTO[]> {
     const institution =
       this.institutionService.getBasicInstitutionDetailById(institutionId);

--- a/sources/packages/backend/apps/api/src/route-controllers/program-year/program-year.controller.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/program-year/program-year.controller.ts
@@ -1,4 +1,10 @@
-import { Controller, Get, NotFoundException, Param } from "@nestjs/common";
+import {
+  Controller,
+  Get,
+  NotFoundException,
+  Param,
+  ParseIntPipe,
+} from "@nestjs/common";
 import { ProgramYearService } from "../../services";
 import { OptionItem } from "../../types";
 import BaseController from "../BaseController";
@@ -33,7 +39,7 @@ export class ProgramYearController extends BaseController {
 
   @Get(":id/active")
   async getActiveProgramYearById(
-    @Param("id") programYearId: number,
+    @Param("id", ParseIntPipe) programYearId: number,
   ): Promise<ProgramYearDto> {
     const programYear = await this.programYearService.getActiveProgramYear(
       programYearId,

--- a/sources/packages/backend/apps/api/src/route-controllers/restriction/models/restriction.dto.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/restriction/models/restriction.dto.ts
@@ -73,3 +73,8 @@ export class StudentRestrictionAPIOutDTO {
    */
   type: RestrictionNotificationType;
 }
+
+export class RestrictionCategoryParamAPIInDTO {
+  @MaxLength(50)
+  restrictionCategory: string;
+}

--- a/sources/packages/backend/apps/api/src/route-controllers/restriction/restriction.aest.controller.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/restriction/restriction.aest.controller.ts
@@ -34,6 +34,7 @@ import {
   ResolveRestrictionAPIInDTO,
   AssignRestrictionAPIInDTO,
   RestrictionStatusAPIOutDTO,
+  RestrictionCategoryParamAPIInDTO,
 } from "./models/restriction.dto";
 import { ClientTypeBaseRoute } from "../../types";
 import { getUserFullName } from "../../utilities";
@@ -109,11 +110,11 @@ export class RestrictionAESTController extends BaseController {
    */
   @Get("category/:restrictionCategory/reasons")
   async getReasonsOptionsList(
-    @Param("restrictionCategory") restrictionCategory: string,
+    @Param() restrictionCategoryParam: RestrictionCategoryParamAPIInDTO,
   ): Promise<OptionItemAPIOutDTO[]> {
     const reasons =
       await this.restrictionService.getRestrictionReasonsByCategory(
-        restrictionCategory,
+        restrictionCategoryParam.restrictionCategory,
       );
     return reasons.map((reason) => ({
       id: reason.id,

--- a/sources/packages/backend/apps/api/src/route-controllers/restriction/restriction.aest.controller.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/restriction/restriction.aest.controller.ts
@@ -14,7 +14,6 @@ import {
   StudentRestrictionService,
   InstitutionRestrictionService,
   RestrictionService,
-  StudentService,
   InstitutionService,
   RESTRICTION_NOT_ACTIVE,
   RESTRICTION_NOT_PROVINCIAL,
@@ -59,7 +58,6 @@ export class RestrictionAESTController extends BaseController {
   constructor(
     private readonly studentRestrictionService: StudentRestrictionService,
     private readonly restrictionService: RestrictionService,
-    private readonly studentService: StudentService,
     private readonly institutionRestrictionService: InstitutionRestrictionService,
     private readonly institutionService: InstitutionService,
   ) {

--- a/sources/packages/backend/apps/api/src/route-controllers/student-appeal/student-appeal.aest.controller.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/student-appeal/student-appeal.aest.controller.ts
@@ -115,7 +115,7 @@ export class StudentAppealAESTController extends BaseController {
       `some appeal request is already in a state different than '${StudentAppealStatus.Pending}'.`,
   })
   async approveStudentAppealRequests(
-    @Param("appealId") appealId: number,
+    @Param("appealId", ParseIntPipe) appealId: number,
     @Body() payload: StudentAppealApprovalAPIInDTO,
     @UserToken() userToken: IUserToken,
   ): Promise<void> {

--- a/sources/packages/backend/apps/api/src/route-controllers/student-appeal/student-appeal.students.controller.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/student-appeal/student-appeal.students.controller.ts
@@ -77,7 +77,7 @@ export class StudentAppealStudentsController extends BaseController {
   })
   @Post("application/:applicationId")
   async submitStudentAppeal(
-    @Param("applicationId") applicationId: number,
+    @Param("applicationId", ParseIntPipe) applicationId: number,
     @Body() payload: StudentAppealAPIInDTO,
     @UserToken() userToken: IUserToken,
   ): Promise<PrimaryIdentifierAPIOutDTO> {

--- a/sources/packages/backend/apps/api/src/route-controllers/student/models/student.dto.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/student/models/student.dto.ts
@@ -236,3 +236,8 @@ export class UpdateSINValidationAPIInDTO {
   @MaxLength(NOTE_DESCRIPTION_MAX_LENGTH)
   noteDescription: string;
 }
+
+export class UniqueFileNameParamAPIInDTO {
+  @MaxLength(500)
+  uniqueFileName: string;
+}

--- a/sources/packages/backend/apps/api/src/route-controllers/student/student.aest.controller.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/student/student.aest.controller.ts
@@ -45,6 +45,7 @@ import {
   CreateSINValidationAPIInDTO,
   SearchStudentAPIOutDTO,
   SINValidationsAPIOutDTO,
+  UniqueFileNameParamAPIInDTO,
   UpdateSINValidationAPIInDTO,
 } from "./models/student.dto";
 import { Response } from "express";
@@ -124,12 +125,12 @@ export class StudentAESTController extends BaseController {
   @Get("files/:uniqueFileName")
   @ApiNotFoundResponse({ description: "Requested file was not found." })
   async getUploadedFile(
-    @Param("uniqueFileName") uniqueFileName: string,
+    @Param() uniqueFileNameParam: UniqueFileNameParamAPIInDTO,
     @Res() response: Response,
   ): Promise<void> {
     await this.studentControllerService.writeFileToResponse(
       response,
-      uniqueFileName,
+      uniqueFileNameParam.uniqueFileName,
     );
   }
 

--- a/sources/packages/backend/apps/api/src/route-controllers/student/student.aest.controller.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/student/student.aest.controller.ts
@@ -101,7 +101,7 @@ export class StudentAESTController extends BaseController {
    */
   @Get(":studentId/documents")
   async getAESTStudentFiles(
-    @Param("studentId") studentId: number,
+    @Param("studentId", ParseIntPipe) studentId: number,
   ): Promise<AESTStudentFileAPIOutDTO[]> {
     const studentDocuments = await this.fileService.getStudentUploadedFiles(
       studentId,
@@ -154,7 +154,7 @@ export class StudentAESTController extends BaseController {
   )
   async uploadFile(
     @UserToken() userToken: IUserToken,
-    @Param("studentId") studentId: number,
+    @Param("studentId", ParseIntPipe) studentId: number,
     @UploadedFile() file: Express.Multer.File,
     @Body("uniqueFileName") uniqueFileName: string,
     @Body("group") groupName: string,
@@ -188,7 +188,7 @@ export class StudentAESTController extends BaseController {
   @ApiNotFoundResponse({ description: "Student not found." })
   async saveStudentUploadedFiles(
     @UserToken() userToken: IUserToken,
-    @Param("studentId") studentId: number,
+    @Param("studentId", ParseIntPipe) studentId: number,
     @Body() payload: AESTFileUploadToStudentAPIInDTO,
   ): Promise<void> {
     const student = await this.studentService.getStudentById(studentId);
@@ -247,7 +247,7 @@ export class StudentAESTController extends BaseController {
   @Get(":studentId")
   @ApiNotFoundResponse({ description: "Not able to find the student." })
   async getStudentProfile(
-    @Param("studentId") studentId: number,
+    @Param("studentId", ParseIntPipe) studentId: number,
   ): Promise<AESTStudentProfileAPIOutDTO> {
     const [student, studentRestrictions] = await Promise.all([
       this.studentControllerService.getStudentProfile(studentId),
@@ -272,7 +272,7 @@ export class StudentAESTController extends BaseController {
   @Get(":studentId/application-summary")
   @ApiNotFoundResponse({ description: "Student does not exists." })
   async getStudentApplicationSummary(
-    @Param("studentId") studentId: number,
+    @Param("studentId", ParseIntPipe) studentId: number,
     @Query() pagination: ApplicationPaginationOptionsAPIInDTO,
   ): Promise<PaginatedResultsAPIOutDTO<ApplicationSummaryAPIOutDTO>> {
     const studentExists = await this.studentService.studentExists(studentId);

--- a/sources/packages/backend/apps/api/src/route-controllers/student/student.students.controller.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/student/student.students.controller.ts
@@ -44,6 +44,7 @@ import {
   StudentFileUploaderAPIInDTO,
   StudentProfileAPIOutDTO,
   StudentUploadFileAPIOutDTO,
+  UniqueFileNameParamAPIInDTO,
   UpdateStudentAPIInDTO,
 } from "./models/student.dto";
 import { ApiProcessError, ClientTypeBaseRoute } from "../../types";
@@ -199,12 +200,12 @@ export class StudentStudentsController extends BaseController {
   })
   async getUploadedFile(
     @UserToken() studentUserToken: StudentUserToken,
-    @Param("uniqueFileName") uniqueFileName: string,
+    @Param() uniqueFileNameParam: UniqueFileNameParamAPIInDTO,
     @Res() response: Response,
   ): Promise<void> {
     await this.studentControllerService.writeFileToResponse(
       response,
-      uniqueFileName,
+      uniqueFileNameParam.uniqueFileName,
       studentUserToken.studentId,
     );
   }

--- a/sources/packages/backend/apps/api/src/route-controllers/student/student.students.controller.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/student/student.students.controller.ts
@@ -247,7 +247,6 @@ export class StudentStudentsController extends BaseController {
    * during form submission, the temporary files
    * (saved during the upload) are update to its proper
    * group,file_origin and add the metadata (if available).
-   * @param userToken authentication token.
    * @Body list of files to be be saved.
    */
   @Patch("save-uploaded-files")

--- a/sources/packages/backend/apps/api/src/route-controllers/supporting-user/supporting-user.aest.controller.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/supporting-user/supporting-user.aest.controller.ts
@@ -1,4 +1,10 @@
-import { Controller, Get, NotFoundException, Param } from "@nestjs/common";
+import {
+  Controller,
+  Get,
+  NotFoundException,
+  Param,
+  ParseIntPipe,
+} from "@nestjs/common";
 import { SupportingUserService } from "../../services";
 import { AuthorizedParties } from "../../auth/authorized-parties.enum";
 import { AllowAuthorizedParty, Groups } from "../../auth/decorators";
@@ -26,7 +32,7 @@ export class SupportingUserAESTController {
    */
   @Get("application/:applicationId")
   async getSupportingUsersOfAnApplication(
-    @Param("applicationId") applicationId: number,
+    @Param("applicationId", ParseIntPipe) applicationId: number,
   ): Promise<ApplicationSupportingUsersApiOutDTO[]> {
     const supportingUserForApplication =
       await this.supportingUserService.getSupportingUsersByApplicationId(
@@ -50,7 +56,7 @@ export class SupportingUserAESTController {
       "Supporting user details not found or Supporting user has not submitted the form.",
   })
   async getSupportingUserFormDetails(
-    @Param("supportingUserId") supportingUserId: number,
+    @Param("supportingUserId", ParseIntPipe) supportingUserId: number,
   ): Promise<SupportingUserFormDataApiOutDTO> {
     const supportingUserForApplication =
       await this.supportingUserService.getSupportingUsersDetails(

--- a/sources/packages/backend/apps/api/src/route-controllers/supporting-user/supporting-user.supporting-users.controller.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/supporting-user/supporting-user.supporting-users.controller.ts
@@ -5,6 +5,7 @@ import {
   HttpCode,
   HttpStatus,
   Param,
+  ParseEnumPipe,
   Patch,
   Post,
   UnprocessableEntityException,
@@ -75,7 +76,8 @@ export class SupportingUserSupportingUsersController extends BaseController {
   })
   async getApplicationDetails(
     @UserToken() userToken: IUserToken,
-    @Param("supportingUserType") supportingUserType: SupportingUserType,
+    @Param("supportingUserType", new ParseEnumPipe(SupportingUserType))
+    supportingUserType: SupportingUserType,
     @Body() payload: ApplicationIdentifierApiInDTO,
   ): Promise<ApplicationApiOutDTO> {
     const application =
@@ -133,7 +135,8 @@ export class SupportingUserSupportingUsersController extends BaseController {
   @ApiBadRequestResponse({ description: "Invalid request." })
   async updateSupportingInformation(
     @UserToken() userToken: IUserToken,
-    @Param("supportingUserType") supportingUserType: SupportingUserType,
+    @Param("supportingUserType", new ParseEnumPipe(SupportingUserType))
+    supportingUserType: SupportingUserType,
     @Body() payload: UpdateSupportingUserApiInDTO,
   ): Promise<void> {
     // Regardless of the API call is successful or not, create/update

--- a/sources/packages/backend/apps/api/src/utilities/class-validation/custom-validators/custom-validation-pipe.ts
+++ b/sources/packages/backend/apps/api/src/utilities/class-validation/custom-validators/custom-validation-pipe.ts
@@ -1,0 +1,28 @@
+import {
+  ArgumentMetadata,
+  Injectable,
+  ParseEnumPipe,
+  ParseEnumPipeOptions,
+} from "@nestjs/common";
+
+/**
+ * Custom validation pipe extended from ParseEnumPipe(Nest JS)
+ * to allow nullable values and validates the only if
+ * value is present.
+ *
+ * This validation pipe is exclusively made for
+ * enum values which are supplied as either optional param or
+ * query param to the API.
+ */
+@Injectable()
+export class ParseEnumQueryPipe<T> extends ParseEnumPipe<T> {
+  constructor(enumType: T, options?: ParseEnumPipeOptions) {
+    super(enumType, options);
+  }
+  transform(value: T, metadata: ArgumentMetadata): Promise<T> {
+    if (value) {
+      return super.transform(value, metadata);
+    }
+    return undefined;
+  }
+}

--- a/sources/packages/backend/apps/api/src/utilities/class-validation/index.ts
+++ b/sources/packages/backend/apps/api/src/utilities/class-validation/index.ts
@@ -7,3 +7,4 @@ export * from "./custom-validators/period-min-length";
 export * from "./custom-validators/period-max-length";
 export * from "./validation-utils";
 export * from "./custom-validators/is-date-after";
+export * from "./custom-validators/custom-validation-pipe";

--- a/sources/packages/web/src/services/http/InstitutionUserApi.ts
+++ b/sources/packages/web/src/services/http/InstitutionUserApi.ts
@@ -34,10 +34,11 @@ export class InstitutionUserApi extends HttpBaseClient {
     paginationOptions: PaginationOptions,
     institutionId?: number,
   ): Promise<PaginatedResults<InstitutionUserAPIOutDTO>> {
-    let url = "institution-user?";
-    if (AuthService.shared.authClientType === ClientIdType.AEST) {
-      url += `institutionId=${institutionId}&`;
-    }
+    let url = `institution-user${
+      AuthService.shared.authClientType === ClientIdType.AEST
+        ? `/institution/${institutionId}`
+        : ""
+    }?`;
     url += getPaginationQueryString(paginationOptions);
     return this.getCallTyped<PaginatedResults<InstitutionUserAPIOutDTO>>(
       this.addClientRoot(url),

--- a/sources/packages/web/src/views/aest/SearchInstitutions.vue
+++ b/sources/packages/web/src/views/aest/SearchInstitutions.vue
@@ -124,12 +124,17 @@ export default {
       if (!validationResult.valid) {
         return;
       }
-      institutions.value = await InstitutionService.shared.searchInstitutions(
-        legalName.value,
-        operatingName.value,
-      );
-      if (institutions.value.length === 0) {
-        snackBar.warn("No Institutions found for the given search criteria.");
+      try {
+        institutions.value = await InstitutionService.shared.searchInstitutions(
+          legalName.value,
+          operatingName.value,
+        );
+
+        if (institutions.value.length === 0) {
+          snackBar.warn("No Institutions found for the given search criteria.");
+        }
+      } catch {
+        snackBar.error("An error happened during the institution search.");
       }
     };
     const institutionsFound = computed(() => {


### PR DESCRIPTION
## Add custom validator for Query Param and validate all the params in application

- [ ] Ensure that ALL parameters and query strings have a way to be validated (Anything different than body)
- [ ] Create custom validators to allow null in query param for controllers

### Solution

By default all the OOTB validation pipes provided by Nest JS(https://docs.nestjs.com/pipes#built-in-pipes) does not accept null and undefined values. Hence to use the validation pipes for Query params nest provides a solution called `DefaultValuePipe(value)` which can be used before the validation pipes. 
```
 @Query("myParam", new DefaultValuePipe(false), ParseBoolPipe)
```
But this seems to be suitable only for boolean and cannot be used for query params which has enum value in it.
```
@Query("noteType") noteType: NoteType
```
Hence we created a custom validation pipe for **_Enum to be used in query param_** by extending the ParseEnumPipe provided by Nest JS.

![image](https://user-images.githubusercontent.com/54600590/197301474-eecaa7e7-96b7-4af8-9f50-85fd44048b80.png)
