### PR TITLE
#1683 - Application Tracker Scholastic Change (Part 2)

### DIFF
--- a/sources/packages/backend/apps/api/src/route-controllers/application/application.students.controller.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/application/application.students.controller.ts
@@ -533,7 +533,7 @@ export class ApplicationStudentsController extends BaseController {
           userToken.studentId,
           { limit: 1 },
         );
-      appealStatus = mostRecentAppeal.status;
+      appealStatus = mostRecentAppeal?.status;
     }
 
     const disbursements =
@@ -543,6 +543,7 @@ export class ApplicationStudentsController extends BaseController {
       a.disbursementDate < b.disbursementDate ? -1 : 1,
     );
     const [firstDisbursement, secondDisbursement] = disbursements;
+    const [scholasticStandingChange] = application.studentScholasticStandings;
     return {
       applicationStatusUpdatedOn: application.applicationStatusUpdatedOn,
       pirStatus: application.pirStatus,
@@ -550,6 +551,7 @@ export class ApplicationStudentsController extends BaseController {
       secondCOEStatus: secondDisbursement?.coeStatus,
       exceptionStatus: application.applicationException?.exceptionStatus,
       appealStatus,
+      scholasticStandingChangeType: scholasticStandingChange?.changeType,
     };
   }
 
@@ -619,11 +621,13 @@ export class ApplicationStudentsController extends BaseController {
       this.applicationControllerService.transformToEnrolmentApplicationDetailsAPIOutDTO(
         application.currentAssessment.disbursementSchedules,
       );
+    const [scholasticStandingChange] = application.studentScholasticStandings;
     return {
       firstDisbursement: enrolmentDetails.firstDisbursement,
       secondDisbursement: enrolmentDetails.secondDisbursement,
       assessmentTriggerType: application.currentAssessment.triggerType,
       appealStatus: mostRecentAppeal?.status,
+      scholasticStandingChangeType: scholasticStandingChange?.changeType,
     };
   }
 }

--- a/sources/packages/backend/apps/api/src/route-controllers/application/models/application.dto.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/application/models/application.dto.ts
@@ -12,6 +12,7 @@ import {
   DisbursementScheduleStatus,
   StudentAppealStatus,
   AssessmentTriggerType,
+  StudentScholasticStandingChangeType,
 } from "@sims/sims-db";
 import { JsonMaxSize } from "../../../utilities/class-validation";
 import { JSON_20KB } from "../../../constants";
@@ -153,6 +154,7 @@ export class ApplicationProgressDetailsAPIOutDTO {
   secondCOEStatus?: COEStatus;
   exceptionStatus?: ApplicationExceptionStatus;
   appealStatus?: StudentAppealStatus;
+  scholasticStandingChangeType?: StudentScholasticStandingChangeType;
 }
 
 export class DisbursementDetailsAPIOutDTO {
@@ -169,4 +171,5 @@ export class EnrolmentApplicationDetailsAPIOutDTO {
 export class CompletedApplicationDetailsAPIOutDTO extends EnrolmentApplicationDetailsAPIOutDTO {
   assessmentTriggerType: AssessmentTriggerType;
   appealStatus?: StudentAppealStatus;
+  scholasticStandingChangeType?: StudentScholasticStandingChangeType;
 }

--- a/sources/packages/backend/apps/api/src/route-controllers/student-scholastic-standings/models/student-scholastic-standings.dto.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/student-scholastic-standings/models/student-scholastic-standings.dto.ts
@@ -3,11 +3,12 @@ import { JsonMaxSize } from "../../../utilities/class-validation";
 import { IsNotEmptyObject } from "class-validator";
 import { ActiveApplicationDataAPIOutDTO } from "../../../route-controllers/institution-locations/models/application.dto";
 import { JSON_10KB } from "../../../constants";
+import { StudentScholasticStandingChangeType } from "@sims/sims-db";
 
 /**
- * The API will also allow other property that are not added below.
+ * The API will also allow other properties that are not added below.
  */
-export class ScholasticStandingDataAPIInDTO {
+export class ScholasticStandingData {
   dateOfChange?: string;
   booksAndSupplies?: number;
   dateOfCompletion?: string;
@@ -16,17 +17,21 @@ export class ScholasticStandingDataAPIInDTO {
   tuition?: number;
   numberOfUnsuccessfulWeeks?: number;
   dateOfWithdrawal?: string;
-  scholasticStanding: string;
+  scholasticStandingChangeType: StudentScholasticStandingChangeType;
 }
 
-// This DTO must/will be validated using the dryRun.
+/**
+ * Dynamic data received for a scholastic standing change. The data is only partially
+ * dynamic, few fields are saved to specific columns and the payload is also
+ * entirely persisted, which means that the form can be expanded.
+ */
 export class ScholasticStandingAPIInDTO {
   @IsNotEmptyObject()
   @JsonMaxSize(JSON_10KB)
-  data: ScholasticStandingDataAPIInDTO;
+  data: ScholasticStandingData;
 }
 
 export class ScholasticStandingSubmittedDetailsAPIOutDTO extends IntersectionType(
-  ScholasticStandingDataAPIInDTO,
+  ScholasticStandingData,
   ActiveApplicationDataAPIOutDTO,
 ) {}

--- a/sources/packages/backend/apps/api/src/services/application/application.service.ts
+++ b/sources/packages/backend/apps/api/src/services/application/application.service.ts
@@ -16,6 +16,7 @@ import {
   AssessmentTriggerType,
   User,
   ApplicationData,
+  StudentScholasticStandingChangeType,
 } from "@sims/sims-db";
 import { StudentFileService } from "../student-file/student-file.service";
 import {
@@ -1425,18 +1426,27 @@ export class ApplicationService extends RecordDataModelService<Application> {
           studystartDate: true,
           howWillYouBeAttendingTheProgram: true,
         },
+        studentScholasticStandings: {
+          id: true,
+          changeType: true,
+        },
       },
       relations: {
         pirDeniedReasonId: true,
         currentAssessment: { offering: true, disbursementSchedules: true },
         applicationException: true,
         location: true,
+        studentScholasticStandings: true,
       },
       where: {
         id: applicationId,
         applicationStatus: Not(ApplicationStatus.Overwritten),
         student: {
           id: studentId,
+        },
+        studentScholasticStandings: {
+          changeType:
+            StudentScholasticStandingChangeType.StudentDidNotCompleteProgram,
         },
       },
     });
@@ -1477,15 +1487,26 @@ export class ApplicationService extends RecordDataModelService<Application> {
             coeDeniedOtherDesc: true,
           },
         },
+        studentScholasticStandings: {
+          id: true,
+          changeType: true,
+        },
       },
       relations: {
-        currentAssessment: { disbursementSchedules: { coeDeniedReason: true } },
+        currentAssessment: {
+          disbursementSchedules: { coeDeniedReason: true },
+        },
+        studentScholasticStandings: true,
       },
       where: {
         id: applicationId,
         applicationStatus: In(applicationStatuses),
         student: {
           id: options?.studentId,
+        },
+        studentScholasticStandings: {
+          changeType:
+            StudentScholasticStandingChangeType.StudentDidNotCompleteProgram,
         },
       },
       order: {

--- a/sources/packages/backend/apps/api/src/services/student-scholastic-standings/constants.ts
+++ b/sources/packages/backend/apps/api/src/services/student-scholastic-standings/constants.ts
@@ -1,2 +1,0 @@
-// Minium unsuccessful weeks.
-export const MINIMUM_UNSUCCESSFUL_WEEKS = 68;

--- a/sources/packages/backend/apps/api/src/services/student-scholastic-standings/constants.ts
+++ b/sources/packages/backend/apps/api/src/services/student-scholastic-standings/constants.ts
@@ -1,8 +1,2 @@
-// When student select "Student did not complete program", then "scholasticStanding" value is
-export const SCHOLASTIC_STANDING_STUDENT_DID_NOT_COMPLETE_PROGRAM =
-  "studentDidNotCompleteProgram";
-// When student select "Student withdrew from program", then "scholasticStanding" value is
-export const SCHOLASTIC_STANDING_STUDENT_WITHDREW_FROM_PROGRAM =
-  "studentWithdrewFromProgram";
 // Minium unsuccessful weeks.
 export const MINIMUM_UNSUCCESSFUL_WEEKS = 68;

--- a/sources/packages/backend/apps/api/src/services/student-scholastic-standings/student-scholastic-standings.model.ts
+++ b/sources/packages/backend/apps/api/src/services/student-scholastic-standings/student-scholastic-standings.model.ts
@@ -1,3 +1,5 @@
+import { StudentScholasticStandingChangeType } from "@sims/sims-db";
+
 export interface ScholasticStanding {
   dateOfChange?: string;
   booksAndSupplies?: number;
@@ -7,5 +9,5 @@ export interface ScholasticStanding {
   tuition?: number;
   numberOfUnsuccessfulWeeks?: number;
   dateOfWithdrawal?: string;
-  scholasticStanding: string;
+  scholasticStandingChangeType: StudentScholasticStandingChangeType;
 }

--- a/sources/packages/backend/apps/api/src/services/student-scholastic-standings/student-scholastic-standings.service.ts
+++ b/sources/packages/backend/apps/api/src/services/student-scholastic-standings/student-scholastic-standings.service.ts
@@ -24,7 +24,7 @@ import { StudentAssessmentService } from "../student-assessment/student-assessme
 import { StudentRestrictionService } from "../restriction/student-restriction.service";
 import { APPLICATION_CHANGE_NOT_ELIGIBLE } from "../../constants";
 import { RestrictionCode } from "../restriction/models/restriction.model";
-import { MINIMUM_UNSUCCESSFUL_WEEKS } from "../../utilities";
+import { SCHOLASTIC_STANDING_MINIMUM_UNSUCCESSFUL_WEEKS } from "../../utilities";
 import {
   NotificationActionsService,
   StudentRestrictionSharedService,
@@ -361,7 +361,7 @@ export class StudentScholasticStandingsService extends RecordDataModelService<St
       if (
         totalExistingUnsuccessfulWeeks +
           scholasticStandingData.numberOfUnsuccessfulWeeks >=
-        MINIMUM_UNSUCCESSFUL_WEEKS
+        SCHOLASTIC_STANDING_MINIMUM_UNSUCCESSFUL_WEEKS
       ) {
         return this.studentRestrictionService.createRestrictionToSave(
           studentId,

--- a/sources/packages/backend/apps/api/src/services/student-scholastic-standings/student-scholastic-standings.service.ts
+++ b/sources/packages/backend/apps/api/src/services/student-scholastic-standings/student-scholastic-standings.service.ts
@@ -167,6 +167,8 @@ export class StudentScholasticStandingsService extends RecordDataModelService<St
 
       // Create StudentScholasticStanding.
       const scholasticStanding = new StudentScholasticStanding();
+      scholasticStanding.changeType =
+        scholasticStandingData.scholasticStandingChangeType;
       scholasticStanding.application = { id: application.id } as Application;
       scholasticStanding.submittedData = scholasticStandingData;
       scholasticStanding.submittedDate = now;

--- a/sources/packages/backend/apps/api/src/services/student-scholastic-standings/student-scholastic-standings.service.ts
+++ b/sources/packages/backend/apps/api/src/services/student-scholastic-standings/student-scholastic-standings.service.ts
@@ -24,7 +24,7 @@ import { StudentAssessmentService } from "../student-assessment/student-assessme
 import { StudentRestrictionService } from "../restriction/student-restriction.service";
 import { APPLICATION_CHANGE_NOT_ELIGIBLE } from "../../constants";
 import { RestrictionCode } from "../restriction/models/restriction.model";
-import { MINIMUM_UNSUCCESSFUL_WEEKS } from "./constants";
+import { MINIMUM_UNSUCCESSFUL_WEEKS } from "../../utilities";
 import {
   NotificationActionsService,
   StudentRestrictionSharedService,

--- a/sources/packages/backend/apps/api/src/utilities/system-configurations-constants.ts
+++ b/sources/packages/backend/apps/api/src/utilities/system-configurations-constants.ts
@@ -81,3 +81,8 @@ export const OFFERING_BULK_UPLOAD_MAX_FILE_SIZE = 4194304;
  * Expected length of the award value code.
  */
 export const AWARD_VALUE_CODE_LENGTH = 4;
+
+/**
+ * Minium unsuccessful weeks.
+ */
+export const MINIMUM_UNSUCCESSFUL_WEEKS = 68;

--- a/sources/packages/backend/apps/api/src/utilities/system-configurations-constants.ts
+++ b/sources/packages/backend/apps/api/src/utilities/system-configurations-constants.ts
@@ -83,6 +83,8 @@ export const OFFERING_BULK_UPLOAD_MAX_FILE_SIZE = 4194304;
 export const AWARD_VALUE_CODE_LENGTH = 4;
 
 /**
- * Minium unsuccessful weeks.
+ * For a scholastic standing of type "Student did not complete program" the number
+ * of unsuccessful weeks must also be reported, along the time if the amount of
+ * weeks reaches the value in the const, a restriction will be generated.
  */
-export const MINIMUM_UNSUCCESSFUL_WEEKS = 68;
+export const SCHOLASTIC_STANDING_MINIMUM_UNSUCCESSFUL_WEEKS = 68;

--- a/sources/packages/backend/apps/db-migrations/src/migrations/1678757112924-CreateStudentScholasticStandingChangeTypes.ts
+++ b/sources/packages/backend/apps/db-migrations/src/migrations/1678757112924-CreateStudentScholasticStandingChangeTypes.ts
@@ -1,0 +1,24 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+import { getSQLFileData } from "../utilities/sqlLoader";
+
+export class CreateStudentScholasticStandingChangeTypes1678757112924
+  implements MigrationInterface
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      getSQLFileData(
+        "Create-student-scholastic-standing-change-types.sql",
+        "Types",
+      ),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      getSQLFileData(
+        "Drop-student-scholastic-standing-change-types.sql",
+        "Types",
+      ),
+    );
+  }
+}

--- a/sources/packages/backend/apps/db-migrations/src/migrations/1678757977330-AddStudentScholasticStandingChangeTypeColumn.ts
+++ b/sources/packages/backend/apps/db-migrations/src/migrations/1678757977330-AddStudentScholasticStandingChangeTypeColumn.ts
@@ -1,0 +1,18 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+import { getSQLFileData } from "../utilities/sqlLoader";
+
+export class AddStudentScholasticStandingChangeTypeColumn1678757977330
+  implements MigrationInterface
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      getSQLFileData("Add-change-type.sql", "StudentScholasticStandings"),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      getSQLFileData("Remove-change-type.sql", "StudentScholasticStandings"),
+    );
+  }
+}

--- a/sources/packages/backend/apps/db-migrations/src/sql/StudentScholasticStandings/Add-change-type.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/StudentScholasticStandings/Add-change-type.sql
@@ -1,0 +1,13 @@
+ALTER TABLE
+  sims.student_scholastic_standings
+ADD
+  COLUMN IF NOT EXISTS change_type sims.student_scholastic_standing_change_types NOT NULL DEFAULT 'Student completed program early';
+
+COMMENT ON COLUMN sims.student_scholastic_standings.change_type IS 'Type of the scholastic standing change reported by an institution when the program enrolled by the student was not completed as expected.';
+
+-- Removing the dummy constraint created just to allow us
+-- to add a "NOT NULL" column in an existing table.
+ALTER TABLE
+  sims.student_scholastic_standings
+ALTER COLUMN
+  change_type DROP DEFAULT;

--- a/sources/packages/backend/apps/db-migrations/src/sql/StudentScholasticStandings/Remove-change-type.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/StudentScholasticStandings/Remove-change-type.sql
@@ -1,0 +1,2 @@
+ALTER TABLE
+  sims.student_scholastic_standings DROP COLUMN IF EXISTS change_type;

--- a/sources/packages/backend/apps/db-migrations/src/sql/Types/Create-student-scholastic-standing-change-types.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/Types/Create-student-scholastic-standing-change-types.sql
@@ -1,0 +1,6 @@
+CREATE TYPE sims.student_scholastic_standing_change_types AS ENUM (
+  'Change in intensity',
+  'Student completed program early',
+  'Student did not complete program',
+  'Student withdrew from program'
+);

--- a/sources/packages/backend/apps/db-migrations/src/sql/Types/Drop-student-scholastic-standing-change-types.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/Types/Drop-student-scholastic-standing-change-types.sql
@@ -1,0 +1,1 @@
+DROP TYPE IF EXISTS sims.student_scholastic_standing_change_types;

--- a/sources/packages/backend/libs/sims-db/src/entities/application.model.ts
+++ b/sources/packages/backend/libs/sims-db/src/entities/application.model.ts
@@ -16,6 +16,7 @@ import {
   OfferingIntensity,
   PIRDeniedReason,
   RelationshipStatus,
+  StudentScholasticStanding,
   SupportingUser,
 } from ".";
 import { ColumnNames, TableNames } from "../constant";
@@ -333,6 +334,19 @@ export class Application extends RecordDataModel {
     nullable: true,
   })
   submittedDate?: Date;
+  /**
+   * Scholastic standings changes associated with this application.
+   */
+  @OneToMany(
+    () => StudentScholasticStanding,
+    (studentScholasticStanding) => studentScholasticStanding.application,
+    {
+      eager: false,
+      cascade: false,
+      nullable: true,
+    },
+  )
+  studentScholasticStandings?: StudentScholasticStanding[];
 }
 
 /**

--- a/sources/packages/backend/libs/sims-db/src/entities/index.ts
+++ b/sources/packages/backend/libs/sims-db/src/entities/index.ts
@@ -66,6 +66,7 @@ export * from "./application-exceptions.model";
 export * from "./disbursement-receipts.model";
 export * from "./disbursement-receipt-values.model";
 export * from "./student-account-application.model";
+export * from "./student-scholastic-standing.type";
 export * from "./student-scholastic-standing.model";
 export * from "./student-user.model";
 export * from "./identity-providers.type";

--- a/sources/packages/backend/libs/sims-db/src/entities/student-scholastic-standing.model.ts
+++ b/sources/packages/backend/libs/sims-db/src/entities/student-scholastic-standing.model.ts
@@ -16,6 +16,7 @@ import {
 } from ".";
 import { ColumnNames, TableNames } from "../constant";
 import { RecordDataModel } from "./record.model";
+import { StudentScholasticStandingChangeType } from "./student-scholastic-standing.type";
 
 /**
  * Represents a scholastic standing change requested by the Institution due to some
@@ -128,4 +129,15 @@ export class StudentScholasticStanding extends RecordDataModel {
     nullable: true,
   })
   unsuccessfulWeeks?: number;
+  /**
+   * Type of the change in the scholastic standing.
+   */
+  @Column({
+    name: "change_type",
+    type: "enum",
+    enum: StudentScholasticStandingChangeType,
+    enumName: "StudentScholasticStandingChangeType",
+    nullable: false,
+  })
+  changeType: StudentScholasticStandingChangeType;
 }

--- a/sources/packages/backend/libs/sims-db/src/entities/student-scholastic-standing.type.ts
+++ b/sources/packages/backend/libs/sims-db/src/entities/student-scholastic-standing.type.ts
@@ -1,0 +1,26 @@
+/**
+ * Possible scholastic standing changes types reported by an institution when the
+ * program enrolled by the student was not completed as expected and the institution
+ * must report the change to the Ministry.
+ */
+export enum StudentScholasticStandingChangeType {
+  /**
+   * Student went from full-time to part-time studies (vice-versa) or started a different program.
+   * This scholastic standing change type is only used to finish the current application. The actual
+   * changing from full-time to part-time studies (vice-versa) is not part of the scholastic standing change.
+   */
+  ChangeInIntensity = "Change in intensity",
+  /**
+   * Student completed the offering before the expected time.
+   */
+  StudentCompletedProgramEarly = "Student completed program early",
+  /**
+   * Student was not able to complete the program (fail to complete).
+   *!This scholastic standing type does not causes an reassessment.
+   */
+  StudentDidNotCompleteProgram = "Student did not complete program",
+  /**
+   * Student withdrew from program.
+   */
+  StudentWithdrewFromProgram = "Student withdrew from program",
+}

--- a/sources/packages/forms/src/form-definitions/reportscholasticstandingchange.json
+++ b/sources/packages/forms/src/form-definitions/reportscholasticstandingchange.json
@@ -3294,22 +3294,22 @@
           "values": [
             {
               "label": "Student went from full-time to part-time studies (vice-versa) or started a different program",
-              "value": "changeInIntensity",
+              "value": "Change in intensity",
               "shortcut": ""
             },
             {
               "label": "Student completed program early",
-              "value": "studentCompletedProgramEarly",
+              "value": "Student completed program early",
               "shortcut": ""
             },
             {
               "label": "Student did not complete program",
-              "value": "studentDidNotCompleteProgram",
+              "value": "Student did not complete program",
               "shortcut": ""
             },
             {
               "label": "Student withdrew from program",
-              "value": "studentWithdrewFromProgram",
+              "value": "Student withdrew from program",
               "shortcut": ""
             }
           ],
@@ -3322,7 +3322,7 @@
             "multiple": false,
             "unique": false
           },
-          "key": "scholasticStanding",
+          "key": "scholasticStandingChangeType",
           "type": "radio",
           "input": true,
           "placeholder": "",

--- a/sources/packages/forms/src/form-definitions/reportscholasticstandingchange.json
+++ b/sources/packages/forms/src/form-definitions/reportscholasticstandingchange.json
@@ -3386,7 +3386,7 @@
           "conditional": {
             "show": true,
             "when": "scholasticStanding",
-            "eq": "changeInIntensity"
+            "eq": "Change in intensity"
           },
           "type": "panel",
           "label": "Panel",
@@ -3655,7 +3655,7 @@
           "conditional": {
             "show": true,
             "when": "scholasticStanding",
-            "eq": "studentCompletedProgramEarly"
+            "eq": "Student completed program early"
           },
           "type": "panel",
           "label": "Panel",
@@ -4640,7 +4640,7 @@
           "conditional": {
             "show": true,
             "when": "scholasticStanding",
-            "eq": "studentDidNotCompleteProgram"
+            "eq": "Student did not complete program"
           },
           "type": "panel",
           "label": "Panel",
@@ -5055,7 +5055,7 @@
           "conditional": {
             "show": true,
             "when": "scholasticStanding",
-            "eq": "studentWithdrewFromProgram"
+            "eq": "Student withdrew from program"
           },
           "type": "panel",
           "label": "Panel",

--- a/sources/packages/forms/src/form-definitions/reportscholasticstandingchange.json
+++ b/sources/packages/forms/src/form-definitions/reportscholasticstandingchange.json
@@ -3385,7 +3385,7 @@
           "key": "differentIntensityProgramPanel",
           "conditional": {
             "show": true,
-            "when": "scholasticStanding",
+            "when": "scholasticStandingChangeType",
             "eq": "Change in intensity"
           },
           "type": "panel",
@@ -3654,7 +3654,7 @@
           "key": "studentCompletedProgramEarlyPanel",
           "conditional": {
             "show": true,
-            "when": "scholasticStanding",
+            "when": "scholasticStandingChangeType",
             "eq": "Student completed program early"
           },
           "type": "panel",
@@ -4639,7 +4639,7 @@
           "key": "studentDidNotCompleteProgramPanel",
           "conditional": {
             "show": true,
-            "when": "scholasticStanding",
+            "when": "scholasticStandingChangeType",
             "eq": "Student did not complete program"
           },
           "type": "panel",
@@ -5054,7 +5054,7 @@
           "key": "studentWithdrewFromProgramPanel",
           "conditional": {
             "show": true,
-            "when": "scholasticStanding",
+            "when": "scholasticStandingChangeType",
             "eq": "Student withdrew from program"
           },
           "type": "panel",

--- a/sources/packages/web/src/components/students/applicationTracker/ApplicationProgressBar.vue
+++ b/sources/packages/web/src/components/students/applicationTracker/ApplicationProgressBar.vue
@@ -49,6 +49,7 @@ import {
   ApplicationExceptionStatus,
   COEStatus,
   StudentAppealStatus,
+  StudentScholasticStandingChangeType,
 } from "@/types";
 import { PropType, ref, defineComponent, computed, onMounted } from "vue";
 import { ApplicationProgressDetailsAPIOutDTO } from "@/services/http/dto/Application.dto";
@@ -125,6 +126,15 @@ export default defineComponent({
         );
 
       if (
+        applicationProgressDetails.value.scholasticStandingChangeType ===
+        StudentScholasticStandingChangeType.StudentDidNotCompleteProgram
+      ) {
+        // Application is complete but has warnings.
+        applicationEndStatus.value = {
+          endStatusType: "error",
+          endStatusIcon: "fa:fas fa-exclamation-circle",
+        };
+      } else if (
         applicationProgressDetails.value.appealStatus ===
         StudentAppealStatus.Pending
       ) {

--- a/sources/packages/web/src/components/students/applicationTracker/ApplicationProgressBar.vue
+++ b/sources/packages/web/src/components/students/applicationTracker/ApplicationProgressBar.vue
@@ -129,7 +129,7 @@ export default defineComponent({
         applicationProgressDetails.value.scholasticStandingChangeType ===
         StudentScholasticStandingChangeType.StudentDidNotCompleteProgram
       ) {
-        // Application is complete but has warnings.
+        // Application is complete has an error.
         applicationEndStatus.value = {
           endStatusType: "error",
           endStatusIcon: "fa:fas fa-exclamation-circle",

--- a/sources/packages/web/src/components/students/applicationTracker/Completed.vue
+++ b/sources/packages/web/src/components/students/applicationTracker/Completed.vue
@@ -1,4 +1,28 @@
 <template>
+  <!-- Scholastic standing changed -->
+  <application-status-tracker-banner
+    v-if="
+      assessmentDetails.assessmentTriggerType ===
+      AssessmentTriggerType.ScholasticStandingChange
+    "
+    label="You have a new assessment due to your scholastic standing"
+    icon="fa:fas fa-check-circle"
+    icon-color="success"
+    :background-color="hasDisbursementEvent ? undefined : 'success-bg'"
+    content="Your institution informed us of your scholastic standing, which changed your assessment evaluation. Please review your new assessment in the table below. You can also click “View request” to see the details from your institution. Please contact the Financial Aid Officer from your institution, if you have questions about your scholastic standing."
+  />
+  <!-- Scholastic standing changed - student did not complete the program -->
+  <application-status-tracker-banner
+    v-if="
+      assessmentDetails.scholasticStandingChangeType ===
+      StudentScholasticStandingChangeType.StudentDidNotCompleteProgram
+    "
+    label="Your institution reported that you did not complete your studies"
+    icon="fa:fas fa-exclamation-circle"
+    icon-color="danger"
+    background-color="error-bg"
+    content="You no longer meet StudentAid BC's requirements to receive funding for financial aid. Any scheduled payments will be cancelled. Please contact the Financial Aid Officer from your institution if you require more information."
+  />
   <!-- Student appeal - waiting approval -->
   <application-status-tracker-banner
     v-if="assessmentDetails.appealStatus === StudentAppealStatus.Pending"
@@ -28,18 +52,6 @@
     icon-color="success"
     :background-color="hasDisbursementEvent ? undefined : 'success-bg'"
     content="StudentAid BC has determined an outcome with 1 or more of your requested change. Please review your new assessment in the table below."
-  />
-  <!-- Scholastic standing changed -->
-  <application-status-tracker-banner
-    v-if="
-      assessmentDetails.assessmentTriggerType ===
-      AssessmentTriggerType.ScholasticStandingChange
-    "
-    label="You have a new assessment due to your scholastic standing"
-    icon="fa:fas fa-check-circle"
-    icon-color="success"
-    :background-color="hasDisbursementEvent ? undefined : 'success-bg'"
-    content="Your institution informed us of your scholastic standing, which changed your assessment evaluation. Please review your new assessment in the table below. You can also click “View request” to see the details from your institution. Please contact the Financial Aid Officer from your institution, if you have questions about your scholastic standing."
   />
   <!-- Offering changed -->
   <application-status-tracker-banner
@@ -76,7 +88,12 @@
   />
 </template>
 <script lang="ts">
-import { AssessmentTriggerType, COEStatus, StudentAppealStatus } from "@/types";
+import {
+  AssessmentTriggerType,
+  COEStatus,
+  StudentAppealStatus,
+  StudentScholasticStandingChangeType,
+} from "@/types";
 import { onMounted, ref, defineComponent, computed } from "vue";
 import { ApplicationService } from "@/services/ApplicationService";
 import { CompletedApplicationDetailsAPIOutDTO } from "@/services/http/dto/Application.dto";
@@ -127,6 +144,7 @@ export default defineComponent({
       AssessmentTriggerType,
       StudentAppealStatus,
       hasDisbursementEvent,
+      StudentScholasticStandingChangeType,
     };
   },
 });

--- a/sources/packages/web/src/services/http/dto/Application.dto.ts
+++ b/sources/packages/web/src/services/http/dto/Application.dto.ts
@@ -9,6 +9,7 @@ import {
   DisbursementScheduleStatus,
   AssessmentTriggerType,
   StudentAppealStatus,
+  StudentScholasticStandingChangeType,
 } from "@/types";
 
 export interface InProgressApplicationDetailsAPIOutDTO {
@@ -96,6 +97,7 @@ export interface ApplicationProgressDetailsAPIOutDTO {
   secondCOEStatus?: COEStatus;
   exceptionStatus?: ApplicationExceptionStatus;
   appealStatus?: StudentAppealStatus;
+  scholasticStandingChangeType?: StudentScholasticStandingChangeType;
 }
 
 export interface DisbursementDetailsAPIOutDTO {
@@ -115,4 +117,5 @@ export interface CompletedApplicationDetailsAPIOutDTO
   firstDisbursement: DisbursementDetailsAPIOutDTO;
   secondDisbursement?: DisbursementDetailsAPIOutDTO;
   appealStatus?: StudentAppealStatus;
+  scholasticStandingChangeType?: StudentScholasticStandingChangeType;
 }

--- a/sources/packages/web/src/types/contracts/StudentScholasticStanding.ts
+++ b/sources/packages/web/src/types/contracts/StudentScholasticStanding.ts
@@ -6,8 +6,8 @@
 export enum StudentScholasticStandingChangeType {
   /**
    * Student went from full-time to part-time studies (vice-versa) or started a different program.
-   * This scholastic standing change type is only used to finish the current application. changing
-   * from full-time to part-time studies (vice-versa) is not part of the scholastic standing change.
+   * This scholastic standing change type is only used to finish the current application. The actual
+   * changing from full-time to part-time studies (vice-versa) is not part of the scholastic standing change.
    */
   ChangeInIntensity = "Change in intensity",
   /**
@@ -16,7 +16,7 @@ export enum StudentScholasticStandingChangeType {
   StudentCompletedProgramEarly = "Student completed program early",
   /**
    * Student was not able to complete the program (fail to complete).
-   *!This scholastic standing type does not cause a reassessment.
+   *!This scholastic standing type does not causes an reassessment.
    */
   StudentDidNotCompleteProgram = "Student did not complete program",
   /**

--- a/sources/packages/web/src/types/index.ts
+++ b/sources/packages/web/src/types/index.ts
@@ -40,3 +40,4 @@ export * from "@/types/contracts/aest/roles";
 export * from "@/types/contracts/StatusInfo";
 export * from "@/types/contracts/Assessment";
 export * from "@/types/contracts/Overaward";
+export * from "@/types/contracts/StudentScholasticStanding";


### PR DESCRIPTION
- Extracted the scholastic standing change type from the dynamic data and persisted as a separate column using a DB enum.
- Created an error card to display the scholastic standing as an error when the change type is `Student did not complete program`.
![image](https://user-images.githubusercontent.com/61259237/225192221-6f33c542-9111-490f-899c-79743a931e28.png)
_Right now there is no further information about what must happen with the disbursement/COE cards nor what should actually happen with the assessment. `Student did not complete program` is the only scholastic standing change type that does not generates a new student assessment._