### PR TITLE
#1692 - Ministry overaward part 2

### DIFF
--- a/sources/packages/backend/apps/api/src/route-controllers/overaward/models/overaward.dto.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/overaward/models/overaward.dto.ts
@@ -6,7 +6,7 @@ import {
   AWARD_VALUE_CODE_LENGTH,
   MONEY_VALUE_FOR_UNKNOWN_MAX_VALUE,
 } from "../../../utilities";
-import { Length, Max, Min } from "class-validator";
+import { Length, Max, Min, NotEquals } from "class-validator";
 
 export class OverawardBalanceAPIOutDTO {
   overawardBalanceValues: Record<string, number>;
@@ -27,5 +27,6 @@ export class OverawardManualRecordAPIInDTO {
   awardValueCode: string;
   @Min(-MONEY_VALUE_FOR_UNKNOWN_MAX_VALUE)
   @Max(MONEY_VALUE_FOR_UNKNOWN_MAX_VALUE)
+  @NotEquals(0)
   overawardValue: number;
 }

--- a/sources/packages/backend/libs/services/src/disbursement-overaward/disbursement-overaward.service.ts
+++ b/sources/packages/backend/libs/services/src/disbursement-overaward/disbursement-overaward.service.ts
@@ -105,7 +105,7 @@ export class DisbursementOverawardService {
         student: { id: studentId },
       },
       order: {
-        createdAt: "ASC",
+        createdAt: "DESC",
       },
     });
   }

--- a/sources/packages/backend/libs/services/src/disbursement-overaward/disbursement-overaward.service.ts
+++ b/sources/packages/backend/libs/services/src/disbursement-overaward/disbursement-overaward.service.ts
@@ -104,6 +104,9 @@ export class DisbursementOverawardService {
       where: {
         student: { id: studentId },
       },
+      order: {
+        createdAt: "ASC",
+      },
     });
   }
 

--- a/sources/packages/web/src/components/aest/students/modals/AddManualOverawardDeduction.vue
+++ b/sources/packages/web/src/components/aest/students/modals/AddManualOverawardDeduction.vue
@@ -31,6 +31,7 @@
                 -MONEY_VALUE_FOR_UNKNOWN_MAX_VALUE,
                 MONEY_VALUE_FOR_UNKNOWN_MAX_VALUE,
                 'Overaward deduction amount',
+                formatCurrency,
               ),
           ]"
         />
@@ -39,7 +40,7 @@
         <check-permission-role :role="allowedRole">
           <template #="{ notAllowed }">
             <footer-buttons
-              primaryLabel="Add Record now"
+              primaryLabel="Add record now"
               @secondaryClick="cancel"
               @primaryClick="submit"
               :disablePrimaryButton="notAllowed"
@@ -52,13 +53,14 @@
 </template>
 <script lang="ts">
 import { PropType, ref, reactive, defineComponent } from "vue";
-import { useModalDialog, useRules } from "@/composables";
+import { useModalDialog, useRules, useFormatters } from "@/composables";
 import { Role, VForm } from "@/types";
 import { OverawardManualRecordAPIInDTO } from "@/services/http/dto";
 import { BannerTypes } from "@/types/contracts/Banner";
 import {
-  FULL_TIME_AWARDS,
-  PART_TIME_AWARDS,
+  AWARDS,
+  FullTimeAwardTypes,
+  PartTimeAwardTypes,
 } from "@/constants/award-constants";
 import { MONEY_VALUE_FOR_UNKNOWN_MAX_VALUE } from "@/constants/system-constants";
 import ErrorSummary from "@/components/generic/ErrorSummary.vue";
@@ -75,17 +77,22 @@ export default defineComponent({
   },
   setup() {
     const { numberRangeRule, checkNullOrEmptyRule } = useRules();
+    const { formatCurrency } = useFormatters();
     const { showDialog, showModal, resolvePromise } = useModalDialog<
       OverawardManualRecordAPIInDTO | boolean
     >();
     const addManualOverawardForm = ref({} as VForm);
     const formModel = reactive({} as OverawardManualRecordAPIInDTO);
-    const awardTypeItems = [...FULL_TIME_AWARDS, ...PART_TIME_AWARDS]
-      .filter((award) => ["CSLF", "CSLP", "BCSL"].includes(award.awardType))
-      .map((award) => ({
-        title: `${award.awardType} (${award.description})`,
-        value: award.awardType,
-      }));
+    const awardTypeItems = AWARDS.filter((award) =>
+      [
+        FullTimeAwardTypes.CSLF,
+        PartTimeAwardTypes.CSLP,
+        FullTimeAwardTypes.BCSL,
+      ].includes(award.awardType),
+    ).map((award) => ({
+      title: `${award.awardType} (${award.description})`,
+      value: award.awardType,
+    }));
 
     const submit = async () => {
       const validationResult = await addManualOverawardForm.value.validate();
@@ -114,6 +121,7 @@ export default defineComponent({
       BannerTypes,
       numberRangeRule,
       checkNullOrEmptyRule,
+      formatCurrency,
       awardTypeItems,
       MONEY_VALUE_FOR_UNKNOWN_MAX_VALUE,
     };

--- a/sources/packages/web/src/components/aest/students/modals/AddManualOverawardDeduction.vue
+++ b/sources/packages/web/src/components/aest/students/modals/AddManualOverawardDeduction.vue
@@ -1,0 +1,122 @@
+<template>
+  <v-form ref="addManualOverawardForm">
+    <modal-dialog-base title="Add manual record" :showDialog="showDialog">
+      <template #content>
+        <error-summary :errors="addManualOverawardForm.errors" />
+        <p class="label-value">
+          Add a record to capture that the student paid back their loans through
+          the National Student Loans Service Centre (NSLSC).
+        </p>
+        <v-select
+          label="Award"
+          density="compact"
+          :items="awardTypeItems"
+          v-model="formModel.awardValueCode"
+          variant="outlined"
+          :rules="[(v) => checkNullOrEmptyRule(v, 'Award Type')]"
+        />
+        <v-text-field
+          hide-details="auto"
+          density="compact"
+          label="Add the dollar amount"
+          v-model="formModel.overawardValue"
+          variant="outlined"
+          type="number"
+          prefix="$"
+          :rules="[
+            (v) => checkNullOrEmptyRule(v, 'Overaward deduction amount'),
+            (v) =>
+              numberRangeRule(
+                v,
+                -MONEY_VALUE_FOR_UNKNOWN_MAX_VALUE,
+                MONEY_VALUE_FOR_UNKNOWN_MAX_VALUE,
+                'Overaward deduction amount',
+              ),
+          ]"
+        />
+      </template>
+      <template #footer>
+        <check-permission-role :role="allowedRole">
+          <template #="{ notAllowed }">
+            <footer-buttons
+              primaryLabel="Add Record now"
+              @secondaryClick="cancel"
+              @primaryClick="submit"
+              :disablePrimaryButton="notAllowed"
+            />
+          </template>
+        </check-permission-role>
+      </template>
+    </modal-dialog-base>
+  </v-form>
+</template>
+<script lang="ts">
+import { PropType, ref, reactive, defineComponent } from "vue";
+import { useModalDialog, useRules } from "@/composables";
+import { Role, VForm } from "@/types";
+import { OverawardManualRecordAPIInDTO } from "@/services/http/dto";
+import { BannerTypes } from "@/types/contracts/Banner";
+import {
+  FULL_TIME_AWARDS,
+  PART_TIME_AWARDS,
+} from "@/constants/award-constants";
+import { MONEY_VALUE_FOR_UNKNOWN_MAX_VALUE } from "@/constants/system-constants";
+import ErrorSummary from "@/components/generic/ErrorSummary.vue";
+import ModalDialogBase from "@/components/generic/ModalDialogBase.vue";
+import CheckPermissionRole from "@/components/generic/CheckPermissionRole.vue";
+
+export default defineComponent({
+  components: { ModalDialogBase, CheckPermissionRole, ErrorSummary },
+  props: {
+    allowedRole: {
+      type: String as PropType<Role>,
+      required: true,
+    },
+  },
+  setup() {
+    const { numberRangeRule, checkNullOrEmptyRule } = useRules();
+    const { showDialog, showModal, resolvePromise } = useModalDialog<
+      OverawardManualRecordAPIInDTO | boolean
+    >();
+    const addManualOverawardForm = ref({} as VForm);
+    const formModel = reactive({} as OverawardManualRecordAPIInDTO);
+    const awardTypeItems = [...FULL_TIME_AWARDS, ...PART_TIME_AWARDS]
+      .filter((award) => ["CSLF", "CSLP", "BCSL"].includes(award.awardType))
+      .map((award) => ({
+        title: `${award.awardType} (${award.description})`,
+        value: award.awardType,
+      }));
+
+    const submit = async () => {
+      const validationResult = await addManualOverawardForm.value.validate();
+      if (!validationResult.valid) {
+        return;
+      }
+      // Copying the payload, as reset is making the formModel properties null.
+      const payload = { ...formModel };
+      resolvePromise(payload);
+      addManualOverawardForm.value.reset();
+    };
+
+    const cancel = () => {
+      addManualOverawardForm.value.reset();
+      addManualOverawardForm.value.resetValidation();
+      resolvePromise(false);
+    };
+
+    return {
+      showDialog,
+      showModal,
+      cancel,
+      submit,
+      addManualOverawardForm,
+      formModel,
+      BannerTypes,
+      numberRangeRule,
+      checkNullOrEmptyRule,
+      awardTypeItems,
+      MONEY_VALUE_FOR_UNKNOWN_MAX_VALUE,
+    };
+  },
+});
+</script>

--- a/sources/packages/web/src/components/common/AwardTable.vue
+++ b/sources/packages/web/src/components/common/AwardTable.vue
@@ -22,11 +22,7 @@
 <script lang="ts">
 import { PropType, defineComponent, computed } from "vue";
 import { OfferingIntensity } from "@/types";
-import {
-  FULL_TIME_AWARDS,
-  PART_TIME_AWARDS,
-  AwardDetail,
-} from "@/constants/award-constants";
+import { AWARDS, AwardDetail } from "@/constants/award-constants";
 
 export default defineComponent({
   props: {
@@ -46,9 +42,9 @@ export default defineComponent({
   },
   setup(props) {
     const awards = computed<AwardDetail[]>(() =>
-      props.offeringIntensity === OfferingIntensity.fullTime
-        ? FULL_TIME_AWARDS
-        : PART_TIME_AWARDS,
+      AWARDS.filter(
+        (award) => award.offeringIntensity === props.offeringIntensity,
+      ),
     );
 
     const getAwardValue = (awardType: string): string | number => {

--- a/sources/packages/web/src/components/common/AwardTable.vue
+++ b/sources/packages/web/src/components/common/AwardTable.vue
@@ -22,11 +22,11 @@
 <script lang="ts">
 import { PropType, defineComponent, computed } from "vue";
 import { OfferingIntensity } from "@/types";
-
-interface AwardTableModel {
-  awardType: string;
-  description: string;
-}
+import {
+  FULL_TIME_AWARDS,
+  PART_TIME_AWARDS,
+  AwardDetail,
+} from "@/constants/award-constants";
 
 export default defineComponent({
   props: {
@@ -45,78 +45,10 @@ export default defineComponent({
     },
   },
   setup(props) {
-    const fullTimeAwards: AwardTableModel[] = [
-      {
-        awardType: "CSLF",
-        description: "Canada Student Loan for Full-time Studies",
-      },
-      {
-        awardType: "CSGP",
-        description:
-          "Canada Student Grant for Student with Permanent Disability",
-      },
-      {
-        awardType: "CSGD",
-        description: "Canada Student Grant for Students with Dependents",
-      },
-      {
-        awardType: "CSGF",
-        description: "Canada Student Grant for Full-time Studies",
-      },
-      {
-        awardType: "CSGT",
-        description: "Canada Student Grant for Full-time Top-up",
-      },
-      {
-        awardType: "BCSL",
-        description: "B.C. Student Loan",
-      },
-      {
-        awardType: "BCAG",
-        description: "B.C. Access Grant",
-      },
-      {
-        awardType: "BGPD",
-        description: "B.C. Permanent Disability Grant",
-      },
-      {
-        awardType: "SBSD",
-        description: "B.C. Supplemental Bursary with Disabilities",
-      },
-    ];
-
-    const partTimeAwards: AwardTableModel[] = [
-      {
-        awardType: "CSLP",
-        description: "Canada Student Loan for Part-time Studies",
-      },
-      {
-        awardType: "CSGP",
-        description:
-          "Canada Student Grant for Student with Permanent Disability",
-      },
-      {
-        awardType: "CSPT",
-        description: "Canada Student Grant for Part-time Studies",
-      },
-      {
-        awardType: "CSGD",
-        description: "Canada Student Grant for Students with Dependents",
-      },
-      {
-        awardType: "BCAG",
-        description: "B.C. Access Grant",
-      },
-      {
-        awardType: "SBSD",
-        description: "B.C. Supplemental Bursary with Disabilities",
-      },
-    ];
-
-    const awards = computed<AwardTableModel[]>(() =>
+    const awards = computed<AwardDetail[]>(() =>
       props.offeringIntensity === OfferingIntensity.fullTime
-        ? fullTimeAwards
-        : partTimeAwards,
+        ? FULL_TIME_AWARDS
+        : PART_TIME_AWARDS,
     );
 
     const getAwardValue = (awardType: string): string | number => {

--- a/sources/packages/web/src/components/common/OverawardDetails.vue
+++ b/sources/packages/web/src/components/common/OverawardDetails.vue
@@ -1,0 +1,180 @@
+<template>
+  <v-card class="mb-5">
+    <v-container>
+      <body-header
+        title="Overawards"
+        subTitle="Overaward amounts generated due to application reassessments"
+      />
+      <content-group>
+        <toggle-content :toggled="!overawards.length">
+          <DataTable
+            :value="overawards"
+            class="p-m-4"
+            :paginator="true"
+            :rows="pageLimit"
+            :rowsPerPageOptions="PAGINATION_LIST"
+          >
+            <Column field="dateAdded" header="Date added">
+              <template #body="slotProps">
+                <span>
+                  {{ dateOnlyLongString(slotProps.data.dateAdded) }}
+                </span>
+              </template>
+            </Column>
+            <Column field="applicationNumber" header="Application #"
+              ><template #body="slotProps">
+                <span>
+                  {{ slotProps.data.applicationNumber ?? "-" }}
+                </span>
+              </template></Column
+            >
+            <Column field="overawardOrigin" header="Origin"></Column>
+            <Column field="assessmentTriggerType" header="Type"></Column>
+            <Column field="awardValueCode" header="Award"></Column>
+            <Column field="overawardValue" header="Overaward amount">
+              <template #body="slotProps">
+                <span>
+                  {{ formatCurrency(slotProps.data.overawardValue, "") }}
+                </span>
+              </template></Column
+            >
+          </DataTable>
+        </toggle-content>
+      </content-group>
+    </v-container>
+  </v-card>
+  <v-card class="mb-5">
+    <v-container>
+      <body-header
+        title="Overaward deductions"
+        subTitle="History of money that was deducted from one or more applications to pay back what is owed"
+      >
+        <template #actions>
+          <check-permission-role :role="Role.StudentAddOverawardManual">
+            <template #="{ notAllowed }">
+              <v-btn
+                class="ml-2 float-right"
+                color="primary"
+                :disabled="notAllowed"
+                prepend-icon="fa:fa fa-plus-circle"
+              >
+                Add manual record
+              </v-btn>
+            </template>
+          </check-permission-role>
+        </template></body-header
+      >
+      <content-group>
+        <toggle-content :toggled="!overawards.length">
+          <DataTable
+            :value="overawardDeductions"
+            class="p-m-4"
+            :paginator="true"
+            :rows="pageLimit"
+            :rowsPerPageOptions="PAGINATION_LIST"
+          >
+            <Column field="dateAdded" header="Date added">
+              <template #body="slotProps">
+                <span>
+                  {{ dateOnlyLongString(slotProps.data.dateAdded) }}
+                </span>
+              </template>
+            </Column>
+            <Column field="applicationNumber" header="Application #">
+              <template #body="slotProps">
+                <span>
+                  {{ slotProps.data.applicationNumber ?? "-" }}
+                </span>
+              </template></Column
+            >
+            <Column field="overawardOrigin" header="Origin"></Column>
+            <Column v-if="showAddedBy" field="addedByUser" header="Added By"
+              ><template #body="slotProps">
+                <span>
+                  {{ slotProps.data.addedByUser ?? "-" }}
+                </span>
+              </template></Column
+            >
+            <Column field="awardValueCode" header="Award"></Column>
+            <Column field="overawardValue" header="Overaward amount">
+              <template #body="slotProps">
+                <span>
+                  {{ formatCurrency(slotProps.data.overawardValue, "") }}
+                </span>
+              </template></Column
+            >
+          </DataTable>
+        </toggle-content>
+      </content-group>
+    </v-container>
+  </v-card>
+</template>
+<script lang="ts">
+import { ref, onMounted, defineComponent, computed } from "vue";
+import { OverawardService } from "@/services/OverawardService";
+import {
+  DEFAULT_PAGE_LIMIT,
+  PAGINATION_LIST,
+  DEFAULT_PAGE_NUMBER,
+  DisbursementOverawardOriginType,
+  Role,
+} from "@/types";
+import { useFormatters } from "@/composables";
+import { OverawardAPIOutDTO } from "@/services/http/dto";
+import CheckPermissionRole from "@/components/generic/CheckPermissionRole.vue";
+
+export default defineComponent({
+  components: { CheckPermissionRole },
+  props: {
+    studentId: {
+      type: Number,
+      required: true,
+    },
+    showAddedBy: {
+      type: Boolean,
+      required: false,
+      default: false,
+    },
+  },
+  setup(props) {
+    const page = ref(DEFAULT_PAGE_NUMBER);
+    const pageLimit = ref(DEFAULT_PAGE_LIMIT);
+    const { dateOnlyLongString, formatCurrency } = useFormatters();
+    const overawardDetails = ref([] as OverawardAPIOutDTO[]);
+    const overawards = computed(() =>
+      overawardDetails.value.filter(
+        (overaward) =>
+          ![
+            DisbursementOverawardOriginType.AwardDeducted,
+            DisbursementOverawardOriginType.ManualRecord,
+          ].includes(overaward.overawardOrigin),
+      ),
+    );
+
+    const overawardDeductions = computed(() =>
+      overawardDetails.value.filter((overaward) =>
+        [
+          DisbursementOverawardOriginType.AwardDeducted,
+          DisbursementOverawardOriginType.ManualRecord,
+        ].includes(overaward.overawardOrigin),
+      ),
+    );
+
+    onMounted(async () => {
+      overawardDetails.value =
+        await OverawardService.shared.getStudentOverawards(props.studentId);
+    });
+
+    return {
+      page,
+      pageLimit,
+      PAGINATION_LIST,
+      dateOnlyLongString,
+      overawards,
+      overawardDeductions,
+      formatCurrency,
+      Role,
+    };
+  },
+});
+</script>

--- a/sources/packages/web/src/components/common/OverawardDetails.vue
+++ b/sources/packages/web/src/components/common/OverawardDetails.vue
@@ -24,7 +24,7 @@
             <Column field="applicationNumber" header="Application #"
               ><template #body="slotProps">
                 <span>
-                  {{ slotProps.data.applicationNumber ?? "-" }}
+                  {{ slotProps.data.applicationNumber ?? emptyStringFiller() }}
                 </span>
               </template></Column
             >
@@ -34,7 +34,7 @@
             <Column field="overawardValue" header="Overaward amount">
               <template #body="slotProps">
                 <span>
-                  {{ formatCurrency(slotProps.data.overawardValue, "") }}
+                  {{ formatCurrency(slotProps.data.overawardValue) }}
                 </span>
               </template></Column
             >
@@ -84,7 +84,7 @@
             <Column field="applicationNumber" header="Application #">
               <template #body="slotProps">
                 <span>
-                  {{ slotProps.data.applicationNumber ?? "-" }}
+                  {{ slotProps.data.applicationNumber ?? emptyStringFiller() }}
                 </span>
               </template></Column
             >
@@ -92,7 +92,7 @@
             <Column v-if="showAddedBy" field="addedByUser" header="Added By"
               ><template #body="slotProps">
                 <span>
-                  {{ slotProps.data.addedByUser ?? "-" }}
+                  {{ slotProps.data.addedByUser ?? emptyStringFiller() }}
                 </span>
               </template></Column
             >
@@ -100,7 +100,7 @@
             <Column field="overawardValue" header="Overaward amount">
               <template #body="slotProps">
                 <span>
-                  {{ formatCurrency(slotProps.data.overawardValue, "") }}
+                  {{ formatCurrency(slotProps.data.overawardValue) }}
                 </span>
               </template></Column
             >
@@ -135,7 +135,7 @@ import AddManualOverawardDeduction from "@/components/aest/students/modals/AddMa
 export default defineComponent({
   components: { CheckPermissionRole, AddManualOverawardDeduction },
   emits: {
-    updateOverawardDetails: null,
+    manualOverawardAdded: null,
   },
   props: {
     studentId: {
@@ -156,28 +156,27 @@ export default defineComponent({
   setup(props, context) {
     const page = ref(DEFAULT_PAGE_NUMBER);
     const pageLimit = ref(DEFAULT_PAGE_LIMIT);
-    const { dateOnlyLongString, formatCurrency } = useFormatters();
+    const { dateOnlyLongString, formatCurrency, emptyStringFiller } =
+      useFormatters();
     const snackBar = useSnackBar();
     const overawardDetails = ref([] as OverawardAPIOutDTO[]);
     const addManualOverawardDeduction = ref(
       {} as ModalDialog<OverawardManualRecordAPIInDTO | boolean>,
     );
+    const overawardDeductionOriginTypes = [
+      DisbursementOverawardOriginType.AwardDeducted,
+      DisbursementOverawardOriginType.ManualRecord,
+    ];
     const overawards = computed(() =>
       overawardDetails.value.filter(
         (overaward) =>
-          ![
-            DisbursementOverawardOriginType.AwardDeducted,
-            DisbursementOverawardOriginType.ManualRecord,
-          ].includes(overaward.overawardOrigin),
+          !overawardDeductionOriginTypes.includes(overaward.overawardOrigin),
       ),
     );
 
     const overawardDeductions = computed(() =>
       overawardDetails.value.filter((overaward) =>
-        [
-          DisbursementOverawardOriginType.AwardDeducted,
-          DisbursementOverawardOriginType.ManualRecord,
-        ].includes(overaward.overawardOrigin),
+        overawardDeductionOriginTypes.includes(overaward.overawardOrigin),
       ),
     );
 
@@ -191,7 +190,7 @@ export default defineComponent({
             manualOveraward as OverawardManualRecordAPIInDTO,
           );
           snackBar.success("Overaward deduction added successfully.");
-          context.emit("updateOverawardDetails");
+          context.emit("manualOverawardAdded");
           await loadOverawardDetails();
         } catch {
           snackBar.error(
@@ -219,6 +218,7 @@ export default defineComponent({
       Role,
       addManualOverawardDeduction,
       addManualOveraward,
+      emptyStringFiller,
     };
   },
 });

--- a/sources/packages/web/src/components/common/OverawardDetails.vue
+++ b/sources/packages/web/src/components/common/OverawardDetails.vue
@@ -24,7 +24,7 @@
             <Column field="applicationNumber" header="Application #"
               ><template #body="slotProps">
                 <span>
-                  {{ slotProps.data.applicationNumber ?? emptyStringFiller() }}
+                  {{ emptyStringFiller(slotProps.data.applicationNumber) }}
                 </span>
               </template></Column
             >
@@ -84,7 +84,7 @@
             <Column field="applicationNumber" header="Application #">
               <template #body="slotProps">
                 <span>
-                  {{ slotProps.data.applicationNumber ?? emptyStringFiller() }}
+                  {{ emptyStringFiller(slotProps.data.applicationNumber) }}
                 </span>
               </template></Column
             >
@@ -92,7 +92,7 @@
             <Column v-if="showAddedBy" field="addedByUser" header="Added By"
               ><template #body="slotProps">
                 <span>
-                  {{ slotProps.data.addedByUser ?? emptyStringFiller() }}
+                  {{ emptyStringFiller(slotProps.data.addedByUser) }}
                 </span>
               </template></Column
             >

--- a/sources/packages/web/src/components/common/StudentOverawardDetails.vue
+++ b/sources/packages/web/src/components/common/StudentOverawardDetails.vue
@@ -51,7 +51,12 @@
       </v-row>
     </v-container>
   </v-card>
-  <overaward-details :studentId="studentId" :showAddedBy="showAddedBy" />
+  <overaward-details
+    :studentId="studentId"
+    :showAddedBy="showAddedBy"
+    :allowManualOverawardDeduction="allowManualOverawardDeduction"
+    @updateOverawardDetails="loadOverawardBalance"
+  />
 </template>
 
 <script lang="ts">
@@ -77,24 +82,34 @@ export default defineComponent({
       required: false,
       default: false,
     },
+    allowManualOverawardDeduction: {
+      type: Boolean,
+      required: false,
+      default: false,
+    },
   },
   setup(props) {
     const { formatCurrency } = useFormatters();
     const overawardBalance = ref({} as OverawardBalanceAPIOutDTO);
 
     const getAwardDescription = (awardType: string): string | undefined => {
-      const awards = [...FULL_TIME_AWARDS, ...PART_TIME_AWARDS];
-      return awards.find((award) => award.awardType === awardType)?.description;
+      return [...FULL_TIME_AWARDS, ...PART_TIME_AWARDS].find(
+        (award) => award.awardType === awardType,
+      )?.description;
     };
 
-    onMounted(async () => {
+    const loadOverawardBalance = async () => {
       overawardBalance.value =
         await OverawardService.shared.getOverawardBalance(props.studentId);
-    });
+    };
+
+    onMounted(loadOverawardBalance);
+
     return {
       overawardBalance,
       formatCurrency,
       getAwardDescription,
+      loadOverawardBalance,
     };
   },
 });

--- a/sources/packages/web/src/components/common/StudentOverawardDetails.vue
+++ b/sources/packages/web/src/components/common/StudentOverawardDetails.vue
@@ -1,0 +1,101 @@
+<template>
+  <v-card class="mb-5">
+    <v-container>
+      <body-header
+        title="Overaward balances"
+        subTitle="A balance of overawards broken down by award type"
+      />
+      <v-row>
+        <v-col>
+          <title-value
+            :propertyValue="
+              formatCurrency(overawardBalance.overawardBalanceValues?.CSLF, '')
+            "
+          >
+            <template #title>
+              CSLF
+              <tooltip-icon>{{
+                getAwardDescription("CSLF")
+              }}</tooltip-icon></template
+            ></title-value
+          >
+        </v-col>
+        <v-col>
+          <title-value
+            :propertyValue="
+              formatCurrency(overawardBalance.overawardBalanceValues?.CSLP, '')
+            "
+          >
+            <template #title>
+              CSLP
+              <tooltip-icon>{{
+                getAwardDescription("CSLP")
+              }}</tooltip-icon></template
+            ></title-value
+          >
+        </v-col>
+        <v-col>
+          <title-value
+            :propertyValue="
+              formatCurrency(overawardBalance.overawardBalanceValues?.BCSL, '')
+            "
+          >
+            <template #title>
+              BCSL
+              <tooltip-icon>{{
+                getAwardDescription("BCSL")
+              }}</tooltip-icon></template
+            >
+          </title-value>
+        </v-col>
+      </v-row>
+    </v-container>
+  </v-card>
+  <overaward-details :studentId="studentId" :showAddedBy="showAddedBy" />
+</template>
+
+<script lang="ts">
+import { onMounted, ref, defineComponent } from "vue";
+import { OverawardService } from "@/services/OverawardService";
+import { useFormatters } from "@/composables";
+import {
+  FULL_TIME_AWARDS,
+  PART_TIME_AWARDS,
+} from "@/constants/award-constants";
+import { OverawardBalanceAPIOutDTO } from "@/services/http/dto";
+import OverawardDetails from "@/components/common/OverawardDetails.vue";
+
+export default defineComponent({
+  components: { OverawardDetails },
+  props: {
+    studentId: {
+      type: Number,
+      required: true,
+    },
+    showAddedBy: {
+      type: Boolean,
+      required: false,
+      default: false,
+    },
+  },
+  setup(props) {
+    const { formatCurrency } = useFormatters();
+    const overawardBalance = ref({} as OverawardBalanceAPIOutDTO);
+
+    const getAwardDescription = (awardType: string): string | undefined => {
+      const awards = [...FULL_TIME_AWARDS, ...PART_TIME_AWARDS];
+      return awards.find((award) => award.awardType === awardType)?.description;
+    };
+
+    onMounted(async () => {
+      overawardBalance.value =
+        await OverawardService.shared.getOverawardBalance(props.studentId);
+    });
+    return {
+      overawardBalance,
+      formatCurrency,
+      getAwardDescription,
+    };
+  },
+});
+</script>

--- a/sources/packages/web/src/components/common/StudentOverawardDetails.vue
+++ b/sources/packages/web/src/components/common/StudentOverawardDetails.vue
@@ -9,13 +9,13 @@
         <v-col>
           <title-value
             :propertyValue="
-              formatCurrency(overawardBalance.overawardBalanceValues?.CSLF, '')
+              formatCurrency(overawardBalance.overawardBalanceValues?.CSLF)
             "
           >
             <template #title>
-              CSLF
+              {{ FullTimeAwardTypes.CSLF }}
               <tooltip-icon>{{
-                getAwardDescription("CSLF")
+                getAwardDescription(FullTimeAwardTypes.CSLF)
               }}</tooltip-icon></template
             ></title-value
           >
@@ -23,13 +23,13 @@
         <v-col>
           <title-value
             :propertyValue="
-              formatCurrency(overawardBalance.overawardBalanceValues?.CSLP, '')
+              formatCurrency(overawardBalance.overawardBalanceValues?.CSLP)
             "
           >
             <template #title>
-              CSLP
+              {{ PartTimeAwardTypes.CSLP }}
               <tooltip-icon>{{
-                getAwardDescription("CSLP")
+                getAwardDescription(PartTimeAwardTypes.CSLP)
               }}</tooltip-icon></template
             ></title-value
           >
@@ -37,13 +37,13 @@
         <v-col>
           <title-value
             :propertyValue="
-              formatCurrency(overawardBalance.overawardBalanceValues?.BCSL, '')
+              formatCurrency(overawardBalance.overawardBalanceValues?.BCSL)
             "
           >
             <template #title>
-              BCSL
+              {{ FullTimeAwardTypes.BCSL }}
               <tooltip-icon>{{
-                getAwardDescription("BCSL")
+                getAwardDescription(FullTimeAwardTypes.BCSL)
               }}</tooltip-icon></template
             >
           </title-value>
@@ -55,7 +55,7 @@
     :studentId="studentId"
     :showAddedBy="showAddedBy"
     :allowManualOverawardDeduction="allowManualOverawardDeduction"
-    @updateOverawardDetails="loadOverawardBalance"
+    @manualOverawardAdded="loadOverawardBalance"
   />
 </template>
 
@@ -64,8 +64,9 @@ import { onMounted, ref, defineComponent } from "vue";
 import { OverawardService } from "@/services/OverawardService";
 import { useFormatters } from "@/composables";
 import {
-  FULL_TIME_AWARDS,
-  PART_TIME_AWARDS,
+  AWARDS,
+  FullTimeAwardTypes,
+  PartTimeAwardTypes,
 } from "@/constants/award-constants";
 import { OverawardBalanceAPIOutDTO } from "@/services/http/dto";
 import OverawardDetails from "@/components/common/OverawardDetails.vue";
@@ -93,9 +94,7 @@ export default defineComponent({
     const overawardBalance = ref({} as OverawardBalanceAPIOutDTO);
 
     const getAwardDescription = (awardType: string): string | undefined => {
-      return [...FULL_TIME_AWARDS, ...PART_TIME_AWARDS].find(
-        (award) => award.awardType === awardType,
-      )?.description;
+      return AWARDS.find((award) => award.awardType === awardType)?.description;
     };
 
     const loadOverawardBalance = async () => {
@@ -110,6 +109,8 @@ export default defineComponent({
       formatCurrency,
       getAwardDescription,
       loadOverawardBalance,
+      FullTimeAwardTypes,
+      PartTimeAwardTypes,
     };
   },
 });

--- a/sources/packages/web/src/components/generic/TitleValue.vue
+++ b/sources/packages/web/src/components/generic/TitleValue.vue
@@ -3,7 +3,9 @@ Used when we need to display title and the value inside a container
 -->
 <template>
   <div class="mb-2">
-    <span class="label-bold">{{ propertyTitle }}</span>
+    <slot name="title">
+      <span class="label-bold">{{ propertyTitle }}</span>
+    </slot>
   </div>
   <div class="mb-2 label-value muted-content">
     {{ propertyValue }}
@@ -14,13 +16,13 @@ Used when we need to display title and the value inside a container
 import { defineComponent } from "vue";
 export default defineComponent({
   props: {
-    propertyTitle: {
-      type: String,
-      required: true,
-    },
     propertyValue: {
       type: String,
       required: true,
+    },
+    propertyTitle: {
+      type: String,
+      required: false,
     },
   },
 });

--- a/sources/packages/web/src/composables/useFormatters.ts
+++ b/sources/packages/web/src/composables/useFormatters.ts
@@ -217,19 +217,13 @@ export function useFormatters() {
    * when value is not provided or zero.
    * @returns formatted currency value.
    */
-  const formatCurrency = (
-    moneyAmount: number | string,
-    currencyCode = "(CAD)",
-    defaultValueAmount = "$0.00",
-  ): string => {
+  const formatCurrency = (moneyAmount: number | string): string => {
     if (moneyAmount === null || moneyAmount === undefined) {
-      return defaultValueAmount;
+      moneyAmount = 0;
     }
     const currencyValue = parseFloat(moneyAmount.toString());
     const negativeValueDisplay = currencyValue < 0 ? "-" : "";
-    return `${negativeValueDisplay}$${Math.abs(currencyValue).toFixed(
-      2,
-    )} ${currencyCode}`;
+    return `${negativeValueDisplay}$${Math.abs(currencyValue).toFixed(2)}`;
   };
 
   return {

--- a/sources/packages/web/src/composables/useFormatters.ts
+++ b/sources/packages/web/src/composables/useFormatters.ts
@@ -210,19 +210,26 @@ export function useFormatters() {
   };
 
   /**
-   * Format a currency value.
+   * Format a currency value including negative currency value.
    * @param moneyAmount value amount.
    * @param currencyCode currency code.
+   * @param defaultValueAmount default value to display
+   * when value is not provided or zero.
    * @returns formatted currency value.
    */
   const formatCurrency = (
     moneyAmount: number | string,
     currencyCode = "(CAD)",
-  ): string | null => {
+    defaultValueAmount = "$0.00",
+  ): string => {
     if (moneyAmount === null || moneyAmount === undefined) {
-      return null;
+      return defaultValueAmount;
     }
-    return `$${parseFloat(moneyAmount.toString()).toFixed(2)} ${currencyCode}`;
+    const currencyValue = parseFloat(moneyAmount.toString());
+    const negativeValueDisplay = currencyValue < 0 ? "-" : "";
+    return `${negativeValueDisplay}$${Math.abs(currencyValue).toFixed(
+      2,
+    )} ${currencyCode}`;
   };
 
   return {

--- a/sources/packages/web/src/constants/award-constants.ts
+++ b/sources/packages/web/src/constants/award-constants.ts
@@ -1,0 +1,70 @@
+export interface AwardDetail {
+  awardType: string;
+  description: string;
+}
+
+export const FULL_TIME_AWARDS: AwardDetail[] = [
+  {
+    awardType: "CSLF",
+    description: "Canada Student Loan for Full-time Studies",
+  },
+  {
+    awardType: "CSGP",
+    description: "Canada Student Grant for Student with Permanent Disability",
+  },
+  {
+    awardType: "CSGD",
+    description: "Canada Student Grant for Students with Dependents",
+  },
+  {
+    awardType: "CSGF",
+    description: "Canada Student Grant for Full-time Studies",
+  },
+  {
+    awardType: "CSGT",
+    description: "Canada Student Grant for Full-time Top-up",
+  },
+  {
+    awardType: "BCSL",
+    description: "B.C. Student Loan",
+  },
+  {
+    awardType: "BCAG",
+    description: "B.C. Access Grant",
+  },
+  {
+    awardType: "BGPD",
+    description: "B.C. Permanent Disability Grant",
+  },
+  {
+    awardType: "SBSD",
+    description: "B.C. Supplemental Bursary with Disabilities",
+  },
+];
+
+export const PART_TIME_AWARDS: AwardDetail[] = [
+  {
+    awardType: "CSLP",
+    description: "Canada Student Loan for Part-time Studies",
+  },
+  {
+    awardType: "CSGP",
+    description: "Canada Student Grant for Student with Permanent Disability",
+  },
+  {
+    awardType: "CSPT",
+    description: "Canada Student Grant for Part-time Studies",
+  },
+  {
+    awardType: "CSGD",
+    description: "Canada Student Grant for Students with Dependents",
+  },
+  {
+    awardType: "BCAG",
+    description: "B.C. Access Grant",
+  },
+  {
+    awardType: "SBSD",
+    description: "B.C. Supplemental Bursary with Disabilities",
+  },
+];

--- a/sources/packages/web/src/constants/award-constants.ts
+++ b/sources/packages/web/src/constants/award-constants.ts
@@ -1,70 +1,106 @@
+import { OfferingIntensity } from "@/types";
+
 export interface AwardDetail {
-  awardType: string;
+  awardType: FullTimeAwardTypes | PartTimeAwardTypes;
   description: string;
+  offeringIntensity: OfferingIntensity;
 }
 
-export const FULL_TIME_AWARDS: AwardDetail[] = [
-  {
-    awardType: "CSLF",
-    description: "Canada Student Loan for Full-time Studies",
-  },
-  {
-    awardType: "CSGP",
-    description: "Canada Student Grant for Student with Permanent Disability",
-  },
-  {
-    awardType: "CSGD",
-    description: "Canada Student Grant for Students with Dependents",
-  },
-  {
-    awardType: "CSGF",
-    description: "Canada Student Grant for Full-time Studies",
-  },
-  {
-    awardType: "CSGT",
-    description: "Canada Student Grant for Full-time Top-up",
-  },
-  {
-    awardType: "BCSL",
-    description: "B.C. Student Loan",
-  },
-  {
-    awardType: "BCAG",
-    description: "B.C. Access Grant",
-  },
-  {
-    awardType: "BGPD",
-    description: "B.C. Permanent Disability Grant",
-  },
-  {
-    awardType: "SBSD",
-    description: "B.C. Supplemental Bursary with Disabilities",
-  },
-];
+export enum FullTimeAwardTypes {
+  CSLF = "CSLF",
+  CSGP = "CSGP",
+  CSGD = "CSGD",
+  CSGF = "CSGF",
+  CSGT = "CSGT",
+  BCSL = "BCSL",
+  BCAG = "BCAG",
+  BGPD = "BGPD",
+  SBSD = "SBSD",
+}
 
-export const PART_TIME_AWARDS: AwardDetail[] = [
+export enum PartTimeAwardTypes {
+  CSLP = "CSLP",
+  CSGP = "CSGP",
+  CSPT = "CSPT",
+  CSGD = "CSGD",
+  BCAG = "BCAG",
+  SBSD = "SBSD",
+}
+
+export const AWARDS: AwardDetail[] = [
   {
-    awardType: "CSLP",
-    description: "Canada Student Loan for Part-time Studies",
+    awardType: FullTimeAwardTypes.CSLF,
+    description: "Canada Student Loan for Full-time Studies",
+    offeringIntensity: OfferingIntensity.fullTime,
   },
   {
-    awardType: "CSGP",
+    awardType: FullTimeAwardTypes.CSGP,
     description: "Canada Student Grant for Student with Permanent Disability",
+    offeringIntensity: OfferingIntensity.fullTime,
   },
   {
-    awardType: "CSPT",
-    description: "Canada Student Grant for Part-time Studies",
-  },
-  {
-    awardType: "CSGD",
+    awardType: FullTimeAwardTypes.CSGD,
     description: "Canada Student Grant for Students with Dependents",
+    offeringIntensity: OfferingIntensity.fullTime,
   },
   {
-    awardType: "BCAG",
+    awardType: FullTimeAwardTypes.CSGF,
+    description: "Canada Student Grant for Full-time Studies",
+    offeringIntensity: OfferingIntensity.fullTime,
+  },
+  {
+    awardType: FullTimeAwardTypes.CSGT,
+    description: "Canada Student Grant for Full-time Top-up",
+    offeringIntensity: OfferingIntensity.fullTime,
+  },
+  {
+    awardType: FullTimeAwardTypes.BCSL,
+    description: "B.C. Student Loan",
+    offeringIntensity: OfferingIntensity.fullTime,
+  },
+  {
+    awardType: FullTimeAwardTypes.BCAG,
     description: "B.C. Access Grant",
+    offeringIntensity: OfferingIntensity.fullTime,
   },
   {
-    awardType: "SBSD",
+    awardType: FullTimeAwardTypes.BGPD,
+    description: "B.C. Permanent Disability Grant",
+    offeringIntensity: OfferingIntensity.fullTime,
+  },
+  {
+    awardType: FullTimeAwardTypes.SBSD,
     description: "B.C. Supplemental Bursary with Disabilities",
+    offeringIntensity: OfferingIntensity.fullTime,
+  },
+  {
+    awardType: PartTimeAwardTypes.CSLP,
+    description: "Canada Student Loan for Part-time Studies",
+    offeringIntensity: OfferingIntensity.partTime,
+  },
+  {
+    awardType: PartTimeAwardTypes.CSGP,
+    description: "Canada Student Grant for Student with Permanent Disability",
+    offeringIntensity: OfferingIntensity.partTime,
+  },
+  {
+    awardType: PartTimeAwardTypes.CSPT,
+    description: "Canada Student Grant for Part-time Studies",
+    offeringIntensity: OfferingIntensity.partTime,
+  },
+  {
+    awardType: PartTimeAwardTypes.CSGD,
+    description: "Canada Student Grant for Students with Dependents",
+    offeringIntensity: OfferingIntensity.partTime,
+  },
+  {
+    awardType: PartTimeAwardTypes.BCAG,
+    description: "B.C. Access Grant",
+    offeringIntensity: OfferingIntensity.partTime,
+  },
+  {
+    awardType: PartTimeAwardTypes.SBSD,
+    description: "B.C. Supplemental Bursary with Disabilities",
+    offeringIntensity: OfferingIntensity.partTime,
   },
 ];

--- a/sources/packages/web/src/constants/routes/RouteConstants.ts
+++ b/sources/packages/web/src/constants/routes/RouteConstants.ts
@@ -83,6 +83,7 @@ export const AESTRoutesConst = {
   STUDENT_FILE_UPLOADS: Symbol(),
   STUDENT_NOTES: Symbol(),
   SIN_MANAGEMENT: Symbol(),
+  OVERAWARDS: Symbol(),
   PROGRAM_DETAILS: Symbol(),
   SEARCH_INSTITUTIONS: Symbol(),
   INSTITUTION_PROFILE: Symbol(),

--- a/sources/packages/web/src/constants/system-constants.ts
+++ b/sources/packages/web/src/constants/system-constants.ts
@@ -30,3 +30,7 @@ export const MAXIMUM_IDLE_TIME_FOR_WARNING_AEST = 270;
  * COUNT_DOWN_TIMER_FOR_LOGOUT in seconds.
  */
 export const COUNT_DOWN_TIMER_FOR_LOGOUT = 30;
+/**
+ * High estimated value to defined a max money amount for inputs that does not have a constrain defined.
+ */
+export const MONEY_VALUE_FOR_UNKNOWN_MAX_VALUE = 999999;

--- a/sources/packages/web/src/router/AESTRoutes.ts
+++ b/sources/packages/web/src/router/AESTRoutes.ts
@@ -46,6 +46,7 @@ import NoticeOfAssessment from "@/views/aest/NoticeOfAssessment.vue";
 import ApplicationExceptionsApproval from "@/views/aest/ApplicationExceptionsApproval.vue";
 import ViewScholasticStanding from "@/views/aest/student/ViewScholasticStanding.vue";
 import SINManagement from "@/views/aest/student/SINManagement.vue";
+import Overawards from "@/views/aest/student/Overawards.vue";
 import StudentApplicationExceptions from "@/views/aest/student/StudentApplicationExceptions.vue";
 import OfferingChangeRequests from "@/views/aest/institution/OfferingChangeRequests.vue";
 import ViewOfferingChangeRequest from "@/views/aest/institution/ViewOfferingChangeRequest.vue";
@@ -155,6 +156,15 @@ export const aestRoutes: Array<RouteRecordRaw> = [
             name: AESTRoutesConst.SIN_MANAGEMENT,
             props: true,
             component: SINManagement,
+            meta: {
+              clientType: ClientIdType.AEST,
+            },
+          },
+          {
+            path: AppRoutes.Overawards,
+            name: AESTRoutesConst.OVERAWARDS,
+            props: true,
+            component: Overawards,
             meta: {
               clientType: ClientIdType.AEST,
             },

--- a/sources/packages/web/src/types/AppRoutes.ts
+++ b/sources/packages/web/src/types/AppRoutes.ts
@@ -101,4 +101,5 @@ export enum AppRoutes {
   NotAllowedUser = "login/not-allowed-user",
   StudentNotes = "student-notes/:studentId",
   StudentRestrictions = "student-restrictions/:studentId",
+  Overawards = "overawards",
 }

--- a/sources/packages/web/src/types/contracts/aest/roles.ts
+++ b/sources/packages/web/src/types/contracts/aest/roles.ts
@@ -17,6 +17,7 @@ export enum Role {
   StudentAddNewSIN = "student-add-new-sin",
   StudentCreateNote = "student-create-note",
   StudentConfirmEnrolment = "student-confirm-enrolment",
+  StudentAddOverawardManual = "student-add-overaward-manual",
   InstitutionEditProfile = "institution-edit-profile",
   InstitutionApproveDeclineProgram = "institution-approve-decline-program",
   InstitutionApproveDeclineOffering = "institution-approve-decline-offering",

--- a/sources/packages/web/src/views/aest/student/Overawards.vue
+++ b/sources/packages/web/src/views/aest/student/Overawards.vue
@@ -1,10 +1,12 @@
 <template>
-  <p class="header-sub-title mt-9">Overawards</p>
-  <student-overaward-details
-    :studentId="studentId"
-    :showAddedBy="true"
-    :allowManualOverawardDeduction="true"
-  />
+  <div class="mt-9">
+    <p class="header-sub-title">Overawards</p>
+    <student-overaward-details
+      :studentId="studentId"
+      :showAddedBy="true"
+      :allowManualOverawardDeduction="true"
+    />
+  </div>
 </template>
 
 <script lang="ts">

--- a/sources/packages/web/src/views/aest/student/Overawards.vue
+++ b/sources/packages/web/src/views/aest/student/Overawards.vue
@@ -1,0 +1,111 @@
+<template>
+  <p class="header-sub-title mt-9">Overawards</p>
+  <v-card>
+    <v-container>
+      <body-header
+        title="Overaward balances"
+        subTitle="A balance of overawards broken down by award type"
+      />
+      <v-row>
+        <v-col>
+          <title-value
+            :propertyValue="
+              formatOverawardValue(
+                overawardBalance.overawardBalanceValues?.CSLF,
+              )
+            "
+          >
+            <template #title>
+              CSLF
+              <tooltip-icon>{{
+                getAwardDescription("CSLF")
+              }}</tooltip-icon></template
+            ></title-value
+          >
+        </v-col>
+        <v-col>
+          <title-value
+            :propertyValue="
+              formatOverawardValue(
+                overawardBalance.overawardBalanceValues?.CSLP,
+              )
+            "
+          >
+            <template #title>
+              CSLP
+              <tooltip-icon>{{
+                getAwardDescription("CSLP")
+              }}</tooltip-icon></template
+            ></title-value
+          >
+        </v-col>
+        <v-col>
+          <title-value
+            :propertyValue="
+              formatOverawardValue(
+                overawardBalance.overawardBalanceValues?.BCSL,
+              )
+            "
+          >
+            <template #title>
+              BCSL
+              <tooltip-icon>{{
+                getAwardDescription("BCSL")
+              }}</tooltip-icon></template
+            >
+          </title-value>
+        </v-col>
+      </v-row>
+    </v-container>
+  </v-card>
+</template>
+
+<script lang="ts">
+import { onMounted, ref, defineComponent } from "vue";
+import { OverawardService } from "@/services/OverawardService";
+import { useFormatters, useSnackBar } from "@/composables";
+import {
+  StudentNoteType,
+  NoteEntityType,
+  LayoutTemplates,
+  Role,
+} from "@/types";
+import {
+  FULL_TIME_AWARDS,
+  PART_TIME_AWARDS,
+} from "@/constants/award-constants";
+import { OverawardBalanceAPIOutDTO } from "@/services/http/dto";
+
+export default defineComponent({
+  components: {},
+  props: {
+    studentId: {
+      type: Number,
+      required: true,
+    },
+  },
+  setup(props: any) {
+    const overawardBalance = ref({} as OverawardBalanceAPIOutDTO);
+
+    const formatOverawardValue = (awardValue: string | number): string => {
+      return awardValue ? `$${awardValue}` : `$0.00`;
+    };
+
+    const getAwardDescription = (awardType: string): string | undefined => {
+      const awards = [...FULL_TIME_AWARDS, ...PART_TIME_AWARDS];
+      return awards.find((award) => award.awardType === awardType)?.description;
+    };
+
+    onMounted(async () => {
+      overawardBalance.value =
+        await OverawardService.shared.getOverawardBalance(props.studentId);
+    });
+    return {
+      overawardBalance,
+      formatOverawardValue,
+      getAwardDescription,
+      Role,
+    };
+  },
+});
+</script>

--- a/sources/packages/web/src/views/aest/student/Overawards.vue
+++ b/sources/packages/web/src/views/aest/student/Overawards.vue
@@ -1,6 +1,10 @@
 <template>
   <p class="header-sub-title mt-9">Overawards</p>
-  <student-overaward-details :studentId="studentId" :showAddedBy="true" />
+  <student-overaward-details
+    :studentId="studentId"
+    :showAddedBy="true"
+    :allowManualOverawardDeduction="true"
+  />
 </template>
 
 <script lang="ts">

--- a/sources/packages/web/src/views/aest/student/Overawards.vue
+++ b/sources/packages/web/src/views/aest/student/Overawards.vue
@@ -1,111 +1,19 @@
 <template>
   <p class="header-sub-title mt-9">Overawards</p>
-  <v-card>
-    <v-container>
-      <body-header
-        title="Overaward balances"
-        subTitle="A balance of overawards broken down by award type"
-      />
-      <v-row>
-        <v-col>
-          <title-value
-            :propertyValue="
-              formatOverawardValue(
-                overawardBalance.overawardBalanceValues?.CSLF,
-              )
-            "
-          >
-            <template #title>
-              CSLF
-              <tooltip-icon>{{
-                getAwardDescription("CSLF")
-              }}</tooltip-icon></template
-            ></title-value
-          >
-        </v-col>
-        <v-col>
-          <title-value
-            :propertyValue="
-              formatOverawardValue(
-                overawardBalance.overawardBalanceValues?.CSLP,
-              )
-            "
-          >
-            <template #title>
-              CSLP
-              <tooltip-icon>{{
-                getAwardDescription("CSLP")
-              }}</tooltip-icon></template
-            ></title-value
-          >
-        </v-col>
-        <v-col>
-          <title-value
-            :propertyValue="
-              formatOverawardValue(
-                overawardBalance.overawardBalanceValues?.BCSL,
-              )
-            "
-          >
-            <template #title>
-              BCSL
-              <tooltip-icon>{{
-                getAwardDescription("BCSL")
-              }}</tooltip-icon></template
-            >
-          </title-value>
-        </v-col>
-      </v-row>
-    </v-container>
-  </v-card>
+  <student-overaward-details :studentId="studentId" :showAddedBy="true" />
 </template>
 
 <script lang="ts">
-import { onMounted, ref, defineComponent } from "vue";
-import { OverawardService } from "@/services/OverawardService";
-import { useFormatters, useSnackBar } from "@/composables";
-import {
-  StudentNoteType,
-  NoteEntityType,
-  LayoutTemplates,
-  Role,
-} from "@/types";
-import {
-  FULL_TIME_AWARDS,
-  PART_TIME_AWARDS,
-} from "@/constants/award-constants";
-import { OverawardBalanceAPIOutDTO } from "@/services/http/dto";
+import { defineComponent } from "vue";
+import StudentOverawardDetails from "@/components/common/StudentOverawardDetails.vue";
 
 export default defineComponent({
-  components: {},
+  components: { StudentOverawardDetails },
   props: {
     studentId: {
       type: Number,
       required: true,
     },
-  },
-  setup(props: any) {
-    const overawardBalance = ref({} as OverawardBalanceAPIOutDTO);
-
-    const formatOverawardValue = (awardValue: string | number): string => {
-      return awardValue ? `$${awardValue}` : `$0.00`;
-    };
-
-    const getAwardDescription = (awardType: string): string | undefined => {
-      const awards = [...FULL_TIME_AWARDS, ...PART_TIME_AWARDS];
-      return awards.find((award) => award.awardType === awardType)?.description;
-    };
-
-    onMounted(async () => {
-      overawardBalance.value =
-        await OverawardService.shared.getOverawardBalance(props.studentId);
-    });
-    return {
-      overawardBalance,
-      formatOverawardValue,
-      getAwardDescription,
-      Role,
-    };
   },
 });
 </script>

--- a/sources/packages/web/src/views/aest/student/StudentDetails.vue
+++ b/sources/packages/web/src/views/aest/student/StudentDetails.vue
@@ -103,6 +103,14 @@ export default defineComponent({
         }),
       },
       {
+        label: "Overawards",
+        icon: "fa:fa fa-circle-dollar-to-slot",
+        command: () => ({
+          name: AESTRoutesConst.OVERAWARDS,
+          params: { studentId: props.studentId },
+        }),
+      },
+      {
         label: "Notes",
         icon: "fa:fa fa-sticky-note",
         command: () => ({


### PR DESCRIPTION
## Ministry overaward part 2

- [x] In student profile, display a new tab called "Overawards"

![image](https://user-images.githubusercontent.com/54600590/220839246-8933db5b-4370-4c78-b64d-6674c0cafe9b.png)

- [x] Display a students overaward balance by CSLF, CSLP, BCSL

![image](https://user-images.githubusercontent.com/54600590/220839354-334d737d-c500-4a72-a2b0-a6d776f69278.png)

- [x] Display in a table a students overawards generated

![image](https://user-images.githubusercontent.com/54600590/220839481-deafc9e1-fd1a-4fcb-a4f2-97c22c1775e3.png)

- [x] Display in a table overawards deducted
![image](https://user-images.githubusercontent.com/54600590/220839570-84c01940-8973-46ff-9312-579639cb73cb.png)

- [x] Display a button called "Add manual record" triggering a modal to open with the type of award and dollar amount that the student paid back

![image](https://user-images.githubusercontent.com/54600590/220839616-4d156e51-0b6b-4124-ad1a-3a0bf89fdd44.png)
![image](https://user-images.githubusercontent.com/54600590/220839666-da14aec6-aedc-48b9-8a0a-3dff2ec41c85.png)
![image](https://user-images.githubusercontent.com/54600590/220839707-d658665c-4074-4485-82e8-8f9bd54ead67.png)


- [x] The value entered into the "Add manual record" modal, must be inverted when inserting into the table.
![image](https://user-images.githubusercontent.com/54600590/220839798-7d69184d-d120-41c2-9eb5-ac64b40e46d7.png)
![image](https://user-images.githubusercontent.com/54600590/220839889-f18536a3-6044-4a73-97c6-07e3dbc2fab6.png)

- [x] Validation for value entered into the "Add manual record" - Between 0 - 99999
![image](https://user-images.githubusercontent.com/54600590/220840006-e9744dac-5af5-446e-9e6f-43454736019f.png)

- [x] All displays to be created as common components (will be eventually reused in Student Portal)
