### PR TITLE
#1693 - Removing env from tests workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,7 +5,6 @@ on: [pull_request]
 jobs:
   api-e2e-tests:
     name: SIMS API E2E Tests
-    environment: DEV
     runs-on: ubuntu-latest
     env:
       PROJECT_NAME: aest-sims

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,9 +1,9 @@
-# This workflow is executed during pull requests triggered by an user or by the GitHub dependabot.
-# When created by the dependabot the access to the env variables are restricted,
-# see https://github.com/dependabot/dependabot-core/issues/3253 and
+# This workflow is executed during pull requests triggered by a user or by the GitHub dependabot.
+# When created by the dependabot the access to the env variables is restricted, please see
+# https://github.com/dependabot/dependabot-core/issues/3253 and
 # https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions
-# To allow access to the secrets on both cases, the test users passwords (or any other secret) are defined at repository
-# level and also at the dependabot secrets for now.
+# To allow access to the secrets in both cases, the test users' passwords (or any other secret) are defined at the
+# repository level and also at the `dependabot` secrets for now.
 name: Tests
 
 on: [pull_request]

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,8 @@
 name: Tests
 
-on: [pull_request]
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
 
 jobs:
   api-e2e-tests:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,8 +1,12 @@
+# This workflow is executed during pull requests triggered by an user or by the GitHub dependabot.
+# When created by the dependabot the access to the env variables are restricted,
+# see https://github.com/dependabot/dependabot-core/issues/3253 and
+# https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions
+# To allow access to the secrets on both cases, the test users passwords (or any other secret) are defined at repository
+# level and also at the dependabot secrets for now.
 name: Tests
 
-on:
-  pull_request:
-    types: [opened, reopened, synchronize]
+on: [pull_request]
 
 jobs:
   api-e2e-tests:

--- a/sources/packages/backend/apps/api/test/auth.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/test/auth.e2e-spec.ts
@@ -35,6 +35,10 @@ describe("Authentication (e2e)", () => {
       "student",
     );
 
+    console.log("E2E_TEST_STUDENT_USERNAME");
+    console.log(process.env.E2E_TEST_STUDENT_USERNAME);
+    console.log(process.env.E2E_TEST_STUDENT_PASSWORD);
+
     const aestToken = await KeycloakService.shared.getToken(
       process.env.E2E_TEST_STUDENT_USERNAME,
       process.env.E2E_TEST_STUDENT_PASSWORD,

--- a/sources/packages/backend/apps/api/test/auth.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/test/auth.e2e-spec.ts
@@ -35,10 +35,6 @@ describe("Authentication (e2e)", () => {
       "student",
     );
 
-    console.log("E2E_TEST_STUDENT_USERNAME");
-    console.log(process.env.E2E_TEST_STUDENT_USERNAME);
-    console.log(process.env.E2E_TEST_STUDENT_PASSWORD);
-
     const aestToken = await KeycloakService.shared.getToken(
       process.env.E2E_TEST_STUDENT_USERNAME,
       process.env.E2E_TEST_STUDENT_PASSWORD,


### PR DESCRIPTION
When GitHub `dependabot` is creating the PR it does not have access to the env and an error happens "Error: Resource not accessible by integration". For instance: https://github.com/bcgov/SIMS/actions/runs/4130521677/jobs/7137296569
Using the closed ticket #1693 for reference only.

This workflow is executed during pull requests triggered by a user or by the GitHub `dependabot`.
When created by the `dependabot` the access to the env variables is restricted, please see https://github.com/dependabot/dependabot-core/issues/3253 and
https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions
To allow access to the secrets in both cases, the test users' passwords (or any other secret) are defined at the repository
level and also at the `dependabot` secrets for now.
