### PR TITLE
Formio dockerfile update

### DIFF
--- a/sources/packages/forms/Dockerfile
+++ b/sources/packages/forms/Dockerfile
@@ -45,6 +45,9 @@ RUN apk del git
 #          See docker-compose.yml for instructions
 RUN ln -sf $NPM_PACKAGES/node_modules node_modules
 
+RUN ls
+RUN PWD
+
 # Set this to inspect more from the application. Examples:
 #   DEBUG=formio:db (see index.js for more)
 #   DEBUG=formio:*

--- a/sources/packages/forms/Dockerfile
+++ b/sources/packages/forms/Dockerfile
@@ -12,16 +12,11 @@ WORKDIR /app
 RUN apk update && \
   apk upgrade && \
   apk add make=4.2.1-r2 && \
-  apk add g++=8.3.0-r0
-
-# At least one buried package dependency is using a `git` path.
-# Hence we need to haul in git.
-RUN apk --update add git
-# Use https to avoid requiring ssh keys for public repos.
-RUN git config --global url."https://github.com/".insteadOf "ssh://git@github.com/"
+  apk add g++=8.3.0-r0 \
+  apk add git
 
 # Clone code
-RUN git clone ${FORMIO_SOURCE_REPO_URL} -b ${FORMIO_SOURCE_REPO_TAG} --single-branch /app
+RUN git clone ${FORMIO_SOURCE_REPO_URL} -b ${FORMIO_SOURCE_REPO_TAG} --single-branch /app/
 
 # Using an alternative package install location
 # to allow overwriting the /app folder at runtime
@@ -35,6 +30,7 @@ RUN echo "prefix = $NPM_PACKAGES" >> ~/.npmrc
 COPY ./package.json $NPM_PACKAGES/
 COPY ./package-lock.json $NPM_PACKAGES/
 
+RUN npm i --prefix=$NPM_PACKAGES
 # Use "Continuous Integration" to install as-is from package-lock.json
 RUN npm ci --prefix=$NPM_PACKAGES
 
@@ -51,6 +47,8 @@ RUN ls
 #   DEBUG=formio:db (see index.js for more)
 #   DEBUG=formio:*
 ENV DEBUG=""
+RUN set -x \
+  && chmod -R 777 /app/
 
 # This will initialize the application based on
 # some questions to the user (login email, password, etc.)

--- a/sources/packages/forms/Dockerfile
+++ b/sources/packages/forms/Dockerfile
@@ -32,7 +32,7 @@ COPY ./package.json $NPM_PACKAGES/
 COPY ./package-lock.json $NPM_PACKAGES/
 
 # Use "Continuous Integration" to install as-is from package-lock.json
-RUN npm ci --prefix=$NPM_PACKAGES
+RUN npm i --prefix=$NPM_PACKAGES
 
 RUN apk del git
 

--- a/sources/packages/forms/Dockerfile
+++ b/sources/packages/forms/Dockerfile
@@ -37,7 +37,7 @@ RUN mkdir -p $NPM_PACKAGES/
 RUN cp package.json $NPM_PACKAGES/
 
 # Use install as-is from package.json
-RUN npm ci --prefix=$NPM_PACKAGES
+RUN npm i --prefix=$NPM_PACKAGES
 
 # Link in the global install because `require()` only looks for ./node_modules
 # WARNING: This is overwritten by volume-mount at runtime!

--- a/sources/packages/forms/Dockerfile
+++ b/sources/packages/forms/Dockerfile
@@ -21,7 +21,7 @@ RUN apk --update add git
 RUN git config --global url."https://github.com/".insteadOf "ssh://git@github.com/"
 
 # Clone code
-RUN git clone ${FORMIO_SOURCE_REPO_URL} -b ${FORMIO_SOURCE_REPO_TAG} --single-branch /formio/
+RUN git clone ${FORMIO_SOURCE_REPO_URL} -b ${FORMIO_SOURCE_REPO_TAG} --single-branch /app
 
 # Using an alternative package install location
 # to allow overwriting the /app folder at runtime
@@ -52,4 +52,4 @@ ENV DEBUG=""
 
 # This will initialize the application based on
 # some questions to the user (login email, password, etc.)
-ENTRYPOINT [ "node", "main" ]
+ENTRYPOINT [ "node", "main.js" ]

--- a/sources/packages/forms/Dockerfile
+++ b/sources/packages/forms/Dockerfile
@@ -4,7 +4,7 @@
 
 # Use Node image, maintained by Docker:
 # hub.docker.com/r/_/node/
-FROM artifacts.developer.gov.bc.ca/docker-remote/node:19.2-alpine
+FROM artifacts.developer.gov.bc.ca/docker-remote/node:19.2
 WORKDIR /app
 
 # "bcrypt" requires python/make/g++, all must be installed in alpine
@@ -46,7 +46,6 @@ RUN apk del git
 RUN ln -sf $NPM_PACKAGES/node_modules node_modules
 
 RUN ls
-RUN PWD
 
 # Set this to inspect more from the application. Examples:
 #   DEBUG=formio:db (see index.js for more)
@@ -55,4 +54,4 @@ ENV DEBUG=""
 
 # This will initialize the application based on
 # some questions to the user (login email, password, etc.)
-ENTRYPOINT [ "node", "main.js" ]
+ENTRYPOINT [ "node", "main" ]

--- a/sources/packages/forms/Dockerfile
+++ b/sources/packages/forms/Dockerfile
@@ -32,7 +32,7 @@ COPY ./package-lock.json $NPM_PACKAGES/
 
 RUN npm i --prefix=$NPM_PACKAGES
 # Use "Continuous Integration" to install as-is from package-lock.json
-RUN npm ci --prefix=$NPM_PACKAGES
+#RUN npm ci --prefix=$NPM_PACKAGES
 
 RUN apk del git
 

--- a/sources/packages/forms/Dockerfile
+++ b/sources/packages/forms/Dockerfile
@@ -4,15 +4,15 @@
 
 # Use Node image, maintained by Docker:
 # hub.docker.com/r/_/node/
-FROM artifacts.developer.gov.bc.ca/docker-remote/node:19.2
+FROM artifacts.developer.gov.bc.ca/docker-remote/node:12.2.0-alpine
 WORKDIR /app
 
 # "bcrypt" requires python/make/g++, all must be installed in alpine
 # (note: using pinned versions to ensure immutable build environment)
 RUN apk update && \
   apk upgrade && \
-  apk add make && \
-  apk add g++
+  apk add make=4.2.1-r2 && \
+  apk add g++=8.3.0-r0
 
 # At least one buried package dependency is using a `git` path.
 # Hence we need to haul in git.

--- a/sources/packages/forms/Dockerfile
+++ b/sources/packages/forms/Dockerfile
@@ -4,7 +4,7 @@
 
 # Use Node image, maintained by Docker:
 # hub.docker.com/r/_/node/
-FROM artifacts.developer.gov.bc.ca/docker-remote/node:lts-alpine3.10
+FROM artifacts.developer.gov.bc.ca/docker-remote/node:12.2.0
 
 WORKDIR /app
 ARG FORMIO_SOURCE_REPO_URL

--- a/sources/packages/forms/Dockerfile
+++ b/sources/packages/forms/Dockerfile
@@ -35,7 +35,6 @@ RUN echo "prefix = $NPM_PACKAGES" >> ~/.npmrc
 RUN mkdir -p $NPM_PACKAGES/
 # Include details of the required dependencies
 RUN cp package.json $NPM_PACKAGES/
-RUN cp package-lock.json $NPM_PACKAGES/
 
 # Use install as-is from package.json
 RUN npm ci --prefix=$NPM_PACKAGES

--- a/sources/packages/forms/Dockerfile
+++ b/sources/packages/forms/Dockerfile
@@ -34,7 +34,7 @@ COPY ./package.json $NPM_PACKAGES/
 COPY ./package-lock.json $NPM_PACKAGES/
 
 # Use "Continuous Integration" to install as-is from package-lock.json
-RUN npm ci --prefix=$NPM_PACKAGES
+RUN npm i --prefix=$NPM_PACKAGES
 
 RUN apk del git
 

--- a/sources/packages/forms/Dockerfile
+++ b/sources/packages/forms/Dockerfile
@@ -17,7 +17,7 @@ RUN apk update && \
   apk add git
 
 # Clone code
-RUN git clone ${FORMIO_SOURCE_REPO_URL} -b ${FORMIO_SOURCE_REPO_TAG} --single-branch /formio/
+RUN git clone ${FORMIO_SOURCE_REPO_URL} -b ${FORMIO_SOURCE_REPO_TAG} --single-branch /app/
 
 # Using an alternative package install location
 # to allow overwriting the /app folder at runtime

--- a/sources/packages/forms/Dockerfile
+++ b/sources/packages/forms/Dockerfile
@@ -4,9 +4,11 @@
 
 # Use Node image, maintained by Docker:
 # hub.docker.com/r/_/node/
-FROM artifacts.developer.gov.bc.ca/docker-remote/node:12.2.0
+FROM artifacts.developer.gov.bc.ca/docker-remote/node:12.2.0-alpine
 
-WORKDIR /app
+# set working directory
+WORKDIR /formio
+
 ARG FORMIO_SOURCE_REPO_URL
 ARG FORMIO_SOURCE_REPO_TAG
 
@@ -19,7 +21,7 @@ RUN apk update && \
   apk add git
 
 # Clone code
-RUN git clone ${FORMIO_SOURCE_REPO_URL} -b ${FORMIO_SOURCE_REPO_TAG} --single-branch /app/
+RUN git clone ${FORMIO_SOURCE_REPO_URL} -b ${FORMIO_SOURCE_REPO_TAG} --single-branch /formio/
 
 # Using an alternative package install location
 # to allow overwriting the /app folder at runtime
@@ -30,13 +32,12 @@ ENV NPM_PACKAGES=/.npm-packages \
 RUN echo "prefix = $NPM_PACKAGES" >> ~/.npmrc
 
 # Include details of the required dependencies
-COPY ./package.json $NPM_PACKAGES/
-COPY ./package-lock.json $NPM_PACKAGES/
+RUN mkdir -p $NPM_PACKAGES/
+# Include details of the required dependencies
+RUN cp package.json $NPM_PACKAGES/
 
-# Use "Continuous Integration" to install as-is from package-lock.json
+# Use install as-is from package.json
 RUN npm i --prefix=$NPM_PACKAGES
-
-RUN apk del git
 
 # Link in the global install because `require()` only looks for ./node_modules
 # WARNING: This is overwritten by volume-mount at runtime!
@@ -47,6 +48,9 @@ RUN ln -sf $NPM_PACKAGES/node_modules node_modules
 #   DEBUG=formio:db (see index.js for more)
 #   DEBUG=formio:*
 ENV DEBUG=""
+
+RUN set -x \
+  && chmod -R 777 /formio/
 
 # This will initialize the application based on
 # some questions to the user (login email, password, etc.)

--- a/sources/packages/forms/Dockerfile
+++ b/sources/packages/forms/Dockerfile
@@ -12,7 +12,7 @@ WORKDIR /app
 RUN apk update && \
   apk upgrade && \
   apk add make=4.2.1-r2 && \
-  apk add g++=8.3.0-r0 \
+  apk add g++=8.3.0-r0 && \
   apk add git
 
 # Clone code

--- a/sources/packages/forms/Dockerfile
+++ b/sources/packages/forms/Dockerfile
@@ -5,7 +5,12 @@
 # Use Node image, maintained by Docker:
 # hub.docker.com/r/_/node/
 FROM artifacts.developer.gov.bc.ca/docker-remote/node:12.2.0-alpine
-WORKDIR /app
+
+# set working directory
+WORKDIR /formio
+
+ARG FORMIO_SOURCE_REPO_URL
+ARG FORMIO_SOURCE_REPO_TAG
 
 # "bcrypt" requires python/make/g++, all must be installed in alpine
 # (note: using pinned versions to ensure immutable build environment)
@@ -16,7 +21,7 @@ RUN apk update && \
   apk add git
 
 # Clone code
-RUN git clone ${FORMIO_SOURCE_REPO_URL} -b ${FORMIO_SOURCE_REPO_TAG} --single-branch /app/
+RUN git clone ${FORMIO_SOURCE_REPO_URL} -b ${FORMIO_SOURCE_REPO_TAG} --single-branch /formio/
 
 # Using an alternative package install location
 # to allow overwriting the /app folder at runtime
@@ -27,28 +32,26 @@ ENV NPM_PACKAGES=/.npm-packages \
 RUN echo "prefix = $NPM_PACKAGES" >> ~/.npmrc
 
 # Include details of the required dependencies
-COPY ./package.json $NPM_PACKAGES/
-#COPY ./package-lock.json $NPM_PACKAGES/
+RUN mkdir -p $NPM_PACKAGES/
+# Include details of the required dependencies
+RUN cp package.json $NPM_PACKAGES/
+RUN cp package-lock.json $NPM_PACKAGES/
 
-RUN npm i --prefix=$NPM_PACKAGES
-# Use "Continuous Integration" to install as-is from package-lock.json
-#RUN npm ci --prefix=$NPM_PACKAGES
-
-RUN apk del git
+# Use install as-is from package.json
+RUN npm ci --prefix=$NPM_PACKAGES
 
 # Link in the global install because `require()` only looks for ./node_modules
 # WARNING: This is overwritten by volume-mount at runtime!
 #          See docker-compose.yml for instructions
 RUN ln -sf $NPM_PACKAGES/node_modules node_modules
 
-RUN ls
-
 # Set this to inspect more from the application. Examples:
 #   DEBUG=formio:db (see index.js for more)
 #   DEBUG=formio:*
 ENV DEBUG=""
+
 RUN set -x \
-  && chmod -R 777 /app/
+  && chmod -R 777 /formio/
 
 # This will initialize the application based on
 # some questions to the user (login email, password, etc.)

--- a/sources/packages/forms/Dockerfile
+++ b/sources/packages/forms/Dockerfile
@@ -6,11 +6,7 @@
 # hub.docker.com/r/_/node/
 FROM artifacts.developer.gov.bc.ca/docker-remote/node:lts-alpine3.10
 
-# set working directory
-WORKDIR /formio
-
-ARG FORMIO_SOURCE_REPO_URL
-ARG FORMIO_SOURCE_REPO_TAG
+WORKDIR /app
 
 # "bcrypt" requires python/make/g++, all must be installed in alpine
 # (note: using pinned versions to ensure immutable build environment)
@@ -32,12 +28,13 @@ ENV NPM_PACKAGES=/.npm-packages \
 RUN echo "prefix = $NPM_PACKAGES" >> ~/.npmrc
 
 # Include details of the required dependencies
-RUN mkdir -p $NPM_PACKAGES/
-# Include details of the required dependencies
-RUN cp package.json $NPM_PACKAGES/
+COPY ./package.json $NPM_PACKAGES/
+COPY ./package-lock.json $NPM_PACKAGES/
 
-# Use install as-is from package.json
-RUN npm i --prefix=$NPM_PACKAGES
+# Use "Continuous Integration" to install as-is from package-lock.json
+RUN npm ci --prefix=$NPM_PACKAGES
+
+RUN apk del git
 
 # Link in the global install because `require()` only looks for ./node_modules
 # WARNING: This is overwritten by volume-mount at runtime!
@@ -48,9 +45,6 @@ RUN ln -sf $NPM_PACKAGES/node_modules node_modules
 #   DEBUG=formio:db (see index.js for more)
 #   DEBUG=formio:*
 ENV DEBUG=""
-
-RUN set -x \
-  && chmod -R 777 /formio/
 
 # This will initialize the application based on
 # some questions to the user (login email, password, etc.)

--- a/sources/packages/forms/Dockerfile
+++ b/sources/packages/forms/Dockerfile
@@ -28,7 +28,7 @@ RUN echo "prefix = $NPM_PACKAGES" >> ~/.npmrc
 
 # Include details of the required dependencies
 COPY ./package.json $NPM_PACKAGES/
-COPY ./package-lock.json $NPM_PACKAGES/
+#COPY ./package-lock.json $NPM_PACKAGES/
 
 RUN npm i --prefix=$NPM_PACKAGES
 # Use "Continuous Integration" to install as-is from package-lock.json

--- a/sources/packages/forms/Dockerfile
+++ b/sources/packages/forms/Dockerfile
@@ -32,7 +32,7 @@ COPY ./package.json $NPM_PACKAGES/
 COPY ./package-lock.json $NPM_PACKAGES/
 
 # Use "Continuous Integration" to install as-is from package-lock.json
-RUN npm i --prefix=$NPM_PACKAGES
+RUN npm ci --prefix=$NPM_PACKAGES
 
 RUN apk del git
 

--- a/sources/packages/forms/Dockerfile
+++ b/sources/packages/forms/Dockerfile
@@ -6,9 +6,7 @@
 # hub.docker.com/r/_/node/
 FROM artifacts.developer.gov.bc.ca/docker-remote/node:12.2.0-alpine
 
-# set working directory
-WORKDIR /formio
-
+WORKDIR /app
 ARG FORMIO_SOURCE_REPO_URL
 ARG FORMIO_SOURCE_REPO_TAG
 
@@ -21,7 +19,7 @@ RUN apk update && \
   apk add git
 
 # Clone code
-RUN git clone ${FORMIO_SOURCE_REPO_URL} -b ${FORMIO_SOURCE_REPO_TAG} --single-branch /formio/
+RUN git clone ${FORMIO_SOURCE_REPO_URL} -b ${FORMIO_SOURCE_REPO_TAG} --single-branch /app/
 
 # Using an alternative package install location
 # to allow overwriting the /app folder at runtime
@@ -50,7 +48,7 @@ RUN ln -sf $NPM_PACKAGES/node_modules node_modules
 ENV DEBUG=""
 
 RUN set -x \
-  && chmod -R 777 /formio/
+  && chmod -R 777 /app/
 
 # This will initialize the application based on
 # some questions to the user (login email, password, etc.)

--- a/sources/packages/forms/Dockerfile
+++ b/sources/packages/forms/Dockerfile
@@ -4,7 +4,7 @@
 
 # Use Node image, maintained by Docker:
 # hub.docker.com/r/_/node/
-FROM artifacts.developer.gov.bc.ca/docker-remote/node:12.2.0-alpine
+FROM artifacts.developer.gov.bc.ca/docker-remote/node:14.17.0-alpine
 
 # set working directory
 WORKDIR /formio

--- a/sources/packages/forms/Dockerfile
+++ b/sources/packages/forms/Dockerfile
@@ -4,7 +4,7 @@
 
 # Use Node image, maintained by Docker:
 # hub.docker.com/r/_/node/
-FROM artifacts.developer.gov.bc.ca/docker-remote/node:14.17.0-alpine
+FROM artifacts.developer.gov.bc.ca/docker-remote/node:lts-alpine3.10
 
 # set working directory
 WORKDIR /formio

--- a/sources/packages/forms/Dockerfile
+++ b/sources/packages/forms/Dockerfile
@@ -4,9 +4,11 @@
 
 # Use Node image, maintained by Docker:
 # hub.docker.com/r/_/node/
-FROM artifacts.developer.gov.bc.ca/docker-remote/node:12.2.0-alpine
+FROM artifacts.developer.gov.bc.ca/docker-remote/node:lts-alpine3.10
 
 WORKDIR /app
+ARG FORMIO_SOURCE_REPO_URL
+ARG FORMIO_SOURCE_REPO_TAG
 
 # "bcrypt" requires python/make/g++, all must be installed in alpine
 # (note: using pinned versions to ensure immutable build environment)

--- a/sources/packages/forms/Dockerfile
+++ b/sources/packages/forms/Dockerfile
@@ -4,7 +4,7 @@
 
 # Use Node image, maintained by Docker:
 # hub.docker.com/r/_/node/
-FROM artifacts.developer.gov.bc.ca/docker-remote/node:lts-alpine3.10
+FROM artifacts.developer.gov.bc.ca/docker-remote/node:12.2.0-alpine
 
 WORKDIR /app
 


### PR DESCRIPTION
As forms image was deleted and the formio was not supporting the latest version of node artifactory, changed the supported version of node and build the dockerfile.