### PR TITLE
#1786 - Enable Search Student for Institutions part 2

### DIFF
--- a/sources/packages/backend/apps/api/src/app.supporting-users.module.ts
+++ b/sources/packages/backend/apps/api/src/app.supporting-users.module.ts
@@ -10,6 +10,8 @@ import {
   EducationProgramOfferingService,
   StudentService,
   EducationProgramOfferingValidationService,
+  InstitutionLocationService,
+  DesignationAgreementLocationService,
 } from "./services";
 import {
   DisbursementOverawardService,
@@ -48,6 +50,8 @@ import { AuthModule } from "./auth/auth.module";
     StudentRestrictionSharedService,
     DisbursementOverawardService,
     NoteSharedService,
+    InstitutionLocationService,
+    DesignationAgreementLocationService,
   ],
 })
 export class AppSupportingUsersModule {}

--- a/sources/packages/backend/apps/api/src/constants/error-code.constants.ts
+++ b/sources/packages/backend/apps/api/src/constants/error-code.constants.ts
@@ -121,3 +121,7 @@ export const DUPLICATE_INSTITUTION_LOCATION_CODE =
  * Duplicate SABC code for the institution.
  */
 export const DUPLICATE_SABC_CODE = "DUPLICATE_SABC_CODE";
+/**
+ * Institution location not valid.
+ */
+export const INSTITUTION_LOCATION_NOT_VALID = "INSTITUTION_LOCATION_NOT_VALID";

--- a/sources/packages/backend/apps/api/src/route-controllers/application/application.students.controller.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/application/application.students.controller.ts
@@ -55,6 +55,7 @@ import { AuthorizedParties } from "../../auth/authorized-parties.enum";
 import { ApiProcessError, ClientTypeBaseRoute } from "../../types";
 import { getPIRDeniedReason, PIR_OR_DATE_OVERLAP_ERROR } from "../../utilities";
 import {
+  INSTITUTION_LOCATION_NOT_VALID,
   INVALID_APPLICATION_NUMBER,
   OFFERING_NOT_VALID,
 } from "../../constants";
@@ -154,7 +155,7 @@ export class ApplicationStudentsController extends BaseController {
       "Selected offering id is invalid or " +
       "invalid study dates or selected study start date is not within the program year" +
       "or APPLICATION_NOT_VALID or INVALID_OPERATION_IN_THE_CURRENT_STATUS or ASSESSMENT_INVALID_OPERATION_IN_THE_CURRENT_STATE " +
-      "or OFFERING_NOT_VALID.",
+      "or INSTITUTION_LOCATION_NOT_VALID or OFFERING_NOT_VALID.",
   })
   @ApiBadRequestResponse({ description: "Form validation failed." })
   @ApiNotFoundResponse({ description: "Application not found." })
@@ -246,6 +247,10 @@ export class ApplicationStudentsController extends BaseController {
         case APPLICATION_NOT_VALID:
         case INVALID_OPERATION_IN_THE_CURRENT_STATUS:
         case PIR_OR_DATE_OVERLAP_ERROR:
+        case INSTITUTION_LOCATION_NOT_VALID:
+          throw new UnprocessableEntityException(
+            new ApiProcessError(error.message, error.name),
+          );
         case OFFERING_NOT_VALID:
           throw new UnprocessableEntityException(
             new ApiProcessError(error.message, error.name),

--- a/sources/packages/backend/apps/api/src/route-controllers/application/application.students.controller.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/application/application.students.controller.ts
@@ -247,7 +247,8 @@ export class ApplicationStudentsController extends BaseController {
         case APPLICATION_NOT_VALID:
         case INVALID_OPERATION_IN_THE_CURRENT_STATUS:
         case PIR_OR_DATE_OVERLAP_ERROR:
-        case INSTITUTION_LOCATION_NOT_VALID || OFFERING_NOT_VALID:
+        case INSTITUTION_LOCATION_NOT_VALID:
+        case OFFERING_NOT_VALID:
           throw new UnprocessableEntityException(
             new ApiProcessError(error.message, error.name),
           );

--- a/sources/packages/backend/apps/api/src/route-controllers/application/application.students.controller.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/application/application.students.controller.ts
@@ -247,11 +247,7 @@ export class ApplicationStudentsController extends BaseController {
         case APPLICATION_NOT_VALID:
         case INVALID_OPERATION_IN_THE_CURRENT_STATUS:
         case PIR_OR_DATE_OVERLAP_ERROR:
-        case INSTITUTION_LOCATION_NOT_VALID:
-          throw new UnprocessableEntityException(
-            new ApiProcessError(error.message, error.name),
-          );
-        case OFFERING_NOT_VALID:
+        case INSTITUTION_LOCATION_NOT_VALID || OFFERING_NOT_VALID:
           throw new UnprocessableEntityException(
             new ApiProcessError(error.message, error.name),
           );

--- a/sources/packages/backend/apps/api/src/route-controllers/student/_tests_/e2e/student.institutions.controller.searchStudents.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/student/_tests_/e2e/student.institutions.controller.searchStudents.e2e-spec.ts
@@ -29,7 +29,7 @@ describe("StudentInstitutionsController(e2e)-searchStudents", () => {
   let collegeFLocation: InstitutionLocation;
   let studentRepo: Repository<Student>;
   let applicationRepo: Repository<Application>;
-  let collegeFInstitutionUserToken;
+  let collegeFInstitutionUserToken: string;
   const endpoint = "/institutions/student/search";
 
   beforeAll(async () => {
@@ -374,6 +374,11 @@ describe("StudentInstitutionsController(e2e)-searchStudents", () => {
       .expect([]);
   });
 
+  /**
+   * Saves a student and an application for the student for College F.
+   * @param applicationStatus application status.
+   * @returns an object with student and application persisted in the database.
+   */
   const saveStudentWithApplicationForCollegeF = async (
     applicationStatus: ApplicationStatus,
   ) => {

--- a/sources/packages/backend/apps/api/src/route-controllers/student/_tests_/e2e/student.institutions.controller.searchStudents.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/student/_tests_/e2e/student.institutions.controller.searchStudents.e2e-spec.ts
@@ -11,6 +11,7 @@ import {
 } from "../../../../testHelpers";
 import {
   createFakeInstitutionLocation,
+  saveFakeApplication,
   saveFakeApplicationDisbursements,
   saveFakeStudent,
 } from "@sims/test-utils";
@@ -52,14 +53,9 @@ describe("StudentInstitutionsController(e2e)-searchStudents", () => {
   it("Should find the student by application number when student has at least one application submitted for the institution.", async () => {
     // Arrange
     // Student who has application submitted to institution.
-    let student = await saveFakeStudent(appDataSource);
-    // Refresh student object to get a birthDate with date only
-    student = await studentRepo.findOne({
-      where: { id: student.id },
-      relations: { sinValidation: true },
-    });
+    const student = await saveFakeStudent(appDataSource);
 
-    const application = await saveFakeApplicationDisbursements(
+    const application = await saveFakeApplication(
       appDataSource,
       {
         institution: collegeF,
@@ -86,7 +82,7 @@ describe("StudentInstitutionsController(e2e)-searchStudents", () => {
       .post(endpoint)
       .send(searchPayload)
       .auth(institutionUserToken, BEARER_AUTH_TYPE)
-      .expect(HttpStatus.CREATED)
+      .expect(HttpStatus.OK)
       .expect([
         {
           id: student.id,
@@ -101,14 +97,9 @@ describe("StudentInstitutionsController(e2e)-searchStudents", () => {
   it("Should find the student by last name when student has at least one application submitted for the institution.", async () => {
     // Arrange
     // Student who has application submitted to institution.
-    let student = await saveFakeStudent(appDataSource);
-    // Refresh student object to get a birthDate with date only
-    student = await studentRepo.findOne({
-      where: { id: student.id },
-      relations: { sinValidation: true },
-    });
+    const student = await saveFakeStudent(appDataSource);
 
-    await saveFakeApplicationDisbursements(
+    await saveFakeApplication(
       appDataSource,
       {
         institution: collegeF,
@@ -135,7 +126,7 @@ describe("StudentInstitutionsController(e2e)-searchStudents", () => {
       .post(endpoint)
       .send(searchPayload)
       .auth(institutionUserToken, BEARER_AUTH_TYPE)
-      .expect(HttpStatus.CREATED)
+      .expect(HttpStatus.OK)
       .then((response) => {
         expect(response.body).toEqual(
           expect.arrayContaining([
@@ -154,14 +145,9 @@ describe("StudentInstitutionsController(e2e)-searchStudents", () => {
   it("Should find the student by first name when student has at least one application submitted for the institution.", async () => {
     // Arrange
     // Student who has application submitted to institution.
-    let student = await saveFakeStudent(appDataSource);
-    // Refresh student object to get a birthDate with date only
-    student = await studentRepo.findOne({
-      where: { id: student.id },
-      relations: { sinValidation: true },
-    });
+    const student = await saveFakeStudent(appDataSource);
 
-    await saveFakeApplicationDisbursements(
+    await saveFakeApplication(
       appDataSource,
       {
         institution: collegeF,
@@ -188,7 +174,7 @@ describe("StudentInstitutionsController(e2e)-searchStudents", () => {
       .post(endpoint)
       .send(searchPayload)
       .auth(institutionUserToken, BEARER_AUTH_TYPE)
-      .expect(HttpStatus.CREATED)
+      .expect(HttpStatus.OK)
       .then((response) => {
         expect(response.body).toEqual(
           expect.arrayContaining([
@@ -207,14 +193,9 @@ describe("StudentInstitutionsController(e2e)-searchStudents", () => {
   it("Should find the student by sin when student has at least one application submitted for the institution.", async () => {
     // Arrange
     // Student who has application submitted to institution.
-    let student = await saveFakeStudent(appDataSource);
-    // Refresh student object to get a birthDate with date only
-    student = await studentRepo.findOne({
-      where: { id: student.id },
-      relations: { sinValidation: true },
-    });
+    const student = await saveFakeStudent(appDataSource);
 
-    await saveFakeApplicationDisbursements(
+    await saveFakeApplication(
       appDataSource,
       {
         institution: collegeF,
@@ -241,7 +222,7 @@ describe("StudentInstitutionsController(e2e)-searchStudents", () => {
       .post(endpoint)
       .send(searchPayload)
       .auth(institutionUserToken, BEARER_AUTH_TYPE)
-      .expect(HttpStatus.CREATED)
+      .expect(HttpStatus.OK)
       .expect([
         {
           id: student.id,
@@ -258,7 +239,7 @@ describe("StudentInstitutionsController(e2e)-searchStudents", () => {
     // Student who has application submitted to institution.
     const student = await saveFakeStudent(appDataSource);
 
-    const application = await saveFakeApplicationDisbursements(
+    const application = await saveFakeApplication(
       appDataSource,
       {
         institution: collegeF,
@@ -289,21 +270,16 @@ describe("StudentInstitutionsController(e2e)-searchStudents", () => {
       .post(endpoint)
       .send(searchPayload)
       .auth(institutionUserToken, BEARER_AUTH_TYPE)
-      .expect(HttpStatus.CREATED)
+      .expect(HttpStatus.OK)
       .expect([]);
   });
 
   it("Should find the student when application submitted and cancelled after the assessment.", async () => {
     // Arrange
     // Student who has application submitted to institution.
-    let student = await saveFakeStudent(appDataSource);
-    // Refresh student object to get a birthDate with date only
-    student = await studentRepo.findOne({
-      where: { id: student.id },
-      relations: { sinValidation: true },
-    });
+    const student = await saveFakeStudent(appDataSource);
 
-    const application = await saveFakeApplicationDisbursements(
+    const application = await saveFakeApplication(
       appDataSource,
       {
         institution: collegeF,
@@ -331,7 +307,7 @@ describe("StudentInstitutionsController(e2e)-searchStudents", () => {
       .post(endpoint)
       .send(searchPayload)
       .auth(institutionUserToken, BEARER_AUTH_TYPE)
-      .expect(HttpStatus.CREATED)
+      .expect(HttpStatus.OK)
       .expect([
         {
           id: student.id,
@@ -377,7 +353,7 @@ describe("StudentInstitutionsController(e2e)-searchStudents", () => {
       .post(endpoint)
       .send(searchPayload)
       .auth(institutionUserToken, BEARER_AUTH_TYPE)
-      .expect(HttpStatus.CREATED)
+      .expect(HttpStatus.OK)
       .expect([]);
   });
 
@@ -397,7 +373,7 @@ describe("StudentInstitutionsController(e2e)-searchStudents", () => {
       InstitutionTokenTypes.CollegeCUser,
       collegeCLocation,
     );
-    const application = await saveFakeApplicationDisbursements(
+    const application = await saveFakeApplication(
       appDataSource,
       {
         institution: collegeF,
@@ -424,7 +400,7 @@ describe("StudentInstitutionsController(e2e)-searchStudents", () => {
       .post(endpoint)
       .send(searchPayload)
       .auth(institutionUserToken, BEARER_AUTH_TYPE)
-      .expect(HttpStatus.CREATED)
+      .expect(HttpStatus.OK)
       .expect([]);
   });
 
@@ -433,7 +409,7 @@ describe("StudentInstitutionsController(e2e)-searchStudents", () => {
     // Student who has application submitted to institution.
     const student = await saveFakeStudent(appDataSource);
 
-    const application = await saveFakeApplicationDisbursements(
+    const application = await saveFakeApplication(
       appDataSource,
       {
         institution: collegeF,
@@ -460,7 +436,7 @@ describe("StudentInstitutionsController(e2e)-searchStudents", () => {
       .post(endpoint)
       .send(searchPayload)
       .auth(institutionUserToken, BEARER_AUTH_TYPE)
-      .expect(HttpStatus.CREATED)
+      .expect(HttpStatus.OK)
       .expect([]);
   });
 

--- a/sources/packages/backend/apps/api/src/route-controllers/student/_tests_/e2e/student.institutions.controller.searchStudents.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/student/_tests_/e2e/student.institutions.controller.searchStudents.e2e-spec.ts
@@ -1,0 +1,434 @@
+import { HttpStatus, INestApplication } from "@nestjs/common";
+import * as request from "supertest";
+import { DataSource, Repository } from "typeorm";
+import {
+  BEARER_AUTH_TYPE,
+  createTestingAppModule,
+  getInstitutionToken,
+  getAuthRelatedEntities,
+  InstitutionTokenTypes,
+  authorizeUserTokenForLocation,
+} from "../../../../testHelpers";
+import {
+  createFakeInstitutionLocation,
+  saveFakeApplicationDisbursements,
+  saveFakeStudent,
+} from "@sims/test-utils";
+import {
+  Application,
+  ApplicationStatus,
+  Institution,
+  InstitutionLocation,
+  Student,
+} from "@sims/sims-db";
+
+describe("StudentInstitutionsController(e2e)-searchStudents", () => {
+  let app: INestApplication;
+  let appDataSource: DataSource;
+  let collegeF: Institution;
+  let collegeFLocation: InstitutionLocation;
+  let studentRepo: Repository<Student>;
+  let applicationRepo: Repository<Application>;
+
+  beforeAll(async () => {
+    const { nestApplication, dataSource } = await createTestingAppModule();
+    app = nestApplication;
+    appDataSource = dataSource;
+    studentRepo = dataSource.getRepository(Student);
+    applicationRepo = dataSource.getRepository(Application);
+    const { institution: collegeF } = await getAuthRelatedEntities(
+      appDataSource,
+      InstitutionTokenTypes.CollegeFUser,
+    );
+    collegeFLocation = createFakeInstitutionLocation(collegeF);
+
+    await authorizeUserTokenForLocation(
+      appDataSource,
+      InstitutionTokenTypes.CollegeFUser,
+      collegeFLocation,
+    );
+  });
+
+  it("Should find the student by application number when student has at least one application submitted for the institution.", async () => {
+    // Arrange
+    // Student who has application submitted to institution.
+    let student = await saveFakeStudent(appDataSource);
+    // Refresh student object to get a birthDate with date only
+    student = await studentRepo.findOne({
+      where: { id: student.id },
+      relations: { sinValidation: true },
+    });
+
+    const application = await saveFakeApplicationDisbursements(
+      appDataSource,
+      {
+        institution: collegeF,
+        institutionLocation: collegeFLocation,
+        student,
+      },
+      {
+        applicationStatus: ApplicationStatus.Submitted,
+      },
+    );
+    const endpoint = "/institutions/student/search";
+    const institutionUserToken = await getInstitutionToken(
+      InstitutionTokenTypes.CollegeFUser,
+    );
+    const searchPayload = {
+      appNumber: application.applicationNumber,
+      firstName: "",
+      lastName: "",
+      sin: "",
+    };
+
+    // Act/Assert
+    await request(app.getHttpServer())
+      .post(endpoint)
+      .send(searchPayload)
+      .auth(institutionUserToken, BEARER_AUTH_TYPE)
+      .expect(HttpStatus.CREATED)
+      .expect([
+        {
+          id: student.id,
+          firstName: student.user.firstName,
+          lastName: student.user.lastName,
+          birthDate: student.birthDate,
+          sin: student.sinValidation.sin,
+        },
+      ]);
+  });
+
+  it("Should find the student by last name when student has at least one application submitted for the institution.", async () => {
+    // Arrange
+    // Student who has application submitted to institution.
+    let student = await saveFakeStudent(appDataSource);
+    // Refresh student object to get a birthDate with date only
+    student = await studentRepo.findOne({
+      where: { id: student.id },
+      relations: { sinValidation: true },
+    });
+
+    await saveFakeApplicationDisbursements(
+      appDataSource,
+      {
+        institution: collegeF,
+        institutionLocation: collegeFLocation,
+        student,
+      },
+      {
+        applicationStatus: ApplicationStatus.Submitted,
+      },
+    );
+    const endpoint = "/institutions/student/search";
+    const institutionUserToken = await getInstitutionToken(
+      InstitutionTokenTypes.CollegeFUser,
+    );
+    const searchPayload = {
+      appNumber: "",
+      firstName: "",
+      lastName: student.user.lastName,
+      sin: "",
+    };
+
+    // Act/Assert
+    await request(app.getHttpServer())
+      .post(endpoint)
+      .send(searchPayload)
+      .auth(institutionUserToken, BEARER_AUTH_TYPE)
+      .expect(HttpStatus.CREATED)
+      .then((response) => {
+        expect(response.body).toEqual(
+          expect.arrayContaining([
+            {
+              id: student.id,
+              firstName: student.user.firstName,
+              lastName: student.user.lastName,
+              birthDate: student.birthDate,
+              sin: student.sinValidation.sin,
+            },
+          ]),
+        );
+      });
+  });
+
+  it("Should find the student by first name when student has at least one application submitted for the institution.", async () => {
+    // Arrange
+    // Student who has application submitted to institution.
+    let student = await saveFakeStudent(appDataSource);
+    // Refresh student object to get a birthDate with date only
+    student = await studentRepo.findOne({
+      where: { id: student.id },
+      relations: { sinValidation: true },
+    });
+
+    await saveFakeApplicationDisbursements(
+      appDataSource,
+      {
+        institution: collegeF,
+        institutionLocation: collegeFLocation,
+        student,
+      },
+      {
+        applicationStatus: ApplicationStatus.Submitted,
+      },
+    );
+    const endpoint = "/institutions/student/search";
+    const institutionUserToken = await getInstitutionToken(
+      InstitutionTokenTypes.CollegeFUser,
+    );
+    const searchPayload = {
+      appNumber: "",
+      firstName: student.user.firstName,
+      lastName: "",
+      sin: "",
+    };
+
+    // Act/Assert
+    await request(app.getHttpServer())
+      .post(endpoint)
+      .send(searchPayload)
+      .auth(institutionUserToken, BEARER_AUTH_TYPE)
+      .expect(HttpStatus.CREATED)
+      .then((response) => {
+        expect(response.body).toEqual(
+          expect.arrayContaining([
+            {
+              id: student.id,
+              firstName: student.user.firstName,
+              lastName: student.user.lastName,
+              birthDate: student.birthDate,
+              sin: student.sinValidation.sin,
+            },
+          ]),
+        );
+      });
+  });
+
+  it("Should find the student by sin when student has at least one application submitted for the institution.", async () => {
+    // Arrange
+    // Student who has application submitted to institution.
+    let student = await saveFakeStudent(appDataSource);
+    // Refresh student object to get a birthDate with date only
+    student = await studentRepo.findOne({
+      where: { id: student.id },
+      relations: { sinValidation: true },
+    });
+
+    await saveFakeApplicationDisbursements(
+      appDataSource,
+      {
+        institution: collegeF,
+        institutionLocation: collegeFLocation,
+        student,
+      },
+      {
+        applicationStatus: ApplicationStatus.Submitted,
+      },
+    );
+    const endpoint = "/institutions/student/search";
+    const institutionUserToken = await getInstitutionToken(
+      InstitutionTokenTypes.CollegeFUser,
+    );
+    const searchPayload = {
+      appNumber: "",
+      firstName: "",
+      lastName: "",
+      sin: student.sinValidation.sin,
+    };
+
+    // Act/Assert
+    await request(app.getHttpServer())
+      .post(endpoint)
+      .send(searchPayload)
+      .auth(institutionUserToken, BEARER_AUTH_TYPE)
+      .expect(HttpStatus.CREATED)
+      .expect([
+        {
+          id: student.id,
+          firstName: student.user.firstName,
+          lastName: student.user.lastName,
+          birthDate: student.birthDate,
+          sin: student.sinValidation.sin,
+        },
+      ]);
+  });
+
+  it("Should not find the student when application submitted and cancelled before the assessment.", async () => {
+    // Arrange
+    // Student who has application submitted to institution.
+    const student = await saveFakeStudent(appDataSource);
+
+    const application = await saveFakeApplicationDisbursements(
+      appDataSource,
+      {
+        institution: collegeF,
+        institutionLocation: collegeFLocation,
+        student,
+      },
+      {
+        applicationStatus: ApplicationStatus.Cancelled,
+      },
+    );
+    // Adjust the application to not have an assessment
+    application.currentAssessment.assessmentData = null;
+    await applicationRepo.save(application);
+
+    const endpoint = "/institutions/student/search";
+    const institutionUserToken = await getInstitutionToken(
+      InstitutionTokenTypes.CollegeFUser,
+    );
+    const searchPayload = {
+      appNumber: application.applicationNumber,
+      firstName: "",
+      lastName: "",
+      sin: "",
+    };
+
+    // Act/Assert
+    await request(app.getHttpServer())
+      .post(endpoint)
+      .send(searchPayload)
+      .auth(institutionUserToken, BEARER_AUTH_TYPE)
+      .expect(HttpStatus.CREATED)
+      .expect([]);
+  });
+
+  it("Should find the student when application submitted and cancelled after the assessment.", async () => {
+    // Arrange
+    // Student who has application submitted to institution.
+    let student = await saveFakeStudent(appDataSource);
+    // Refresh student object to get a birthDate with date only
+    student = await studentRepo.findOne({
+      where: { id: student.id },
+      relations: { sinValidation: true },
+    });
+
+    const application = await saveFakeApplicationDisbursements(
+      appDataSource,
+      {
+        institution: collegeF,
+        institutionLocation: collegeFLocation,
+        student,
+      },
+      {
+        applicationStatus: ApplicationStatus.Cancelled,
+      },
+    );
+
+    const endpoint = "/institutions/student/search";
+    const institutionUserToken = await getInstitutionToken(
+      InstitutionTokenTypes.CollegeFUser,
+    );
+    const searchPayload = {
+      appNumber: application.applicationNumber,
+      firstName: "",
+      lastName: "",
+      sin: "",
+    };
+
+    // Act/Assert
+    await request(app.getHttpServer())
+      .post(endpoint)
+      .send(searchPayload)
+      .auth(institutionUserToken, BEARER_AUTH_TYPE)
+      .expect(HttpStatus.CREATED)
+      .expect([
+        {
+          id: student.id,
+          firstName: student.user.firstName,
+          lastName: student.user.lastName,
+          birthDate: student.birthDate,
+          sin: student.sinValidation.sin,
+        },
+      ]);
+  });
+
+  it("Should not find the student when user is not active.", async () => {
+    // Arrange
+    // Student who has application submitted to institution.
+    const student = await saveFakeStudent(appDataSource);
+    student.user.isActive = false;
+    await studentRepo.save(student);
+
+    const application = await saveFakeApplicationDisbursements(
+      appDataSource,
+      {
+        institution: collegeF,
+        institutionLocation: collegeFLocation,
+        student,
+      },
+      {
+        applicationStatus: ApplicationStatus.Submitted,
+      },
+    );
+    const endpoint = "/institutions/student/search";
+    const institutionUserToken = await getInstitutionToken(
+      InstitutionTokenTypes.CollegeFUser,
+    );
+    const searchPayload = {
+      appNumber: application.applicationNumber,
+      firstName: "",
+      lastName: "",
+      sin: "",
+    };
+
+    // Act/Assert
+    await request(app.getHttpServer())
+      .post(endpoint)
+      .send(searchPayload)
+      .auth(institutionUserToken, BEARER_AUTH_TYPE)
+      .expect(HttpStatus.CREATED)
+      .expect([]);
+  });
+
+  it.only("Should not find the student when institution is different.", async () => {
+    // Arrange
+    // Student who has application submitted to institution.
+    const student = await saveFakeStudent(appDataSource);
+
+    const { institution: collegeC } = await getAuthRelatedEntities(
+      appDataSource,
+      InstitutionTokenTypes.CollegeCUser,
+    );
+    const collegeCLocation = createFakeInstitutionLocation(collegeC);
+
+    await authorizeUserTokenForLocation(
+      appDataSource,
+      InstitutionTokenTypes.CollegeCUser,
+      collegeCLocation,
+    );
+    const application = await saveFakeApplicationDisbursements(
+      appDataSource,
+      {
+        institution: collegeF,
+        institutionLocation: collegeFLocation,
+        student,
+      },
+      {
+        applicationStatus: ApplicationStatus.Submitted,
+      },
+    );
+    const endpoint = "/institutions/student/search";
+    const institutionUserToken = await getInstitutionToken(
+      InstitutionTokenTypes.CollegeCUser,
+    );
+    const searchPayload = {
+      appNumber: application.applicationNumber,
+      firstName: "",
+      lastName: "",
+      sin: "",
+    };
+
+    // Act/Assert
+    await request(app.getHttpServer())
+      .post(endpoint)
+      .send(searchPayload)
+      .auth(institutionUserToken, BEARER_AUTH_TYPE)
+      .expect(HttpStatus.CREATED)
+      .expect([]);
+  });
+
+  afterAll(async () => {
+    await app?.close();
+  });
+});

--- a/sources/packages/backend/apps/api/src/route-controllers/student/_tests_/e2e/student.institutions.controller.searchStudents.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/student/_tests_/e2e/student.institutions.controller.searchStudents.e2e-spec.ts
@@ -381,7 +381,7 @@ describe("StudentInstitutionsController(e2e)-searchStudents", () => {
       .expect([]);
   });
 
-  it.only("Should not find the student when institution is different.", async () => {
+  it("Should not find the student when institution is different.", async () => {
     // Arrange
     // Student who has application submitted to institution.
     const student = await saveFakeStudent(appDataSource);
@@ -411,6 +411,42 @@ describe("StudentInstitutionsController(e2e)-searchStudents", () => {
     const endpoint = "/institutions/student/search";
     const institutionUserToken = await getInstitutionToken(
       InstitutionTokenTypes.CollegeCUser,
+    );
+    const searchPayload = {
+      appNumber: application.applicationNumber,
+      firstName: "",
+      lastName: "",
+      sin: "",
+    };
+
+    // Act/Assert
+    await request(app.getHttpServer())
+      .post(endpoint)
+      .send(searchPayload)
+      .auth(institutionUserToken, BEARER_AUTH_TYPE)
+      .expect(HttpStatus.CREATED)
+      .expect([]);
+  });
+
+  it("Should not find the student when student has only a draft application.", async () => {
+    // Arrange
+    // Student who has application submitted to institution.
+    const student = await saveFakeStudent(appDataSource);
+
+    const application = await saveFakeApplicationDisbursements(
+      appDataSource,
+      {
+        institution: collegeF,
+        institutionLocation: collegeFLocation,
+        student,
+      },
+      {
+        applicationStatus: ApplicationStatus.Draft,
+      },
+    );
+    const endpoint = "/institutions/student/search";
+    const institutionUserToken = await getInstitutionToken(
+      InstitutionTokenTypes.CollegeFUser,
     );
     const searchPayload = {
       appNumber: application.applicationNumber,

--- a/sources/packages/backend/apps/api/src/route-controllers/student/student.aest.controller.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/student/student.aest.controller.ts
@@ -2,6 +2,8 @@ import {
   Body,
   Controller,
   Get,
+  HttpCode,
+  HttpStatus,
   NotFoundException,
   Param,
   ParseIntPipe,
@@ -221,10 +223,13 @@ export class StudentAESTController extends BaseController {
 
   /**
    * Search students based on the search criteria.
+   * Returns a 200 HTTP status instead of 201 to indicate that the operation
+   * was completed with success but no resource was created.
    * @param searchCriteria criteria to be used in the search.
    * @returns searched student details.
    */
   @Post("search")
+  @HttpCode(HttpStatus.OK)
   async searchStudents(
     @Body() searchCriteria: StudentSearchAPIInDTO,
   ): Promise<SearchStudentAPIOutDTO[]> {

--- a/sources/packages/backend/apps/api/src/route-controllers/student/student.institutions.controller.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/student/student.institutions.controller.ts
@@ -38,7 +38,7 @@ export class StudentInstitutionsController extends BaseController {
 
   /**
    * Search students based on the search criteria.
-   * Return a 200 HTTP status instead of 201 to indicate that the operation
+   * Returns a 200 HTTP status instead of 201 to indicate that the operation
    * was completed with success but no resource was created.
    * TODO add decorator to restrict to BC Public institutions.
    * @param searchCriteria criteria to be used in the search.

--- a/sources/packages/backend/apps/api/src/route-controllers/student/student.institutions.controller.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/student/student.institutions.controller.ts
@@ -2,6 +2,8 @@ import {
   Body,
   Controller,
   Get,
+  HttpCode,
+  HttpStatus,
   Param,
   ParseIntPipe,
   Post,
@@ -36,11 +38,14 @@ export class StudentInstitutionsController extends BaseController {
 
   /**
    * Search students based on the search criteria.
+   * Return a 200 HTTP status instead of 201 to indicate that the operation
+   * was completed with success but no resource was created.
    * TODO add decorator to restrict to BC Public institutions.
    * @param searchCriteria criteria to be used in the search.
    * @returns searched student details.
    */
   @Post("search")
+  @HttpCode(HttpStatus.OK)
   async searchStudents(
     @UserToken() userToken: IInstitutionUserToken,
     @Body() searchCriteria: StudentSearchAPIInDTO,

--- a/sources/packages/backend/apps/api/src/services/application/application.service.ts
+++ b/sources/packages/backend/apps/api/src/services/application/application.service.ts
@@ -17,7 +17,6 @@ import {
   User,
   ApplicationData,
   getUserFullNameLikeSearch,
-  InstitutionLocation,
 } from "@sims/sims-db";
 import { StudentFileService } from "../student-file/student-file.service";
 import {

--- a/sources/packages/backend/apps/api/src/services/application/application.service.ts
+++ b/sources/packages/backend/apps/api/src/services/application/application.service.ts
@@ -17,6 +17,7 @@ import {
   User,
   ApplicationData,
   getUserFullNameLikeSearch,
+  InstitutionLocation,
 } from "@sims/sims-db";
 import { StudentFileService } from "../student-file/student-file.service";
 import {
@@ -186,6 +187,9 @@ export class ApplicationService extends RecordDataModelService<Application> {
       application.studentAssessments = [originalAssessment];
       application.currentAssessment = originalAssessment;
       application.submittedDate = now;
+      application.location = {
+        id: applicationData.selectedLocation,
+      } as InstitutionLocation;
 
       // When application and assessment are saved, assess for SIN restriction.
       await this.dataSource.transaction(async (transactionalEntityManager) => {
@@ -239,6 +243,9 @@ export class ApplicationService extends RecordDataModelService<Application> {
       [],
       associatedFiles,
     );
+    newApplication.location = {
+      id: applicationData.selectedLocation,
+    } as InstitutionLocation;
     // While editing an application, a new application record is created and a new
     // assessment record is also created to be the used as a "current Assessment" record.
     // The application and the assessment records have a DB relationship and the

--- a/sources/packages/backend/apps/api/src/services/student/student.service.ts
+++ b/sources/packages/backend/apps/api/src/services/student/student.service.ts
@@ -469,9 +469,9 @@ export class StudentService extends RecordDataModelService<Student> {
           "application",
           "application.student.id = student.id",
         )
-        .leftJoin("application.location", "institutionLocation")
-        .leftJoin("institutionLocation.institution", "institution")
-        .leftJoin("application.currentAssessment", "studentAssessment");
+        .innerJoin("application.location", "institutionLocation")
+        .innerJoin("institutionLocation.institution", "institution")
+        .innerJoin("application.currentAssessment", "studentAssessment");
     } else {
       searchQuery.leftJoin(
         Application,

--- a/sources/packages/backend/apps/api/src/services/student/student.service.ts
+++ b/sources/packages/backend/apps/api/src/services/student/student.service.ts
@@ -13,7 +13,7 @@ import {
   DisbursementOveraward,
   DisbursementOverawardOriginType,
 } from "@sims/sims-db";
-import { Brackets, DataSource, EntityManager } from "typeorm";
+import { DataSource, EntityManager } from "typeorm";
 import { StudentUserToken } from "../../auth/userToken.interface";
 import { LoggerService, InjectLogger } from "@sims/utilities/logger";
 import { removeWhiteSpaces, transformAddressDetails } from "../../utilities";

--- a/sources/packages/backend/apps/api/src/services/student/student.service.ts
+++ b/sources/packages/backend/apps/api/src/services/student/student.service.ts
@@ -496,20 +496,13 @@ export class StudentService extends RecordDataModelService<Student> {
                   })
                   .andWhere("studentAssessment.assessmentData is not null");
               }),
-            ).orWhere(
-              new Brackets((qb2) => {
-                qb2
-                  .where("application.applicationStatus != :cancelledStatus", {
-                    cancelledStatus: ApplicationStatus.Cancelled,
-                  })
-                  .andWhere(
-                    "application.applicationStatus != :overwrittenStatus",
-                    {
-                      overwrittenStatus: ApplicationStatus.Overwritten,
-                    },
-                  );
-              }),
-            );
+            ).orWhere("application.applicationStatus not in (:...statuses)", {
+              statuses: [
+                ApplicationStatus.Cancelled,
+                ApplicationStatus.Overwritten,
+                ApplicationStatus.Draft,
+              ],
+            });
           }),
         );
     }

--- a/sources/packages/backend/apps/api/src/services/student/student.service.ts
+++ b/sources/packages/backend/apps/api/src/services/student/student.service.ts
@@ -470,8 +470,7 @@ export class StudentService extends RecordDataModelService<Student> {
           "application.student.id = student.id",
         )
         .innerJoin("application.location", "institutionLocation")
-        .innerJoin("institutionLocation.institution", "institution")
-        .innerJoin("application.currentAssessment", "studentAssessment");
+        .innerJoin("institutionLocation.institution", "institution");
     } else {
       searchQuery.leftJoin(
         Application,
@@ -484,29 +483,11 @@ export class StudentService extends RecordDataModelService<Student> {
       .innerJoin("student.sinValidation", "sinValidation")
       .where("user.isActive = true");
     if (institutionId) {
-      searchQuery
-        .andWhere("institution.id = :institutionId", { institutionId })
-        .andWhere(
-          new Brackets((qb) => {
-            qb.where(
-              new Brackets((qb2) => {
-                qb2
-                  .where("application.applicationStatus = :cancelledStatus", {
-                    cancelledStatus: ApplicationStatus.Cancelled,
-                  })
-                  .andWhere("studentAssessment.assessmentData is not null");
-              }),
-            ).orWhere("application.applicationStatus not in (:...statuses)", {
-              statuses: [
-                ApplicationStatus.Cancelled,
-                ApplicationStatus.Overwritten,
-                ApplicationStatus.Draft,
-              ],
-            });
-          }),
-        );
+      searchQuery.andWhere("institution.id = :institutionId", {
+        institutionId,
+      });
     }
-    if (!institutionId && searchCriteria.appNumber) {
+    if (institutionId || searchCriteria.appNumber) {
       searchQuery.andWhere(
         "application.applicationStatus != :overwrittenStatus",
         {

--- a/sources/packages/backend/apps/api/src/testHelpers/auth/institution-auth-helpers.ts
+++ b/sources/packages/backend/apps/api/src/testHelpers/auth/institution-auth-helpers.ts
@@ -12,10 +12,13 @@ import { createFakeInstitutionUser } from "@sims/test-utils";
 import {
   COLLEGE_C_BUSINESS_GUID,
   COLLEGE_D_BUSINESS_GUID,
+  COLLEGE_F_BUSINESS_GUID,
   SIMS2_COLLC_USER,
   SIMS2_COLLD_USER,
+  SIMS2_COLLF_USER,
   SIMS_COLLC_ADMIN_LEGAL_SIGNING_USER,
   SIMS_COLLD_ADMIN_NON_LEGAL_SIGNING_USER,
+  SIMS_COLLF_ADMIN_LEGAL_SIGNING_USER,
 } from "@sims/test-utils/constants";
 import { DataSource, IsNull } from "typeorm";
 import { InstitutionTokenTypes } from "./institution-token-helpers";
@@ -49,6 +52,14 @@ export async function getAuthRelatedEntities(
     case InstitutionTokenTypes.CollegeDUser:
       businessGuid = COLLEGE_D_BUSINESS_GUID;
       userName = SIMS2_COLLD_USER;
+      break;
+    case InstitutionTokenTypes.CollegeFAdminLegalSigningUser:
+      businessGuid = COLLEGE_F_BUSINESS_GUID;
+      userName = SIMS_COLLF_ADMIN_LEGAL_SIGNING_USER;
+      break;
+    case InstitutionTokenTypes.CollegeFUser:
+      businessGuid = COLLEGE_F_BUSINESS_GUID;
+      userName = SIMS2_COLLF_USER;
       break;
   }
   const institutionRepo = dataSource.getRepository(Institution);

--- a/sources/packages/backend/apps/api/src/testHelpers/auth/institution-token-helpers.ts
+++ b/sources/packages/backend/apps/api/src/testHelpers/auth/institution-token-helpers.ts
@@ -1,8 +1,10 @@
 import {
   SIMS2_COLLC_USER,
   SIMS2_COLLD_USER,
+  SIMS2_COLLF_USER,
   SIMS_COLLC_ADMIN_LEGAL_SIGNING_USER,
   SIMS_COLLD_ADMIN_NON_LEGAL_SIGNING_USER,
+  SIMS_COLLF_ADMIN_LEGAL_SIGNING_USER,
 } from "@sims/test-utils/constants";
 import { UserPasswordCredential } from "@sims/utilities/config";
 import { AuthorizedParties } from "../../auth";
@@ -28,6 +30,14 @@ export enum InstitutionTokenTypes {
    * SIMS2_COLLD user configured as a regular user.
    */
   CollegeDUser,
+  /**
+   * SIMS_COLLF user configured as an admin and also as a legal signing officer.
+   */
+  CollegeFAdminLegalSigningUser,
+  /**
+   * SIMS2_COLLF user configured as a regular user.
+   */
+  CollegeFUser,
 }
 
 /**
@@ -61,6 +71,18 @@ export async function getInstitutionToken(
     case InstitutionTokenTypes.CollegeDUser:
       credential = {
         userName: SIMS2_COLLD_USER,
+        password: process.env.E2E_TEST_PASSWORD,
+      };
+      break;
+    case InstitutionTokenTypes.CollegeFAdminLegalSigningUser:
+      credential = {
+        userName: SIMS_COLLF_ADMIN_LEGAL_SIGNING_USER,
+        password: process.env.E2E_TEST_PASSWORD,
+      };
+      break;
+    case InstitutionTokenTypes.CollegeFUser:
+      credential = {
+        userName: SIMS2_COLLF_USER,
         password: process.env.E2E_TEST_PASSWORD,
       };
       break;

--- a/sources/packages/backend/apps/db-migrations/src/migrations/1681162016660-UpdateLocationIdComment.ts
+++ b/sources/packages/backend/apps/db-migrations/src/migrations/1681162016660-UpdateLocationIdComment.ts
@@ -1,0 +1,18 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+import { getSQLFileData } from "../utilities/sqlLoader";
+
+export class UpdateLocationIdComment1681162016660
+  implements MigrationInterface
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      getSQLFileData("Update-comment-location-id.sql", "Applications"),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      getSQLFileData("Rollback-update-comment-location-id.sql", "Applications"),
+    );
+  }
+}

--- a/sources/packages/backend/apps/db-migrations/src/sql/Applications/Rollback-update-comment-location-id.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/Applications/Rollback-update-comment-location-id.sql
@@ -1,0 +1,1 @@
+COMMENT ON COLUMN sims.applications.location_id IS 'References the program related to the application. For applications that do not have an offering defined yet (need a PIR) this is the way to figure out the related program.';

--- a/sources/packages/backend/apps/db-migrations/src/sql/Applications/Update-comment-location-id.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/Applications/Update-comment-location-id.sql
@@ -1,0 +1,1 @@
+COMMENT ON COLUMN sims.applications.location_id IS 'References the location related to the application at the submission. From the location it is possible to get the institution for example.';

--- a/sources/packages/backend/apps/db-migrations/src/sql/Applications/Update-comment-location-id.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/Applications/Update-comment-location-id.sql
@@ -1,1 +1,1 @@
-COMMENT ON COLUMN sims.applications.location_id IS 'References the location related to the application at the submission. From the location it is possible to get the institution for example.';
+COMMENT ON COLUMN sims.applications.location_id IS 'References the institution location of the application.';

--- a/sources/packages/backend/apps/test-db-seeding/src/db-seeding/institution/basic-seeding/create-institutions-and-authentication-users.model.ts
+++ b/sources/packages/backend/apps/test-db-seeding/src/db-seeding/institution/basic-seeding/create-institutions-and-authentication-users.model.ts
@@ -1,11 +1,18 @@
 import { InstitutionUserRoles, InstitutionUserTypes } from "@sims/sims-db";
 import {
+  INSTITUTION_TYPE_BC_PRIVATE,
+  INSTITUTION_TYPE_BC_PUBLIC,
+} from "@sims/sims-db/constant";
+import {
   COLLEGE_C_BUSINESS_GUID,
   COLLEGE_D_BUSINESS_GUID,
+  COLLEGE_F_BUSINESS_GUID,
   SIMS2_COLLC_USER,
   SIMS2_COLLD_USER,
+  SIMS2_COLLF_USER,
   SIMS_COLLC_ADMIN_LEGAL_SIGNING_USER,
   SIMS_COLLD_ADMIN_NON_LEGAL_SIGNING_USER,
+  SIMS_COLLF_ADMIN_LEGAL_SIGNING_USER,
 } from "@sims/test-utils/constants";
 
 export interface InstitutionUserBaseData {
@@ -20,6 +27,7 @@ export interface InstitutionBaseData {
   legalOperatingName: string;
   operatingName: string;
   businessGuid: string;
+  institutionTypeId: number;
   users: InstitutionUserBaseData[];
 }
 
@@ -28,6 +36,7 @@ export const INSTITUTIONS_INITIAL_DATA: InstitutionBaseData[] = [
     legalOperatingName: "College C - Business BCeID",
     operatingName: "College C (non-legal operating name)",
     businessGuid: COLLEGE_C_BUSINESS_GUID,
+    institutionTypeId: INSTITUTION_TYPE_BC_PRIVATE,
     users: [
       {
         userName: SIMS_COLLC_ADMIN_LEGAL_SIGNING_USER,
@@ -49,6 +58,7 @@ export const INSTITUTIONS_INITIAL_DATA: InstitutionBaseData[] = [
     legalOperatingName: "College D - Business BCeID",
     operatingName: "College D (non-legal operating name)",
     businessGuid: COLLEGE_D_BUSINESS_GUID,
+    institutionTypeId: INSTITUTION_TYPE_BC_PRIVATE,
     users: [
       {
         userName: SIMS_COLLD_ADMIN_NON_LEGAL_SIGNING_USER,
@@ -61,6 +71,28 @@ export const INSTITUTIONS_INITIAL_DATA: InstitutionBaseData[] = [
         userName: SIMS2_COLLD_USER,
         firstName: "SIMS2",
         lastName: "COLLD",
+        userType: InstitutionUserTypes.user,
+        userRole: undefined,
+      },
+    ],
+  },
+  {
+    legalOperatingName: "College F - Business BCeID",
+    operatingName: "College F (non-legal operating name)",
+    businessGuid: COLLEGE_F_BUSINESS_GUID,
+    institutionTypeId: INSTITUTION_TYPE_BC_PUBLIC,
+    users: [
+      {
+        userName: SIMS_COLLF_ADMIN_LEGAL_SIGNING_USER,
+        firstName: "SIMS",
+        lastName: "COLLF",
+        userType: InstitutionUserTypes.admin,
+        userRole: InstitutionUserRoles.legalSigningAuthority,
+      },
+      {
+        userName: SIMS2_COLLF_USER,
+        firstName: "SIMS2",
+        lastName: "COLLF",
         userType: InstitutionUserTypes.user,
         userRole: undefined,
       },

--- a/sources/packages/backend/apps/test-db-seeding/src/db-seeding/institution/basic-seeding/create-institutions-and-authentication-users.ts
+++ b/sources/packages/backend/apps/test-db-seeding/src/db-seeding/institution/basic-seeding/create-institutions-and-authentication-users.ts
@@ -3,6 +3,7 @@ import { InjectRepository } from "@nestjs/typeorm";
 import {
   Institution,
   InstitutionLocation,
+  InstitutionType,
   InstitutionUser,
   InstitutionUserAuth,
   InstitutionUserTypes,
@@ -68,6 +69,9 @@ export class CreateInstitutionsAndAuthenticationUsers {
     fakeInstitution.legalOperatingName = institutionsData.legalOperatingName;
     fakeInstitution.operatingName = institutionsData.operatingName;
     fakeInstitution.businessGuid = institutionsData.businessGuid;
+    fakeInstitution.institutionType = {
+      id: institutionsData.institutionTypeId,
+    } as InstitutionType;
     const savedInstitution = await this.institutionRepo.save(fakeInstitution);
     // Create the users associated with the institution.
     for (const user of institutionsData.users) {

--- a/sources/packages/backend/apps/workers/src/controllers/program-info-request/program-info-request.controller.ts
+++ b/sources/packages/backend/apps/workers/src/controllers/program-info-request/program-info-request.controller.ts
@@ -10,7 +10,6 @@ import {
 import { APPLICATION_NOT_FOUND } from "../../constants";
 import {
   APPLICATION_ID,
-  STUDENT_DATA_SELECTED_LOCATION,
   STUDENT_DATA_SELECTED_PROGRAM,
 } from "@sims/services/workflow/variables/assessment-gateway";
 import { MaxJobsToActivate } from "../../types";
@@ -26,11 +25,7 @@ export class ProgramInfoRequestController {
    * @returns most updated status of the PIR.
    */
   @ZeebeWorker(Workers.ProgramInfoRequest, {
-    fetchVariable: [
-      APPLICATION_ID,
-      STUDENT_DATA_SELECTED_LOCATION,
-      STUDENT_DATA_SELECTED_PROGRAM,
-    ],
+    fetchVariable: [APPLICATION_ID, STUDENT_DATA_SELECTED_PROGRAM],
     maxJobsToActivate: MaxJobsToActivate.High,
   })
   async updateApplicationStatus(

--- a/sources/packages/backend/apps/workers/src/controllers/program-info-request/program-info-request.controller.ts
+++ b/sources/packages/backend/apps/workers/src/controllers/program-info-request/program-info-request.controller.ts
@@ -61,7 +61,6 @@ export class ProgramInfoRequestController {
     await this.applicationService.updateProgramInfoStatus(
       job.variables.applicationId,
       job.customHeaders.programInfoStatus,
-      job.variables.studentDataSelectedLocation,
       job.variables.studentDataSelectedProgram,
     );
     return job.complete({

--- a/sources/packages/backend/apps/workers/src/controllers/program-info-request/program-info-request.dto.ts
+++ b/sources/packages/backend/apps/workers/src/controllers/program-info-request/program-info-request.dto.ts
@@ -1,14 +1,12 @@
 import {
   APPLICATION_ID,
   PROGRAM_INFO_STATUS,
-  STUDENT_DATA_SELECTED_LOCATION,
   STUDENT_DATA_SELECTED_PROGRAM,
 } from "@sims/services/workflow/variables/assessment-gateway";
 import { ProgramInfoStatus } from "@sims/sims-db";
 
 export interface ProgramInfoRequestJobInDTO {
   [APPLICATION_ID]: number;
-  [STUDENT_DATA_SELECTED_LOCATION]: number;
   [STUDENT_DATA_SELECTED_PROGRAM]?: number;
 }
 

--- a/sources/packages/backend/apps/workers/src/services/application/application.service.ts
+++ b/sources/packages/backend/apps/workers/src/services/application/application.service.ts
@@ -39,7 +39,6 @@ export class ApplicationService extends RecordDataModelService<Application> {
    * Updates the Program Information Request (PIR) for the first time.
    * @param applicationId application to have the PIR updated.
    * @param pirStatus status to be updated.
-   * @param locationId location selected by the student.
    * @param pirProgram optional program selected by the student.
    * When not provided the PIR will be required to be completed by
    * the institution.
@@ -48,7 +47,6 @@ export class ApplicationService extends RecordDataModelService<Application> {
   async updateProgramInfoStatus(
     applicationId: number,
     pirStatus: ProgramInfoStatus,
-    locationId: number,
     pirProgram?: number,
   ): Promise<UpdateResult> {
     return this.repo.update(
@@ -57,7 +55,6 @@ export class ApplicationService extends RecordDataModelService<Application> {
       },
       {
         pirStatus,
-        location: { id: locationId },
         pirProgram: { id: pirProgram },
       },
     );

--- a/sources/packages/backend/libs/services/src/workflow/variables/assessment-gateway.ts
+++ b/sources/packages/backend/libs/services/src/workflow/variables/assessment-gateway.ts
@@ -12,11 +12,6 @@ export const ASSESSMENT_DATA = "assessmentData";
  */
 export const APPLICATION_ID = "applicationId";
 /**
- * Institution location id selected by the student for
- * the application.
- */
-export const STUDENT_DATA_SELECTED_LOCATION = "studentDataSelectedLocation";
-/**
  * Institution offering program id if selected by the student.
  * If not selected a PIR will be needed.
  */

--- a/sources/packages/backend/libs/test-utils/src/constants/institution.constants.ts
+++ b/sources/packages/backend/libs/test-utils/src/constants/institution.constants.ts
@@ -25,3 +25,16 @@ export const SIMS2_COLLD_USER = "2260473f105e4a54bad8c7e348cd9b82@bceidboth";
  * College D business guid.
  */
 export const COLLEGE_D_BUSINESS_GUID = "B0BF341C26164156AD486F274108539A";
+/**
+ * SIMS_COLLF user configured as an admin and also as a legal signing officer.
+ */
+export const SIMS_COLLF_ADMIN_LEGAL_SIGNING_USER =
+  "fa06d4f6be904e10882085db1b7ac564@bceidboth";
+/**
+ * SIMS2_COLLF user configured as a regular user.
+ */
+export const SIMS2_COLLF_USER = "b7aa48239e1449279aee013dc6e4df23@bceidboth";
+/**
+ * College F business guid.
+ */
+export const COLLEGE_F_BUSINESS_GUID = "64118F10542349AC8574AE7184B0FCF3";

--- a/sources/packages/backend/libs/test-utils/src/factories/application.ts
+++ b/sources/packages/backend/libs/test-utils/src/factories/application.ts
@@ -224,5 +224,8 @@ export async function saveFakeApplication(
     fakeOriginalAssessment,
   );
   savedApplication.currentAssessment = savedOriginalAssessment;
+  if (options?.applicationStatus === ApplicationStatus.Draft) {
+    savedApplication.location = null;
+  }
   return applicationRepo.save(savedApplication);
 }

--- a/sources/packages/backend/libs/test-utils/src/factories/application.ts
+++ b/sources/packages/backend/libs/test-utils/src/factories/application.ts
@@ -103,7 +103,7 @@ export async function saveFakeApplicationDisbursements(
   // Create and save application.
   const fakeApplication = createFakeApplication({
     student: savedStudent,
-    location: relations.institutionLocation,
+    location: relations?.institutionLocation,
   });
   fakeApplication.applicationStatus = applicationStatus;
   const savedApplication = await applicationRepo.save(fakeApplication);

--- a/sources/packages/backend/libs/test-utils/src/factories/application.ts
+++ b/sources/packages/backend/libs/test-utils/src/factories/application.ts
@@ -101,7 +101,10 @@ export async function saveFakeApplicationDisbursements(
     savedStudent = await studentRepo.save(createFakeStudent(savedUser));
   }
   // Create and save application.
-  const fakeApplication = createFakeApplication({ student: savedStudent });
+  const fakeApplication = createFakeApplication({
+    student: savedStudent,
+    location: relations.institutionLocation,
+  });
   fakeApplication.applicationStatus = applicationStatus;
   const savedApplication = await applicationRepo.save(fakeApplication);
   // Original assessment.

--- a/sources/packages/backend/libs/test-utils/src/factories/student.ts
+++ b/sources/packages/backend/libs/test-utils/src/factories/student.ts
@@ -3,12 +3,13 @@ import { SINValidation, Student, User } from "@sims/sims-db";
 import { createFakeUser } from "@sims/test-utils";
 import { DataSource } from "typeorm";
 import { createFakeSINValidation } from "./sin-validation";
+import { getISODateOnlyString } from "@sims/utilities";
 // TODO: the parameter user must be moved to relations and all the references must be
 // updated.
 export function createFakeStudent(user?: User): Student {
   const student = new Student();
   student.user = user ?? createFakeUser();
-  student.birthDate = faker.date.past(18).toISOString();
+  student.birthDate = getISODateOnlyString(faker.date.past(18));
   student.gender = "X";
   student.contactInfo = {
     address: {

--- a/sources/packages/web/src/assets/css/base.scss
+++ b/sources/packages/web/src/assets/css/base.scss
@@ -393,11 +393,3 @@ strong {
   color: #fff;
   background-color: rgba(51, 51, 51, 0.95);
 }
-
-.search {
-  padding: 5px;
-  .v-input {
-    min-width: 120px;
-    margin: 5px;
-  }
-}

--- a/sources/packages/web/src/assets/css/base.scss
+++ b/sources/packages/web/src/assets/css/base.scss
@@ -393,3 +393,11 @@ strong {
   color: #fff;
   background-color: rgba(51, 51, 51, 0.95);
 }
+
+.search {
+  padding: 5px;
+  .v-input {
+    min-width: 120px;
+    margin: 5px;
+  }
+}

--- a/sources/packages/web/src/components/common/SearchStudents.vue
+++ b/sources/packages/web/src/components/common/SearchStudents.vue
@@ -1,60 +1,66 @@
 <template>
   <v-form ref="searchStudentsForm">
     <content-group class="mb-8">
-      <v-row
-        ><v-col>
-          <v-text-field
-            label="Application number"
-            density="compact"
-            data-cy="appNumber"
-            variant="outlined"
-            v-model="appNumber"
-            @keyup.enter="searchStudents"
-            hide-details
-          />
+      <v-row>
+        <v-col cols="11" lg="11" md="10" sm="12">
+          <v-row
+            ><v-col cols="12" lg="3" md="6">
+              <v-text-field
+                label="Application number"
+                density="compact"
+                data-cy="appNumber"
+                variant="outlined"
+                v-model="appNumber"
+                @keyup.enter="searchStudents"
+                hide-details
+              />
+            </v-col>
+            <v-col cols="12" lg="3" md="6">
+              <v-text-field
+                label="SIN"
+                density="compact"
+                data-cy="sin"
+                variant="outlined"
+                v-model="sin"
+                @keyup.enter="searchStudents"
+                hide-details
+              />
+            </v-col>
+            <v-col cols="12" lg="3" md="6">
+              <v-text-field
+                label="Given names"
+                density="compact"
+                data-cy="firstName"
+                variant="outlined"
+                v-model="firstName"
+                @keyup.enter="searchStudents"
+                hide-details
+              /> </v-col
+            ><v-col cols="12" lg="3" md="6">
+              <v-text-field
+                label="Last name"
+                density="compact"
+                data-cy="lastName"
+                variant="outlined"
+                v-model="lastName"
+                @keyup.enter="searchStudents"
+                hide-details
+              />
+            </v-col>
+          </v-row>
         </v-col>
-        <v-col>
-          <v-text-field
-            label="SIN"
-            density="compact"
-            data-cy="sin"
-            variant="outlined"
-            v-model="sin"
-            @keyup.enter="searchStudents"
-            hide-details
-          />
-        </v-col>
-        <v-col>
-          <v-text-field
-            label="Given names"
-            density="compact"
-            data-cy="firstName"
-            variant="outlined"
-            v-model="firstName"
-            @keyup.enter="searchStudents"
-            hide-details
-          /> </v-col
-        ><v-col>
-          <v-text-field
-            label="Last name"
-            density="compact"
-            data-cy="lastName"
-            variant="outlined"
-            v-model="lastName"
-            @keyup.enter="searchStudents"
-            hide-details
-          /> </v-col
-        ><v-col
-          ><v-btn
+        <v-col cols="1">
+          <v-btn
             color="primary"
             class="p-button-raised"
             data-cy="searchStudents"
             @click="searchStudents()"
           >
             Search
-          </v-btn></v-col
-        >
+          </v-btn>
+        </v-col>
       </v-row>
+
       <v-input
         :rules="[isValidSearch()]"
         hide-details="auto"

--- a/sources/packages/web/src/components/common/SearchStudents.vue
+++ b/sources/packages/web/src/components/common/SearchStudents.vue
@@ -2,9 +2,9 @@
   <v-form ref="searchStudentsForm">
     <content-group class="mb-8">
       <v-row>
-        <v-col cols="11" lg="11" md="10" sm="12">
+        <v-col cols="12" lg="11">
           <v-row
-            ><v-col cols="12" lg="3" md="6">
+            ><v-col cols="12" lg="3">
               <v-text-field
                 label="Application number"
                 density="compact"
@@ -15,7 +15,7 @@
                 hide-details
               />
             </v-col>
-            <v-col cols="12" lg="3" md="6">
+            <v-col cols="12" lg="3">
               <v-text-field
                 label="SIN"
                 density="compact"
@@ -26,7 +26,7 @@
                 hide-details
               />
             </v-col>
-            <v-col cols="12" lg="3" md="6">
+            <v-col cols="12" lg="3">
               <v-text-field
                 label="Given names"
                 density="compact"
@@ -36,7 +36,7 @@
                 @keyup.enter="searchStudents"
                 hide-details
               /> </v-col
-            ><v-col cols="12" lg="3" md="6">
+            ><v-col cols="12" lg="3">
               <v-text-field
                 label="Last name"
                 density="compact"


### PR DESCRIPTION
- Added BC Public institution (COLLF) to test seed data;
- Added COLLF users to test-utils;
- Adjusted query to not get either Cancelled applications that weren't assessed or Draft applications;
- Persisted institution location at the submit time;
- Removed application update for institution location from PIR process;
- Updated comment on sims.applications.location_id;
- Added E2E testes for the search student API.
- Fixed responsiveness for the form:
![image](https://user-images.githubusercontent.com/78114138/232110827-cf444660-e438-4228-9bb6-8d7efeb58f6d.png)
![image](https://user-images.githubusercontent.com/78114138/232111104-598bb36a-9b76-4b4f-8f1a-5386d46f2f29.png)
