### PR TITLE
[workers][api][SIMS #577]Workers ad Student Login Sync Fixes

### DIFF
--- a/sources/packages/backend/apps/workers/src/utilities/jsonpath/jsonpath-utils.ts
+++ b/sources/packages/backend/apps/workers/src/utilities/jsonpath/jsonpath-utils.ts
@@ -121,7 +121,11 @@ export function filterObjectProperties(
   const resultObject = {} as Record<string, unknown>;
   Object.keys(filter).forEach((filterKey: string) => {
     if (object) {
-      resultObject[filterKey] = getJsonPathNodeValue(object, filter[filterKey]);
+      // If the value returned by getJsonPathNodeValue is undefined null will be used as fallback.
+      // This method is mostly used to return values to the Workflow and if the property
+      // is set as undefined it will prevent the variable from being created on Camunda.
+      resultObject[filterKey] =
+        getJsonPathNodeValue(object, filter[filterKey]) ?? null;
     } else {
       resultObject[filterKey] = null;
     }


### PR DESCRIPTION
- Changed worker filter object to ensure that when a value is `undefined` it will be converted to `null` to allow the variable to always be created on Camunda.
- Found an issue in the Student User Sync that would prevent the Student to see the top menu navigation and also from having his data revalidated when his name or DOB is changed on BCSC.