### PR TITLE
#582 - Restrict non BC Public Institutions from accessing Routes for BC Public institutions

### DIFF
--- a/sources/packages/web/src/composables/institution/useInstitutionAuth.ts
+++ b/sources/packages/web/src/composables/institution/useInstitutionAuth.ts
@@ -1,8 +1,4 @@
-import {
-  InstitutionLocationState,
-  InstitutionUserAuthRolesAndLocation,
-  InstitutionUserRoles,
-} from "@/types";
+import { InstitutionLocationState, InstitutionUserRoles } from "@/types";
 import { computed } from "vue";
 import { Store, useStore } from "vuex";
 import { useAuth } from "..";
@@ -17,8 +13,7 @@ export function useInstitutionAuth(rootStore?: Store<any>) {
   // From institution details in store, get institution user details and authorizations.
   const institutionUserDetails = institutionDetails.userState;
   const authorizations =
-    (institutionDetails.authorizationsState
-      .authorizations as InstitutionUserAuthRolesAndLocation[]) ?? [];
+    institutionDetails.authorizationsState.authorizations ?? [];
 
   const { isAuthenticated } = useAuth();
   const isAuthenticatedInstitutionUser = computed(

--- a/sources/packages/web/src/composables/institution/useInstitutionAuth.ts
+++ b/sources/packages/web/src/composables/institution/useInstitutionAuth.ts
@@ -1,7 +1,7 @@
 import {
+  InstitutionLocationState,
   InstitutionUserAuthRolesAndLocation,
   InstitutionUserRoles,
-  UserStateForStore,
 } from "@/types";
 import { computed } from "vue";
 import { Store, useStore } from "vuex";
@@ -10,11 +10,14 @@ import { useAuth } from "..";
 export function useInstitutionAuth(rootStore?: Store<any>) {
   const store = rootStore ?? useStore();
 
-  // From store get user details and authorizations.
-  const institutionUserDetails = store.state.institution
-    .userState as UserStateForStore;
+  // From store get institution details.
+  const institutionDetails = store.state
+    .institution as InstitutionLocationState;
+
+  // From institution details in store, get institution user details and authorizations.
+  const institutionUserDetails = institutionDetails.userState;
   const authorizations =
-    (store.state.institution.authorizationsState
+    (institutionDetails.authorizationsState
       .authorizations as InstitutionUserAuthRolesAndLocation[]) ?? [];
 
   const { isAuthenticated } = useAuth();
@@ -44,6 +47,10 @@ export function useInstitutionAuth(rootStore?: Store<any>) {
   // User type Admin | User.
   const userType = computed(() => userAuthorization?.userType);
 
+  const isBCPublic = computed(
+    () => institutionDetails.institutionState?.isBCPublic,
+  );
+
   return {
     isAdmin,
     isAuthenticated,
@@ -55,5 +62,6 @@ export function useInstitutionAuth(rootStore?: Store<any>) {
     isInstitutionSetupUser,
     hasLocationAccess,
     userType,
+    isBCPublic,
   };
 }

--- a/sources/packages/web/src/router/InstitutionRouteHelper.ts
+++ b/sources/packages/web/src/router/InstitutionRouteHelper.ts
@@ -59,6 +59,7 @@ function isInstitutionUserAllowed(to: RouteLocationNormalized): boolean {
     isAdmin,
     isLegalSigningAuthority,
     userType,
+    isBCPublic,
     hasLocationAccess,
   } = useInstitutionAuth(store);
 
@@ -81,7 +82,11 @@ function isInstitutionUserAllowed(to: RouteLocationNormalized): boolean {
     return false;
   }
 
-  // TODO: Validate the route for BCPublic institutions must be done here.
+  // If the route is suppose to be accessible only for BC Public institutions
+  // reject the access for other institution types.
+  if (to.meta.allowOnlyBCPublic && !isBCPublic.value) {
+    return false;
+  }
 
   // If the user is institution admin, then they have access to all routes
   // except the routes which are accessible only for legal signing authority.

--- a/sources/packages/web/src/router/InstitutionRoutes.ts
+++ b/sources/packages/web/src/router/InstitutionRoutes.ts
@@ -460,6 +460,7 @@ export const institutionRoutes: Array<RouteRecordRaw> = [
             InstitutionUserTypes.admin,
             InstitutionUserTypes.user,
           ],
+          allowOnlyBCPublic: true,
         },
         children: [
           {
@@ -469,7 +470,6 @@ export const institutionRoutes: Array<RouteRecordRaw> = [
             component: InstitutionStudentProfile,
             meta: {
               clientType: ClientIdType.Institution,
-              allowOnlyBCPublic: true,
               institutionUserTypes: [
                 InstitutionUserTypes.admin,
                 InstitutionUserTypes.user,
@@ -483,7 +483,6 @@ export const institutionRoutes: Array<RouteRecordRaw> = [
             component: InstitutionStudentApplications,
             meta: {
               clientType: ClientIdType.Institution,
-              allowOnlyBCPublic: true,
               institutionUserTypes: [
                 InstitutionUserTypes.admin,
                 InstitutionUserTypes.user,
@@ -497,7 +496,6 @@ export const institutionRoutes: Array<RouteRecordRaw> = [
             component: InstitutionStudentRestrictions,
             meta: {
               clientType: ClientIdType.Institution,
-              allowOnlyBCPublic: true,
               institutionUserTypes: [
                 InstitutionUserTypes.admin,
                 InstitutionUserTypes.user,
@@ -511,7 +509,6 @@ export const institutionRoutes: Array<RouteRecordRaw> = [
             component: InstitutionStudentFileUploads,
             meta: {
               clientType: ClientIdType.Institution,
-              allowOnlyBCPublic: true,
               institutionUserTypes: [
                 InstitutionUserTypes.admin,
                 InstitutionUserTypes.user,
@@ -525,7 +522,6 @@ export const institutionRoutes: Array<RouteRecordRaw> = [
             component: InstitutionStudentNotes,
             meta: {
               clientType: ClientIdType.Institution,
-              allowOnlyBCPublic: true,
               institutionUserTypes: [
                 InstitutionUserTypes.admin,
                 InstitutionUserTypes.user,

--- a/sources/packages/web/src/router/InstitutionRoutes.ts
+++ b/sources/packages/web/src/router/InstitutionRoutes.ts
@@ -108,6 +108,7 @@ export const institutionRoutes: Array<RouteRecordRaw> = [
         },
         meta: {
           clientType: ClientIdType.Institution,
+          allowOnlyBCPublic: true,
           institutionUserTypes: [
             InstitutionUserTypes.admin,
             InstitutionUserTypes.user,
@@ -468,6 +469,7 @@ export const institutionRoutes: Array<RouteRecordRaw> = [
             component: InstitutionStudentProfile,
             meta: {
               clientType: ClientIdType.Institution,
+              allowOnlyBCPublic: true,
               institutionUserTypes: [
                 InstitutionUserTypes.admin,
                 InstitutionUserTypes.user,
@@ -481,6 +483,7 @@ export const institutionRoutes: Array<RouteRecordRaw> = [
             component: InstitutionStudentApplications,
             meta: {
               clientType: ClientIdType.Institution,
+              allowOnlyBCPublic: true,
               institutionUserTypes: [
                 InstitutionUserTypes.admin,
                 InstitutionUserTypes.user,
@@ -494,6 +497,7 @@ export const institutionRoutes: Array<RouteRecordRaw> = [
             component: InstitutionStudentRestrictions,
             meta: {
               clientType: ClientIdType.Institution,
+              allowOnlyBCPublic: true,
               institutionUserTypes: [
                 InstitutionUserTypes.admin,
                 InstitutionUserTypes.user,
@@ -507,6 +511,7 @@ export const institutionRoutes: Array<RouteRecordRaw> = [
             component: InstitutionStudentFileUploads,
             meta: {
               clientType: ClientIdType.Institution,
+              allowOnlyBCPublic: true,
               institutionUserTypes: [
                 InstitutionUserTypes.admin,
                 InstitutionUserTypes.user,
@@ -520,6 +525,7 @@ export const institutionRoutes: Array<RouteRecordRaw> = [
             component: InstitutionStudentNotes,
             meta: {
               clientType: ClientIdType.Institution,
+              allowOnlyBCPublic: true,
               institutionUserTypes: [
                 InstitutionUserTypes.admin,
                 InstitutionUserTypes.user,


### PR DESCRIPTION
Based on the route meta property `allowOnlyBCPublic` block access for non BC Public Institution users from accessing routes which are for BCPublic institutions.