### PR TITLE
#1726 - E2E/Units Tests - Add Units Tests to Helpers (COEApprovalPeriodStatus)

### DIFF
--- a/sources/packages/backend/apps/api/src/services/disbursement-schedule/_tests_/unit/disbursement-schedule.getCOEApprovalPeriodStatus.spec.ts
+++ b/sources/packages/backend/apps/api/src/services/disbursement-schedule/_tests_/unit/disbursement-schedule.getCOEApprovalPeriodStatus.spec.ts
@@ -36,7 +36,7 @@ describe("DisbursementScheduleService-getCOEApprovalPeriodStatus", () => {
     );
   });
 
-  it("Should throw an error when both disbursement date and studyEndDate are undefined.", () => {
+  it("Should throw an error when both the disbursement date and study end date are undefined.", () => {
     // Arrange
     const disbursementDate = undefined;
     const studyEndDate = undefined;

--- a/sources/packages/backend/apps/api/src/services/disbursement-schedule/_tests_/unit/disbursement-schedule.getCOEApprovalPeriodStatus.spec.ts
+++ b/sources/packages/backend/apps/api/src/services/disbursement-schedule/_tests_/unit/disbursement-schedule.getCOEApprovalPeriodStatus.spec.ts
@@ -14,10 +14,8 @@ describe("DisbursementScheduleService-getCOEApprovalPeriodStatus", () => {
   beforeAll(async () => {
     const dataSource = {} as DataSource;
     dataSource.getRepository = jest.fn();
-    const sequenceService: SequenceControlService =
-      {} as SequenceControlService;
-    const notificationActionsService: NotificationActionsService =
-      {} as NotificationActionsService;
+    const sequenceService = {} as SequenceControlService;
+    const notificationActionsService = {} as NotificationActionsService;
     service = new DisbursementScheduleService(
       dataSource,
       sequenceService,
@@ -25,7 +23,7 @@ describe("DisbursementScheduleService-getCOEApprovalPeriodStatus", () => {
     );
   });
 
-  it("Should throw error when disbursementDate is undefined", () => {
+  it("Should throw an error when the disbursement date is undefined.", () => {
     // Arrange
     const disbursementDate = undefined;
     const studyEndDate = new Date();
@@ -38,7 +36,7 @@ describe("DisbursementScheduleService-getCOEApprovalPeriodStatus", () => {
     );
   });
 
-  it("Should throw error when both disbursementDate and studyEndDate is undefined", () => {
+  it("Should throw an error when both disbursement date and studyEndDate are undefined.", () => {
     // Arrange
     const disbursementDate = undefined;
     const studyEndDate = undefined;
@@ -51,10 +49,27 @@ describe("DisbursementScheduleService-getCOEApprovalPeriodStatus", () => {
     );
   });
 
-  it(`Should return "${COEApprovalPeriodStatus.WithinApprovalPeriod}" when enrolment now within eligible approval period.`, () => {
+  it(`Should return "${COEApprovalPeriodStatus.WithinApprovalPeriod}" when enrolment now is the first day of (within) the allowed approval period.`, () => {
     // Arrange
-    const disbursementDate = addDays(1, new Date());
+    const disbursementDate = addDays(COE_WINDOW, new Date());
     const studyEndDate = addDays(60, new Date());
+
+    // Act
+    const coeApprovalPeriodStatus = service.getCOEApprovalPeriodStatus(
+      disbursementDate,
+      studyEndDate,
+    );
+
+    // Assert.
+    expect(coeApprovalPeriodStatus).toEqual(
+      COEApprovalPeriodStatus.WithinApprovalPeriod,
+    );
+  });
+
+  it(`Should return "${COEApprovalPeriodStatus.WithinApprovalPeriod}" when enrolment now is the last day of (within) the allowed approval period.`, () => {
+    // Arrange
+    const disbursementDate = addDays(COE_WINDOW, new Date());
+    const studyEndDate = new Date();
 
     // Act
     const coeApprovalPeriodStatus = service.getCOEApprovalPeriodStatus(

--- a/sources/packages/backend/apps/api/src/services/disbursement-schedule/_tests_/unit/disbursement-schedule.getMaxTuitionRemittance.spec.ts
+++ b/sources/packages/backend/apps/api/src/services/disbursement-schedule/_tests_/unit/disbursement-schedule.getMaxTuitionRemittance.spec.ts
@@ -1,0 +1,100 @@
+import {
+  NotificationActionsService,
+  SequenceControlService,
+} from "@sims/services";
+import { DisbursementScheduleService } from "../../disbursement-schedule-service";
+import { DataSource } from "typeorm";
+import { addDays } from "@sims/utilities";
+import { COE_WINDOW } from "../../../../utilities";
+import { COEApprovalPeriodStatus } from "../../disbursement-schedule.models";
+
+describe("DisbursementScheduleService-getCOEApprovalPeriodStatus", () => {
+  let service: DisbursementScheduleService;
+
+  beforeAll(async () => {
+    const dataSource = {} as DataSource;
+    dataSource.getRepository = jest.fn();
+    let sequenceService: SequenceControlService;
+    let notificationActionsService: NotificationActionsService;
+    service = new DisbursementScheduleService(
+      dataSource,
+      sequenceService,
+      notificationActionsService,
+    );
+  });
+
+  it("Should throw error when disbursementDate is undefined", () => {
+    // Arrange
+    const disbursementDate = undefined;
+    const studyEndDate = new Date();
+    // Act and Assert.
+    expect(() => {
+      service.getCOEApprovalPeriodStatus(disbursementDate, studyEndDate);
+    }).toThrow(
+      "disbursementDate and studyEndDate are required for COE window verification.",
+    );
+  });
+
+  it("Should throw error when both disbursementDate and studyEndDate is undefined", () => {
+    // Arrange
+    const disbursementDate = undefined;
+    const studyEndDate = undefined;
+    // Act and Assert.
+    expect(() => {
+      service.getCOEApprovalPeriodStatus(disbursementDate, studyEndDate);
+    }).toThrow(
+      "disbursementDate and studyEndDate are required for COE window verification.",
+    );
+  });
+
+  it(`Should return "${COEApprovalPeriodStatus.WithinApprovalPeriod}" when enrolment now within eligible approval period.`, () => {
+    // Arrange
+    const disbursementDate = addDays(1, new Date());
+    const studyEndDate = addDays(60, new Date());
+
+    // Act
+    const coeApprovalPeriodStatus = service.getCOEApprovalPeriodStatus(
+      disbursementDate,
+      studyEndDate,
+    );
+
+    // Assert.
+    expect(coeApprovalPeriodStatus).toEqual(
+      COEApprovalPeriodStatus.WithinApprovalPeriod,
+    );
+  });
+
+  it(`Should return "${COEApprovalPeriodStatus.BeforeApprovalPeriod}" when enrolment now is before the eligible approval period.`, () => {
+    // Arrange
+    const disbursementDate = addDays(COE_WINDOW + 1, new Date());
+    const studyEndDate = addDays(60, new Date());
+
+    // Act
+    const coeApprovalPeriodStatus = service.getCOEApprovalPeriodStatus(
+      disbursementDate,
+      studyEndDate,
+    );
+
+    // Assert.
+    expect(coeApprovalPeriodStatus).toEqual(
+      COEApprovalPeriodStatus.BeforeApprovalPeriod,
+    );
+  });
+
+  it(`Should return "${COEApprovalPeriodStatus.AfterApprovalPeriod}" when enrolment now is after the eligible approval period.`, () => {
+    // Arrange
+    const disbursementDate = addDays(-30, new Date());
+    const studyEndDate = addDays(-1, new Date());
+
+    // Act
+    const coeApprovalPeriodStatus = service.getCOEApprovalPeriodStatus(
+      disbursementDate,
+      studyEndDate,
+    );
+
+    // Assert.
+    expect(coeApprovalPeriodStatus).toEqual(
+      COEApprovalPeriodStatus.AfterApprovalPeriod,
+    );
+  });
+});

--- a/sources/packages/backend/apps/api/src/services/disbursement-schedule/_tests_/unit/disbursement-schedule.getMaxTuitionRemittance.spec.ts
+++ b/sources/packages/backend/apps/api/src/services/disbursement-schedule/_tests_/unit/disbursement-schedule.getMaxTuitionRemittance.spec.ts
@@ -14,8 +14,10 @@ describe("DisbursementScheduleService-getCOEApprovalPeriodStatus", () => {
   beforeAll(async () => {
     const dataSource = {} as DataSource;
     dataSource.getRepository = jest.fn();
-    let sequenceService: SequenceControlService;
-    let notificationActionsService: NotificationActionsService;
+    const sequenceService: SequenceControlService =
+      {} as SequenceControlService;
+    const notificationActionsService: NotificationActionsService =
+      {} as NotificationActionsService;
     service = new DisbursementScheduleService(
       dataSource,
       sequenceService,
@@ -27,6 +29,7 @@ describe("DisbursementScheduleService-getCOEApprovalPeriodStatus", () => {
     // Arrange
     const disbursementDate = undefined;
     const studyEndDate = new Date();
+
     // Act and Assert.
     expect(() => {
       service.getCOEApprovalPeriodStatus(disbursementDate, studyEndDate);
@@ -39,6 +42,7 @@ describe("DisbursementScheduleService-getCOEApprovalPeriodStatus", () => {
     // Arrange
     const disbursementDate = undefined;
     const studyEndDate = undefined;
+
     // Act and Assert.
     expect(() => {
       service.getCOEApprovalPeriodStatus(disbursementDate, studyEndDate);


### PR DESCRIPTION
- Added unit test for the method `getCOEApprovalPeriodStatus`. 
-  DisbursementScheduleService-getCOEApprovalPeriodStatus - Tests covered
   ✓ Should throw an error when the disbursement date is undefined. (16 ms)
    ✓ Should throw an error when both the disbursement date and study end date are undefined. (1 ms)
    ✓ Should return "Within approval period" when enrolment now is the first day of (within) the allowed approval period. (4 ms)
    ✓ Should return "Within approval period" when enrolment now is the last day of (within) the allowed approval period. (2 ms)
    ✓ Should return "Before approval period" when enrolment now is before the eligible approval period. (3 ms)
    ✓ Should return "After approval period" when enrolment now is after the eligible approval period. (1 ms)

![image](https://user-images.githubusercontent.com/77353155/222241802-4e739598-db14-417a-9827-93a2b8242495.png)
