### PR TITLE
#1834 - Hierarchical mocks for workflow E2E tests

### DIFF
--- a/sources/packages/backend/libs/test-utils/src/models/common.model.ts
+++ b/sources/packages/backend/libs/test-utils/src/models/common.model.ts
@@ -31,7 +31,25 @@ export enum OfferingDeliveryOptions {
   Blended = "blended",
 }
 
+/**
+ * The load consolidated assessment data can be happen for three different scenarios:
+ * 1. When the application is submitted for the first time ever;
+ * 2. After the data collection happens (PIR, parents, partner, income);
+ * 3. During a reassessment.
+ * For the scenario 1, the load assessment will return less data, since the collection phase
+ * did not happen yet.
+ * For the scenarios 2 and 3, the data is fully acquired and the assessment calculation can happen.
+ * This enum defines the 2 different moments for the 3 different scenarios where there is a
+ * difference between the data returned.
+ */
 export enum AssessmentDataType {
+  /**
+   * PIR, parents, partner, income, etc. did not happen yet and the assessment consolidated
+   * data is pretty much the data reported by the student on the application form.
+   */
   Submit,
+  /**
+   * All data needed was acquired and the assessment is ready to be calculated.
+   */
   PreAssessment,
 }

--- a/sources/packages/backend/libs/test-utils/src/models/common.model.ts
+++ b/sources/packages/backend/libs/test-utils/src/models/common.model.ts
@@ -30,3 +30,8 @@ export enum OfferingDeliveryOptions {
   Online = "online",
   Blended = "blended",
 }
+
+export enum AssessmentDataType {
+  Submit,
+  PreAssessment,
+}

--- a/sources/packages/backend/workflow/BPMN/camunda-8/assessment-gateway.bpmn
+++ b/sources/packages/backend/workflow/BPMN/camunda-8/assessment-gateway.bpmn
@@ -179,10 +179,10 @@
         <zeebe:calledElement processId="supporting-user-information-request" propagateAllChildVariables="false" />
         <zeebe:ioMapping>
           <zeebe:input source="=createdSupportingUsersIds[1]" target="supportingUserId" />
-          <zeebe:input source="=append(parentSubprocesses, &#34;retrieveSupportingInfoParent1Subprocess&#34;)" target="parentSubprocesses" />
+          <zeebe:input source="=[&#34;retrieveSupportingInfoParent1Subprocess&#34;]" target="parentSubprocesses" />
           <zeebe:output source="=supportingUserId" target="parent1SupportingUserId" />
           <zeebe:output source="=totalIncome" target="supportingUserParent1TotalIncome" />
-          <zeebe:output source="=&#34;retrieveSupportingInfoParent1Subprocess&#34;" target="retrieveSupportingInfoParent1Subprocess" />
+          <zeebe:output source="=&#34;retrieveSupportingInfoParent1Subprocess&#34;" target="retrieveSupportingInfoParent1Subprocess_passthrough" />
         </zeebe:ioMapping>
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_1u5ion6</bpmn:incoming>
@@ -193,10 +193,10 @@
         <zeebe:calledElement processId="supporting-user-information-request" propagateAllChildVariables="false" />
         <zeebe:ioMapping>
           <zeebe:input source="=createdSupportingUsersIds[2]" target="supportingUserId" />
-          <zeebe:input source="=append(parentSubprocesses, &#34;retrieveSupportingInfoParent2Subprocess&#34;)" target="parentSubprocesses" />
+          <zeebe:input source="=[&#34;retrieveSupportingInfoParent2Subprocess&#34;]" target="parentSubprocesses" />
           <zeebe:output source="=supportingUserId" target="parent2SupportingUserId" />
           <zeebe:output source="=totalIncome" target="parent2TotalIncome" />
-          <zeebe:output source="=&#34;retrieveSupportingInfoParent2Subprocess&#34;" target="retrieveSupportingInfoParent2Subprocess" />
+          <zeebe:output source="=&#34;retrieveSupportingInfoParent2Subprocess&#34;" target="retrieveSupportingInfoParent2Subprocess_passthrough" />
         </zeebe:ioMapping>
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_1lbai2h</bpmn:incoming>
@@ -208,8 +208,8 @@
         <zeebe:ioMapping>
           <zeebe:input source="=parent2TotalIncome" target="reportedIncome" />
           <zeebe:input source="=parent2SupportingUserId" target="supportingUserId" />
-          <zeebe:input source="=append(parentSubprocesses, &#34;parent2IncomeVerificationSubprocess&#34;)" target="parentSubprocesses" />
-          <zeebe:output source="=&#34;parent2IncomeVerificationSubprocess&#34;" target="parent2IncomeVerificationSubprocess" />
+          <zeebe:input source="=[&#34;parent2IncomeVerificationSubprocess&#34;]" target="parentSubprocesses" />
+          <zeebe:output source="=&#34;parent2IncomeVerificationSubprocess&#34;" target="parent2IncomeVerificationSubprocess_passthrough" />
         </zeebe:ioMapping>
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_0l30wbo</bpmn:incoming>
@@ -221,8 +221,8 @@
         <zeebe:ioMapping>
           <zeebe:input source="=supportingUserParent1TotalIncome" target="reportedIncome" />
           <zeebe:input source="=parent1SupportingUserId" target="supportingUserId" />
-          <zeebe:input source="=append(parentSubprocesses, &#34;parent1IncomeVerificationSubprocess&#34;)" target="parentSubprocesses" />
-          <zeebe:output source="=&#34;parent1IncomeVerificationSubprocess&#34;" target="parent1IncomeVerificationSubprocess" />
+          <zeebe:input source="=[&#34;parent1IncomeVerificationSubprocess&#34;]" target="parentSubprocesses" />
+          <zeebe:output source="=&#34;parent1IncomeVerificationSubprocess&#34;" target="parent1IncomeVerificationSubprocess_passthrough" />
         </zeebe:ioMapping>
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_1g59sq3</bpmn:incoming>
@@ -269,10 +269,10 @@
         <zeebe:calledElement processId="supporting-user-information-request" propagateAllChildVariables="false" />
         <zeebe:ioMapping>
           <zeebe:input source="=createdSupportingUsersIds[1]" target="supportingUserId" />
-          <zeebe:input source="=append(parentSubprocesses, &#34;retrieveSupportingInfoPartnerSubprocess&#34;)" target="parentSubprocesses" />
+          <zeebe:input source="=[&#34;retrieveSupportingInfoPartnerSubprocess&#34;]" target="parentSubprocesses" />
           <zeebe:output source="=totalIncome" target="partner1TotalIncome" />
           <zeebe:output source="=supportingUserId" target="partnerSupportingUserId" />
-          <zeebe:output source="=&#34;retrieveSupportingInfoPartnerSubprocess&#34;" target="retrieveSupportingInfoPartnerSubprocess" />
+          <zeebe:output source="=&#34;retrieveSupportingInfoPartnerSubprocess&#34;" target="retrieveSupportingInfoPartnerSubprocess_passthrough" />
         </zeebe:ioMapping>
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_03zfrkx</bpmn:incoming>
@@ -284,9 +284,9 @@
         <zeebe:ioMapping>
           <zeebe:input source="=partner1TotalIncome" target="reportedIncome" />
           <zeebe:input source="=partnerSupportingUserId" target="supportingUserId" />
-          <zeebe:input source="=append(parentSubprocesses, &#34;partnerIncomeVerificationSubprocess&#34;)" target="parentSubprocesses" />
+          <zeebe:input source="=[&#34;partnerIncomeVerificationSubprocess&#34;]" target="parentSubprocesses" />
           <zeebe:output source="=true" target="partnerIncomeVerification" />
-          <zeebe:output source="=&#34;partnerIncomeVerificationSubprocess&#34;" target="partnerIncomeVerificationSubprocess" />
+          <zeebe:output source="=&#34;partnerIncomeVerificationSubprocess&#34;" target="partnerIncomeVerificationSubprocess_passthrough" />
         </zeebe:ioMapping>
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_1wde0bi</bpmn:incoming>
@@ -298,8 +298,8 @@
         <zeebe:ioMapping>
           <zeebe:input source="=studentDataTaxReturnIncome" target="reportedIncome" />
           <zeebe:input source="=null" target="supportingUserId" />
-          <zeebe:input source="=append(parentSubprocesses, &#34;studentIncomeVerificationSubprocess&#34;)" target="parentSubprocesses" />
-          <zeebe:output source="=&#34;studentIncomeVerificationSubprocess&#34;" target="studentIncomeVerificationSubprocess" />
+          <zeebe:input source="=[&#34;studentIncomeVerificationSubprocess&#34;]" target="parentSubprocesses" />
+          <zeebe:output source="=&#34;studentIncomeVerificationSubprocess&#34;" target="studentIncomeVerificationSubprocess_passthrough" />
         </zeebe:ioMapping>
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_18qbsu1</bpmn:incoming>
@@ -382,8 +382,8 @@
       <bpmn:extensionElements>
         <zeebe:calledElement processId="load-assessment-consolidated-data" propagateAllChildVariables="true" />
         <zeebe:ioMapping>
-          <zeebe:input source="=append(parentSubprocesses, &#34;loadConsolidatedDataPreAssessmentSubprocess&#34;)" target="parentSubprocesses" />
-          <zeebe:input source="=&#34;loadConsolidatedDataPreAssessmentSubprocess&#34;" target="loadConsolidatedDataPreAssessmentSubprocess" />
+          <zeebe:input source="=[&#34;loadConsolidatedDataPreAssessmentSubprocess&#34;]" target="parentSubprocesses" />
+          <zeebe:input source="=&#34;loadConsolidatedDataPreAssessmentSubprocess&#34;" target="loadConsolidatedDataPreAssessmentSubprocess_passthrough" />
         </zeebe:ioMapping>
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_16d5gro</bpmn:incoming>
@@ -393,8 +393,8 @@
       <bpmn:extensionElements>
         <zeebe:calledElement processId="load-assessment-consolidated-data" propagateAllChildVariables="true" />
         <zeebe:ioMapping>
-          <zeebe:input source="=append(parentSubprocesses, &#34;loadConsolidatedDataOnSubmitOrReassessmentSubprocess&#34;)" target="parentSubprocesses" />
-          <zeebe:input source="=&#34;loadConsolidatedDataOnSubmitOrReassessmentSubprocess&#34;" target="loadConsolidatedDataOnSubmitOrReassessmentSubprocess" />
+          <zeebe:input source="=[&#34;loadConsolidatedDataOnSubmitOrReassessmentSubprocess&#34;]" target="parentSubprocesses" />
+          <zeebe:input source="=&#34;loadConsolidatedDataOnSubmitOrReassessmentSubprocess&#34;" target="loadConsolidatedDataOnSubmitOrReassessmentSubprocess_passthrough" />
         </zeebe:ioMapping>
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_1wrj7fh</bpmn:incoming>

--- a/sources/packages/backend/workflow/BPMN/camunda-8/assessment-gateway.bpmn
+++ b/sources/packages/backend/workflow/BPMN/camunda-8/assessment-gateway.bpmn
@@ -378,16 +378,24 @@
       <bpmn:incoming>Flow_1s8wnxz</bpmn:incoming>
       <bpmn:outgoing>Flow_16d5gro</bpmn:outgoing>
     </bpmn:parallelGateway>
-    <bpmn:callActivity id="Activity_1nsp43k" name="Load consolidated data">
+    <bpmn:callActivity id="Activity_1nsp43k" name="Load consolidated data (Pre-assessment)">
       <bpmn:extensionElements>
         <zeebe:calledElement processId="load-assessment-consolidated-data" propagateAllChildVariables="true" />
+        <zeebe:ioMapping>
+          <zeebe:input source="=append(parentSubprocesses, &#34;loadConsolidatedDataPreAssessmentSubprocess&#34;)" target="parentSubprocesses" />
+          <zeebe:input source="=&#34;loadConsolidatedDataPreAssessmentSubprocess&#34;" target="loadConsolidatedDataPreAssessmentSubprocess" />
+        </zeebe:ioMapping>
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_16d5gro</bpmn:incoming>
       <bpmn:outgoing>Flow_1btetiq</bpmn:outgoing>
     </bpmn:callActivity>
-    <bpmn:callActivity id="load-assessment-data-task" name="Load consolidated data">
+    <bpmn:callActivity id="load-assessment-data-task" name="Load consolidated data (Submit or Reassessment)">
       <bpmn:extensionElements>
         <zeebe:calledElement processId="load-assessment-consolidated-data" propagateAllChildVariables="true" />
+        <zeebe:ioMapping>
+          <zeebe:input source="=append(parentSubprocesses, &#34;loadConsolidatedDataOnSubmitOrReassessmentSubprocess&#34;)" target="parentSubprocesses" />
+          <zeebe:input source="=&#34;loadConsolidatedDataOnSubmitOrReassessmentSubprocess&#34;" target="loadConsolidatedDataOnSubmitOrReassessmentSubprocess" />
+        </zeebe:ioMapping>
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_1wrj7fh</bpmn:incoming>
       <bpmn:outgoing>Flow_0rxxozm</bpmn:outgoing>
@@ -880,9 +888,11 @@
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_15mfyg8_di" bpmnElement="Activity_1nsp43k">
         <dc:Bounds x="2430" y="1050" width="100" height="80" />
+        <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_0yu5184_di" bpmnElement="load-assessment-data-task">
         <dc:Bounds x="461" y="561" width="100" height="80" />
+        <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="assessment-start-event">
         <dc:Bounds x="242" y="584" width="36" height="36" />

--- a/sources/packages/backend/workflow/BPMN/camunda-8/assessment-gateway.bpmn
+++ b/sources/packages/backend/workflow/BPMN/camunda-8/assessment-gateway.bpmn
@@ -26,19 +26,19 @@
         <bpmn:flowNodeRef>create-supporting-users-for-parents-task</bpmn:flowNodeRef>
         <bpmn:flowNodeRef>Gateway_1mg1n21</bpmn:flowNodeRef>
         <bpmn:flowNodeRef>Gateway_0vft251</bpmn:flowNodeRef>
-        <bpmn:flowNodeRef>retrieve-supporting-info-for-parent-1-task</bpmn:flowNodeRef>
-        <bpmn:flowNodeRef>retrieve-supporting-info-for-parent-2-task</bpmn:flowNodeRef>
-        <bpmn:flowNodeRef>parent-2-income-verification-task</bpmn:flowNodeRef>
-        <bpmn:flowNodeRef>parent-1-income-verification-task</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>retrieve-supporting-info-for-parent-1-subprocess</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>retrieve-supporting-info-for-parent-2-subprocess</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>parent-2-income-verification-subprocess</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>parent-1-income-verification-subprocess</bpmn:flowNodeRef>
         <bpmn:flowNodeRef>Gateway_0ny5tkb</bpmn:flowNodeRef>
         <bpmn:flowNodeRef>Gateway_0b7tdao</bpmn:flowNodeRef>
         <bpmn:flowNodeRef>Gateway_00mly8t</bpmn:flowNodeRef>
         <bpmn:flowNodeRef>Gateway_05k6rp7</bpmn:flowNodeRef>
         <bpmn:flowNodeRef>Gateway_176fysj</bpmn:flowNodeRef>
         <bpmn:flowNodeRef>create-supporting-user-for-the-partner-task</bpmn:flowNodeRef>
-        <bpmn:flowNodeRef>retrieve-supporting-info-for-partner-activity</bpmn:flowNodeRef>
-        <bpmn:flowNodeRef>partner-income-verification-task</bpmn:flowNodeRef>
-        <bpmn:flowNodeRef>student-income-verification-task</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>retrieve-supporting-info-for-partner-subprocess</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>partner-income-verification-subprocess</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>student-income-verification-subprocess</bpmn:flowNodeRef>
         <bpmn:flowNodeRef>needs-pir-gateway</bpmn:flowNodeRef>
         <bpmn:flowNodeRef>program-info-not-required-task</bpmn:flowNodeRef>
         <bpmn:flowNodeRef>program-info-required-task</bpmn:flowNodeRef>
@@ -51,8 +51,8 @@
         <bpmn:flowNodeRef>Gateway_1hgcddi</bpmn:flowNodeRef>
         <bpmn:flowNodeRef>pir-declined-end-event</bpmn:flowNodeRef>
         <bpmn:flowNodeRef>Gateway_0jc5bz6</bpmn:flowNodeRef>
-        <bpmn:flowNodeRef>Activity_1nsp43k</bpmn:flowNodeRef>
-        <bpmn:flowNodeRef>load-assessment-data-task</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>load-assessment-data-pre-assessment-subprocess</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>load-assessment-data-submit-or-reassessment-subprocess</bpmn:flowNodeRef>
         <bpmn:flowNodeRef>assessment-start-event</bpmn:flowNodeRef>
         <bpmn:flowNodeRef>associate-workflow-instance-task</bpmn:flowNodeRef>
       </bpmn:lane>
@@ -174,55 +174,55 @@
       <bpmn:outgoing>Flow_1lbai2h</bpmn:outgoing>
       <bpmn:outgoing>Flow_0bo0mn4</bpmn:outgoing>
     </bpmn:exclusiveGateway>
-    <bpmn:callActivity id="retrieve-supporting-info-for-parent-1-task" name="Retrieve supporting info for parent 1">
+    <bpmn:callActivity id="retrieve-supporting-info-for-parent-1-subprocess" name="Retrieve supporting info for parent 1">
       <bpmn:extensionElements>
         <zeebe:calledElement processId="supporting-user-information-request" propagateAllChildVariables="false" />
         <zeebe:ioMapping>
           <zeebe:input source="=createdSupportingUsersIds[1]" target="supportingUserId" />
-          <zeebe:input source="=[&#34;retrieveSupportingInfoParent1Subprocess&#34;]" target="parentSubprocesses" />
+          <zeebe:input source="=[&#34;retrieve-supporting-info-for-parent-1-subprocess&#34;]" target="parentSubprocesses" />
           <zeebe:output source="=supportingUserId" target="parent1SupportingUserId" />
           <zeebe:output source="=totalIncome" target="supportingUserParent1TotalIncome" />
-          <zeebe:output source="=&#34;retrieveSupportingInfoParent1Subprocess&#34;" target="retrieveSupportingInfoParent1Subprocess_passthrough" />
+          <zeebe:output source="=&#34;retrieve-supporting-info-for-parent-1-subprocess&#34;" target="retrieve_supporting_info_for_parent_1_subprocess_passthrough" />
         </zeebe:ioMapping>
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_1u5ion6</bpmn:incoming>
       <bpmn:outgoing>Flow_1g59sq3</bpmn:outgoing>
     </bpmn:callActivity>
-    <bpmn:callActivity id="retrieve-supporting-info-for-parent-2-task" name="Retrieve supporting info for parent 2">
+    <bpmn:callActivity id="retrieve-supporting-info-for-parent-2-subprocess" name="Retrieve supporting info for parent 2">
       <bpmn:extensionElements>
         <zeebe:calledElement processId="supporting-user-information-request" propagateAllChildVariables="false" />
         <zeebe:ioMapping>
           <zeebe:input source="=createdSupportingUsersIds[2]" target="supportingUserId" />
-          <zeebe:input source="=[&#34;retrieveSupportingInfoParent2Subprocess&#34;]" target="parentSubprocesses" />
+          <zeebe:input source="=[&#34;retrieve-supporting-info-for-parent-2-subprocess&#34;]" target="parentSubprocesses" />
           <zeebe:output source="=supportingUserId" target="parent2SupportingUserId" />
           <zeebe:output source="=totalIncome" target="parent2TotalIncome" />
-          <zeebe:output source="=&#34;retrieveSupportingInfoParent2Subprocess&#34;" target="retrieveSupportingInfoParent2Subprocess_passthrough" />
+          <zeebe:output source="=&#34;retrieve-supporting-info-for-parent-2-subprocess&#34;" target="retrieve_supporting_info_for_parent_2_subprocess_passthrough" />
         </zeebe:ioMapping>
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_1lbai2h</bpmn:incoming>
       <bpmn:outgoing>Flow_0l30wbo</bpmn:outgoing>
     </bpmn:callActivity>
-    <bpmn:callActivity id="parent-2-income-verification-task" name="Parent 2 Income Verification">
+    <bpmn:callActivity id="parent-2-income-verification-subprocess" name="Parent 2 Income Verification">
       <bpmn:extensionElements>
         <zeebe:calledElement processId="cra-integration-income-verification" propagateAllChildVariables="false" />
         <zeebe:ioMapping>
           <zeebe:input source="=parent2TotalIncome" target="reportedIncome" />
           <zeebe:input source="=parent2SupportingUserId" target="supportingUserId" />
-          <zeebe:input source="=[&#34;parent2IncomeVerificationSubprocess&#34;]" target="parentSubprocesses" />
-          <zeebe:output source="=&#34;parent2IncomeVerificationSubprocess&#34;" target="parent2IncomeVerificationSubprocess_passthrough" />
+          <zeebe:input source="=[&#34;parent-2-income-verification-subprocess&#34;]" target="parentSubprocesses" />
+          <zeebe:output source="=&#34;parent-2-income-verification-subprocess&#34;" target="parent_2_income_verification_subprocess_passthrough" />
         </zeebe:ioMapping>
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_0l30wbo</bpmn:incoming>
       <bpmn:outgoing>Flow_1j7i68d</bpmn:outgoing>
     </bpmn:callActivity>
-    <bpmn:callActivity id="parent-1-income-verification-task" name="Parent 1 Income Verification">
+    <bpmn:callActivity id="parent-1-income-verification-subprocess" name="Parent 1 Income Verification">
       <bpmn:extensionElements>
         <zeebe:calledElement processId="cra-integration-income-verification" propagateAllChildVariables="false" />
         <zeebe:ioMapping>
           <zeebe:input source="=supportingUserParent1TotalIncome" target="reportedIncome" />
           <zeebe:input source="=parent1SupportingUserId" target="supportingUserId" />
-          <zeebe:input source="=[&#34;parent1IncomeVerificationSubprocess&#34;]" target="parentSubprocesses" />
-          <zeebe:output source="=&#34;parent1IncomeVerificationSubprocess&#34;" target="parent1IncomeVerificationSubprocess_passthrough" />
+          <zeebe:input source="=[&#34;parent-1-income-verification-subprocess&#34;]" target="parentSubprocesses" />
+          <zeebe:output source="=&#34;parent-1-income-verification-subprocess&#34;" target="parent_1_income_verification_subprocess_passthrough" />
         </zeebe:ioMapping>
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_1g59sq3</bpmn:incoming>
@@ -264,42 +264,42 @@
       <bpmn:incoming>Flow_14701yl</bpmn:incoming>
       <bpmn:outgoing>Flow_03zfrkx</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:callActivity id="retrieve-supporting-info-for-partner-activity" name="Retrieve supporting info for partner">
+    <bpmn:callActivity id="retrieve-supporting-info-for-partner-subprocess" name="Retrieve supporting info for partner">
       <bpmn:extensionElements>
         <zeebe:calledElement processId="supporting-user-information-request" propagateAllChildVariables="false" />
         <zeebe:ioMapping>
           <zeebe:input source="=createdSupportingUsersIds[1]" target="supportingUserId" />
-          <zeebe:input source="=[&#34;retrieveSupportingInfoPartnerSubprocess&#34;]" target="parentSubprocesses" />
+          <zeebe:input source="=[&#34;retrieve-supporting-info-for-partner-subprocess&#34;]" target="parentSubprocesses" />
           <zeebe:output source="=totalIncome" target="partner1TotalIncome" />
           <zeebe:output source="=supportingUserId" target="partnerSupportingUserId" />
-          <zeebe:output source="=&#34;retrieveSupportingInfoPartnerSubprocess&#34;" target="retrieveSupportingInfoPartnerSubprocess_passthrough" />
+          <zeebe:output source="=&#34;retrieve-supporting-info-for-partner-subprocess&#34;" target="retrieve_supporting_info_for_partner_subprocess_passthrough" />
         </zeebe:ioMapping>
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_03zfrkx</bpmn:incoming>
       <bpmn:outgoing>Flow_1wde0bi</bpmn:outgoing>
     </bpmn:callActivity>
-    <bpmn:callActivity id="partner-income-verification-task" name="Partner Income Verification">
+    <bpmn:callActivity id="partner-income-verification-subprocess" name="Partner Income Verification">
       <bpmn:extensionElements>
         <zeebe:calledElement processId="cra-integration-income-verification" propagateAllChildVariables="false" />
         <zeebe:ioMapping>
           <zeebe:input source="=partner1TotalIncome" target="reportedIncome" />
           <zeebe:input source="=partnerSupportingUserId" target="supportingUserId" />
-          <zeebe:input source="=[&#34;partnerIncomeVerificationSubprocess&#34;]" target="parentSubprocesses" />
+          <zeebe:input source="=[&#34;partner-income-verification-subprocess&#34;]" target="parentSubprocesses" />
           <zeebe:output source="=true" target="partnerIncomeVerification" />
-          <zeebe:output source="=&#34;partnerIncomeVerificationSubprocess&#34;" target="partnerIncomeVerificationSubprocess_passthrough" />
+          <zeebe:output source="=&#34;partner-income-verification-subprocess&#34;" target="partner_income_verification_subprocess_passthrough" />
         </zeebe:ioMapping>
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_1wde0bi</bpmn:incoming>
       <bpmn:outgoing>Flow_0jrbmj3</bpmn:outgoing>
     </bpmn:callActivity>
-    <bpmn:callActivity id="student-income-verification-task" name="Student Income Verification">
+    <bpmn:callActivity id="student-income-verification-subprocess" name="Student Income Verification">
       <bpmn:extensionElements>
         <zeebe:calledElement processId="cra-integration-income-verification" propagateAllChildVariables="false" />
         <zeebe:ioMapping>
           <zeebe:input source="=studentDataTaxReturnIncome" target="reportedIncome" />
           <zeebe:input source="=null" target="supportingUserId" />
-          <zeebe:input source="=[&#34;studentIncomeVerificationSubprocess&#34;]" target="parentSubprocesses" />
-          <zeebe:output source="=&#34;studentIncomeVerificationSubprocess&#34;" target="studentIncomeVerificationSubprocess_passthrough" />
+          <zeebe:input source="=[&#34;student-income-verification-subprocess&#34;]" target="parentSubprocesses" />
+          <zeebe:output source="=&#34;student-income-verification-subprocess&#34;" target="student_income_verification_subprocess_passthrough" />
         </zeebe:ioMapping>
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_18qbsu1</bpmn:incoming>
@@ -378,23 +378,23 @@
       <bpmn:incoming>Flow_1s8wnxz</bpmn:incoming>
       <bpmn:outgoing>Flow_16d5gro</bpmn:outgoing>
     </bpmn:parallelGateway>
-    <bpmn:callActivity id="Activity_1nsp43k" name="Load consolidated data (Pre-assessment)">
+    <bpmn:callActivity id="load-assessment-data-pre-assessment-subprocess" name="Load consolidated data (Pre-assessment)">
       <bpmn:extensionElements>
         <zeebe:calledElement processId="load-assessment-consolidated-data" propagateAllChildVariables="true" />
         <zeebe:ioMapping>
-          <zeebe:input source="=[&#34;loadConsolidatedDataPreAssessmentSubprocess&#34;]" target="parentSubprocesses" />
-          <zeebe:input source="=&#34;loadConsolidatedDataPreAssessmentSubprocess&#34;" target="loadConsolidatedDataPreAssessmentSubprocess_passthrough" />
+          <zeebe:input source="=[&#34;load-assessment-data-pre-assessment-subprocess&#34;]" target="parentSubprocesses" />
+          <zeebe:input source="=&#34;load-assessment-data-pre-assessment-subprocess&#34;" target="load_assessment_data_pre_assessment_subprocess_passthrough" />
         </zeebe:ioMapping>
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_16d5gro</bpmn:incoming>
       <bpmn:outgoing>Flow_1btetiq</bpmn:outgoing>
     </bpmn:callActivity>
-    <bpmn:callActivity id="load-assessment-data-task" name="Load consolidated data (Submit or Reassessment)">
+    <bpmn:callActivity id="load-assessment-data-submit-or-reassessment-subprocess" name="Load consolidated data (Submit or Reassessment)">
       <bpmn:extensionElements>
         <zeebe:calledElement processId="load-assessment-consolidated-data" propagateAllChildVariables="true" />
         <zeebe:ioMapping>
-          <zeebe:input source="=[&#34;loadConsolidatedDataOnSubmitOrReassessmentSubprocess&#34;]" target="parentSubprocesses" />
-          <zeebe:input source="=&#34;loadConsolidatedDataOnSubmitOrReassessmentSubprocess&#34;" target="loadConsolidatedDataOnSubmitOrReassessmentSubprocess_passthrough" />
+          <zeebe:input source="=[&#34;load-assessment-data-submit-or-reassessment-subprocess&#34;]" target="parentSubprocesses" />
+          <zeebe:input source="=&#34;load-assessment-data-submit-or-reassessment-subprocess&#34;" target="load_assessment_data_submit_or_reassessment_subprocess_passthrough" />
         </zeebe:ioMapping>
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_1wrj7fh</bpmn:incoming>
@@ -421,14 +421,14 @@
       </bpmn:extensionElements>
       <bpmn:outgoing>Flow_1ef3map</bpmn:outgoing>
     </bpmn:startEvent>
-    <bpmn:sequenceFlow id="Flow_1btetiq" sourceRef="Activity_1nsp43k" targetRef="Gateway_11qgy63" />
-    <bpmn:sequenceFlow id="Flow_16d5gro" sourceRef="Gateway_0jc5bz6" targetRef="Activity_1nsp43k" />
+    <bpmn:sequenceFlow id="Flow_1btetiq" sourceRef="load-assessment-data-pre-assessment-subprocess" targetRef="Gateway_11qgy63" />
+    <bpmn:sequenceFlow id="Flow_16d5gro" sourceRef="Gateway_0jc5bz6" targetRef="load-assessment-data-pre-assessment-subprocess" />
     <bpmn:sequenceFlow id="pir-pending-declined-flow" name="Declined" sourceRef="pir-pending-declined-complted-gateway" targetRef="pir-declined-end-event">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=programInfoStatus = "Declined"</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="Flow_1mbspca" sourceRef="student-income-verification-task" targetRef="Gateway_0jc5bz6" />
-    <bpmn:sequenceFlow id="Flow_1wde0bi" sourceRef="retrieve-supporting-info-for-partner-activity" targetRef="partner-income-verification-task" />
-    <bpmn:sequenceFlow id="Flow_03zfrkx" sourceRef="create-supporting-user-for-the-partner-task" targetRef="retrieve-supporting-info-for-partner-activity" />
+    <bpmn:sequenceFlow id="Flow_1mbspca" sourceRef="student-income-verification-subprocess" targetRef="Gateway_0jc5bz6" />
+    <bpmn:sequenceFlow id="Flow_1wde0bi" sourceRef="retrieve-supporting-info-for-partner-subprocess" targetRef="partner-income-verification-subprocess" />
+    <bpmn:sequenceFlow id="Flow_03zfrkx" sourceRef="create-supporting-user-for-the-partner-task" targetRef="retrieve-supporting-info-for-partner-subprocess" />
     <bpmn:sequenceFlow id="Flow_14701yl" name="Has valid SIN" sourceRef="Gateway_176fysj" targetRef="create-supporting-user-for-the-partner-task">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=studentDataIsYourSpouseACanadianCitizen = "yes"</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
@@ -438,18 +438,18 @@
     <bpmn:sequenceFlow id="Flow_19wmdao" sourceRef="Gateway_00mly8t" targetRef="Gateway_0b7tdao" />
     <bpmn:sequenceFlow id="Flow_1uh1kyu" sourceRef="Gateway_0ny5tkb" targetRef="Gateway_0jc5bz6" />
     <bpmn:sequenceFlow id="Flow_0kjnr9t" sourceRef="Gateway_0b7tdao" targetRef="Gateway_0ny5tkb" />
-    <bpmn:sequenceFlow id="Flow_11q8vuj" sourceRef="parent-1-income-verification-task" targetRef="Gateway_0b7tdao" />
-    <bpmn:sequenceFlow id="Flow_1j7i68d" sourceRef="parent-2-income-verification-task" targetRef="Gateway_00mly8t" />
-    <bpmn:sequenceFlow id="Flow_0l30wbo" sourceRef="retrieve-supporting-info-for-parent-2-task" targetRef="parent-2-income-verification-task" />
-    <bpmn:sequenceFlow id="Flow_1g59sq3" sourceRef="retrieve-supporting-info-for-parent-1-task" targetRef="parent-1-income-verification-task" />
+    <bpmn:sequenceFlow id="Flow_11q8vuj" sourceRef="parent-1-income-verification-subprocess" targetRef="Gateway_0b7tdao" />
+    <bpmn:sequenceFlow id="Flow_1j7i68d" sourceRef="parent-2-income-verification-subprocess" targetRef="Gateway_00mly8t" />
+    <bpmn:sequenceFlow id="Flow_0l30wbo" sourceRef="retrieve-supporting-info-for-parent-2-subprocess" targetRef="parent-2-income-verification-subprocess" />
+    <bpmn:sequenceFlow id="Flow_1g59sq3" sourceRef="retrieve-supporting-info-for-parent-1-subprocess" targetRef="parent-1-income-verification-subprocess" />
     <bpmn:sequenceFlow id="Flow_0bo0mn4" name="No" sourceRef="Gateway_0vft251" targetRef="Gateway_00mly8t">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=studentDataNumberOfParents != 2</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="Flow_1lbai2h" name="Yes" sourceRef="Gateway_0vft251" targetRef="retrieve-supporting-info-for-parent-2-task">
+    <bpmn:sequenceFlow id="Flow_1lbai2h" name="Yes" sourceRef="Gateway_0vft251" targetRef="retrieve-supporting-info-for-parent-2-subprocess">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=studentDataNumberOfParents = 2</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
     <bpmn:sequenceFlow id="Flow_1cd204k" sourceRef="Gateway_1mg1n21" targetRef="Gateway_0vft251" />
-    <bpmn:sequenceFlow id="Flow_1u5ion6" sourceRef="Gateway_1mg1n21" targetRef="retrieve-supporting-info-for-parent-1-task" />
+    <bpmn:sequenceFlow id="Flow_1u5ion6" sourceRef="Gateway_1mg1n21" targetRef="retrieve-supporting-info-for-parent-1-subprocess" />
     <bpmn:sequenceFlow id="Flow_0dii2b3" sourceRef="create-supporting-users-for-parents-task" targetRef="Gateway_1mg1n21" />
     <bpmn:sequenceFlow id="parents-verification-dependantstatus-independant-flow" name="Independant" sourceRef="parents-verification-has-dependant-gateway" targetRef="Gateway_0ny5tkb">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=studentDataDependantstatus != "dependant"</bpmn:conditionExpression>
@@ -470,8 +470,8 @@
     <bpmn:sequenceFlow id="Flow_1u0qixu" name="No" sourceRef="Gateway_05k6rp7" targetRef="Gateway_1jdrla2">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=studentDataRelationshipStatus != "married"</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="Flow_0jrbmj3" sourceRef="partner-income-verification-task" targetRef="Gateway_1jdrla2" />
-    <bpmn:sequenceFlow id="Flow_18qbsu1" sourceRef="in-progress-main-parallel-info-gathering-gateway" targetRef="student-income-verification-task" />
+    <bpmn:sequenceFlow id="Flow_0jrbmj3" sourceRef="partner-income-verification-subprocess" targetRef="Gateway_1jdrla2" />
+    <bpmn:sequenceFlow id="Flow_18qbsu1" sourceRef="in-progress-main-parallel-info-gathering-gateway" targetRef="student-income-verification-subprocess" />
     <bpmn:sequenceFlow id="Flow_18xo3dr" sourceRef="in-progress-main-parallel-info-gathering-gateway" targetRef="parents-verification-has-dependant-gateway" />
     <bpmn:sequenceFlow id="Flow_0v2i46e" sourceRef="in-progress-main-parallel-info-gathering-gateway" targetRef="Gateway_05k6rp7" />
     <bpmn:sequenceFlow id="Flow_1a980l7" sourceRef="in-progress-main-parallel-info-gathering-gateway" targetRef="needs-pir-gateway" />
@@ -496,7 +496,7 @@
     <bpmn:sequenceFlow id="assessment-flow" name="Assessment" sourceRef="first-assessment-gateway" targetRef="update-application-status-to-in-progress-task">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=assessmentTriggerType = "Original assessment"</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="Flow_0rxxozm" sourceRef="load-assessment-data-task" targetRef="first-assessment-gateway" />
+    <bpmn:sequenceFlow id="Flow_0rxxozm" sourceRef="load-assessment-data-submit-or-reassessment-subprocess" targetRef="first-assessment-gateway" />
     <bpmn:sequenceFlow id="Flow_1ef3map" sourceRef="assessment-start-event" targetRef="associate-workflow-instance-task" />
     <bpmn:sequenceFlow id="Flow_1s8wnxz" sourceRef="Gateway_1hgcddi" targetRef="Gateway_0jc5bz6" />
     <bpmn:sequenceFlow id="needs-pir-flow" name="Needs PIR" sourceRef="needs-pir-gateway" targetRef="program-info-required-task">
@@ -524,7 +524,7 @@
     <bpmn:sequenceFlow id="Flow_0ozt4pg" name="Reassessment" sourceRef="first-assessment-gateway" targetRef="Gateway_11qgy63">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=assessmentTriggerType != "Original assessment"</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="Flow_1wrj7fh" sourceRef="associate-workflow-instance-task" targetRef="load-assessment-data-task" />
+    <bpmn:sequenceFlow id="Flow_1wrj7fh" sourceRef="associate-workflow-instance-task" targetRef="load-assessment-data-submit-or-reassessment-subprocess" />
     <bpmn:serviceTask id="associate-workflow-instance-task" name="Associate workflow instance">
       <bpmn:extensionElements>
         <zeebe:taskDefinition type="associate-workflow-instance" />
@@ -795,19 +795,19 @@
           <dc:Bounds x="1790" y="1167" width="59" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="BPMNShape_0mtktoi" bpmnElement="retrieve-supporting-info-for-parent-1-task">
+      <bpmndi:BPMNShape id="BPMNShape_0mtktoi" bpmnElement="retrieve-supporting-info-for-parent-1-subprocess">
         <dc:Bounds x="1880" y="1060" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="BPMNShape_1k3ypvz" bpmnElement="retrieve-supporting-info-for-parent-2-task">
+      <bpmndi:BPMNShape id="BPMNShape_1k3ypvz" bpmnElement="retrieve-supporting-info-for-parent-2-subprocess">
         <dc:Bounds x="1880" y="1180" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="BPMNShape_0dtll1x" bpmnElement="parent-2-income-verification-task">
+      <bpmndi:BPMNShape id="BPMNShape_0dtll1x" bpmnElement="parent-2-income-verification-subprocess">
         <dc:Bounds x="2020" y="1180" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="BPMNShape_03h2twt" bpmnElement="parent-1-income-verification-task">
+      <bpmndi:BPMNShape id="BPMNShape_03h2twt" bpmnElement="parent-1-income-verification-subprocess">
         <dc:Bounds x="2020" y="1060" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
@@ -833,15 +833,15 @@
         <dc:Bounds x="1627" y="750" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="BPMNShape_02m7l5a" bpmnElement="retrieve-supporting-info-for-partner-activity">
+      <bpmndi:BPMNShape id="BPMNShape_02m7l5a" bpmnElement="retrieve-supporting-info-for-partner-subprocess">
         <dc:Bounds x="1769" y="750" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="BPMNShape_1c34e2g" bpmnElement="partner-income-verification-task">
+      <bpmndi:BPMNShape id="BPMNShape_1c34e2g" bpmnElement="partner-income-verification-subprocess">
         <dc:Bounds x="1910" y="750" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="BPMNShape_1r6pjw3" bpmnElement="student-income-verification-task">
+      <bpmndi:BPMNShape id="BPMNShape_1r6pjw3" bpmnElement="student-income-verification-subprocess">
         <dc:Bounds x="1750" y="562" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
@@ -886,11 +886,11 @@
       <bpmndi:BPMNShape id="BPMNShape_0gfaqjk" bpmnElement="Gateway_0jc5bz6">
         <dc:Bounds x="2405" y="577" width="50" height="50" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_15mfyg8_di" bpmnElement="Activity_1nsp43k">
+      <bpmndi:BPMNShape id="Activity_15mfyg8_di" bpmnElement="load-assessment-data-pre-assessment-subprocess">
         <dc:Bounds x="2430" y="1050" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_0yu5184_di" bpmnElement="load-assessment-data-task">
+      <bpmndi:BPMNShape id="Activity_0yu5184_di" bpmnElement="load-assessment-data-submit-or-reassessment-subprocess">
         <dc:Bounds x="461" y="561" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>

--- a/sources/packages/backend/workflow/BPMN/camunda-8/load-assessment-consolidated-data.bpmn
+++ b/sources/packages/backend/workflow/BPMN/camunda-8/load-assessment-consolidated-data.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_0yotgp9" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.9.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.1.0">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_0yotgp9" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.4.2" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.1.0">
   <bpmn:process id="load-assessment-consolidated-data" name="Load Assessment Consolidated Data" isExecutable="true">
     <bpmn:startEvent id="StartEvent_1">
       <bpmn:extensionElements />
@@ -105,7 +105,6 @@
       <bpmn:outgoing>Flow_0e9728l</bpmn:outgoing>
     </bpmn:serviceTask>
     <bpmn:endEvent id="Event_1qp0tlo">
-      <bpmn:extensionElements />
       <bpmn:incoming>Flow_0e9728l</bpmn:incoming>
     </bpmn:endEvent>
     <bpmn:sequenceFlow id="Flow_0e9728l" sourceRef="load-assessment-data-task" targetRef="Event_1qp0tlo" />

--- a/sources/packages/backend/workflow/BPMN/camunda-8/load-assessment-consolidated-data.bpmn
+++ b/sources/packages/backend/workflow/BPMN/camunda-8/load-assessment-consolidated-data.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_0yotgp9" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.4.2" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.1.0">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_0yotgp9" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.9.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.1.0">
   <bpmn:process id="load-assessment-consolidated-data" name="Load Assessment Consolidated Data" isExecutable="true">
     <bpmn:startEvent id="StartEvent_1">
       <bpmn:extensionElements />
@@ -105,6 +105,7 @@
       <bpmn:outgoing>Flow_0e9728l</bpmn:outgoing>
     </bpmn:serviceTask>
     <bpmn:endEvent id="Event_1qp0tlo">
+      <bpmn:extensionElements />
       <bpmn:incoming>Flow_0e9728l</bpmn:incoming>
     </bpmn:endEvent>
     <bpmn:sequenceFlow id="Flow_0e9728l" sourceRef="load-assessment-data-task" targetRef="Event_1qp0tlo" />

--- a/sources/packages/backend/workflow/test/2022-2023/assessment-gateway/assessment-gateway.originalAssessment.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2022-2023/assessment-gateway/assessment-gateway.originalAssessment.e2e-spec.ts
@@ -42,7 +42,7 @@ describe(`E2E Test Workflow assessment gateway on original assessment for ${PROG
     // Arrange
 
     // Assessment consolidated mocked data.
-    const assessmentDataOnSubmit: AssessmentConsolidatedData = {
+    const assessmentConsolidatedData: AssessmentConsolidatedData = {
       assessmentTriggerType: AssessmentTriggerType.OriginalAssessment,
       ...createFakeConsolidatedFulltimeData(PROGRAM_YEAR),
       ...createFakeSingleIndependentStudentData(),
@@ -51,15 +51,7 @@ describe(`E2E Test Workflow assessment gateway on original assessment for ${PROG
     };
 
     const workersMockedData = createWorkersMockedData([
-      createLoadAssessmentDataTaskMock({
-        assessmentConsolidatedData: assessmentDataOnSubmit,
-        subprocess:
-          WorkflowSubprocesses.LoadConsolidatedDataSubmitOrReassessment,
-      }),
-      createLoadAssessmentDataTaskMock({
-        assessmentConsolidatedData: assessmentDataOnSubmit,
-        subprocess: WorkflowSubprocesses.LoadConsolidatedDataPreAssessment,
-      }),
+      createLoadAssessmentDataTaskMock({ assessmentConsolidatedData }),
       createVerifyApplicationExceptionsTaskMock(),
       createIncomeRequestTaskMock({
         incomeVerificationId: incomeVerificationId++,

--- a/sources/packages/backend/workflow/test/2022-2023/assessment-gateway/assessment-gateway.originalAssessment.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2022-2023/assessment-gateway/assessment-gateway.originalAssessment.e2e-spec.ts
@@ -50,6 +50,23 @@ describe(`E2E Test Workflow assessment gateway on original assessment for ${PROG
       studentDataSelectedOffering: 1,
     };
 
+    const workersMockedData = createWorkersMockedData([
+      createLoadAssessmentDataTaskMock({
+        assessmentConsolidatedData: assessmentDataOnSubmit,
+        subprocess:
+          WorkflowSubprocesses.LoadConsolidatedDataSubmitOrReassessment,
+      }),
+      createLoadAssessmentDataTaskMock({
+        assessmentConsolidatedData: assessmentDataOnSubmit,
+        subprocess: WorkflowSubprocesses.LoadConsolidatedDataPreAssessment,
+      }),
+      createVerifyApplicationExceptionsTaskMock(),
+      createIncomeRequestTaskMock({
+        incomeVerificationId: incomeVerificationId++,
+        subprocesses: WorkflowSubprocesses.StudentIncomeVerification,
+      }),
+    ]);
+
     const currentAssessmentId = assessmentId++;
 
     // Act/Assert
@@ -58,20 +75,7 @@ describe(`E2E Test Workflow assessment gateway on original assessment for ${PROG
         bpmnProcessId: "assessment-gateway",
         variables: {
           [ASSESSMENT_ID]: currentAssessmentId,
-          ...createLoadAssessmentDataTaskMock({
-            assessmentConsolidatedData: assessmentDataOnSubmit,
-            subprocess:
-              WorkflowSubprocesses.LoadConsolidatedDataSubmitOrReassessment,
-          }),
-          ...createLoadAssessmentDataTaskMock({
-            assessmentConsolidatedData: assessmentDataOnSubmit,
-            subprocess: WorkflowSubprocesses.LoadConsolidatedDataPreAssessment,
-          }),
-          ...createVerifyApplicationExceptionsTaskMock(),
-          ...createIncomeRequestTaskMock({
-            incomeVerificationId: incomeVerificationId++,
-            subprocesses: WorkflowSubprocesses.StudentIncomeVerification,
-          }),
+          ...workersMockedData,
         },
         requestTimeout: PROCESS_INSTANCE_CREATE_TIMEOUT,
       });
@@ -88,7 +92,7 @@ describe(`E2E Test Workflow assessment gateway on original assessment for ${PROG
     );
   });
 
-  it.only("Should check for both parents incomes when the student is dependant and parents have SIN.", async () => {
+  it("Should check for both parents incomes when the student is dependant and parents have SIN.", async () => {
     // Arrange
     const currentAssessmentId = assessmentId++;
     const parent1SupportingUserId = supportingUserId++;
@@ -154,8 +158,6 @@ describe(`E2E Test Workflow assessment gateway on original assessment for ${PROG
         subprocesses: WorkflowSubprocesses.Parent2IncomeVerification,
       }),
     ]);
-
-    console.log(JSON.stringify(workersMockedData, null, 2));
 
     // Act
     const assessmentGatewayResponse =
@@ -280,7 +282,7 @@ describe(`E2E Test Workflow assessment gateway on original assessment for ${PROG
     );
   });
 
-  it.only("Should skip parent income verification when the student is dependant and informed that parents do not have SIN.", async () => {
+  it("Should skip parent income verification when the student is dependant and informed that parents do not have SIN.", async () => {
     // Arrange
     const currentAssessmentId = assessmentId++;
     // Assessment consolidated mocked data.
@@ -319,8 +321,6 @@ describe(`E2E Test Workflow assessment gateway on original assessment for ${PROG
         subprocesses: WorkflowSubprocesses.StudentIncomeVerification,
       }),
     ]);
-
-    console.log(JSON.stringify(workersMockedData, null, 2));
 
     // Act
     const assessmentGatewayResponse =

--- a/sources/packages/backend/workflow/test/2022-2023/assessment-gateway/assessment-gateway.originalAssessment.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2022-2023/assessment-gateway/assessment-gateway.originalAssessment.e2e-spec.ts
@@ -19,13 +19,14 @@ import {
   createCreateSupportingUsersParentsTaskMock,
   createCheckSupportingUserResponseTaskMock,
   createCheckIncomeRequestTaskMock,
-  createLoadAssessmentConsolidatedDataMock,
+  createWorkersMockedData,
+  createLoadAssessmentDataTaskMock,
 } from "../../test-utils/mock";
 import {
   PROGRAM_YEAR,
   PROGRAM_YEAR_BASE_ID,
 } from "../constants/program-year.constants";
-import { YesNoOptions } from "@sims/test-utils";
+import { AssessmentDataType, YesNoOptions } from "@sims/test-utils";
 
 describe(`E2E Test Workflow assessment gateway on original assessment for ${PROGRAM_YEAR}`, () => {
   let zeebeClientProvider: ZBClient;
@@ -41,9 +42,9 @@ describe(`E2E Test Workflow assessment gateway on original assessment for ${PROG
     // Arrange
 
     // Assessment consolidated mocked data.
-    const assessmentConsolidatedData: AssessmentConsolidatedData = {
-      ...createFakeConsolidatedFulltimeData(PROGRAM_YEAR),
+    const assessmentDataOnSubmit: AssessmentConsolidatedData = {
       assessmentTriggerType: AssessmentTriggerType.OriginalAssessment,
+      ...createFakeConsolidatedFulltimeData(PROGRAM_YEAR),
       ...createFakeSingleIndependentStudentData(),
       // Application with PIR not required.
       studentDataSelectedOffering: 1,
@@ -57,8 +58,14 @@ describe(`E2E Test Workflow assessment gateway on original assessment for ${PROG
         bpmnProcessId: "assessment-gateway",
         variables: {
           [ASSESSMENT_ID]: currentAssessmentId,
-          ...createLoadAssessmentConsolidatedDataMock({
-            assessmentConsolidatedData,
+          ...createLoadAssessmentDataTaskMock({
+            assessmentConsolidatedData: assessmentDataOnSubmit,
+            subprocess:
+              WorkflowSubprocesses.LoadConsolidatedDataSubmitOrReassessment,
+          }),
+          ...createLoadAssessmentDataTaskMock({
+            assessmentConsolidatedData: assessmentDataOnSubmit,
+            subprocess: WorkflowSubprocesses.LoadConsolidatedDataPreAssessment,
           }),
           ...createVerifyApplicationExceptionsTaskMock(),
           ...createIncomeRequestTaskMock({
@@ -71,6 +78,8 @@ describe(`E2E Test Workflow assessment gateway on original assessment for ${PROG
     expectToPassThroughServiceTasks(
       assessmentGatewayResponse.variables,
       WorkflowServiceTasks.AssociateWorkflowInstance,
+      WorkflowSubprocesses.LoadConsolidatedDataSubmitOrReassessment,
+      WorkflowSubprocesses.LoadConsolidatedDataPreAssessment,
       WorkflowServiceTasks.VerifyApplicationExceptions,
       WorkflowServiceTasks.ProgramInfoNotRequired,
       WorkflowServiceTasks.SaveDisbursementSchedules,
@@ -79,74 +88,92 @@ describe(`E2E Test Workflow assessment gateway on original assessment for ${PROG
     );
   });
 
-  it("Should check for both parents incomes when the student is dependant and parents have SIN.", async () => {
+  it.only("Should check for both parents incomes when the student is dependant and parents have SIN.", async () => {
     // Arrange
     const currentAssessmentId = assessmentId++;
     const parent1SupportingUserId = supportingUserId++;
     const parent2SupportingUserId = supportingUserId++;
     // Assessment consolidated mocked data.
-    const assessmentConsolidatedData: AssessmentConsolidatedData = {
+    const dataOnSubmit: AssessmentConsolidatedData = {
       assessmentTriggerType: AssessmentTriggerType.OriginalAssessment,
       ...createFakeConsolidatedFulltimeData(PROGRAM_YEAR),
       ...createParentsData({ numberOfParents: 2 }),
       // Application with PIR not required.
       studentDataSelectedOffering: 1,
     };
-
-    const assessmentStartData = {
-      bpmnProcessId: "assessment-gateway",
-      variables: {
-        [ASSESSMENT_ID]: currentAssessmentId,
-        ...createLoadAssessmentConsolidatedDataMock({
-          assessmentConsolidatedData,
-        }),
-        ...createVerifyApplicationExceptionsTaskMock(),
-        ...createCreateSupportingUsersParentsTaskMock({
-          supportingUserIds: [parent1SupportingUserId, parent2SupportingUserId],
-        }),
-        ...createCheckSupportingUserResponseTaskMock({
-          totalIncome: 1,
-          subprocesses: WorkflowSubprocesses.RetrieveSupportingInfoParent1,
-        }),
-        ...createCheckSupportingUserResponseTaskMock({
-          totalIncome: 1,
-          subprocesses: WorkflowSubprocesses.RetrieveSupportingInfoParent2,
-        }),
-        ...createIncomeRequestTaskMock({
-          incomeVerificationId: incomeVerificationId++,
-          subprocesses: WorkflowSubprocesses.StudentIncomeVerification,
-        }),
-        ...createIncomeRequestTaskMock({
-          incomeVerificationId: incomeVerificationId++,
-          subprocesses: WorkflowSubprocesses.Parent1IncomeVerification,
-        }),
-        ...createIncomeRequestTaskMock({
-          incomeVerificationId: incomeVerificationId++,
-          subprocesses: WorkflowSubprocesses.Parent2IncomeVerification,
-        }),
-        ...createCheckIncomeRequestTaskMock({
-          subprocesses: WorkflowSubprocesses.StudentIncomeVerification,
-        }),
-        ...createCheckIncomeRequestTaskMock({
-          subprocesses: WorkflowSubprocesses.Parent1IncomeVerification,
-        }),
-        ...createCheckIncomeRequestTaskMock({
-          subprocesses: WorkflowSubprocesses.Parent2IncomeVerification,
-        }),
-      },
-      requestTimeout: PROCESS_INSTANCE_CREATE_TIMEOUT,
+    const dataPreAssessment: AssessmentConsolidatedData = {
+      assessmentTriggerType: AssessmentTriggerType.OriginalAssessment,
+      ...createFakeConsolidatedFulltimeData(PROGRAM_YEAR),
+      ...createParentsData({
+        dataType: AssessmentDataType.PreAssessment,
+        numberOfParents: 2,
+      }),
     };
+
+    const workersMockedData = createWorkersMockedData([
+      createLoadAssessmentDataTaskMock({
+        assessmentConsolidatedData: dataOnSubmit,
+        subprocess:
+          WorkflowSubprocesses.LoadConsolidatedDataSubmitOrReassessment,
+      }),
+      createLoadAssessmentDataTaskMock({
+        assessmentConsolidatedData: dataPreAssessment,
+        subprocess: WorkflowSubprocesses.LoadConsolidatedDataPreAssessment,
+      }),
+      createVerifyApplicationExceptionsTaskMock(),
+      createCreateSupportingUsersParentsTaskMock({
+        supportingUserIds: [parent1SupportingUserId, parent2SupportingUserId],
+      }),
+      createCheckSupportingUserResponseTaskMock({
+        totalIncome: 1,
+        subprocesses: WorkflowSubprocesses.RetrieveSupportingInfoParent1,
+      }),
+      createCheckSupportingUserResponseTaskMock({
+        totalIncome: 1,
+        subprocesses: WorkflowSubprocesses.RetrieveSupportingInfoParent2,
+      }),
+      createIncomeRequestTaskMock({
+        incomeVerificationId: incomeVerificationId++,
+        subprocesses: WorkflowSubprocesses.StudentIncomeVerification,
+      }),
+      createIncomeRequestTaskMock({
+        incomeVerificationId: incomeVerificationId++,
+        subprocesses: WorkflowSubprocesses.Parent1IncomeVerification,
+      }),
+      createIncomeRequestTaskMock({
+        incomeVerificationId: incomeVerificationId++,
+        subprocesses: WorkflowSubprocesses.Parent2IncomeVerification,
+      }),
+      createCheckIncomeRequestTaskMock({
+        subprocesses: WorkflowSubprocesses.StudentIncomeVerification,
+      }),
+      createCheckIncomeRequestTaskMock({
+        subprocesses: WorkflowSubprocesses.Parent1IncomeVerification,
+      }),
+      createCheckIncomeRequestTaskMock({
+        subprocesses: WorkflowSubprocesses.Parent2IncomeVerification,
+      }),
+    ]);
+
+    console.log(JSON.stringify(workersMockedData, null, 2));
 
     // Act
     const assessmentGatewayResponse =
-      await zeebeClientProvider.createProcessInstanceWithResult(
-        assessmentStartData,
-      );
+      await zeebeClientProvider.createProcessInstanceWithResult({
+        bpmnProcessId: "assessment-gateway",
+        variables: {
+          [ASSESSMENT_ID]: currentAssessmentId,
+          ...workersMockedData,
+        },
+        requestTimeout: PROCESS_INSTANCE_CREATE_TIMEOUT,
+      });
 
     // Assert
     expectToPassThroughServiceTasks(
       assessmentGatewayResponse.variables,
       WorkflowServiceTasks.AssociateWorkflowInstance,
+      WorkflowSubprocesses.LoadConsolidatedDataSubmitOrReassessment,
+      WorkflowSubprocesses.LoadConsolidatedDataPreAssessment,
       WorkflowServiceTasks.VerifyApplicationExceptions,
       WorkflowServiceTasks.ProgramInfoNotRequired,
       WorkflowSubprocesses.StudentIncomeVerification,
@@ -169,57 +196,73 @@ describe(`E2E Test Workflow assessment gateway on original assessment for ${PROG
     const currentAssessmentId = assessmentId++;
     const parent1SupportingUserId = supportingUserId++;
     // Assessment consolidated mocked data.
-    const assessmentConsolidatedData: AssessmentConsolidatedData = {
+    const dataOnSubmit: AssessmentConsolidatedData = {
       assessmentTriggerType: AssessmentTriggerType.OriginalAssessment,
       ...createFakeConsolidatedFulltimeData(PROGRAM_YEAR),
       ...createParentsData({ numberOfParents: 1 }),
       // Application with PIR not required.
       studentDataSelectedOffering: 1,
     };
-
-    const assessmentStartData = {
-      bpmnProcessId: "assessment-gateway",
-      variables: {
-        [ASSESSMENT_ID]: currentAssessmentId,
-        ...createLoadAssessmentConsolidatedDataMock({
-          assessmentConsolidatedData,
-        }),
-        ...createVerifyApplicationExceptionsTaskMock(),
-        ...createCreateSupportingUsersParentsTaskMock({
-          supportingUserIds: [parent1SupportingUserId],
-        }),
-        ...createCheckSupportingUserResponseTaskMock({
-          totalIncome: 1,
-          subprocesses: WorkflowSubprocesses.RetrieveSupportingInfoParent1,
-        }),
-        ...createIncomeRequestTaskMock({
-          incomeVerificationId: incomeVerificationId++,
-          subprocesses: WorkflowSubprocesses.StudentIncomeVerification,
-        }),
-        ...createIncomeRequestTaskMock({
-          incomeVerificationId: incomeVerificationId++,
-          subprocesses: WorkflowSubprocesses.Parent1IncomeVerification,
-        }),
-        ...createCheckIncomeRequestTaskMock({
-          subprocesses: WorkflowSubprocesses.StudentIncomeVerification,
-        }),
-        ...createCheckIncomeRequestTaskMock({
-          subprocesses: WorkflowSubprocesses.Parent1IncomeVerification,
-        }),
-      },
-      requestTimeout: PROCESS_INSTANCE_CREATE_TIMEOUT,
+    const dataPreAssessment: AssessmentConsolidatedData = {
+      assessmentTriggerType: AssessmentTriggerType.OriginalAssessment,
+      ...createFakeConsolidatedFulltimeData(PROGRAM_YEAR),
+      ...createParentsData({
+        dataType: AssessmentDataType.PreAssessment,
+        numberOfParents: 1,
+      }),
     };
+
+    const workersMockedData = createWorkersMockedData([
+      createLoadAssessmentDataTaskMock({
+        assessmentConsolidatedData: dataOnSubmit,
+        subprocess:
+          WorkflowSubprocesses.LoadConsolidatedDataSubmitOrReassessment,
+      }),
+      createLoadAssessmentDataTaskMock({
+        assessmentConsolidatedData: dataPreAssessment,
+        subprocess: WorkflowSubprocesses.LoadConsolidatedDataPreAssessment,
+      }),
+      createVerifyApplicationExceptionsTaskMock(),
+      createCreateSupportingUsersParentsTaskMock({
+        supportingUserIds: [parent1SupportingUserId],
+      }),
+      createCheckSupportingUserResponseTaskMock({
+        totalIncome: 1,
+        subprocesses: WorkflowSubprocesses.RetrieveSupportingInfoParent1,
+      }),
+      createIncomeRequestTaskMock({
+        incomeVerificationId: incomeVerificationId++,
+        subprocesses: WorkflowSubprocesses.StudentIncomeVerification,
+      }),
+      createIncomeRequestTaskMock({
+        incomeVerificationId: incomeVerificationId++,
+        subprocesses: WorkflowSubprocesses.Parent1IncomeVerification,
+      }),
+      createCheckIncomeRequestTaskMock({
+        subprocesses: WorkflowSubprocesses.StudentIncomeVerification,
+      }),
+      createCheckIncomeRequestTaskMock({
+        subprocesses: WorkflowSubprocesses.Parent1IncomeVerification,
+      }),
+    ]);
 
     // Act
     const assessmentGatewayResponse =
-      await zeebeClientProvider.createProcessInstanceWithResult(
-        assessmentStartData,
-      );
+      await zeebeClientProvider.createProcessInstanceWithResult({
+        bpmnProcessId: "assessment-gateway",
+        variables: {
+          [ASSESSMENT_ID]: currentAssessmentId,
+          ...workersMockedData,
+        },
+        requestTimeout: PROCESS_INSTANCE_CREATE_TIMEOUT,
+      });
 
     // Assert
     expectToPassThroughServiceTasks(
       assessmentGatewayResponse.variables,
       WorkflowServiceTasks.AssociateWorkflowInstance,
+      WorkflowSubprocesses.LoadConsolidatedDataSubmitOrReassessment,
+      WorkflowSubprocesses.LoadConsolidatedDataPreAssessment,
       WorkflowServiceTasks.VerifyApplicationExceptions,
       WorkflowServiceTasks.ProgramInfoNotRequired,
       WorkflowSubprocesses.StudentIncomeVerification,
@@ -237,47 +280,65 @@ describe(`E2E Test Workflow assessment gateway on original assessment for ${PROG
     );
   });
 
-  it("Should skip parent income verification when the student is dependant and informed that parents do not have SIN.", async () => {
+  it.only("Should skip parent income verification when the student is dependant and informed that parents do not have SIN.", async () => {
     // Arrange
     const currentAssessmentId = assessmentId++;
     // Assessment consolidated mocked data.
-    const assessmentConsolidatedData: AssessmentConsolidatedData = {
+    const dataOnSubmit: AssessmentConsolidatedData = {
       assessmentTriggerType: AssessmentTriggerType.OriginalAssessment,
       ...createFakeConsolidatedFulltimeData(PROGRAM_YEAR),
       ...createParentsData({ validSinNumber: YesNoOptions.No }),
       // Application with PIR not required.
       studentDataSelectedOffering: 1,
     };
-
-    const assessmentStartData = {
-      bpmnProcessId: "assessment-gateway",
-      variables: {
-        [ASSESSMENT_ID]: currentAssessmentId,
-        ...createLoadAssessmentConsolidatedDataMock({
-          assessmentConsolidatedData,
-        }),
-        ...createVerifyApplicationExceptionsTaskMock(),
-        ...createIncomeRequestTaskMock({
-          incomeVerificationId: incomeVerificationId++,
-          subprocesses: WorkflowSubprocesses.StudentIncomeVerification,
-        }),
-        ...createCheckIncomeRequestTaskMock({
-          subprocesses: WorkflowSubprocesses.StudentIncomeVerification,
-        }),
-      },
-      requestTimeout: PROCESS_INSTANCE_CREATE_TIMEOUT,
+    const dataPreAssessment: AssessmentConsolidatedData = {
+      assessmentTriggerType: AssessmentTriggerType.OriginalAssessment,
+      ...createFakeConsolidatedFulltimeData(PROGRAM_YEAR),
+      ...createParentsData({
+        dataType: AssessmentDataType.PreAssessment,
+        validSinNumber: YesNoOptions.No,
+      }),
     };
+
+    const workersMockedData = createWorkersMockedData([
+      createLoadAssessmentDataTaskMock({
+        assessmentConsolidatedData: dataOnSubmit,
+        subprocess:
+          WorkflowSubprocesses.LoadConsolidatedDataSubmitOrReassessment,
+      }),
+      createLoadAssessmentDataTaskMock({
+        assessmentConsolidatedData: dataPreAssessment,
+        subprocess: WorkflowSubprocesses.LoadConsolidatedDataPreAssessment,
+      }),
+      createVerifyApplicationExceptionsTaskMock(),
+      createIncomeRequestTaskMock({
+        incomeVerificationId: incomeVerificationId++,
+        subprocesses: WorkflowSubprocesses.StudentIncomeVerification,
+      }),
+      createCheckIncomeRequestTaskMock({
+        subprocesses: WorkflowSubprocesses.StudentIncomeVerification,
+      }),
+    ]);
+
+    console.log(JSON.stringify(workersMockedData, null, 2));
 
     // Act
     const assessmentGatewayResponse =
-      await zeebeClientProvider.createProcessInstanceWithResult(
-        assessmentStartData,
-      );
+      await zeebeClientProvider.createProcessInstanceWithResult({
+        bpmnProcessId: "assessment-gateway",
+        variables: {
+          [ASSESSMENT_ID]: currentAssessmentId,
+          ...workersMockedData,
+        },
+        requestTimeout: PROCESS_INSTANCE_CREATE_TIMEOUT,
+      });
 
     // Assert
     expectToPassThroughServiceTasks(
       assessmentGatewayResponse.variables,
       WorkflowServiceTasks.AssociateWorkflowInstance,
+      WorkflowSubprocesses.LoadConsolidatedDataSubmitOrReassessment,
+      WorkflowSubprocesses.LoadConsolidatedDataPreAssessment,
       WorkflowServiceTasks.VerifyApplicationExceptions,
       WorkflowServiceTasks.ProgramInfoNotRequired,
       WorkflowSubprocesses.StudentIncomeVerification,

--- a/sources/packages/backend/workflow/test/2022-2023/assessment-gateway/assessment-gateway.studentAppeal.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2022-2023/assessment-gateway/assessment-gateway.studentAppeal.e2e-spec.ts
@@ -10,7 +10,6 @@ import {
   createFakeSingleIndependentStudentData,
   expectToPassThroughServiceTasks,
   expectNotToPassThroughServiceTasks,
-  WorkflowSubprocesses,
 } from "../../test-utils";
 import { PROGRAM_YEAR } from "../constants/program-year.constants";
 import {
@@ -35,12 +34,6 @@ describe(`E2E Test Workflow assessment gateway on student appeal for ${PROGRAM_Y
     const workersMockedData = createWorkersMockedData([
       createLoadAssessmentDataTaskMock({
         assessmentConsolidatedData: assessmentConsolidatedData,
-        subprocess:
-          WorkflowSubprocesses.LoadConsolidatedDataSubmitOrReassessment,
-      }),
-      createLoadAssessmentDataTaskMock({
-        assessmentConsolidatedData: assessmentConsolidatedData,
-        subprocess: WorkflowSubprocesses.LoadConsolidatedDataPreAssessment,
       }),
     ]);
 

--- a/sources/packages/backend/workflow/test/2023-2024/assessment-gateway/assessment-gateway.originalAssessment.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2023-2024/assessment-gateway/assessment-gateway.originalAssessment.e2e-spec.ts
@@ -20,6 +20,7 @@ import {
   createCheckSupportingUserResponseTaskMock,
   createCheckIncomeRequestTaskMock,
   createLoadAssessmentConsolidatedDataMock,
+  createWorkersMockedData,
 } from "../../test-utils/mock";
 import {
   PROGRAM_YEAR,
@@ -79,7 +80,7 @@ describe(`E2E Test Workflow assessment gateway on original assessment for ${PROG
     );
   });
 
-  it("Should check for both parents incomes when the student is dependant and parents have SIN.", async () => {
+  it.only("Should check for both parents incomes when the student is dependant and parents have SIN.", async () => {
     // Arrange
     const currentAssessmentId = assessmentId++;
     const parent1SupportingUserId = supportingUserId++;
@@ -93,55 +94,57 @@ describe(`E2E Test Workflow assessment gateway on original assessment for ${PROG
       studentDataSelectedOffering: 1,
     };
 
-    const assessmentStartData = {
-      bpmnProcessId: "assessment-gateway",
-      variables: {
-        [ASSESSMENT_ID]: currentAssessmentId,
-        ...createLoadAssessmentConsolidatedDataMock({
-          assessmentConsolidatedData,
-        }),
-        ...createVerifyApplicationExceptionsTaskMock(),
-        ...createCreateSupportingUsersParentsTaskMock({
-          supportingUserIds: [parent1SupportingUserId, parent2SupportingUserId],
-        }),
-        ...createCheckSupportingUserResponseTaskMock({
-          totalIncome: 1,
-          subprocesses: WorkflowSubprocesses.RetrieveSupportingInfoParent1,
-        }),
-        ...createCheckSupportingUserResponseTaskMock({
-          totalIncome: 1,
-          subprocesses: WorkflowSubprocesses.RetrieveSupportingInfoParent2,
-        }),
-        ...createIncomeRequestTaskMock({
-          incomeVerificationId: incomeVerificationId++,
-          subprocesses: WorkflowSubprocesses.StudentIncomeVerification,
-        }),
-        ...createIncomeRequestTaskMock({
-          incomeVerificationId: incomeVerificationId++,
-          subprocesses: WorkflowSubprocesses.Parent1IncomeVerification,
-        }),
-        ...createIncomeRequestTaskMock({
-          incomeVerificationId: incomeVerificationId++,
-          subprocesses: WorkflowSubprocesses.Parent2IncomeVerification,
-        }),
-        ...createCheckIncomeRequestTaskMock({
-          subprocesses: WorkflowSubprocesses.StudentIncomeVerification,
-        }),
-        ...createCheckIncomeRequestTaskMock({
-          subprocesses: WorkflowSubprocesses.Parent1IncomeVerification,
-        }),
-        ...createCheckIncomeRequestTaskMock({
-          subprocesses: WorkflowSubprocesses.Parent2IncomeVerification,
-        }),
-      },
-      requestTimeout: PROCESS_INSTANCE_CREATE_TIMEOUT,
-    };
+    const workersMockedData = createWorkersMockedData([
+      createLoadAssessmentConsolidatedDataMock({
+        assessmentConsolidatedData,
+      }),
+      createVerifyApplicationExceptionsTaskMock(),
+      createCreateSupportingUsersParentsTaskMock({
+        supportingUserIds: [parent1SupportingUserId, parent2SupportingUserId],
+      }),
+      createCheckSupportingUserResponseTaskMock({
+        totalIncome: 1,
+        subprocesses: WorkflowSubprocesses.RetrieveSupportingInfoParent1,
+      }),
+      createCheckSupportingUserResponseTaskMock({
+        totalIncome: 1,
+        subprocesses: WorkflowSubprocesses.RetrieveSupportingInfoParent2,
+      }),
+      createIncomeRequestTaskMock({
+        incomeVerificationId: incomeVerificationId++,
+        subprocesses: WorkflowSubprocesses.StudentIncomeVerification,
+      }),
+      createIncomeRequestTaskMock({
+        incomeVerificationId: incomeVerificationId++,
+        subprocesses: WorkflowSubprocesses.Parent1IncomeVerification,
+      }),
+      createIncomeRequestTaskMock({
+        incomeVerificationId: incomeVerificationId++,
+        subprocesses: WorkflowSubprocesses.Parent2IncomeVerification,
+      }),
+      createCheckIncomeRequestTaskMock({
+        subprocesses: WorkflowSubprocesses.StudentIncomeVerification,
+      }),
+      createCheckIncomeRequestTaskMock({
+        subprocesses: WorkflowSubprocesses.Parent1IncomeVerification,
+      }),
+      createCheckIncomeRequestTaskMock({
+        subprocesses: WorkflowSubprocesses.Parent2IncomeVerification,
+      }),
+    ]);
+
+    //console.log(JSON.stringify(startEventMockedData, null, 2));
 
     // Act
     const assessmentGatewayResponse =
-      await zeebeClientProvider.createProcessInstanceWithResult(
-        assessmentStartData,
-      );
+      await zeebeClientProvider.createProcessInstanceWithResult({
+        bpmnProcessId: "assessment-gateway",
+        variables: {
+          [ASSESSMENT_ID]: currentAssessmentId,
+          ...workersMockedData,
+        },
+        requestTimeout: PROCESS_INSTANCE_CREATE_TIMEOUT,
+      });
 
     // Assert
     expectToPassThroughServiceTasks(

--- a/sources/packages/backend/workflow/test/2023-2024/assessment-gateway/assessment-gateway.originalAssessment.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2023-2024/assessment-gateway/assessment-gateway.originalAssessment.e2e-spec.ts
@@ -42,7 +42,7 @@ describe(`E2E Test Workflow assessment gateway on original assessment for ${PROG
     // Arrange
 
     // Assessment consolidated mocked data.
-    const assessmentDataOnSubmit: AssessmentConsolidatedData = {
+    const assessmentConsolidatedData: AssessmentConsolidatedData = {
       assessmentTriggerType: AssessmentTriggerType.OriginalAssessment,
       ...createFakeConsolidatedFulltimeData(PROGRAM_YEAR),
       ...createFakeSingleIndependentStudentData(),
@@ -51,15 +51,7 @@ describe(`E2E Test Workflow assessment gateway on original assessment for ${PROG
     };
 
     const workersMockedData = createWorkersMockedData([
-      createLoadAssessmentDataTaskMock({
-        assessmentConsolidatedData: assessmentDataOnSubmit,
-        subprocess:
-          WorkflowSubprocesses.LoadConsolidatedDataSubmitOrReassessment,
-      }),
-      createLoadAssessmentDataTaskMock({
-        assessmentConsolidatedData: assessmentDataOnSubmit,
-        subprocess: WorkflowSubprocesses.LoadConsolidatedDataPreAssessment,
-      }),
+      createLoadAssessmentDataTaskMock({ assessmentConsolidatedData }),
       createVerifyApplicationExceptionsTaskMock(),
       createIncomeRequestTaskMock({
         incomeVerificationId: incomeVerificationId++,

--- a/sources/packages/backend/workflow/test/2023-2024/assessment-gateway/assessment-gateway.studentAppeal.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2023-2024/assessment-gateway/assessment-gateway.studentAppeal.e2e-spec.ts
@@ -10,7 +10,6 @@ import {
   createFakeSingleIndependentStudentData,
   expectToPassThroughServiceTasks,
   expectNotToPassThroughServiceTasks,
-  WorkflowSubprocesses,
 } from "../../test-utils";
 import { PROGRAM_YEAR } from "../constants/program-year.constants";
 import {
@@ -35,12 +34,6 @@ describe(`E2E Test Workflow assessment gateway on student appeal for ${PROGRAM_Y
     const workersMockedData = createWorkersMockedData([
       createLoadAssessmentDataTaskMock({
         assessmentConsolidatedData: assessmentConsolidatedData,
-        subprocess:
-          WorkflowSubprocesses.LoadConsolidatedDataSubmitOrReassessment,
-      }),
-      createLoadAssessmentDataTaskMock({
-        assessmentConsolidatedData: assessmentConsolidatedData,
-        subprocess: WorkflowSubprocesses.LoadConsolidatedDataPreAssessment,
       }),
     ]);
 

--- a/sources/packages/backend/workflow/test/test-utils/constants/mock-constants.ts
+++ b/sources/packages/backend/workflow/test/test-utils/constants/mock-constants.ts
@@ -1,14 +1,4 @@
 /**
- * Separator used while creating mock variables names resulted
- * from the concatenation of other identifiers.
- */
-export const MOCKS_SEPARATOR = "_";
-/**
- * Service task id separator usually used on workflows to identify
- * the service task ids.
- */
-export const SERVICE_TASK_ID_SEPARATOR = "-";
-/**
  * Suffix of the mocked objects intended to be returned as a result
  * of a service task completed job.
  */

--- a/sources/packages/backend/workflow/test/test-utils/constants/mock-constants.ts
+++ b/sources/packages/backend/workflow/test/test-utils/constants/mock-constants.ts
@@ -1,4 +1,14 @@
 /**
+ * Separator used while creating mock variables names resulted
+ * from the concatenation of other identifiers.
+ */
+export const MOCKS_SEPARATOR = "_";
+/**
+ * Service task id separator usually used on workflows to identify
+ * the service task ids.
+ */
+export const SERVICE_TASK_ID_SEPARATOR = "-";
+/**
  * Suffix of the mocked objects intended to be returned as a result
  * of a service task completed job.
  */
@@ -12,3 +22,7 @@ export const JOB_MESSAGE_RESULT_SUFFIX = "messageResult";
  * Identifier of subprocesses in the workflow.
  */
 export const PARENT_SUBPROCESSES_VARIABLE = "parentSubprocesses";
+/**
+ * Suffix that indicates if a task or subprocess was invoked by the workflow.
+ */
+export const JOB_PASSTHROUGH_SUFFIX = "passthrough";

--- a/sources/packages/backend/workflow/test/test-utils/constants/workflow-variables-constants.ts
+++ b/sources/packages/backend/workflow/test/test-utils/constants/workflow-variables-constants.ts
@@ -33,6 +33,8 @@ export enum WorkflowServiceTasks {
  * the workflow execution passed through those tasks.
  */
 export enum WorkflowSubprocesses {
+  LoadConsolidatedDataSubmitOrReassessment = "loadConsolidatedDataOnSubmitOrReassessmentSubprocess",
+  LoadConsolidatedDataPreAssessment = "loadConsolidatedDataPreAssessmentSubprocess",
   StudentIncomeVerification = "studentIncomeVerificationSubprocess",
   RetrieveSupportingInfoPartner = "retrieveSupportingInfoPartnerSubprocess",
   RetrieveSupportingInfoParent1 = "retrieveSupportingInfoParent1Subprocess",

--- a/sources/packages/backend/workflow/test/test-utils/constants/workflow-variables-constants.ts
+++ b/sources/packages/backend/workflow/test/test-utils/constants/workflow-variables-constants.ts
@@ -33,13 +33,13 @@ export enum WorkflowServiceTasks {
  * the workflow execution passed through those tasks.
  */
 export enum WorkflowSubprocesses {
-  LoadConsolidatedDataSubmitOrReassessment = "loadConsolidatedDataOnSubmitOrReassessmentSubprocess",
-  LoadConsolidatedDataPreAssessment = "loadConsolidatedDataPreAssessmentSubprocess",
-  StudentIncomeVerification = "studentIncomeVerificationSubprocess",
-  RetrieveSupportingInfoPartner = "retrieveSupportingInfoPartnerSubprocess",
-  RetrieveSupportingInfoParent1 = "retrieveSupportingInfoParent1Subprocess",
-  RetrieveSupportingInfoParent2 = "retrieveSupportingInfoParent2Subprocess",
-  PartnerIncomeVerification = "partnerIncomeVerificationSubprocess",
-  Parent1IncomeVerification = "parent1IncomeVerificationSubprocess",
-  Parent2IncomeVerification = "parent2IncomeVerificationSubprocess",
+  LoadConsolidatedDataSubmitOrReassessment = "load-assessment-data-submit-or-reassessment-subprocess",
+  LoadConsolidatedDataPreAssessment = "load-assessment-data-pre-assessment-subprocess",
+  StudentIncomeVerification = "student-income-verification-subprocess",
+  RetrieveSupportingInfoPartner = "retrieve-supporting-info-for-partner-subprocess",
+  RetrieveSupportingInfoParent1 = "retrieve-supporting-info-for-parent-1-subprocess",
+  RetrieveSupportingInfoParent2 = "retrieve-supporting-info-for-parent-2-subprocess",
+  PartnerIncomeVerification = "partner-income-verification-subprocess",
+  Parent1IncomeVerification = "parent-1-income-verification-subprocess",
+  Parent2IncomeVerification = "parent-2-income-verification-subprocess",
 }

--- a/sources/packages/backend/workflow/test/test-utils/factories/assessment-consolidated-data.ts
+++ b/sources/packages/backend/workflow/test/test-utils/factories/assessment-consolidated-data.ts
@@ -3,6 +3,7 @@ import {
   Provinces,
   YesNoOptions,
   OfferingDeliveryOptions,
+  AssessmentDataType,
 } from "@sims/test-utils";
 import { OfferingIntensity } from "@sims/sims-db";
 
@@ -149,10 +150,12 @@ export function createFakeSingleIndependentStudentData(): Partial<AssessmentCons
  * @returns parents data to be used.
  */
 export function createParentsData(options?: {
+  dataType?: AssessmentDataType;
   numberOfParents?: 1 | 2;
   validSinNumber?: YesNoOptions;
 }): Partial<AssessmentConsolidatedData> {
   // Default values for options when not provided.
+  const dataType = options.dataType ?? AssessmentDataType.Submit;
   const numberOfParents = options?.numberOfParents ?? 1;
   const validSinNumber = options?.validSinNumber ?? YesNoOptions.Yes;
   // Make the student a dependant.
@@ -165,6 +168,9 @@ export function createParentsData(options?: {
     parentsData.studentDataPleaseProvideAnEstimationOfYourParentsIncome = 150000;
   }
   parentsData.studentDataParentValidSinNumber = validSinNumber;
+  if (dataType === AssessmentDataType.Submit) {
+    return parentsData;
+  }
   // Create specific parent data for 1 or 2 parents.
   for (let i = 1; i <= numberOfParents; i++) {
     parentsData[`parent${i}NetAssests`] = 300000;

--- a/sources/packages/backend/workflow/test/test-utils/factories/assessment-consolidated-data.ts
+++ b/sources/packages/backend/workflow/test/test-utils/factories/assessment-consolidated-data.ts
@@ -145,6 +145,7 @@ export function createFakeSingleIndependentStudentData(): Partial<AssessmentCons
  * are present in the application, if they need income verification or if they are not able
  * to use a BCSC to provide data using the supporting users portal.
  * @param options creation options.
+ * - `dataType` indicates which moment the assessment data should represents.
  * - `numberOfParents` generate information for one or two parents.
  * - `validSinNumber` determine if parents can have a BCSC and access the supporting users portal.
  * @returns parents data to be used.

--- a/sources/packages/backend/workflow/test/test-utils/mock/assessment-gateway/create-supporting-users-parents-task-mock.ts
+++ b/sources/packages/backend/workflow/test/test-utils/mock/assessment-gateway/create-supporting-users-parents-task-mock.ts
@@ -2,7 +2,7 @@ import {
   PUBLISH_MESSAGE_TIME_TO_LEAVE_SECONDS,
   WorkflowServiceTasks,
 } from "../..";
-import { createMockedWorkerResult } from "..";
+import { WorkerMockedData } from "..";
 
 /**
  * Creates the mock for 'Create supporting users for parent/parents' completed task
@@ -15,7 +15,7 @@ import { createMockedWorkerResult } from "..";
  */
 export function createCreateSupportingUsersParentsTaskMock(options: {
   supportingUserIds: number[];
-}): Record<string, unknown> {
+}): WorkerMockedData {
   // Create messages to be published for each supporting user id provided.
   // For instance, for parent 1 and parent 2 it will be needed one message
   // for each parent to unblock the workflow.
@@ -25,13 +25,13 @@ export function createCreateSupportingUsersParentsTaskMock(options: {
     variables: {},
     timeToLive: PUBLISH_MESSAGE_TIME_TO_LEAVE_SECONDS,
   }));
-  return createMockedWorkerResult(
-    WorkflowServiceTasks.CreateSupportingUsersParentsTask,
-    {
+  return {
+    serviceTaskId: WorkflowServiceTasks.CreateSupportingUsersParentsTask,
+    options: {
       jobCompleteMock: {
         createdSupportingUsersIds: options.supportingUserIds,
       },
       jobMessageMocks,
     },
-  );
+  };
 }

--- a/sources/packages/backend/workflow/test/test-utils/mock/assessment-gateway/load-assessment-consolidated-data-mock.ts
+++ b/sources/packages/backend/workflow/test/test-utils/mock/assessment-gateway/load-assessment-consolidated-data-mock.ts
@@ -4,20 +4,23 @@ import { AssessmentConsolidatedData } from "../../../models";
 
 /**
  * Creates the mock for the 'Load assessment data task' completed.
- * @param assessmentConsolidatedData assessment consolidated data.
+ * @param options.
+ * - `assessmentConsolidatedData` assessment consolidated data.
+ * - `subprocess` related subprocess to mock the data.
  * @returns mock for the 'Load assessment data task' completed.
  */
 export function createLoadAssessmentDataTaskMock(options: {
   assessmentConsolidatedData: AssessmentConsolidatedData;
-  subprocess:
+  subprocess?:
     | WorkflowSubprocesses.LoadConsolidatedDataSubmitOrReassessment
     | WorkflowSubprocesses.LoadConsolidatedDataPreAssessment;
 }): WorkerMockedData {
+  const subprocesses = options.subprocess ? [options.subprocess] : null;
   return {
     serviceTaskId: WorkflowServiceTasks.LoadAssessmentConsolidatedData,
     options: {
       jobCompleteMock: options.assessmentConsolidatedData,
-      subprocesses: [options.subprocess],
+      subprocesses,
     },
   };
 }

--- a/sources/packages/backend/workflow/test/test-utils/mock/assessment-gateway/load-assessment-consolidated-data-mock.ts
+++ b/sources/packages/backend/workflow/test/test-utils/mock/assessment-gateway/load-assessment-consolidated-data-mock.ts
@@ -1,5 +1,5 @@
 import { WorkflowServiceTasks } from "../..";
-import { createMockedWorkerResult } from "..";
+import { WorkerMockedData } from "..";
 import { AssessmentConsolidatedData } from "../../../models";
 
 /**
@@ -9,11 +9,11 @@ import { AssessmentConsolidatedData } from "../../../models";
  */
 export function createLoadAssessmentConsolidatedDataMock(options: {
   assessmentConsolidatedData: AssessmentConsolidatedData;
-}): Record<string, unknown> {
-  return createMockedWorkerResult(
-    WorkflowServiceTasks.LoadAssessmentConsolidatedData,
-    {
+}): WorkerMockedData {
+  return {
+    serviceTaskId: WorkflowServiceTasks.LoadAssessmentConsolidatedData,
+    options: {
       jobCompleteMock: options.assessmentConsolidatedData,
     },
-  );
+  };
 }

--- a/sources/packages/backend/workflow/test/test-utils/mock/assessment-gateway/load-assessment-consolidated-data-mock.ts
+++ b/sources/packages/backend/workflow/test/test-utils/mock/assessment-gateway/load-assessment-consolidated-data-mock.ts
@@ -1,19 +1,23 @@
-import { WorkflowServiceTasks } from "../..";
+import { WorkflowServiceTasks, WorkflowSubprocesses } from "../..";
 import { WorkerMockedData } from "..";
 import { AssessmentConsolidatedData } from "../../../models";
 
 /**
- * Creates the mock for the 'Load consolidated data' completed subprocess.
+ * Creates the mock for the 'Load assessment data task' completed.
  * @param assessmentConsolidatedData assessment consolidated data.
- * @returns mock for the 'Load consolidated data' completed subprocess.
+ * @returns mock for the 'Load assessment data task' completed.
  */
-export function createLoadAssessmentConsolidatedDataMock(options: {
+export function createLoadAssessmentDataTaskMock(options: {
   assessmentConsolidatedData: AssessmentConsolidatedData;
+  subprocess:
+    | WorkflowSubprocesses.LoadConsolidatedDataSubmitOrReassessment
+    | WorkflowSubprocesses.LoadConsolidatedDataPreAssessment;
 }): WorkerMockedData {
   return {
     serviceTaskId: WorkflowServiceTasks.LoadAssessmentConsolidatedData,
     options: {
       jobCompleteMock: options.assessmentConsolidatedData,
+      subprocesses: [options.subprocess],
     },
   };
 }

--- a/sources/packages/backend/workflow/test/test-utils/mock/assessment-gateway/verify-application-exceptions-task-mock.ts
+++ b/sources/packages/backend/workflow/test/test-utils/mock/assessment-gateway/verify-application-exceptions-task-mock.ts
@@ -1,6 +1,6 @@
 import { ApplicationExceptionStatus } from "@sims/sims-db";
 import { WorkflowServiceTasks } from "../..";
-import { createMockedWorkerResult } from "..";
+import { WorkerMockedData } from "..";
 
 /**
  * Creates the mock for 'Verify Application Exceptions' completed task.
@@ -11,13 +11,13 @@ import { createMockedWorkerResult } from "..";
  */
 export function createVerifyApplicationExceptionsTaskMock(options?: {
   status: ApplicationExceptionStatus;
-}) {
+}): WorkerMockedData {
   const applicationExceptionStatus =
     options?.status ?? ApplicationExceptionStatus.Approved;
-  return createMockedWorkerResult(
-    WorkflowServiceTasks.VerifyApplicationExceptions,
-    {
+  return {
+    serviceTaskId: WorkflowServiceTasks.VerifyApplicationExceptions,
+    options: {
       jobCompleteMock: { applicationExceptionStatus },
     },
-  );
+  };
 }

--- a/sources/packages/backend/workflow/test/test-utils/mock/cra-integration-income-verification/check-income-request-task-mock.ts
+++ b/sources/packages/backend/workflow/test/test-utils/mock/cra-integration-income-verification/check-income-request-task-mock.ts
@@ -1,5 +1,5 @@
 import { WorkflowServiceTasks, WorkflowSubprocesses } from "../..";
-import { createMockedWorkerResult } from "../mock.utils";
+import { WorkerMockedData } from "../mock.utils";
 
 /**
  * Creates the mock for 'Check income request' task.
@@ -11,11 +11,14 @@ import { createMockedWorkerResult } from "../mock.utils";
  */
 export function createCheckIncomeRequestTaskMock(options?: {
   subprocesses?: WorkflowSubprocesses;
-}): Record<string, unknown> {
-  return createMockedWorkerResult(WorkflowServiceTasks.CheckIncomeRequest, {
-    jobCompleteMock: {
-      incomeVerificationCompleted: true,
+}): WorkerMockedData {
+  return {
+    serviceTaskId: WorkflowServiceTasks.CheckIncomeRequest,
+    options: {
+      jobCompleteMock: {
+        incomeVerificationCompleted: true,
+      },
+      subprocesses: [options?.subprocesses],
     },
-    subprocesses: [options?.subprocesses],
-  });
+  };
 }

--- a/sources/packages/backend/workflow/test/test-utils/mock/cra-integration-income-verification/create-income-request-task-mock.ts
+++ b/sources/packages/backend/workflow/test/test-utils/mock/cra-integration-income-verification/create-income-request-task-mock.ts
@@ -3,7 +3,7 @@ import {
   WorkflowServiceTasks,
   WorkflowSubprocesses,
 } from "../..";
-import { createMockedWorkerResult } from "../mock.utils";
+import { WorkerMockedData } from "../mock.utils";
 
 /**
  * Creates the mock for 'Create Income request' completed task
@@ -20,21 +20,24 @@ import { createMockedWorkerResult } from "../mock.utils";
 export function createIncomeRequestTaskMock(options?: {
   incomeVerificationId: number;
   subprocesses?: WorkflowSubprocesses;
-}): Record<string, unknown> {
+}): WorkerMockedData {
   const incomeVerificationId = options?.incomeVerificationId ?? 1;
-  return createMockedWorkerResult(WorkflowServiceTasks.CreateIncomeRequest, {
-    jobCompleteMock: {
-      incomeVerificationCompleted: true,
-      incomeVerificationId,
-    },
-    jobMessageMocks: [
-      {
-        name: "income-verified",
-        correlationKey: incomeVerificationId.toString(),
-        variables: {},
-        timeToLive: PUBLISH_MESSAGE_TIME_TO_LEAVE_SECONDS,
+  return {
+    serviceTaskId: WorkflowServiceTasks.CreateIncomeRequest,
+    options: {
+      jobCompleteMock: {
+        incomeVerificationCompleted: true,
+        incomeVerificationId,
       },
-    ],
-    subprocesses: [options?.subprocesses],
-  });
+      jobMessageMocks: [
+        {
+          name: "income-verified",
+          correlationKey: incomeVerificationId.toString(),
+          variables: {},
+          timeToLive: PUBLISH_MESSAGE_TIME_TO_LEAVE_SECONDS,
+        },
+      ],
+      subprocesses: [options?.subprocesses],
+    },
+  };
 }

--- a/sources/packages/backend/workflow/test/test-utils/mock/cra-integration-income-verification/create-income-request-task-mock.ts
+++ b/sources/packages/backend/workflow/test/test-utils/mock/cra-integration-income-verification/create-income-request-task-mock.ts
@@ -17,22 +17,21 @@ import { WorkerMockedData } from "../mock.utils";
  * @returns mock for 'Create Income request' completed task and also publish
  * the message to unblock the workflow.
  */
-export function createIncomeRequestTaskMock(options?: {
+export function createIncomeRequestTaskMock(options: {
   incomeVerificationId: number;
   subprocesses?: WorkflowSubprocesses;
 }): WorkerMockedData {
-  const incomeVerificationId = options?.incomeVerificationId ?? 1;
   return {
     serviceTaskId: WorkflowServiceTasks.CreateIncomeRequest,
     options: {
       jobCompleteMock: {
         incomeVerificationCompleted: true,
-        incomeVerificationId,
+        incomeVerificationId: options.incomeVerificationId,
       },
       jobMessageMocks: [
         {
           name: "income-verified",
-          correlationKey: incomeVerificationId.toString(),
+          correlationKey: options.incomeVerificationId.toString(),
           variables: {},
           timeToLive: PUBLISH_MESSAGE_TIME_TO_LEAVE_SECONDS,
         },

--- a/sources/packages/backend/workflow/test/test-utils/mock/mock.utils.ts
+++ b/sources/packages/backend/workflow/test/test-utils/mock/mock.utils.ts
@@ -2,11 +2,56 @@ import { PublishMessageRequest } from "zeebe-node";
 import {
   JOB_COMPLETED_RESULT_SUFFIX,
   JOB_MESSAGE_RESULT_SUFFIX,
+  JOB_PASSTHROUGH_SUFFIX,
+  MOCKS_SEPARATOR,
+  SERVICE_TASK_ID_SEPARATOR,
 } from "../constants/mock-constants";
 import {
   WorkflowServiceTasks,
   WorkflowSubprocesses,
 } from "../constants/workflow-variables-constants";
+
+/**
+ * Regex for replace all.
+ */
+const SERVICE_TASK_ID_SEPARATOR_REGEX = new RegExp(
+  SERVICE_TASK_ID_SEPARATOR,
+  "g",
+);
+
+/**
+ * Get the passthrough mock identifier for a completed job,
+ * for instance, create_supporting_users_for_parents_task_passthrough, where:
+ * - `create_supporting_users_for_parents_task`: service task id;
+ * - `passthrough`: suffix that identifies the job passthrough identifier.
+ * @param serviceTaskId service task id that will have the job passthrough defined.
+ * @returns passthrough mock identifier for a completed job.
+ */
+export function getPassthroughTaskId(serviceTaskId: string) {
+  return `${getNormalizedServiceTaskId(
+    serviceTaskId,
+  )}${MOCKS_SEPARATOR}${JOB_PASSTHROUGH_SUFFIX}`;
+}
+
+/**
+ * Convert the service task id, usually declared as 'service-task-id' to the expected
+ * Camunda variable name like service_task_id.
+ * The usual variables along the workflow are following the camelCase pattern but service
+ * task ids are actually following the kebab-case pattern, which is not a problem in general.
+ * Based on it, while trying to use the service task ids as variables names we can
+ * respect the Camunda recommendations (link below) and just convert the kebab-case to
+ * snake_case pattern.
+ * @see https://docs.camunda.io/docs/components/concepts/variables/#variable-names
+ * @param serviceTaskId workflow service task id.
+ * @returns service task id, usually declared as 'service-task-id' to the expected
+ * Camunda variable name like service_task_id.
+ */
+function getNormalizedServiceTaskId(serviceTaskId: string) {
+  return serviceTaskId.replace(
+    SERVICE_TASK_ID_SEPARATOR_REGEX,
+    MOCKS_SEPARATOR,
+  );
+}
 
 /**
  * Information to create a mocked worker including the job completed object and/or the

--- a/sources/packages/backend/workflow/test/test-utils/mock/mock.utils.ts
+++ b/sources/packages/backend/workflow/test/test-utils/mock/mock.utils.ts
@@ -46,7 +46,7 @@ export function getPassthroughTaskId(serviceTaskId: string) {
  * @returns service task id, usually declared as 'service-task-id' to the expected
  * Camunda variable name like service_task_id.
  */
-function getNormalizedServiceTaskId(serviceTaskId: string) {
+export function getNormalizedServiceTaskId(serviceTaskId: string) {
   return serviceTaskId.replace(
     SERVICE_TASK_ID_SEPARATOR_REGEX,
     MOCKS_SEPARATOR,
@@ -94,8 +94,8 @@ export interface WorkerMockedData {
  * @returns mocked objects, see example below for one single mocked worker for 2
  * subprocesses that also need to have messages published.
  * @example
-   "create-income-request-task": {
-    "studentIncomeVerificationSubprocess": {
+   "create_income_request_task": {
+    "student_income_verification_subprocess": {
       "result": {
         "incomeVerificationCompleted": true,
         "incomeVerificationId": 1000
@@ -114,7 +114,7 @@ export interface WorkerMockedData {
         }
       ]
     },
-    "parent1IncomeVerificationSubprocess": {
+    "parent1_income_verification_subprocess": {
       "result": {
         "incomeVerificationCompleted": true,
         "incomeVerificationId": 1001
@@ -141,18 +141,22 @@ export function createWorkersMockedData(
   // Keep the consolidation of all mocked workers.
   const rootMockedData: Record<string, unknown> = {};
   for (const mockedWorker of mockedWorkers) {
-    if (!rootMockedData[mockedWorker.serviceTaskId]) {
-      rootMockedData[mockedWorker.serviceTaskId] = {};
+    const serviceTaskId = getNormalizedServiceTaskId(
+      mockedWorker.serviceTaskId,
+    );
+    if (!rootMockedData[serviceTaskId]) {
+      rootMockedData[serviceTaskId] = {};
     }
     // Creates a subprocess hierarchy to store the worker mock assuming
     // that the hierarchy could be partially created already due to another
     // subprocess for the same service task id.
-    let mockedData = rootMockedData[mockedWorker.serviceTaskId];
+    let mockedData = rootMockedData[serviceTaskId];
     mockedWorker.options.subprocesses?.forEach((subprocess) => {
-      if (!mockedData[subprocess]) {
-        mockedData[subprocess] = {};
+      const subprocessId = getNormalizedServiceTaskId(subprocess);
+      if (!mockedData[subprocessId]) {
+        mockedData[subprocessId] = {};
       }
-      mockedData = mockedData[subprocess];
+      mockedData = mockedData[subprocessId];
     });
     // Create result mocked object.
     if (mockedWorker.options.jobCompleteMock) {

--- a/sources/packages/backend/workflow/test/test-utils/mock/mock.utils.ts
+++ b/sources/packages/backend/workflow/test/test-utils/mock/mock.utils.ts
@@ -1,94 +1,12 @@
-import { PublishMessageRequest, ZeebeJob } from "zeebe-node";
+import { PublishMessageRequest } from "zeebe-node";
 import {
   JOB_COMPLETED_RESULT_SUFFIX,
   JOB_MESSAGE_RESULT_SUFFIX,
-  MOCKS_SEPARATOR,
-  PARENT_SUBPROCESSES_VARIABLE,
-  SERVICE_TASK_ID_SEPARATOR,
 } from "../constants/mock-constants";
 import {
   WorkflowServiceTasks,
   WorkflowSubprocesses,
 } from "../constants/workflow-variables-constants";
-
-/**
- * Regex for replace all.
- */
-const SERVICE_TASK_ID_SEPARATOR_REGEX = new RegExp(
-  SERVICE_TASK_ID_SEPARATOR,
-  "g",
-);
-
-/**
- * Get the mock identifier for a completed job to be sent to the workflow,
- * for instance, create_supporting_users_for_parents_task_result, where:
- * - `create_supporting_users_for_parents_task`: service task id;
- * - `result`: suffix that identifies the job completed object.
- * @param serviceTaskId service task id that will have the job completed returned.
- * @returns mock identifier for a completed job to be sent to the workflow.
- */
-export function getServiceTaskResultMockId(serviceTaskId: string) {
-  return `${getNormalizedServiceTaskId(
-    serviceTaskId,
-  )}${MOCKS_SEPARATOR}${JOB_COMPLETED_RESULT_SUFFIX}`;
-}
-
-/**
- * Get the mock identifier for a message to be sent to the workflow,
- * for instance, create_supporting_users_for_parents_task_messageResult, where:
- * - `create_supporting_users_for_parents_task`: service task id;
- * - `messageResult`: suffix that identifies a message payload to be sent to the
- * workflow.
- * @param serviceTaskId service task id that will need to publish the message.
- * @returns mock identifier for a message to be sent to the workflow.
- */
-export function getPublishMessageResultMockId(serviceTaskId: string) {
-  return `${getNormalizedServiceTaskId(
-    serviceTaskId,
-  )}${MOCKS_SEPARATOR}${JOB_MESSAGE_RESULT_SUFFIX}`;
-}
-
-/**
- * Convert the service task id, usually declared as 'service-task-id' to the expected
- * Camunda variable name like service_task_id.
- * The usual variables along the workflow are following the camelCase pattern but service
- * task ids are actually following the kebab-case pattern, which is not a problem in general.
- * Based on it, while trying to use the service task ids as variables names we can
- * respect the Camunda recommendations (link below) and just convert the kebab-case to
- * snake_case pattern.
- * @see https://docs.camunda.io/docs/components/concepts/variables/#variable-names
- * @param serviceTaskId workflow service task id.
- * @returns service task id, usually declared as 'service-task-id' to the expected
- * Camunda variable name like service_task_id.
- */
-function getNormalizedServiceTaskId(serviceTaskId: string) {
-  return serviceTaskId.replace(
-    SERVICE_TASK_ID_SEPARATOR_REGEX,
-    MOCKS_SEPARATOR,
-  );
-}
-
-/**
- * The service task id (a.k.a. elementId) is unique in the workflow where it is present but
- * can exist in multiple sub-processes (e.g. 'create-income-request'). In this case a special
- * variable, named as 'parentSubprocesses', is used to create a unique service task id.
- * The 'parentSubprocesses' variable is a list that can be appended with multiple scopes allowing
- * uniquely identifying the service ids at any level, for instance, a sub-process calling
- * a sub-process.
- * @param job worker job.
- * @returns unique service task id.
- */
-export function getScopedServiceTaskId(job: ZeebeJob<unknown>): string {
-  // Check if the service task id is in a sub-process.
-  const parentSubprocesses: string[] | undefined =
-    job.variables[PARENT_SUBPROCESSES_VARIABLE];
-  if (parentSubprocesses?.length) {
-    const scopedElementId = [...parentSubprocesses, job.elementId];
-    return scopedElementId.join(MOCKS_SEPARATOR);
-  }
-  // If the element is not in a sub-process just return the element id.
-  return job.elementId;
-}
 
 /**
  * Information to create a mocked worker including the job completed object and/or the

--- a/sources/packages/backend/workflow/test/test-utils/mock/supporting-user-information-request/check-supporting-user-response-task-mock.ts
+++ b/sources/packages/backend/workflow/test/test-utils/mock/supporting-user-information-request/check-supporting-user-response-task-mock.ts
@@ -1,5 +1,5 @@
 import { WorkflowSubprocesses, WorkflowServiceTasks } from "../..";
-import { createMockedWorkerResult } from "../mock.utils";
+import { WorkerMockedData } from "../mock.utils";
 
 /**
  * Creates the mock for 'Check Supporting User Response' completed task.
@@ -14,14 +14,14 @@ import { createMockedWorkerResult } from "../mock.utils";
 export function createCheckSupportingUserResponseTaskMock(options: {
   totalIncome: number;
   subprocesses?: WorkflowSubprocesses;
-}): Record<string, unknown> {
-  return createMockedWorkerResult(
-    WorkflowServiceTasks.CheckSupportingUserResponseTask,
-    {
+}): WorkerMockedData {
+  return {
+    serviceTaskId: WorkflowServiceTasks.CheckSupportingUserResponseTask,
+    options: {
       jobCompleteMock: {
         totalIncome: options.totalIncome,
       },
       subprocesses: [options?.subprocesses],
     },
-  );
+  };
 }

--- a/sources/packages/backend/workflow/test/test-utils/validation/workflow-validation.utils.ts
+++ b/sources/packages/backend/workflow/test/test-utils/validation/workflow-validation.utils.ts
@@ -2,6 +2,7 @@ import {
   WorkflowServiceTasks,
   WorkflowSubprocesses,
 } from "../constants/workflow-variables-constants";
+import { getPassthroughTaskId } from "../mock";
 
 export type WorkflowExpectedTask = WorkflowServiceTasks | WorkflowSubprocesses;
 
@@ -16,7 +17,9 @@ export function expectToPassThroughServiceTasks(
   ...expectedTasks: WorkflowExpectedTask[]
 ) {
   expectedTasks.forEach((expectedTask) => {
-    expect(workflowResultVariables[expectedTask]).toBe(expectedTask);
+    expect(workflowResultVariables[getPassthroughTaskId(expectedTask)]).toBe(
+      expectedTask,
+    );
   });
 }
 
@@ -31,6 +34,8 @@ export function expectNotToPassThroughServiceTasks(
   ...expectedTasks: WorkflowExpectedTask[]
 ) {
   expectedTasks.forEach((expectedTask) => {
-    expect(workflowResultVariables[expectedTask]).toBeUndefined();
+    expect(
+      workflowResultVariables[getPassthroughTaskId(expectedTask)],
+    ).toBeUndefined();
   });
 }


### PR DESCRIPTION
The service task ids are now the root of the mocked objects. When the same service task id exists for multiple subprocesses, these subprocesses are added as a child of the root service task id object. In the below sample, `create_supporting_users_for_parents_task` is not invoked by any subprocess, so the mocked objects for `result` and `messageResult` are direct properties of the root service task id. On the other hand, `create_income_request_task` is invoked by multiple subprocesses, and `result` and `messageResult` are associated with each one of them.

The `load-assessment-data-?` subprocess, which is potentially invoked twice, is now treated as a regular subprocess where we should provide mocked data for both subprocesses (the same data can be provided twice).

### Sample Hierarchical Mocks

Please that some `null` or empty values were removed from consolidated data for better visualization here.
The main differences between `load_assessment_data_submit_or_reassessment_subprocess` and `load_assessment_data_pre_assessment_subprocess` are related to the variables prefixed with `parent1` and `parent2`.

```json
{
  "load_assessment_data_task": {
    "load_assessment_data_submit_or_reassessment_subprocess": {
      "result": {
        "assessmentTriggerType": "Original assessment",
        "studentDataParentValidSinNumber": "yes",
        "studentDataNumberOfParents": 2,
        "studentDataSelectedOffering": 1,
        "studentDataDependantstatus": "dependant",
        "programYear": "2022-2023",
        "programYearStartDate": "2022-08-01",
        "studentDataRelationshipStatus": "single",
        "studentDataTaxReturnIncome": 40000,
        "studentDataWhenDidYouGraduateOrLeaveHighSchool": "2017-03-01",
        "studentDataIndigenousStatus": "no",
        "studentDataHasDependents": "no",
        "studentDataLivingWithParents": "no",
        "studentDataYouthInCare": "no",
        "studentPDStatus": false,
        "studentTaxYear": 2021,
        "programLocation": "BC",
        "institutionLocationProvince": "BC",
        "institutionType": "BC Public",
        "programLength": "1YearToLessThan2Years",
        "programCredentialType": "undergraduateDegree",
        "offeringDelivered": "onsite",
        "offeringProgramRelatedCosts": 5000,
        "offeringActualTuitionCosts": 20000,
        "offeringMandatoryFees": 500,
        "offeringExceptionalExpenses": 500,
        "offeringWeeks": 16,
        "offeringIntensity": "Full Time",
        "offeringStudyStartDate": "2023-02-01",
        "offeringStudyEndDate": "2023-05-24"
      }
    },
    "load_assessment_data_pre_assessment_subprocess": {
      "result": {
        "assessmentTriggerType": "Original assessment",
        "studentDataParentValidSinNumber": "yes",
        "studentDataNumberOfParents": 2,
        "parent1Contributions": 10000,
        "parent1Ei": 0,
        "parent1NetAssests": 300000,
        "parent1Tax": 0,
        "parent1TotalIncome": 75000,
        "parent1CppEmployment": 5000,
        "parent1CppSelfemploymentOther": 200,
        "parent2Contributions": 10000,
        "parent2CppSelfemploymentOther": 200,
        "parent2Ei": 0,
        "parent2NetAssests": 300000,
        "parent2Tax": 0,
        "parent2TotalIncome": 75000,
        "parent2CppEmployment": 5000,
        "studentDataDependantstatus": "dependant",
        "programYear": "2022-2023",
        "programYearStartDate": "2022-08-01",
        "studentDataRelationshipStatus": "single",
        "studentDataTaxReturnIncome": 40000,
        "studentDataWhenDidYouGraduateOrLeaveHighSchool": "2017-03-01",
        "studentDataIndigenousStatus": "no",
        "studentDataHasDependents": "no",
        "studentDataLivingWithParents": "no",
        "studentDataYouthInCare": "no",
        "studentPDStatus": false,
        "studentTaxYear": 2021,
        "programLocation": "BC",
        "institutionLocationProvince": "BC",
        "institutionType": "BC Public",
        "programLength": "1YearToLessThan2Years",
        "programCredentialType": "undergraduateDegree",
        "offeringDelivered": "onsite",
        "offeringProgramRelatedCosts": 5000,
        "offeringActualTuitionCosts": 20000,
        "offeringMandatoryFees": 500,
        "offeringExceptionalExpenses": 500,
        "offeringWeeks": 16,
        "offeringIntensity": "Full Time",
        "offeringStudyStartDate": "2023-02-01",
        "offeringStudyEndDate": "2023-05-24"
      }
    }
  },
  "verify_application_exceptions_task": {
    "result": {
      "applicationExceptionStatus": "Approved"
    }
  },
  "create_supporting_users_for_parents_task": {
    "result": {
      "createdSupportingUsersIds": [
        1000,
        1001
      ]
    },
    "messageResult": [
      {
        "name": "supporting-user-info-received",
        "correlationKey": "1000",
        "variables": {},
        "timeToLive": {
          "type": "SECONDS",
          "value": 10,
          "valueType": "TYPED_DURATION",
          "unit": "s"
        }
      },
      {
        "name": "supporting-user-info-received",
        "correlationKey": "1001",
        "variables": {},
        "timeToLive": {
          "type": "SECONDS",
          "value": 10,
          "valueType": "TYPED_DURATION",
          "unit": "s"
        }
      }
    ]
  },
  "check_supporting_user_response_task": {
    "retrieve_supporting_info_for_parent_1_subprocess": {
      "result": {
        "totalIncome": 1
      }
    },
    "retrieve_supporting_info_for_parent_2_subprocess": {
      "result": {
        "totalIncome": 1
      }
    }
  },
  "create_income_request_task": {
    "student_income_verification_subprocess": {
      "result": {
        "incomeVerificationCompleted": true,
        "incomeVerificationId": 1000
      },
      "messageResult": [
        {
          "name": "income-verified",
          "correlationKey": "1000",
          "variables": {},
          "timeToLive": {
            "type": "SECONDS",
            "value": 10,
            "valueType": "TYPED_DURATION",
            "unit": "s"
          }
        }
      ]
    },
    "parent_1_income_verification_subprocess": {
      "result": {
        "incomeVerificationCompleted": true,
        "incomeVerificationId": 1001
      },
      "messageResult": [
        {
          "name": "income-verified",
          "correlationKey": "1001",
          "variables": {},
          "timeToLive": {
            "type": "SECONDS",
            "value": 10,
            "valueType": "TYPED_DURATION",
            "unit": "s"
          }
        }
      ]
    },
    "parent_2_income_verification_subprocess": {
      "result": {
        "incomeVerificationCompleted": true,
        "incomeVerificationId": 1002
      },
      "messageResult": [
        {
          "name": "income-verified",
          "correlationKey": "1002",
          "variables": {},
          "timeToLive": {
            "type": "SECONDS",
            "value": 10,
            "valueType": "TYPED_DURATION",
            "unit": "s"
          }
        }
      ]
    }
  },
  "check_income_request_task": {
    "student_income_verification_subprocess": {
      "result": {
        "incomeVerificationCompleted": true
      }
    },
    "parent_1_income_verification_subprocess": {
      "result": {
        "incomeVerificationCompleted": true
      }
    },
    "parent_2_income_verification_subprocess": {
      "result": {
        "incomeVerificationCompleted": true
      }
    }
  }
}
```

### Resuing the same mock for multiple subprocesses.

A mocked object can be reused for multiple tasks under different subprocesses, as shown below.

![image](https://user-images.githubusercontent.com/61259237/230961447-afd67483-d4d2-4996-888e-224f35b7a005.png)

![image](https://user-images.githubusercontent.com/61259237/230961428-c382ddfa-af47-47ad-b99d-891357b08485.png)

### Test summary readability

To allow better readability of the test summary, the Zeebe logging is disabled.

![image](https://user-images.githubusercontent.com/61259237/230502610-2c2e562b-01ef-492a-ae2a-fc2d194e6539.png)

### Varibales naming conventions

The possible change in the naming conventions for the service task ids is not considered for this PR.

`WorkflowServiceTasks` and `WorkflowSubprocesses` are now following the same convention, as shown below.
Right now service task ids are still using the "-" as separators while Camunda E2E-related variables are using "_", which makes it easier to identify a variable on the workflow that is related to E2E.

![image](https://user-images.githubusercontent.com/61259237/230504863-525d16bc-c45f-47cd-bcf3-eed752757d4f.png)
