### PR TITLE
1866 - Bug fix for issue when accessing some locationIds from Institutions portal

### DIFF
--- a/sources/packages/web/src/router/InstitutionRoutes.ts
+++ b/sources/packages/web/src/router/InstitutionRoutes.ts
@@ -128,7 +128,7 @@ export const institutionRoutes: Array<RouteRecordRaw> = [
         },
         props: {
           default: (route) => ({
-            locationId: parseInt(route.params.locationId[0]),
+            locationId: parseInt(route.params.locationId as string),
           }),
         },
         meta: {
@@ -148,7 +148,7 @@ export const institutionRoutes: Array<RouteRecordRaw> = [
         },
         props: {
           default: (route: RouteLocationNormalized) => ({
-            locationId: parseInt(route.params.locationId[0]),
+            locationId: parseInt(route.params.locationId as string),
           }),
         },
         meta: {
@@ -181,7 +181,7 @@ export const institutionRoutes: Array<RouteRecordRaw> = [
         },
         props: {
           default: (route) => ({
-            locationId: parseInt(route.params.locationId[0]),
+            locationId: parseInt(route.params.locationId as string),
           }),
         },
         meta: {
@@ -201,7 +201,7 @@ export const institutionRoutes: Array<RouteRecordRaw> = [
         },
         props: {
           default: (route) => ({
-            locationId: parseInt(route.params.locationId[0]),
+            locationId: parseInt(route.params.locationId as string),
           }),
         },
         meta: {


### PR DESCRIPTION
- replaced getting the first item by using route.params.locationId as string.