### PR TITLE
#1683 - Application Completed Status - Progress Tracker (Part 1 of 2)

### DIFF
--- a/sources/packages/backend/apps/api/src/route-controllers/application/application.controller.service.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/application/application.controller.service.ts
@@ -12,6 +12,7 @@ import {
   SuccessWaitingStatus,
   ApplicationIncomeVerification,
   ApplicationSupportingUserDetails,
+  EnrolmentApplicationDetailsAPIOutDTO,
 } from "./models/application.dto";
 import {
   credentialTypeToDisplay,
@@ -137,6 +138,35 @@ export class ApplicationControllerService {
       applicationFormName: application.programYear.formName,
       applicationProgramYearID: application.programYear.id,
     };
+  }
+
+  /**
+   * Convert disbursements into the enrolment DTO with information
+   * about first and second disbursements.
+   * @param disbursementSchedules disbursements to be converted to the DTO.
+   * @returns enrolment DTO.
+   */
+  transformToEnrolmentApplicationDetailsAPIOutDTO(
+    disbursementSchedules: DisbursementSchedule[],
+  ): EnrolmentApplicationDetailsAPIOutDTO {
+    const [firstDisbursement, secondDisbursement] = disbursementSchedules;
+    const details: EnrolmentApplicationDetailsAPIOutDTO = {
+      firstDisbursement: {
+        coeStatus: firstDisbursement.coeStatus,
+        disbursementScheduleStatus:
+          firstDisbursement.disbursementScheduleStatus,
+        coeDenialReason: getCOEDeniedReason(firstDisbursement),
+      },
+    };
+    if (secondDisbursement) {
+      details.secondDisbursement = {
+        coeStatus: secondDisbursement.coeStatus,
+        disbursementScheduleStatus:
+          secondDisbursement.disbursementScheduleStatus,
+        coeDenialReason: getCOEDeniedReason(secondDisbursement),
+      };
+    }
+    return details;
   }
 
   /**

--- a/sources/packages/backend/apps/api/src/route-controllers/application/application.students.controller.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/application/application.students.controller.ts
@@ -53,11 +53,7 @@ import {
 } from "../../auth/decorators";
 import { AuthorizedParties } from "../../auth/authorized-parties.enum";
 import { ApiProcessError, ClientTypeBaseRoute } from "../../types";
-import {
-  getPIRDeniedReason,
-  PIR_OR_DATE_OVERLAP_ERROR,
-  getCOEDeniedReason,
-} from "../../utilities";
+import { getPIRDeniedReason, PIR_OR_DATE_OVERLAP_ERROR } from "../../utilities";
 import {
   INVALID_APPLICATION_NUMBER,
   OFFERING_NOT_VALID,

--- a/sources/packages/backend/apps/api/src/route-controllers/application/application.students.controller.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/application/application.students.controller.ts
@@ -581,27 +581,9 @@ export class ApplicationStudentsController extends BaseController {
         `Application id ${applicationId} not found or not in relevant status to get enrolment details.`,
       );
     }
-    const [firstDisbursement, secondDisbursement] =
-      application.currentAssessment.disbursementSchedules;
-
-    const details: EnrolmentApplicationDetailsAPIOutDTO = {
-      firstDisbursement: {
-        coeStatus: firstDisbursement.coeStatus,
-        disbursementScheduleStatus:
-          firstDisbursement.disbursementScheduleStatus,
-        coeDenialReason: getCOEDeniedReason(firstDisbursement),
-      },
-    };
-
-    if (secondDisbursement) {
-      details.secondDisbursement = {
-        coeStatus: secondDisbursement.coeStatus,
-        disbursementScheduleStatus:
-          secondDisbursement.disbursementScheduleStatus,
-        coeDenialReason: getCOEDeniedReason(secondDisbursement),
-      };
-    }
-    return details;
+    return this.applicationControllerService.transformToEnrolmentApplicationDetailsAPIOutDTO(
+      application.currentAssessment.disbursementSchedules,
+    );
   }
 
   /**
@@ -632,35 +614,20 @@ export class ApplicationStudentsController extends BaseController {
       getApplicationPromise,
       mostRecentAppealsPromises,
     ]);
-
     if (!application) {
       throw new NotFoundException(
         `Application not found or not on ${ApplicationStatus.Completed} status.`,
       );
     }
-
-    const [firstDisbursement, secondDisbursement] =
-      application.currentAssessment.disbursementSchedules;
-
-    const details: CompletedApplicationDetailsAPIOutDTO = {
+    const enrolmentDetails =
+      this.applicationControllerService.transformToEnrolmentApplicationDetailsAPIOutDTO(
+        application.currentAssessment.disbursementSchedules,
+      );
+    return {
+      firstDisbursement: enrolmentDetails.firstDisbursement,
+      secondDisbursement: enrolmentDetails.secondDisbursement,
       assessmentTriggerType: application.currentAssessment.triggerType,
       appealStatus: mostRecentAppeal?.status,
-      firstDisbursement: {
-        coeStatus: firstDisbursement.coeStatus,
-        disbursementScheduleStatus:
-          firstDisbursement.disbursementScheduleStatus,
-        coeDenialReason: getCOEDeniedReason(firstDisbursement),
-      },
     };
-
-    if (secondDisbursement) {
-      details.secondDisbursement = {
-        coeStatus: secondDisbursement.coeStatus,
-        disbursementScheduleStatus:
-          secondDisbursement.disbursementScheduleStatus,
-        coeDenialReason: getCOEDeniedReason(secondDisbursement),
-      };
-    }
-    return details;
   }
 }

--- a/sources/packages/backend/apps/api/src/route-controllers/application/application.students.controller.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/application/application.students.controller.ts
@@ -30,6 +30,7 @@ import {
   ASSESSMENT_INVALID_OPERATION_IN_THE_CURRENT_STATE,
   CRAIncomeVerificationService,
   SupportingUserService,
+  StudentAppealService,
 } from "../../services";
 import { IUserToken, StudentUserToken } from "../../auth/userToken.interface";
 import BaseController from "../BaseController";
@@ -41,7 +42,8 @@ import {
   ApplicationNumberParamAPIInDTO,
   InProgressApplicationDetailsAPIOutDTO,
   ApplicationProgressDetailsAPIOutDTO,
-  ApplicationCOEDetailsAPIOutDTO,
+  EnrolmentApplicationDetailsAPIOutDTO,
+  CompletedApplicationDetailsAPIOutDTO,
 } from "./models/application.dto";
 import {
   AllowAuthorizedParty,
@@ -71,6 +73,7 @@ import { ApplicationControllerService } from "./application.controller.service";
 import { CustomNamedError } from "@sims/utilities";
 import { PrimaryIdentifierAPIOutDTO } from "../models/primary.identifier.dto";
 import { ApplicationData } from "@sims/sims-db/entities/application.model";
+import { ApplicationStatus, StudentAppealStatus } from "@sims/sims-db";
 
 @AllowAuthorizedParty(AuthorizedParties.student)
 @RequiresStudentAccount()
@@ -88,6 +91,7 @@ export class ApplicationStudentsController extends BaseController {
     private readonly applicationControllerService: ApplicationControllerService,
     private readonly craIncomeVerificationService: CRAIncomeVerificationService,
     private readonly supportingUserService: SupportingUserService,
+    private readonly studentAppealService: StudentAppealService,
   ) {
     super();
   }
@@ -524,6 +528,18 @@ export class ApplicationStudentsController extends BaseController {
         `Application id ${applicationId} was not found.`,
       );
     }
+
+    let appealStatus: StudentAppealStatus;
+    if (application.applicationStatus === ApplicationStatus.Completed) {
+      const [mostRecentAppeal] =
+        await this.studentAppealService.getAppealsForApplication(
+          applicationId,
+          userToken.studentId,
+          { limit: 1 },
+        );
+      appealStatus = mostRecentAppeal.status;
+    }
+
     const disbursements =
       application.currentAssessment?.disbursementSchedules ?? [];
 
@@ -537,27 +553,28 @@ export class ApplicationStudentsController extends BaseController {
       firstCOEStatus: firstDisbursement?.coeStatus,
       secondCOEStatus: secondDisbursement?.coeStatus,
       exceptionStatus: application.applicationException?.exceptionStatus,
+      appealStatus,
     };
   }
 
   /**
-   * Get status of all enrollments of a student application.
-   * @param applicationId Student application.
-   * @returns application progress details.
+   * Get details for the application enrolment status of a student application.
+   * @param applicationId student application id.
+   * @returns details for the application enrolment status.
    */
   @ApiNotFoundResponse({
     description:
       "Application not found or not in relevant status to get enrolment details.",
   })
   @Get(":applicationId/enrolment-details")
-  async getApplicationEnrolmentDetails(
+  async getEnrolmentApplicationDetails(
     @Param("applicationId", ParseIntPipe) applicationId: number,
     @UserToken() userToken: StudentUserToken,
-  ): Promise<ApplicationCOEDetailsAPIOutDTO> {
+  ): Promise<EnrolmentApplicationDetailsAPIOutDTO> {
     const application =
-      await this.applicationService.getApplicationEnrolmentDetails(
+      await this.applicationService.getApplicationAssessmentDetails(
         applicationId,
-        userToken.studentId,
+        { studentId: userToken.studentId },
       );
     if (!application) {
       throw new NotFoundException(
@@ -567,8 +584,8 @@ export class ApplicationStudentsController extends BaseController {
     const [firstDisbursement, secondDisbursement] =
       application.currentAssessment.disbursementSchedules;
 
-    const applicationCOEDetails: ApplicationCOEDetailsAPIOutDTO = {
-      firstCOE: {
+    const details: EnrolmentApplicationDetailsAPIOutDTO = {
+      firstDisbursement: {
         coeStatus: firstDisbursement.coeStatus,
         disbursementScheduleStatus:
           firstDisbursement.disbursementScheduleStatus,
@@ -577,13 +594,73 @@ export class ApplicationStudentsController extends BaseController {
     };
 
     if (secondDisbursement) {
-      applicationCOEDetails.secondCOE = {
+      details.secondDisbursement = {
         coeStatus: secondDisbursement.coeStatus,
         disbursementScheduleStatus:
           secondDisbursement.disbursementScheduleStatus,
         coeDenialReason: getCOEDeniedReason(secondDisbursement),
       };
     }
-    return applicationCOEDetails;
+    return details;
+  }
+
+  /**
+   * Get details for an application at completed status.
+   * @param applicationId application id.
+   * @returns details for an application on at completed status.
+   */
+  @ApiNotFoundResponse({
+    description: `Application not found or not on ${ApplicationStatus.Completed} status.`,
+  })
+  @Get(":applicationId/completed-details")
+  async getCompletedApplicationDetails(
+    @Param("applicationId", ParseIntPipe) applicationId: number,
+    @UserToken() userToken: StudentUserToken,
+  ): Promise<CompletedApplicationDetailsAPIOutDTO> {
+    const getApplicationPromise =
+      this.applicationService.getApplicationAssessmentDetails(applicationId, {
+        studentId: userToken.studentId,
+        applicationStatus: [ApplicationStatus.Completed],
+      });
+    const mostRecentAppealsPromises =
+      this.studentAppealService.getAppealsForApplication(
+        applicationId,
+        userToken.studentId,
+        { limit: 1 },
+      );
+    const [application, [mostRecentAppeal]] = await Promise.all([
+      getApplicationPromise,
+      mostRecentAppealsPromises,
+    ]);
+
+    if (!application) {
+      throw new NotFoundException(
+        `Application not found or not on ${ApplicationStatus.Completed} status.`,
+      );
+    }
+
+    const [firstDisbursement, secondDisbursement] =
+      application.currentAssessment.disbursementSchedules;
+
+    const details: CompletedApplicationDetailsAPIOutDTO = {
+      assessmentTriggerType: application.currentAssessment.triggerType,
+      appealStatus: mostRecentAppeal?.status,
+      firstDisbursement: {
+        coeStatus: firstDisbursement.coeStatus,
+        disbursementScheduleStatus:
+          firstDisbursement.disbursementScheduleStatus,
+        coeDenialReason: getCOEDeniedReason(firstDisbursement),
+      },
+    };
+
+    if (secondDisbursement) {
+      details.secondDisbursement = {
+        coeStatus: secondDisbursement.coeStatus,
+        disbursementScheduleStatus:
+          secondDisbursement.disbursementScheduleStatus,
+        coeDenialReason: getCOEDeniedReason(secondDisbursement),
+      };
+    }
+    return details;
   }
 }

--- a/sources/packages/backend/apps/api/src/route-controllers/application/application.students.controller.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/application/application.students.controller.ts
@@ -562,7 +562,7 @@ export class ApplicationStudentsController extends BaseController {
     description:
       "Application not found or not in relevant status to get enrolment details.",
   })
-  @Get(":applicationId/enrolment-details")
+  @Get(":applicationId/enrolment")
   async getEnrolmentApplicationDetails(
     @Param("applicationId", ParseIntPipe) applicationId: number,
     @UserToken() userToken: StudentUserToken,
@@ -590,7 +590,7 @@ export class ApplicationStudentsController extends BaseController {
   @ApiNotFoundResponse({
     description: `Application not found or not on ${ApplicationStatus.Completed} status.`,
   })
-  @Get(":applicationId/completed-details")
+  @Get(":applicationId/completed")
   async getCompletedApplicationDetails(
     @Param("applicationId", ParseIntPipe) applicationId: number,
     @UserToken() userToken: StudentUserToken,

--- a/sources/packages/backend/apps/api/src/route-controllers/application/models/application.dto.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/application/models/application.dto.ts
@@ -166,9 +166,7 @@ export class EnrolmentApplicationDetailsAPIOutDTO {
   secondDisbursement?: DisbursementDetailsAPIOutDTO;
 }
 
-export class CompletedApplicationDetailsAPIOutDTO {
+export class CompletedApplicationDetailsAPIOutDTO extends EnrolmentApplicationDetailsAPIOutDTO {
   assessmentTriggerType: AssessmentTriggerType;
-  firstDisbursement: DisbursementDetailsAPIOutDTO;
-  secondDisbursement?: DisbursementDetailsAPIOutDTO;
   appealStatus?: StudentAppealStatus;
 }

--- a/sources/packages/backend/apps/api/src/route-controllers/application/models/application.dto.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/application/models/application.dto.ts
@@ -10,6 +10,8 @@ import {
   OfferingIntensity,
   APPLICATION_NUMBER_LENGTH,
   DisbursementScheduleStatus,
+  StudentAppealStatus,
+  AssessmentTriggerType,
 } from "@sims/sims-db";
 import { JsonMaxSize } from "../../../utilities/class-validation";
 import { JSON_20KB } from "../../../constants";
@@ -150,15 +152,23 @@ export class ApplicationProgressDetailsAPIOutDTO {
   firstCOEStatus?: COEStatus;
   secondCOEStatus?: COEStatus;
   exceptionStatus?: ApplicationExceptionStatus;
+  appealStatus?: StudentAppealStatus;
 }
 
-export class COEDetailsAPIOutDTO {
+export class DisbursementDetailsAPIOutDTO {
   coeStatus: COEStatus;
   disbursementScheduleStatus: DisbursementScheduleStatus;
   coeDenialReason: string;
 }
 
-export class ApplicationCOEDetailsAPIOutDTO {
-  firstCOE: COEDetailsAPIOutDTO;
-  secondCOE?: COEDetailsAPIOutDTO;
+export class EnrolmentApplicationDetailsAPIOutDTO {
+  firstDisbursement: DisbursementDetailsAPIOutDTO;
+  secondDisbursement?: DisbursementDetailsAPIOutDTO;
+}
+
+export class CompletedApplicationDetailsAPIOutDTO {
+  assessmentTriggerType: AssessmentTriggerType;
+  firstDisbursement: DisbursementDetailsAPIOutDTO;
+  secondDisbursement?: DisbursementDetailsAPIOutDTO;
+  appealStatus?: StudentAppealStatus;
 }

--- a/sources/packages/backend/apps/api/src/route-controllers/assessment/assessment.controller.service.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/assessment/assessment.controller.service.ts
@@ -222,7 +222,7 @@ export class AssessmentControllerService {
     const studentAppeal =
       await this.studentAppealService.getPendingAndDeniedAppeals(
         applicationId,
-        studentId,
+        { studentId },
       );
     const studentAppealArray: RequestAssessmentSummaryAPIOutDTO[] =
       studentAppeal.map((appeals) => ({

--- a/sources/packages/backend/apps/api/src/route-controllers/assessment/assessment.controller.service.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/assessment/assessment.controller.service.ts
@@ -222,7 +222,7 @@ export class AssessmentControllerService {
     const studentAppeal =
       await this.studentAppealService.getPendingAndDeniedAppeals(
         applicationId,
-        { studentId },
+        studentId,
       );
     const studentAppealArray: RequestAssessmentSummaryAPIOutDTO[] =
       studentAppeal.map((appeals) => ({

--- a/sources/packages/backend/apps/api/src/services/application/application.service.ts
+++ b/sources/packages/backend/apps/api/src/services/application/application.service.ts
@@ -1443,22 +1443,29 @@ export class ApplicationService extends RecordDataModelService<Application> {
   }
 
   /**
-   * Get enrolment details of an application.
-   * While fetching the enrolment details, the application
-   * expected to be in status Assessment or Enrolment or Completed.
+   * Get assessment details of an application.
    * @param applicationId application.
    * @param studentId applicant student.
    * @returns application details
    */
-  async getApplicationEnrolmentDetails(
+  async getApplicationAssessmentDetails(
     applicationId: number,
-    studentId?: number,
+    options: {
+      studentId?: number;
+      applicationStatus?: ApplicationStatus[];
+    },
   ): Promise<Application> {
+    const applicationStatuses = options?.applicationStatus ?? [
+      ApplicationStatus.Assessment,
+      ApplicationStatus.Enrolment,
+      ApplicationStatus.Completed,
+    ];
     return this.repo.findOne({
       select: {
         id: true,
         currentAssessment: {
           id: true,
+          triggerType: true,
           disbursementSchedules: {
             id: true,
             coeStatus: true,
@@ -1474,13 +1481,9 @@ export class ApplicationService extends RecordDataModelService<Application> {
       },
       where: {
         id: applicationId,
-        applicationStatus: In([
-          ApplicationStatus.Assessment,
-          ApplicationStatus.Enrolment,
-          ApplicationStatus.Completed,
-        ]),
+        applicationStatus: In(applicationStatuses),
         student: {
-          id: studentId,
+          id: options?.studentId,
         },
       },
       order: {

--- a/sources/packages/backend/apps/api/src/services/application/application.service.ts
+++ b/sources/packages/backend/apps/api/src/services/application/application.service.ts
@@ -1445,7 +1445,9 @@ export class ApplicationService extends RecordDataModelService<Application> {
   /**
    * Get assessment details of an application.
    * @param applicationId application.
-   * @param studentId applicant student.
+   * @param options query options
+   * - `studentId` student id used for authorization.
+   * - `applicationStatus` application status to be considered.
    * @returns application details
    */
   async getApplicationAssessmentDetails(

--- a/sources/packages/backend/apps/api/src/services/application/application.service.ts
+++ b/sources/packages/backend/apps/api/src/services/application/application.service.ts
@@ -1447,7 +1447,7 @@ export class ApplicationService extends RecordDataModelService<Application> {
    * @param applicationId application.
    * @param options query options
    * - `studentId` student id used for authorization.
-   * - `applicationStatus` application status to be considered.
+   * - `applicationStatus` application status/statuses to be considered.
    * @returns application details
    */
   async getApplicationAssessmentDetails(

--- a/sources/packages/backend/apps/api/src/services/disbursement-schedule/disbursement-schedule-service.ts
+++ b/sources/packages/backend/apps/api/src/services/disbursement-schedule/disbursement-schedule-service.ts
@@ -159,7 +159,8 @@ export class DisbursementScheduleService extends RecordDataModelService<Disburse
       .innerJoin("offering.institutionLocation", "location")
       .innerJoin("application.student", "student")
       .innerJoin("student.user", "user")
-      .where("location.id = :locationId", { locationId })
+      .where("studentAssessment.id = currentAssessment.id")
+      .andWhere("location.id = :locationId", { locationId })
       .andWhere("application.applicationStatus IN (:...status)", {
         status: [ApplicationStatus.Enrolment, ApplicationStatus.Completed],
       });
@@ -413,7 +414,8 @@ export class DisbursementScheduleService extends RecordDataModelService<Disburse
       .innerJoin("studentAssessment.application", "application")
       .innerJoin("application.currentAssessment", "currentAssessment")
       .leftJoin("disbursementSchedule.coeDeniedReason", "coeDeniedReason")
-      .where("application.applicationStatus IN (:...status)", {
+      .where("studentAssessment.id = currentAssessment.id")
+      .andWhere("application.applicationStatus IN (:...status)", {
         status: [ApplicationStatus.Enrolment, ApplicationStatus.Completed],
       })
       .andWhere("application.id = :applicationId", {

--- a/sources/packages/backend/apps/api/src/services/student-appeal/student-appeal.service.ts
+++ b/sources/packages/backend/apps/api/src/services/student-appeal/student-appeal.service.ts
@@ -4,9 +4,7 @@ import {
   RecordDataModelService,
   Application,
   AssessmentTriggerType,
-  Note,
   NoteType,
-  Student,
   StudentAppeal,
   StudentAppealRequest,
   StudentAppealStatus,
@@ -159,7 +157,7 @@ export class StudentAppealService extends RecordDataModelService<StudentAppeal> 
       );
     if (options?.studentId) {
       query.andWhere("application.student.id = :studentId", {
-        studentId: options?.studentId,
+        studentId: options.studentId,
       });
     }
     if (options?.limit) {
@@ -227,6 +225,14 @@ export class StudentAppealService extends RecordDataModelService<StudentAppeal> 
     return appealWithStatus;
   }
 
+  /**
+   * Get student appeals and their status.
+   * @param applicationId application id.
+   * @param studentId student id.
+   * @param options query options
+   * - `limit` limit of records to be retrieved.
+   * @returns student appeals and their status.
+   */
   async getAppealsForApplication(
     applicationId: number,
     studentId: number,

--- a/sources/packages/backend/apps/api/src/services/student-appeal/student-appeal.service.ts
+++ b/sources/packages/backend/apps/api/src/services/student-appeal/student-appeal.service.ts
@@ -117,16 +117,13 @@ export class StudentAppealService extends RecordDataModelService<StudentAppeal> 
    * * condition, we get Declined.
    * * andWhere: will only take Pending and
    * * Declined status.
-   * @param applicationId application id .
+   * @param applicationId application id.
    * @param studentId applicant student.
    * @returns StudentAppeal list.
    */
   async getPendingAndDeniedAppeals(
     applicationId: number,
-    options?: {
-      studentId?: number;
-      limit?: number;
-    },
+    studentId?: number,
   ): Promise<PendingAndDeniedAppeals[]> {
     const query = this.repo
       .createQueryBuilder("studentAppeal")
@@ -155,13 +152,10 @@ export class StudentAppealService extends RecordDataModelService<StudentAppeal> 
           );
         }),
       );
-    if (options?.studentId) {
+    if (studentId) {
       query.andWhere("application.student.id = :studentId", {
-        studentId: options.studentId,
+        studentId,
       });
-    }
-    if (options?.limit) {
-      query.limit(options?.limit);
     }
     const queryResult = await query
       .orderBy(

--- a/sources/packages/backend/libs/sims-db/src/entities/student-appeal.model.ts
+++ b/sources/packages/backend/libs/sims-db/src/entities/student-appeal.model.ts
@@ -42,7 +42,7 @@ export class StudentAppeal extends RecordDataModel {
    */
   @ManyToOne(() => Application, {
     eager: false,
-    cascade: false,
+    cascade: ["update"],
     nullable: false,
   })
   @JoinColumn({

--- a/sources/packages/web/src/components/common/notes/Notes.vue
+++ b/sources/packages/web/src/components/common/notes/Notes.vue
@@ -24,7 +24,12 @@
           >No notes found. Please click on create new note to add one.</v-col
         ></v-row
       >
-      <v-timeline side="end" class="justify-content-start" truncate-line="both">
+      <v-timeline
+        side="end"
+        align="start"
+        class="justify-content-start"
+        truncate-line="both"
+      >
         <v-timeline-item
           v-for="note in notes"
           :key="note"

--- a/sources/packages/web/src/components/students/applicationTracker/ApplicationProgressBar.vue
+++ b/sources/packages/web/src/components/students/applicationTracker/ApplicationProgressBar.vue
@@ -48,6 +48,7 @@ import {
   ProgramInfoStatus,
   ApplicationExceptionStatus,
   COEStatus,
+  StudentAppealStatus,
 } from "@/types";
 import { PropType, ref, defineComponent, computed, onMounted } from "vue";
 import { ApplicationProgressDetailsAPIOutDTO } from "@/services/http/dto/Application.dto";
@@ -62,7 +63,7 @@ import Enrolment from "@/components/students/applicationTracker/Enrolment.vue";
 import Completed from "@/components/students/applicationTracker/Completed.vue";
 
 interface ApplicationEndStatusIconDetails {
-  endStatusType?: "success" | "error";
+  endStatusType?: "success" | "warning" | "error";
   endStatusIcon?: string;
 }
 const INITIAL_THUMB_SIZE = 14;
@@ -107,7 +108,11 @@ export default defineComponent({
       if (applicationEndStatus.value.endStatusType === "error") {
         return "error";
       }
-      if (props.applicationStatus === ApplicationStatus.Completed) {
+      if (
+        props.applicationStatus === ApplicationStatus.Completed &&
+        applicationProgressDetails.value.appealStatus !==
+          StudentAppealStatus.Pending
+      ) {
         return "success";
       }
       return "warning";
@@ -118,8 +123,18 @@ export default defineComponent({
         await ApplicationService.shared.getApplicationProgressDetails(
           props.applicationId,
         );
-      // Application is complete.
+
       if (
+        applicationProgressDetails.value.appealStatus ===
+        StudentAppealStatus.Pending
+      ) {
+        // Application is complete but has warnings.
+        applicationEndStatus.value = {
+          endStatusType: "warning",
+          endStatusIcon: "fa:fas fa-exclamation-triangle",
+        };
+      } else if (
+        // Application is complete.
         applicationProgressDetails.value.firstCOEStatus ===
           COEStatus.completed &&
         (!applicationProgressDetails.value.secondCOEStatus ||
@@ -130,9 +145,8 @@ export default defineComponent({
           endStatusType: "success",
           endStatusIcon: "fa:fas fa-check-circle",
         };
-      }
-      // One of the requests or confirmation is declined.
-      else if (
+      } else if (
+        // One of the requests or confirmations is declined.
         applicationProgressDetails.value.pirStatus ===
           ProgramInfoStatus.declined ||
         applicationProgressDetails.value.exceptionStatus ===

--- a/sources/packages/web/src/components/students/applicationTracker/Completed.vue
+++ b/sources/packages/web/src/components/students/applicationTracker/Completed.vue
@@ -1,15 +1,4 @@
 <template>
-  <!-- Student appeal - approved -->
-  <application-status-tracker-banner
-    label="Your requested change was approved! Please review your new assessment."
-    icon="fa:fas fa-check-circle"
-    icon-color="success"
-    content="StudentAid BC has determined an outcome with 1 or more of your requested change. Please review your new assessment in the table below."
-    v-if="
-      assessmentDetails.assessmentTriggerType ===
-      AssessmentTriggerType.StudentAppeal
-    "
-  />
   <!-- Student appeal - waiting approval -->
   <application-status-tracker-banner
     label="Your requested change is in progress"
@@ -27,6 +16,18 @@
     icon-color="danger"
     background-color="error-bg"
     content="StudentAid BC has determined an outcome with 1 or more of your requested changes. You can review the outcomes of your requested changes in the table below by clicking “View request”. Please note your application will proceed without your requested changes, based on your last assessment."
+  />
+  <!-- Student appeal - approved -->
+  <application-status-tracker-banner
+    label="Your requested change was approved! Please review your new assessment."
+    icon="fa:fas fa-check-circle"
+    icon-color="success"
+    :background-color="hasDisbursementEvent ? undefined : 'success-bg'"
+    content="StudentAid BC has determined an outcome with 1 or more of your requested change. Please review your new assessment in the table below."
+    v-if="
+      assessmentDetails.assessmentTriggerType ===
+      AssessmentTriggerType.StudentAppeal
+    "
   />
   <!-- Scholastic standing changed -->
   <application-status-tracker-banner
@@ -50,6 +51,7 @@
       AssessmentTriggerType.OfferingChange
     "
   />
+  <!-- Disbursement/COE banners -->
   <multiple-disbursement-banner
     v-if="assessmentDetails?.secondDisbursement"
     :firstCOEStatus="assessmentDetails?.firstDisbursement?.coeStatus"
@@ -73,7 +75,7 @@
 </template>
 <script lang="ts">
 import { AssessmentTriggerType, COEStatus, StudentAppealStatus } from "@/types";
-import { onMounted, ref, defineComponent } from "vue";
+import { onMounted, ref, defineComponent, computed } from "vue";
 import { ApplicationService } from "@/services/ApplicationService";
 import { CompletedApplicationDetailsAPIOutDTO } from "@/services/http/dto/Application.dto";
 import ApplicationStatusTrackerBanner from "@/components/students/applicationTracker/generic/ApplicationStatusTrackerBanner.vue";
@@ -110,12 +112,20 @@ export default defineComponent({
         assessmentDetails.value.secondDisbursement?.coeDenialReason;
     });
 
+    const hasDisbursementEvent = computed(() => {
+      return (
+        assessmentDetails.value.firstDisbursement.coeStatus !==
+        COEStatus.required
+      );
+    });
+
     return {
       assessmentDetails,
       multipleCOEDenialReason,
       COEStatus,
       AssessmentTriggerType,
       StudentAppealStatus,
+      hasDisbursementEvent,
     };
   },
 });

--- a/sources/packages/web/src/components/students/applicationTracker/Completed.vue
+++ b/sources/packages/web/src/components/students/applicationTracker/Completed.vue
@@ -34,6 +34,7 @@
     label="You have a new assessment due to your scholastic standing"
     icon="fa:fas fa-check-circle"
     icon-color="success"
+    :background-color="hasDisbursementEvent ? undefined : 'success-bg'"
     content="Your institution informed us of your scholastic standing, which changed your assessment evaluation. Please review your new assessment in the table below. You can also click “View request” to see the details from your institution. Please contact the Financial Aid Officer from your institution, if you have questions about your scholastic standing."
     v-if="
       assessmentDetails.assessmentTriggerType ===
@@ -45,6 +46,7 @@
     label="You have a new assessment due to an update with your study period"
     icon="fa:fas fa-check-circle"
     icon-color="success"
+    :background-color="hasDisbursementEvent ? undefined : 'success-bg'"
     content="Your institution updated the study period that was submitted with your application, which changed your assessment evaluation. Please review your new assessment in the table below. If you have concerns or require more information, please contact the Financial Aid Officer from your institution."
     v-if="
       assessmentDetails?.assessmentTriggerType ===

--- a/sources/packages/web/src/components/students/applicationTracker/Completed.vue
+++ b/sources/packages/web/src/components/students/applicationTracker/Completed.vue
@@ -1,12 +1,12 @@
 <template>
   <!-- Student appeal - waiting approval -->
   <application-status-tracker-banner
+    v-if="assessmentDetails.appealStatus === StudentAppealStatus.Pending"
     label="Your requested change is in progress"
     icon="fa:fas fa-exclamation-triangle"
     icon-color="warning"
     background-color="warning-bg"
     content="StudentAid BC is reviewing your requested change. If your requested change is approved, your application will be re-evaluated with a new assessment below."
-    v-if="assessmentDetails.appealStatus === StudentAppealStatus.Pending"
   />
   <!-- Student appeal - declined -->
   <application-status-tracker-banner
@@ -19,39 +19,39 @@
   />
   <!-- Student appeal - approved -->
   <application-status-tracker-banner
+    v-if="
+      assessmentDetails.assessmentTriggerType ===
+      AssessmentTriggerType.StudentAppeal
+    "
     label="Your requested change was approved! Please review your new assessment."
     icon="fa:fas fa-check-circle"
     icon-color="success"
     :background-color="hasDisbursementEvent ? undefined : 'success-bg'"
     content="StudentAid BC has determined an outcome with 1 or more of your requested change. Please review your new assessment in the table below."
-    v-if="
-      assessmentDetails.assessmentTriggerType ===
-      AssessmentTriggerType.StudentAppeal
-    "
   />
   <!-- Scholastic standing changed -->
   <application-status-tracker-banner
+    v-if="
+      assessmentDetails.assessmentTriggerType ===
+      AssessmentTriggerType.ScholasticStandingChange
+    "
     label="You have a new assessment due to your scholastic standing"
     icon="fa:fas fa-check-circle"
     icon-color="success"
     :background-color="hasDisbursementEvent ? undefined : 'success-bg'"
     content="Your institution informed us of your scholastic standing, which changed your assessment evaluation. Please review your new assessment in the table below. You can also click “View request” to see the details from your institution. Please contact the Financial Aid Officer from your institution, if you have questions about your scholastic standing."
-    v-if="
-      assessmentDetails.assessmentTriggerType ===
-      AssessmentTriggerType.ScholasticStandingChange
-    "
   />
   <!-- Offering changed -->
   <application-status-tracker-banner
+    v-if="
+      assessmentDetails?.assessmentTriggerType ===
+      AssessmentTriggerType.OfferingChange
+    "
     label="You have a new assessment due to an update with your study period"
     icon="fa:fas fa-check-circle"
     icon-color="success"
     :background-color="hasDisbursementEvent ? undefined : 'success-bg'"
     content="Your institution updated the study period that was submitted with your application, which changed your assessment evaluation. Please review your new assessment in the table below. If you have concerns or require more information, please contact the Financial Aid Officer from your institution."
-    v-if="
-      assessmentDetails?.assessmentTriggerType ===
-      AssessmentTriggerType.OfferingChange
-    "
   />
   <!-- Disbursement/COE banners -->
   <multiple-disbursement-banner

--- a/sources/packages/web/src/components/students/applicationTracker/Completed.vue
+++ b/sources/packages/web/src/components/students/applicationTracker/Completed.vue
@@ -44,7 +44,7 @@
   <!-- Offering changed -->
   <application-status-tracker-banner
     v-if="
-      assessmentDetails?.assessmentTriggerType ===
+      assessmentDetails.assessmentTriggerType ===
       AssessmentTriggerType.OfferingChange
     "
     label="You have a new assessment due to an update with your study period"
@@ -55,23 +55,23 @@
   />
   <!-- Disbursement/COE banners -->
   <multiple-disbursement-banner
-    v-if="assessmentDetails?.secondDisbursement"
-    :firstCOEStatus="assessmentDetails?.firstDisbursement?.coeStatus"
-    :secondCOEStatus="assessmentDetails?.secondDisbursement?.coeStatus"
+    v-if="assessmentDetails.secondDisbursement"
+    :firstCOEStatus="assessmentDetails.firstDisbursement?.coeStatus"
+    :secondCOEStatus="assessmentDetails.secondDisbursement?.coeStatus"
     :coeDenialReason="multipleCOEDenialReason"
     :firstDisbursementStatus="
-      assessmentDetails?.firstDisbursement?.disbursementScheduleStatus
+      assessmentDetails.firstDisbursement?.disbursementScheduleStatus
     "
     :secondDisbursementStatus="
-      assessmentDetails?.secondDisbursement?.disbursementScheduleStatus
+      assessmentDetails.secondDisbursement?.disbursementScheduleStatus
     "
   />
   <disbursement-banner
     v-else
-    :coeStatus="assessmentDetails?.firstDisbursement?.coeStatus"
-    :coeDenialReason="assessmentDetails?.firstDisbursement?.coeDenialReason"
+    :coeStatus="assessmentDetails.firstDisbursement?.coeStatus"
+    :coeDenialReason="assessmentDetails.firstDisbursement?.coeDenialReason"
     :disbursementStatus="
-      assessmentDetails?.firstDisbursement?.disbursementScheduleStatus
+      assessmentDetails.firstDisbursement?.disbursementScheduleStatus
     "
   />
 </template>

--- a/sources/packages/web/src/components/students/applicationTracker/Completed.vue
+++ b/sources/packages/web/src/components/students/applicationTracker/Completed.vue
@@ -103,7 +103,6 @@ export default defineComponent({
         await ApplicationService.shared.getCompletedApplicationDetails(
           props.applicationId,
         );
-      console.log(assessmentDetails);
       // Even though if an application has multiple COEs
       // COE can be declined only once, either first COE is declined
       // or the second COE.

--- a/sources/packages/web/src/components/students/applicationTracker/Completed.vue
+++ b/sources/packages/web/src/components/students/applicationTracker/Completed.vue
@@ -1,35 +1,88 @@
 <template>
+  <!-- Student appeal - approved -->
+  <application-status-tracker-banner
+    label="Your requested change was approved! Please review your new assessment."
+    icon="fa:fas fa-check-circle"
+    icon-color="success"
+    content="StudentAid BC has determined an outcome with 1 or more of your requested change. Please review your new assessment in the table below."
+    v-if="
+      assessmentDetails.assessmentTriggerType ===
+      AssessmentTriggerType.StudentAppeal
+    "
+  />
+  <!-- Student appeal - waiting approval -->
+  <application-status-tracker-banner
+    label="Your requested change is in progress"
+    icon="fa:fas fa-exclamation-triangle"
+    icon-color="warning"
+    background-color="warning-bg"
+    content="StudentAid BC is reviewing your requested change. If your requested change is approved, your application will be re-evaluated with a new assessment below."
+    v-if="assessmentDetails.appealStatus === StudentAppealStatus.Pending"
+  />
+  <!-- Student appeal - declined -->
+  <application-status-tracker-banner
+    v-if="assessmentDetails.appealStatus === StudentAppealStatus.Declined"
+    label="Your requested change was declined"
+    icon="fa:fas fa-exclamation-circle"
+    icon-color="danger"
+    background-color="error-bg"
+    content="StudentAid BC has determined an outcome with 1 or more of your requested changes. You can review the outcomes of your requested changes in the table below by clicking “View request”. Please note your application will proceed without your requested changes, based on your last assessment."
+  />
+  <!-- Scholastic standing changed -->
+  <application-status-tracker-banner
+    label="You have a new assessment due to your scholastic standing"
+    icon="fa:fas fa-check-circle"
+    icon-color="success"
+    content="Your institution informed us of your scholastic standing, which changed your assessment evaluation. Please review your new assessment in the table below. You can also click “View request” to see the details from your institution. Please contact the Financial Aid Officer from your institution, if you have questions about your scholastic standing."
+    v-if="
+      assessmentDetails.assessmentTriggerType ===
+      AssessmentTriggerType.ScholasticStandingChange
+    "
+  />
+  <!-- Offering changed -->
+  <application-status-tracker-banner
+    label="You have a new assessment due to an update with your study period"
+    icon="fa:fas fa-check-circle"
+    icon-color="success"
+    content="Your institution updated the study period that was submitted with your application, which changed your assessment evaluation. Please review your new assessment in the table below. If you have concerns or require more information, please contact the Financial Aid Officer from your institution."
+    v-if="
+      assessmentDetails?.assessmentTriggerType ===
+      AssessmentTriggerType.OfferingChange
+    "
+  />
   <multiple-disbursement-banner
-    v-if="applicationCOEDetails?.secondCOE"
-    :firstCOEStatus="applicationCOEDetails?.firstCOE?.coeStatus"
-    :secondCOEStatus="applicationCOEDetails?.secondCOE?.coeStatus"
+    v-if="assessmentDetails?.secondDisbursement"
+    :firstCOEStatus="assessmentDetails?.firstDisbursement?.coeStatus"
+    :secondCOEStatus="assessmentDetails?.secondDisbursement?.coeStatus"
     :coeDenialReason="multipleCOEDenialReason"
     :firstDisbursementStatus="
-      applicationCOEDetails?.firstCOE?.disbursementScheduleStatus
+      assessmentDetails?.firstDisbursement?.disbursementScheduleStatus
     "
     :secondDisbursementStatus="
-      applicationCOEDetails?.secondCOE?.disbursementScheduleStatus
+      assessmentDetails?.secondDisbursement?.disbursementScheduleStatus
     "
   />
   <disbursement-banner
     v-else
-    :coeStatus="applicationCOEDetails?.firstCOE?.coeStatus"
-    :coeDenialReason="applicationCOEDetails?.firstCOE?.coeDenialReason"
+    :coeStatus="assessmentDetails?.firstDisbursement?.coeStatus"
+    :coeDenialReason="assessmentDetails?.firstDisbursement?.coeDenialReason"
     :disbursementStatus="
-      applicationCOEDetails?.firstCOE?.disbursementScheduleStatus
+      assessmentDetails?.firstDisbursement?.disbursementScheduleStatus
     "
   />
 </template>
 <script lang="ts">
-import { COEStatus } from "@/types";
+import { AssessmentTriggerType, COEStatus, StudentAppealStatus } from "@/types";
 import { onMounted, ref, defineComponent } from "vue";
 import { ApplicationService } from "@/services/ApplicationService";
-import { ApplicationCOEDetailsAPIOutDTO } from "@/services/http/dto/Application.dto";
+import { CompletedApplicationDetailsAPIOutDTO } from "@/services/http/dto/Application.dto";
+import ApplicationStatusTrackerBanner from "@/components/students/applicationTracker/generic/ApplicationStatusTrackerBanner.vue";
 import DisbursementBanner from "@/components/students/applicationTracker/DisbursementBanner.vue";
 import MultipleDisbursementBanner from "@/components/students/applicationTracker/MultipleDisbursementBanner.vue";
 
 export default defineComponent({
   components: {
+    ApplicationStatusTrackerBanner,
     DisbursementBanner,
     MultipleDisbursementBanner,
   },
@@ -40,26 +93,29 @@ export default defineComponent({
     },
   },
   setup(props) {
-    const applicationCOEDetails = ref({} as ApplicationCOEDetailsAPIOutDTO);
+    const assessmentDetails = ref({} as CompletedApplicationDetailsAPIOutDTO);
     const multipleCOEDenialReason = ref<string>();
 
     onMounted(async () => {
-      applicationCOEDetails.value =
-        await ApplicationService.shared.getApplicationEnrolmentDetails(
+      assessmentDetails.value =
+        await ApplicationService.shared.getCompletedApplicationDetails(
           props.applicationId,
         );
+      console.log(assessmentDetails);
       // Even though if an application has multiple COEs
       // COE can be declined only once, either first COE is declined
       // or the second COE.
       multipleCOEDenialReason.value =
-        applicationCOEDetails.value.firstCOE?.coeDenialReason ??
-        applicationCOEDetails.value.secondCOE?.coeDenialReason;
+        assessmentDetails.value.firstDisbursement?.coeDenialReason ??
+        assessmentDetails.value.secondDisbursement?.coeDenialReason;
     });
 
     return {
-      applicationCOEDetails,
+      assessmentDetails,
       multipleCOEDenialReason,
       COEStatus,
+      AssessmentTriggerType,
+      StudentAppealStatus,
     };
   },
 });

--- a/sources/packages/web/src/components/students/applicationTracker/Enrolment.vue
+++ b/sources/packages/web/src/components/students/applicationTracker/Enrolment.vue
@@ -1,21 +1,21 @@
 <template>
   <multiple-disbursement-banner
-    v-if="applicationCOEDetails?.secondCOE"
-    :firstCOEStatus="applicationCOEDetails?.firstCOE?.coeStatus"
-    :secondCOEStatus="applicationCOEDetails?.secondCOE?.coeStatus"
+    v-if="applicationCOEDetails?.secondDisbursement"
+    :firstCOEStatus="applicationCOEDetails?.firstDisbursement?.coeStatus"
+    :secondCOEStatus="applicationCOEDetails?.secondDisbursement?.coeStatus"
     :coeDenialReason="multipleCOEDenialReason"
   />
   <disbursement-banner
     v-else
-    :coeStatus="applicationCOEDetails?.firstCOE?.coeStatus"
-    :coeDenialReason="applicationCOEDetails?.firstCOE?.coeDenialReason"
+    :coeStatus="applicationCOEDetails?.firstDisbursement?.coeStatus"
+    :coeDenialReason="applicationCOEDetails?.firstDisbursement?.coeDenialReason"
   />
 </template>
 <script lang="ts">
 import { COEStatus } from "@/types";
 import { onMounted, ref, defineComponent } from "vue";
 import { ApplicationService } from "@/services/ApplicationService";
-import { ApplicationCOEDetailsAPIOutDTO } from "@/services/http/dto/Application.dto";
+import { EnrolmentApplicationDetailsAPIOutDTO } from "@/services/http/dto/Application.dto";
 import DisbursementBanner from "@/components/students/applicationTracker/DisbursementBanner.vue";
 import MultipleDisbursementBanner from "@/components/students/applicationTracker/MultipleDisbursementBanner.vue";
 
@@ -31,20 +31,22 @@ export default defineComponent({
     },
   },
   setup(props) {
-    const applicationCOEDetails = ref({} as ApplicationCOEDetailsAPIOutDTO);
+    const applicationCOEDetails = ref(
+      {} as EnrolmentApplicationDetailsAPIOutDTO,
+    );
     const multipleCOEDenialReason = ref<string>();
 
     onMounted(async () => {
       applicationCOEDetails.value =
-        await ApplicationService.shared.getApplicationEnrolmentDetails(
+        await ApplicationService.shared.getEnrolmentApplicationDetails(
           props.applicationId,
         );
       // Even though if an application has multiple COEs
       // COE can be declined only once, either first COE is declined
       // or the second COE.
       multipleCOEDenialReason.value =
-        applicationCOEDetails.value.firstCOE?.coeDenialReason ??
-        applicationCOEDetails.value.secondCOE?.coeDenialReason;
+        applicationCOEDetails.value.firstDisbursement?.coeDenialReason ??
+        applicationCOEDetails.value.secondDisbursement?.coeDenialReason;
     });
 
     return {

--- a/sources/packages/web/src/services/ApplicationService.ts
+++ b/sources/packages/web/src/services/ApplicationService.ts
@@ -16,7 +16,8 @@ import {
   ApplicationIdentifiersAPIOutDTO,
   PrimaryIdentifierAPIOutDTO,
   ApplicationProgressDetailsAPIOutDTO,
-  ApplicationCOEDetailsAPIOutDTO,
+  EnrolmentApplicationDetailsAPIOutDTO,
+  CompletedApplicationDetailsAPIOutDTO,
 } from "@/services/http/dto";
 
 export class ApplicationService {
@@ -134,13 +135,24 @@ export class ApplicationService {
   }
 
   /**
-   * Get status of all enrollments of a student application.
-   * @param applicationId Student application.
-   * @returns application progress details.
+   * Get details for the application enrolment status of a student application.
+   * @param applicationId student application id.
+   * @returns details for the application enrolment status.
    */
-  async getApplicationEnrolmentDetails(
+  async getEnrolmentApplicationDetails(
     applicationId: number,
-  ): Promise<ApplicationCOEDetailsAPIOutDTO> {
-    return ApiClient.Application.getApplicationEnrolmentDetails(applicationId);
+  ): Promise<EnrolmentApplicationDetailsAPIOutDTO> {
+    return ApiClient.Application.getEnrolmentApplicationDetails(applicationId);
+  }
+
+  /**
+   * Get details for an application on at completed status.
+   * @param applicationId application id.
+   * @returns details for an application on at completed status.
+   */
+  async getCompletedApplicationDetails(
+    applicationId: number,
+  ): Promise<CompletedApplicationDetailsAPIOutDTO> {
+    return ApiClient.Application.getCompletedApplicationDetails(applicationId);
   }
 }

--- a/sources/packages/web/src/services/http/ApplicationApi.ts
+++ b/sources/packages/web/src/services/http/ApplicationApi.ts
@@ -19,7 +19,8 @@ import {
   InProgressApplicationDetailsAPIOutDTO,
   PrimaryIdentifierAPIOutDTO,
   ApplicationProgressDetailsAPIOutDTO,
-  ApplicationCOEDetailsAPIOutDTO,
+  EnrolmentApplicationDetailsAPIOutDTO,
+  CompletedApplicationDetailsAPIOutDTO,
 } from "@/services/http/dto";
 
 export class ApplicationApi extends HttpBaseClient {
@@ -155,15 +156,28 @@ export class ApplicationApi extends HttpBaseClient {
   }
 
   /**
-   * Get status of all enrollments of a student application.
-   * @param applicationId Student application.
-   * @returns application progress details.
+   * Get details for the application enrolment status of a student application.
+   * @param applicationId student application id.
+   * @returns details for the application enrolment status.
    */
-  async getApplicationEnrolmentDetails(
+  async getEnrolmentApplicationDetails(
     applicationId: number,
-  ): Promise<ApplicationCOEDetailsAPIOutDTO> {
-    return this.getCall<ApplicationCOEDetailsAPIOutDTO>(
+  ): Promise<EnrolmentApplicationDetailsAPIOutDTO> {
+    return this.getCall<EnrolmentApplicationDetailsAPIOutDTO>(
       this.addClientRoot(`application/${applicationId}/enrolment-details`),
+    );
+  }
+
+  /**
+   * Get details for an application on at completed status.
+   * @param applicationId application id.
+   * @returns details for an application on at completed status.
+   */
+  async getCompletedApplicationDetails(
+    applicationId: number,
+  ): Promise<CompletedApplicationDetailsAPIOutDTO> {
+    return this.getCall<CompletedApplicationDetailsAPIOutDTO>(
+      this.addClientRoot(`application/${applicationId}/completed-details`),
     );
   }
 }

--- a/sources/packages/web/src/services/http/ApplicationApi.ts
+++ b/sources/packages/web/src/services/http/ApplicationApi.ts
@@ -164,7 +164,7 @@ export class ApplicationApi extends HttpBaseClient {
     applicationId: number,
   ): Promise<EnrolmentApplicationDetailsAPIOutDTO> {
     return this.getCall<EnrolmentApplicationDetailsAPIOutDTO>(
-      this.addClientRoot(`application/${applicationId}/enrolment-details`),
+      this.addClientRoot(`application/${applicationId}/enrolment`),
     );
   }
 
@@ -177,7 +177,7 @@ export class ApplicationApi extends HttpBaseClient {
     applicationId: number,
   ): Promise<CompletedApplicationDetailsAPIOutDTO> {
     return this.getCall<CompletedApplicationDetailsAPIOutDTO>(
-      this.addClientRoot(`application/${applicationId}/completed-details`),
+      this.addClientRoot(`application/${applicationId}/completed`),
     );
   }
 }

--- a/sources/packages/web/src/services/http/dto/Application.dto.ts
+++ b/sources/packages/web/src/services/http/dto/Application.dto.ts
@@ -7,6 +7,8 @@ import {
   AssessmentStatus,
   OfferingIntensity,
   DisbursementScheduleStatus,
+  AssessmentTriggerType,
+  StudentAppealStatus,
 } from "@/types";
 
 export interface InProgressApplicationDetailsAPIOutDTO {
@@ -93,15 +95,23 @@ export interface ApplicationProgressDetailsAPIOutDTO {
   firstCOEStatus?: COEStatus;
   secondCOEStatus?: COEStatus;
   exceptionStatus?: ApplicationExceptionStatus;
+  appealStatus?: StudentAppealStatus;
 }
 
-export interface COEDetailsAPIOutDTO {
+export interface DisbursementDetailsAPIOutDTO {
   coeStatus: COEStatus;
   disbursementScheduleStatus: DisbursementScheduleStatus;
   coeDenialReason: string;
 }
 
-export interface ApplicationCOEDetailsAPIOutDTO {
-  firstCOE: COEDetailsAPIOutDTO;
-  secondCOE?: COEDetailsAPIOutDTO;
+export interface EnrolmentApplicationDetailsAPIOutDTO {
+  firstDisbursement: DisbursementDetailsAPIOutDTO;
+  secondDisbursement?: DisbursementDetailsAPIOutDTO;
+}
+
+export interface CompletedApplicationDetailsAPIOutDTO {
+  assessmentTriggerType: AssessmentTriggerType;
+  firstDisbursement: DisbursementDetailsAPIOutDTO;
+  secondDisbursement?: DisbursementDetailsAPIOutDTO;
+  appealStatus?: StudentAppealStatus;
 }

--- a/sources/packages/web/src/services/http/dto/Application.dto.ts
+++ b/sources/packages/web/src/services/http/dto/Application.dto.ts
@@ -109,7 +109,8 @@ export interface EnrolmentApplicationDetailsAPIOutDTO {
   secondDisbursement?: DisbursementDetailsAPIOutDTO;
 }
 
-export interface CompletedApplicationDetailsAPIOutDTO {
+export interface CompletedApplicationDetailsAPIOutDTO
+  extends EnrolmentApplicationDetailsAPIOutDTO {
   assessmentTriggerType: AssessmentTriggerType;
   firstDisbursement: DisbursementDetailsAPIOutDTO;
   secondDisbursement?: DisbursementDetailsAPIOutDTO;

--- a/sources/packages/web/src/types/contracts/NoteContract.ts
+++ b/sources/packages/web/src/types/contracts/NoteContract.ts
@@ -49,9 +49,21 @@ export enum StudentNoteType {
    */
   General = "General",
   /**
+   * Note type Application.
+   */
+  Application = "Application",
+  /**
+   * Note type Program.
+   */
+  Program = "Program",
+  /**
    * Note type Restriction.
    */
   Restriction = "Restriction",
+  /**
+   * Note type Designation.
+   */
+  Designation = "Designation",
   /**
    * Note type Overaward.
    */

--- a/sources/packages/web/src/types/contracts/NoteContract.ts
+++ b/sources/packages/web/src/types/contracts/NoteContract.ts
@@ -53,17 +53,9 @@ export enum StudentNoteType {
    */
   Application = "Application",
   /**
-   * Note type Program.
-   */
-  Program = "Program",
-  /**
    * Note type Restriction.
    */
   Restriction = "Restriction",
-  /**
-   * Note type Designation.
-   */
-  Designation = "Designation",
   /**
    * Note type Overaward.
    */


### PR DESCRIPTION
### New cards added for Student Appeal: Pending, Approved, Declined

#### Pending
![image](https://user-images.githubusercontent.com/61259237/224224286-5ddbee69-a935-468b-9384-242ae17869be.png)

#### Pending (when there was one previous appeal already approved)
![image](https://user-images.githubusercontent.com/61259237/224223668-40119011-8e66-4c68-ac92-ab21c63639f2.png)

#### Declined
![image](https://user-images.githubusercontent.com/61259237/224224461-a88e06f3-2334-40d6-add3-6ee7d0c2494b.png)

#### Declined (when there was one previous appeal already approved)
![image](https://user-images.githubusercontent.com/61259237/224223754-08300b2a-3f5a-4129-ad41-a2451f4937d7.png)

### New cards added for Offering Changed

####  Offering Changed - waiting for first COE confirmation
![image](https://user-images.githubusercontent.com/61259237/224381984-b36b451d-9441-459c-8895-d497b6b34027.png)

####  Offering Changed - COE Confirmed
![image](https://user-images.githubusercontent.com/61259237/224382156-7c790078-1827-48e9-8317-1560313d2311.png)

### Refactors
- Renamed `ApplicationCOEDetailsAPIOutDTO` (and related) to EnrolmentApplicationDetailsAPIOutDTO. This is an attempt to leave "In Progress", "Enrolment" and "Completed" statuses more aligned, respectively using `InProgressApplicationDetailsAPIOutDTO`, `EnrolmentApplicationDetailsAPIOutDTO`, and `CompletedApplicationDetailsAPIOutDTO`.

### New cards added for Scholastic Standing Changed

####  Scholastic Standing Changed - waiting for first COE confirmation
![image](https://user-images.githubusercontent.com/61259237/224426438-18174e67-fb78-438b-929b-570df08f61ef.png)

####  Scholastic Standing Changed - waiting for first COE confirmation
![image](https://user-images.githubusercontent.com/61259237/224426583-7a953ce1-a2a8-4bf5-8988-f02e820bfd2a.png)

### Bug fixes
- Student appeal assessment record was not updated on the application `current_assessment_id`.
- COE records were displayed multiple times when the application had multiple assessments associated.
- COE confirmation sometimes failed when the application had multiple assessments associated.
- Added missing note categories to filters and adjusted timeline "bullets" alignment.
![image](https://user-images.githubusercontent.com/61259237/224427518-5cf1f1b7-03a5-4314-9cb8-2705f7836d4a.png)

### Upcoming PR
- New cards for scholastic standing.
- E2E tests