### PR TITLE
#1666-Dependabot dependency error

### DIFF
--- a/sources/packages/backend/package-lock.json
+++ b/sources/packages/backend/package-lock.json
@@ -2042,7 +2042,7 @@
       "peerDependencies": {
         "@nestjs/common": "^7.0.8 || ^8.0.0 || ^9.0.0",
         "class-transformer": "^0.2.0 || ^0.3.0 || ^0.4.0 || ^0.5.0",
-        "class-validator": "^0.11.1 || ^0.12.0 || ^0.13.0",
+        "class-validator": "^0.14.0",
         "reflect-metadata": "^0.1.12"
       },
       "peerDependenciesMeta": {


### PR DESCRIPTION
<img width="844" alt="image" src="https://user-images.githubusercontent.com/62901416/214445914-0d709976-d1ed-4271-9456-6f8865930442.png">
Resolved the dependency which the @nestjs/mapped-types version that did not update, once they implement the class-validator in their version, the package-lock will be updated automatically.

FYI: Similar reference of error in build in Stackoverflow
https://stackoverflow.com/questions/75139457/error-or-breaking-changes-in-nest-class-validator0-13-2