### PR TITLE
#1715 COE and Tuition Remittance - e-Cert Adjustments

### DIFF
--- a/sources/packages/backend/apps/api/src/services/student-assessment/student-assessment.service.ts
+++ b/sources/packages/backend/apps/api/src/services/student-assessment/student-assessment.service.ts
@@ -161,7 +161,6 @@ export class StudentAssessmentService extends RecordDataModelService<StudentAsse
         ASSESSMENT_INVALID_OPERATION_IN_THE_CURRENT_STATE,
       );
     }
-
     await this.startAssessmentQueue.add({
       workflowName: assessment.application.data.workflowName,
       assessmentId: assessment.id,

--- a/sources/packages/backend/apps/db-migrations/src/migrations/1679688897417-AddTuitionRemittanceEffectiveAmountCol.ts
+++ b/sources/packages/backend/apps/db-migrations/src/migrations/1679688897417-AddTuitionRemittanceEffectiveAmountCol.ts
@@ -1,0 +1,24 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+import { getSQLFileData } from "../utilities/sqlLoader";
+
+export class AddTuitionRemittanceEffectiveAmountCol1679688897417
+  implements MigrationInterface
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      getSQLFileData(
+        "Add-tuition-remittance-effective-amount-col.sql",
+        "DisbursementSchedules",
+      ),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      getSQLFileData(
+        "Remove-tuition-remittance-effective-amount-col.sql",
+        "DisbursementSchedules",
+      ),
+    );
+  }
+}

--- a/sources/packages/backend/apps/db-migrations/src/sql/DisbursementSchedules/Add-tuition-remittance-effective-amount-col.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/DisbursementSchedules/Add-tuition-remittance-effective-amount-col.sql
@@ -1,0 +1,7 @@
+-- Add tuition_remittance_effective_amount to disbursement_schedules table.
+ALTER TABLE
+    sims.disbursement_schedules
+ADD
+    COLUMN IF NOT EXISTS tuition_remittance_effective_amount INT NOT NULL DEFAULT 0;
+
+COMMENT ON COLUMN sims.disbursement_schedules.tuition_remittance_effective_amount IS 'Column which indicates the tuition remittance effective amount of a disbursement.';

--- a/sources/packages/backend/apps/db-migrations/src/sql/DisbursementSchedules/Remove-tuition-remittance-effective-amount-col.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/DisbursementSchedules/Remove-tuition-remittance-effective-amount-col.sql
@@ -1,0 +1,3 @@
+-- Drop tuition_remittance_effective_amount from sims.disbursement_schedules. 
+ALTER TABLE
+    sims.disbursement_schedules DROP COLUMN IF EXISTS tuition_remittance_effective_amount;

--- a/sources/packages/backend/libs/integrations/src/esdc-integration/e-cert-integration/e-cert-file-handler.ts
+++ b/sources/packages/backend/libs/integrations/src/esdc-integration/e-cert-integration/e-cert-file-handler.ts
@@ -281,6 +281,8 @@ export class ECertFileHandler extends ESDCFileHandler {
       gender: application.student.gender,
       maritalStatus: application.relationshipStatus,
       studentNumber: application.studentNumber,
+      tuitionRemittanceEffectiveAmount:
+        disbursement.tuitionRemittanceEffectiveAmount,
       awards,
     } as ECertRecord;
   }

--- a/sources/packages/backend/libs/integrations/src/esdc-integration/e-cert-integration/e-cert-full-time-integration/e-cert-full-time.integration.service.ts
+++ b/sources/packages/backend/libs/integrations/src/esdc-integration/e-cert-integration/e-cert-full-time-integration/e-cert-full-time.integration.service.ts
@@ -71,8 +71,8 @@ export class ECertFullTimeIntegrationService extends ECertIntegrationService {
       // ! All awards effective values are rounded to the nearest integer (0.5 rounds up).
       // ! studentAmount and schoolAmount have the decimal part combined into the integer part because
       // ! the schoolAmount contains decimals and schoolAmount is used to determine the studentAmount.
-      const studentAmount = disbursementAmount - ecertRecord.schoolAmount;
-
+      const studentAmount =
+        disbursementAmount - ecertRecord.tuitionRemittanceEffectiveAmount;
       const cslAwardAmount = getTotalDisbursementEffectiveAmount(
         ecertRecord.awards,
         [DisbursementValueType.CanadaLoan],

--- a/sources/packages/backend/libs/integrations/src/esdc-integration/e-cert-integration/e-cert-integration.module.ts
+++ b/sources/packages/backend/libs/integrations/src/esdc-integration/e-cert-integration/e-cert-integration.module.ts
@@ -4,6 +4,7 @@ import {
   SequenceControlService,
   StudentRestrictionSharedService,
   NoteSharedService,
+  ConfirmationOfEnrollmentService,
 } from "@sims/services";
 import { ECertFileHandler } from "./e-cert-file-handler";
 import { ECertFullTimeFileFooter } from "./e-cert-full-time-integration/e-cert-files/e-cert-file-footer";
@@ -42,6 +43,7 @@ import { SystemUsersService } from "@sims/services/system-users";
     ECertGenerationService,
     DisbursementOverawardService,
     NoteSharedService,
+    ConfirmationOfEnrollmentService,
   ],
   exports: [ECertFileHandler],
 })

--- a/sources/packages/backend/libs/integrations/src/esdc-integration/e-cert-integration/models/e-cert-integration-model.ts
+++ b/sources/packages/backend/libs/integrations/src/esdc-integration/e-cert-integration/models/e-cert-integration-model.ts
@@ -45,6 +45,7 @@ export interface ECertRecord {
   awards: Award[];
   stopFullTimeBCFunding: boolean;
   courseLoad?: number;
+  tuitionRemittanceEffectiveAmount: number;
 }
 
 export type Award = Pick<

--- a/sources/packages/backend/libs/integrations/src/services/disbursement-schedule/e-cert-generation.service.ts
+++ b/sources/packages/backend/libs/integrations/src/services/disbursement-schedule/e-cert-generation.service.ts
@@ -4,6 +4,7 @@ import { addDays, round } from "@sims/utilities";
 import { EntityManager } from "typeorm";
 import {
   AwardValueWithRelatedSchedule,
+  ConfirmationOfEnrollmentService,
   DisbursementOverawardService,
   StudentRestrictionSharedService,
 } from "@sims/services";
@@ -29,6 +30,11 @@ import {
   LOAN_TYPES,
 } from "@sims/services/constants";
 import { SystemUsersService } from "@sims/services/system-users";
+import {
+  Award,
+  MaxTuitionRemittanceTypes,
+  OfferingCosts,
+} from "@sims/services/confirmation-of-enrollment/models/confirmation-of-enrollment.models";
 
 /**
  * While performing a possible huge amount of updates,
@@ -48,6 +54,7 @@ export class ECertGenerationService {
     private readonly studentRestrictionService: StudentRestrictionSharedService,
     private readonly disbursementOverawardService: DisbursementOverawardService,
     private readonly systemUsersService: SystemUsersService,
+    private readonly confirmationOfEnrollmentService: ConfirmationOfEnrollmentService,
   ) {}
 
   /**
@@ -77,10 +84,12 @@ export class ECertGenerationService {
     await this.applyOverawardsDeductions(disbursements, entityManager);
     // Step 2 - Execute the calculation to define the final value to be used for the e-Cert.
     this.calculateEffectiveValue(disbursements);
-    // Step 3 - Calculate BC total grants after all others calculations are done.
+    // Step 3 - Calculate tuition remittance effective amount.
+    this.calculateTuitionRemittanceEffectiveAmount(disbursements);
+    // Step 4 - Calculate BC total grants after all others calculations are done.
     //!This step relies on the effective value calculation (step 2).
     await this.createBCTotalGrants(disbursements);
-    // Step 4 - Mark all disbursements as 'sent'.
+    // Step 5 - Mark all disbursements as 'sent'.
     const now = new Date();
     disbursements.forEach((disbursement) => {
       disbursement.disbursementScheduleStatus = DisbursementScheduleStatus.Sent;
@@ -151,6 +160,8 @@ export class ECertGenerationService {
         "offering.studyEndDate",
         "offering.yearOfStudy",
         "offering.offeringIntensity",
+        "offering.actualTuitionCosts",
+        "offering.programRelatedCosts",
         "educationProgram.id",
         "educationProgram.fieldOfStudyCode",
         "educationProgram.completionYears",
@@ -495,6 +506,40 @@ export class ECertGenerationService {
         currentBalance -= availableAwardValueAmount;
         award.overawardAmountSubtracted = availableAwardValueAmount;
       }
+    }
+  }
+
+  /**
+   * Calculate tuition remittance effective amount.
+   * @param disbursements all disbursements that are part of one e-Cert.
+   */
+  private calculateTuitionRemittanceEffectiveAmount(
+    disbursements: ECertDisbursementSchedule[],
+  ) {
+    for (const disbursement of disbursements) {
+      const award: Award[] = disbursement.disbursementValues?.map(
+        (eachDisbursementValue: DisbursementValue) => ({
+          valueType: eachDisbursementValue.valueType,
+          disbursedAmountSubtracted:
+            eachDisbursementValue.disbursedAmountSubtracted,
+          valueAmount: eachDisbursementValue.valueAmount,
+          effectiveAmount: eachDisbursementValue.effectiveAmount,
+        }),
+      );
+      const offering =
+        disbursement.studentAssessment.application.currentAssessment.offering;
+      const offeringCosts: OfferingCosts = {
+        actualTuitionCosts: offering.actualTuitionCosts,
+        programRelatedCosts: offering.programRelatedCosts,
+      };
+      const calculationType = MaxTuitionRemittanceTypes.Effective;
+
+      disbursement.tuitionRemittanceEffectiveAmount =
+        this.confirmationOfEnrollmentService.getMaxTuitionRemittance(
+          award,
+          offeringCosts,
+          calculationType,
+        );
     }
   }
 }

--- a/sources/packages/backend/libs/sims-db/src/entities/disbursement-schedule.model.ts
+++ b/sources/packages/backend/libs/sims-db/src/entities/disbursement-schedule.model.ts
@@ -159,4 +159,12 @@ export class DisbursementSchedule extends RecordDataModel {
     nullable: false,
   })
   disbursementScheduleStatus: DisbursementScheduleStatus;
+  /**
+   * Tuition remittance effective amount of a disbursement.
+   */
+  @Column({
+    name: "tuition_remittance_effective_amount",
+    nullable: false,
+  })
+  tuitionRemittanceEffectiveAmount: number;
 }


### PR DESCRIPTION
- Added a new field in `tuition_remittance_effective_amount`  in `DisbursementSchedule`
- Added a function to reuse the logic implemented on [#1714](https://github.com/bcgov/SIMS/issues/1714) to determine the maximum award using the effective_value calculated for the e-Cert and used as Step 3 in `prepareDisbursementsForECertGeneration`
- Replaced the `schoolAmount` used during the e-Cert generation to reflect the value calculated for the column `tuition_remittance_effective_amount`,  it is using the COE requested value 