### PR TITLE
[web][SIMS #990] Logout timer bug

### DIFF
--- a/sources/packages/web/src/components/common/IdleTimeChecker.vue
+++ b/sources/packages/web/src/components/common/IdleTimeChecker.vue
@@ -79,21 +79,21 @@ export default {
         resetIdleCheckerTimer();
       }
     };
-    let n = 0;
     const checkIdle = () => {
-      console.log("Seconds: ", ++n);
-      const idleTimeInMinutes = getDatesDiff(
+      const idleTimeInSeconds = getDatesDiff(
         lastActivityLogin.value,
         new Date(),
         "second",
-        true,
+        false,
       );
-      if (idleTimeInMinutes > minimumIdleTime.value) {
-        logoff();
-      } else if (
-        idleTimeInMinutes >=
-        minimumIdleTime.value - COUNT_DOWN_TIMER_FOR_LOGOUT
+      console.log("idleTimeInSeconds", idleTimeInSeconds);
+      if (
+        idleTimeInSeconds >
+        minimumIdleTime.value + COUNT_DOWN_TIMER_FOR_LOGOUT
       ) {
+        // Logoff immediately in case session is expired.
+        logoff();
+      } else if (idleTimeInSeconds >= minimumIdleTime.value) {
         confirmExtendTimeModal();
       }
     };

--- a/sources/packages/web/src/components/common/IdleTimeChecker.vue
+++ b/sources/packages/web/src/components/common/IdleTimeChecker.vue
@@ -113,7 +113,6 @@ export default {
     };
 
     const confirmExtendTimeModal = async () => {
-      console.log("confirmExtendTimeModal");
       modalOpen.value = true;
       if (await extendTimeModal.value.showModal()) {
         extendUserSessionTime();
@@ -132,7 +131,6 @@ export default {
         "second",
         false,
       );
-      console.log("idleTimeInSeconds", idleTimeInSeconds.value);
 
       // Exceeded user session time.
       if (idleTimeInSeconds.value > maximumIdleTime.value) {

--- a/sources/packages/web/src/components/common/IdleTimeChecker.vue
+++ b/sources/packages/web/src/components/common/IdleTimeChecker.vue
@@ -50,7 +50,6 @@ export default {
     const { getDatesDiff } = useFormatters();
     const { executeLogout } = useAuth();
     const countdown = ref(COUNT_DOWN_TIMER_FOR_LOGOUT);
-    const modalOpen = ref(false);
     const IDLE_CHECKER_TIMER_INTERVAL = 1000;
     const COUNTDOWN_INTERVAL = 1000;
     const LAST_ACTIVITY_TIME_LOCAL_STORAGE_ITEM = "lastActivityTime";
@@ -185,7 +184,6 @@ export default {
       extendTimeModal,
       isAuthenticated,
       countdown,
-      modalOpen,
       extendUserSessionTime,
     };
   },

--- a/sources/packages/web/src/components/common/IdleTimeChecker.vue
+++ b/sources/packages/web/src/components/common/IdleTimeChecker.vue
@@ -26,11 +26,13 @@ import {
   useFormatters,
 } from "@/composables";
 import {
-  MINIMUM_IDLE_TIME_FOR_WARNING_SUPPORTING_USER,
-  MINIMUM_IDLE_TIME_FOR_WARNING_STUDENT,
-  MINIMUM_IDLE_TIME_FOR_WARNING_INSTITUTION,
-  MINIMUM_IDLE_TIME_FOR_WARNING_AEST,
+  MAXIMUM_IDLE_TIME_FOR_WARNING_SUPPORTING_USER,
+  MAXIMUM_IDLE_TIME_FOR_WARNING_STUDENT,
+  MAXIMUM_IDLE_TIME_FOR_WARNING_INSTITUTION,
+  MAXIMUM_IDLE_TIME_FOR_WARNING_AEST,
   COUNT_DOWN_TIMER_FOR_LOGOUT,
+  LAST_ACTIVITY_TIME_LOCAL_STORAGE_ITEM,
+  LOGGED_OUT_LOCAL_STORAGE_ITEM,
 } from "@/constants/system-constants";
 import ConfirmExtendTime from "@/components/common/modals/ConfirmExtendTime.vue";
 
@@ -57,22 +59,22 @@ export default {
     onMounted(async () => {
       setLastActivityTime();
       resetIdleCheckerTimer();
-      localStorage.removeItem("loggedOut");
+      localStorage.removeItem(LOGGED_OUT_LOCAL_STORAGE_ITEM);
     });
 
     const logoff = async () => {
       await executeLogout(props.clientIdType);
     };
-    const minimumIdleTime = computed(() => {
+    const maximumIdleTime = computed(() => {
       switch (props.clientIdType) {
         case ClientIdType.Student:
-          return MINIMUM_IDLE_TIME_FOR_WARNING_STUDENT;
+          return MAXIMUM_IDLE_TIME_FOR_WARNING_STUDENT;
         case ClientIdType.Institution:
-          return MINIMUM_IDLE_TIME_FOR_WARNING_INSTITUTION;
+          return MAXIMUM_IDLE_TIME_FOR_WARNING_INSTITUTION;
         case ClientIdType.SupportingUsers:
-          return MINIMUM_IDLE_TIME_FOR_WARNING_SUPPORTING_USER;
+          return MAXIMUM_IDLE_TIME_FOR_WARNING_SUPPORTING_USER;
         case ClientIdType.AEST:
-          return MINIMUM_IDLE_TIME_FOR_WARNING_AEST;
+          return MAXIMUM_IDLE_TIME_FOR_WARNING_AEST;
         default:
           console.error("Invalid Client type");
           return 0;
@@ -92,7 +94,7 @@ export default {
         if (newValue) {
           countdownInterval.value = setInterval(() => {
             if (countdown.value > 0) {
-              countdown.value = minimumIdleTime.value - idleTimeInSeconds.value;
+              countdown.value = maximumIdleTime.value - idleTimeInSeconds.value;
             }
           }, 1000);
         } else {
@@ -133,7 +135,7 @@ export default {
       console.log("idleTimeInSeconds", idleTimeInSeconds.value);
 
       // Exceeded user session time.
-      if (idleTimeInSeconds.value > minimumIdleTime.value) {
+      if (idleTimeInSeconds.value > maximumIdleTime.value) {
         if (modalOpen.value === true) {
           modalOpen.value = false;
           clearInterval(countdownInterval.value);
@@ -142,7 +144,7 @@ export default {
         logoff();
       } else if (
         idleTimeInSeconds.value >=
-        minimumIdleTime.value - COUNT_DOWN_TIMER_FOR_LOGOUT
+        maximumIdleTime.value - COUNT_DOWN_TIMER_FOR_LOGOUT
       ) {
         confirmExtendTimeModal();
       } else {
@@ -155,14 +157,16 @@ export default {
     const setLastActivityTime = () => {
       if (isAuthenticated.value) {
         localStorage.setItem(
-          "lastActivityTime",
+          LAST_ACTIVITY_TIME_LOCAL_STORAGE_ITEM,
           new Date().getTime().toString(),
         );
       }
     };
 
     const getLastActivityTime = () => {
-      const localStorageValue = localStorage.getItem("lastActivityTime");
+      const localStorageValue = localStorage.getItem(
+        LAST_ACTIVITY_TIME_LOCAL_STORAGE_ITEM,
+      );
       if (localStorageValue) {
         return new Date(+localStorageValue);
       }
@@ -170,11 +174,13 @@ export default {
     };
 
     const setLoggedOut = () => {
-      localStorage.setItem("loggedOut", "true");
+      localStorage.setItem(LOGGED_OUT_LOCAL_STORAGE_ITEM, "true");
     };
 
     const getLoggedOut = () => {
-      const localStorageValue = localStorage.getItem("loggedOut");
+      const localStorageValue = localStorage.getItem(
+        LOGGED_OUT_LOCAL_STORAGE_ITEM,
+      );
       if (localStorageValue === "true") {
         return true;
       }

--- a/sources/packages/web/src/components/common/IdleTimeChecker.vue
+++ b/sources/packages/web/src/components/common/IdleTimeChecker.vue
@@ -8,7 +8,6 @@
     <slot></slot>
     <confirm-extend-time
       ref="extendTimeModal"
-      :clientIdType="clientIdType"
       :countdown="countdown"
       @dialogClosedEvent="extendUserSessionTime"
     />

--- a/sources/packages/web/src/components/common/modals/ConfirmExtendTime.vue
+++ b/sources/packages/web/src/components/common/modals/ConfirmExtendTime.vue
@@ -3,7 +3,6 @@
     title="Confirm Extend Time"
     dialogType="warning"
     :showDialog="showDialog"
-    @click="extendTime"
   >
     <template v-slot:content>
       <v-container class="p-component text-dark">
@@ -19,8 +18,8 @@
       <footer-buttons
         primaryLabel="Yes"
         secondaryLabel="No"
-        @primaryClick="extendTime"
-        @secondaryClick="dialogClosed"
+        @primaryClick="resolvePromise(true)"
+        @secondaryClick="resolvePromise(false)"
       />
     </template>
   </modal-dialog-base>
@@ -29,42 +28,24 @@
 <script lang="ts">
 import ModalDialogBase from "@/components/generic/ModalDialogBase.vue";
 import { useModalDialog } from "@/composables";
-import { ClientIdType } from "@/types/contracts/ConfigContract";
 
 export default {
   components: {
     ModalDialogBase,
   },
   props: {
-    clientIdType: {
-      type: String,
-      required: true,
-      default: "" as ClientIdType,
-    },
     countdown: {
       type: Number,
       required: true,
     },
-    showDialog: {
-      type: Boolean,
-      required: true,
-    },
   },
   setup() {
-    const { resolvePromise, showModal } = useModalDialog<boolean>();
-
-    const dialogClosed = () => {
-      resolvePromise(false);
-    };
-
-    const extendTime = async () => {
-      resolvePromise(true);
-    };
+    const { resolvePromise, showModal, showDialog } = useModalDialog<boolean>();
 
     return {
       showModal,
-      dialogClosed,
-      extendTime,
+      resolvePromise,
+      showDialog,
     };
   },
 };

--- a/sources/packages/web/src/components/common/modals/ConfirmExtendTime.vue
+++ b/sources/packages/web/src/components/common/modals/ConfirmExtendTime.vue
@@ -28,8 +28,7 @@
 
 <script lang="ts">
 import ModalDialogBase from "@/components/generic/ModalDialogBase.vue";
-import { useModalDialog, useAuth } from "@/composables";
-import { ref } from "vue";
+import { useModalDialog } from "@/composables";
 import { ClientIdType } from "@/types/contracts/ConfigContract";
 
 export default {
@@ -51,23 +50,14 @@ export default {
       required: true,
     },
   },
-  setup(props: any) {
+  setup() {
     const { resolvePromise, showModal } = useModalDialog<boolean>();
-    const interval = ref();
-    const { executeLogout } = useAuth();
-
-    const logoff = async () => {
-      await executeLogout(props.clientIdType);
-    };
 
     const dialogClosed = () => {
-      clearInterval(interval.value);
-      logoff();
       resolvePromise(false);
     };
 
     const extendTime = async () => {
-      clearInterval(interval.value);
       resolvePromise(true);
     };
 

--- a/sources/packages/web/src/components/common/modals/ConfirmExtendTime.vue
+++ b/sources/packages/web/src/components/common/modals/ConfirmExtendTime.vue
@@ -29,8 +29,7 @@
 <script lang="ts">
 import ModalDialogBase from "@/components/generic/ModalDialogBase.vue";
 import { useModalDialog, useAuth } from "@/composables";
-import { COUNT_DOWN_TIMER_FOR_LOGOUT } from "@/constants/system-constants";
-import { ref, watch } from "vue";
+import { ref } from "vue";
 import { ClientIdType } from "@/types/contracts/ConfigContract";
 
 export default {
@@ -43,10 +42,17 @@ export default {
       required: true,
       default: "" as ClientIdType,
     },
+    countdown: {
+      type: Number,
+      required: true,
+    },
+    showDialog: {
+      type: Boolean,
+      required: true,
+    },
   },
   setup(props: any) {
-    const countdown = ref(COUNT_DOWN_TIMER_FOR_LOGOUT);
-    const { showDialog, resolvePromise, showModal } = useModalDialog<boolean>();
+    const { resolvePromise, showModal } = useModalDialog<boolean>();
     const interval = ref();
     const { executeLogout } = useAuth();
 
@@ -60,48 +66,15 @@ export default {
       resolvePromise(false);
     };
 
-    const updateTimer = () => {
-      if (countdown.value > 0) {
-        countdown.value--;
-      } else {
-        dialogClosed();
-      }
-    };
-
-    const initializeCounter = () => {
-      countdown.value = COUNT_DOWN_TIMER_FOR_LOGOUT;
-    };
-
-    const countDownTimer = () => {
-      clearInterval(interval.value);
-      initializeCounter();
-      // * Set timer for 1 second, every 1 second updateTimer will be called.
-      interval.value = setInterval(updateTimer, 1000);
-    };
-
     const extendTime = async () => {
       clearInterval(interval.value);
       resolvePromise(true);
-      initializeCounter();
     };
 
-    watch(
-      () => showDialog.value,
-      (currValue: boolean) => {
-        if (currValue) {
-          countDownTimer();
-        } else {
-          clearInterval(interval.value);
-        }
-      },
-    );
-
     return {
-      showDialog,
       showModal,
       dialogClosed,
       extendTime,
-      countdown,
     };
   },
 };

--- a/sources/packages/web/src/composables/useAuth.ts
+++ b/sources/packages/web/src/composables/useAuth.ts
@@ -2,9 +2,10 @@ import { RouteHelper } from "@/helpers";
 import { AuthService } from "@/services/AuthService";
 import { AppIDPType, ClientIdType, Role } from "@/types";
 import { computed } from "vue";
-import { LOGGED_OUT_LOCAL_STORAGE_ITEM } from "@/constants/system-constants";
 
 export function useAuth() {
+  const LOGGED_OUT_LOCAL_STORAGE_ITEM = "loggedOut";
+
   const isAuthenticated = computed(
     () => AuthService.shared.keycloak?.authenticated === true,
   );
@@ -26,10 +27,6 @@ export function useAuth() {
     await AuthService.shared.logout(clientType);
   };
 
-  const setLoggedOut = () => {
-    localStorage.setItem(LOGGED_OUT_LOCAL_STORAGE_ITEM, "true");
-  };
-
   const hasRole = (role: Role): boolean => {
     const userToken = AuthService.shared.userToken;
     if (userToken?.resource_access && userToken?.azp) {
@@ -39,11 +36,28 @@ export function useAuth() {
     return false;
   };
 
+  const setLoggedOut = () => {
+    localStorage.setItem(LOGGED_OUT_LOCAL_STORAGE_ITEM, "true");
+  };
+
+  const isLoggedOut = () => {
+    const loggedOutStringValue = localStorage.getItem(
+      LOGGED_OUT_LOCAL_STORAGE_ITEM,
+    );
+    return loggedOutStringValue === "true";
+  };
+
+  const resetLoggedOut = () => {
+    localStorage.removeItem(LOGGED_OUT_LOCAL_STORAGE_ITEM);
+  };
+
   return {
     isAuthenticated,
     parsedToken,
     executeLogin,
     executeLogout,
     hasRole,
+    isLoggedOut,
+    resetLoggedOut,
   };
 }

--- a/sources/packages/web/src/composables/useAuth.ts
+++ b/sources/packages/web/src/composables/useAuth.ts
@@ -2,6 +2,7 @@ import { RouteHelper } from "@/helpers";
 import { AuthService } from "@/services/AuthService";
 import { AppIDPType, ClientIdType, Role } from "@/types";
 import { computed } from "vue";
+import { LOGGED_OUT_LOCAL_STORAGE_ITEM } from "@/constants/system-constants";
 
 export function useAuth() {
   const isAuthenticated = computed(
@@ -21,7 +22,12 @@ export function useAuth() {
   };
 
   const executeLogout = async (clientType: ClientIdType): Promise<void> => {
+    setLoggedOut();
     await AuthService.shared.logout(clientType);
+  };
+
+  const setLoggedOut = () => {
+    localStorage.setItem(LOGGED_OUT_LOCAL_STORAGE_ITEM, "true");
   };
 
   const hasRole = (role: Role): boolean => {

--- a/sources/packages/web/src/composables/useModalDialog.ts
+++ b/sources/packages/web/src/composables/useModalDialog.ts
@@ -1,4 +1,4 @@
-import { ref } from "vue";
+import { Ref, ref } from "vue";
 
 export function useModalDialog<T, TParameter = any>() {
   const showDialog = ref(false);
@@ -28,4 +28,5 @@ export function useModalDialog<T, TParameter = any>() {
 
 export interface ModalDialog<T, TParameter = any> {
   showModal: (params?: TParameter) => Promise<T>;
+  showDialog: Ref<boolean>;
 }

--- a/sources/packages/web/src/constants/system-constants.ts
+++ b/sources/packages/web/src/constants/system-constants.ts
@@ -2,7 +2,7 @@
 export const MINIMUM_TOKEN_VALIDITY = 180;
 // TODO : for development  added all IDLE timeout as 1hour, revert it back to 4.5 before merging to PROD
 // * MINIMUM_IDLE_TIME_FOR_WARNING_STUDENT in seconds, i,e 270 seconds is 4.5 minutes
-export const MINIMUM_IDLE_TIME_FOR_WARNING_STUDENT = 3600;
+export const MINIMUM_IDLE_TIME_FOR_WARNING_STUDENT = 60;
 // * MINIMUM_IDLE_TIME_FOR_WARNING_STUDENT in seconds i,e 270 seconds is 4.5 minutes
 export const MINIMUM_IDLE_TIME_FOR_WARNING_INSTITUTION = 3600;
 // * MINIMUM_IDLE_TIME_FOR_WARNING_STUDENT in seconds i,e 270 seconds is 4.5 minutes

--- a/sources/packages/web/src/constants/system-constants.ts
+++ b/sources/packages/web/src/constants/system-constants.ts
@@ -2,7 +2,7 @@
 export const MINIMUM_TOKEN_VALIDITY = 180;
 // TODO : for development  added all IDLE timeout as 1hour, revert it back to 4.5 before merging to PROD
 // * MINIMUM_IDLE_TIME_FOR_WARNING_STUDENT in seconds, i,e 270 seconds is 4.5 minutes
-export const MINIMUM_IDLE_TIME_FOR_WARNING_STUDENT = 60;
+export const MINIMUM_IDLE_TIME_FOR_WARNING_STUDENT = 3600;
 // * MINIMUM_IDLE_TIME_FOR_WARNING_STUDENT in seconds i,e 270 seconds is 4.5 minutes
 export const MINIMUM_IDLE_TIME_FOR_WARNING_INSTITUTION = 3600;
 // * MINIMUM_IDLE_TIME_FOR_WARNING_STUDENT in seconds i,e 270 seconds is 4.5 minutes

--- a/sources/packages/web/src/constants/system-constants.ts
+++ b/sources/packages/web/src/constants/system-constants.ts
@@ -1,15 +1,19 @@
 // * MINIMUM_TOKEN_VALIDITY in seconds, i,e 180 seconds is 3 minutes
 export const MINIMUM_TOKEN_VALIDITY = 180;
 // TODO : for development  added all IDLE timeout as 1hour, revert it back to 4.5 before merging to PROD
-// * MINIMUM_IDLE_TIME_FOR_WARNING_STUDENT in seconds, i,e 270 seconds is 4.5 minutes
-export const MINIMUM_IDLE_TIME_FOR_WARNING_STUDENT = 3600;
-// * MINIMUM_IDLE_TIME_FOR_WARNING_STUDENT in seconds i,e 270 seconds is 4.5 minutes
-export const MINIMUM_IDLE_TIME_FOR_WARNING_INSTITUTION = 3600;
-// * MINIMUM_IDLE_TIME_FOR_WARNING_STUDENT in seconds i,e 270 seconds is 4.5 minutes
-export const MINIMUM_IDLE_TIME_FOR_WARNING_SUPPORTING_USER = 3600;
-// * MINIMUM_IDLE_TIME_FOR_WARNING_STUDENT in seconds i,e 270 seconds is 4.5 minutes
-export const MINIMUM_IDLE_TIME_FOR_WARNING_AEST = 3600;
+// * MAXIMUM_IDLE_TIME_FOR_WARNING_STUDENT in seconds, i,e 270 seconds is 4.5 minutes
+export const MAXIMUM_IDLE_TIME_FOR_WARNING_STUDENT = 3600;
+// * MAXIMUM_IDLE_TIME_FOR_WARNING_STUDENT in seconds i,e 270 seconds is 4.5 minutes
+export const MAXIMUM_IDLE_TIME_FOR_WARNING_INSTITUTION = 3600;
+// * MAXIMUM_IDLE_TIME_FOR_WARNING_STUDENT in seconds i,e 270 seconds is 4.5 minutes
+export const MAXIMUM_IDLE_TIME_FOR_WARNING_SUPPORTING_USER = 3600;
+// * MAXIMUM_IDLE_TIME_FOR_WARNING_STUDENT in seconds i,e 270 seconds is 4.5 minutes
+export const MAXIMUM_IDLE_TIME_FOR_WARNING_AEST = 3600;
 // * COUNT_DOWN_TIMER_FOR_LOGOUT in seconds
 export const COUNT_DOWN_TIMER_FOR_LOGOUT = 30;
 // * renew auth token if expired checker should happen every seconds
 export const RENEW_AUTH_TOKEN_TIMER = 30;
+// * LocalStorage item name for the last activity time in epoch date number
+export const LAST_ACTIVITY_TIME_LOCAL_STORAGE_ITEM = "lastActivityTime";
+// * LocalStorage item name for the loggedOut boolean flag
+export const LOGGED_OUT_LOCAL_STORAGE_ITEM = "loggedOut";

--- a/sources/packages/web/src/constants/system-constants.ts
+++ b/sources/packages/web/src/constants/system-constants.ts
@@ -13,6 +13,3 @@ export const MAXIMUM_IDLE_TIME_FOR_WARNING_AEST = 3600;
 export const COUNT_DOWN_TIMER_FOR_LOGOUT = 30;
 // * renew auth token if expired checker should happen every seconds
 export const RENEW_AUTH_TOKEN_TIMER = 30;
-
-// * LocalStorage item name for the loggedOut boolean flag
-export const LOGGED_OUT_LOCAL_STORAGE_ITEM = "loggedOut";

--- a/sources/packages/web/src/constants/system-constants.ts
+++ b/sources/packages/web/src/constants/system-constants.ts
@@ -13,7 +13,6 @@ export const MAXIMUM_IDLE_TIME_FOR_WARNING_AEST = 3600;
 export const COUNT_DOWN_TIMER_FOR_LOGOUT = 30;
 // * renew auth token if expired checker should happen every seconds
 export const RENEW_AUTH_TOKEN_TIMER = 30;
-// * LocalStorage item name for the last activity time in epoch date number
-export const LAST_ACTIVITY_TIME_LOCAL_STORAGE_ITEM = "lastActivityTime";
+
 // * LocalStorage item name for the loggedOut boolean flag
 export const LOGGED_OUT_LOCAL_STORAGE_ITEM = "loggedOut";


### PR DESCRIPTION
If the computer hibernates or the tab/window is inactive, the setInterval does not work but when it gets back to "active" state it should count the time the user session is idle and then:
- if it is already expired, logout;
- it is not expired but there's less than COUNT_DOWN_TIMER_FOR_LOGOUT (in seconds) left, it should show the correct seconds that are left in the modal;
- otherwise the timer should count the same time independent when it got in the active state.

Also, every tab should check if the user extended their time or if they logged out. 

Some of the main changes:
- removed logic from modal; 
- created logic to use the right remaining time in IdleTimeChecker.vue; 
- logout when the other tab has logged out; 
- close modal when requested more time in other tab/window; 
- shared activity time for all tabs/windows;

![image](https://user-images.githubusercontent.com/78114138/207195095-6f530a36-2f19-466e-b697-ce1c43ed174f.png)
![image](https://user-images.githubusercontent.com/78114138/207196542-29945acd-f608-4bfe-b544-c42399b284a5.png)
