### PR TITLE
#1346 - Converted DB numeric string to number

### DIFF
--- a/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/esdc-integration/ecert-integration/tests/ecert-full-time-process-integration.scheduler.e2e-spec.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/esdc-integration/ecert-integration/tests/ecert-full-time-process-integration.scheduler.e2e-spec.ts
@@ -110,30 +110,30 @@ describe("Schedulers - e-Cert full time integration - Create e-Cert file", () =>
         createFakeDisbursementValue(
           DisbursementValueType.CanadaLoan,
           "CSLF",
-          "5000",
-          { disbursedAmountSubtracted: "1000" },
+          5000,
+          { disbursedAmountSubtracted: 1000 },
         ),
         createFakeDisbursementValue(
           DisbursementValueType.BCLoan,
           "BCSL",
-          "4000",
-          { disbursedAmountSubtracted: "500" },
+          4000,
+          { disbursedAmountSubtracted: 500 },
         ),
         createFakeDisbursementValue(
           DisbursementValueType.CanadaGrant,
           "CSGP",
-          "2000",
+          2000,
         ),
         createFakeDisbursementValue(
           DisbursementValueType.BCGrant,
           "BCAG",
-          "1500",
-          { disbursedAmountSubtracted: "500" },
+          1500,
+          { disbursedAmountSubtracted: 500 },
         ),
         createFakeDisbursementValue(
           DisbursementValueType.BCGrant,
           "BGPD",
-          "2500",
+          2500,
         ),
       ],
     });
@@ -159,7 +159,7 @@ describe("Schedulers - e-Cert full time integration - Create e-Cert file", () =>
       student: savedStudent,
     });
     fakeCanadaLoanOverawardBalance.disbursementValueCode = "CSLF";
-    fakeCanadaLoanOverawardBalance.overawardValue = "4500";
+    fakeCanadaLoanOverawardBalance.overawardValue = 4500;
     await disbursementOverawardRepo.save(fakeCanadaLoanOverawardBalance);
 
     // Act
@@ -174,7 +174,7 @@ describe("Schedulers - e-Cert full time integration - Create e-Cert file", () =>
           student: {
             id: savedStudent.id,
           },
-          overawardValue: "-4000",
+          overawardValue: -4000,
           disbursementValueCode: "CSLF",
           originType: DisbursementOverawardOriginType.AwardValueAdjusted,
         },
@@ -201,18 +201,18 @@ describe("Schedulers - e-Cert full time integration - Create e-Cert file", () =>
     const hasExpectedCSLF = awards.filter(
       (award) =>
         award.valueCode === "CSLF" &&
-        award.disbursedAmountSubtracted === "1000.00" &&
-        award.overawardAmountSubtracted === "4000.00" &&
-        award.effectiveAmount === "0.00",
+        award.disbursedAmountSubtracted === 1000 &&
+        award.overawardAmountSubtracted === 4000 &&
+        award.effectiveAmount === 0,
     );
     expect(hasExpectedCSLF.length).toBe(1);
     // Assert BCSL.
     const hasExpectedBCSL = awards.filter(
       (award) =>
         award.valueCode === "BCSL" &&
-        award.disbursedAmountSubtracted === "500.00" &&
+        award.disbursedAmountSubtracted === 500 &&
         !award.overawardAmountSubtracted &&
-        award.effectiveAmount === "3500.00",
+        award.effectiveAmount === 3500,
     );
     expect(hasExpectedBCSL.length).toBe(1);
     // Assert CSGP.
@@ -221,16 +221,16 @@ describe("Schedulers - e-Cert full time integration - Create e-Cert file", () =>
         award.valueCode === "CSGP" &&
         !award.disbursedAmountSubtracted &&
         !award.overawardAmountSubtracted &&
-        award.effectiveAmount === "2000.00",
+        award.effectiveAmount === 2000,
     );
     expect(hasExpectedCSGP.length).toBe(1);
     // Assert BCAG.
     const hasExpectedBCAG = awards.filter(
       (award) =>
         award.valueCode === "BCAG" &&
-        award.disbursedAmountSubtracted === "500.00" &&
+        award.disbursedAmountSubtracted === 500 &&
         !award.overawardAmountSubtracted &&
-        award.effectiveAmount === "1000.00",
+        award.effectiveAmount === 1000,
     );
     expect(hasExpectedBCAG.length).toBe(1);
     // Assert BGPD.
@@ -239,7 +239,7 @@ describe("Schedulers - e-Cert full time integration - Create e-Cert file", () =>
         award.valueCode === "BGPD" &&
         !award.disbursedAmountSubtracted &&
         !award.overawardAmountSubtracted &&
-        award.effectiveAmount === "2500.00",
+        award.effectiveAmount === 2500,
     );
     expect(hasExpectedBGPD.length).toBe(1);
     // The BC total grant (BCSG) will be generated and
@@ -249,7 +249,7 @@ describe("Schedulers - e-Cert full time integration - Create e-Cert file", () =>
         award.valueCode === "BCSG" &&
         !award.disbursedAmountSubtracted &&
         !award.overawardAmountSubtracted &&
-        award.effectiveAmount === "3500.00",
+        award.effectiveAmount === 3500,
     );
     expect(hasExpectedBCSG.length).toBe(1);
     // At least one file must be generated.

--- a/sources/packages/backend/apps/workers/src/controllers/disbursement/tests/disbursement.controller.e2e-spec.ts
+++ b/sources/packages/backend/apps/workers/src/controllers/disbursement/tests/disbursement.controller.e2e-spec.ts
@@ -88,20 +88,18 @@ describe("Disbursement Schedule Service - Create disbursement", () => {
         createFakeDisbursementValue(
           DisbursementValueType.CanadaLoan,
           "CSLF",
-          "1250",
-          { effectiveAmount: "1250" },
+          1250,
+          { effectiveAmount: 1250 },
         ),
-        createFakeDisbursementValue(
-          DisbursementValueType.BCLoan,
-          "BCSL",
-          "800",
-          { disbursedAmountSubtracted: "50", effectiveAmount: "750" },
-        ),
+        createFakeDisbursementValue(DisbursementValueType.BCLoan, "BCSL", 800, {
+          disbursedAmountSubtracted: 50,
+          effectiveAmount: 750,
+        }),
         createFakeDisbursementValue(
           DisbursementValueType.CanadaGrant,
           "CSGP",
-          "1500",
-          { effectiveAmount: "1500" },
+          1500,
+          { effectiveAmount: 1500 },
         ),
       ],
     });
@@ -113,13 +111,9 @@ describe("Disbursement Schedule Service - Create disbursement", () => {
         createFakeDisbursementValue(
           DisbursementValueType.CanadaGrant,
           "CSLF",
-          "1000",
+          1000,
         ),
-        createFakeDisbursementValue(
-          DisbursementValueType.BCLoan,
-          "BCSL",
-          "500",
-        ),
+        createFakeDisbursementValue(DisbursementValueType.BCLoan, "BCSL", 500),
       ],
     });
     secondSchedule.disbursementScheduleStatus =
@@ -252,9 +246,9 @@ describe("Disbursement Schedule Service - Create disbursement", () => {
       (scheduleValue) => scheduleValue.valueType === valueType,
     );
     expect(award).toBeDefined();
-    expect(+award.valueAmount).toBe(+assertValues.valueAmount);
-    expect(+award.disbursedAmountSubtracted).toBe(
-      +assertValues.disbursedAmountSubtracted?.toString(),
+    expect(award.valueAmount).toBe(+assertValues.valueAmount);
+    expect(award.disbursedAmountSubtracted).toBe(
+      assertValues.disbursedAmountSubtracted,
     );
   }
 
@@ -269,7 +263,7 @@ describe("Disbursement Schedule Service - Create disbursement", () => {
     );
     expect(awardOverawards).toHaveLength(1);
     const [overaward] = awardOverawards;
-    expect(+overaward.overawardValue).toBe(awardValue);
+    expect(overaward.overawardValue).toBe(awardValue);
     expect(overaward.originType).toBe(
       DisbursementOverawardOriginType.ReassessmentOveraward,
     );

--- a/sources/packages/backend/libs/integrations/src/esdc-integration/disbursement-receipt-integration/disbursement-receipt-files/disbursement-receipt-file-detail.ts
+++ b/sources/packages/backend/libs/integrations/src/esdc-integration/disbursement-receipt-integration/disbursement-receipt-files/disbursement-receipt-file-detail.ts
@@ -21,7 +21,7 @@ const GRANT_AMOUNT_LENGTH = 7;
 export class DisbursementReceiptGrant {
   constructor(
     public readonly grantType: string,
-    public readonly grantAmount: string,
+    public readonly grantAmount: number,
   ) {}
 }
 
@@ -48,11 +48,11 @@ export class DisbursementReceiptDetail extends DisbursementReceiptRecord {
   }
 
   get totalEntitledDisbursedAmount() {
-    return this.convertToAmountString(this.line.substring(37, 44));
+    return this.convertToAmount(this.line.substring(37, 44));
   }
 
   get totalDisbursedAmount() {
-    return this.convertToAmountString(this.line.substring(44, 51));
+    return this.convertToAmount(this.line.substring(44, 51));
   }
 
   get disburseDate() {
@@ -60,11 +60,11 @@ export class DisbursementReceiptDetail extends DisbursementReceiptRecord {
   }
 
   get disburseAmountStudent() {
-    return this.convertToAmountString(this.line.substring(59, 66));
+    return this.convertToAmount(this.line.substring(59, 66));
   }
 
   get disburseAmountInstitution() {
-    return this.convertToAmountString(this.line.substring(66, 73));
+    return this.convertToAmount(this.line.substring(66, 73));
   }
 
   get dateSignedInstitution() {
@@ -84,19 +84,19 @@ export class DisbursementReceiptDetail extends DisbursementReceiptRecord {
   }
 
   get totalEntitledGrantAmount() {
-    return this.convertToAmountString(this.line.substring(94, 101));
+    return this.convertToAmount(this.line.substring(94, 101));
   }
 
   get totalDisbursedGrantAmount() {
-    return this.convertToAmountString(this.line.substring(101, 108));
+    return this.convertToAmount(this.line.substring(101, 108));
   }
 
   get totalDisbursedGrantAmountStudent() {
-    return this.convertToAmountString(this.line.substring(108, 115));
+    return this.convertToAmount(this.line.substring(108, 115));
   }
 
   get totalDisbursedGrantAmountInstitution() {
-    return this.convertToAmountString(this.line.substring(115, 122));
+    return this.convertToAmount(this.line.substring(115, 122));
   }
 
   get grants() {
@@ -114,7 +114,7 @@ export class DisbursementReceiptDetail extends DisbursementReceiptRecord {
       );
       grantIndex += GRANT_AMOUNT_LENGTH;
 
-      const grantAmount = this.convertToAmountString(grantAmountText);
+      const grantAmount = this.convertToAmount(grantAmountText);
 
       if (grantType && grantAmount) {
         grants.push(new DisbursementReceiptGrant(grantType, grantAmount));

--- a/sources/packages/backend/libs/integrations/src/esdc-integration/disbursement-receipt-integration/disbursement-receipt-files/disbursement-receipt-file-record.ts
+++ b/sources/packages/backend/libs/integrations/src/esdc-integration/disbursement-receipt-integration/disbursement-receipt-files/disbursement-receipt-file-record.ts
@@ -32,12 +32,12 @@ export abstract class DisbursementReceiptRecord {
   }
 
   /**
-   * Parses any amount field to numeric string.
+   * Parses any amount field to number.
    ** parseInt is used to convert string like 00520 to 520.
    * @param amountText the amount field string parsed from file.
-   * @returns amount value as numeric string.
+   * @returns amount value as a number.
    */
-  protected convertToAmountString(amountText: string) {
-    return (+amountText.substring(0, 5)).toString();
+  protected convertToAmount(amountText: string): number {
+    return +amountText.substring(0, 5);
   }
 }

--- a/sources/packages/backend/libs/integrations/src/services/disbursement-receipt/disbursement-receipt.model.ts
+++ b/sources/packages/backend/libs/integrations/src/services/disbursement-receipt/disbursement-receipt.model.ts
@@ -1,24 +1,24 @@
 export interface DisbursementReceiptGrantModel {
   grantType: string;
-  grantAmount: string;
+  grantAmount: number;
 }
 
 export interface DisbursementReceiptModel {
   documentNumber: number;
   studentSIN: string;
   fundingType: string;
-  totalEntitledDisbursedAmount: string;
-  totalDisbursedAmount: string;
+  totalEntitledDisbursedAmount: number;
+  totalDisbursedAmount: number;
   disburseDate: Date;
-  disburseAmountStudent: string;
-  disburseAmountInstitution: string;
+  disburseAmountStudent: number;
+  disburseAmountInstitution: number;
   dateSignedInstitution: Date;
   institutionCode: string;
   disburseMethodStudent: string;
   studyPeriodEndDate: Date;
-  totalEntitledGrantAmount: string;
-  totalDisbursedGrantAmount: string;
-  totalDisbursedGrantAmountStudent: string;
-  totalDisbursedGrantAmountInstitution: string;
+  totalEntitledGrantAmount: number;
+  totalDisbursedGrantAmount: number;
+  totalDisbursedGrantAmountStudent: number;
+  totalDisbursedGrantAmountInstitution: number;
   grants: DisbursementReceiptGrantModel[];
 }

--- a/sources/packages/backend/libs/integrations/src/services/disbursement-schedule/e-cert-generation.service.ts
+++ b/sources/packages/backend/libs/integrations/src/services/disbursement-schedule/e-cert-generation.service.ts
@@ -323,7 +323,7 @@ export class ECertGenerationService {
         )
         // Sum all BC grants.
         .reduce((previousValue, currentValue) => {
-          return previousValue + +currentValue.effectiveAmount;
+          return previousValue + currentValue.effectiveAmount;
         }, 0);
       bcTotalGrant.valueAmount = bcTotalGrantValueAmount;
       bcTotalGrant.effectiveAmount = bcTotalGrantValueAmount;

--- a/sources/packages/backend/libs/integrations/src/services/disbursement-schedule/e-cert-generation.service.ts
+++ b/sources/packages/backend/libs/integrations/src/services/disbursement-schedule/e-cert-generation.service.ts
@@ -279,13 +279,13 @@ export class ECertGenerationService {
     for (const disbursement of disbursements) {
       for (const disbursementValue of disbursement.disbursementValues) {
         if (this.shouldStopFunding(disbursement, disbursementValue)) {
-          disbursementValue.effectiveAmount = "0";
+          disbursementValue.effectiveAmount = 0;
         } else {
           const effectiveValue =
-            +disbursementValue.valueAmount -
-            +(disbursementValue.disbursedAmountSubtracted ?? 0) -
-            +(disbursementValue.overawardAmountSubtracted ?? 0);
-          disbursementValue.effectiveAmount = round(effectiveValue).toString();
+            disbursementValue.valueAmount -
+            (disbursementValue.disbursedAmountSubtracted ?? 0) -
+            (disbursementValue.overawardAmountSubtracted ?? 0);
+          disbursementValue.effectiveAmount = round(effectiveValue);
         }
       }
     }
@@ -324,8 +324,7 @@ export class ECertGenerationService {
         // Sum all BC grants.
         .reduce((previousValue, currentValue) => {
           return previousValue + +currentValue.effectiveAmount;
-        }, 0)
-        .toString();
+        }, 0);
       bcTotalGrant.valueAmount = bcTotalGrantValueAmount;
       bcTotalGrant.effectiveAmount = bcTotalGrantValueAmount;
     }
@@ -397,9 +396,7 @@ export class ECertGenerationService {
             studentAssessment: loan.relatedSchedule.studentAssessment,
             disbursementSchedule: loan.relatedSchedule as DisbursementSchedule,
             disbursementValueCode: valueCode,
-            overawardValue: (
-              +loan.awardValue.overawardAmountSubtracted * -1
-            ).toString(),
+            overawardValue: loan.awardValue.overawardAmountSubtracted * -1,
             originType: DisbursementOverawardOriginType.AwardValueAdjusted,
             creator: auditUser,
           } as DisbursementOveraward);
@@ -469,7 +466,7 @@ export class ECertGenerationService {
     for (const award of awards) {
       // Award amount that is available to be taken for the overaward balance adjustment.
       const availableAwardValueAmount =
-        +award.valueAmount - +award.disbursedAmountSubtracted;
+        award.valueAmount - (award.disbursedAmountSubtracted ?? 0);
       if (availableAwardValueAmount >= currentBalance) {
         // Current disbursement value is enough to pay the debit.
         // For instance:
@@ -479,7 +476,7 @@ export class ECertGenerationService {
         // - Award: $1000
         // - overawardAmountSubtracted: $750
         // - currentBalance: $0
-        award.overawardAmountSubtracted = currentBalance.toString();
+        award.overawardAmountSubtracted = currentBalance;
         // Cancel because there is nothing else to be deducted.
         return;
       } else {
@@ -496,7 +493,7 @@ export class ECertGenerationService {
         // overaward balance will be taken from there, if possible executing the
         // second iteration of this for loop.
         currentBalance -= availableAwardValueAmount;
-        award.overawardAmountSubtracted = availableAwardValueAmount.toString();
+        award.overawardAmountSubtracted = availableAwardValueAmount;
       }
     }
   }

--- a/sources/packages/backend/libs/services/src/disbursement-schedule/disbursement-schedule.service.ts
+++ b/sources/packages/backend/libs/services/src/disbursement-schedule/disbursement-schedule.service.ts
@@ -118,7 +118,7 @@ export class DisbursementScheduleService extends RecordDataModelService<Disburse
             const newValue = new DisbursementValue();
             newValue.valueType = disbursementValue.valueType;
             newValue.valueCode = disbursementValue.valueCode;
-            newValue.valueAmount = disbursementValue.valueAmount.toString();
+            newValue.valueAmount = disbursementValue.valueAmount;
             newValue.creator = auditUser;
             return newValue;
           },
@@ -469,8 +469,8 @@ export class DisbursementScheduleService extends RecordDataModelService<Disburse
       .forEach((disbursementValue) => {
         totalPerValueCode[disbursementValue.valueCode] =
           (totalPerValueCode[disbursementValue.valueCode] ?? 0) +
-          +(disbursementValue.overawardAmountSubtracted ?? 0) +
-          +(disbursementValue.effectiveAmount ?? 0);
+          (disbursementValue.overawardAmountSubtracted ?? 0) +
+          (disbursementValue.effectiveAmount ?? 0);
       });
     return totalPerValueCode;
   }
@@ -567,7 +567,7 @@ export class DisbursementScheduleService extends RecordDataModelService<Disburse
           student: { id: studentId } as Student,
           studentAssessment: { id: assessmentId } as StudentAssessment,
           disbursementValueCode: valueCode,
-          overawardValue: remainingStudentDebit.toString(),
+          overawardValue: remainingStudentDebit,
           originType: DisbursementOverawardOriginType.ReassessmentOveraward,
           creator: auditUser,
         } as DisbursementOveraward);
@@ -616,8 +616,7 @@ export class DisbursementScheduleService extends RecordDataModelService<Disburse
   ): number {
     let studentDebit = totalStudentDebit;
     for (const award of awards) {
-      const awardValueAmount = +award.valueAmount;
-      if (awardValueAmount >= totalStudentDebit) {
+      if (award.valueAmount >= totalStudentDebit) {
         // Current disbursement value is enough to pay the debit.
         // For instance:
         // - Award: $1000
@@ -626,7 +625,7 @@ export class DisbursementScheduleService extends RecordDataModelService<Disburse
         // - Award: $1000
         // - disbursedAmountSubtracted: $750
         // - Student debit: $0
-        award.disbursedAmountSubtracted = studentDebit.toString();
+        award.disbursedAmountSubtracted = studentDebit;
         studentDebit = 0;
       } else {
         // Current disbursement is not enough to pay the debit.
@@ -641,7 +640,7 @@ export class DisbursementScheduleService extends RecordDataModelService<Disburse
         // If there is one more disbursement with the same award, the $250
         // student debit will be taken from there, if possible executing the
         // second iteration of this for loop.
-        studentDebit -= awardValueAmount;
+        studentDebit -= award.valueAmount;
         award.disbursedAmountSubtracted = award.valueAmount;
       }
     }

--- a/sources/packages/backend/libs/sims-db/src/entities/disbursement-overaward.model.ts
+++ b/sources/packages/backend/libs/sims-db/src/entities/disbursement-overaward.model.ts
@@ -14,6 +14,7 @@ import {
   StudentAssessment,
 } from ".";
 import { ColumnNames, TableNames } from "../constant";
+import { numericTransformer } from "../transformers/numeric.transformer";
 
 /**
  * Students overawards resulted from reassessments calculations.
@@ -63,10 +64,11 @@ export class DisbursementOveraward extends RecordDataModel {
    */
   @Column({
     name: "overaward_value",
-    type: "decimal",
+    type: "numeric",
     nullable: false,
+    transformer: numericTransformer,
   })
-  overawardValue: string;
+  overawardValue: number;
   /**
    * Value code related to the overaward_value, for instance, CSLF, CSPT, BCSL.
    */

--- a/sources/packages/backend/libs/sims-db/src/entities/disbursement-receipt-values.model.ts
+++ b/sources/packages/backend/libs/sims-db/src/entities/disbursement-receipt-values.model.ts
@@ -7,6 +7,7 @@ import {
 } from "typeorm";
 import { DisbursementReceipt } from ".";
 import { ColumnNames, TableNames } from "../constant";
+import { numericTransformer } from "../transformers/numeric.transformer";
 import { RecordDataModel } from "./record.model";
 
 /**
@@ -38,12 +39,12 @@ export class DisbursementReceiptValue extends RecordDataModel {
 
   /**
    * Grant amount.
-   * !Decimal values are retrieved by Typeorm as string from Postgres.
    */
   @Column({
     name: "grant_amount",
     type: "numeric",
     nullable: false,
+    transformer: numericTransformer,
   })
-  grantAmount: string;
+  grantAmount: number;
 }

--- a/sources/packages/backend/libs/sims-db/src/entities/disbursement-receipts.model.ts
+++ b/sources/packages/backend/libs/sims-db/src/entities/disbursement-receipts.model.ts
@@ -9,6 +9,7 @@ import {
 } from "typeorm";
 import { DisbursementSchedule, DisbursementReceiptValue } from ".";
 import { ColumnNames, TableNames } from "../constant";
+import { numericTransformer } from "../transformers/numeric.transformer";
 import { RecordDataModel } from "./record.model";
 
 /**
@@ -72,8 +73,9 @@ export class DisbursementReceipt extends RecordDataModel {
     name: "total_entitled_disbursed_amount",
     type: "numeric",
     nullable: false,
+    transformer: numericTransformer,
   })
-  totalEntitledDisbursedAmount: string;
+  totalEntitledDisbursedAmount: number;
 
   /**
    * Total disbursed amount for either FE(Federal) or BC(Provincial).
@@ -82,8 +84,9 @@ export class DisbursementReceipt extends RecordDataModel {
     name: "total_disbursed_amount",
     type: "numeric",
     nullable: false,
+    transformer: numericTransformer,
   })
-  totalDisbursedAmount: string;
+  totalDisbursedAmount: number;
 
   /**
    * Financial posting date of NSLSC.
@@ -102,8 +105,9 @@ export class DisbursementReceipt extends RecordDataModel {
     name: "disburse_amount_student",
     type: "numeric",
     nullable: false,
+    transformer: numericTransformer,
   })
-  disburseAmountStudent: string;
+  disburseAmountStudent: number;
 
   /**
    * Amount disbursed to the institution.
@@ -112,8 +116,9 @@ export class DisbursementReceipt extends RecordDataModel {
     name: "disburse_amount_institution",
     type: "numeric",
     nullable: false,
+    transformer: numericTransformer,
   })
-  disburseAmountInstitution: string;
+  disburseAmountInstitution: number;
 
   /**
    * The date signed by the institution of the student at the time they receive the loan certificate.
@@ -150,8 +155,9 @@ export class DisbursementReceipt extends RecordDataModel {
     name: "total_entitled_grant_amount",
     type: "numeric",
     nullable: false,
+    transformer: numericTransformer,
   })
-  totalEntitledGrantAmount: string;
+  totalEntitledGrantAmount: number;
 
   /**
    * Total Federal or BC grant disbursed amount.
@@ -160,8 +166,9 @@ export class DisbursementReceipt extends RecordDataModel {
     name: "total_disbursed_grant_amount",
     type: "numeric",
     nullable: false,
+    transformer: numericTransformer,
   })
-  totalDisbursedGrantAmount: string;
+  totalDisbursedGrantAmount: number;
 
   /**
    * Total Federal or BC grant disbursed amount to student.
@@ -170,8 +177,9 @@ export class DisbursementReceipt extends RecordDataModel {
     name: "total_disbursed_grant_amount_student",
     type: "numeric",
     nullable: false,
+    transformer: numericTransformer,
   })
-  totalDisbursedGrantAmountStudent: string;
+  totalDisbursedGrantAmountStudent: number;
 
   /**
    * Total Federal or BC grant disbursed amount to institution.
@@ -180,8 +188,9 @@ export class DisbursementReceipt extends RecordDataModel {
     name: "total_disbursed_grant_amount_institution",
     type: "numeric",
     nullable: false,
+    transformer: numericTransformer,
   })
-  totalDisbursedGrantAmountInstitution: string;
+  totalDisbursedGrantAmountInstitution: number;
 
   /**
    * Values for this disbursement.

--- a/sources/packages/backend/libs/sims-db/src/entities/disbursement-values.model.ts
+++ b/sources/packages/backend/libs/sims-db/src/entities/disbursement-values.model.ts
@@ -7,6 +7,7 @@ import {
   RelationId,
 } from "typeorm";
 import { ColumnNames, TableNames } from "../constant";
+import { numericTransformer } from "../transformers/numeric.transformer";
 import { DisbursementSchedule } from "./disbursement-schedule.model";
 import { DisbursementValueType } from "./disbursement-value-type";
 import { RecordDataModel } from "./record.model";
@@ -41,47 +42,47 @@ export class DisbursementValue extends RecordDataModel {
   valueCode: string;
   /**
    * Amount of money to be disbursed for one particular loan/grant.
-   * !Decimal values are retrieved by Typeorm as string from Postgres.
    */
   @Column({
     name: "value_amount",
     type: "numeric",
     nullable: false,
+    transformer: numericTransformer,
   })
-  valueAmount: string;
+  valueAmount: number;
   /**
    * Overaward amount value subtracted from the award calculated.
-   * !Decimal values are retrieved by Typeorm as string from Postgres.
    */
   @Column({
     name: "overaward_amount_subtracted",
     type: "numeric",
     nullable: false,
+    transformer: numericTransformer,
   })
-  overawardAmountSubtracted: string;
+  overawardAmountSubtracted: number;
   /**
    * Value amount already disbursed for the same application and
    * the same award that was subtracted from the calculated award.
-   * !Decimal values are retrieved by Typeorm as string from Postgres.
    */
   @Column({
     name: "disbursed_amount_subtracted",
     type: "numeric",
     nullable: true,
+    transformer: numericTransformer,
   })
-  disbursedAmountSubtracted?: string;
+  disbursedAmountSubtracted?: number;
   /**
    * Value resulted from the calculation between the award value_amount,
    * disbursed_amount_subtracted and overaward_amount_subtracted. This is
    * the value that was sent on the e-Cert and effectively paid to the student.
-   * !Decimal values are retrieved by Typeorm as string from Postgres.
    */
   @Column({
     name: "effective_amount",
     type: "numeric",
     nullable: true,
+    transformer: numericTransformer,
   })
-  effectiveAmount?: string;
+  effectiveAmount?: number;
   /**
    * Disbursement value ids.
    */

--- a/sources/packages/backend/libs/sims-db/src/transformers/numeric.transformer.ts
+++ b/sources/packages/backend/libs/sims-db/src/transformers/numeric.transformer.ts
@@ -1,0 +1,30 @@
+import { ValueTransformer } from "typeorm";
+
+/***
+ * Allow a numeric column type on Postgres to bo be mapped to a javascript
+ * number type instead of the out-of-box conversion to a string.
+ * This transformer should be used only if the expected number
+ * stored on Postgres is not expected to exceed the maximum
+ * value supported by the javascript number type.
+ */
+export const numericTransformer: ValueTransformer = {
+  /**
+   * Converts the database value, received as string, to a number.
+   * @param value values received from database as string.
+   * @returns numeric/decimal string converted to a number.
+   */
+  from: (value: string | null): number | null => {
+    if (value) {
+      return parseFloat(value);
+    }
+    return null;
+  },
+  /**
+   * Converts the number to a string as expected by Typeorm.
+   * @param value number to be converted to the string.
+   * @returns the converted string.
+   */
+  to: (value?: number): string => {
+    return value?.toString();
+  },
+};

--- a/sources/packages/backend/libs/sims-db/src/transformers/numeric.transformer.ts
+++ b/sources/packages/backend/libs/sims-db/src/transformers/numeric.transformer.ts
@@ -1,7 +1,7 @@
 import { ValueTransformer } from "typeorm";
 
 /***
- * Allow a numeric column type on Postgres to bo be mapped to a javascript
+ * Allow a numeric column type on Postgres to be mapped to a javascript
  * number type instead of the out-of-box conversion to a string.
  * This transformer should be used only if the expected number
  * stored on Postgres is not expected to exceed the maximum
@@ -19,6 +19,7 @@ export const numericTransformer: ValueTransformer = {
     }
     return null;
   },
+
   /**
    * Converts the number to a string as expected by Typeorm.
    * @param value number to be converted to the string.

--- a/sources/packages/backend/libs/test-utils/src/factories/disbursement-overaward.ts
+++ b/sources/packages/backend/libs/test-utils/src/factories/disbursement-overaward.ts
@@ -18,9 +18,10 @@ export function createFakeDisbursementOveraward(relations?: {
   disbursementOveraward.student = relations?.student;
   disbursementOveraward.studentAssessment = relations?.studentAssessment;
   disbursementOveraward.disbursementSchedule = relations?.disbursementSchedule;
-  disbursementOveraward.overawardValue = faker.random
-    .number({ min: 500, max: 50000 })
-    .toString();
+  disbursementOveraward.overawardValue = faker.random.number({
+    min: 500,
+    max: 50000,
+  });
   disbursementOveraward.disbursementValueCode = faker.random
     .alpha({
       count: 4,

--- a/sources/packages/backend/libs/test-utils/src/factories/disbursement-value.ts
+++ b/sources/packages/backend/libs/test-utils/src/factories/disbursement-value.ts
@@ -7,11 +7,11 @@ import {
 export function createFakeDisbursementValue(
   valueType: DisbursementValueType,
   valueCode: string,
-  valueAmount: string,
+  valueAmount: number,
   options?: {
-    overawardAmountSubtracted?: string;
-    disbursedAmountSubtracted?: string;
-    effectiveAmount?: string;
+    overawardAmountSubtracted?: number;
+    disbursedAmountSubtracted?: number;
+    effectiveAmount?: number;
   },
   relations?: {
     disbursementSchedule: DisbursementSchedule;

--- a/sources/packages/backend/libs/utilities/src/disbursements-utils.ts
+++ b/sources/packages/backend/libs/utilities/src/disbursements-utils.ts
@@ -41,7 +41,7 @@ export function getTotalDisbursementAmount(
   types: DisbursementValueType[],
 ): number {
   return getDisbursementValuesByType(awards, types).reduce(
-    (totalAmount, award) => totalAmount + +award.valueAmount,
+    (totalAmount, award) => totalAmount + award.valueAmount,
     0,
   );
 }


### PR DESCRIPTION
Changed the DB entity models mapped to "numeric" and typed as `string` to `number` with a Typeorm transformer.
Dealing with all the numbers mapped as `string` was proving to be more error-prone and they were causing the code to be more complex than needed.