### PR TITLE
#1692 - UI label fix and Ordering awards in Federal and BC order

### DIFF
--- a/sources/packages/web/src/components/aest/students/modals/AddManualOverawardDeduction.vue
+++ b/sources/packages/web/src/components/aest/students/modals/AddManualOverawardDeduction.vue
@@ -17,6 +17,8 @@
         />
         <v-text-field
           hide-details="auto"
+          hint="You can also include a negative value to remove a data entry error (e.g. -200)"
+          persistent-hint
           density="compact"
           label="Add the dollar amount"
           v-model="formModel.overawardValue"

--- a/sources/packages/web/src/components/common/OverawardDetails.vue
+++ b/sources/packages/web/src/components/common/OverawardDetails.vue
@@ -97,7 +97,7 @@
               </template></Column
             >
             <Column field="awardValueCode" header="Award"></Column>
-            <Column field="overawardValue" header="Overaward amount">
+            <Column field="overawardValue" header="Amount deducted">
               <template #body="slotProps">
                 <span>
                   {{ formatCurrency(slotProps.data.overawardValue) }}

--- a/sources/packages/web/src/constants/award-constants.ts
+++ b/sources/packages/web/src/constants/award-constants.ts
@@ -54,26 +54,6 @@ export const AWARDS: AwardDetail[] = [
     offeringIntensity: OfferingIntensity.fullTime,
   },
   {
-    awardType: FullTimeAwardTypes.BCSL,
-    description: "B.C. Student Loan",
-    offeringIntensity: OfferingIntensity.fullTime,
-  },
-  {
-    awardType: FullTimeAwardTypes.BCAG,
-    description: "B.C. Access Grant",
-    offeringIntensity: OfferingIntensity.fullTime,
-  },
-  {
-    awardType: FullTimeAwardTypes.BGPD,
-    description: "B.C. Permanent Disability Grant",
-    offeringIntensity: OfferingIntensity.fullTime,
-  },
-  {
-    awardType: FullTimeAwardTypes.SBSD,
-    description: "B.C. Supplemental Bursary with Disabilities",
-    offeringIntensity: OfferingIntensity.fullTime,
-  },
-  {
     awardType: PartTimeAwardTypes.CSLP,
     description: "Canada Student Loan for Part-time Studies",
     offeringIntensity: OfferingIntensity.partTime,
@@ -92,6 +72,26 @@ export const AWARDS: AwardDetail[] = [
     awardType: PartTimeAwardTypes.CSGD,
     description: "Canada Student Grant for Students with Dependents",
     offeringIntensity: OfferingIntensity.partTime,
+  },
+  {
+    awardType: FullTimeAwardTypes.BCSL,
+    description: "B.C. Student Loan",
+    offeringIntensity: OfferingIntensity.fullTime,
+  },
+  {
+    awardType: FullTimeAwardTypes.BCAG,
+    description: "B.C. Access Grant",
+    offeringIntensity: OfferingIntensity.fullTime,
+  },
+  {
+    awardType: FullTimeAwardTypes.BGPD,
+    description: "B.C. Permanent Disability Grant",
+    offeringIntensity: OfferingIntensity.fullTime,
+  },
+  {
+    awardType: FullTimeAwardTypes.SBSD,
+    description: "B.C. Supplemental Bursary with Disabilities",
+    offeringIntensity: OfferingIntensity.fullTime,
   },
   {
     awardType: PartTimeAwardTypes.BCAG,


### PR DESCRIPTION
 - [x] Fixed the label to be Amount deducted in overaward deductions table.
![image](https://user-images.githubusercontent.com/54600590/221087262-e7ea5e3a-ed20-4e80-ba86-698158162c00.png)


 - [x] Added hint text to add manual overaward modal.
![image](https://user-images.githubusercontent.com/54600590/221087362-1cb8261f-70cd-447b-a4b7-fda89aeae16d.png)

 - [x] When the constants FULL_TIME_AWARDS and PART_TIME_AWARDS are merged into AWARDS  the order of awards as in federal awards coming first followed by bc awards is restored.
