### PR TITLE
#1683 - Show success icon when application is completed

### DIFF
--- a/sources/packages/backend/apps/api/src/route-controllers/application/application.students.controller.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/application/application.students.controller.ts
@@ -545,6 +545,7 @@ export class ApplicationStudentsController extends BaseController {
     const [firstDisbursement, secondDisbursement] = disbursements;
     const [scholasticStandingChange] = application.studentScholasticStandings;
     return {
+      applicationStatus: application.applicationStatus,
       applicationStatusUpdatedOn: application.applicationStatusUpdatedOn,
       pirStatus: application.pirStatus,
       firstCOEStatus: firstDisbursement?.coeStatus,

--- a/sources/packages/backend/apps/api/src/route-controllers/application/models/application.dto.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/application/models/application.dto.ts
@@ -148,6 +148,7 @@ export class InProgressApplicationDetailsAPIOutDTO extends IntersectionType(
 }
 
 export class ApplicationProgressDetailsAPIOutDTO {
+  applicationStatus: ApplicationStatus;
   applicationStatusUpdatedOn: Date;
   pirStatus?: ProgramInfoStatus;
   firstCOEStatus?: COEStatus;

--- a/sources/packages/web/src/components/students/applicationTracker/ApplicationProgressBar.vue
+++ b/sources/packages/web/src/components/students/applicationTracker/ApplicationProgressBar.vue
@@ -157,11 +157,12 @@ export default defineComponent({
         applicationProgressDetails.value.appealStatus ===
         StudentAppealStatus.Pending
       ) {
-        // Application is complete but has warnings.
+        // Application is completed but has warnings.
         statusIconDetails.value = STATUS_ICON_WARNING;
       } else if (
-        // Application is complete.
-        applicationProgressDetails.value.firstCOEStatus === COEStatus.completed
+        // Application is completed.
+        applicationProgressDetails.value.applicationStatus ===
+        ApplicationStatus.Completed
       ) {
         statusIconDetails.value = STATUS_ICON_SUCCESS;
       }

--- a/sources/packages/web/src/components/students/applicationTracker/MultipleDisbursementBanner.vue
+++ b/sources/packages/web/src/components/students/applicationTracker/MultipleDisbursementBanner.vue
@@ -156,7 +156,7 @@ export default defineComponent({
     },
     coeDenialReason: {
       type: String,
-      required: true,
+      required: false,
     },
     firstDisbursementStatus: {
       type: String as PropType<DisbursementScheduleStatus>,

--- a/sources/packages/web/src/services/http/dto/Application.dto.ts
+++ b/sources/packages/web/src/services/http/dto/Application.dto.ts
@@ -91,6 +91,7 @@ export interface ApplicationSummaryDTO extends ApplicationIdentifiersAPIOutDTO {
 }
 
 export interface ApplicationProgressDetailsAPIOutDTO {
+  applicationStatus: ApplicationStatus;
   applicationStatusUpdatedOn: Date;
   pirStatus?: ProgramInfoStatus;
   firstCOEStatus?: COEStatus;


### PR DESCRIPTION
The success icon was not displayed for a reassessment because the check relied on the COE confirmation.
Change the check to be based on the application status.

![image](https://user-images.githubusercontent.com/61259237/229595264-34848e9c-c587-4cac-996b-36bc3b39fee0.png)
