### PR TITLE
#1864 - PT Integration Files Review - e-Cert and Feedback Files

### DIFF
--- a/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/esdc-integration/ecert-integration/ecert-part-time-feedback-integration.scheduler.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/esdc-integration/ecert-integration/ecert-part-time-feedback-integration.scheduler.ts
@@ -30,13 +30,13 @@ export class PartTimeECertFeedbackIntegrationScheduler extends BaseScheduler<voi
       jobLogger: job,
     });
     await summary.info(
-      `Processing E-Cert Part-time integration job ${job.id} of type ${job.name}.`,
+      `Processing e-Cert part-time feedback integration job ${job.id} of type ${job.name}.`,
     );
     const partTimeResults =
       await this.eCertFileHandler.processPartTimeResponses();
     await this.cleanSchedulerQueueHistory();
     await summary.info(
-      `Completed E-Cert Part-time integration job ${job.id} of type ${job.name}.`,
+      `Completed e-Cert part-time feedback integration job ${job.id} of type ${job.name}.`,
     );
     return partTimeResults.map((partTimeResult) => ({
       processSummary: partTimeResult.processSummary,

--- a/sources/packages/backend/libs/integrations/src/esdc-integration/e-cert-integration/e-cert-file-handler.ts
+++ b/sources/packages/backend/libs/integrations/src/esdc-integration/e-cert-integration/e-cert-file-handler.ts
@@ -197,7 +197,7 @@ export class ECertFileHandler extends ESDCFileHandler {
         this.createECertRecord(disbursement),
       );
 
-      this.logger.log(`Creating  ${offeringIntensity} e-Cert file content...`);
+      this.logger.log(`Creating ${offeringIntensity} e-Cert file content...`);
       const fileContent = eCertIntegrationService.createRequestContent(
         disbursementRecords,
         sequenceNumber,

--- a/sources/packages/backend/libs/integrations/src/esdc-integration/e-cert-integration/e-cert-file-handler.ts
+++ b/sources/packages/backend/libs/integrations/src/esdc-integration/e-cert-integration/e-cert-file-handler.ts
@@ -237,6 +237,7 @@ export class ECertFileHandler extends ESDCFileHandler {
   createECertRecord(disbursement: ECertDisbursementSchedule): ECertRecord {
     const now = new Date();
     const application = disbursement.studentAssessment.application;
+    const student = application.student;
     const addressInfo = application.student.contactInfo.address;
     const offering = application.currentAssessment.offering;
 
@@ -251,7 +252,7 @@ export class ECertFileHandler extends ESDCFileHandler {
     );
 
     return {
-      sin: application.student.sinValidation.sin,
+      sin: student.sinValidation.sin,
       stopFullTimeBCFunding: disbursement.stopFullTimeBCFunding,
       courseLoad: offering.courseLoad,
       applicationNumber: application.applicationNumber,
@@ -268,17 +269,18 @@ export class ECertFileHandler extends ESDCFileHandler {
       yearOfStudy: offering.yearOfStudy,
       completionYears: offering.educationProgram.completionYears,
       enrollmentConfirmationDate: disbursement.coeUpdatedAt,
-      dateOfBirth: new Date(application.student.birthDate),
-      lastName: application.student.user.lastName,
-      firstName: application.student.user.firstName,
+      dateOfBirth: new Date(student.birthDate),
+      lastName: student.user.lastName,
+      firstName: student.user.firstName,
       addressLine1: addressInfo.addressLine1,
       addressLine2: addressInfo.addressLine2,
       city: addressInfo.city,
       country: addressInfo.country,
       provinceState: addressInfo.provinceState,
       postalCode: addressInfo.postalCode,
-      email: application.student.user.email,
-      gender: application.student.gender,
+      email: student.user.email,
+      gender: student.gender,
+      ppdFlag: student.studentPDVerified,
       maritalStatus: application.relationshipStatus,
       studentNumber: application.studentNumber,
       awards,

--- a/sources/packages/backend/libs/integrations/src/esdc-integration/e-cert-integration/e-cert-file-handler.ts
+++ b/sources/packages/backend/libs/integrations/src/esdc-integration/e-cert-integration/e-cert-file-handler.ts
@@ -280,6 +280,8 @@ export class ECertFileHandler extends ESDCFileHandler {
       postalCode: addressInfo.postalCode,
       email: student.user.email,
       gender: student.gender,
+      // TODO: getting the information directly from the student profile since there is no
+      // direction from the business at this moment from where it should actually come.
       ppdFlag: student.studentPDVerified,
       maritalStatus: application.relationshipStatus,
       studentNumber: application.studentNumber,

--- a/sources/packages/backend/libs/integrations/src/esdc-integration/e-cert-integration/e-cert-full-time-integration/e-cert-full-time.integration.service.ts
+++ b/sources/packages/backend/libs/integrations/src/esdc-integration/e-cert-integration/e-cert-full-time-integration/e-cert-full-time.integration.service.ts
@@ -37,11 +37,10 @@ export class ECertFullTimeIntegrationService extends ECertIntegrationService {
   }
 
   /**
-   * Create the ECert file content, by populating the
-   * header, detail and trailer records.
-   * @param ecertRecords student, User and application data.
-   * @param fileSequence unique file sequence.
-   * @returns complete ECert content to be sent.
+   * Create the e-Cert file content, by populating the header, detail and trailer records.
+   * @param ecertRecords data needed to generate the e-Cert file.
+   * @param fileSequence file sequence.
+   * @returns complete e-Cert content to be sent.
    */
   createRequestContent(
     ecertRecords: ECertRecord[],

--- a/sources/packages/backend/libs/integrations/src/esdc-integration/e-cert-integration/e-cert-part-time-integration/e-cert-files/e-cert-file-footer.ts
+++ b/sources/packages/backend/libs/integrations/src/esdc-integration/e-cert-integration/e-cert-part-time-integration/e-cert-files/e-cert-file-footer.ts
@@ -33,6 +33,6 @@ export class ECertPartTimeFileFooter extends ECertFileFooter {
   }
 
   getFeedbackFooterRecordType(): RecordTypeCodes {
-    return RecordTypeCodes.ECertPartTimeFeedbackFooter;
+    return RecordTypeCodes.ECertPartTimeFooter;
   }
 }

--- a/sources/packages/backend/libs/integrations/src/esdc-integration/e-cert-integration/e-cert-part-time-integration/e-cert-files/e-cert-file-footer.ts
+++ b/sources/packages/backend/libs/integrations/src/esdc-integration/e-cert-integration/e-cert-part-time-integration/e-cert-files/e-cert-file-footer.ts
@@ -25,11 +25,10 @@ export class ECertPartTimeFileFooter extends ECertFileFooter {
 
   createFromLine(line: string): ECertPartTimeFileFooter {
     const footer = new ECertPartTimeFileFooter();
-    footer.recordTypeCode = line.substring(0, 3) as RecordTypeCodes;
-    // Here total record count is the total records.
-    footer.recordCount =
-      parseInt(line.substring(43, 52)) + parseInt(line.substring(52, 61));
-    footer.totalSINHash = parseInt(line.substring(61, 76));
+    footer.recordTypeCode = line.substring(0, 2) as RecordTypeCodes;
+    // Total number of records not including header and footer.
+    footer.recordCount = +line.substring(51, 60);
+    footer.totalSINHash = parseInt(line.substring(60, 75));
     return footer;
   }
 

--- a/sources/packages/backend/libs/integrations/src/esdc-integration/e-cert-integration/e-cert-part-time-integration/e-cert-files/e-cert-file-header.ts
+++ b/sources/packages/backend/libs/integrations/src/esdc-integration/e-cert-integration/e-cert-part-time-integration/e-cert-files/e-cert-file-header.ts
@@ -1,7 +1,7 @@
 import { getDateOnlyFromFormat, StringBuilder } from "@sims/utilities";
 import {
   DATE_FORMAT,
-  ECERT_SENT_TITLE,
+  ECERT_PT_SENT_TITLE,
   RecordTypeCodes,
   SPACE_FILLER,
 } from "../../models/e-cert-integration-model";
@@ -20,7 +20,7 @@ export class ECertPartTimeFileHeader extends ECertFileHeader {
     const header = new StringBuilder();
     header.append(this.recordTypeCode);
     header.appendWithEndFiller(ORIGINATOR_CODE, 4, SPACE_FILLER);
-    header.appendWithEndFiller(ECERT_SENT_TITLE, 40, SPACE_FILLER);
+    header.appendWithEndFiller(ECERT_PT_SENT_TITLE, 40, SPACE_FILLER);
     header.appendDate(this.processDate, DATE_FORMAT);
     header.appendDate(this.processDate, TIME_FORMAT);
     header.repeatAppend(SPACE_FILLER, 698); // Trailing space.

--- a/sources/packages/backend/libs/integrations/src/esdc-integration/e-cert-integration/e-cert-part-time-integration/e-cert-files/e-cert-file-header.ts
+++ b/sources/packages/backend/libs/integrations/src/esdc-integration/e-cert-integration/e-cert-part-time-integration/e-cert-files/e-cert-file-header.ts
@@ -40,6 +40,6 @@ export class ECertPartTimeFileHeader extends ECertFileHeader {
   }
 
   getFeedbackHeaderRecordType(): RecordTypeCodes {
-    return RecordTypeCodes.ECertPartTimeFeedbackHeader;
+    return RecordTypeCodes.ECertPartTimeHeader;
   }
 }

--- a/sources/packages/backend/libs/integrations/src/esdc-integration/e-cert-integration/e-cert-part-time-integration/e-cert-files/e-cert-file-header.ts
+++ b/sources/packages/backend/libs/integrations/src/esdc-integration/e-cert-integration/e-cert-part-time-integration/e-cert-files/e-cert-file-header.ts
@@ -31,7 +31,7 @@ export class ECertPartTimeFileHeader extends ECertFileHeader {
 
   createFromLine(line: string): ECertPartTimeFileHeader {
     const header = new ECertPartTimeFileHeader();
-    header.recordTypeCode = line.substring(0, 3) as RecordTypeCodes;
+    header.recordTypeCode = line.substring(0, 2) as RecordTypeCodes;
     header.processDate = getDateOnlyFromFormat(
       line.substring(56, 64),
       DATE_FORMAT,

--- a/sources/packages/backend/libs/integrations/src/esdc-integration/e-cert-integration/e-cert-part-time-integration/e-cert-files/e-cert-file-header.ts
+++ b/sources/packages/backend/libs/integrations/src/esdc-integration/e-cert-integration/e-cert-part-time-integration/e-cert-files/e-cert-file-header.ts
@@ -2,6 +2,7 @@ import { getDateOnlyFromFormat, StringBuilder } from "@sims/utilities";
 import {
   DATE_FORMAT,
   ECERT_PT_SENT_TITLE,
+  NUMBER_FILLER,
   RecordTypeCodes,
   SPACE_FILLER,
 } from "../../models/e-cert-integration-model";
@@ -23,6 +24,7 @@ export class ECertPartTimeFileHeader extends ECertFileHeader {
     header.appendWithEndFiller(ECERT_PT_SENT_TITLE, 40, SPACE_FILLER);
     header.appendDate(this.processDate, DATE_FORMAT);
     header.appendDate(this.processDate, TIME_FORMAT);
+    header.appendWithStartFiller(this.sequence, 6, NUMBER_FILLER);
     header.repeatAppend(SPACE_FILLER, 698); // Trailing space.
     return header.toString();
   }

--- a/sources/packages/backend/libs/integrations/src/esdc-integration/e-cert-integration/e-cert-part-time-integration/e-cert-files/e-cert-file-record.ts
+++ b/sources/packages/backend/libs/integrations/src/esdc-integration/e-cert-integration/e-cert-part-time-integration/e-cert-files/e-cert-file-record.ts
@@ -215,7 +215,7 @@ export class ECertPartTimeFileRecord extends ECertFileRecord {
       record.appendWithStartFiller(this.schoolAmount, 7, NUMBER_FILLER);
       record.appendWithStartFiller(this.courseLoad, 2, NUMBER_FILLER);
       record.append(this.ppdFlag, 1);
-      record.repeatAppend(SPACE_FILLER, 25); // Space Filler.
+      record.repeatAppend(SPACE_FILLER, 25); // Space filler.
       return record.toString();
     } catch (error: unknown) {
       throw new Error(

--- a/sources/packages/backend/libs/integrations/src/esdc-integration/e-cert-integration/e-cert-part-time-integration/e-cert-files/e-cert-file-record.ts
+++ b/sources/packages/backend/libs/integrations/src/esdc-integration/e-cert-integration/e-cert-part-time-integration/e-cert-files/e-cert-file-record.ts
@@ -169,7 +169,7 @@ export class ECertPartTimeFileRecord extends ECertFileRecord {
       record.appendWithEndFiller(this.city, 25, SPACE_FILLER);
       record.appendWithEndFiller(this.provinceState ?? "", 4, SPACE_FILLER);
       record.appendWithEndFiller(this.country, 4, SPACE_FILLER);
-      record.repeatAppend(this.postalCode ?? "", 16);
+      record.appendWithEndFiller(this.postalCode ?? "", 16, SPACE_FILLER);
       record.repeatAppend(SPACE_FILLER, 16); // Telephone, optional, not provided.
       record.repeatAppend(SPACE_FILLER, 40); // Alternate Address 1, optional, not provided.
       record.repeatAppend(SPACE_FILLER, 40); // Alternate Address 2, optional, not provided.

--- a/sources/packages/backend/libs/integrations/src/esdc-integration/e-cert-integration/e-cert-part-time-integration/e-cert-files/e-cert-file-record.ts
+++ b/sources/packages/backend/libs/integrations/src/esdc-integration/e-cert-integration/e-cert-part-time-integration/e-cert-files/e-cert-file-record.ts
@@ -92,9 +92,21 @@ export class ECertPartTimeFileRecord extends ECertFileRecord {
    */
   city: string;
   /**
+   * Student country name.
+   */
+  country: string;
+  /**
    * Student email address.
    */
   emailAddress: string;
+  /**
+   * State/province, mandatory when Canada.
+   */
+  provinceState?: string;
+  /**
+   * Postal code, mandatory when Canada.
+   */
+  postalCode?: string;
   /**
    * Student gender M=Male F=Female.
    */
@@ -135,6 +147,10 @@ export class ECertPartTimeFileRecord extends ECertFileRecord {
    * CourseLoad for the PartTime course.
    */
   courseLoad: number;
+  /**
+   * Persistent or prolonged disability flag (Y or N).
+   */
+  ppdFlag: string;
 
   public getFixedFormat(): string {
     const record = new StringBuilder();
@@ -151,9 +167,9 @@ export class ECertPartTimeFileRecord extends ECertFileRecord {
       record.appendWithEndFiller(this.addressLine2 ?? "", 40, SPACE_FILLER);
       record.repeatAppend(SPACE_FILLER, 40); // AddressLine 3, optional, not provided.
       record.appendWithEndFiller(this.city, 25, SPACE_FILLER);
-      record.appendWithEndFiller("BC", 4, SPACE_FILLER); //TODO Province, is hardcoded to "BC  ".
-      record.appendWithEndFiller("CAN", 4, SPACE_FILLER); // TODO Country, is hardcoded to "CAN ".
-      record.repeatAppend(SPACE_FILLER, 16); //TODO Postal code, Filled with space as not provided.
+      record.appendWithEndFiller(this.provinceState ?? "", 4, SPACE_FILLER);
+      record.appendWithEndFiller(this.country, 4, SPACE_FILLER);
+      record.repeatAppend(this.postalCode ?? "", 16);
       record.repeatAppend(SPACE_FILLER, 16); // Telephone, optional, not provided.
       record.repeatAppend(SPACE_FILLER, 40); // Alternate Address 1, optional, not provided.
       record.repeatAppend(SPACE_FILLER, 40); // Alternate Address 2, optional, not provided.
@@ -175,8 +191,8 @@ export class ECertPartTimeFileRecord extends ECertFileRecord {
       record.appendWithStartFiller(this.weeksOfStudy, 3, NUMBER_FILLER);
       record.appendDate(this.documentProducedDate, DATE_FORMAT);
       record.repeatAppend(SPACE_FILLER, 8); // TODO Cancel Date, E-cert cancellation date.
-      record.repeatAppend(SPACE_FILLER, 9); //CAG PD Amt, No longer used.
-      record.repeatAppend(SPACE_FILLER, 9); //CAG LI Amt, No longer used.
+      record.repeatAppend(NUMBER_FILLER, 9); // CAG PD Amt, no longer used.
+      record.repeatAppend(NUMBER_FILLER, 9); // CAG LI Amt, no longer used.
       record.appendWithStartFiller(this.totalGrantAmount, 5, NUMBER_FILLER);
       record.appendWithStartFiller(this.totalCSGPPTAmount, 5, NUMBER_FILLER);
       record.repeatAppend(NUMBER_FILLER, 5); // CSGP NBD MI Amt, No longer used.
@@ -185,19 +201,20 @@ export class ECertPartTimeFileRecord extends ECertFileRecord {
       record.repeatAppend(NUMBER_FILLER, 5); // Amount of Grant for Services and Equipment for Students with Permanent Disabilities (CSGP-PDSE) at the study start, No longer used.
       record.appendWithStartFiller(this.totalBCSGAmount, 5, NUMBER_FILLER);
       record.repeatAppend(NUMBER_FILLER, 5); // BC Part-time grant amount 2 - Reserved for future use
-      record.repeatAppend(SPACE_FILLER, 10); // Space Filler.
+      record.repeatAppend(SPACE_FILLER, 10); // Space filler.
       record.repeatAppend(SPACE_FILLER, 8); // CSGP MP Date, No longer used.
       record.repeatAppend(SPACE_FILLER, 5); // CSGP MP PT Amt, No longer used.
       record.repeatAppend(SPACE_FILLER, 5); // CSGP MP MI Amt, No longer used.
       record.repeatAppend(SPACE_FILLER, 5); // CSGP MP PD Amt, No longer used.
       record.repeatAppend(SPACE_FILLER, 5); // CSGP MP PTDEP Amt, No longer used.
       record.repeatAppend(SPACE_FILLER, 5); // CSGP MP PDSE Amt, No longer used.
-      record.repeatAppend(SPACE_FILLER, 20); // Space Filler.
+      record.repeatAppend(SPACE_FILLER, 20); // Space filler.
       record.appendWithEndFiller(this.emailAddress, 75, SPACE_FILLER);
       record.append("P"); // 'P' for part-time. Full time is done by another integration to another system.
       record.appendDate(this.enrollmentConfirmationDate, DATE_FORMAT);
       record.appendWithStartFiller(this.schoolAmount, 7, NUMBER_FILLER);
       record.appendWithStartFiller(this.courseLoad, 2, NUMBER_FILLER);
+      record.append(this.ppdFlag, 1);
       record.repeatAppend(SPACE_FILLER, 25); // Space Filler.
       return record.toString();
     } catch (error: unknown) {

--- a/sources/packages/backend/libs/integrations/src/esdc-integration/e-cert-integration/e-cert-part-time-integration/e-cert-files/e-cert-response-record.ts
+++ b/sources/packages/backend/libs/integrations/src/esdc-integration/e-cert-integration/e-cert-part-time-integration/e-cert-files/e-cert-response-record.ts
@@ -17,48 +17,48 @@ export class ECertPartTimeResponseRecord extends ECertResponseRecord {
    * Financial document number associated with this disbursement.
    */
   get documentNumber(): number {
-    return parseInt(this.line.substring(467, 474));
+    return parseInt(this.line.substring(466, 473));
   }
 
   /**
    * Error code-1 associated with the document number.
    */
   get errorCode1(): string {
-    return this.line.substring(732, 742).trim();
+    return this.line.substring(756, 766).trim();
   }
 
   /**
    * Error code-2 associated with the document number.
    */
   get errorCode2(): string {
-    return this.line.substring(742, 752).trim();
+    return this.line.substring(766, 776).trim();
   }
 
   /**
    * Error code-3 associated with the document number.
    */
   get errorCode3(): string {
-    return this.line.substring(752, 762).trim();
+    return this.line.substring(776, 786).trim();
   }
 
   /**
    * Error code-4 associated with the document number.
    */
   get errorCode4(): string {
-    return this.line.substring(762, 772).trim();
+    return this.line.substring(786, 796).trim();
   }
 
   /**
    * Error code-5 associated with the document number.
    */
   get errorCode5(): string {
-    return this.line.substring(772, 782).trim();
+    return this.line.substring(796, 806).trim();
   }
 
   /**
    * SIN associated with the document number.
    */
   get sin(): number {
-    return parseInt(this.line.substring(46, 55));
+    return parseInt(this.line.substring(45, 54));
   }
 }

--- a/sources/packages/backend/libs/integrations/src/esdc-integration/e-cert-integration/e-cert-part-time-integration/e-cert-part-time.integration.service.ts
+++ b/sources/packages/backend/libs/integrations/src/esdc-integration/e-cert-integration/e-cert-part-time-integration/e-cert-part-time.integration.service.ts
@@ -19,6 +19,7 @@ import {
   combineDecimalPlaces,
   getDisbursementEffectiveAmountByValueCode,
   getGenderCode,
+  getPPDFlag,
   getPartTimeMaritalStatusCode,
   getTotalDisbursementEffectiveAmount,
 } from "@sims/utilities";
@@ -39,17 +40,21 @@ export class ECertPartTimeIntegrationService extends ECertIntegrationService {
   }
 
   /**
-   * Create the ECert file content, by populating the
-   * header, detail and trailer records.
-   * @param ecertRecords student, User and application data.
-   * @returns complete ECert content to be sent.
+   * Create the e-Cert file content, by populating the header, detail and trailer records.
+   * @param ecertRecords data needed to generate the e-Cert file.
+   * @param fileSequence file sequence.
+   * @returns complete e-Cert content to be sent.
    */
-  createRequestContent(ecertRecords: ECertRecord[]): FixedFormatFileLine[] {
+  createRequestContent(
+    ecertRecords: ECertRecord[],
+    fileSequence: number,
+  ): FixedFormatFileLine[] {
     const fileLines: FixedFormatFileLine[] = [];
     // Header record
     const header = new ECertPartTimeFileHeader();
     header.recordTypeCode = RecordTypeCodes.ECertPartTimeHeader;
     header.processDate = new Date();
+    header.sequence = fileSequence;
     fileLines.push(header);
 
     // Detail records
@@ -104,12 +109,16 @@ export class ECertPartTimeIntegrationService extends ECertIntegrationService {
       record.addressLine1 = ecertRecord.addressLine1;
       record.addressLine2 = ecertRecord.addressLine2;
       record.city = ecertRecord.city;
+      record.country = ecertRecord.country;
+      record.provinceState = ecertRecord.provinceState;
+      record.postalCode = ecertRecord.postalCode;
       record.emailAddress = ecertRecord.email;
       record.gender = getGenderCode(ecertRecord.gender);
       record.maritalStatus = getPartTimeMaritalStatusCode(
         ecertRecord.maritalStatus,
       );
       record.studentNumber = ecertRecord.studentNumber;
+      record.ppdFlag = getPPDFlag(ecertRecord.ppdFlag);
       record.totalGrantAmount = totalGrantAmount;
       record.totalBCSGAmount = totalBCSGAmount;
       record.totalCSGPPTAmount = totalCSGPPTAmount;

--- a/sources/packages/backend/libs/integrations/src/esdc-integration/e-cert-integration/e-cert.integration.service.ts
+++ b/sources/packages/backend/libs/integrations/src/esdc-integration/e-cert-integration/e-cert.integration.service.ts
@@ -16,13 +16,14 @@ export abstract class ECertIntegrationService extends SFTPIntegrationBase<
   ECertResponseRecord[]
 > {
   /**
-   * This method will be implemented in the extended class and is used to create the ECert request content.
-   * @param ecertRecords
-   * @param fileSequence
+   * This method will be implemented in the extended class and is used to create the e-Cert request content.
+   * @param ecertRecords data needed to generate the e-Cert file.
+   * @param fileSequence file sequence.
+   * @returns when overridden in a derived class, returns the complete e-Cert content to be sent.
    */
   abstract createRequestContent(
     ecertRecords: ECertRecord[],
-    fileSequence?: number,
+    fileSequence: number,
   ): FixedFormatFileLine[];
 
   /**

--- a/sources/packages/backend/libs/integrations/src/esdc-integration/e-cert-integration/models/e-cert-integration-model.ts
+++ b/sources/packages/backend/libs/integrations/src/esdc-integration/e-cert-integration/models/e-cert-integration-model.ts
@@ -1,6 +1,8 @@
 import { DisbursementValue, RelationshipStatus } from "@sims/sims-db";
 
 export const ECERT_SENT_TITLE = "NEW ENTITLEMENT";
+export const ECERT_PT_SENT_TITLE = "NEW PT ENTITLEMENT";
+
 /**
  * Amount of Grant for Part-time Studies (CSGP-PT) at the study start.
  */

--- a/sources/packages/backend/libs/integrations/src/esdc-integration/e-cert-integration/models/e-cert-integration-model.ts
+++ b/sources/packages/backend/libs/integrations/src/esdc-integration/e-cert-integration/models/e-cert-integration-model.ts
@@ -47,6 +47,10 @@ export interface ECertRecord {
   awards: Award[];
   stopFullTimeBCFunding: boolean;
   courseLoad?: number;
+  /**
+   * Persistent or prolonged disability flag.
+   */
+  ppdFlag?: boolean;
 }
 
 export type Award = Pick<

--- a/sources/packages/backend/libs/integrations/src/esdc-integration/e-cert-integration/models/e-cert-integration-model.ts
+++ b/sources/packages/backend/libs/integrations/src/esdc-integration/e-cert-integration/models/e-cert-integration-model.ts
@@ -69,9 +69,9 @@ export enum RecordTypeCodes {
   ECertPartTimeHeader = "01",
   ECertPartTimeRecord = "02",
   ECertPartTimeFooter = "99",
-  ECertPartTimeFeedbackHeader = "001",
-  ECertPartTimeFeedbackRecord = "002",
-  ECertPartTimeFeedbackFooter = "999",
+  ECertPartTimeFeedbackHeader = "01",
+  ECertPartTimeFeedbackRecord = "02",
+  ECertPartTimeFeedbackFooter = "99",
 }
 
 /**

--- a/sources/packages/backend/libs/integrations/src/esdc-integration/e-cert-integration/models/e-cert-integration-model.ts
+++ b/sources/packages/backend/libs/integrations/src/esdc-integration/e-cert-integration/models/e-cert-integration-model.ts
@@ -59,8 +59,8 @@ export type Award = Pick<
 >;
 
 /**
- * Codes used to start all the lines of the e-Cert
- * files sent to ESDC.
+ * Codes used to start all the lines of the e-Cert files sent to ESDC
+ * and feedback files received with possible e-Cert errors.
  */
 export enum RecordTypeCodes {
   ECertFullTimeHeader = "100",

--- a/sources/packages/backend/libs/integrations/src/esdc-integration/e-cert-integration/models/e-cert-integration-model.ts
+++ b/sources/packages/backend/libs/integrations/src/esdc-integration/e-cert-integration/models/e-cert-integration-model.ts
@@ -69,9 +69,6 @@ export enum RecordTypeCodes {
   ECertPartTimeHeader = "01",
   ECertPartTimeRecord = "02",
   ECertPartTimeFooter = "99",
-  ECertPartTimeFeedbackHeader = "01",
-  ECertPartTimeFeedbackRecord = "02",
-  ECertPartTimeFeedbackFooter = "99",
 }
 
 /**

--- a/sources/packages/backend/libs/integrations/src/services/disbursement-schedule-errors/disbursement-schedule-errors.service.ts
+++ b/sources/packages/backend/libs/integrations/src/services/disbursement-schedule-errors/disbursement-schedule-errors.service.ts
@@ -4,7 +4,6 @@ import {
   RecordDataModelService,
   DisbursementFeedbackErrors,
   DisbursementSchedule,
-  DatabaseConstraintNames,
 } from "@sims/sims-db";
 import { SystemUsersService } from "@sims/services";
 

--- a/sources/packages/backend/libs/integrations/src/services/disbursement-schedule-errors/disbursement-schedule-errors.service.ts
+++ b/sources/packages/backend/libs/integrations/src/services/disbursement-schedule-errors/disbursement-schedule-errors.service.ts
@@ -6,6 +6,7 @@ import {
   DisbursementSchedule,
   DatabaseConstraintNames,
 } from "@sims/sims-db";
+import { SystemUsersService } from "@sims/services";
 
 /**
  * Service layer for Disbursement Schedule Errors
@@ -13,7 +14,10 @@ import {
  */
 @Injectable()
 export class DisbursementScheduleErrorsService extends RecordDataModelService<DisbursementFeedbackErrors> {
-  constructor(dataSource: DataSource) {
+  constructor(
+    private readonly systemUsersService: SystemUsersService,
+    dataSource: DataSource,
+  ) {
     super(dataSource.getRepository(DisbursementFeedbackErrors));
   }
 
@@ -29,12 +33,14 @@ export class DisbursementScheduleErrorsService extends RecordDataModelService<Di
     errorCodes: string[],
     dateReceived: Date,
   ): Promise<InsertResult> {
+    const auditUser = await this.systemUsersService.systemUser();
     const errorCodesObject = errorCodes.map((errorCode) => {
       const newDisbursementsFeedbackErrors = new DisbursementFeedbackErrors();
       newDisbursementsFeedbackErrors.disbursementSchedule =
         disbursementSchedule;
       newDisbursementsFeedbackErrors.errorCode = errorCode;
       newDisbursementsFeedbackErrors.dateReceived = dateReceived;
+      newDisbursementsFeedbackErrors.creator = auditUser;
       return newDisbursementsFeedbackErrors;
     });
     return this.repo
@@ -42,9 +48,7 @@ export class DisbursementScheduleErrorsService extends RecordDataModelService<Di
       .insert()
       .into(DisbursementFeedbackErrors)
       .values(errorCodesObject)
-      .onConflict(
-        `ON CONSTRAINT ${DatabaseConstraintNames.DisbursementScheduleIDErrorCodeUnique} DO NOTHING`,
-      )
+      .orIgnore()
       .execute();
   }
 }

--- a/sources/packages/backend/libs/integrations/src/services/disbursement-schedule/disbursement-schedule.service.ts
+++ b/sources/packages/backend/libs/integrations/src/services/disbursement-schedule/disbursement-schedule.service.ts
@@ -18,14 +18,17 @@ export class DisbursementScheduleService extends RecordDataModelService<Disburse
   }
 
   /**
-   * Get DisbursementSchedule by documentNumber
-   * @param documentNumber document Number
-   * @returns DisbursementSchedule respective to passed documentNumber.
+   * Get the disbursement schedule by its document number.
+   * @param documentNumber document number.
+   * @returns disbursement schedule respective to passed documentNumber.
    */
   async getDisbursementScheduleByDocumentNumber(
     documentNumber: number,
   ): Promise<DisbursementSchedule> {
-    return this.repo.findOne({ where: { documentNumber } });
+    return this.repo.findOne({
+      select: { id: true },
+      where: { documentNumber },
+    });
   }
 
   /**

--- a/sources/packages/backend/libs/integrations/src/services/disbursement-schedule/disbursement-schedule.service.ts
+++ b/sources/packages/backend/libs/integrations/src/services/disbursement-schedule/disbursement-schedule.service.ts
@@ -20,7 +20,7 @@ export class DisbursementScheduleService extends RecordDataModelService<Disburse
   /**
    * Get the disbursement schedule by its document number.
    * @param documentNumber document number.
-   * @returns disbursement schedule respective to passed documentNumber.
+   * @returns disbursement schedule respective to the provided document number.
    */
   async getDisbursementScheduleByDocumentNumber(
     documentNumber: number,

--- a/sources/packages/backend/libs/integrations/src/services/disbursement-schedule/e-cert-generation.service.ts
+++ b/sources/packages/backend/libs/integrations/src/services/disbursement-schedule/e-cert-generation.service.ts
@@ -170,6 +170,7 @@ export class ECertGenerationService {
         "student.birthDate",
         "student.gender",
         "student.contactInfo",
+        "student.studentPDVerified",
         "institutionLocation.id",
         "institutionLocation.institutionCode",
         "disbursementValue.id",

--- a/sources/packages/backend/libs/sims-db/src/error-handler.ts
+++ b/sources/packages/backend/libs/sims-db/src/error-handler.ts
@@ -11,11 +11,6 @@ export enum DatabaseConstraintNames {
    * Applied on table sims.education_programs_offerings.
    */
   LocationIDProgramIDOfferingNameStudyDatesIndex = "location_id_program_id_offering_name_study_dates_index",
-  /**
-   * Ensures error code is unique for a disbursement receipt.
-   * Applied on table disbursement_feedback_errors.
-   */
-  DisbursementScheduleIDErrorCodeUnique = "disbursement_schedule_id_error_code_unique",
 }
 
 /**

--- a/sources/packages/backend/libs/test-utils/src/factories/disbursement-schedule.ts
+++ b/sources/packages/backend/libs/test-utils/src/factories/disbursement-schedule.ts
@@ -17,7 +17,9 @@ export function createFakeDisbursementSchedule(relations?: {
   const now = new Date();
   const nowString = getISODateOnlyString(now);
   const schedule = new DisbursementSchedule();
-  schedule.documentNumber = faker.random.number(2147483647);
+  // Fake number generated based on the max value that a document number can have as
+  // per e-Cert documentation. Numbers under 1000000 can still be used for E2E tests.
+  schedule.documentNumber = faker.random.number({ min: 1000000, max: 9999999 });
   schedule.disbursementDate = nowString;
   schedule.negotiatedExpiryDate = nowString;
   schedule.dateSent = null;

--- a/sources/packages/backend/libs/utilities/src/disbursements-utils.ts
+++ b/sources/packages/backend/libs/utilities/src/disbursements-utils.ts
@@ -97,14 +97,18 @@ export function combineDecimalPlaces(
  * !and the overaward deductions or possible restrictions are applied.
  * @param awards list of awards (disbursement values).
  * @param valueCode valueCode to be extracted.
- * @returns award amount of the specified types.
+ * @returns award amount of the specified types. If the code is not present
+ * it will return 0 (zero).
  */
 export function getDisbursementEffectiveAmountByValueCode(
   awards: Award[],
   valueCode: string,
 ): number {
-  return +awards.find((award) => award.valueCode.includes(valueCode))
-    .effectiveAmount;
+  const award = awards.find((award) => award.valueCode === valueCode);
+  if (award?.effectiveAmount) {
+    return +award.effectiveAmount;
+  }
+  return 0;
 }
 
 /**

--- a/sources/packages/backend/libs/utilities/src/esdc-utils.ts
+++ b/sources/packages/backend/libs/utilities/src/esdc-utils.ts
@@ -67,7 +67,7 @@ export function getPartTimeMaritalStatusCode(
 }
 
 /**
- * Get the e-Cert flag for the borrower's persistent or prolonged disability.
+ * Get the e-Cert flag for the borrower's persistent or prolonged disability status.
  * @param hasPDorPPD indicates if a borrower has a persistent or prolonged disability.
  * @returns "Y" or "N" flag.
  */

--- a/sources/packages/backend/libs/utilities/src/esdc-utils.ts
+++ b/sources/packages/backend/libs/utilities/src/esdc-utils.ts
@@ -65,3 +65,12 @@ export function getPartTimeMaritalStatusCode(
   }
   return maritalStatus === RelationshipStatus.Single ? "SI" : "SP";
 }
+
+/**
+ * Get the e-Cert flag for the borrower's persistent or prolonged disability.
+ * @param hasPDorPPD indicates if a borrower has a persistent or prolonged disability.
+ * @returns "Y" or "N" flag.
+ */
+export function getPPDFlag(hasPPD?: boolean): string {
+  return hasPPD === true ? "Y" : "N";
+}


### PR DESCRIPTION
### Part-time e-Cert file
- Adjusted new header/record/footer record types from 3 to 2 characters.
- Changed the "sent title" using a new const `ECERT_PT_SENT_TITLE`.
- Added a new field for PD/PDD. Currently reading from the student profile. Later it should be determined from where it will be actually read.
- Reading country, province, and postal code in the same way as it is for full-time. This is still pending business answers about how it will properly work.
- Header record now includes the file sequence.

### Part-time feedback file
- Fixes for all the positions that were shifted by 1.
- Fix for the total "number of records" calculation.
- Replace the obsolete method `onConflict`.
- Removed no longer needed different codes for the feedback file.
- Fix an error preventing the e-Cert from being generated when some awards were not present.