### PR TITLE
[form][web][api][SIMS #1499]Convert 10% warning to info

### DIFF
--- a/sources/packages/backend/apps/api/src/route-controllers/education-program-offering/education-program-offering.controller.service.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/education-program-offering/education-program-offering.controller.service.ts
@@ -233,8 +233,8 @@ export class EducationProgramOfferingControllerService {
             offeringStatus: validation.offeringStatus,
             errors: validation.errors,
             warnings: validation.warnings.map((warning) => ({
-              warningType: warning.warningType,
-              warningMessage: warning.warningMessage,
+              typeCode: warning.typeCode,
+              message: warning.message,
             })),
           };
         });
@@ -326,8 +326,9 @@ export class EducationProgramOfferingControllerService {
       assessedDate: offering.assessedDate,
       courseLoad: offering.courseLoad,
       hasExistingApplication,
-      warnings: validatedOffering.warnings.map(
-        (warning) => warning.warningType,
+      validationInfos: validatedOffering.infos.map((info) => info.typeCode),
+      validationWarnings: validatedOffering.warnings.map(
+        (warning) => warning.typeCode,
       ),
     };
   }

--- a/sources/packages/backend/apps/api/src/route-controllers/education-program-offering/education-program-offering.controller.service.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/education-program-offering/education-program-offering.controller.service.ts
@@ -188,6 +188,7 @@ export class EducationProgramOfferingControllerService {
           startDate: validation.csvModel.studyStartDate,
           endDate: validation.csvModel.studyEndDate,
           errors: validation.errors,
+          infos: [],
           warnings: [],
         }));
       throw new BadRequestException(
@@ -232,6 +233,10 @@ export class EducationProgramOfferingControllerService {
             endDate: validation.offeringModel.studyEndDate,
             offeringStatus: validation.offeringStatus,
             errors: validation.errors,
+            infos: validation.infos.map((info) => ({
+              typeCode: info.typeCode,
+              message: info.message,
+            })),
             warnings: validation.warnings.map((warning) => ({
               typeCode: warning.typeCode,
               message: warning.message,
@@ -267,6 +272,7 @@ export class EducationProgramOfferingControllerService {
         startDate: error.validatedOffering.offeringModel.studyStartDate,
         endDate: error.validatedOffering.offeringModel.studyEndDate,
         errors: [error.error],
+        infos: [],
         warnings: [],
       },
     ];

--- a/sources/packages/backend/apps/api/src/route-controllers/education-program-offering/education-program-offering.institutions.controller.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/education-program-offering/education-program-offering.institutions.controller.ts
@@ -134,6 +134,7 @@ export class EducationProgramOfferingInstitutionsController extends BaseControll
     return {
       offeringStatus: offeringValidation.offeringStatus,
       errors: offeringValidation.errors,
+      infos: offeringValidation.infos,
       warnings: offeringValidation.warnings,
       studyPeriodBreakdown: {
         fundedStudyPeriodDays: calculatedStudyBreaks.fundedStudyPeriodDays,

--- a/sources/packages/backend/apps/api/src/route-controllers/education-program-offering/models/education-program-offering.dto.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/education-program-offering/models/education-program-offering.dto.ts
@@ -9,6 +9,7 @@ import { Allow, IsEnum, IsIn, IsNotEmpty, MaxLength } from "class-validator";
 import { Type } from "class-transformer";
 import {
   OfferingDeliveryOptions,
+  OfferingValidationInfos,
   OfferingValidationWarnings,
   WILComponentOptions,
 } from "../../../services";
@@ -125,7 +126,8 @@ export class EducationProgramOfferingAPIOutDTO {
   hasExistingApplication?: boolean;
   locationName?: string;
   institutionName?: string;
-  warnings: string[];
+  validationWarnings: string[];
+  validationInfos: string[];
 }
 
 export class EducationProgramOfferingSummaryAPIOutDTO {
@@ -185,7 +187,8 @@ export class OfferingChangeAssessmentAPIInDTO {
 export class OfferingValidationResultAPIOutDTO {
   offeringStatus?: OfferingStatus.Approved | OfferingStatus.CreationPending;
   errors: string[];
-  warnings: ValidationWarningResultAPIOutDTO[];
+  infos: ValidationResultAPIOutDTO[];
+  warnings: ValidationResultAPIOutDTO[];
   studyPeriodBreakdown: StudyPeriodBreakdownAPIOutDTO;
 }
 
@@ -202,15 +205,16 @@ export class OfferingBulkInsertValidationResultAPIOutDTO {
   endDate?: string;
   offeringStatus?: OfferingStatus.Approved | OfferingStatus.CreationPending;
   errors: string[];
-  warnings: ValidationWarningResultAPIOutDTO[];
+  warnings: ValidationResultAPIOutDTO[];
 }
 
 /**
  * Represents an error considered not critical for
  * an offering and provides a user-friendly message
- * and a type that uniquely identifies this warning.
+ * and a type that uniquely identifies this warning
+ * or info.
  */
-export class ValidationWarningResultAPIOutDTO {
-  warningType: OfferingValidationWarnings;
-  warningMessage: string;
+export class ValidationResultAPIOutDTO {
+  typeCode: OfferingValidationWarnings | OfferingValidationInfos;
+  message: string;
 }

--- a/sources/packages/backend/apps/api/src/route-controllers/education-program-offering/models/education-program-offering.dto.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/education-program-offering/models/education-program-offering.dto.ts
@@ -205,6 +205,7 @@ export class OfferingBulkInsertValidationResultAPIOutDTO {
   endDate?: string;
   offeringStatus?: OfferingStatus.Approved | OfferingStatus.CreationPending;
   errors: string[];
+  infos: ValidationResultAPIOutDTO[];
   warnings: ValidationResultAPIOutDTO[];
 }
 

--- a/sources/packages/backend/apps/api/src/services/education-program-offering/education-program-offering-validation.models.ts
+++ b/sources/packages/backend/apps/api/src/services/education-program-offering/education-program-offering-validation.models.ts
@@ -220,6 +220,7 @@ export class ValidationContext {
     newContext.typeCode = warningTypeCode;
     return newContext;
   }
+
   /**
    * Creates an error context that will make the error downgraded to
    * a condition of a simple information that will still allow the
@@ -233,6 +234,7 @@ export class ValidationContext {
     newContext.typeCode = infoTypeCode;
     return newContext;
   }
+
   /**
    * Context type.
    */

--- a/sources/packages/backend/apps/api/src/services/education-program-offering/education-program-offering-validation.models.ts
+++ b/sources/packages/backend/apps/api/src/services/education-program-offering/education-program-offering-validation.models.ts
@@ -205,16 +205,20 @@ export enum OfferingValidationInfos {
  * the warning or information contexts will not be considered critical.
  */
 export class ValidationContext {
-  static CreateWarning(warningTypeCode: OfferingValidationWarnings) {
+  static CreateWarning(
+    warningTypeCode: OfferingValidationWarnings,
+  ): ValidationContext {
     const newContext = new ValidationContext();
     newContext.type = ValidationContextTypes.Warning;
     newContext.typeCode = warningTypeCode;
+    return newContext;
   }
 
-  static CreateInfo(infoTypeCode: OfferingValidationInfos) {
+  static CreateInfo(infoTypeCode: OfferingValidationInfos): ValidationContext {
     const newContext = new ValidationContext();
     newContext.type = ValidationContextTypes.Information;
     newContext.typeCode = infoTypeCode;
+    return newContext;
   }
 
   type: ValidationContextTypes;

--- a/sources/packages/backend/apps/api/src/services/education-program-offering/education-program-offering-validation.models.ts
+++ b/sources/packages/backend/apps/api/src/services/education-program-offering/education-program-offering-validation.models.ts
@@ -205,6 +205,13 @@ export enum OfferingValidationInfos {
  * the warning or information contexts will not be considered critical.
  */
 export class ValidationContext {
+  /**
+   * Creates an error context that will make the error downgrade to
+   * a condition of a warning information will force the offering
+   * to be reviewed by the Ministry.
+   * @param warningTypeCode warning code that uniquely identifies this condition.
+   * @returns the warning context.
+   */
   static CreateWarning(
     warningTypeCode: OfferingValidationWarnings,
   ): ValidationContext {
@@ -213,18 +220,33 @@ export class ValidationContext {
     newContext.typeCode = warningTypeCode;
     return newContext;
   }
-
+  /**
+   * Creates an error context that will make the error downgraded to
+   * a condition of a simple information that will still allow the
+   * offering to be automatically approved.
+   * @param infoTypeCode information code that uniquely identifies this condition.
+   * @returns the information context.
+   */
   static CreateInfo(infoTypeCode: OfferingValidationInfos): ValidationContext {
     const newContext = new ValidationContext();
     newContext.type = ValidationContextTypes.Information;
     newContext.typeCode = infoTypeCode;
     return newContext;
   }
-
+  /**
+   * Context type.
+   */
   type: ValidationContextTypes;
+  /**
+   * Unique identifier of the validation error.
+   */
   typeCode: OfferingValidationWarnings | OfferingValidationInfos;
 }
 
+/**
+ * Types of non-critical errors that will not prevent
+ * the offering from being saved.
+ */
 export enum ValidationContextTypes {
   Warning = "warning",
   Information = "information",

--- a/sources/packages/backend/apps/api/src/utilities/class-validation/custom-validators/period-max-length.ts
+++ b/sources/packages/backend/apps/api/src/utilities/class-validation/custom-validators/period-max-length.ts
@@ -17,9 +17,10 @@ class PeriodMaxLengthConstraint implements ValidatorConstraintInterface {
   validate(value: Date | string, args: ValidationArguments): boolean {
     const [startDateProperty, maxDaysAllowed] = args.constraints;
     const periodStartDate = startDateProperty(args.object);
-    if (!periodStartDate) {
-      // The related property does not exists in the provided object to be compared.
-      return false;
+    if (!value || !periodStartDate) {
+      // While the two dates are not provided just ignore this validation.
+      // The presence of both dates must be ensured by other validators.
+      return true;
     }
     return dateDifference(value, periodStartDate) <= maxDaysAllowed;
   }

--- a/sources/packages/forms/src/form-definitions/educationprogramoffering.json
+++ b/sources/packages/forms/src/form-definitions/educationprogramoffering.json
@@ -661,6 +661,9 @@
             },
             {
               "label": "HTML",
+              "labelWidth": "",
+              "labelMargin": "",
+              "tag": "p",
               "className": "alert alert-info fa fa-info-circle w-100",
               "attrs": [
                 {
@@ -671,11 +674,27 @@
               "content": "<strong class=\"ml-2\"> Here’s an example of what students will see.</strong>\n<br>e.g. 2022 Winter co-op (Jan 15 2022 - Mar 20 2022) - Year 1",
               "refreshOnChange": false,
               "customClass": "banner-info",
+              "hidden": false,
+              "modalEdit": false,
               "key": "html7",
+              "tags": [],
+              "properties": {},
               "conditional": {
                 "show": true,
                 "when": "showYearOfStudy",
-                "eq": "true"
+                "eq": "true",
+                "json": ""
+              },
+              "customConditional": "",
+              "logic": [],
+              "attributes": {},
+              "overlay": {
+                "style": "",
+                "page": "",
+                "left": "",
+                "top": "",
+                "width": "",
+                "height": ""
               },
               "type": "htmlelement",
               "input": false,
@@ -688,11 +707,9 @@
               "protected": false,
               "unique": false,
               "persistent": false,
-              "hidden": false,
               "clearOnHide": true,
               "refreshOn": "",
               "redrawOn": "",
-              "modalEdit": false,
               "dataGridLabel": false,
               "labelPosition": "top",
               "description": "",
@@ -707,7 +724,6 @@
               "calculateValue": "",
               "calculateServer": false,
               "widget": null,
-              "attributes": {},
               "validateOn": "change",
               "validate": {
                 "required": false,
@@ -717,22 +733,13 @@
                 "multiple": false,
                 "unique": false
               },
-              "overlay": {
-                "style": "",
-                "left": "",
-                "top": "",
-                "width": "",
-                "height": ""
-              },
               "allowCalculateOverride": false,
               "encrypted": false,
               "showCharCount": false,
               "showWordCount": false,
-              "properties": {},
               "allowMultipleMasks": false,
               "addons": [],
-              "tag": "p",
-              "id": "exactv"
+              "id": "ey5iid"
             },
             {
               "label": "How will this be offered?",
@@ -788,7 +795,9 @@
               "errorLabel": "",
               "errors": "",
               "key": "offeringIntensity",
-              "tags": [],
+              "tags": [
+                "execute-validation"
+              ],
               "properties": {},
               "conditional": {
                 "show": null,
@@ -826,7 +835,7 @@
               "addons": [],
               "inputType": "radio",
               "fieldSet": false,
-              "id": "evasqch",
+              "id": "epwmfzr",
               "defaultValue": ""
             },
             {
@@ -1069,9 +1078,21 @@
             },
             {
               "label": "How will this offering be delivered?",
+              "labelPosition": "top",
+              "labelWidth": "",
+              "labelMargin": "",
               "optionsLabelPosition": "right",
+              "description": "",
+              "tooltip": "",
+              "customClass": "",
+              "tabindex": "",
               "inline": false,
+              "hidden": false,
+              "hideLabel": false,
+              "autofocus": false,
+              "disabled": false,
               "tableView": false,
+              "modalEdit": false,
               "values": [
                 {
                   "label": "Onsite",
@@ -1089,73 +1110,74 @@
                   "shortcut": ""
                 }
               ],
+              "dataType": "",
+              "persistent": true,
+              "protected": false,
+              "dbIndex": false,
+              "encrypted": false,
+              "redrawOn": "",
+              "clearOnHide": true,
+              "customDefaultValue": "",
+              "calculateValue": "",
+              "calculateServer": false,
+              "allowCalculateOverride": false,
               "validate": {
                 "required": true,
                 "onlyAvailableItems": true,
+                "customMessage": "",
                 "custom": "",
                 "customPrivate": false,
+                "json": "",
                 "strictDateValidation": false,
                 "multiple": false,
                 "unique": false
               },
+              "errorLabel": "",
+              "errors": "",
               "key": "offeringDelivered",
+              "tags": [
+                "execute-validation"
+              ],
+              "properties": {},
+              "conditional": {
+                "show": null,
+                "when": null,
+                "eq": "",
+                "json": ""
+              },
+              "customConditional": "",
+              "logic": [],
               "attributes": {
                 "data-cy": "offeringDelivered"
+              },
+              "overlay": {
+                "style": "",
+                "page": "",
+                "left": "",
+                "top": "",
+                "width": "",
+                "height": ""
               },
               "type": "radio",
               "input": true,
               "hideOnChildrenHidden": false,
               "placeholder": "",
               "prefix": "",
-              "customClass": "",
               "suffix": "",
               "multiple": false,
-              "defaultValue": null,
-              "protected": false,
               "unique": false,
-              "persistent": true,
-              "hidden": false,
-              "clearOnHide": true,
               "refreshOn": "",
-              "redrawOn": "",
-              "modalEdit": false,
               "dataGridLabel": false,
-              "labelPosition": "top",
-              "description": "",
-              "errorLabel": "",
-              "tooltip": "",
-              "hideLabel": false,
-              "tabindex": "",
-              "disabled": false,
-              "autofocus": false,
-              "dbIndex": false,
-              "customDefaultValue": "",
-              "calculateValue": "",
-              "calculateServer": false,
               "widget": null,
               "validateOn": "change",
-              "conditional": {
-                "show": null,
-                "when": null,
-                "eq": ""
-              },
-              "overlay": {
-                "style": "",
-                "left": "",
-                "top": "",
-                "width": "",
-                "height": ""
-              },
-              "allowCalculateOverride": false,
-              "encrypted": false,
               "showCharCount": false,
               "showWordCount": false,
-              "properties": {},
               "allowMultipleMasks": false,
               "addons": [],
               "inputType": "radio",
               "fieldSet": false,
-              "id": "eal85aq"
+              "id": "edsywf7",
+              "defaultValue": ""
             },
             {
               "label": "HTML",
@@ -1235,9 +1257,21 @@
             },
             {
               "label": "Does this contain a work-integrated learning component?",
+              "labelPosition": "top",
+              "labelWidth": "",
+              "labelMargin": "",
               "optionsLabelPosition": "right",
+              "description": "",
+              "tooltip": "",
+              "customClass": "",
+              "tabindex": "",
               "inline": false,
+              "hidden": false,
+              "hideLabel": false,
+              "autofocus": false,
+              "disabled": false,
               "tableView": false,
+              "modalEdit": false,
               "values": [
                 {
                   "label": "Yes",
@@ -1250,72 +1284,73 @@
                   "shortcut": ""
                 }
               ],
+              "dataType": "",
+              "persistent": true,
+              "protected": false,
+              "dbIndex": false,
+              "encrypted": false,
+              "redrawOn": "",
+              "clearOnHide": true,
+              "customDefaultValue": "",
+              "calculateValue": "",
+              "calculateServer": false,
+              "allowCalculateOverride": false,
               "validate": {
                 "required": true,
                 "onlyAvailableItems": true,
+                "customMessage": "",
                 "custom": "",
                 "customPrivate": false,
+                "json": "",
                 "strictDateValidation": false,
                 "multiple": false,
                 "unique": false
               },
-              "key": "hasOfferingWILComponent",
-              "attributes": {
-                "data-cy": "hasOfferingWILComponent"
-              },
-              "type": "radio",
-              "input": true,
-              "placeholder": "",
-              "prefix": "",
-              "customClass": "",
-              "suffix": "",
-              "multiple": false,
-              "defaultValue": null,
-              "protected": false,
-              "unique": false,
-              "persistent": true,
-              "hidden": false,
-              "clearOnHide": true,
-              "refreshOn": "",
-              "redrawOn": "",
-              "modalEdit": false,
-              "dataGridLabel": false,
-              "labelPosition": "top",
-              "description": "",
               "errorLabel": "",
-              "tooltip": "",
-              "hideLabel": false,
-              "tabindex": "",
-              "disabled": false,
-              "autofocus": false,
-              "dbIndex": false,
-              "customDefaultValue": "",
-              "calculateValue": "",
-              "calculateServer": false,
-              "widget": null,
-              "validateOn": "change",
+              "errors": "",
+              "key": "hasOfferingWILComponent",
+              "tags": [
+                "execute-validation"
+              ],
+              "properties": {},
               "conditional": {
                 "show": null,
                 "when": null,
-                "eq": ""
+                "eq": "",
+                "json": ""
+              },
+              "customConditional": "",
+              "logic": [],
+              "attributes": {
+                "data-cy": "hasOfferingWILComponent"
               },
               "overlay": {
                 "style": "",
+                "page": "",
                 "left": "",
                 "top": "",
                 "width": "",
                 "height": ""
               },
-              "allowCalculateOverride": false,
-              "encrypted": false,
+              "type": "radio",
+              "input": true,
+              "placeholder": "",
+              "prefix": "",
+              "suffix": "",
+              "multiple": false,
+              "unique": false,
+              "refreshOn": "",
+              "dataGridLabel": false,
+              "widget": null,
+              "validateOn": "change",
               "showCharCount": false,
               "showWordCount": false,
-              "properties": {},
               "allowMultipleMasks": false,
               "addons": [],
               "inputType": "radio",
               "fieldSet": false,
-              "id": "eh3xnvp"
+              "id": "er8r2ja",
+              "defaultValue": ""
             },
             {
               "label": "HTML",
@@ -1728,7 +1763,7 @@
                               "errors": "",
                               "key": "studyStartDate",
                               "tags": [
-                                "execute-calculation"
+                                "execute-validation"
                               ],
                               "properties": {},
                               "conditional": {
@@ -1756,7 +1791,7 @@
                               "dataGridLabel": false,
                               "addons": [],
                               "inputType": "text",
-                              "id": "earft89",
+                              "id": "e9c0jo",
                               "defaultValue": ""
                             }
                           ],
@@ -1847,7 +1882,7 @@
                               "errors": "",
                               "key": "studyEndDate",
                               "tags": [
-                                "execute-calculation"
+                                "execute-validation"
                               ],
                               "properties": {},
                               "conditional": {
@@ -1875,7 +1910,7 @@
                               "dataGridLabel": false,
                               "addons": [],
                               "inputType": "text",
-                              "id": "ecipe58",
+                              "id": "ef8521a",
                               "defaultValue": ""
                             }
                           ],
@@ -2556,7 +2591,7 @@
                       "errors": "",
                       "key": "breakStartDate",
                       "tags": [
-                        "execute-calculation"
+                        "execute-validation"
                       ],
                       "properties": {},
                       "conditional": {
@@ -2583,7 +2618,7 @@
                       "refreshOn": "",
                       "addons": [],
                       "inputType": "text",
-                      "id": "eya3d0r0000000000000000000000",
+                      "id": "ejgboq00",
                       "defaultValue": ""
                     },
                     {
@@ -2665,7 +2700,7 @@
                       "errors": "",
                       "key": "breakEndDate",
                       "tags": [
-                        "execute-calculation"
+                        "execute-validation"
                       ],
                       "properties": {},
                       "conditional": {
@@ -2692,7 +2727,7 @@
                       "refreshOn": "",
                       "addons": [],
                       "inputType": "text",
-                      "id": "eke9ttb000000000000000000000",
+                      "id": "esg89z90",
                       "defaultValue": ""
                     },
                     {
@@ -2723,7 +2758,7 @@
                       "key": "breakDays",
                       "type": "number",
                       "input": true,
-                      "id": "ewdj5ald0000000000000000000000000000000000000000000",
+                      "id": "ewdj5ald0000000000000000000000000000000000000000000000000000000000000000",
                       "placeholder": "",
                       "prefix": "",
                       "customClass": "",
@@ -2798,7 +2833,7 @@
                       "key": "eligibleBreakDays",
                       "type": "number",
                       "input": true,
-                      "id": "eqifkdp0000000000000000000000000000000000000000000",
+                      "id": "eqifkdp0000000000000000000000000000000000000000000000000000000000000000",
                       "placeholder": "",
                       "prefix": "",
                       "customClass": "",
@@ -2874,7 +2909,7 @@
                       "key": "ineligibleBreakDays",
                       "type": "number",
                       "input": true,
-                      "id": "e3snjj70000000000000000000000000000000000000000000",
+                      "id": "e3snjj70000000000000000000000000000000000000000000000000000000000000000",
                       "placeholder": "",
                       "prefix": "",
                       "customClass": "",
@@ -3869,7 +3904,10 @@
             },
             {
               "label": "HTML",
-              "className": "alert alert-warning fa fa-exclamation-triangle w-100",
+              "labelWidth": "",
+              "labelMargin": "",
+              "tag": "p",
+              "className": "alert alert-info fa fa-info-circle w-100",
               "attrs": [
                 {
                   "attr": "",
@@ -3878,9 +3916,29 @@
               ],
               "content": "<strong class=\"ml-2\">The combined study breaks exceed the 10% threshold as outlined in StudentAid BC policy</strong>\n<br>\n<span>Excess break will be deducted from total funded study period weeks.</span>",
               "refreshOnChange": true,
-              "customClass": "banner-warning",
+              "customClass": "banner-info",
+              "hidden": false,
+              "modalEdit": false,
               "key": "invalidStudyBreaksCombinedThresholdPercentage",
-              "customConditional": "show = data.warnings.indexOf(component.key) !== -1;",
+              "tags": [],
+              "properties": {},
+              "conditional": {
+                "show": null,
+                "when": null,
+                "eq": "",
+                "json": ""
+              },
+              "customConditional": "show = data.infos.indexOf(component.key) !== -1;",
+              "logic": [],
+              "attributes": {},
+              "overlay": {
+                "style": "",
+                "page": "",
+                "left": "",
+                "top": "",
+                "width": "",
+                "height": ""
+              },
               "type": "htmlelement",
               "input": false,
               "tableView": false,
@@ -3892,11 +3950,9 @@
               "protected": false,
               "unique": false,
               "persistent": false,
-              "hidden": false,
               "clearOnHide": true,
               "refreshOn": "",
               "redrawOn": "",
-              "modalEdit": false,
               "dataGridLabel": false,
               "labelPosition": "top",
               "description": "",
@@ -3911,7 +3967,6 @@
               "calculateValue": "",
               "calculateServer": false,
               "widget": null,
-              "attributes": {},
               "validateOn": "change",
               "validate": {
                 "required": false,
@@ -3921,27 +3976,13 @@
                 "multiple": false,
                 "unique": false
               },
-              "conditional": {
-                "show": null,
-                "when": null,
-                "eq": ""
-              },
-              "overlay": {
-                "style": "",
-                "left": "",
-                "top": "",
-                "width": "",
-                "height": ""
-              },
               "allowCalculateOverride": false,
               "encrypted": false,
               "showCharCount": false,
               "showWordCount": false,
-              "properties": {},
               "allowMultipleMasks": false,
               "addons": [],
-              "tag": "p",
-              "id": "edzxabs"
+              "id": "e6gjslr"
             },
             {
               "label": "HTML",
@@ -5427,6 +5468,79 @@
       "addons": [],
       "inputType": "hidden",
       "id": "ectrof5"
+    },
+    {
+      "label": "Array of offerings information (banners) calculated on the server and used to display warnings banners",
+      "labelWidth": "",
+      "labelMargin": "",
+      "customClass": "",
+      "modalEdit": false,
+      "defaultValue": null,
+      "persistent": "client-only",
+      "protected": false,
+      "dbIndex": false,
+      "encrypted": false,
+      "redrawOn": "",
+      "customDefaultValue": "",
+      "calculateValue": "",
+      "calculateServer": false,
+      "key": "infos",
+      "tags": [],
+      "properties": {},
+      "logic": [],
+      "attributes": {},
+      "overlay": {
+        "style": "",
+        "page": "",
+        "left": "",
+        "top": "",
+        "width": "",
+        "height": ""
+      },
+      "type": "hidden",
+      "input": true,
+      "tableView": false,
+      "placeholder": "",
+      "prefix": "",
+      "suffix": "",
+      "multiple": false,
+      "unique": false,
+      "hidden": false,
+      "clearOnHide": true,
+      "refreshOn": "",
+      "dataGridLabel": false,
+      "labelPosition": "top",
+      "description": "",
+      "errorLabel": "",
+      "tooltip": "",
+      "hideLabel": false,
+      "tabindex": "",
+      "disabled": false,
+      "autofocus": false,
+      "widget": {
+        "type": "input"
+      },
+      "validateOn": "change",
+      "validate": {
+        "required": false,
+        "custom": "",
+        "customPrivate": false,
+        "strictDateValidation": false,
+        "multiple": false,
+        "unique": false
+      },
+      "conditional": {
+        "show": null,
+        "when": null,
+        "eq": ""
+      },
+      "allowCalculateOverride": false,
+      "showCharCount": false,
+      "showWordCount": false,
+      "allowMultipleMasks": false,
+      "addons": [],
+      "inputType": "hidden",
+      "id": "ex1qhin"
     },
     {
       "label": "applicationId",

--- a/sources/packages/forms/src/form-definitions/educationprogramoffering.json
+++ b/sources/packages/forms/src/form-definitions/educationprogramoffering.json
@@ -840,6 +840,8 @@
             },
             {
               "label": "Study period intensity popup",
+              "labelWidth": "",
+              "labelMargin": "",
               "tag": "div",
               "className": "alert alert-warning fa fa-exclamation-triangle w-100",
               "attrs": [
@@ -852,8 +854,27 @@
               "refreshOnChange": true,
               "customClass": "banner-warning",
               "hidden": true,
+              "modalEdit": false,
               "key": "programOfferingIntensityMismatch",
-              "customConditional": "show = data.warnings.indexOf(component.key) !== -1;",
+              "tags": [],
+              "properties": {},
+              "conditional": {
+                "show": null,
+                "when": null,
+                "eq": "",
+                "json": ""
+              },
+              "customConditional": "show = data.validationWarnings.indexOf(component.key) !== -1;",
+              "logic": [],
+              "attributes": {},
+              "overlay": {
+                "style": "",
+                "page": "",
+                "left": "",
+                "top": "",
+                "width": "",
+                "height": ""
+              },
               "type": "htmlelement",
               "input": false,
               "tableView": false,
@@ -868,7 +889,6 @@
               "clearOnHide": true,
               "refreshOn": "",
               "redrawOn": "",
-              "modalEdit": false,
               "dataGridLabel": false,
               "labelPosition": "top",
               "description": "",
@@ -883,7 +903,6 @@
               "calculateValue": "",
               "calculateServer": false,
               "widget": null,
-              "attributes": {},
               "validateOn": "change",
               "validate": {
                 "required": false,
@@ -893,26 +912,13 @@
                 "multiple": false,
                 "unique": false
               },
-              "conditional": {
-                "show": null,
-                "when": null,
-                "eq": ""
-              },
-              "overlay": {
-                "style": "",
-                "left": "",
-                "top": "",
-                "width": "",
-                "height": ""
-              },
               "allowCalculateOverride": false,
               "encrypted": false,
               "showCharCount": false,
               "showWordCount": false,
-              "properties": {},
               "allowMultipleMasks": false,
               "addons": [],
-              "id": "em87dp9"
+              "id": "eizjue"
             },
             {
               "title": "Course Load Panel",
@@ -1181,6 +1187,9 @@
             },
             {
               "label": "HTML",
+              "labelWidth": "",
+              "labelMargin": "",
+              "tag": "p",
               "className": "alert alert-warning fa fa-exclamation-triangle w-100",
               "attrs": [
                 {
@@ -1191,8 +1200,28 @@
               "content": "<strong class=\"ml-2\">The study period delivery is dependent on the program delivery</strong>\n<br>\n<span>Your program must have the correct delivery method(s) to be able to select the offering delivery here.</span>",
               "refreshOnChange": true,
               "customClass": "banner-warning",
+              "hidden": false,
+              "modalEdit": false,
               "key": "programOfferingDeliveryMismatch",
-              "customConditional": "show = data.warnings.indexOf(component.key) !== -1;",
+              "tags": [],
+              "properties": {},
+              "conditional": {
+                "show": null,
+                "when": null,
+                "eq": "",
+                "json": ""
+              },
+              "customConditional": "show = data.validationWarnings.indexOf(component.key) !== -1;",
+              "logic": [],
+              "attributes": {},
+              "overlay": {
+                "style": "",
+                "page": "",
+                "left": "",
+                "top": "",
+                "width": "",
+                "height": ""
+              },
               "type": "htmlelement",
               "input": false,
               "tableView": false,
@@ -1204,11 +1233,9 @@
               "protected": false,
               "unique": false,
               "persistent": false,
-              "hidden": false,
               "clearOnHide": true,
               "refreshOn": "",
               "redrawOn": "",
-              "modalEdit": false,
               "dataGridLabel": false,
               "labelPosition": "top",
               "description": "",
@@ -1223,7 +1250,6 @@
               "calculateValue": "",
               "calculateServer": false,
               "widget": null,
-              "attributes": {},
               "validateOn": "change",
               "validate": {
                 "required": false,
@@ -1233,27 +1259,13 @@
                 "multiple": false,
                 "unique": false
               },
-              "conditional": {
-                "show": null,
-                "when": null,
-                "eq": ""
-              },
-              "overlay": {
-                "style": "",
-                "left": "",
-                "top": "",
-                "width": "",
-                "height": ""
-              },
               "allowCalculateOverride": false,
               "encrypted": false,
               "showCharCount": false,
               "showWordCount": false,
-              "properties": {},
               "allowMultipleMasks": false,
               "addons": [],
-              "tag": "p",
-              "id": "eqap88"
+              "id": "e0fns5b"
             },
             {
               "label": "Does this contain a work-integrated learning component?",
@@ -1354,6 +1366,9 @@
             },
             {
               "label": "HTML",
+              "labelWidth": "",
+              "labelMargin": "",
+              "tag": "p",
               "className": "alert alert-warning fa fa-exclamation-triangle w-100",
               "attrs": [
                 {
@@ -1364,8 +1379,28 @@
               "content": "<strong class=\"ml-2\">This study period can’t contain a work-integrated component</strong>\n<br>\n<span>Your program must be approved with a work-integrated component first.</span>",
               "refreshOnChange": false,
               "customClass": "banner-warning",
+              "hidden": false,
+              "modalEdit": false,
               "key": "programOfferingWILMismatch",
-              "customConditional": "show = data.warnings.indexOf(component.key) !== -1;",
+              "tags": [],
+              "properties": {},
+              "conditional": {
+                "show": null,
+                "when": null,
+                "eq": "",
+                "json": ""
+              },
+              "customConditional": "show = data.validationWarnings.indexOf(component.key) !== -1;",
+              "logic": [],
+              "attributes": {},
+              "overlay": {
+                "style": "",
+                "page": "",
+                "left": "",
+                "top": "",
+                "width": "",
+                "height": ""
+              },
               "type": "htmlelement",
               "input": false,
               "tableView": false,
@@ -1377,11 +1412,9 @@
               "protected": false,
               "unique": false,
               "persistent": false,
-              "hidden": false,
               "clearOnHide": true,
               "refreshOn": "",
               "redrawOn": "",
-              "modalEdit": false,
               "dataGridLabel": false,
               "labelPosition": "top",
               "description": "",
@@ -1396,7 +1429,6 @@
               "calculateValue": "",
               "calculateServer": false,
               "widget": null,
-              "attributes": {},
               "validateOn": "change",
               "validate": {
                 "required": false,
@@ -1406,27 +1438,13 @@
                 "multiple": false,
                 "unique": false
               },
-              "conditional": {
-                "show": null,
-                "when": null,
-                "eq": ""
-              },
-              "overlay": {
-                "style": "",
-                "left": "",
-                "top": "",
-                "width": "",
-                "height": ""
-              },
               "allowCalculateOverride": false,
               "encrypted": false,
               "showCharCount": false,
               "showWordCount": false,
-              "properties": {},
               "allowMultipleMasks": false,
               "addons": [],
-              "tag": "p",
-              "id": "efk9n1p"
+              "id": "eawrio9"
             },
             {
               "title": "Panel",
@@ -1763,7 +1781,8 @@
                               "errors": "",
                               "key": "studyStartDate",
                               "tags": [
-                                "execute-validation"
+                                "execute-validation",
+                                "execute-calculation"
                               ],
                               "properties": {},
                               "conditional": {
@@ -1791,7 +1810,7 @@
                               "dataGridLabel": false,
                               "addons": [],
                               "inputType": "text",
-                              "id": "e9c0jo",
+                              "id": "eamkmv",
                               "defaultValue": ""
                             }
                           ],
@@ -1882,7 +1901,8 @@
                               "errors": "",
                               "key": "studyEndDate",
                               "tags": [
-                                "execute-validation"
+                                "execute-validation",
+                                "execute-calculation"
                               ],
                               "properties": {},
                               "conditional": {
@@ -1910,7 +1930,7 @@
                               "dataGridLabel": false,
                               "addons": [],
                               "inputType": "text",
-                              "id": "ef8521a",
+                              "id": "e8f7cn6k",
                               "defaultValue": ""
                             }
                           ],
@@ -2055,6 +2075,9 @@
                 },
                 {
                   "label": "Invalid study dates popup",
+                  "labelWidth": "",
+                  "labelMargin": "",
+                  "tag": "p",
                   "className": "alert alert-warning fa fa-exclamation-triangle w-100",
                   "attrs": [
                     {
@@ -2065,8 +2088,28 @@
                   "content": "<strong class=\"ml-2\">This study period is ineligible for StudentAid BC funding</strong>\n<br>\n<span>Your dates must be between 42 to 365 days.</span>",
                   "refreshOnChange": true,
                   "customClass": "banner-warning ",
+                  "hidden": false,
+                  "modalEdit": false,
                   "key": "invalidStudyDatesPeriodLength",
-                  "customConditional": "show = data.warnings.indexOf(component.key) !== -1;",
+                  "tags": [],
+                  "properties": {},
+                  "conditional": {
+                    "show": null,
+                    "when": null,
+                    "eq": "",
+                    "json": ""
+                  },
+                  "customConditional": "show = data.validationWarnings.indexOf(component.key) !== -1;",
+                  "logic": [],
+                  "attributes": {},
+                  "overlay": {
+                    "style": "",
+                    "page": "",
+                    "left": "",
+                    "top": "",
+                    "width": "",
+                    "height": ""
+                  },
                   "type": "htmlelement",
                   "input": false,
                   "tableView": false,
@@ -2078,11 +2121,9 @@
                   "protected": false,
                   "unique": false,
                   "persistent": false,
-                  "hidden": false,
                   "clearOnHide": true,
                   "refreshOn": "",
                   "redrawOn": "",
-                  "modalEdit": false,
                   "dataGridLabel": false,
                   "labelPosition": "top",
                   "description": "",
@@ -2097,7 +2138,6 @@
                   "calculateValue": "",
                   "calculateServer": false,
                   "widget": null,
-                  "attributes": {},
                   "validateOn": "change",
                   "validate": {
                     "required": false,
@@ -2107,27 +2147,13 @@
                     "multiple": false,
                     "unique": false
                   },
-                  "conditional": {
-                    "show": null,
-                    "when": null,
-                    "eq": ""
-                  },
-                  "overlay": {
-                    "style": "",
-                    "left": "",
-                    "top": "",
-                    "width": "",
-                    "height": ""
-                  },
                   "allowCalculateOverride": false,
                   "encrypted": false,
                   "showCharCount": false,
                   "showWordCount": false,
-                  "properties": {},
                   "allowMultipleMasks": false,
                   "addons": [],
-                  "tag": "p",
-                  "id": "e1f3bl"
+                  "id": "ebhbfou"
                 }
               ],
               "placeholder": "",
@@ -2392,6 +2418,7 @@
                   "errors": "",
                   "key": "lacksStudyBreaks",
                   "tags": [
+                    "execute-validation",
                     "execute-calculation"
                   ],
                   "properties": {},
@@ -2430,7 +2457,7 @@
                   "showWordCount": false,
                   "allowMultipleMasks": false,
                   "addons": [],
-                  "id": "ecyeu4"
+                  "id": "eqekqf"
                 },
                 {
                   "label": "Break dates",
@@ -2490,7 +2517,10 @@
                   "errorLabel": "",
                   "errors": "",
                   "key": "studyBreaks",
-                  "tags": [],
+                  "tags": [
+                    "execute-validation",
+                    "execute-calculation"
+                  ],
                   "properties": {},
                   "conditional": {
                     "show": true,
@@ -2591,7 +2621,8 @@
                       "errors": "",
                       "key": "breakStartDate",
                       "tags": [
-                        "execute-validation"
+                        "execute-validation",
+                        "execute-calculation"
                       ],
                       "properties": {},
                       "conditional": {
@@ -2618,7 +2649,7 @@
                       "refreshOn": "",
                       "addons": [],
                       "inputType": "text",
-                      "id": "ejgboq00",
+                      "id": "eufdf4l00",
                       "defaultValue": ""
                     },
                     {
@@ -2700,7 +2731,8 @@
                       "errors": "",
                       "key": "breakEndDate",
                       "tags": [
-                        "execute-validation"
+                        "execute-validation",
+                        "execute-calculation"
                       ],
                       "properties": {},
                       "conditional": {
@@ -2727,7 +2759,7 @@
                       "refreshOn": "",
                       "addons": [],
                       "inputType": "text",
-                      "id": "esg89z90",
+                      "id": "endqveo0",
                       "defaultValue": ""
                     },
                     {
@@ -2758,7 +2790,7 @@
                       "key": "breakDays",
                       "type": "number",
                       "input": true,
-                      "id": "ewdj5ald0000000000000000000000000000000000000000000000000000000000000000",
+                      "id": "eumrjyw00",
                       "placeholder": "",
                       "prefix": "",
                       "customClass": "",
@@ -2833,7 +2865,7 @@
                       "key": "eligibleBreakDays",
                       "type": "number",
                       "input": true,
-                      "id": "eqifkdp0000000000000000000000000000000000000000000000000000000000000000",
+                      "id": "etjg41y00",
                       "placeholder": "",
                       "prefix": "",
                       "customClass": "",
@@ -2909,7 +2941,7 @@
                       "key": "ineligibleBreakDays",
                       "type": "number",
                       "input": true,
-                      "id": "e3snjj70000000000000000000000000000000000000000000000000000000000000000",
+                      "id": "el99z42d00",
                       "placeholder": "",
                       "prefix": "",
                       "customClass": "",
@@ -2974,7 +3006,7 @@
                   "addons": [],
                   "tree": true,
                   "lazyLoad": false,
-                  "id": "efo4roq"
+                  "id": "ek2lf66"
                 },
                 {
                   "label": "Study Breaks Overlapping Detection",
@@ -3828,6 +3860,9 @@
             },
             {
               "label": "HTML",
+              "labelWidth": "",
+              "labelMargin": "",
+              "tag": "p",
               "className": "alert alert-warning fa fa-exclamation-triangle w-100",
               "attrs": [
                 {
@@ -3838,88 +3873,9 @@
               "content": "<strong class=\"ml-2\">This study break exceeds the 21 consecutive day threshold as outlined in StudentAid BC policy</strong>\n<br>\n<span>Excess break will be deducted from total funded study period weeks.</span>",
               "refreshOnChange": true,
               "customClass": "banner-warning",
+              "hidden": false,
+              "modalEdit": false,
               "key": "invalidStudyBreakAmountOfDays",
-              "customConditional": "show = data.warnings.indexOf(component.key) !== -1;",
-              "type": "htmlelement",
-              "input": false,
-              "tableView": false,
-              "placeholder": "",
-              "prefix": "",
-              "suffix": "",
-              "multiple": false,
-              "defaultValue": null,
-              "protected": false,
-              "unique": false,
-              "persistent": false,
-              "hidden": false,
-              "clearOnHide": true,
-              "refreshOn": "",
-              "redrawOn": "",
-              "modalEdit": false,
-              "dataGridLabel": false,
-              "labelPosition": "top",
-              "description": "",
-              "errorLabel": "",
-              "tooltip": "",
-              "hideLabel": false,
-              "tabindex": "",
-              "disabled": false,
-              "autofocus": false,
-              "dbIndex": false,
-              "customDefaultValue": "",
-              "calculateValue": "",
-              "calculateServer": false,
-              "widget": null,
-              "attributes": {},
-              "validateOn": "change",
-              "validate": {
-                "required": false,
-                "custom": "",
-                "customPrivate": false,
-                "strictDateValidation": false,
-                "multiple": false,
-                "unique": false
-              },
-              "conditional": {
-                "show": null,
-                "when": null,
-                "eq": ""
-              },
-              "overlay": {
-                "style": "",
-                "left": "",
-                "top": "",
-                "width": "",
-                "height": ""
-              },
-              "allowCalculateOverride": false,
-              "encrypted": false,
-              "showCharCount": false,
-              "showWordCount": false,
-              "properties": {},
-              "allowMultipleMasks": false,
-              "addons": [],
-              "tag": "p",
-              "id": "eyyq5n"
-            },
-            {
-              "label": "HTML",
-              "labelWidth": "",
-              "labelMargin": "",
-              "tag": "p",
-              "className": "alert alert-info fa fa-info-circle w-100",
-              "attrs": [
-                {
-                  "attr": "",
-                  "value": ""
-                }
-              ],
-              "content": "<strong class=\"ml-2\">The combined study breaks exceed the 10% threshold as outlined in StudentAid BC policy</strong>\n<br>\n<span>Excess break will be deducted from total funded study period weeks.</span>",
-              "refreshOnChange": true,
-              "customClass": "banner-info",
-              "hidden": false,
-              "modalEdit": false,
-              "key": "invalidStudyBreaksCombinedThresholdPercentage",
               "tags": [],
               "properties": {},
               "conditional": {
@@ -3928,7 +3884,7 @@
                 "eq": "",
                 "json": ""
               },
-              "customConditional": "show = data.infos.indexOf(component.key) !== -1;",
+              "customConditional": "show = data.validationWarnings.indexOf(component.key) !== -1;",
               "logic": [],
               "attributes": {},
               "overlay": {
@@ -3982,7 +3938,89 @@
               "showWordCount": false,
               "allowMultipleMasks": false,
               "addons": [],
-              "id": "e6gjslr"
+              "id": "e0ddt67"
+            },
+            {
+              "label": "HTML",
+              "labelWidth": "",
+              "labelMargin": "",
+              "tag": "p",
+              "className": "alert alert-info fa fa-info-circle w-100",
+              "attrs": [
+                {
+                  "attr": "",
+                  "value": ""
+                }
+              ],
+              "content": "<strong class=\"ml-2\">The combined study breaks exceed the 10% threshold as outlined in StudentAid BC policy</strong>\n<br>\n<span>Excess break will be deducted from total funded study period weeks.</span>",
+              "refreshOnChange": true,
+              "customClass": "banner-info",
+              "hidden": false,
+              "modalEdit": false,
+              "key": "invalidStudyBreaksCombinedThresholdPercentage",
+              "tags": [],
+              "properties": {},
+              "conditional": {
+                "show": null,
+                "when": null,
+                "eq": "",
+                "json": ""
+              },
+              "customConditional": "show = data.validationInfos.indexOf(component.key) !== -1;",
+              "logic": [],
+              "attributes": {},
+              "overlay": {
+                "style": "",
+                "page": "",
+                "left": "",
+                "top": "",
+                "width": "",
+                "height": ""
+              },
+              "type": "htmlelement",
+              "input": false,
+              "tableView": false,
+              "placeholder": "",
+              "prefix": "",
+              "suffix": "",
+              "multiple": false,
+              "defaultValue": null,
+              "protected": false,
+              "unique": false,
+              "persistent": false,
+              "clearOnHide": true,
+              "refreshOn": "",
+              "redrawOn": "",
+              "dataGridLabel": false,
+              "labelPosition": "top",
+              "description": "",
+              "errorLabel": "",
+              "tooltip": "",
+              "hideLabel": false,
+              "tabindex": "",
+              "disabled": false,
+              "autofocus": false,
+              "dbIndex": false,
+              "customDefaultValue": "",
+              "calculateValue": "",
+              "calculateServer": false,
+              "widget": null,
+              "validateOn": "change",
+              "validate": {
+                "required": false,
+                "custom": "",
+                "customPrivate": false,
+                "strictDateValidation": false,
+                "multiple": false,
+                "unique": false
+              },
+              "allowCalculateOverride": false,
+              "encrypted": false,
+              "showCharCount": false,
+              "showWordCount": false,
+              "allowMultipleMasks": false,
+              "addons": [],
+              "id": "enjgj8f"
             },
             {
               "label": "HTML",
@@ -5411,7 +5449,7 @@
       "customDefaultValue": "",
       "calculateValue": "",
       "calculateServer": false,
-      "key": "warnings",
+      "key": "validationWarnings",
       "tags": [],
       "properties": {},
       "logic": [],
@@ -5467,7 +5505,7 @@
       "allowMultipleMasks": false,
       "addons": [],
       "inputType": "hidden",
-      "id": "ectrof5"
+      "id": "ebz0dy"
     },
     {
       "label": "Array of offerings information (banners) calculated on the server and used to display warnings banners",
@@ -5484,7 +5522,7 @@
       "customDefaultValue": "",
       "calculateValue": "",
       "calculateServer": false,
-      "key": "infos",
+      "key": "validationInfos",
       "tags": [],
       "properties": {},
       "logic": [],
@@ -5540,7 +5578,7 @@
       "allowMultipleMasks": false,
       "addons": [],
       "inputType": "hidden",
-      "id": "ex1qhin"
+      "id": "e1t0135"
     },
     {
       "label": "applicationId",

--- a/sources/packages/web/src/components/common/OfferingFormSubmit.vue
+++ b/sources/packages/web/src/components/common/OfferingFormSubmit.vue
@@ -116,16 +116,17 @@ export default defineComponent({
         validationResult.validationDate > lastCalculationDate
       ) {
         // Update the form component only if the API result is the most recent.
-        const warningsTypes = validationResult.warnings.map(
-          (warning) => warning.typeCode,
-        );
+
         setComponentValue(
           offeringForm,
           FORMIO_STUDY_PERIOD_BREAK_DOWN_KEY,
           validationResult.studyPeriodBreakdown,
         );
+        // Avoid updating the validation fields if the validation was never manually requested.
         if (validationStarted) {
-          // Avoid updating the validation fields if the validation was never manually requested.
+          const warningsTypes = validationResult.warnings.map(
+            (warning) => warning.typeCode,
+          );
           setComponentValue(
             offeringForm,
             FORMIO_WARNINGS_HIDDEN_FIELD_KEY,

--- a/sources/packages/web/src/components/common/OfferingFormSubmit.vue
+++ b/sources/packages/web/src/components/common/OfferingFormSubmit.vue
@@ -42,7 +42,7 @@ import {
   EducationProgramOfferingAPIInDTO,
   OfferingValidationResultAPIOutDTO,
   StudyPeriodBreakdownAPIOutDTO,
-  ValidationWarningResultAPIOutDTO,
+  ValidationResultAPIOutDTO,
 } from "@/services/http/dto";
 import ConfirmModal from "@/components/common/modals/ConfirmModal.vue";
 import { EducationProgramOfferingService } from "@/services/EducationProgramOfferingService";
@@ -107,7 +107,7 @@ export default defineComponent({
             data,
           );
         const warningsTypes = validationResult.warnings.map(
-          (warning) => warning.warningType,
+          (warning) => warning.typeCode,
         );
         setComponentValue(
           offeringForm,
@@ -160,11 +160,9 @@ export default defineComponent({
     /**
      * Move the screen to the first warning banner, is any.
      */
-    const scrollToWarningBanner = (
-      warnings: ValidationWarningResultAPIOutDTO[],
-    ) => {
+    const scrollToWarningBanner = (warnings: ValidationResultAPIOutDTO[]) => {
       const [warningToScroll] = warnings;
-      const warningBannerComponent = `formio-component-${warningToScroll.warningType}`;
+      const warningBannerComponent = `formio-component-${warningToScroll.typeCode}`;
       const [warningBanner] = document.getElementsByClassName(
         warningBannerComponent,
       );

--- a/sources/packages/web/src/components/common/OfferingFormSubmit.vue
+++ b/sources/packages/web/src/components/common/OfferingFormSubmit.vue
@@ -83,6 +83,11 @@ export default defineComponent({
       type: Number,
       required: true,
     },
+    enableValidationsOnInit: {
+      type: Boolean,
+      required: true,
+      default: false,
+    },
   },
   setup(props, context) {
     const snackBar = useSnackBar();
@@ -93,6 +98,10 @@ export default defineComponent({
     // further validations to happen automatically when a component
     // tagged with FORMIO_EXECUTE_VALIDATION_TAG changes.
     let validationStarted = false;
+
+    const allowValidation = (): boolean => {
+      return validationStarted || props.enableValidationsOnInit;
+    };
 
     // Keep the form reference once it is created
     // to use the setComponentValue later.
@@ -123,7 +132,7 @@ export default defineComponent({
           validationResult.studyPeriodBreakdown,
         );
         // Avoid updating the validation fields if the validation was never manually requested.
-        if (validationStarted) {
+        if (allowValidation()) {
           const warningsTypes = validationResult.warnings.map(
             (warning) => warning.typeCode,
           );
@@ -235,12 +244,13 @@ export default defineComponent({
       event: FormIOChangeEvent,
     ) => {
       if (
-        event.changed?.component?.tags?.includes(FORMIO_EXECUTE_CALCULATION_TAG)
-      ) {
-        await validateOfferingData(form.data);
-      } else if (
-        validationStarted &&
-        event.changed?.component?.tags?.includes(FORMIO_EXECUTE_VALIDATION_TAG)
+        event.changed?.component?.tags?.includes(
+          FORMIO_EXECUTE_CALCULATION_TAG,
+        ) ||
+        (allowValidation() &&
+          event.changed?.component?.tags?.includes(
+            FORMIO_EXECUTE_VALIDATION_TAG,
+          ))
       ) {
         await validateOfferingData(form.data);
       }

--- a/sources/packages/web/src/services/http/dto/EducationProgramOffering.dto.ts
+++ b/sources/packages/web/src/services/http/dto/EducationProgramOffering.dto.ts
@@ -147,6 +147,7 @@ export interface OfferingBulkInsertValidationResultAPIOutDTO {
   endDate?: string;
   offeringStatus?: OfferingStatus.Approved | OfferingStatus.CreationPending;
   errors: string[];
+  infos: ValidationResultAPIOutDTO[];
   warnings: ValidationResultAPIOutDTO[];
 }
 

--- a/sources/packages/web/src/services/http/dto/EducationProgramOffering.dto.ts
+++ b/sources/packages/web/src/services/http/dto/EducationProgramOffering.dto.ts
@@ -110,7 +110,8 @@ export interface EducationProgramOfferingAPIOutDTO {
   hasExistingApplication?: boolean;
   locationName?: string;
   institutionName?: string;
-  warnings: string[];
+  validationWarnings: string[];
+  validationInfos: string[];
 }
 
 export interface StudyBreakAPIOutDTO {
@@ -146,17 +147,18 @@ export interface OfferingBulkInsertValidationResultAPIOutDTO {
   endDate?: string;
   offeringStatus?: OfferingStatus.Approved | OfferingStatus.CreationPending;
   errors: string[];
-  warnings: ValidationWarningResultAPIOutDTO[];
+  warnings: ValidationResultAPIOutDTO[];
 }
 
 /**
  * Represents an error considered not critical for
  * an offering and provides a user-friendly message
- * and a type that uniquely identifies this warning.
+ * and a type that uniquely identifies this warning
+ * or info.
  */
-export interface ValidationWarningResultAPIOutDTO {
-  warningType: string;
-  warningMessage: string;
+export interface ValidationResultAPIOutDTO {
+  typeCode: string;
+  message: string;
 }
 
 export interface StudyPeriodBreakdownAPIOutDTO {
@@ -173,7 +175,7 @@ export interface StudyPeriodBreakdownAPIOutDTO {
 export interface OfferingValidationResultAPIOutDTO {
   offeringStatus?: OfferingStatus.Approved | OfferingStatus.CreationPending;
   errors: string[];
-  warnings: ValidationWarningResultAPIOutDTO[];
+  warnings: ValidationResultAPIOutDTO[];
   studyPeriodBreakdown: StudyPeriodBreakdownAPIOutDTO;
   validationDate: Date;
 }

--- a/sources/packages/web/src/services/http/dto/EducationProgramOffering.dto.ts
+++ b/sources/packages/web/src/services/http/dto/EducationProgramOffering.dto.ts
@@ -175,6 +175,7 @@ export interface StudyPeriodBreakdownAPIOutDTO {
 export interface OfferingValidationResultAPIOutDTO {
   offeringStatus?: OfferingStatus.Approved | OfferingStatus.CreationPending;
   errors: string[];
+  infos: ValidationResultAPIOutDTO[];
   warnings: ValidationResultAPIOutDTO[];
   studyPeriodBreakdown: StudyPeriodBreakdownAPIOutDTO;
   validationDate: Date;

--- a/sources/packages/web/src/views/institution/OfferingsUpload.vue
+++ b/sources/packages/web/src/views/institution/OfferingsUpload.vue
@@ -178,6 +178,16 @@
                     </li>
                   </ul>
                 </div>
+                <div
+                  class="alert alert-info"
+                  v-if="slotProps.data.infos.length"
+                >
+                  <ul class="m-2">
+                    <li v-for="info in slotProps.data.infos" :key="info">
+                      {{ info.message }}
+                    </li>
+                  </ul>
+                </div>
               </template></Column
             >
           </DataTable>

--- a/sources/packages/web/src/views/institution/OfferingsUpload.vue
+++ b/sources/packages/web/src/views/institution/OfferingsUpload.vue
@@ -174,7 +174,7 @@
                       v-for="warning in slotProps.data.warnings"
                       :key="warning"
                     >
-                      {{ warning.warningMessage }}
+                      {{ warning.message }}
                     </li>
                   </ul>
                 </div>
@@ -188,7 +188,7 @@
 </template>
 
 <script lang="ts">
-import { ref, computed } from "vue";
+import { ref, computed, defineComponent } from "vue";
 import {
   OfferingsUploadBulkInsert,
   DEFAULT_PAGE_LIMIT,
@@ -208,7 +208,7 @@ import { OFFERING_VALIDATION_CSV_PARSE_ERROR } from "@/constants";
 const ACCEPTED_FILE_TYPE = "text/csv";
 const MAX_OFFERING_UPLOAD_SIZE = 4194304;
 
-export default {
+export default defineComponent({
   components: {
     StatusChipOffering,
   },
@@ -338,5 +338,5 @@ export default {
       uploadProgress,
     };
   },
-};
+});
 </script>

--- a/sources/packages/web/src/views/institution/locations/offerings/OfferingEdit.vue
+++ b/sources/packages/web/src/views/institution/locations/offerings/OfferingEdit.vue
@@ -66,6 +66,7 @@
       :formMode="formMode"
       :locationId="locationId"
       :programId="programId"
+      :enableValidationsOnInit="true"
       @submit="submit"
       @cancel="goBack"
     ></offering-form-submit>

--- a/sources/packages/web/src/views/institution/locations/offerings/OfferingRequestChange.vue
+++ b/sources/packages/web/src/views/institution/locations/offerings/OfferingRequestChange.vue
@@ -98,7 +98,6 @@ export default defineComponent({
     });
 
     const submit = async (data: EducationProgramOfferingAPIInDTO) => {
-      console.log(data);
       try {
         processing.value = true;
         await EducationProgramOfferingService.shared.requestChange(


### PR DESCRIPTION
- Converted the 10% warning message to an information banner only that will no longer make the offering to be pending.

![image](https://user-images.githubusercontent.com/61259237/200995641-8281b993-4a3f-4ad9-aafa-5c56809bfa49.png)

- Executing the validations on the server during the "on change" of specific form.io components marked with the tag "execute-validation" or "execute-calculation".
    - The calculation happen always that one component tagged with "execute-calculation" changed.
    - The validation "on change" started to happen only the first manual validation is triggered and for components marked with the tag "execute-validation".

- Added info also to the bulk upload.

![image](https://user-images.githubusercontent.com/61259237/201184767-351e9d4a-4d13-4106-9566-62fe27388d62.png)

