### PR TITLE
#1753 - Add student notes during add manual overaward deduction - part 1

### DIFF
--- a/sources/packages/backend/apps/db-migrations/src/migrations/1677801820875-AddManualOverawardNoteIdToDisbursementOverawards.ts
+++ b/sources/packages/backend/apps/db-migrations/src/migrations/1677801820875-AddManualOverawardNoteIdToDisbursementOverawards.ts
@@ -1,0 +1,24 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+import { getSQLFileData } from "../utilities/sqlLoader";
+
+export class AddManualOverawardNoteIdToDisbursementOverawards1677801820875
+  implements MigrationInterface
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      getSQLFileData(
+        "Add-note-id-added-by-added-date.sql",
+        "DisbursementOverawards",
+      ),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      getSQLFileData(
+        "Remove-note-id-added-by-added-date.sql",
+        "DisbursementOverawards",
+      ),
+    );
+  }
+}

--- a/sources/packages/backend/apps/db-migrations/src/migrations/1677801820875-AddNoteIdAddedByAddedDateToDisbursementOverawards.ts
+++ b/sources/packages/backend/apps/db-migrations/src/migrations/1677801820875-AddNoteIdAddedByAddedDateToDisbursementOverawards.ts
@@ -1,7 +1,7 @@
 import { MigrationInterface, QueryRunner } from "typeorm";
 import { getSQLFileData } from "../utilities/sqlLoader";
 
-export class AddManualOverawardNoteIdToDisbursementOverawards1677801820875
+export class AddNoteIdAddedByAddedDateToDisbursementOverawards1677801820875
   implements MigrationInterface
 {
   public async up(queryRunner: QueryRunner): Promise<void> {

--- a/sources/packages/backend/apps/db-migrations/src/migrations/1677805984987-AddNoteTypeOveraward.ts
+++ b/sources/packages/backend/apps/db-migrations/src/migrations/1677805984987-AddNoteTypeOveraward.ts
@@ -1,0 +1,16 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+import { getSQLFileData } from "../utilities/sqlLoader";
+
+export class AddNoteTypeOveraward1677805984987 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      getSQLFileData("Add-note-type-overaward.sql", "Types"),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      getSQLFileData("Drop-note-type-overaward.sql", "Types"),
+    );
+  }
+}

--- a/sources/packages/backend/apps/db-migrations/src/sql/DisbursementOverawards/Add-note-id-added-by-added-date.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/DisbursementOverawards/Add-note-id-added-by-added-date.sql
@@ -18,6 +18,6 @@ COMMENT ON COLUMN sims.disbursement_overawards.added_by IS 'User id of the user 
 ALTER TABLE
     sims.disbursement_overawards
 ADD
-    COLUMN IF NOT EXISTS added_date TIMESTAMP WITHOUT TIME ZONE;
+    COLUMN IF NOT EXISTS added_date TIMESTAMP WITH TIME ZONE;
 
 COMMENT ON COLUMN sims.disbursement_overawards.added_date IS 'Date that the manual record was added.';

--- a/sources/packages/backend/apps/db-migrations/src/sql/DisbursementOverawards/Add-note-id-added-by-added-date.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/DisbursementOverawards/Add-note-id-added-by-added-date.sql
@@ -2,7 +2,7 @@
 ALTER TABLE
     sims.disbursement_overawards
 ADD
-    COLUMN IF NOT EXISTS note_id INTEGER REFERENCES sims.notes(id);
+    COLUMN IF NOT EXISTS note_id INT REFERENCES sims.notes(id);
 
 COMMENT ON COLUMN sims.disbursement_overawards.note_id IS 'Note id for the disbursement overaward record.';
 
@@ -10,7 +10,7 @@ COMMENT ON COLUMN sims.disbursement_overawards.note_id IS 'Note id for the disbu
 ALTER TABLE
     sims.disbursement_overawards
 ADD
-    COLUMN IF NOT EXISTS added_by INTEGER REFERENCES sims.users(id);
+    COLUMN IF NOT EXISTS added_by INT REFERENCES sims.users(id);
 
 COMMENT ON COLUMN sims.disbursement_overawards.added_by IS 'User id of the user adding a manual record.';
 
@@ -20,4 +20,4 @@ ALTER TABLE
 ADD
     COLUMN IF NOT EXISTS added_date TIMESTAMP WITHOUT TIME ZONE;
 
-COMMENT ON COLUMN sims.disbursement_overawards.added_date  IS 'Date that the manual record was added.';
+COMMENT ON COLUMN sims.disbursement_overawards.added_date IS 'Date that the manual record was added.';

--- a/sources/packages/backend/apps/db-migrations/src/sql/DisbursementOverawards/Add-note-id-added-by-added-date.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/DisbursementOverawards/Add-note-id-added-by-added-date.sql
@@ -1,3 +1,4 @@
+-- Add column note_id to sims.disbursement_overawards.
 ALTER TABLE
     sims.disbursement_overawards
 ADD
@@ -5,6 +6,7 @@ ADD
 
 COMMENT ON COLUMN sims.disbursement_overawards.note_id IS 'Note id for the disbursement overaward record.';
 
+-- Add column added_by to sims.disbursement_overawards.
 ALTER TABLE
     sims.disbursement_overawards
 ADD
@@ -12,6 +14,7 @@ ADD
 
 COMMENT ON COLUMN sims.disbursement_overawards.added_by IS 'User id of the user adding a manual record.';
 
+-- Add column added_date to sims.disbursement_overawards.
 ALTER TABLE
     sims.disbursement_overawards
 ADD

--- a/sources/packages/backend/apps/db-migrations/src/sql/DisbursementOverawards/Add-note-id-added-by-added-date.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/DisbursementOverawards/Add-note-id-added-by-added-date.sql
@@ -1,0 +1,20 @@
+ALTER TABLE
+    sims.disbursement_overawards
+ADD
+    COLUMN IF NOT EXISTS note_id INTEGER REFERENCES sims.notes(id);
+
+COMMENT ON COLUMN sims.disbursement_overawards.note_id IS 'Note id for the disbursement overaward record.';
+
+ALTER TABLE
+    sims.disbursement_overawards
+ADD
+    COLUMN IF NOT EXISTS added_by INTEGER REFERENCES sims.users(id);
+
+COMMENT ON COLUMN sims.disbursement_overawards.added_by IS 'User id of the user adding a manual record.';
+
+ALTER TABLE
+    sims.disbursement_overawards
+ADD
+    COLUMN IF NOT EXISTS added_date TIMESTAMP WITHOUT TIME ZONE;
+
+COMMENT ON COLUMN sims.disbursement_overawards.added_date  IS 'Date that the manual record was added.';

--- a/sources/packages/backend/apps/db-migrations/src/sql/DisbursementOverawards/Remove-note-id-added-by-added-date.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/DisbursementOverawards/Remove-note-id-added-by-added-date.sql
@@ -1,8 +1,11 @@
+-- Remove column note_id from sims.disbursement_overawards.
 ALTER TABLE
     sims.disbursement_overawards DROP COLUMN IF EXISTS note_id;
 
+-- Remove column added_by from sims.disbursement_overawards.
 ALTER TABLE
     sims.disbursement_overawards DROP COLUMN IF EXISTS added_by;
 
+-- Remove column added_date from sims.disbursement_overawards.
 ALTER TABLE
     sims.disbursement_overawards DROP COLUMN IF EXISTS added_date;

--- a/sources/packages/backend/apps/db-migrations/src/sql/DisbursementOverawards/Remove-note-id-added-by-added-date.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/DisbursementOverawards/Remove-note-id-added-by-added-date.sql
@@ -1,0 +1,8 @@
+ALTER TABLE
+    sims.disbursement_overawards DROP COLUMN IF EXISTS note_id;
+
+ALTER TABLE
+    sims.disbursement_overawards DROP COLUMN IF EXISTS added_by;
+
+ALTER TABLE
+    sims.disbursement_overawards DROP COLUMN IF EXISTS added_date;

--- a/sources/packages/backend/apps/db-migrations/src/sql/Types/Add-note-type-overaward.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/Types/Add-note-type-overaward.sql
@@ -1,0 +1,6 @@
+-- Add Designation to note types.
+ALTER TYPE sims.note_types
+ADD
+    VALUE 'Overaward'
+AFTER
+    'Designation';

--- a/sources/packages/backend/apps/db-migrations/src/sql/Types/Add-note-type-overaward.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/Types/Add-note-type-overaward.sql
@@ -1,4 +1,4 @@
--- Add Designation to note types.
+-- Add Overaward to note types.
 ALTER TYPE sims.note_types
 ADD
     VALUE 'Overaward'

--- a/sources/packages/backend/apps/db-migrations/src/sql/Types/Drop-note-type-overaward.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/Types/Drop-note-type-overaward.sql
@@ -1,4 +1,4 @@
---Removing the value Application from sims.note_types for the rollback.
+--Removing the value Overaward from sims.note_types for the rollback.
 --As postgres does not support removal of an Enum Value, We create a temporary enum and rename it.
 CREATE TYPE sims.note_types_to_rollback AS ENUM (
 	'General',

--- a/sources/packages/backend/apps/db-migrations/src/sql/Types/Drop-note-type-overaward.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/Types/Drop-note-type-overaward.sql
@@ -1,0 +1,27 @@
+--Removing the value Application from sims.note_types for the rollback.
+--As postgres does not support removal of an Enum Value, We create a temporary enum and rename it.
+CREATE TYPE sims.note_types_to_rollback AS ENUM (
+	'General',
+	'Application',
+	'Program',
+	'Restriction',
+	'Designation',
+	'System Actions'
+);
+
+-- Update the dependent column to start using the new enum with the expected values.
+ALTER TABLE
+    sims.notes
+ALTER COLUMN
+    note_type TYPE sims.note_types_to_rollback USING (
+        CASE
+            note_type :: text
+            WHEN 'Overaward' THEN 'General'
+            ELSE note_type :: text
+        END
+    ) :: sims.note_types_to_rollback;
+
+
+DROP TYPE sims.note_types;
+
+ALTER TYPE sims.note_types_to_rollback RENAME TO note_types;


### PR DESCRIPTION
- DB changes for the ticket #1753:
  - added note_id, added_by and added_date to sims. disbursement_overawards table.