### PR TITLE
Openshift Patroni Shortcuts for Local DEV Environment

### DIFF
--- a/sources/Makefile
+++ b/sources/Makefile
@@ -198,6 +198,12 @@ queue-consumers:
 	@docker-compose -f docker-compose.yml build queue-consumers
 	@docker-compose -f docker-compose.yml up -d queue-consumers
 
+# Runs workers application
+workers:
+	@echo "+\n++ Make: Camunda workers only"
+	@docker-compose -f docker-compose.yml build workers
+	@docker-compose -f docker-compose.yml up -d workers
+
 # Enable local DB connection to Openshift DEV/TEST/QA
 connect-dev-db:
 	@echo "Forward local port 5454 to Openshift Patroni-master default port."

--- a/sources/Makefile
+++ b/sources/Makefile
@@ -198,5 +198,21 @@ queue-consumers:
 	@docker-compose -f docker-compose.yml build queue-consumers
 	@docker-compose -f docker-compose.yml up -d queue-consumers
 
+# Enable local DB connection to Openshift DEV/TEST/QA
+connect-dev-db:
+	@echo "Forward local port 5454 to Openshift Patroni-master default port."
+	@echo "Use your prefered DB Manager (e.g. pgAdmin or DBeaver) to connect to the Postgres database using the local port 5454."
+	@oc project 0c27fb-dev
+	@oc port-forward services/patroni-master 5454:5432 
 
+connect-test-db:
+	@echo "Forward local port 5555 to Openshift Patroni-master default port."
+	@echo "Use your prefered DB Manager (e.g. pgAdmin or DBeaver) to connect to the Postgres database using the local port 5555."
+	@oc project 0c27fb-test
+	@oc port-forward services/patroni-master 5555:5432 
 
+connect-qa-db:
+	@echo "Forward local port 5656 to Openshift Patroni-master default port."
+	@echo "Use your prefered DB Manager (e.g. pgAdmin or DBeaver) to connect to the Postgres database using the local port 5656."
+	@oc project 0c27fb-test
+	@oc port-forward services/patroni-master 5656:5432 


### PR DESCRIPTION
Added shortcuts to connect to Openshif Patroni DEV/TEST/QA databases.