### PR TITLE
#1730 Upgrade Vuetify to Release Version#1730

### DIFF
--- a/sources/packages/backend/apps/api/src/route-controllers/models/pagination.dto.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/models/pagination.dto.ts
@@ -24,9 +24,10 @@ abstract class PaginationOptionsAPIInDTO {
   page: number;
   /**
    * Page size or records per page.
+   * -1 means all records.
    */
-  @Min(1)
-  @Max(50)
+  @Min(-1)
+  @Max(100)
   pageLimit: number;
   /**
    * Criteria to be used to filter the records.

--- a/sources/packages/backend/apps/api/src/route-controllers/models/pagination.dto.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/models/pagination.dto.ts
@@ -25,7 +25,7 @@ abstract class PaginationOptionsAPIInDTO {
   /**
    * Page size or records per page.
    */
-  @Min(0)
+  @Min(1)
   @Max(100)
   pageLimit: number;
   /**

--- a/sources/packages/backend/apps/api/src/route-controllers/models/pagination.dto.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/models/pagination.dto.ts
@@ -24,9 +24,8 @@ abstract class PaginationOptionsAPIInDTO {
   page: number;
   /**
    * Page size or records per page.
-   * -1 means all records.
    */
-  @Min(-1)
+  @Min(0)
   @Max(100)
   pageLimit: number;
   /**

--- a/sources/packages/backend/apps/api/src/services/education-program/education-program.service.ts
+++ b/sources/packages/backend/apps/api/src/services/education-program/education-program.service.ts
@@ -268,7 +268,7 @@ export class EducationProgramService extends RecordDataModelService<EducationPro
     // For getting total raw count before pagination.
     const sqlQuery = paginatedProgramQuery.getSql();
 
-    if (paginationOptions.pageLimit > 0) {
+    if (paginationOptions.pageLimit) {
       paginatedProgramQuery.limit(paginationOptions.pageLimit);
     }
 

--- a/sources/packages/backend/apps/api/src/services/education-program/education-program.service.ts
+++ b/sources/packages/backend/apps/api/src/services/education-program/education-program.service.ts
@@ -268,16 +268,14 @@ export class EducationProgramService extends RecordDataModelService<EducationPro
     // For getting total raw count before pagination.
     const sqlQuery = paginatedProgramQuery.getSql();
 
-    if (paginationOptions.pageLimit) {
+    if (paginationOptions.pageLimit > 0) {
       paginatedProgramQuery.limit(paginationOptions.pageLimit);
     }
-    if (paginationOptions.page) {
-      paginatedProgramQuery.offset(
-        paginationOptions.page * paginationOptions.pageLimit,
-      );
-    } else {
-      paginatedProgramQuery.limit(0);
-    }
+
+    paginatedProgramQuery.offset(
+      paginationOptions.page * paginationOptions.pageLimit,
+    );
+
     // sort
     if (paginationOptions.sortField && paginationOptions.sortOrder) {
       paginatedProgramQuery.orderBy(

--- a/sources/packages/web/package-lock.json
+++ b/sources/packages/web/package-lock.json
@@ -30,7 +30,7 @@
         "vue": "^3.2.31",
         "vue-class-component": "^8.0.0-0",
         "vue-router": "^4.0.14",
-        "vuetify": "^3.0.0-beta.13",
+        "vuetify": "^3.1.5",
         "vuex": "^4.0.2",
         "yup": "^0.32.11"
       },
@@ -16723,9 +16723,9 @@
       }
     },
     "node_modules/vuetify": {
-      "version": "3.0.0-beta.13",
-      "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-3.0.0-beta.13.tgz",
-      "integrity": "sha512-CgDyKCIBZ0ogKUxRw3gNswx9GA6eSSp7otZcJapWJCVuon/RooQPQjf3bDuRb5ZpJ55NkX13ugjl2nq+b0U8SA==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-3.1.5.tgz",
+      "integrity": "sha512-6DJYNuKrbxuL+MThmj+VbtvK9X3mY+s8Rqj1juj4RyeLSIAhE3byZf8Bo2/GxrU5Jv3zR07LZdpiq4wIl0ONzA==",
       "engines": {
         "node": "^12.20 || >=14.13"
       },
@@ -16734,16 +16734,12 @@
         "url": "https://github.com/sponsors/johnleider"
       },
       "peerDependencies": {
-        "@formatjs/intl": "^1.0.0 || ^2.0.0",
         "vite-plugin-vuetify": "^1.0.0-alpha.12",
         "vue": "^3.2.0",
         "vue-i18n": "^9.0.0",
         "webpack-plugin-vuetify": "^2.0.0-alpha.11"
       },
       "peerDependenciesMeta": {
-        "@formatjs/intl": {
-          "optional": true
-        },
         "vite-plugin-vuetify": {
           "optional": true
         },
@@ -30032,9 +30028,9 @@
       }
     },
     "vuetify": {
-      "version": "3.0.0-beta.13",
-      "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-3.0.0-beta.13.tgz",
-      "integrity": "sha512-CgDyKCIBZ0ogKUxRw3gNswx9GA6eSSp7otZcJapWJCVuon/RooQPQjf3bDuRb5ZpJ55NkX13ugjl2nq+b0U8SA==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-3.1.5.tgz",
+      "integrity": "sha512-6DJYNuKrbxuL+MThmj+VbtvK9X3mY+s8Rqj1juj4RyeLSIAhE3byZf8Bo2/GxrU5Jv3zR07LZdpiq4wIl0ONzA==",
       "requires": {}
     },
     "vuex": {

--- a/sources/packages/web/package.json
+++ b/sources/packages/web/package.json
@@ -32,7 +32,7 @@
     "vue": "^3.2.31",
     "vue-class-component": "^8.0.0-0",
     "vue-router": "^4.0.14",
-    "vuetify": "^3.0.0-beta.13",
+    "vuetify": "^3.1.5",
     "vuex": "^4.0.2",
     "yup": "^0.32.11"
   },

--- a/sources/packages/web/src/assets/css/base.scss
+++ b/sources/packages/web/src/assets/css/base.scss
@@ -378,3 +378,8 @@ b,
 strong {
   font-weight: $font-weight-bold;
 }
+
+// Added FontAwesome as fallback.
+.mdi:before {
+  font-family: "Material Design Icons", "FontAwesome" !important;
+}

--- a/sources/packages/web/src/assets/css/base.scss
+++ b/sources/packages/web/src/assets/css/base.scss
@@ -380,6 +380,6 @@ strong {
 }
 
 // Added FontAwesome as fallback.
-.mdi:before {
-  font-family: "Material Design Icons", "FontAwesome", "BCSans", sans-serif !important;
+.fas:before {
+  font-family: "FontAwesome", $font-bold !important;
 }

--- a/sources/packages/web/src/assets/css/base.scss
+++ b/sources/packages/web/src/assets/css/base.scss
@@ -381,5 +381,5 @@ strong {
 
 // Added FontAwesome as fallback.
 .mdi:before {
-  font-family: "Material Design Icons", "FontAwesome" !important;
+  font-family: "Material Design Icons", "FontAwesome", "BCSans", sans-serif !important;
 }

--- a/sources/packages/web/src/helpers/helpers/uri.ts
+++ b/sources/packages/web/src/helpers/helpers/uri.ts
@@ -7,7 +7,7 @@ import {
 } from "@/types";
 
 /**
- * todo: remove sortOrder: DataTableSortOrder when all primevue datatables are removed.
+ * @deprecated use getPaginationQueryString
  * Helper to append pagination sort and order to the url
  * @param url api url
  * @param sortField sortField
@@ -30,6 +30,7 @@ export function addSortOptions(
 }
 
 /**
+ * @deprecated use getPaginationQueryString
  * Utility to build the pagination query parameters.
  * @param url
  * @param page
@@ -56,7 +57,7 @@ export const getPaginationQueryString = (
   paginationOptions: PaginationOptions,
 ) => {
   const parameters: string[] = [];
-  // Paginations parameters.
+  // Pagination parameters.
   parameters.push(`${PaginationParams.Page}=${paginationOptions.page}`);
   parameters.push(
     `${PaginationParams.PageLimit}=${paginationOptions.pageLimit}`,

--- a/sources/packages/web/src/helpers/helpers/uri.ts
+++ b/sources/packages/web/src/helpers/helpers/uri.ts
@@ -55,7 +55,12 @@ export const addPaginationOptions = (
  */
 export const getPaginationQueryString = (
   paginationOptions: PaginationOptions,
+  enableZeroPage = false,
 ) => {
+  if (enableZeroPage) {
+    paginationOptions.page = paginationOptions.page - 1;
+  }
+
   const parameters: string[] = [];
   // Pagination parameters.
   parameters.push(`${PaginationParams.Page}=${paginationOptions.page}`);

--- a/sources/packages/web/src/helpers/helpers/uri.ts
+++ b/sources/packages/web/src/helpers/helpers/uri.ts
@@ -1,4 +1,5 @@
 import {
+  DataTableSortByOrder,
   DataTableSortOrder,
   FieldSortOrder,
   PaginationOptions,
@@ -6,7 +7,8 @@ import {
 } from "@/types";
 
 /**
- * helper to append pagination sort and order to the url
+ * todo: remove sortOrder: DataTableSortOrder when all primevue datatables are removed.
+ * Helper to append pagination sort and order to the url
  * @param url api url
  * @param sortField sortField
  * @param sortOrder sortOrder
@@ -15,7 +17,7 @@ import {
 export function addSortOptions(
   url: string,
   sortField?: string,
-  sortOrder?: DataTableSortOrder,
+  sortOrder?: DataTableSortOrder | DataTableSortByOrder,
 ): string {
   if (sortField && sortOrder) {
     const sortDBOrder =

--- a/sources/packages/web/src/helpers/helpers/uri.ts
+++ b/sources/packages/web/src/helpers/helpers/uri.ts
@@ -51,6 +51,8 @@ export const addPaginationOptions = (
 /**
  * Builds the query string parameters for pagination.
  * @param paginationOptions pagination options.
+ * @param enableZeroPage enabling this will make the page staring from 0 instead of 1.
+ * this is a temporary solution.
  * @returns the URL query string in a format like parameter1=value1&parameter2=value2.
  */
 export const getPaginationQueryString = (

--- a/sources/packages/web/src/helpers/helpers/uri.ts
+++ b/sources/packages/web/src/helpers/helpers/uri.ts
@@ -51,8 +51,8 @@ export const addPaginationOptions = (
 /**
  * Builds the query string parameters for pagination.
  * @param paginationOptions pagination options.
- * @param enableZeroPage enabling this will make the page staring from 0 instead of 1.
- * this is a temporary solution.
+ * @param enableZeroPage enabling this will make the page staring from 0 instead of 1,
+ * enableZeroPage is a temporary solution.
  * @returns the URL query string in a format like parameter1=value1&parameter2=value2.
  */
 export const getPaginationQueryString = (

--- a/sources/packages/web/src/plugins/vuetify.ts
+++ b/sources/packages/web/src/plugins/vuetify.ts
@@ -3,12 +3,17 @@ import "@fortawesome/fontawesome-free/css/all.css";
 import "vuetify/lib/styles/main.sass";
 import { createVuetify } from "vuetify";
 import * as components from "vuetify/lib/components";
+// Todo: remove import from vuetify/labs/ and its corresponding logics when the components are available in vetify/lib/components.
+import { VDataTableServer } from "vuetify/labs/VDataTable";
 import * as directives from "vuetify/lib/directives";
 import { aliases, fa } from "vuetify/iconsets/fa";
 import { mdi } from "vuetify/iconsets/mdi";
 
 export default createVuetify({
-  components,
+  components: {
+    ...components,
+    VDataTableServer,
+  },
   directives,
   default: {},
   theme: {

--- a/sources/packages/web/src/services/http/EducationProgramApi.ts
+++ b/sources/packages/web/src/services/http/EducationProgramApi.ts
@@ -25,6 +25,7 @@ export class EducationProgramApi extends HttpBaseClient {
   ): Promise<PaginatedResultsAPIOutDTO<EducationProgramsSummaryAPIOutDTO>> {
     const url = `education-program/location/${locationId}/summary?${getPaginationQueryString(
       paginationOptions,
+      true,
     )}`;
 
     return this.getCall<

--- a/sources/packages/web/src/types/contracts/DataTableContract.ts
+++ b/sources/packages/web/src/types/contracts/DataTableContract.ts
@@ -77,12 +77,10 @@ export const ProgramSummaryHeaders = [
   },
   {
     title: "Program Name",
-    sortable: true,
     key: "programName",
   },
   {
     title: "Credential",
-    sortable: true,
     key: "credentialType",
   },
   {

--- a/sources/packages/web/src/types/contracts/DataTableContract.ts
+++ b/sources/packages/web/src/types/contracts/DataTableContract.ts
@@ -39,6 +39,7 @@ export enum DataTableSortOrder {
 }
 
 export const DEFAULT_PAGE_LIMIT = 10;
+// TODO: Remove DEFAULT_PAGE_NUMBER when all primevue datatable removed.
 export const DEFAULT_PAGE_NUMBER = 0;
 export const PAGINATION_LIST = [10, 20, 50];
 
@@ -144,9 +145,16 @@ export enum DataTableSortByOrder {
   ASC = "asc",
 }
 
-// Datatable options.
+/**
+ * DataTable options.
+ */
 export interface DataTableOptions {
   itemsPerPage: number;
   page: number;
   sortBy: { key: string; order: DataTableSortByOrder }[] | [];
 }
+
+/**
+ * Default DataTable page number.
+ */
+export const DEFAULT_DATATABLE_PAGE_NUMBER = 1;

--- a/sources/packages/web/src/types/contracts/DataTableContract.ts
+++ b/sources/packages/web/src/types/contracts/DataTableContract.ts
@@ -68,6 +68,39 @@ export enum ProgramSummaryFields {
   IsActive = "isActive",
 }
 
+export const ProgramSummaryHeaders = [
+  {
+    title: "CIP",
+    sortable: false,
+    key: "cipCode",
+  },
+  {
+    title: "Program Name",
+    sortable: true,
+    key: "programName",
+  },
+  {
+    title: "Credential",
+    sortable: true,
+    key: "credentialType",
+  },
+  {
+    title: "Study periods",
+    sortable: false,
+    key: "totalOfferings",
+  },
+  {
+    title: "Status",
+    sortable: false,
+    key: "programStatus",
+  },
+  {
+    title: "Action",
+    sortable: false,
+    key: "programId",
+  },
+];
+
 /**
  * Pagination Query param constants
  */
@@ -80,12 +113,13 @@ export enum PaginationParams {
 }
 
 /**
- * Pagination Options
+ * Pagination Options.
+ * todo: remove sortOrder: DataTableSortOrder when all primevue datatables are removed.
  */
 export interface PaginationOptions {
   searchCriteria?: string;
   sortField?: string;
-  sortOrder?: DataTableSortOrder;
+  sortOrder?: DataTableSortOrder | DataTableSortByOrder;
   page: number;
   pageLimit: number;
 }
@@ -100,4 +134,19 @@ export interface PageAndSortEvent {
   rows: number;
   sortField: string;
   sortOrder: number;
+}
+
+/**
+ * Vuetify dataTable sort order.
+ */
+export enum DataTableSortByOrder {
+  DESC = "desc",
+  ASC = "asc",
+}
+
+// Datatable options.
+export interface DataTableOptions {
+  itemsPerPage: number;
+  page: number;
+  sortBy: { key: string; order: DataTableSortByOrder }[] | [];
 }

--- a/sources/packages/web/src/views/institution/locations/programs/LocationPrograms.vue
+++ b/sources/packages/web/src/views/institution/locations/programs/LocationPrograms.vue
@@ -45,7 +45,7 @@
           :items-per-page="DEFAULT_PAGE_LIMIT"
           @update:options="paginationAndSortEvent"
         >
-          <template v-slot:item="{ item }">
+          <template #item="{ item }">
             <tr>
               <td data-cy="programCIP">{{ item.columns.cipCode }}</td>
               <td data-cy="programName">{{ item.columns.programName }}</td>
@@ -83,7 +83,7 @@ import { InstitutionService } from "@/services/InstitutionService";
 import { InstitutionRoutesConst } from "@/constants/routes/RouteConstants";
 import {
   DEFAULT_PAGE_LIMIT,
-  DEFAULT_PAGE_NUMBER,
+  DEFAULT_DATATABLE_PAGE_NUMBER,
   PAGINATION_LIST,
   ProgramSummaryFields,
   EducationProgramsSummary,
@@ -122,13 +122,13 @@ export default defineComponent({
 
     /**
      * Function to load program list and count for institution.
-     * @param page page number, if nothing passed then DEFAULT_PAGE_NUMBER.
+     * @param page page number, if nothing passed then DEFAULT_DATATABLE_PAGE_NUMBER.
      * @param pageCount page limit, if nothing passed then DEFAULT_PAGE_LIMIT.
      * @param sortField sort field, if nothing passed then api sorts with programStatus.
      * @param sortOrder sort oder, if nothing passed then DataTableSortByOrder.ASC.
      */
     const loadSummary = async (
-      page = DEFAULT_PAGE_NUMBER,
+      page = DEFAULT_DATATABLE_PAGE_NUMBER,
       pageCount = DEFAULT_PAGE_LIMIT,
       sortField?: string,
       sortOrder?: DataTableSortByOrder,
@@ -150,11 +150,11 @@ export default defineComponent({
 
     // Pagination sort event callback.
     const paginationAndSortEvent = async (event: DataTableOptions) => {
-      currentPage.value = event.page - 1;
+      currentPage.value = event.page;
       currentPageLimit.value = event.itemsPerPage;
       const [sortByOptions] = event.sortBy;
       await loadSummary(
-        event.page - 1,
+        event.page,
         event.itemsPerPage,
         sortByOptions?.key,
         sortByOptions?.order,
@@ -171,7 +171,7 @@ export default defineComponent({
     // Search program table.
     const searchProgramTable = async () => {
       await loadSummary(
-        currentPage.value ?? DEFAULT_PAGE_NUMBER,
+        currentPage.value ?? DEFAULT_DATATABLE_PAGE_NUMBER,
         currentPageLimit.value ?? DEFAULT_PAGE_LIMIT,
       );
     };
@@ -210,7 +210,7 @@ export default defineComponent({
       goToViewProgram,
       locationDetails,
       DEFAULT_PAGE_LIMIT,
-      DEFAULT_PAGE_NUMBER,
+      DEFAULT_DATATABLE_PAGE_NUMBER,
       PAGINATION_LIST,
       paginationAndSortEvent,
       searchProgramTable,

--- a/sources/packages/web/src/views/institution/locations/programs/LocationPrograms.vue
+++ b/sources/packages/web/src/views/institution/locations/programs/LocationPrograms.vue
@@ -43,7 +43,7 @@
           :items-length="programAndCount.count"
           :loading="loading"
           :items-per-page="DEFAULT_PAGE_LIMIT"
-          @update:options="programOptions"
+          @update:options="paginationAndSortEvent"
         >
           <template v-slot:[`item.programStatus`]="{ item }">
             <status-chip-program
@@ -137,6 +137,19 @@ export default defineComponent({
       loading.value = false;
     };
 
+    // Sort and pagination for the datatable.
+    const paginationAndSortEvent = async (event: DataTableOptions) => {
+      currentPage.value = event.page - 1;
+      currentPageLimit.value = event.itemsPerPage;
+      const [sortByOptions] = event.sortBy;
+      await loadSummary(
+        event.page - 1,
+        event.itemsPerPage,
+        sortByOptions?.key,
+        sortByOptions?.order,
+      );
+    };
+
     const loadProgramDetails = async () => {
       locationDetails.value =
         await InstitutionService.shared.getInstitutionLocation(
@@ -180,19 +193,6 @@ export default defineComponent({
       });
     };
 
-    // Sort and pagination for the datatable.
-    const programOptions = async (event: DataTableOptions) => {
-      currentPage.value = event.page - 1;
-      currentPageLimit.value = event.itemsPerPage;
-      const [sortByOptions] = event.sortBy;
-      await loadSummary(
-        event.page - 1,
-        event.itemsPerPage,
-        sortByOptions?.key,
-        sortByOptions?.order,
-      );
-    };
-
     return {
       programAndCount,
       goToAddNewProgram,
@@ -201,12 +201,12 @@ export default defineComponent({
       DEFAULT_PAGE_LIMIT,
       DEFAULT_PAGE_NUMBER,
       PAGINATION_LIST,
+      paginationAndSortEvent,
       searchProgramTable,
       loading,
       searchBox,
       ProgramSummaryFields,
       locationName,
-      programOptions,
       ProgramSummaryHeaders,
     };
   },

--- a/sources/packages/web/src/views/institution/locations/programs/LocationPrograms.vue
+++ b/sources/packages/web/src/views/institution/locations/programs/LocationPrograms.vue
@@ -45,18 +45,30 @@
           :items-per-page="DEFAULT_PAGE_LIMIT"
           @update:options="paginationAndSortEvent"
         >
-          <template v-slot:[`item.programStatus`]="{ item }">
-            <status-chip-program
-              :status="item.value.programStatus"
-            ></status-chip-program>
-          </template>
-          <template v-slot:[`item.programId`]="{ item }">
-            <v-btn
-              color="primary"
-              @click="goToViewProgram(item.value.programId)"
-              data-cy="viewProgram"
-              >View</v-btn
-            >
+          <template v-slot:item="{ item }">
+            <tr>
+              <td data-cy="programCIP">{{ item.columns.cipCode }}</td>
+              <td data-cy="programName">{{ item.columns.programName }}</td>
+              <td data-cy="programCredential">
+                {{ item.columns.credentialType }}
+              </td>
+              <td data-cy="programStudyPeriods">
+                {{ item.columns.totalOfferings }}
+              </td>
+              <td data-cy="programStatus">
+                <status-chip-program
+                  :status="item.columns.programStatus"
+                ></status-chip-program>
+              </td>
+              <td>
+                <v-btn
+                  color="primary"
+                  @click="goToViewProgram(item.columns.programId)"
+                  data-cy="viewProgram"
+                  >View</v-btn
+                >
+              </td>
+            </tr>
           </template>
         </v-data-table-server>
       </toggle-content>
@@ -101,7 +113,6 @@ export default defineComponent({
     const locationDetails = ref();
     const loading = ref(false);
     const searchBox = ref("");
-
     const currentPage = ref();
     const currentPageLimit = ref();
 

--- a/sources/packages/web/src/views/institution/locations/programs/LocationPrograms.vue
+++ b/sources/packages/web/src/views/institution/locations/programs/LocationPrograms.vue
@@ -137,7 +137,7 @@ export default defineComponent({
       loading.value = false;
     };
 
-    // Sort and pagination for the datatable.
+    // Pagination sort event callback.
     const paginationAndSortEvent = async (event: DataTableOptions) => {
       currentPage.value = event.page - 1;
       currentPageLimit.value = event.itemsPerPage;


### PR DESCRIPTION
- Upgrade Vuetify to 3.1.5.
- Imported `VDataTableServer` from "vuetify/labs/VDataTable".
- Replaced Location program datatate with <v-data-table-server
- Implemented <v-data-table-server default sort and pagination
- Search feature is not in the <v-data-table-server 
- There was a bug in the existing API, for page 0, it was returning the entire values,- fixed

![image](https://user-images.githubusercontent.com/77353155/221058190-760dec00-28ae-48f1-aebd-3ae7e9d52af2.png)
