### PR TITLE
#1753 - Add student notes during add manual overaward deduction - part 2

### DIFF
--- a/sources/packages/backend/apps/api/src/app.aest.module.ts
+++ b/sources/packages/backend/apps/api/src/app.aest.module.ts
@@ -77,6 +77,7 @@ import {
   ReportService,
   DisbursementOverawardService,
   ConfirmationOfEnrollmentService,
+  NoteSharedService,
 } from "@sims/services";
 
 @Module({
@@ -154,6 +155,7 @@ import {
     ConfirmationOfEnrollmentService,
     DisbursementScheduleService,
     DisbursementOverawardService,
+    NoteSharedService,
   ],
 })
 export class AppAESTModule {}

--- a/sources/packages/backend/apps/api/src/app.institutions.module.ts
+++ b/sources/packages/backend/apps/api/src/app.institutions.module.ts
@@ -50,6 +50,7 @@ import {
   SequenceControlService,
   StudentRestrictionSharedService,
   WorkflowClientService,
+  NoteSharedService,
 } from "@sims/services";
 import {
   SFASIndividualService,
@@ -115,6 +116,7 @@ import { UserControllerService } from "./route-controllers/user/user.controller.
     ConfirmationOfEnrollmentControllerService,
     ConfirmationOfEnrollmentService,
     DisbursementOverawardService,
+    NoteSharedService,
   ],
 })
 export class AppInstitutionsModule {}

--- a/sources/packages/backend/apps/api/src/app.students.module.ts
+++ b/sources/packages/backend/apps/api/src/app.students.module.ts
@@ -47,6 +47,7 @@ import {
   SequenceControlService,
   StudentRestrictionSharedService,
   WorkflowClientService,
+  NoteSharedService,
 } from "@sims/services";
 import {
   SFASIndividualService,
@@ -104,6 +105,7 @@ import { ATBCIntegrationModule } from "@sims/integrations/atbc-integration";
     SupportingUserService,
     StudentRestrictionSharedService,
     DisbursementOverawardService,
+    NoteSharedService,
   ],
 })
 export class AppStudentsModule {}

--- a/sources/packages/backend/apps/api/src/app.supporting-users.module.ts
+++ b/sources/packages/backend/apps/api/src/app.supporting-users.module.ts
@@ -16,6 +16,7 @@ import {
   SequenceControlService,
   StudentRestrictionSharedService,
   WorkflowClientService,
+  NoteSharedService,
 } from "@sims/services";
 import {
   SFASIndividualService,
@@ -46,6 +47,7 @@ import { AuthModule } from "./auth/auth.module";
     WorkflowClientService,
     StudentRestrictionSharedService,
     DisbursementOverawardService,
+    NoteSharedService,
   ],
 })
 export class AppSupportingUsersModule {}

--- a/sources/packages/backend/apps/api/src/auth/auth.module.ts
+++ b/sources/packages/backend/apps/api/src/auth/auth.module.ts
@@ -27,8 +27,10 @@ import {
 import { RolesGuard } from "./guards/roles.guard";
 import { ConfigModule } from "@sims/utilities/config";
 import { SFASIndividualService } from "@sims/services/sfas";
-import { DisbursementOverawardService } from "@sims/services";
-import { NoteSharedService } from "@sims/services/note/note.shared.service";
+import {
+  DisbursementOverawardService,
+  NoteSharedService,
+} from "@sims/services";
 
 const jwtModule = JwtModule.register({
   publicKey: KeycloakConfig.PEM_PublicKey,

--- a/sources/packages/backend/apps/api/src/auth/auth.module.ts
+++ b/sources/packages/backend/apps/api/src/auth/auth.module.ts
@@ -28,6 +28,7 @@ import { RolesGuard } from "./guards/roles.guard";
 import { ConfigModule } from "@sims/utilities/config";
 import { SFASIndividualService } from "@sims/services/sfas";
 import { DisbursementOverawardService } from "@sims/services";
+import { NoteSharedService } from "@sims/services/note/note.shared.service";
 
 const jwtModule = JwtModule.register({
   publicKey: KeycloakConfig.PEM_PublicKey,
@@ -47,6 +48,7 @@ const jwtModule = JwtModule.register({
     SINValidationService,
     DesignationAgreementLocationService,
     DisbursementOverawardService,
+    NoteSharedService,
     {
       provide: APP_GUARD,
       useClass: JwtAuthGuard,

--- a/sources/packages/backend/apps/api/src/route-controllers/note/_tests_/e2e/note.aest.controller.addStudentNote.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/note/_tests_/e2e/note.aest.controller.addStudentNote.e2e-spec.ts
@@ -104,7 +104,7 @@ describe("NoteAESTController(e2e)-addStudentNotes", () => {
       .expect({
         statusCode: HttpStatus.BAD_REQUEST,
         message: [
-          "noteType must be one of the following values: General, Application, Program, Restriction, Designation, System Actions",
+          "noteType must be one of the following values: General, Application, Program, Restriction, Designation, Overaward, System Actions",
         ],
         error: "Bad Request",
       });

--- a/sources/packages/backend/apps/api/src/route-controllers/overaward/_tests_/e2e/overaward.aest.controller.addManualOveraward.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/overaward/_tests_/e2e/overaward.aest.controller.addManualOveraward.e2e-spec.ts
@@ -44,10 +44,10 @@ describe("OverawardAESTController(e2e)-addManualOveraward", () => {
 
     const updatedStudent = await studentRepo.findOne({
       select: { notes: true },
-      where: { id: student.id },
       relations: { notes: true },
+      where: { id: student.id },
     });
-    const createdNote = updatedStudent.notes[0];
+    const [createdNote] = updatedStudent.notes;
     expect(createdNote.noteType).toBe(NoteType.Overaward);
     expect(createdNote.description).toBe(manualOverawardPayload.overawardNotes);
   });

--- a/sources/packages/backend/apps/api/src/route-controllers/overaward/_tests_/e2e/overaward.aest.controller.addManualOveraward.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/overaward/_tests_/e2e/overaward.aest.controller.addManualOveraward.e2e-spec.ts
@@ -2,7 +2,7 @@ import { HttpStatus, INestApplication } from "@nestjs/common";
 import * as request from "supertest";
 import { createFakeStudent } from "@sims/test-utils";
 import { Repository } from "typeorm";
-import { Student } from "@sims/sims-db";
+import { NoteType, Student } from "@sims/sims-db";
 
 import {
   AESTGroups,
@@ -41,6 +41,15 @@ describe("OverawardAESTController(e2e)-addManualOveraward", () => {
         BEARER_AUTH_TYPE,
       )
       .expect(HttpStatus.CREATED);
+
+    const updatedStudent = await studentRepo.findOne({
+      select: { notes: true },
+      where: { id: student.id },
+      relations: { notes: true },
+    });
+    const createdNote = updatedStudent.notes[0];
+    expect(createdNote.noteType).toBe(NoteType.Overaward);
+    expect(createdNote.description).toBe(manualOverawardPayload.overawardNotes);
   });
 
   it("Should throw forbidden error when AEST user does not belong to business-administrators group", async () => {

--- a/sources/packages/backend/apps/api/src/route-controllers/overaward/_tests_/e2e/overaward.aest.controller.addManualOveraward.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/overaward/_tests_/e2e/overaward.aest.controller.addManualOveraward.e2e-spec.ts
@@ -18,6 +18,7 @@ describe("OverawardAESTController(e2e)-addManualOveraward", () => {
   const manualOverawardPayload: OverawardManualRecordAPIInDTO = {
     awardValueCode: "CSLF",
     overawardValue: -300,
+    overawardNotes: "Overaward notes...",
   };
 
   beforeAll(async () => {

--- a/sources/packages/backend/apps/api/src/route-controllers/overaward/_tests_/e2e/overaward.aest.controller.addManualOveraward.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/overaward/_tests_/e2e/overaward.aest.controller.addManualOveraward.e2e-spec.ts
@@ -2,7 +2,7 @@ import { HttpStatus, INestApplication } from "@nestjs/common";
 import * as request from "supertest";
 import { createFakeStudent } from "@sims/test-utils";
 import { Repository } from "typeorm";
-import { NoteType, Student } from "@sims/sims-db";
+import { DisbursementOveraward, NoteType, Student } from "@sims/sims-db";
 
 import {
   AESTGroups,
@@ -15,6 +15,8 @@ import { OverawardManualRecordAPIInDTO } from "../../models/overaward.dto";
 describe("OverawardAESTController(e2e)-addManualOveraward", () => {
   let app: INestApplication;
   let studentRepo: Repository<Student>;
+  let disbursementOverawardRepo: Repository<DisbursementOveraward>;
+
   const manualOverawardPayload: OverawardManualRecordAPIInDTO = {
     awardValueCode: "CSLF",
     overawardValue: -300,
@@ -25,6 +27,7 @@ describe("OverawardAESTController(e2e)-addManualOveraward", () => {
     const { nestApplication, dataSource } = await createTestingAppModule();
     app = nestApplication;
     studentRepo = dataSource.getRepository(Student);
+    disbursementOverawardRepo = dataSource.getRepository(DisbursementOveraward);
   });
 
   it("Should create manual overaward when AEST user belong to business-administrators group", async () => {
@@ -33,7 +36,7 @@ describe("OverawardAESTController(e2e)-addManualOveraward", () => {
     const endpoint = `/aest/overaward/student/${student.id}`;
 
     // Act/Assert
-    await request(app.getHttpServer())
+    const overawardResponse = await request(app.getHttpServer())
       .post(endpoint)
       .send(manualOverawardPayload)
       .auth(
@@ -42,14 +45,19 @@ describe("OverawardAESTController(e2e)-addManualOveraward", () => {
       )
       .expect(HttpStatus.CREATED);
 
-    const updatedStudent = await studentRepo.findOne({
-      select: { notes: true },
-      relations: { notes: true },
-      where: { id: student.id },
+    const overawardCreated = await disbursementOverawardRepo.findOne({
+      select: {
+        id: true,
+        overawardNotes: { noteType: true, description: true },
+      },
+      relations: { overawardNotes: true },
+      where: { id: overawardResponse.body.id },
     });
-    const [createdNote] = updatedStudent.notes;
-    expect(createdNote.noteType).toBe(NoteType.Overaward);
-    expect(createdNote.description).toBe(manualOverawardPayload.overawardNotes);
+
+    expect(overawardCreated.overawardNotes.noteType).toBe(NoteType.Overaward);
+    expect(overawardCreated.overawardNotes.description).toBe(
+      manualOverawardPayload.overawardNotes,
+    );
   });
 
   it("Should throw forbidden error when AEST user does not belong to business-administrators group", async () => {

--- a/sources/packages/backend/apps/api/src/route-controllers/overaward/_tests_/e2e/overaward.aest.controller.getOverawardsByStudent.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/overaward/_tests_/e2e/overaward.aest.controller.getOverawardsByStudent.e2e-spec.ts
@@ -100,6 +100,8 @@ describe("OverawardAESTController(e2e)-getOverawardsByStudent", () => {
     reassessmentOveraward.overawardValue = 500;
     reassessmentOveraward.originType =
       DisbursementOverawardOriginType.ReassessmentOveraward;
+    reassessmentOveraward.addedBy = user;
+    reassessmentOveraward.addedDate = new Date();
     await disbursementOverawardRepo.save(reassessmentOveraward);
     const endpoint = `/aest/overaward/student/${student.id}`;
 
@@ -115,13 +117,13 @@ describe("OverawardAESTController(e2e)-getOverawardsByStudent", () => {
         expect(response.body).toHaveLength(1);
         const [overaward] = response.body as OverawardAPIOutDTO[];
         expect(overaward.dateAdded).toBe(
-          reassessmentOveraward.createdAt.toISOString(),
+          reassessmentOveraward.addedDate.toISOString(),
         );
         expect(overaward.overawardOrigin).toBe(
           DisbursementOverawardOriginType.ReassessmentOveraward,
         );
         expect(overaward.addedByUser).toBe(
-          getUserFullName(reassessmentOveraward.creator),
+          getUserFullName(reassessmentOveraward.addedBy),
         );
         expect(overaward.applicationNumber).toBe(application.applicationNumber);
         expect(overaward.assessmentTriggerType).toBe(

--- a/sources/packages/backend/apps/api/src/route-controllers/overaward/models/overaward.dto.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/overaward/models/overaward.dto.ts
@@ -1,12 +1,20 @@
 import {
   AssessmentTriggerType,
   DisbursementOverawardOriginType,
+  NOTE_DESCRIPTION_MAX_LENGTH,
 } from "@sims/sims-db";
 import {
   AWARD_VALUE_CODE_LENGTH,
   MONEY_VALUE_FOR_UNKNOWN_MAX_VALUE,
 } from "../../../utilities";
-import { Length, Max, Min, NotEquals } from "class-validator";
+import {
+  Length,
+  Max,
+  Min,
+  NotEquals,
+  IsNotEmpty,
+  MaxLength,
+} from "class-validator";
 
 export class OverawardBalanceAPIOutDTO {
   overawardBalanceValues: Record<string, number>;
@@ -29,4 +37,7 @@ export class OverawardManualRecordAPIInDTO {
   @Max(MONEY_VALUE_FOR_UNKNOWN_MAX_VALUE)
   @NotEquals(0)
   overawardValue: number;
+  @IsNotEmpty()
+  @MaxLength(NOTE_DESCRIPTION_MAX_LENGTH)
+  overawardNotes: string;
 }

--- a/sources/packages/backend/apps/api/src/route-controllers/overaward/overaward.aest.controller.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/overaward/overaward.aest.controller.ts
@@ -82,11 +82,11 @@ export class OverawardAESTController extends BaseController {
     const studentOverawards =
       await this.disbursementOverawardService.getOverawardsByStudent(studentId);
     return studentOverawards.map((overaward) => ({
-      dateAdded: overaward.createdAt,
+      dateAdded: overaward.addedDate,
       overawardOrigin: overaward.originType,
       awardValueCode: overaward.disbursementValueCode,
       overawardValue: overaward.overawardValue,
-      addedByUser: getUserFullName(overaward.creator),
+      addedByUser: getUserFullName(overaward.addedBy),
       applicationNumber:
         overaward.studentAssessment?.application.applicationNumber,
       assessmentTriggerType: overaward.studentAssessment?.triggerType,
@@ -117,6 +117,7 @@ export class OverawardAESTController extends BaseController {
       await this.disbursementOverawardService.addManualOveraward(
         payload.awardValueCode,
         payload.overawardValue,
+        payload.overawardNotes,
         studentId,
         userToken.userId,
       );

--- a/sources/packages/backend/apps/api/src/services/restriction/student-restriction.service.ts
+++ b/sources/packages/backend/apps/api/src/services/restriction/student-restriction.service.ts
@@ -14,9 +14,11 @@ import {
 import { DataSource, EntityManager } from "typeorm";
 import { CustomNamedError } from "@sims/utilities";
 import { RestrictionService } from "./restriction.service";
-import { StudentService } from "../student/student.service";
 import { RestrictionCode } from "./models/restriction.model";
-import { StudentRestrictionSharedService } from "@sims/services";
+import {
+  NoteSharedService,
+  StudentRestrictionSharedService,
+} from "@sims/services";
 export const RESTRICTION_NOT_ACTIVE = "RESTRICTION_NOT_ACTIVE";
 export const RESTRICTION_NOT_PROVINCIAL = "RESTRICTION_NOT_PROVINCIAL";
 
@@ -28,7 +30,7 @@ export class StudentRestrictionService extends RecordDataModelService<StudentRes
   constructor(
     readonly dataSource: DataSource,
     private readonly restrictionService: RestrictionService,
-    private readonly studentService: StudentService,
+    private readonly noteSharedService: NoteSharedService,
     private readonly studentRestrictionsService: StudentRestrictionSharedService,
   ) {
     super(dataSource.getRepository(StudentRestriction));
@@ -126,7 +128,7 @@ export class StudentRestrictionService extends RecordDataModelService<StudentRes
     noteDescription: string,
   ): Promise<StudentRestriction> {
     return this.dataSource.transaction(async (transactionalEntityManager) => {
-      const note = await this.studentService.createStudentNote(
+      const note = await this.noteSharedService.createStudentNote(
         studentId,
         NoteType.Restriction,
         noteDescription,
@@ -192,7 +194,7 @@ export class StudentRestrictionService extends RecordDataModelService<StudentRes
       );
     }
     return this.dataSource.transaction(async (transactionalEntityManager) => {
-      const note = await this.studentService.createStudentNote(
+      const note = await this.noteSharedService.createStudentNote(
         studentId,
         NoteType.Restriction,
         noteDescription,

--- a/sources/packages/backend/apps/api/src/services/sin-validation/sin-validation.service.ts
+++ b/sources/packages/backend/apps/api/src/services/sin-validation/sin-validation.service.ts
@@ -9,12 +9,12 @@ import {
 } from "@sims/sims-db";
 import { LoggerService, InjectLogger } from "@sims/utilities/logger";
 import { CustomNamedError } from "@sims/utilities";
-import { StudentService } from "../student/student.service";
 import { removeWhiteSpaces } from "../../utilities";
 import {
   SIN_VALIDATION_RECORD_INVALID_OPERATION,
   SIN_VALIDATION_RECORD_NOT_FOUND,
 } from "../../constants";
+import { NoteSharedService } from "@sims/services";
 
 /**
  * Service layer for SIN Validations.
@@ -23,7 +23,7 @@ import {
 export class SINValidationService extends RecordDataModelService<SINValidation> {
   constructor(
     private readonly dataSource: DataSource,
-    private readonly studentService: StudentService,
+    private readonly noteSharedService: NoteSharedService,
   ) {
     super(dataSource.getRepository(SINValidation));
   }
@@ -77,7 +77,7 @@ export class SINValidationService extends RecordDataModelService<SINValidation> 
   ): Promise<SINValidation> {
     return this.dataSource.transaction(async (transactionalEntityManager) => {
       const auditUser = { id: auditUserId } as User;
-      const savedNote = await this.studentService.createStudentNote(
+      const savedNote = await this.noteSharedService.createStudentNote(
         studentId,
         NoteType.General,
         noteDescription,
@@ -164,7 +164,7 @@ export class SINValidationService extends RecordDataModelService<SINValidation> 
 
       const auditUser = { id: auditUserId } as User;
       const now = new Date();
-      const savedNote = await this.studentService.createStudentNote(
+      const savedNote = await this.noteSharedService.createStudentNote(
         studentId,
         NoteType.General,
         noteDescription,

--- a/sources/packages/backend/apps/test-db-seeding/src/db-seeding/aest/basic-seeding/create-aest-users.ts
+++ b/sources/packages/backend/apps/test-db-seeding/src/db-seeding/aest/basic-seeding/create-aest-users.ts
@@ -1,0 +1,49 @@
+import { Injectable } from "@nestjs/common";
+import { InjectRepository } from "@nestjs/typeorm";
+import { User } from "@sims/sims-db";
+import { createFakeUser } from "@sims/test-utils";
+import {
+  DataSeed,
+  DataSeedMethod,
+  SeedPriorityOrder,
+} from "../../../seed-executors";
+import { Repository } from "typeorm";
+import * as faker from "faker";
+
+@Injectable()
+@DataSeed({ order: SeedPriorityOrder.Priority1 })
+export class CreateAESTUsers {
+  constructor(
+    @InjectRepository(User)
+    private readonly userRepo: Repository<User>,
+  ) {}
+
+  /**
+   * Create AEST users used for tests.
+   */
+  @DataSeedMethod()
+  private async createAESTUsers(): Promise<void> {
+    await this.createAESTUser(
+      process.env.E2E_TEST_AEST_BUSINESS_ADMINISTRATORS_USER,
+    );
+    await this.createAESTUser(process.env.E2E_TEST_AEST_OPERATIONS_USER);
+    await this.createAESTUser(
+      process.env.E2E_TEST_AEST_OPERATIONS_ADMINISTRATORS_USER,
+    );
+    await this.createAESTUser(process.env.E2E_TEST_AEST_MOF_OPERATIONS_USER);
+    await this.createAESTUser(process.env.E2E_TEST_AEST_READ_ONLY_USER);
+  }
+
+  /**
+   * Create a fake AEST user persisted in the DB.
+   * @param userName username of the AEST user to be created.
+   */
+  private async createAESTUser(userName: string): Promise<void> {
+    // Create fake user.
+    const fakeUser = createFakeUser(userName);
+    fakeUser.firstName = faker.name.firstName();
+    fakeUser.lastName = faker.name.firstName();
+    // Save user to DB.
+    await this.userRepo.save(fakeUser);
+  }
+}

--- a/sources/packages/backend/apps/test-db-seeding/src/db-seeding/aest/basic-seeding/create-aest-users.ts
+++ b/sources/packages/backend/apps/test-db-seeding/src/db-seeding/aest/basic-seeding/create-aest-users.ts
@@ -8,7 +8,6 @@ import {
   SeedPriorityOrder,
 } from "../../../seed-executors";
 import { Repository } from "typeorm";
-import * as faker from "faker";
 
 @Injectable()
 @DataSeed({ order: SeedPriorityOrder.Priority1 })

--- a/sources/packages/backend/apps/test-db-seeding/src/db-seeding/aest/basic-seeding/create-aest-users.ts
+++ b/sources/packages/backend/apps/test-db-seeding/src/db-seeding/aest/basic-seeding/create-aest-users.ts
@@ -22,16 +22,29 @@ export class CreateAESTUsers {
    * Create AEST users used for tests.
    */
   @DataSeedMethod()
-  private async createAESTUsers(): Promise<void> {
-    await this.createAESTUser(
+  async createAESTUsers(): Promise<void> {
+    const businessAdministratorsUserPromise = this.createAESTUser(
       process.env.E2E_TEST_AEST_BUSINESS_ADMINISTRATORS_USER,
     );
-    await this.createAESTUser(process.env.E2E_TEST_AEST_OPERATIONS_USER);
-    await this.createAESTUser(
+    const operationsUserPromise = this.createAESTUser(
+      process.env.E2E_TEST_AEST_OPERATIONS_USER,
+    );
+    const operationsAdministratorsUserPromise = this.createAESTUser(
       process.env.E2E_TEST_AEST_OPERATIONS_ADMINISTRATORS_USER,
     );
-    await this.createAESTUser(process.env.E2E_TEST_AEST_MOF_OPERATIONS_USER);
-    await this.createAESTUser(process.env.E2E_TEST_AEST_READ_ONLY_USER);
+    const mofOperationsUserPromise = this.createAESTUser(
+      process.env.E2E_TEST_AEST_MOF_OPERATIONS_USER,
+    );
+    const readOnlyUserPromise = this.createAESTUser(
+      process.env.E2E_TEST_AEST_READ_ONLY_USER,
+    );
+    await Promise.all([
+      businessAdministratorsUserPromise,
+      operationsUserPromise,
+      operationsAdministratorsUserPromise,
+      mofOperationsUserPromise,
+      readOnlyUserPromise,
+    ]);
   }
 
   /**
@@ -41,9 +54,7 @@ export class CreateAESTUsers {
   private async createAESTUser(userName: string): Promise<void> {
     // Create fake user.
     const fakeUser = createFakeUser(userName);
-    fakeUser.firstName = faker.name.firstName();
-    fakeUser.lastName = faker.name.firstName();
     // Save user to DB.
-    await this.userRepo.save(fakeUser);
+    this.userRepo.save(fakeUser);
   }
 }

--- a/sources/packages/backend/apps/test-db-seeding/src/db-seeding/aest/basic-seeding/create-aest-users.ts
+++ b/sources/packages/backend/apps/test-db-seeding/src/db-seeding/aest/basic-seeding/create-aest-users.ts
@@ -50,10 +50,10 @@ export class CreateAESTUsers {
    * Create a fake AEST user persisted in the DB.
    * @param userName username of the AEST user to be created.
    */
-  private async createAESTUser(userName: string): Promise<void> {
+  private async createAESTUser(userName: string): Promise<User> {
     // Create fake user.
     const fakeUser = createFakeUser(userName);
     // Save user to DB.
-    this.userRepo.save(fakeUser);
+    return this.userRepo.save(fakeUser);
   }
 }

--- a/sources/packages/backend/apps/test-db-seeding/src/db-seeding/aest/index.ts
+++ b/sources/packages/backend/apps/test-db-seeding/src/db-seeding/aest/index.ts
@@ -1,0 +1,1 @@
+export * from "./basic-seeding/create-aest-users";

--- a/sources/packages/backend/apps/test-db-seeding/src/test-db-seeding.module.ts
+++ b/sources/packages/backend/apps/test-db-seeding/src/test-db-seeding.module.ts
@@ -14,6 +14,7 @@ import {
   UserTypeRoleHelperService,
 } from "./services";
 import { ConfigModule } from "@sims/utilities/config";
+import { CreateAESTUsers } from "./db-seeding/aest";
 
 @Module({
   imports: [DatabaseModule, ConfigModule],
@@ -27,6 +28,7 @@ import { ConfigModule } from "@sims/utilities/config";
     InstitutionHelperService,
     UserTypeRoleHelperService,
     CreateInstitutionsAndAuthenticationUsers,
+    CreateAESTUsers,
   ],
 })
 export class TestDbSeedingModule {}

--- a/sources/packages/backend/apps/workers/src/workers.module.ts
+++ b/sources/packages/backend/apps/workers/src/workers.module.ts
@@ -24,6 +24,7 @@ import {
   ZeebeModule,
   DisbursementOverawardService,
   NotificationsModule,
+  NoteSharedService,
 } from "@sims/services";
 import { LoggerModule } from "@sims/utilities/logger";
 import { ConfigModule } from "@sims/utilities/config";
@@ -58,6 +59,7 @@ import { SystemUserModule } from "@sims/services/system-users";
     SequenceControlService,
     MSFAANumberService,
     DisbursementOverawardService,
+    NoteSharedService,
   ],
 })
 export class WorkersModule {}

--- a/sources/packages/backend/libs/integrations/src/esdc-integration/e-cert-integration/e-cert-integration.module.ts
+++ b/sources/packages/backend/libs/integrations/src/esdc-integration/e-cert-integration/e-cert-integration.module.ts
@@ -3,6 +3,7 @@ import {
   DisbursementOverawardService,
   SequenceControlService,
   StudentRestrictionSharedService,
+  NoteSharedService,
 } from "@sims/services";
 import { ECertFileHandler } from "./e-cert-file-handler";
 import { ECertFullTimeFileFooter } from "./e-cert-full-time-integration/e-cert-files/e-cert-file-footer";
@@ -40,6 +41,7 @@ import { SystemUsersService } from "@sims/services/system-users";
     StudentRestrictionSharedService,
     ECertGenerationService,
     DisbursementOverawardService,
+    NoteSharedService,
   ],
   exports: [ECertFileHandler],
 })

--- a/sources/packages/backend/libs/services/src/disbursement-overaward/disbursement-overaward.service.ts
+++ b/sources/packages/backend/libs/services/src/disbursement-overaward/disbursement-overaward.service.ts
@@ -147,32 +147,32 @@ export class DisbursementOverawardService {
     studentId: number,
     auditUserId: number,
   ): Promise<DisbursementOveraward> {
-    let persistedOverawardManualRecord = null;
-    await this.dataSource.transaction(async (transactionalEntityManager) => {
-      // Create the note for the overaward and associate the note with the student.
-      const noteEntity = await this.noteSharedService.createStudentNote(
-        studentId,
-        NoteType.Overaward,
-        overawardNotes,
-        auditUserId,
-        transactionalEntityManager,
-      );
+    return await this.dataSource.transaction(
+      async (transactionalEntityManager) => {
+        // Create the note for the overaward and associate the note with the student.
+        const noteEntity = await this.noteSharedService.createStudentNote(
+          studentId,
+          NoteType.Overaward,
+          overawardNotes,
+          auditUserId,
+          transactionalEntityManager,
+        );
 
-      // Save disbursement overaward record.
-      const overawardManualRecord = new DisbursementOveraward();
-      overawardManualRecord.creator = { id: auditUserId } as User;
-      overawardManualRecord.disbursementValueCode = awardValueCode;
-      overawardManualRecord.overawardValue = overawardValue;
-      overawardManualRecord.originType =
-        DisbursementOverawardOriginType.ManualRecord;
-      overawardManualRecord.student = { id: studentId } as Student;
-      overawardManualRecord.overawardNotes = noteEntity;
-      overawardManualRecord.addedBy = { id: auditUserId } as User;
-      overawardManualRecord.addedDate = new Date();
-      persistedOverawardManualRecord = await transactionalEntityManager
-        .getRepository(DisbursementOveraward)
-        .save(overawardManualRecord);
-    });
-    return persistedOverawardManualRecord;
+        // Save disbursement overaward record.
+        const overawardManualRecord = new DisbursementOveraward();
+        overawardManualRecord.creator = { id: auditUserId } as User;
+        overawardManualRecord.disbursementValueCode = awardValueCode;
+        overawardManualRecord.overawardValue = overawardValue;
+        overawardManualRecord.originType =
+          DisbursementOverawardOriginType.ManualRecord;
+        overawardManualRecord.student = { id: studentId } as Student;
+        overawardManualRecord.overawardNotes = noteEntity;
+        overawardManualRecord.addedBy = { id: auditUserId } as User;
+        overawardManualRecord.addedDate = new Date();
+        return await transactionalEntityManager
+          .getRepository(DisbursementOveraward)
+          .save(overawardManualRecord);
+      },
+    );
   }
 }

--- a/sources/packages/backend/libs/services/src/disbursement-overaward/disbursement-overaward.service.ts
+++ b/sources/packages/backend/libs/services/src/disbursement-overaward/disbursement-overaward.service.ts
@@ -105,11 +105,9 @@ export class DisbursementOverawardService {
   ): Promise<DisbursementOveraward[]> {
     return this.disbursementOverawardRepo.find({
       select: {
-        createdAt: true,
         originType: true,
         overawardValue: true,
         disbursementValueCode: true,
-        creator: { firstName: true, lastName: true },
         studentAssessment: {
           id: true,
           application: { applicationNumber: true },

--- a/sources/packages/backend/libs/services/src/disbursement-overaward/disbursement-overaward.service.ts
+++ b/sources/packages/backend/libs/services/src/disbursement-overaward/disbursement-overaward.service.ts
@@ -115,10 +115,13 @@ export class DisbursementOverawardService {
           application: { applicationNumber: true },
           triggerType: true,
         },
+        addedBy: { firstName: true, lastName: true },
+        addedDate: true,
       },
       relations: {
         creator: true,
         studentAssessment: { application: true },
+        addedBy: true,
       },
       where: {
         student: { id: studentId },

--- a/sources/packages/backend/libs/services/src/disbursement-overaward/disbursement-overaward.service.ts
+++ b/sources/packages/backend/libs/services/src/disbursement-overaward/disbursement-overaward.service.ts
@@ -1,8 +1,9 @@
 import { Injectable } from "@nestjs/common";
-import { EntityManager, Repository } from "typeorm";
+import { EntityManager, Repository, DataSource } from "typeorm";
 import {
   DisbursementOveraward,
   DisbursementOverawardOriginType,
+  NoteType,
   Student,
   User,
 } from "@sims/sims-db";
@@ -11,6 +12,7 @@ import {
   StudentOverawardBalance,
 } from "./disbursement-overaward.models";
 import { InjectRepository } from "@nestjs/typeorm";
+import { NoteSharedService } from "../note/note.shared.service";
 
 /**
  * Service layer for Student Application disbursement schedules.
@@ -18,6 +20,8 @@ import { InjectRepository } from "@nestjs/typeorm";
 @Injectable()
 export class DisbursementOverawardService {
   constructor(
+    private readonly dataSource: DataSource,
+    private readonly noteSharedService: NoteSharedService,
     @InjectRepository(DisbursementOveraward)
     private readonly disbursementOverawardRepo: Repository<DisbursementOveraward>,
   ) {}
@@ -136,16 +140,36 @@ export class DisbursementOverawardService {
   async addManualOveraward(
     awardValueCode: string,
     overawardValue: number,
+    overawardNotes: string,
     studentId: number,
     auditUserId: number,
   ): Promise<DisbursementOveraward> {
-    const overawardManualRecord = new DisbursementOveraward();
-    overawardManualRecord.creator = { id: auditUserId } as User;
-    overawardManualRecord.disbursementValueCode = awardValueCode;
-    overawardManualRecord.overawardValue = overawardValue;
-    overawardManualRecord.originType =
-      DisbursementOverawardOriginType.ManualRecord;
-    overawardManualRecord.student = { id: studentId } as Student;
-    return this.disbursementOverawardRepo.save(overawardManualRecord);
+    let persistedOverawardManualRecord = null;
+    await this.dataSource.transaction(async (transactionalEntityManager) => {
+      // Create the note for the overaward and associate the note with the student.
+      const noteEntity = await this.noteSharedService.createStudentNote(
+        studentId,
+        NoteType.Overaward,
+        overawardNotes,
+        auditUserId,
+        transactionalEntityManager,
+      );
+
+      // Save disbursement overaward record.
+      const overawardManualRecord = new DisbursementOveraward();
+      overawardManualRecord.creator = { id: auditUserId } as User;
+      overawardManualRecord.disbursementValueCode = awardValueCode;
+      overawardManualRecord.overawardValue = overawardValue;
+      overawardManualRecord.originType =
+        DisbursementOverawardOriginType.ManualRecord;
+      overawardManualRecord.student = { id: studentId } as Student;
+      overawardManualRecord.overawardNotes = noteEntity;
+      overawardManualRecord.addedBy = { id: auditUserId } as User;
+      overawardManualRecord.addedDate = new Date();
+      persistedOverawardManualRecord = await transactionalEntityManager
+        .getRepository(DisbursementOveraward)
+        .save(overawardManualRecord);
+    });
+    return persistedOverawardManualRecord;
   }
 }

--- a/sources/packages/backend/libs/services/src/disbursement-overaward/disbursement-overaward.service.ts
+++ b/sources/packages/backend/libs/services/src/disbursement-overaward/disbursement-overaward.service.ts
@@ -117,7 +117,6 @@ export class DisbursementOverawardService {
         addedDate: true,
       },
       relations: {
-        creator: true,
         studentAssessment: { application: true },
         addedBy: true,
       },

--- a/sources/packages/backend/libs/services/src/index.ts
+++ b/sources/packages/backend/libs/services/src/index.ts
@@ -18,3 +18,4 @@ export * from "./report/report.models";
 export * from "./report/report.service";
 export * from "./sin-validation/models/sin-validation-models";
 export * from "./confirmation-of-enrollment/confirmation-of-enrollment.service";
+export * from "./note/note.shared.service";

--- a/sources/packages/backend/libs/services/src/note/note.shared.service.ts
+++ b/sources/packages/backend/libs/services/src/note/note.shared.service.ts
@@ -1,0 +1,43 @@
+import { Injectable } from "@nestjs/common";
+import { Note, NoteType, Student, User } from "@sims/sims-db";
+import { EntityManager } from "typeorm";
+
+/**
+ * Shared service layer for Note.
+ */
+@Injectable()
+export class NoteSharedService {
+  /**
+   * Creates a new note and associate it with the student.
+   * This method is most likely to be used alongside with some other
+   * DB data changes and must be executed in a DB transaction.
+   * @param studentId student to have the note associated.
+   * @param noteType note type.
+   * @param noteDescription note description.
+   * @param auditUserId user that should be considered the one that is causing the changes.
+   * @param entityManager transactional entity manager.
+   */
+  async createStudentNote(
+    studentId: number,
+    noteType: NoteType,
+    noteDescription: string,
+    auditUserId: number,
+    entityManager: EntityManager,
+  ): Promise<Note> {
+    const auditUser = { id: auditUserId } as User;
+    // Create the note to be associated with the student.
+    const newNote = new Note();
+    newNote.description = noteDescription;
+    newNote.noteType = noteType;
+    newNote.creator = auditUser;
+    const savedNote = await entityManager.getRepository(Note).save(newNote);
+    // Associate the created note with the student.
+    await entityManager
+      .getRepository(Student)
+      .createQueryBuilder()
+      .relation(Student, "notes")
+      .of({ id: studentId } as Student)
+      .add(savedNote);
+    return newNote;
+  }
+}

--- a/sources/packages/backend/libs/services/src/note/note.shared.service.ts
+++ b/sources/packages/backend/libs/services/src/note/note.shared.service.ts
@@ -16,6 +16,7 @@ export class NoteSharedService {
    * @param noteDescription note description.
    * @param auditUserId user that should be considered the one that is causing the changes.
    * @param entityManager transactional entity manager.
+   * @returns note created for the student.
    */
   async createStudentNote(
     studentId: number,
@@ -38,6 +39,6 @@ export class NoteSharedService {
       .relation(Student, "notes")
       .of({ id: studentId } as Student)
       .add(savedNote);
-    return newNote;
+    return savedNote;
   }
 }

--- a/sources/packages/backend/libs/sims-db/src/entities/disbursement-overaward.model.ts
+++ b/sources/packages/backend/libs/sims-db/src/entities/disbursement-overaward.model.ts
@@ -103,28 +103,28 @@ export class DisbursementOveraward extends RecordDataModel {
   /**
    * Note entered during manual overaward record added.
    */
-  @OneToOne(() => Note, { eager: false, cascade: true })
+  @OneToOne(() => Note, { eager: false, cascade: true, nullable: true })
   @JoinColumn({
     name: "note_id",
     referencedColumnName: ColumnNames.ID,
   })
-  overawardNotes: Note;
-
+  overawardNotes?: Note;
   /**
    * User who added overaward manual record.
    */
-  @OneToOne(() => User, { eager: true, cascade: true })
+  @ManyToOne(() => User, { eager: false, cascade: false, nullable: true })
   @JoinColumn({
     name: "added_by",
-    referencedColumnName: "id",
+    referencedColumnName: ColumnNames.ID,
   })
-  addedBy: User;
-
+  addedBy?: User;
   /**
    * Date when the manual record was added.
    */
   @Column({
     name: "added_date",
+    type: "timestamptz",
+    nullable: true,
   })
   addedDate?: Date;
 }

--- a/sources/packages/backend/libs/sims-db/src/entities/disbursement-overaward.model.ts
+++ b/sources/packages/backend/libs/sims-db/src/entities/disbursement-overaward.model.ts
@@ -5,6 +5,7 @@ import {
   JoinColumn,
   ManyToOne,
   PrimaryGeneratedColumn,
+  OneToOne,
 } from "typeorm";
 import {
   DisbursementOverawardOriginType,
@@ -12,6 +13,8 @@ import {
   RecordDataModel,
   Student,
   StudentAssessment,
+  Note,
+  User,
 } from ".";
 import { ColumnNames, TableNames } from "../constant";
 import { numericTransformer } from "../transformers/numeric.transformer";
@@ -97,4 +100,31 @@ export class DisbursementOveraward extends RecordDataModel {
     nullable: true,
   })
   deletedAt?: Date;
+  /**
+   * Note entered during manual overaward record added.
+   */
+  @OneToOne(() => Note, { eager: false, cascade: true })
+  @JoinColumn({
+    name: "note_id",
+    referencedColumnName: ColumnNames.ID,
+  })
+  overawardNotes: Note;
+
+  /**
+   * User who added overaward manual record.
+   */
+  @OneToOne(() => User, { eager: true, cascade: true })
+  @JoinColumn({
+    name: "added_by",
+    referencedColumnName: "id",
+  })
+  addedBy: User;
+
+  /**
+   * Date when the manual record was added.
+   */
+  @Column({
+    name: "added_date",
+  })
+  addedDate?: Date;
 }

--- a/sources/packages/backend/libs/sims-db/src/entities/disbursement-overaward.model.ts
+++ b/sources/packages/backend/libs/sims-db/src/entities/disbursement-overaward.model.ts
@@ -103,7 +103,7 @@ export class DisbursementOveraward extends RecordDataModel {
   /**
    * Note entered during manual overaward record added.
    */
-  @OneToOne(() => Note, { eager: false, cascade: true, nullable: true })
+  @OneToOne(() => Note, { eager: false, cascade: false, nullable: true })
   @JoinColumn({
     name: "note_id",
     referencedColumnName: ColumnNames.ID,

--- a/sources/packages/backend/libs/sims-db/src/entities/note.type.ts
+++ b/sources/packages/backend/libs/sims-db/src/entities/note.type.ts
@@ -23,6 +23,10 @@ export enum NoteType {
    */
   Designation = "Designation",
   /**
+   * Note type Overaward.
+   */
+  Overaward = "Overaward",
+  /**
    * Note type System.
    */
   System = "System Actions",

--- a/sources/packages/backend/libs/test-utils/src/factories/disbursement-overaward.ts
+++ b/sources/packages/backend/libs/test-utils/src/factories/disbursement-overaward.ts
@@ -5,6 +5,7 @@ import {
   ProgramYear,
   Student,
   StudentAssessment,
+  User,
 } from "@sims/sims-db";
 import * as faker from "faker";
 
@@ -13,6 +14,8 @@ export function createFakeDisbursementOveraward(relations?: {
   programYear?: ProgramYear;
   studentAssessment?: StudentAssessment;
   disbursementSchedule?: DisbursementSchedule;
+  addedBy?: User;
+  addedDate?: Date;
 }): DisbursementOveraward {
   const disbursementOveraward = new DisbursementOveraward();
   disbursementOveraward.student = relations?.student;
@@ -30,5 +33,7 @@ export function createFakeDisbursementOveraward(relations?: {
   disbursementOveraward.originType =
     DisbursementOverawardOriginType.ManualRecord;
   disbursementOveraward.deletedAt = null;
+  disbursementOveraward.addedBy = relations.addedBy;
+  disbursementOveraward.addedDate = relations.addedDate;
   return disbursementOveraward;
 }

--- a/sources/packages/backend/libs/test-utils/src/factories/disbursement-overaward.ts
+++ b/sources/packages/backend/libs/test-utils/src/factories/disbursement-overaward.ts
@@ -15,7 +15,6 @@ export function createFakeDisbursementOveraward(relations?: {
   studentAssessment?: StudentAssessment;
   disbursementSchedule?: DisbursementSchedule;
   addedBy?: User;
-  addedDate?: Date;
 }): DisbursementOveraward {
   const disbursementOveraward = new DisbursementOveraward();
   disbursementOveraward.student = relations?.student;
@@ -34,6 +33,6 @@ export function createFakeDisbursementOveraward(relations?: {
     DisbursementOverawardOriginType.ManualRecord;
   disbursementOveraward.deletedAt = null;
   disbursementOveraward.addedBy = relations?.addedBy;
-  disbursementOveraward.addedDate = relations?.addedDate;
+  disbursementOveraward.addedDate = null;
   return disbursementOveraward;
 }

--- a/sources/packages/backend/libs/test-utils/src/factories/disbursement-overaward.ts
+++ b/sources/packages/backend/libs/test-utils/src/factories/disbursement-overaward.ts
@@ -33,7 +33,7 @@ export function createFakeDisbursementOveraward(relations?: {
   disbursementOveraward.originType =
     DisbursementOverawardOriginType.ManualRecord;
   disbursementOveraward.deletedAt = null;
-  disbursementOveraward.addedBy = relations.addedBy;
-  disbursementOveraward.addedDate = relations.addedDate;
+  disbursementOveraward.addedBy = relations?.addedBy;
+  disbursementOveraward.addedDate = relations?.addedDate;
   return disbursementOveraward;
 }

--- a/sources/packages/backend/package.json
+++ b/sources/packages/backend/package.json
@@ -22,7 +22,7 @@
     "test:watch": "jest --watch ",
     "test:cov": "cross-env ENVIRONMENT=test jest --coverage --forceExit",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
-    "test:e2e:api": "npm run db:seed:test filter=CreateInstitutionsAndAuthenticationUsers && cross-env ENVIRONMENT=test jest --collect-coverage --verbose --config ./apps/api/test/jest-e2e.json --forceExit",
+    "test:e2e:api": "npm run db:seed:test filter=CreateInstitutionsAndAuthenticationUsers,CreateAESTUsers && cross-env ENVIRONMENT=test jest --collect-coverage --verbose --config ./apps/api/test/jest-e2e.json --forceExit",
     "test:e2e:api:local": "cross-env ENVIRONMENT=test jest --config ./apps/api/test/jest-e2e.json --forceExit",
     "test:e2e:workers": "npm run migration:run && cross-env ENVIRONMENT=test jest --collect-coverage --verbose --config ./apps/workers/test/jest-e2e.json --forceExit",
     "test:e2e:queue-consumers": "npm run migration:run && cross-env ENVIRONMENT=test jest --collect-coverage --verbose --config ./apps/queue-consumers/test/jest-e2e.json --forceExit",

--- a/sources/packages/web/src/components/aest/students/modals/AddManualOverawardDeduction.vue
+++ b/sources/packages/web/src/components/aest/students/modals/AddManualOverawardDeduction.vue
@@ -41,7 +41,7 @@
           v-model="formModel.overawardNotes"
           variant="outlined"
           label="Notes"
-          :rules="[checkNotesLengthRule]"
+          :rules="[(v) => checkNotesLengthRule(v, 'Notes')]"
           required
           class="mt-4 mb-n4"
         ></v-textarea>

--- a/sources/packages/web/src/components/aest/students/modals/AddManualOverawardDeduction.vue
+++ b/sources/packages/web/src/components/aest/students/modals/AddManualOverawardDeduction.vue
@@ -40,8 +40,8 @@
         <v-textarea
           v-model="formModel.overawardNotes"
           variant="outlined"
-          label="Notes"
-          :rules="[(v) => checkNotesLengthRule(v, 'Notes')]"
+          label="Note"
+          :rules="[checkNotesLengthRule]"
           required
           class="mt-4"
           hide-details="auto"

--- a/sources/packages/web/src/components/aest/students/modals/AddManualOverawardDeduction.vue
+++ b/sources/packages/web/src/components/aest/students/modals/AddManualOverawardDeduction.vue
@@ -43,7 +43,8 @@
           label="Notes"
           :rules="[(v) => checkNotesLengthRule(v, 'Notes')]"
           required
-          class="mt-4 mb-n4"
+          class="mt-4"
+          hide-details="auto"
         ></v-textarea>
       </template>
       <template #footer>

--- a/sources/packages/web/src/components/aest/students/modals/AddManualOverawardDeduction.vue
+++ b/sources/packages/web/src/components/aest/students/modals/AddManualOverawardDeduction.vue
@@ -37,6 +37,14 @@
               ),
           ]"
         />
+        <v-textarea
+          v-model="formModel.overawardNotes"
+          variant="outlined"
+          label="Notes"
+          :rules="[checkNotesLengthRule]"
+          required
+          class="mt-4 mb-n4"
+        ></v-textarea>
       </template>
       <template #footer>
         <check-permission-role :role="allowedRole">
@@ -78,7 +86,8 @@ export default defineComponent({
     },
   },
   setup() {
-    const { numberRangeRule, checkNullOrEmptyRule } = useRules();
+    const { numberRangeRule, checkNullOrEmptyRule, checkNotesLengthRule } =
+      useRules();
     const { formatCurrency } = useFormatters();
     const { showDialog, showModal, resolvePromise } = useModalDialog<
       OverawardManualRecordAPIInDTO | boolean
@@ -123,6 +132,7 @@ export default defineComponent({
       BannerTypes,
       numberRangeRule,
       checkNullOrEmptyRule,
+      checkNotesLengthRule,
       formatCurrency,
       awardTypeItems,
       MONEY_VALUE_FOR_UNKNOWN_MAX_VALUE,

--- a/sources/packages/web/src/components/common/notes/CreateNoteModal.vue
+++ b/sources/packages/web/src/components/common/notes/CreateNoteModal.vue
@@ -18,7 +18,7 @@
           variant="outlined"
           :rules="[(v) => checkNullOrEmptyRule(v, 'Note type')]" />
         <v-textarea
-          label="Note body"
+          label="Note"
           placeholder="Long text..."
           v-model="formModel.description"
           variant="outlined"

--- a/sources/packages/web/src/composables/useRules.ts
+++ b/sources/packages/web/src/composables/useRules.ts
@@ -11,14 +11,14 @@ export function useRules() {
     return "SIN is required.";
   };
 
-  const checkNotesLengthRule = (notes: string) => {
+  const checkNotesLengthRule = (notes: string, noteTitle?: string) => {
     if (notes) {
       return (
         checkMaxCharacters(notes, NOTES_MAX_CHARACTERS) ||
         `Max ${NOTES_MAX_CHARACTERS} characters.`
       );
     }
-    return "Note body is required.";
+    return `${noteTitle ? noteTitle : "Note body"} is required.`;
   };
 
   const checkStringDateFormatRule = (dateString: string) => {

--- a/sources/packages/web/src/composables/useRules.ts
+++ b/sources/packages/web/src/composables/useRules.ts
@@ -11,14 +11,14 @@ export function useRules() {
     return "SIN is required.";
   };
 
-  const checkNotesLengthRule = (notes: string, noteTitle?: string) => {
+  const checkNotesLengthRule = (notes: string) => {
     if (notes) {
       return (
         checkMaxCharacters(notes, NOTES_MAX_CHARACTERS) ||
         `Max ${NOTES_MAX_CHARACTERS} characters.`
       );
     }
-    return `${noteTitle ? noteTitle : "Note body"} is required.`;
+    return "Note is required.";
   };
 
   const checkStringDateFormatRule = (dateString: string) => {

--- a/sources/packages/web/src/services/OverawardService.ts
+++ b/sources/packages/web/src/services/OverawardService.ts
@@ -53,6 +53,7 @@ export class OverawardService {
     const payloadDeducted: OverawardManualRecordAPIInDTO = {
       awardValueCode: payload.awardValueCode,
       overawardValue: payload.overawardValue * -1,
+      overawardNotes: payload.overawardNotes,
     };
     await ApiClient.OverawardApi.addManualOveraward(studentId, payloadDeducted);
   }

--- a/sources/packages/web/src/services/http/dto/Overaward.dto.ts
+++ b/sources/packages/web/src/services/http/dto/Overaward.dto.ts
@@ -20,4 +20,5 @@ export interface OverawardAPIOutDTO {
 export interface OverawardManualRecordAPIInDTO {
   awardValueCode: string;
   overawardValue: number;
+  overawardNotes: string;
 }

--- a/sources/packages/web/src/types/contracts/NoteContract.ts
+++ b/sources/packages/web/src/types/contracts/NoteContract.ts
@@ -53,6 +53,10 @@ export enum StudentNoteType {
    */
   Restriction = "Restriction",
   /**
+   * Note type Overaward.
+   */
+  Overaward = "Overaward",
+  /**
    * Note type System.
    */
   System = "System Actions",

--- a/testing/src/cypress/page-objects/ministry-objects/InstitutionNoteRestrictionsObject.ts
+++ b/testing/src/cypress/page-objects/ministry-objects/InstitutionNoteRestrictionsObject.ts
@@ -96,7 +96,7 @@ export default class InstitutionNoteRestrictionsObject {
   }
 
   noteBodyErrorMessage() {
-    return cy.contains("Note Body is required");
+    return cy.contains("Note is required");
   }
 
   noteTypeErrorMessage() {

--- a/testing/src/cypress/page-objects/ministry-objects/StudentNoteRestrictionsObject.ts
+++ b/testing/src/cypress/page-objects/ministry-objects/StudentNoteRestrictionsObject.ts
@@ -124,7 +124,7 @@ export default class StudentNoteRestrictionsObject {
   }
 
   noteBodyErrorMessage() {
-    return cy.contains("Note Body is required");
+    return cy.contains("Note is required");
   }
 
   noteAddedSuccessfully() {


### PR DESCRIPTION
- [x]  Added by is currently based on the column creator and now added_by must be used.
- [x] Assign the audit user to added by column while adding manual record
- [x] Update the UI to have notes during add manual overaward process and associate the note with overawards table and student_notes table.

Also:
- Added "Overaward" to StudentNoteType.
- Added DB Seeding to persist AEST users.  

![image](https://user-images.githubusercontent.com/78114138/223821084-f3242c58-72f7-4492-b5d5-d63dec9d09bc.png)
![image](https://user-images.githubusercontent.com/78114138/223823935-9b610614-6668-46bf-9e10-0c3d1cf58e9b.png)
![image](https://user-images.githubusercontent.com/78114138/223824804-b62bc2e2-c380-4ea7-9f11-a0858aef760a.png)
![image](https://user-images.githubusercontent.com/78114138/223824994-0d4b9c0c-f270-4392-b99d-1f6fb1894362.png)

