### PR TITLE
[api][SIMS #1453]Notifications for Student Restrictions - Part 1

### DIFF
--- a/sources/packages/backend/apps/api/src-sql/federal-restrictions/Bulk-insert-new-restrictions.sql
+++ b/sources/packages/backend/apps/api/src-sql/federal-restrictions/Bulk-insert-new-restrictions.sql
@@ -9,10 +9,10 @@ INSERT INTO
 SELECT
     fed_restrictions.student_id student_id,
     fed_restrictions.restriction_id restriction_id,
-    true is_active
+    TRUE is_active
 FROM
     sims.federal_restrictions fed_restrictions
-    INNER JOIN sims.students students on students.id = fed_restrictions.student_id
+    INNER JOIN sims.students students ON students.id = fed_restrictions.student_id
 WHERE
     NOT EXISTS (
         SELECT
@@ -22,5 +22,6 @@ WHERE
         WHERE
             student_restrictions.student_id = fed_restrictions.student_id
             AND student_restrictions.restriction_id = fed_restrictions.restriction_id
-            AND student_restrictions.is_active = true
-    )
+            AND student_restrictions.is_active = TRUE
+    ) RETURNING id,
+    student_id;

--- a/sources/packages/backend/apps/api/src-sql/federal-restrictions/Bulk-insert-new-restrictions.sql
+++ b/sources/packages/backend/apps/api/src-sql/federal-restrictions/Bulk-insert-new-restrictions.sql
@@ -3,6 +3,8 @@
  * that are not present and active in the table. The same federal restriction
  * can be activated and deactivated multiple times for the same student,
  * generating a new record for every time that the restriction changes its state.
+ * The returned IDs in this query is used to generate notifications for the new
+ * restrictions added to the student account.
  */
 INSERT INTO
     sims.student_restrictions(student_id, restriction_id, is_active)

--- a/sources/packages/backend/apps/api/src-sql/federal-restrictions/Bulk-insert-new-restrictions.sql
+++ b/sources/packages/backend/apps/api/src-sql/federal-restrictions/Bulk-insert-new-restrictions.sql
@@ -23,5 +23,4 @@ WHERE
             student_restrictions.student_id = fed_restrictions.student_id
             AND student_restrictions.restriction_id = fed_restrictions.restriction_id
             AND student_restrictions.is_active = TRUE
-    ) RETURNING id,
-    student_id;
+    ) RETURNING id

--- a/sources/packages/backend/apps/api/src-sql/federal-restrictions/Bulk-update-students-foreign-key.sql
+++ b/sources/packages/backend/apps/api/src-sql/federal-restrictions/Bulk-update-students-foreign-key.sql
@@ -11,7 +11,8 @@ SET
 FROM
     sims.students students
     INNER JOIN sims.users users ON students.user_id = users.id
+    INNER JOIN sims.sin_validations sin_validations ON sin_validations.id = students.sin_validation_id
 WHERE
     students.birth_date = sims.federal_restrictions.birth_date
-    AND students.sin = sims.federal_restrictions.sin
+    AND sin_validations.sin = sims.federal_restrictions.sin
     AND lower(users.last_name) = lower(sims.federal_restrictions.last_name)

--- a/sources/packages/backend/apps/api/src/app.system-access.module.ts
+++ b/sources/packages/backend/apps/api/src/app.system-access.module.ts
@@ -32,6 +32,10 @@ import {
   StudentAppealService,
   StudentAppealRequestsService,
   StudentScholasticStandingsService,
+  GCNotifyActionsService,
+  GCNotifyService,
+  NotificationService,
+  NotificationMessageService,
 } from "./services";
 import {
   AssessmentControllerService,
@@ -135,6 +139,10 @@ import { IER12IntegrationService } from "./institution-integration/ier-integrati
     StudentAppealService,
     StudentAppealRequestsService,
     StudentScholasticStandingsService,
+    GCNotifyActionsService,
+    GCNotifyService,
+    NotificationService,
+    NotificationMessageService,
   ],
 })
 export class AppSystemAccessModule {}

--- a/sources/packages/backend/apps/api/src/auth/auth.module.ts
+++ b/sources/packages/backend/apps/api/src/auth/auth.module.ts
@@ -14,6 +14,10 @@ import {
   SINValidationService,
   DesignationAgreementLocationService,
   RestrictionService,
+  GCNotifyService,
+  GCNotifyActionsService,
+  NotificationService,
+  NotificationMessageService,
 } from "../services";
 import { JwtAuthGuard } from "./guards/jwt-auth.guard";
 import { JwtStrategy } from "./jwt.strategy";
@@ -49,6 +53,10 @@ const jwtModule = JwtModule.register({
     SINValidationService,
     RestrictionService,
     DesignationAgreementLocationService,
+    GCNotifyService,
+    GCNotifyActionsService,
+    NotificationService,
+    NotificationMessageService,
     {
       provide: APP_GUARD,
       useClass: JwtAuthGuard,

--- a/sources/packages/backend/apps/api/src/esdc-integration/disbursement-receipt-integration/disbursement-receipt-integration.module.ts
+++ b/sources/packages/backend/apps/api/src/esdc-integration/disbursement-receipt-integration/disbursement-receipt-integration.module.ts
@@ -8,6 +8,10 @@ import {
   ReportService,
   StudentService,
   SFASIndividualService,
+  GCNotifyActionsService,
+  GCNotifyService,
+  NotificationService,
+  NotificationMessageService,
 } from "../../services";
 import { SequenceControlService } from "@sims/services";
 import { DisbursementReceiptIntegrationService } from "./disbursement-receipt-integration.service";
@@ -31,6 +35,10 @@ import { ConfigModule } from "@sims/utilities/config";
     RestrictionService,
     StudentService,
     SFASIndividualService,
+    GCNotifyService,
+    GCNotifyActionsService,
+    NotificationService,
+    NotificationMessageService,
   ],
   exports: [
     DisbursementReceiptIntegrationService,

--- a/sources/packages/backend/apps/api/src/esdc-integration/e-cert-integration/e-cert-integration.module.ts
+++ b/sources/packages/backend/apps/api/src/esdc-integration/e-cert-integration/e-cert-integration.module.ts
@@ -8,6 +8,10 @@ import {
   RestrictionService,
   StudentService,
   SFASIndividualService,
+  GCNotifyService,
+  GCNotifyActionsService,
+  NotificationService,
+  NotificationMessageService,
 } from "../../services";
 import { SequenceControlService } from "@sims/services";
 import { ECertFileHandler } from "./e-cert-file-handler";
@@ -37,6 +41,10 @@ import { ConfigModule } from "@sims/utilities/config";
     RestrictionService,
     StudentService,
     SFASIndividualService,
+    GCNotifyService,
+    GCNotifyActionsService,
+    NotificationService,
+    NotificationMessageService,
   ],
   exports: [
     ECertFullTimeIntegrationService,

--- a/sources/packages/backend/apps/api/src/esdc-integration/fed-restriction-integration/fed-restriction-integration.module.ts
+++ b/sources/packages/backend/apps/api/src/esdc-integration/fed-restriction-integration/fed-restriction-integration.module.ts
@@ -3,8 +3,15 @@ import { ConfigModule } from "@sims/utilities/config";
 import { AuthModule } from "../../auth/auth.module";
 import {
   FederalRestrictionService,
+  GCNotifyActionsService,
+  GCNotifyService,
+  NotificationMessageService,
+  NotificationService,
   RestrictionService,
+  SFASIndividualService,
   SshService,
+  StudentRestrictionService,
+  StudentService,
 } from "../../services";
 import { FedRestrictionIntegrationService } from "./fed-restriction-integration.service";
 import { FedRestrictionProcessingService } from "./fed-restriction-processing.service";
@@ -16,7 +23,14 @@ import { FedRestrictionProcessingService } from "./fed-restriction-processing.se
     FedRestrictionIntegrationService,
     FedRestrictionProcessingService,
     RestrictionService,
+    StudentService,
+    StudentRestrictionService,
+    SFASIndividualService,
     FederalRestrictionService,
+    GCNotifyActionsService,
+    GCNotifyService,
+    NotificationService,
+    NotificationMessageService,
   ],
   exports: [FedRestrictionIntegrationService, FedRestrictionProcessingService],
 })

--- a/sources/packages/backend/apps/api/src/esdc-integration/fed-restriction-integration/fed-restriction-processing.service.ts
+++ b/sources/packages/backend/apps/api/src/esdc-integration/fed-restriction-integration/fed-restriction-processing.service.ts
@@ -245,8 +245,8 @@ export class FedRestrictionProcessingService {
       this.logger.log("Process finished, transaction committed.");
 
       // The process of sending the notifications happens after the restrictions are committed
-      // because the notifications are considered as a lower priority and any error related to
-      // the notification should not interfere in the federal restriction process.
+      // because the notifications are considered a lower priority and any error related to the
+      // notification should not interfere with the federal restriction process.
       try {
         if (insertedRestrictionsIDs?.length) {
           this.logger.log(

--- a/sources/packages/backend/apps/api/src/esdc-integration/fed-restriction-integration/fed-restriction-processing.service.ts
+++ b/sources/packages/backend/apps/api/src/esdc-integration/fed-restriction-integration/fed-restriction-processing.service.ts
@@ -42,9 +42,10 @@ export class FedRestrictionProcessingService {
   async process(): Promise<ProcessSFTPResponseResult> {
     // Get the list of all files from SFTP ordered by file name.
     const fileSearch = new RegExp(
-      `^${this.esdcConfig.environmentCode}CSLS.PBC.RESTR.LIST.D[\w]*\.[0-9]*`,
+      `^${this.esdcConfig.environmentCode}CSLS\\.PBC\\.RESTR\\.LIST\\.D[\\w]*\\.[\\d]*$`,
       "i",
     );
+
     const filePaths = await this.integrationService.getResponseFilesFullPath(
       this.esdcConfig.ftpResponseFolder,
       fileSearch,
@@ -228,11 +229,14 @@ export class FedRestrictionProcessingService {
       this.logger.log(
         "Starting bulk operations to update student restrictions.",
       );
-      await this.federalRestrictionService.executeBulkStepsChanges(
-        queryRunner.manager,
-      );
+      const newlyInsertedRestrictions =
+        await this.federalRestrictionService.executeBulkStepsChanges(
+          queryRunner.manager,
+        );
 
       await queryRunner.commitTransaction();
+      // TODO: insert into notifications message table.
+      console.log(newlyInsertedRestrictions);
       this.logger.log("Process finished, transaction committed.");
     } catch (error) {
       const logMessage =

--- a/sources/packages/backend/apps/api/src/route-controllers/esdc-integration/fed-restrictions-integration.system-access.controller.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/esdc-integration/fed-restrictions-integration.system-access.controller.ts
@@ -1,12 +1,13 @@
 import { Controller, Post } from "@nestjs/common";
 import { LoggerService, InjectLogger } from "@sims/utilities/logger";
-import { AllowAuthorizedParty } from "../../auth/decorators";
+import { AllowAuthorizedParty, UserToken } from "../../auth/decorators";
 import { AuthorizedParties } from "../../auth/authorized-parties.enum";
 import { FedRestrictionProcessingService } from "../../esdc-integration/fed-restriction-integration/fed-restriction-processing.service";
 import { ESDCFileResponseAPIOutDTO } from "./models/esdc.dto";
 import { ApiTags } from "@nestjs/swagger";
 import BaseController from "../BaseController";
 import { ClientTypeBaseRoute } from "../../types";
+import { IUserToken } from "../../auth/userToken.interface";
 
 @AllowAuthorizedParty(AuthorizedParties.formsFlowBPM)
 @Controller("fed-restrictions")
@@ -19,9 +20,11 @@ export class FedRestrictionsIntegrationSystemAccessController extends BaseContro
   }
 
   @Post("process")
-  async processFedRestrictionsImport(): Promise<ESDCFileResponseAPIOutDTO> {
+  async processFedRestrictionsImport(
+    @UserToken() userToken: IUserToken,
+  ): Promise<ESDCFileResponseAPIOutDTO> {
     this.logger.log("Starting federal restrictions import...");
-    const uploadResult = await this.processingService.process();
+    const uploadResult = await this.processingService.process(userToken.userId);
     this.logger.log("Federal restrictions import process finished.");
     return {
       processSummary: uploadResult.processSummary,

--- a/sources/packages/backend/apps/api/src/services/notification/gc-notify-actions.service.ts
+++ b/sources/packages/backend/apps/api/src/services/notification/gc-notify-actions.service.ts
@@ -3,6 +3,7 @@ import { NotificationMessageType } from "@sims/sims-db";
 import { getDateOnlyFormat, getPSTPDTDateTime } from "@sims/utilities";
 import { NotificationMessageService } from "../notification-message/notification-message.service";
 import {
+  FederalStudentRestrictionPersonalization,
   GCNotifyResult,
   MinistryStudentFileUploadNotification,
   StudentFileUploadNotification,
@@ -90,6 +91,35 @@ export class GCNotifyActionsService {
     );
 
     return this.notificationService.sendEmailNotification(notificationSaved.id);
+  }
+
+  async sendFederalStudentRestrictionNotification(
+    notifications: FederalStudentRestrictionPersonalization[],
+    auditUserId: number,
+  ): Promise<void> {
+    const templateId = await this.notificationMessageService.getTemplateId(
+      NotificationMessageType.FederalStudentRestriction,
+    );
+
+    const notificationsToSend = notifications.map((notification) => ({
+      userId: notification.userId,
+      messageType: NotificationMessageType.FederalStudentRestriction,
+      messagePayload: {
+        email_address: notification.toAddress,
+        template_id: templateId,
+        personalisation: {
+          givenNames: notification.givenNames ?? "",
+          lastName: notification.lastName,
+          date: this.getDateTimeOnPSTTimeZone(),
+        },
+      },
+    }));
+
+    // Save notification into notification table.
+    await this.notificationService.saveNotifications(
+      notificationsToSend,
+      auditUserId,
+    );
   }
 
   /**

--- a/sources/packages/backend/apps/api/src/services/notification/gc-notify-actions.service.ts
+++ b/sources/packages/backend/apps/api/src/services/notification/gc-notify-actions.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from "@nestjs/common";
 import { NotificationMessageType } from "@sims/sims-db";
 import { getDateOnlyFormat, getPSTPDTDateTime } from "@sims/utilities";
+import { EntityManager } from "typeorm";
 import { NotificationMessageService } from "../notification-message/notification-message.service";
 import {
   StudentRestrictionAddedPersonalization,
@@ -97,10 +98,14 @@ export class GCNotifyActionsService {
    * Creates a new notification when a new restriction is added to the student account.
    * @param notifications notifications information.
    * @param auditUserId user that should be considered the one that is causing the changes.
+   * @param entityManager optional repository that can be provided, for instance,
+   * to include the command as part of an existing transaction. If not provided
+   * the local repository will be used instead.
    */
   async sendStudentRestrictionAddedNotification(
     notifications: StudentRestrictionAddedPersonalization[],
     auditUserId: number,
+    entityManager?: EntityManager,
   ): Promise<void> {
     const templateId = await this.notificationMessageService.getTemplateId(
       NotificationMessageType.StudentRestrictionAdded,
@@ -124,6 +129,7 @@ export class GCNotifyActionsService {
     const notificationsIds = await this.notificationService.saveNotifications(
       notificationsToSend,
       auditUserId,
+      entityManager,
     );
 
     // TODO: Temporary code to be removed once queue/schedulers are in place.

--- a/sources/packages/backend/apps/api/src/services/notification/gc-notify-actions.service.ts
+++ b/sources/packages/backend/apps/api/src/services/notification/gc-notify-actions.service.ts
@@ -99,7 +99,7 @@ export class GCNotifyActionsService {
    * @param notifications notifications information.
    * @param auditUserId user that should be considered the one that is causing the changes.
    * @param entityManager optional repository that can be provided, for instance,
-   * to include the command as part of an existing transaction. If not provided
+   * to execute the command as part of an existing transaction. If not provided
    * the local repository will be used instead.
    */
   async sendStudentRestrictionAddedNotification(

--- a/sources/packages/backend/apps/api/src/services/notification/gc-notify.model.ts
+++ b/sources/packages/backend/apps/api/src/services/notification/gc-notify.model.ts
@@ -52,3 +52,10 @@ export interface MinistryStudentFileUploadPersonalization {
   givenNames: string;
   lastName: string;
 }
+
+export interface FederalStudentRestrictionPersonalization {
+  givenNames: string;
+  lastName: string;
+  toAddress: string;
+  userId: number;
+}

--- a/sources/packages/backend/apps/api/src/services/notification/gc-notify.model.ts
+++ b/sources/packages/backend/apps/api/src/services/notification/gc-notify.model.ts
@@ -53,7 +53,7 @@ export interface MinistryStudentFileUploadPersonalization {
   lastName: string;
 }
 
-export interface FederalStudentRestrictionPersonalization {
+export interface StudentRestrictionAddedPersonalization {
   givenNames: string;
   lastName: string;
   toAddress: string;

--- a/sources/packages/backend/apps/api/src/services/notification/notification.model.ts
+++ b/sources/packages/backend/apps/api/src/services/notification/notification.model.ts
@@ -3,5 +3,8 @@ import { NotificationMessageType } from "@sims/sims-db";
 export interface SaveNotificationModel {
   userId?: number;
   messageType: NotificationMessageType;
-  messagePayload: unknown;
+  messagePayload: {
+    email_address: string;
+    template_id: string;
+  };
 }

--- a/sources/packages/backend/apps/api/src/services/notification/notification.model.ts
+++ b/sources/packages/backend/apps/api/src/services/notification/notification.model.ts
@@ -1,0 +1,7 @@
+import { NotificationMessageType } from "@sims/sims-db";
+
+export interface SaveNotificationModel {
+  userId?: number;
+  messageType: NotificationMessageType;
+  messagePayload: unknown;
+}

--- a/sources/packages/backend/apps/api/src/services/notification/notification.service.ts
+++ b/sources/packages/backend/apps/api/src/services/notification/notification.service.ts
@@ -55,7 +55,7 @@ export class NotificationService extends RecordDataModelService<Notification> {
   async saveNotifications(
     notifications: SaveNotificationModel[],
     auditUserId: number,
-  ): Promise<InsertResult> {
+  ): Promise<number[]> {
     const newNotifications = notifications.map((notification) => ({
       user: { id: notification.userId } as User,
       creator: { id: auditUserId } as User,
@@ -65,7 +65,7 @@ export class NotificationService extends RecordDataModelService<Notification> {
       } as NotificationMessage,
     }));
     const insertResult = await this.repo.insert(newNotifications);
-    return insertResult;
+    return insertResult.identifiers.map((identifier) => +identifier.id);
   }
 
   /**

--- a/sources/packages/backend/apps/api/src/services/notification/notification.service.ts
+++ b/sources/packages/backend/apps/api/src/services/notification/notification.service.ts
@@ -53,11 +53,11 @@ export class NotificationService extends RecordDataModelService<Notification> {
   }
 
   /**
-   * Saves all notifications at once.
-   * @param notifications information to create the notification.
-   * @param auditUserId id of the user creating the notification.
+   * Saves all notifications.
+   * @param notifications information to create the notifications.
+   * @param auditUserId id of the user creating the notifications.
    * @param entityManager optional repository that can be provided, for instance,
-   * to include the command as part of an existing transaction. If not provided
+   * to execute the command as part of an existing transaction. If not provided
    * the local repository will be used instead.
    * @returns created notification ids.
    */

--- a/sources/packages/backend/apps/api/src/services/restriction/federal-restriction.service.ts
+++ b/sources/packages/backend/apps/api/src/services/restriction/federal-restriction.service.ts
@@ -2,7 +2,6 @@ import { Injectable } from "@nestjs/common";
 import { DataModelService, FederalRestriction } from "@sims/sims-db";
 import { DataSource, EntityManager } from "typeorm";
 import { getSQLFileData } from "../../utilities";
-import { FederalStudentRestrictionInsertedRecord } from "./models/federal-restriction.model";
 
 const FEDERAL_RESTRICTIONS_RAW_SQL_FOLDER = "federal-restrictions";
 

--- a/sources/packages/backend/apps/api/src/services/restriction/federal-restriction.service.ts
+++ b/sources/packages/backend/apps/api/src/services/restriction/federal-restriction.service.ts
@@ -62,7 +62,7 @@ export class FederalRestrictionService extends DataModelService<FederalRestricti
    * present in the federal data.
    * 4. Update modified date for the active restrictions. The time between creation
    * date and modified date can provide for how long that restriction is active.
-   * @returns inserted records ids.
+   * @returns inserted records ids into student restrictions.
    */
   async executeBulkStepsChanges(manager: EntityManager): Promise<number[]> {
     // STEP 1

--- a/sources/packages/backend/apps/api/src/services/restriction/federal-restriction.service.ts
+++ b/sources/packages/backend/apps/api/src/services/restriction/federal-restriction.service.ts
@@ -55,8 +55,8 @@ export class FederalRestrictionService extends DataModelService<FederalRestricti
   /**
    * Once the table with all federal restriction is fully imported, these
    * process executes the sequence of bulk operations to:
-   * 1. Create new active restrictions;
-   * 2. Deactivate restrictions that are no longer present in the federal data;
+   * 1. Create new active restrictions.
+   * 2. Deactivate restrictions that are no longer present in the federal data.
    * 3. Update the updated_at date for the active restrictions that are still
    * present in the federal data.
    * 4. Update modified date for the active restrictions. The time between creation

--- a/sources/packages/backend/apps/api/src/services/restriction/federal-restriction.service.ts
+++ b/sources/packages/backend/apps/api/src/services/restriction/federal-restriction.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from "@nestjs/common";
 import { DataModelService, FederalRestriction } from "@sims/sims-db";
 import { DataSource, EntityManager } from "typeorm";
 import { getSQLFileData } from "../../utilities";
+import { FederalStudentRestrictionInsertedRecord } from "./models/federal-restriction.model";
 
 const FEDERAL_RESTRICTIONS_RAW_SQL_FOLDER = "federal-restrictions";
 
@@ -44,7 +45,7 @@ export class FederalRestrictionService extends DataModelService<FederalRestricti
    * of the entire federal restrictions snapshot. The process of deleting the entire data
    * and bulk inserting again proved to be faster and more efficient.
    */
-  async resetFederalRestrictionsTable(manager: EntityManager): Promise<any> {
+  async resetFederalRestrictionsTable(manager: EntityManager): Promise<void> {
     await manager.query(
       `TRUNCATE TABLE ${
         this.dataSource.getMetadata(FederalRestriction).tablePath
@@ -55,25 +56,32 @@ export class FederalRestrictionService extends DataModelService<FederalRestricti
   /**
    * Once the table with all federal restriction is fully imported, these
    * process executes the sequence of bulk operations to:
-   * 1 - Create new active restrictions;
-   * 2 - Deactivate restrictions that are no longer present in the federal data;
-   * 3 - Update the updated_at date for the active restrictions that are still
+   * 1. Create new active restrictions;
+   * 2. Deactivate restrictions that are no longer present in the federal data;
+   * 3. Update the updated_at date for the active restrictions that are still
    * present in the federal data.
+   * 4. Update modified date for the active restrictions. The time between creation
+   * date and modified date can provide for how long that restriction is active.
+   * @returns inserted records.
    */
-  async executeBulkStepsChanges(manager: EntityManager): Promise<void> {
+  async executeBulkStepsChanges(
+    manager: EntityManager,
+  ): Promise<FederalStudentRestrictionInsertedRecord[]> {
     // STEP 1
     // ! This bulk update MUST happen before the next operations to assign
     // ! the student foreign keys correctly.
     await this.bulkUpdateStudentsForeignKey(manager);
     // This bulk updates expects that the student foreign key is updated.
     // STEP 2
-    await this.bulkInsertNewRestrictions(manager);
+    const insertedRestrictions = await this.bulkInsertNewRestrictions(manager);
     // STEP 3
     await this.bulkDeactivateRestrictions(manager);
     // This last update is not critical but allows the system to keep track
     // of the last time that an active restriction was received.
     // STEP 4
     await this.bulkUpdateActiveRestrictions(manager);
+
+    return insertedRestrictions;
   }
 
   /*
@@ -93,11 +101,19 @@ export class FederalRestrictionService extends DataModelService<FederalRestricti
    * that are not present and active in the table. The same federal restriction
    * can be activated and deactivated multiple times for the same student,
    * generating a new record for every time that the restriction changes its state.
+   * @returns inserted records.
    */
   private async bulkInsertNewRestrictions(
     manager: EntityManager,
-  ): Promise<void> {
-    await manager.query(this.bulkInsertNewRestrictionsSQL);
+  ): Promise<FederalStudentRestrictionInsertedRecord[]> {
+    const insertedRestrictions: {
+      id: number;
+      student_id: number;
+    }[] = await manager.query(this.bulkInsertNewRestrictionsSQL);
+    return insertedRestrictions.map((restriction) => ({
+      id: restriction.id,
+      studentId: restriction.student_id,
+    }));
   }
 
   /*

--- a/sources/packages/backend/apps/api/src/services/restriction/models/federal-restriction.model.ts
+++ b/sources/packages/backend/apps/api/src/services/restriction/models/federal-restriction.model.ts
@@ -4,8 +4,3 @@ export class EnsureFederalRestrictionResult {
   restrictions: Restriction[] = [];
   createdRestrictionsCodes: string[] = [];
 }
-
-export interface FederalStudentRestrictionInsertedRecord {
-  id: number;
-  studentId: number;
-}

--- a/sources/packages/backend/apps/api/src/services/restriction/models/federal-restriction.model.ts
+++ b/sources/packages/backend/apps/api/src/services/restriction/models/federal-restriction.model.ts
@@ -4,3 +4,8 @@ export class EnsureFederalRestrictionResult {
   restrictions: Restriction[] = [];
   createdRestrictionsCodes: string[] = [];
 }
+
+export interface FederalStudentRestrictionInsertedRecord {
+  id: number;
+  studentId: number;
+}

--- a/sources/packages/backend/apps/api/src/services/restriction/restriction.service.ts
+++ b/sources/packages/backend/apps/api/src/services/restriction/restriction.service.ts
@@ -2,6 +2,8 @@ import { Injectable } from "@nestjs/common";
 import {
   RecordDataModelService,
   Restriction,
+  RestrictionActionType,
+  RestrictionNotificationType,
   RestrictionType,
 } from "@sims/sims-db";
 import { DataSource, Repository } from "typeorm";
@@ -88,6 +90,11 @@ export class RestrictionService extends RecordDataModelService<Restriction> {
     newRestriction.description = FEDERAL_RESTRICTIONS_UNIDENTIFIED_DESCRIPTION;
     newRestriction.restrictionCode = code;
     newRestriction.restrictionType = RestrictionType.Federal;
+    newRestriction.notificationType = RestrictionNotificationType.Error;
+    newRestriction.actionType = [
+      RestrictionActionType.StopFullTimeDisbursement,
+      RestrictionActionType.StopPartTimeDisbursement,
+    ];
     /*  Restriction Category is hard coded for federal restrictions.  */
     newRestriction.restrictionCategory = "Federal";
     return repo.save(newRestriction);

--- a/sources/packages/backend/apps/api/src/services/restriction/student-restriction.service.ts
+++ b/sources/packages/backend/apps/api/src/services/restriction/student-restriction.service.ts
@@ -11,7 +11,14 @@ import {
   EducationProgramOffering,
   RestrictionActionType,
 } from "@sims/sims-db";
-import { DataSource, EntityManager, SelectQueryBuilder } from "typeorm";
+import {
+  ArrayContains,
+  DataSource,
+  EntityManager,
+  In,
+  Not,
+  SelectQueryBuilder,
+} from "typeorm";
 import { CustomNamedError } from "@sims/utilities";
 import { RestrictionService } from "./restriction.service";
 import { StudentService } from "../student/student.service";
@@ -408,5 +415,33 @@ export class StudentRestrictionService extends RecordDataModelService<StudentRes
       );
       await entityManager.getRepository(StudentRestriction).save(restriction);
     }
+  }
+
+  async getRestrictionsForNotifications(
+    restrictionIds: number[],
+  ): Promise<StudentRestriction[]> {
+    return this.repo.find({
+      select: {
+        id: true,
+        student: {
+          id: true,
+          user: {
+            id: true,
+            firstName: true,
+            lastName: true,
+            email: true,
+          },
+        },
+      },
+      relations: {
+        student: { user: true },
+      },
+      where: {
+        id: In(restrictionIds),
+        restriction: {
+          restrictionType: Not(ArrayContains([RestrictionActionType.NoEffect])),
+        },
+      },
+    });
   }
 }

--- a/sources/packages/backend/apps/api/src/services/restriction/student-restriction.service.ts
+++ b/sources/packages/backend/apps/api/src/services/restriction/student-restriction.service.ts
@@ -417,6 +417,12 @@ export class StudentRestrictionService extends RecordDataModelService<StudentRes
     }
   }
 
+  /**
+   * Gets the notifications information for student restrictions that are
+   * eligible to generate a notification (actionType not defined as NoEffect).
+   * @param restrictionIds student restriction ids.
+   * @returns student restrictions eligible to generate a notification.
+   */
   async getRestrictionsForNotifications(
     restrictionIds: number[],
   ): Promise<StudentRestriction[]> {

--- a/sources/packages/backend/apps/api/src/services/restriction/student-restriction.service.ts
+++ b/sources/packages/backend/apps/api/src/services/restriction/student-restriction.service.ts
@@ -439,7 +439,7 @@ export class StudentRestrictionService extends RecordDataModelService<StudentRes
       where: {
         id: In(restrictionIds),
         restriction: {
-          restrictionType: Not(ArrayContains([RestrictionActionType.NoEffect])),
+          actionType: Not(ArrayContains([RestrictionActionType.NoEffect])),
         },
       },
     });

--- a/sources/packages/backend/apps/api/src/services/restriction/student-restriction.service.ts
+++ b/sources/packages/backend/apps/api/src/services/restriction/student-restriction.service.ts
@@ -442,7 +442,7 @@ export class StudentRestrictionService extends RecordDataModelService<StudentRes
    * @param restrictionsIds ids to generate the notifications.
    * @param auditUserId user that should be considered the one that is causing the changes.
    * @param entityManager optional repository that can be provided, for instance,
-   * to include the command as part of an existing transaction. If not provided
+   * to execute the command as part of an existing transaction. If not provided
    * the local repository will be used instead.
    */
   async createNotifications(
@@ -477,7 +477,7 @@ export class StudentRestrictionService extends RecordDataModelService<StudentRes
    * eligible to generate a notification (actionType not defined as NoEffect).
    * @param restrictionIds student restriction ids.
    * @param entityManager optional repository that can be provided, for instance,
-   * to include the command as part of an existing transaction. If not provided
+   * to execute the command as part of an existing transaction. If not provided
    * the local repository will be used instead.
    * @returns student restrictions eligible to generate a notification.
    */

--- a/sources/packages/backend/apps/api/src/services/restriction/student-restriction.service.ts
+++ b/sources/packages/backend/apps/api/src/services/restriction/student-restriction.service.ts
@@ -487,12 +487,15 @@ export class StudentRestrictionService extends RecordDataModelService<StudentRes
   ): Promise<StudentRestriction[]> {
     const repository =
       entityManager?.getRepository(StudentRestriction) ?? this.repo;
+    // Copy the input array to avoid changing the one received by parameter.
+    const idsToProcess = [...restrictionIds];
+    // Restrictions to be returned and must have a notification created.
     const allRestrictions: StudentRestriction[] = [];
-    while (restrictionIds.length > 0) {
+    while (idsToProcess.length > 0) {
       // Breaks the execution in chunks to allow the selects of a huge amount of records.
       // The query will fail over a 65535 parameters. Even not being the expected amount of records,
       // the code will be able to process this amount under an unusual circumstance.
-      const ids = restrictionIds.splice(0, NOTIFICATIONS_SELECT_CHUNK_SIZE);
+      const ids = idsToProcess.splice(0, NOTIFICATIONS_SELECT_CHUNK_SIZE);
       const restrictions = await repository.find({
         select: {
           id: true,

--- a/sources/packages/backend/apps/api/src/services/student-scholastic-standings/student-scholastic-standings.service.ts
+++ b/sources/packages/backend/apps/api/src/services/student-scholastic-standings/student-scholastic-standings.service.ts
@@ -245,7 +245,7 @@ export class StudentScholasticStandingsService extends RecordDataModelService<St
       // Left as the last step to ensure that everything else was processed with
       // success and the notification will not be generated otherwise.
       if (createdRestriction) {
-        this.studentRestrictionService.createNotifications(
+        await this.studentRestrictionService.createNotifications(
           [createdRestriction.id],
           auditUserId,
           transactionalEntityManager,

--- a/sources/packages/backend/apps/api/src/services/student-scholastic-standings/student-scholastic-standings.service.ts
+++ b/sources/packages/backend/apps/api/src/services/student-scholastic-standings/student-scholastic-standings.service.ts
@@ -143,8 +143,10 @@ export class StudentScholasticStandingsService extends RecordDataModelService<St
         auditUserId,
         application.id,
       );
+      let createdRestriction: StudentRestriction | undefined = undefined;
       if (studentRestriction) {
-        await transactionalEntityManager
+        // Used later to send the notification at the end of the process.
+        createdRestriction = await transactionalEntityManager
           .getRepository(StudentRestriction)
           .save(studentRestriction);
       }
@@ -238,6 +240,17 @@ export class StudentScholasticStandingsService extends RecordDataModelService<St
       await transactionalEntityManager
         .getRepository(Application)
         .save(application);
+
+      // Case a restriction was created, send a notification to the student.
+      // Left as the last step to ensure that everything else was processed with
+      // success and the notification will not be generated otherwise.
+      if (createdRestriction) {
+        this.studentRestrictionService.createNotifications(
+          [createdRestriction.id],
+          auditUserId,
+          transactionalEntityManager,
+        );
+      }
 
       return studentScholasticStanding;
     });

--- a/sources/packages/backend/apps/api/src/utilities/system-configurations-constants.ts
+++ b/sources/packages/backend/apps/api/src/utilities/system-configurations-constants.ts
@@ -21,9 +21,9 @@ export const DISBURSEMENT_FILE_GENERATION_ANTICIPATION_DAYS = 5;
  * While importing the federal restrictions to our DB for processing
  * a series of bulk inserts are executed. The amount of each bulk
  * insert is defined by below number.
- * 200 = 1:20.134
- * 500 = 1:04.731
- * 1000 = 1:08.829
+ * - 200 = 1:20.134
+ * - 500 = 1:04.731
+ * - 1000 = 1:08.829
  */
 export const FEDERAL_RESTRICTIONS_BULK_INSERT_AMOUNT = 500;
 /**

--- a/sources/packages/backend/apps/api/src/utilities/system-configurations-constants.ts
+++ b/sources/packages/backend/apps/api/src/utilities/system-configurations-constants.ts
@@ -21,9 +21,9 @@ export const DISBURSEMENT_FILE_GENERATION_ANTICIPATION_DAYS = 5;
  * While importing the federal restrictions to our DB for processing
  * a series of bulk inserts are executed. The amount of each bulk
  * insert is defined by below number.
- * - 200 = 1:20.134
- * - 500 = 1:04.731
- * - 1000 = 1:08.829
+ * 200 = 1:20.134
+ * 500 = 1:04.731
+ * 1000 = 1:08.829
  */
 export const FEDERAL_RESTRICTIONS_BULK_INSERT_AMOUNT = 500;
 /**

--- a/sources/packages/backend/apps/db-migrations/src/migrations/1668746601780-InsertStudentRestrictionMessage.ts
+++ b/sources/packages/backend/apps/db-migrations/src/migrations/1668746601780-InsertStudentRestrictionMessage.ts
@@ -1,0 +1,24 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+import { getSQLFileData } from "../utilities/sqlLoader";
+
+export class InsertStudentRestrictionMessage1668746601780
+  implements MigrationInterface
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      getSQLFileData(
+        "Insert-student-restriction-message.sql",
+        "NotificationMessages",
+      ),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      getSQLFileData(
+        "Delete-student-restriction-message.sql",
+        "NotificationMessages",
+      ),
+    );
+  }
+}

--- a/sources/packages/backend/apps/db-migrations/src/sql/NotificationMessages/Delete-student-restriction-message.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/NotificationMessages/Delete-student-restriction-message.sql
@@ -1,0 +1,4 @@
+DELETE FROM
+    sims.notification_messages
+WHERE
+    ID = 3;

--- a/sources/packages/backend/apps/db-migrations/src/sql/NotificationMessages/Insert-student-restriction-message.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/NotificationMessages/Insert-student-restriction-message.sql
@@ -1,0 +1,8 @@
+INSERT INTO
+    sims.notification_messages(id, description, template_id)
+VALUES
+    (
+        3,
+        'A restriction has placed on your account. Please visit your account activity page to view additional details.',
+        '2b64245f-770c-4493-9d3c-4e0f86773987'
+    );

--- a/sources/packages/backend/libs/sims-db/src/entities/notification.model.ts
+++ b/sources/packages/backend/libs/sims-db/src/entities/notification.model.ts
@@ -81,8 +81,8 @@ export enum NotificationMessageType {
   /**
    * A new restriction was added to the student account.
    * Possible scenarios:
-   * 1. Ministry places restriction on student account;
-   * 2. System-generated restrictions on student account;
+   * 1. Ministry places restriction on student account.
+   * 2. System-generated restrictions on student account.
    * 3. Federal restriction placed on student account.
    */
   StudentRestrictionAdded = 3,

--- a/sources/packages/backend/libs/sims-db/src/entities/notification.model.ts
+++ b/sources/packages/backend/libs/sims-db/src/entities/notification.model.ts
@@ -71,11 +71,15 @@ export class Notification extends RecordDataModel {
  */
 export enum NotificationMessageType {
   /**
-   * Notification Message type student file upload.
+   * Student uploaded a file into his account.
    */
   StudentFileUpload = 1,
   /**
-   * Notification  Message type ministry file upload.
+   * Ministry uploaded a file to the student account.
    */
   MinistryFileUpload = 2,
+  /**
+   * New federal restriction added to the student account.
+   */
+  FederalStudentRestriction = 3,
 }

--- a/sources/packages/backend/libs/sims-db/src/entities/notification.model.ts
+++ b/sources/packages/backend/libs/sims-db/src/entities/notification.model.ts
@@ -22,12 +22,12 @@ export class Notification extends RecordDataModel {
   /**
    * User associated with this notification.
    */
-  @ManyToOne(() => User, { eager: false, cascade: false })
+  @ManyToOne(() => User, { eager: false, cascade: false, nullable: true })
   @JoinColumn({
     name: "user_id",
     referencedColumnName: ColumnNames.ID,
   })
-  user: User;
+  user?: User;
   /**
    * Message notification payload.
    */
@@ -79,7 +79,11 @@ export enum NotificationMessageType {
    */
   MinistryFileUpload = 2,
   /**
-   * New federal restriction added to the student account.
+   * A new restriction was added to the student account.
+   * Possible scenarios:
+   * 1. Ministry places restriction on student account;
+   * 2. System-generated restrictions on student account;
+   * 3. Federal restriction placed on student account.
    */
-  FederalStudentRestriction = 3,
+  StudentRestrictionAdded = 3,
 }


### PR DESCRIPTION
- Changed the federal restrictions insert script to return the inserted IDs to be used to generate the notifications to students;
- Fixed an error in the federal restrictions queries that were not considering the SIN change from the `students` table to the `sin_vallidations` table.
- Created a unified method to get the student data needed to send the notification and create the notifications.

Todo
- Add transactions to the existing notifications;
- Move notifications to the shared library.
- Sonarcloud issues mostly about a method to be removed in the upcoming PR.