### PR TITLE
#1761 - Handling full time BCSL lifetime and federal maximums -  fix

### DIFF
--- a/sources/packages/backend/libs/services/src/disbursement-schedule/disbursement-schedule-shared.service.ts
+++ b/sources/packages/backend/libs/services/src/disbursement-schedule/disbursement-schedule-shared.service.ts
@@ -680,7 +680,7 @@ export class DisbursementScheduleSharedService extends RecordDataModelService<Di
   async totalDisbursedBCSLAmount(studentId: number): Promise<number> {
     const total = await this.repo
       .createQueryBuilder("disbursement")
-      .select("SUM(disbursementValue.valueAmount)")
+      .select("SUM(disbursementValue.effectiveAmount)")
       .innerJoin("disbursement.disbursementValues", "disbursementValue")
       .innerJoin("disbursement.studentAssessment", "studentAssessment")
       .innerJoin("studentAssessment.application", "application")


### PR DESCRIPTION
- `totalDisbursedBCSLAmount` was calculating `valueAmount` sum instead of `effectiveAmount`., which was causing the issue