### PR TITLE
[web][api][SIMS #1546]Changed warning to info

### DIFF
--- a/sources/packages/backend/apps/api/src/services/education-program-offering/education-program-offering-validation.models.ts
+++ b/sources/packages/backend/apps/api/src/services/education-program-offering/education-program-offering-validation.models.ts
@@ -182,7 +182,6 @@ export type CalculatedStudyBreaksAndWeeks = StudyBreaksAndWeeks & {
  * !These keys are also consumed in the UI to display/hide warning banners.
  */
 export enum OfferingValidationWarnings {
-  InvalidStudyBreakAmountOfDays = "invalidStudyBreakAmountOfDays",
   ProgramOfferingIntensityMismatch = "programOfferingIntensityMismatch",
   ProgramOfferingDeliveryMismatch = "programOfferingDeliveryMismatch",
   ProgramOfferingWILMismatch = "programOfferingWILMismatch",
@@ -194,6 +193,7 @@ export enum OfferingValidationWarnings {
  * !These keys are also consumed in the UI to display/hide info banners.
  */
 export enum OfferingValidationInfos {
+  InvalidStudyBreakAmountOfDays = "invalidStudyBreakAmountOfDays",
   InvalidStudyBreaksCombinedThresholdPercentage = "invalidStudyBreaksCombinedThresholdPercentage",
 }
 
@@ -300,8 +300,8 @@ export class StudyBreak {
     OFFERING_STUDY_BREAK_MAX_DAYS,
     userFriendlyNames.breakEndDate,
     {
-      context: ValidationContext.CreateWarning(
-        OfferingValidationWarnings.InvalidStudyBreakAmountOfDays,
+      context: ValidationContext.CreateInfo(
+        OfferingValidationInfos.InvalidStudyBreakAmountOfDays,
       ),
     },
   )

--- a/sources/packages/backend/apps/api/src/services/education-program-offering/education-program-offering.service.ts
+++ b/sources/packages/backend/apps/api/src/services/education-program-offering/education-program-offering.service.ts
@@ -503,7 +503,7 @@ export class EducationProgramOfferingService extends RecordDataModelService<Educ
     offeringValidationModel.offeringDeclaration = offering.offeringDeclaration;
     offeringValidationModel.offeringType = offering.offeringType;
     offeringValidationModel.courseLoad = offering.courseLoad;
-    offeringValidationModel.studyBreaks = offering.studyBreaks.studyBreaks;
+    offeringValidationModel.studyBreaks = offering.studyBreaks?.studyBreaks;
     return offeringValidationModel;
   }
 

--- a/sources/packages/forms/src/form-definitions/educationprogramoffering.json
+++ b/sources/packages/forms/src/form-definitions/educationprogramoffering.json
@@ -2649,7 +2649,7 @@
                       "refreshOn": "",
                       "addons": [],
                       "inputType": "text",
-                      "id": "eufdf4l00",
+                      "id": "eufdf4l0000000",
                       "defaultValue": ""
                     },
                     {
@@ -2759,7 +2759,7 @@
                       "refreshOn": "",
                       "addons": [],
                       "inputType": "text",
-                      "id": "endqveo0",
+                      "id": "endqveo000000",
                       "defaultValue": ""
                     },
                     {
@@ -2790,7 +2790,7 @@
                       "key": "breakDays",
                       "type": "number",
                       "input": true,
-                      "id": "eumrjyw00",
+                      "id": "eumrjyw0000000",
                       "placeholder": "",
                       "prefix": "",
                       "customClass": "",
@@ -2865,7 +2865,7 @@
                       "key": "eligibleBreakDays",
                       "type": "number",
                       "input": true,
-                      "id": "etjg41y00",
+                      "id": "etjg41y0000000",
                       "placeholder": "",
                       "prefix": "",
                       "customClass": "",
@@ -2941,7 +2941,7 @@
                       "key": "ineligibleBreakDays",
                       "type": "number",
                       "input": true,
-                      "id": "el99z42d00",
+                      "id": "el99z42d0000000",
                       "placeholder": "",
                       "prefix": "",
                       "customClass": "",
@@ -3863,7 +3863,7 @@
               "labelWidth": "",
               "labelMargin": "",
               "tag": "p",
-              "className": "alert alert-warning fa fa-exclamation-triangle w-100",
+              "className": "alert alert-info fa fa-info-circle w-100",
               "attrs": [
                 {
                   "attr": "",
@@ -3872,7 +3872,7 @@
               ],
               "content": "<strong class=\"ml-2\">This study break exceeds the 21 consecutive day threshold as outlined in StudentAid BC policy</strong>\n<br>\n<span>Excess break will be deducted from total funded study period weeks.</span>",
               "refreshOnChange": true,
-              "customClass": "banner-warning",
+              "customClass": "banner-info",
               "hidden": false,
               "modalEdit": false,
               "key": "invalidStudyBreakAmountOfDays",
@@ -3884,7 +3884,7 @@
                 "eq": "",
                 "json": ""
               },
-              "customConditional": "show = data.validationWarnings.indexOf(component.key) !== -1;",
+              "customConditional": "show = data.validationInfos.indexOf(component.key) !== -1;",
               "logic": [],
               "attributes": {},
               "overlay": {
@@ -3938,7 +3938,7 @@
               "showWordCount": false,
               "allowMultipleMasks": false,
               "addons": [],
-              "id": "e0ddt67"
+              "id": "eygtwd"
             },
             {
               "label": "HTML",
@@ -4020,7 +4020,7 @@
               "showWordCount": false,
               "allowMultipleMasks": false,
               "addons": [],
-              "id": "enjgj8f"
+              "id": "edpt89"
             },
             {
               "label": "HTML",

--- a/sources/packages/web/src/components/common/OfferingFormSubmit.vue
+++ b/sources/packages/web/src/components/common/OfferingFormSubmit.vue
@@ -131,6 +131,12 @@ export default defineComponent({
           FORMIO_STUDY_PERIOD_BREAK_DOWN_KEY,
           validationResult.studyPeriodBreakdown,
         );
+        const infoTypes = validationResult.infos.map((info) => info.typeCode);
+        setComponentValue(
+          offeringForm,
+          FORMIO_INFOS_HIDDEN_FIELD_KEY,
+          infoTypes,
+        );
         // Avoid updating the validation fields if the validation was never manually requested.
         if (allowValidation()) {
           const warningsTypes = validationResult.warnings.map(
@@ -140,12 +146,6 @@ export default defineComponent({
             offeringForm,
             FORMIO_WARNINGS_HIDDEN_FIELD_KEY,
             warningsTypes,
-          );
-          const infoTypes = validationResult.infos.map((info) => info.typeCode);
-          setComponentValue(
-            offeringForm,
-            FORMIO_INFOS_HIDDEN_FIELD_KEY,
-            infoTypes,
           );
         }
       }


### PR DESCRIPTION
- Converted the 21 days waning banner to info banner.
![image](https://user-images.githubusercontent.com/61259237/202058843-a0544da6-52d2-4210-b0b9-38ee39ea7684.png)
- Allow the info banners to be displayed even when the validation was not triggered yet.
