### PR TITLE
#1649 - Request Basic BCeID account creation limited to one at a time

### DIFF
--- a/devops/Makefile
+++ b/devops/Makefile
@@ -331,7 +331,6 @@ deploy-api:
 		-p ATBC_ENDPOINT=$(ATBC_ENDPOINT) \
 		-p BYPASS_APPLICATION_SUBMIT_VALIDATIONS=$(BYPASS_APPLICATION_SUBMIT_VALIDATIONS) \
 		-p SWAGGER_ENABLED=$(SWAGGER_ENABLED) \
-		-p APPLICATION_ARCHIVE_DAYS=$(APPLICATION_ARCHIVE_DAYS) \
 		-p SWAGGER_NAME=$(SWAGGER_NAME) \
 		-p QUEUE_PREFIX=$(QUEUE_PREFIX) \
 		| oc -n $(NAMESPACE) apply -f -
@@ -373,6 +372,7 @@ deploy-queue-consumers:
 	test -n "$(QUEUE_PREFIX)"
 	test -n "$(ATBC_LOGIN_ENDPOINT)"
 	test -n "$(ATBC_ENDPOINT)"
+	test -n "$(APPLICATION_ARCHIVE_DAYS)"
 	@echo "+\n++ Deploying Queues with tag: $(BUILD_TAG)\n+"
 	@oc -n $(NAMESPACE) process -f openshift/queue-consumers-deploy.yml \
 		-p NAME=$(QUEUE_CONSUMERS) \
@@ -387,6 +387,7 @@ deploy-queue-consumers:
 		-p QUEUE_PREFIX=$(QUEUE_PREFIX) \
 		-p ATBC_LOGIN_ENDPOINT=$(ATBC_LOGIN_ENDPOINT) \
 		-p ATBC_ENDPOINT=$(ATBC_ENDPOINT) \
+		-p APPLICATION_ARCHIVE_DAYS=$(APPLICATION_ARCHIVE_DAYS) \
 		| oc -n $(NAMESPACE) apply -f -
 	$(call rollout_and_wait,dc/$(QUEUE_CONSUMERS))
 

--- a/sources/packages/backend/apps/api/src/route-controllers/student-account-applications/student-account-application.students.controller.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/student-account-applications/student-account-application.students.controller.ts
@@ -76,7 +76,7 @@ export class StudentAccountApplicationStudentsController extends BaseController 
       // on DB so check for possible pending student account applications.
       const hasPendingStudentAccountApplication =
         await this.studentAccountApplicationsService.hasPendingStudentAccountApplication(
-          userToken.userId,
+          userToken.userName,
         );
       if (hasPendingStudentAccountApplication) {
         throw new UnprocessableEntityException(
@@ -123,7 +123,7 @@ export class StudentAccountApplicationStudentsController extends BaseController 
   ): Promise<StudentAccountApplicationAPIOutDTO> {
     const hasPendingApplication =
       await this.studentAccountApplicationsService.hasPendingStudentAccountApplication(
-        studentUserToken.userId,
+        studentUserToken.userName,
       );
     return { hasPendingApplication };
   }

--- a/sources/packages/backend/apps/api/src/services/student-account-applications/student-account-applications.service.ts
+++ b/sources/packages/backend/apps/api/src/services/student-account-applications/student-account-applications.service.ts
@@ -198,11 +198,13 @@ export class StudentAccountApplicationsService extends RecordDataModelService<St
 
   /**
    * Checks if the user has a pending student account applications.
-   * @param userId user to be verified.
+   * @param userName user name to be verified.
    * @returns true, if there is a pending student account application,
    * otherwise, false.
    */
-  async hasPendingStudentAccountApplication(userId: number): Promise<boolean> {
+  async hasPendingStudentAccountApplication(
+    userName: string,
+  ): Promise<boolean> {
     const accountApplication = await this.repo.findOne({
       select: {
         id: true,
@@ -210,7 +212,7 @@ export class StudentAccountApplicationsService extends RecordDataModelService<St
       where: {
         assessedDate: IsNull(),
         user: {
-          id: userId,
+          userName,
         },
       },
     });


### PR DESCRIPTION
TypeOrm has a [bug:](https://github.com/typeorm/typeorm/issues/9316) that returns a record when the param is `null` or `undefined`! 😲 
The issue happened because userId is `undefined` in `studentUserToken` in the request to check if the student has pending account application.  Then used `userName` instead of `userId`.