### PR TITLE
[API][SIMS #1453]Notifications - date sent not saved

### DIFF
--- a/sources/packages/backend/libs/services/src/notifications/notification/notification.service.ts
+++ b/sources/packages/backend/libs/services/src/notifications/notification/notification.service.ts
@@ -119,7 +119,7 @@ export class NotificationService extends RecordDataModelService<Notification> {
     );
 
     // Update date sent column in notification table after sending email notification successfully.
-    await this.updateNotification(notification.id);
+    await this.updateNotification(notification.id, entityManager);
 
     return gcNotifyResult;
   }


### PR DESCRIPTION
The date_sent column was not updated after the notifications were changed to be created in a DB transaction.