### PR TITLE
[workflow][CI/CD][SIMS #577]Deploy DMNs

### DIFF
--- a/.github/workflows/deploy-all.yml
+++ b/.github/workflows/deploy-all.yml
@@ -11,10 +11,6 @@ on:
         description: "Build Id"
         required: true
         default: "NULL"
-      resourcesFolder:
-        description: "Folder with the resources to be deployed"
-        required: true
-        default: "BPMN/camunda-8"
       environment:
         required: true
         type: environment
@@ -32,9 +28,6 @@ on:
         required: true
         type: string
       buildId:
-        required: true
-        type: string
-      resourcesFolder:
         required: true
         type: string
       environment:
@@ -119,7 +112,6 @@ jobs:
       - deploy
     uses: ./.github/workflows/deploy-camunda-definitions.yml
     with:
-      resourcesFolder: ${{ github.event.inputs.resourcesFolder }}
       environment: ${{ github.event.inputs.environment }}
     secrets: inherit
   deployFormioDefinitions:

--- a/.github/workflows/deploy-camunda-definitions.yml
+++ b/.github/workflows/deploy-camunda-definitions.yml
@@ -3,18 +3,11 @@ name: Deploy Camunda Resources
 on:
   workflow_dispatch:
     inputs:
-      resourcesFolder:
-        description: "Folder with the resources to be deployed"
-        required: true
-        default: "BPMN/camunda-8"
       environment:
         required: true
         type: environment
   workflow_call:
     inputs:
-      resourcesFolder:
-        required: true
-        type: string
       environment:
         required: true
         type: string
@@ -25,7 +18,6 @@ jobs:
     runs-on: ubuntu-latest
     environment: ${{ github.event.inputs.environment }}
     env:
-      RESOURCES_FOLDER: ${{ github.event.inputs.resourcesFolder }}
       ZEEBE_ADDRESS: ${{ secrets.ZEEBE_ADDRESS }}
       ZEEBE_AUTHORIZATION_SERVER_URL: ${{ secrets.ZEEBE_AUTHORIZATION_SERVER_URL }}
       ZEEBE_CLIENT_ID: ${{ secrets.ZEEBE_CLIENT_ID }}

--- a/sources/packages/workflow/src/deploy.models.ts
+++ b/sources/packages/workflow/src/deploy.models.ts
@@ -11,7 +11,7 @@ export interface DecisionDeploymentResult {
   requirementsId: string;
   requirementsName: string;
   requirementsKey: number;
-  resourceName: string;
+  resourceName: string | undefined;
   metadata: string;
   version: number;
   deploymentKey: number;

--- a/sources/packages/workflow/src/deploy.models.ts
+++ b/sources/packages/workflow/src/deploy.models.ts
@@ -1,0 +1,26 @@
+export const PROCESSES_EXTENSION = ".bpmn";
+export const DECISIONS_EXTENSION = ".dmn";
+export const DEPLOYMENT_METADATA_TYPE = "Metadata";
+
+export enum DeployMetadataTypes {
+  DecisionRequirements = "decisionRequirements",
+  Decision = "decision",
+}
+
+export interface DecisionDeploymentResult {
+  requirementsId: string;
+  requirementsName: string;
+  requirementsKey: number;
+  resourceName: string;
+  metadata: string;
+  version: number;
+  deploymentKey: number;
+}
+
+export interface ProcessDeploymentResult {
+  bpmnProcessId: string;
+  processDefinitionKey: string;
+  resourceName: string;
+  version: number;
+  deploymentKey: number;
+}

--- a/sources/packages/workflow/src/deploy.models.ts
+++ b/sources/packages/workflow/src/deploy.models.ts
@@ -1,8 +1,8 @@
 export const PROCESSES_EXTENSION = ".bpmn";
 export const DECISIONS_EXTENSION = ".dmn";
-export const DEPLOYMENT_METADATA_TYPE = "Metadata";
+export const DEPLOYMENT_METADATA_PROPERTY_NAME = "Metadata";
 
-export enum DeployMetadataTypes {
+export enum DeploymentMetadataTypes {
   DecisionRequirements = "decisionRequirements",
   Decision = "decision",
 }

--- a/sources/packages/workflow/src/deploy.ts
+++ b/sources/packages/workflow/src/deploy.ts
@@ -78,7 +78,7 @@ dotenv.config({ path: path.join(__dirname, "../../../../.env") });
                 requirementsName: decision.dmnDecisionName,
                 requirementsKey: decision.decisionRequirementsKey,
                 metadata: deployment[DEPLOYMENT_METADATA_PROPERTY_NAME],
-                resourceName: null,
+                resourceName: undefined,
                 version: decision.version,
                 deploymentKey: deploymentResult.key,
               });

--- a/sources/packages/workflow/src/deploy.ts
+++ b/sources/packages/workflow/src/deploy.ts
@@ -47,6 +47,7 @@ dotenv.config({ path: path.join(__dirname, "../../../../.env") });
       (filePath) => path.extname(filePath) === DECISIONS_EXTENSION
     );
     for (const decisionFilename of decisionsFileNames) {
+      console.info(`Deploying decision: ${path.basename(decisionFilename)}`);
       const deploymentResult = await zeebeClient.deployResource({
         decisionFilename,
       });
@@ -97,6 +98,7 @@ dotenv.config({ path: path.join(__dirname, "../../../../.env") });
       (filePath) => path.extname(filePath) === PROCESSES_EXTENSION
     );
     for (const processFilename of processes) {
+      console.info(`Deploying process: ${path.basename(processFilename)}`);
       const deploymentResult = await zeebeClient.deployResource({
         processFilename,
       });
@@ -112,7 +114,7 @@ dotenv.config({ path: path.join(__dirname, "../../../../.env") });
 
     console.info(`\nDeployment successful!\n`);
     console.info(
-      "Please see below the definitions deployed (non-modified definitions will not generate a new version).\n"
+      "Please see below the definitions deployed (non-modified definitions will not generate a new version)."
     );
 
     console.info("\nSummary of decisions(DMN) deployments\n");

--- a/sources/packages/workflow/src/deploy.ts
+++ b/sources/packages/workflow/src/deploy.ts
@@ -1,7 +1,20 @@
 import * as fs from "fs";
 import * as path from "path";
-import { ZBClient } from "zeebe-node";
+import {
+  DecisionDeployment,
+  DecisionRequirementsDeployment,
+  Deployment,
+  ZBClient,
+} from "zeebe-node";
 import * as dotenv from "dotenv";
+import {
+  DecisionDeploymentResult,
+  DECISIONS_EXTENSION,
+  DEPLOYMENT_METADATA_TYPE,
+  DeployMetadataTypes,
+  ProcessDeploymentResult,
+  PROCESSES_EXTENSION,
+} from "./deploy.models";
 
 dotenv.config({ path: path.join(__dirname, "../../../../.env") });
 
@@ -25,13 +38,85 @@ dotenv.config({ path: path.join(__dirname, "../../../../.env") });
   console.info(`Files found: ${fileNames.join(", ")}`);
   const zeebeClient = new ZBClient();
   try {
-    const deploymentResults = await zeebeClient.deployProcess(filesPaths);
+    // Deploy all decision files (BPMNs).
+    const decisionDeploymentResults: DecisionDeploymentResult[] = [];
+    const decisionsFileNames = filesPaths.filter(
+      (filePath) => path.extname(filePath) === DECISIONS_EXTENSION
+    );
+    for (const decisionFilename of decisionsFileNames) {
+      const deploymentResult = await zeebeClient.deployResource({
+        decisionFilename,
+      });
+      deploymentResult.deployments.forEach((deployment: Deployment) => {
+        switch (deployment[DEPLOYMENT_METADATA_TYPE]) {
+          case DeployMetadataTypes.DecisionRequirements:
+            {
+              const decisionRequirement =
+                deployment as DecisionRequirementsDeployment;
+              const decision = decisionRequirement.decisionRequirements;
+              decisionDeploymentResults.push({
+                requirementsId: decision.dmnDecisionRequirementsId,
+                requirementsName: decision.dmnDecisionRequirementsName,
+                requirementsKey: decision.decisionRequirementsKey,
+                metadata: deployment[DEPLOYMENT_METADATA_TYPE],
+                resourceName: path.basename(decision.resourceName),
+                version: decision.version,
+                deploymentKey: deploymentResult.key,
+              });
+            }
+            break;
+          case DeployMetadataTypes.Decision:
+            {
+              const decisionDeployment = deployment as DecisionDeployment;
+              const decision = decisionDeployment.decision;
+              decisionDeploymentResults.push({
+                requirementsId: decision.dmnDecisionId,
+                requirementsName: decision.dmnDecisionName,
+                requirementsKey: decision.decisionRequirementsKey,
+                metadata: deployment[DEPLOYMENT_METADATA_TYPE],
+                resourceName: null,
+                version: decision.version,
+                deploymentKey: deploymentResult.key,
+              });
+            }
+            break;
+          default:
+            console.warn("\nUnknown metadata\n");
+            console.warn(deployment);
+            break;
+        }
+      });
+    }
+
+    // Deploy all processes (BPMNs).
+    const processesDeploymentResults: ProcessDeploymentResult[] = [];
+    const processes = filesPaths.filter(
+      (filePath) => path.extname(filePath) === PROCESSES_EXTENSION
+    );
+    for (const processFilename of processes) {
+      const deploymentResult = await zeebeClient.deployResource({
+        processFilename,
+      });
+      const results = deploymentResult.deployments.map((deployment) => ({
+        bpmnProcessId: deployment.process.bpmnProcessId,
+        processDefinitionKey: deployment.process.processDefinitionKey,
+        resourceName: path.basename(deployment.process.resourceName),
+        version: deployment.process.version,
+        deploymentKey: deploymentResult.key,
+      }));
+      processesDeploymentResults.push(...results);
+    }
+
     console.info(`\nDeployment successful!\n`);
     console.info(
-      "Please see below the definitions deployed (non-modified definitions will not generate a new version)."
+      "Please see below the definitions deployed (non-modified definitions will not generate a new version).\n"
     );
-    console.table(deploymentResults.processes);
-    console.info(`Deployment key: ${deploymentResults.key}`);
+
+    console.info("\nSummary of decisions(DMN) deployments\n");
+    console.table(decisionDeploymentResults);
+
+    console.info("\nSummary of processes(BPMN) deployments\n");
+    console.table(processesDeploymentResults);
   } catch (error: unknown) {
     console.error("Error while executing the deployment.");
     console.error(error);

--- a/sources/packages/workflow/src/deploy.ts
+++ b/sources/packages/workflow/src/deploy.ts
@@ -10,8 +10,8 @@ import * as dotenv from "dotenv";
 import {
   DecisionDeploymentResult,
   DECISIONS_EXTENSION,
-  DEPLOYMENT_METADATA_TYPE,
-  DeployMetadataTypes,
+  DEPLOYMENT_METADATA_PROPERTY_NAME,
+  DeploymentMetadataTypes,
   ProcessDeploymentResult,
   PROCESSES_EXTENSION,
 } from "./deploy.models";
@@ -35,7 +35,10 @@ dotenv.config({ path: path.join(__dirname, "../../../../.env") });
   const filesPaths = fileNames.map((fileName) =>
     path.join(directory, fileName)
   );
-  console.info(`Files found: ${fileNames.join(", ")}`);
+
+  console.info(`\nFiles found:`);
+  console.table(fileNames);
+
   const zeebeClient = new ZBClient();
   try {
     // Deploy all decision files (BPMNs).
@@ -48,8 +51,8 @@ dotenv.config({ path: path.join(__dirname, "../../../../.env") });
         decisionFilename,
       });
       deploymentResult.deployments.forEach((deployment: Deployment) => {
-        switch (deployment[DEPLOYMENT_METADATA_TYPE]) {
-          case DeployMetadataTypes.DecisionRequirements:
+        switch (deployment[DEPLOYMENT_METADATA_PROPERTY_NAME]) {
+          case DeploymentMetadataTypes.DecisionRequirements:
             {
               const decisionRequirement =
                 deployment as DecisionRequirementsDeployment;
@@ -58,14 +61,14 @@ dotenv.config({ path: path.join(__dirname, "../../../../.env") });
                 requirementsId: decision.dmnDecisionRequirementsId,
                 requirementsName: decision.dmnDecisionRequirementsName,
                 requirementsKey: decision.decisionRequirementsKey,
-                metadata: deployment[DEPLOYMENT_METADATA_TYPE],
+                metadata: deployment[DEPLOYMENT_METADATA_PROPERTY_NAME],
                 resourceName: path.basename(decision.resourceName),
                 version: decision.version,
                 deploymentKey: deploymentResult.key,
               });
             }
             break;
-          case DeployMetadataTypes.Decision:
+          case DeploymentMetadataTypes.Decision:
             {
               const decisionDeployment = deployment as DecisionDeployment;
               const decision = decisionDeployment.decision;
@@ -73,7 +76,7 @@ dotenv.config({ path: path.join(__dirname, "../../../../.env") });
                 requirementsId: decision.dmnDecisionId,
                 requirementsName: decision.dmnDecisionName,
                 requirementsKey: decision.decisionRequirementsKey,
-                metadata: deployment[DEPLOYMENT_METADATA_TYPE],
+                metadata: deployment[DEPLOYMENT_METADATA_PROPERTY_NAME],
                 resourceName: null,
                 version: decision.version,
                 deploymentKey: deploymentResult.key,


### PR DESCRIPTION
- Camunda deployment changed to support also DMNs deployment.
- Removed `Camunda Folder` input from GitHub actions (it was not actually being used).

The method `deployProcess` is deprecated and the recommended method `deployResource` supports BPMN and DMN deployments, as per[ Zeebe documentation](https://github.com/camunda-community-hub/zeebe-client-node-js#deploy-process-models-and-decision-tables).
Please note that the new method `deployResource` supports BPMN/DMN but the method has different overloads that produce different outputs. This causes additional changes to the code and BPMN/DMN are handled in different ways.

Log summary including DMNs.

![image](https://user-images.githubusercontent.com/61259237/202347918-baf6dbac-f795-4bea-af11-994777320250.png)
