### PR TITLE
#1837 - Fixed the Designation Request bug

### DIFF
--- a/sources/packages/backend/apps/api/src/route-controllers/designation-agreement/models/designation-agreement.dto.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/designation-agreement/models/designation-agreement.dto.ts
@@ -75,6 +75,11 @@ export class SubmitDesignationAgreementAPIInDTO {
   @ValidateNested({ each: true })
   @Type(() => SubmittedLocationsAPIInDTO)
   locations: SubmittedLocationsAPIInDTO[];
+
+  /**
+   * Indicates if Institution is private or public
+   */
+  isBCPrivate: boolean;
 }
 
 /**

--- a/sources/packages/backend/apps/api/src/route-controllers/institution/institution.controller.service.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/institution/institution.controller.service.ts
@@ -80,4 +80,15 @@ export class InstitutionControllerService {
       description: institutionType.name,
     }));
   }
+
+  /**
+   * Check if institution is private or public.
+   * @param institutionId is the institution id.
+   * @returns boolean true if institution is private, else false.
+   */
+  async checkIfInstitutionIsPrivate(institutionId: number): Promise<boolean> {
+    const institutionType =
+      await this.institutionService.getInstitutionTypeById(institutionId);
+    return INSTITUTION_TYPE_BC_PRIVATE === institutionType.institutionType.id;
+  }
 }

--- a/sources/packages/backend/apps/api/src/services/institution/institution.service.ts
+++ b/sources/packages/backend/apps/api/src/services/institution/institution.service.ts
@@ -695,6 +695,27 @@ export class InstitutionService extends RecordDataModelService<Institution> {
   }
 
   /**
+   * Get the institutionType by institution id.
+   * @param institutionId Institution id.
+   * @returns Institution retrieved, if found, otherwise returns null.
+   */
+  async getInstitutionTypeById(institutionId: number): Promise<Institution> {
+    return this.repo.findOne({
+      select: {
+        institutionType: {
+          id: true,
+        },
+      },
+      where: {
+        id: institutionId,
+      },
+      relations: {
+        institutionType: true,
+      },
+    });
+  }
+
+  /**
    * Get the basic info of the institution by ID.
    * @param institutionId Institution id.
    * @returns Institution retrieved, if found, otherwise returns null.


### PR DESCRIPTION
The following was fixed as a part of this PR:

- Private Institution User

When the private institution user submits a Designation Request as below:

![image](https://user-images.githubusercontent.com/7859295/228601978-973d2d10-dc72-4141-ba99-b6725e1aff93.png)

The Pending and the Approved Designation Request can be viewed by the institution user with all the details properly populated.

![image](https://user-images.githubusercontent.com/7859295/228602402-98563d66-e20f-4816-a85a-05e260d4563e.png)

When the ministry user logs in to approve this Designation Request, they can see all the details related to the Designation Request being properly populated.

![image](https://user-images.githubusercontent.com/7859295/228603734-ade4a17f-6dac-48b0-9412-6ade62133390.png)

- Public Institution User

For the public institution user, verified that their Designation Request View remains as before.

![image](https://user-images.githubusercontent.com/7859295/228604646-d0b55971-6969-40b6-8fb0-d09657ac0779.png)


