### PR TITLE
#1929 - Current days of study/studybreaks count is 1 short of total

### DIFF
--- a/sources/packages/backend/apps/api/src/services/education-program-offering/_tests_/unit/education-program-offering.service-getCalculatedStudyBreaksAndWeeks.spec.ts
+++ b/sources/packages/backend/apps/api/src/services/education-program-offering/_tests_/unit/education-program-offering.service-getCalculatedStudyBreaksAndWeeks.spec.ts
@@ -18,7 +18,7 @@ describe("EducationProgramOfferingService-getCalculatedStudyBreaksAndWeeks", () 
       );
 
     // Assert
-    expect(calculatedStudyBreaksAndWeeks).toEqual({
+    expect(calculatedStudyBreaksAndWeeks).toStrictEqual({
       allowableStudyBreaksDaysAmount: 1,
       fundedStudyPeriodDays: 10,
       studyBreaks: [],
@@ -46,7 +46,7 @@ describe("EducationProgramOfferingService-getCalculatedStudyBreaksAndWeeks", () 
       );
 
     // Assert
-    expect(calculatedStudyBreaksAndWeeks).toEqual({
+    expect(calculatedStudyBreaksAndWeeks).toStrictEqual({
       allowableStudyBreaksDaysAmount: NaN,
       fundedStudyPeriodDays: NaN,
       studyBreaks: [],
@@ -74,7 +74,7 @@ describe("EducationProgramOfferingService-getCalculatedStudyBreaksAndWeeks", () 
       );
 
     // Assert
-    expect(calculatedStudyBreaksAndWeeks).toEqual({
+    expect(calculatedStudyBreaksAndWeeks).toStrictEqual({
       allowableStudyBreaksDaysAmount: NaN,
       fundedStudyPeriodDays: NaN,
       studyBreaks: [],
@@ -111,7 +111,7 @@ describe("EducationProgramOfferingService-getCalculatedStudyBreaksAndWeeks", () 
       );
 
     // Assert
-    expect(calculatedStudyBreaksAndWeeks).toEqual({
+    expect(calculatedStudyBreaksAndWeeks).toStrictEqual({
       allowableStudyBreaksDaysAmount: NaN,
       fundedStudyPeriodDays: NaN,
       studyBreaks: [
@@ -159,7 +159,7 @@ describe("EducationProgramOfferingService-getCalculatedStudyBreaksAndWeeks", () 
       );
 
     // Assert
-    expect(calculatedStudyBreaksAndWeeks).toEqual({
+    expect(calculatedStudyBreaksAndWeeks).toStrictEqual({
       allowableStudyBreaksDaysAmount: NaN,
       fundedStudyPeriodDays: NaN,
       studyBreaks: [],
@@ -192,7 +192,7 @@ describe("EducationProgramOfferingService-getCalculatedStudyBreaksAndWeeks", () 
       );
 
     // Assert
-    expect(calculatedStudyBreaksAndWeeks).toEqual({
+    expect(calculatedStudyBreaksAndWeeks).toStrictEqual({
       allowableStudyBreaksDaysAmount: NaN,
       fundedStudyPeriodDays: NaN,
       studyBreaks: [],
@@ -225,7 +225,7 @@ describe("EducationProgramOfferingService-getCalculatedStudyBreaksAndWeeks", () 
       );
 
     // Assert
-    expect(calculatedStudyBreaksAndWeeks).toEqual({
+    expect(calculatedStudyBreaksAndWeeks).toStrictEqual({
       allowableStudyBreaksDaysAmount: 12.4,
       fundedStudyPeriodDays: 113.4,
       studyBreaks: [

--- a/sources/packages/backend/apps/api/src/services/education-program-offering/_tests_/unit/education-program-offering.service-getCalculatedStudyBreaksAndWeeks.spec.ts
+++ b/sources/packages/backend/apps/api/src/services/education-program-offering/_tests_/unit/education-program-offering.service-getCalculatedStudyBreaksAndWeeks.spec.ts
@@ -1,0 +1,192 @@
+import { OfferingStudyBreakCalculationContext } from "../../education-program-offering-validation.models";
+import { EducationProgramOfferingService } from "../../education-program-offering.service";
+
+describe("EducationProgramOfferingService-getCalculatedStudyBreaksAndWeeks", () => {
+  it("Should calculate fundedStudyPeriodDays and totalDays counting start and end dates when studyStartDate and studyEndDate are available.", () => {
+    //Arrange
+    const offeringStudyBreakCalculationContext: OfferingStudyBreakCalculationContext =
+      {
+        studyStartDate: "2023-01-01",
+        studyEndDate: "2023-01-10",
+        studyBreaks: [],
+      };
+
+    // Act
+    const calculatedStudyBreaksAndWeeks =
+      EducationProgramOfferingService.getCalculatedStudyBreaksAndWeeks(
+        offeringStudyBreakCalculationContext,
+      );
+
+    // Assert
+    expect(calculatedStudyBreaksAndWeeks).toEqual({
+      allowableStudyBreaksDaysAmount: 1,
+      fundedStudyPeriodDays: 10,
+      studyBreaks: [],
+      sumOfTotalEligibleBreakDays: 0,
+      sumOfTotalIneligibleBreakDays: 0,
+      totalDays: 10,
+      totalFundedWeeks: 2,
+      unfundedStudyPeriodDays: 0,
+    });
+  });
+
+  it("Should not calculate fundedStudyPeriodDays and totalDays counting start and end dates when studyStartDate is not available.", () => {
+    //Arrange
+    const offeringStudyBreakCalculationContext: OfferingStudyBreakCalculationContext =
+      {
+        studyStartDate: "",
+        studyEndDate: "2023-01-10",
+        studyBreaks: [],
+      };
+
+    // Act
+    const calculatedStudyBreaksAndWeeks =
+      EducationProgramOfferingService.getCalculatedStudyBreaksAndWeeks(
+        offeringStudyBreakCalculationContext,
+      );
+
+    // Assert
+    expect(calculatedStudyBreaksAndWeeks).toEqual({
+      allowableStudyBreaksDaysAmount: NaN,
+      fundedStudyPeriodDays: NaN,
+      studyBreaks: [],
+      sumOfTotalEligibleBreakDays: 0,
+      sumOfTotalIneligibleBreakDays: 0,
+      totalDays: NaN,
+      totalFundedWeeks: NaN,
+      unfundedStudyPeriodDays: NaN,
+    });
+  });
+
+  it("Should not calculate fundedStudyPeriodDays and totalDays counting start and end dates when studyEndDate is not available.", () => {
+    //Arrange
+    const offeringStudyBreakCalculationContext: OfferingStudyBreakCalculationContext =
+      {
+        studyStartDate: "2023-01-01",
+        studyEndDate: "",
+        studyBreaks: [],
+      };
+
+    // Act
+    const calculatedStudyBreaksAndWeeks =
+      EducationProgramOfferingService.getCalculatedStudyBreaksAndWeeks(
+        offeringStudyBreakCalculationContext,
+      );
+
+    // Assert
+    expect(calculatedStudyBreaksAndWeeks).toEqual({
+      allowableStudyBreaksDaysAmount: NaN,
+      fundedStudyPeriodDays: NaN,
+      studyBreaks: [],
+      sumOfTotalEligibleBreakDays: 0,
+      sumOfTotalIneligibleBreakDays: 0,
+      totalDays: NaN,
+      totalFundedWeeks: NaN,
+      unfundedStudyPeriodDays: NaN,
+    });
+  });
+
+  it("Should calculate studyBreaks counting start and end dates when study break dates available.", () => {
+    //Arrange
+    const offeringStudyBreakCalculationContext: OfferingStudyBreakCalculationContext =
+      {
+        studyStartDate: "",
+        studyEndDate: "",
+        studyBreaks: [
+          {
+            breakStartDate: "2023-05-29",
+            breakEndDate: "2023-06-06",
+          },
+          {
+            breakStartDate: "2023-06-08",
+            breakEndDate: "2023-06-13",
+          },
+        ],
+      };
+
+    // Act
+    const calculatedStudyBreaksAndWeeks =
+      EducationProgramOfferingService.getCalculatedStudyBreaksAndWeeks(
+        offeringStudyBreakCalculationContext,
+      );
+
+    // Assert
+    expect(calculatedStudyBreaksAndWeeks).toEqual({
+      allowableStudyBreaksDaysAmount: NaN,
+      fundedStudyPeriodDays: NaN,
+      studyBreaks: [
+        {
+          breakDays: 9,
+          breakEndDate: "2023-06-06",
+          breakStartDate: "2023-05-29",
+          eligibleBreakDays: 9,
+          ineligibleBreakDays: 0,
+        },
+        {
+          breakDays: 6,
+          breakEndDate: "2023-06-13",
+          breakStartDate: "2023-06-08",
+          eligibleBreakDays: 6,
+          ineligibleBreakDays: 0,
+        },
+      ],
+      sumOfTotalEligibleBreakDays: 15,
+      sumOfTotalIneligibleBreakDays: 0,
+      totalDays: NaN,
+      totalFundedWeeks: NaN,
+      unfundedStudyPeriodDays: NaN,
+    });
+  });
+
+  it("Should calculate funded periods and allowed study breaks when there are data available.", () => {
+    //Arrange
+    const offeringStudyBreakCalculationContext: OfferingStudyBreakCalculationContext =
+      {
+        studyStartDate: "2023-05-29",
+        studyEndDate: "2023-09-29",
+        studyBreaks: [
+          {
+            breakStartDate: "2023-05-29",
+            breakEndDate: "2023-06-06",
+          },
+          {
+            breakStartDate: "2023-06-08",
+            breakEndDate: "2023-06-30",
+          },
+        ],
+      };
+
+    // Act
+    const calculatedStudyBreaksAndWeeks =
+      EducationProgramOfferingService.getCalculatedStudyBreaksAndWeeks(
+        offeringStudyBreakCalculationContext,
+      );
+
+    // Assert
+    expect(calculatedStudyBreaksAndWeeks).toEqual({
+      allowableStudyBreaksDaysAmount: 12.4,
+      fundedStudyPeriodDays: 104.4,
+      studyBreaks: [
+        {
+          breakDays: 9,
+          breakEndDate: "2023-06-06",
+          breakStartDate: "2023-05-29",
+          eligibleBreakDays: 9,
+          ineligibleBreakDays: 0,
+        },
+        {
+          breakDays: 23,
+          breakEndDate: "2023-06-30",
+          breakStartDate: "2023-06-08",
+          eligibleBreakDays: 21,
+          ineligibleBreakDays: 2,
+        },
+      ],
+      sumOfTotalEligibleBreakDays: 30,
+      sumOfTotalIneligibleBreakDays: 2,
+      totalDays: 124,
+      totalFundedWeeks: 15,
+      unfundedStudyPeriodDays: 19.6,
+    });
+  });
+});

--- a/sources/packages/backend/apps/api/src/services/education-program-offering/_tests_/unit/education-program-offering.service-getCalculatedStudyBreaksAndWeeks.spec.ts
+++ b/sources/packages/backend/apps/api/src/services/education-program-offering/_tests_/unit/education-program-offering.service-getCalculatedStudyBreaksAndWeeks.spec.ts
@@ -2,7 +2,7 @@ import { OfferingStudyBreakCalculationContext } from "../../education-program-of
 import { EducationProgramOfferingService } from "../../education-program-offering.service";
 
 describe("EducationProgramOfferingService-getCalculatedStudyBreaksAndWeeks", () => {
-  it("Should calculate fundedStudyPeriodDays and totalDays counting start and end dates when studyStartDate and studyEndDate are available.", () => {
+  it("Should calculate funded study period and total days when study start and end study dates are available.", () => {
     //Arrange
     const offeringStudyBreakCalculationContext: OfferingStudyBreakCalculationContext =
       {
@@ -30,7 +30,7 @@ describe("EducationProgramOfferingService-getCalculatedStudyBreaksAndWeeks", () 
     });
   });
 
-  it("Should not calculate funded study period days and total days counting start and end dates when study start date is not available.", () => {
+  it("Should not calculate funded study period days and total days when study start date is not available.", () => {
     //Arrange
     const offeringStudyBreakCalculationContext: OfferingStudyBreakCalculationContext =
       {
@@ -58,7 +58,7 @@ describe("EducationProgramOfferingService-getCalculatedStudyBreaksAndWeeks", () 
     });
   });
 
-  it("Should not calculate funded study period days and total days counting start and end dates when study end date is not available.", () => {
+  it("Should not calculate funded study period days and total days when study end date is not available.", () => {
     //Arrange
     const offeringStudyBreakCalculationContext: OfferingStudyBreakCalculationContext =
       {
@@ -86,7 +86,7 @@ describe("EducationProgramOfferingService-getCalculatedStudyBreaksAndWeeks", () 
     });
   });
 
-  it("Should calculate study breaks counting start and end dates when study break dates available.", () => {
+  it("Should calculate study breaks when start and end study break dates available.", () => {
     //Arrange
     const offeringStudyBreakCalculationContext: OfferingStudyBreakCalculationContext =
       {
@@ -138,7 +138,7 @@ describe("EducationProgramOfferingService-getCalculatedStudyBreaksAndWeeks", () 
     });
   });
 
-  it("Should not calculate study breaks counting start and end dates when start study break date is not available.", () => {
+  it("Should not calculate study breaks when start study break date is not available.", () => {
     //Arrange
     const offeringStudyBreakCalculationContext: OfferingStudyBreakCalculationContext =
       {
@@ -171,7 +171,7 @@ describe("EducationProgramOfferingService-getCalculatedStudyBreaksAndWeeks", () 
     });
   });
 
-  it("Should not calculate study breaks counting start and end dates when end study break date is not available.", () => {
+  it("Should not calculate study breaks when end study break date is not available.", () => {
     //Arrange
     const offeringStudyBreakCalculationContext: OfferingStudyBreakCalculationContext =
       {
@@ -201,58 +201,6 @@ describe("EducationProgramOfferingService-getCalculatedStudyBreaksAndWeeks", () 
       totalDays: NaN,
       totalFundedWeeks: NaN,
       unfundedStudyPeriodDays: NaN,
-    });
-  });
-
-  it("Should calculate funded periods study breaks when there are data available.", () => {
-    //Arrange
-    const offeringStudyBreakCalculationContext: OfferingStudyBreakCalculationContext =
-      {
-        studyStartDate: "2023-05-29",
-        studyEndDate: "2023-09-29",
-        studyBreaks: [
-          {
-            breakStartDate: "2023-05-29",
-            breakEndDate: "2023-06-06",
-          },
-          {
-            breakStartDate: "2023-06-08",
-            breakEndDate: "2023-06-20",
-          },
-        ],
-      };
-
-    // Act
-    const calculatedStudyBreaksAndWeeks =
-      EducationProgramOfferingService.getCalculatedStudyBreaksAndWeeks(
-        offeringStudyBreakCalculationContext,
-      );
-
-    // Assert
-    expect(calculatedStudyBreaksAndWeeks).toEqual({
-      allowableStudyBreaksDaysAmount: 12.4,
-      fundedStudyPeriodDays: 114.4,
-      studyBreaks: [
-        {
-          breakDays: 9,
-          breakEndDate: "2023-06-06",
-          breakStartDate: "2023-05-29",
-          eligibleBreakDays: 9,
-          ineligibleBreakDays: 0,
-        },
-        {
-          breakDays: 13,
-          breakEndDate: "2023-06-20",
-          breakStartDate: "2023-06-08",
-          eligibleBreakDays: 13,
-          ineligibleBreakDays: 0,
-        },
-      ],
-      sumOfTotalEligibleBreakDays: 22,
-      sumOfTotalIneligibleBreakDays: 0,
-      totalDays: 124,
-      totalFundedWeeks: 17,
-      unfundedStudyPeriodDays: 9.6,
     });
   });
 

--- a/sources/packages/backend/apps/api/src/services/education-program-offering/_tests_/unit/education-program-offering.service-getCalculatedStudyBreaksAndWeeks.spec.ts
+++ b/sources/packages/backend/apps/api/src/services/education-program-offering/_tests_/unit/education-program-offering.service-getCalculatedStudyBreaksAndWeeks.spec.ts
@@ -30,7 +30,7 @@ describe("EducationProgramOfferingService-getCalculatedStudyBreaksAndWeeks", () 
     });
   });
 
-  it("Should not calculate fundedStudyPeriodDays and totalDays counting start and end dates when studyStartDate is not available.", () => {
+  it("Should not calculate funded study period days and total days counting start and end dates when study start date is not available.", () => {
     //Arrange
     const offeringStudyBreakCalculationContext: OfferingStudyBreakCalculationContext =
       {
@@ -58,7 +58,7 @@ describe("EducationProgramOfferingService-getCalculatedStudyBreaksAndWeeks", () 
     });
   });
 
-  it("Should not calculate fundedStudyPeriodDays and totalDays counting start and end dates when studyEndDate is not available.", () => {
+  it("Should not calculate funded study period days and total days counting start and end dates when study end date is not available.", () => {
     //Arrange
     const offeringStudyBreakCalculationContext: OfferingStudyBreakCalculationContext =
       {
@@ -86,7 +86,7 @@ describe("EducationProgramOfferingService-getCalculatedStudyBreaksAndWeeks", () 
     });
   });
 
-  it("Should calculate studyBreaks counting start and end dates when study break dates available.", () => {
+  it("Should calculate study breaks counting start and end dates when study break dates available.", () => {
     //Arrange
     const offeringStudyBreakCalculationContext: OfferingStudyBreakCalculationContext =
       {
@@ -138,7 +138,73 @@ describe("EducationProgramOfferingService-getCalculatedStudyBreaksAndWeeks", () 
     });
   });
 
-  it("Should calculate funded periods and allowed study breaks when there are data available.", () => {
+  it("Should not calculate study breaks counting start and end dates when start study break date is not available.", () => {
+    //Arrange
+    const offeringStudyBreakCalculationContext: OfferingStudyBreakCalculationContext =
+      {
+        studyStartDate: "",
+        studyEndDate: "",
+        studyBreaks: [
+          {
+            breakStartDate: "",
+            breakEndDate: "2023-06-06",
+          },
+        ],
+      };
+
+    // Act
+    const calculatedStudyBreaksAndWeeks =
+      EducationProgramOfferingService.getCalculatedStudyBreaksAndWeeks(
+        offeringStudyBreakCalculationContext,
+      );
+
+    // Assert
+    expect(calculatedStudyBreaksAndWeeks).toEqual({
+      allowableStudyBreaksDaysAmount: NaN,
+      fundedStudyPeriodDays: NaN,
+      studyBreaks: [],
+      sumOfTotalEligibleBreakDays: 0,
+      sumOfTotalIneligibleBreakDays: 0,
+      totalDays: NaN,
+      totalFundedWeeks: NaN,
+      unfundedStudyPeriodDays: NaN,
+    });
+  });
+
+  it("Should not calculate study breaks counting start and end dates when end study break date is not available.", () => {
+    //Arrange
+    const offeringStudyBreakCalculationContext: OfferingStudyBreakCalculationContext =
+      {
+        studyStartDate: "",
+        studyEndDate: "",
+        studyBreaks: [
+          {
+            breakStartDate: "2023-06-06",
+            breakEndDate: "",
+          },
+        ],
+      };
+
+    // Act
+    const calculatedStudyBreaksAndWeeks =
+      EducationProgramOfferingService.getCalculatedStudyBreaksAndWeeks(
+        offeringStudyBreakCalculationContext,
+      );
+
+    // Assert
+    expect(calculatedStudyBreaksAndWeeks).toEqual({
+      allowableStudyBreaksDaysAmount: NaN,
+      fundedStudyPeriodDays: NaN,
+      studyBreaks: [],
+      sumOfTotalEligibleBreakDays: 0,
+      sumOfTotalIneligibleBreakDays: 0,
+      totalDays: NaN,
+      totalFundedWeeks: NaN,
+      unfundedStudyPeriodDays: NaN,
+    });
+  });
+
+  it("Should calculate funded periods study breaks when there are data available.", () => {
     //Arrange
     const offeringStudyBreakCalculationContext: OfferingStudyBreakCalculationContext =
       {
@@ -149,6 +215,54 @@ describe("EducationProgramOfferingService-getCalculatedStudyBreaksAndWeeks", () 
             breakStartDate: "2023-05-29",
             breakEndDate: "2023-06-06",
           },
+          {
+            breakStartDate: "2023-06-08",
+            breakEndDate: "2023-06-20",
+          },
+        ],
+      };
+
+    // Act
+    const calculatedStudyBreaksAndWeeks =
+      EducationProgramOfferingService.getCalculatedStudyBreaksAndWeeks(
+        offeringStudyBreakCalculationContext,
+      );
+
+    // Assert
+    expect(calculatedStudyBreaksAndWeeks).toEqual({
+      allowableStudyBreaksDaysAmount: 12.4,
+      fundedStudyPeriodDays: 114.4,
+      studyBreaks: [
+        {
+          breakDays: 9,
+          breakEndDate: "2023-06-06",
+          breakStartDate: "2023-05-29",
+          eligibleBreakDays: 9,
+          ineligibleBreakDays: 0,
+        },
+        {
+          breakDays: 13,
+          breakEndDate: "2023-06-20",
+          breakStartDate: "2023-06-08",
+          eligibleBreakDays: 13,
+          ineligibleBreakDays: 0,
+        },
+      ],
+      sumOfTotalEligibleBreakDays: 22,
+      sumOfTotalIneligibleBreakDays: 0,
+      totalDays: 124,
+      totalFundedWeeks: 17,
+      unfundedStudyPeriodDays: 9.6,
+    });
+  });
+
+  it("Should calculate eligible break days as a maximum of 21 days when a study break exceeds it.", () => {
+    //Arrange
+    const offeringStudyBreakCalculationContext: OfferingStudyBreakCalculationContext =
+      {
+        studyStartDate: "2023-05-29",
+        studyEndDate: "2023-09-29",
+        studyBreaks: [
           {
             breakStartDate: "2023-06-08",
             breakEndDate: "2023-06-30",
@@ -165,15 +279,8 @@ describe("EducationProgramOfferingService-getCalculatedStudyBreaksAndWeeks", () 
     // Assert
     expect(calculatedStudyBreaksAndWeeks).toEqual({
       allowableStudyBreaksDaysAmount: 12.4,
-      fundedStudyPeriodDays: 104.4,
+      fundedStudyPeriodDays: 113.4,
       studyBreaks: [
-        {
-          breakDays: 9,
-          breakEndDate: "2023-06-06",
-          breakStartDate: "2023-05-29",
-          eligibleBreakDays: 9,
-          ineligibleBreakDays: 0,
-        },
         {
           breakDays: 23,
           breakEndDate: "2023-06-30",
@@ -182,11 +289,11 @@ describe("EducationProgramOfferingService-getCalculatedStudyBreaksAndWeeks", () 
           ineligibleBreakDays: 2,
         },
       ],
-      sumOfTotalEligibleBreakDays: 30,
+      sumOfTotalEligibleBreakDays: 21,
       sumOfTotalIneligibleBreakDays: 2,
       totalDays: 124,
-      totalFundedWeeks: 15,
-      unfundedStudyPeriodDays: 19.6,
+      totalFundedWeeks: 17,
+      unfundedStudyPeriodDays: 10.6,
     });
   });
 });

--- a/sources/packages/backend/apps/api/src/services/education-program-offering/education-program-offering.service.ts
+++ b/sources/packages/backend/apps/api/src/services/education-program-offering/education-program-offering.service.ts
@@ -1260,6 +1260,7 @@ export class EducationProgramOfferingService extends RecordDataModelService<Educ
         newStudyBreak.breakDays = dateDifference(
           eachBreak.breakEndDate,
           eachBreak.breakStartDate,
+          true,
         );
         newStudyBreak.breakStartDate = eachBreak.breakStartDate;
         newStudyBreak.breakEndDate = eachBreak.breakEndDate;
@@ -1279,6 +1280,7 @@ export class EducationProgramOfferingService extends RecordDataModelService<Educ
     const totalDays = dateDifference(
       offering.studyEndDate,
       offering.studyStartDate,
+      true,
     );
 
     // Allowable amount of break days allowed.

--- a/sources/packages/backend/apps/api/src/services/education-program-offering/education-program-offering.service.ts
+++ b/sources/packages/backend/apps/api/src/services/education-program-offering/education-program-offering.service.ts
@@ -1260,7 +1260,6 @@ export class EducationProgramOfferingService extends RecordDataModelService<Educ
         newStudyBreak.breakDays = dateDifference(
           eachBreak.breakEndDate,
           eachBreak.breakStartDate,
-          true,
         );
         newStudyBreak.breakStartDate = eachBreak.breakStartDate;
         newStudyBreak.breakEndDate = eachBreak.breakEndDate;
@@ -1280,7 +1279,6 @@ export class EducationProgramOfferingService extends RecordDataModelService<Educ
     const totalDays = dateDifference(
       offering.studyEndDate,
       offering.studyStartDate,
-      true,
     );
 
     // Allowable amount of break days allowed.

--- a/sources/packages/backend/libs/utilities/src/date-utils.ts
+++ b/sources/packages/backend/libs/utilities/src/date-utils.ts
@@ -53,13 +53,16 @@ export const isAfter = (
  * Difference in days between endDate and startDate (endDate-startDate).
  * @param endDate end date.
  * @param startDate start date.
+ * @param inclusiveDiff whether it should consider start and end date as part of the calculation.
  * @returns the date difference in days.
  */
 export const dateDifference = (
   endDate: string | Date,
   startDate: string | Date,
+  inclusiveDiff?: boolean,
 ): number => {
-  return dayjs(endDate).diff(startDate, "days");
+  const diff = dayjs(endDate).diff(startDate, "days");
+  return inclusiveDiff ? diff + 1 : diff;
 };
 
 /**

--- a/sources/packages/backend/libs/utilities/src/date-utils.ts
+++ b/sources/packages/backend/libs/utilities/src/date-utils.ts
@@ -50,19 +50,16 @@ export const isAfter = (
 };
 
 /**
- * Difference in days between endDate and startDate (endDate-startDate).
+ * Difference in days between endDate and startDate (endDate-startDate) with start and end date inclusive.
  * @param endDate end date.
  * @param startDate start date.
- * @param inclusiveDiff whether it should consider start and end date as part of the calculation.
  * @returns the date difference in days.
  */
 export const dateDifference = (
   endDate: string | Date,
   startDate: string | Date,
-  inclusiveDiff?: boolean,
 ): number => {
-  const diff = dayjs(endDate).diff(startDate, "days");
-  return inclusiveDiff ? diff + 1 : diff;
+  return dayjs(endDate).diff(startDate, "days") + 1;
 };
 
 /**

--- a/sources/packages/forms/src/form-definitions/educationprogramoffering.json
+++ b/sources/packages/forms/src/form-definitions/educationprogramoffering.json
@@ -2771,7 +2771,7 @@
                       "requireDecimal": false,
                       "inputFormat": "plain",
                       "truncateMultipleSpaces": false,
-                      "calculateValue": "value = 0;\r\nif (row.breakStartDate && row.breakEndDate) {\r\n  const diffDays = moment(row.breakEndDate, \"YYYY-MM-DD\").diff(\r\n    moment(row.breakStartDate, \"YYYY-MM-DD\"),\r\n    \"days\"\r\n  );\r\n  value = Math.max(diffDays, 0);\r\n}\r\n",
+                      "calculateValue": "value = 0;\r\nif (row.breakStartDate && row.breakEndDate) {\r\n  const diffDays = moment(row.breakEndDate, \"YYYY-MM-DD\").diff(\r\n    moment(row.breakStartDate, \"YYYY-MM-DD\"),\r\n    \"days\"\r\n  ) + 1 ;\r\n  value = Math.max(diffDays, 0);\r\n}\r\n",
                       "calculateServer": true,
                       "validate": {
                         "required": true,


### PR DESCRIPTION
- Added 1 day to the calculation of `dateDifference` as all date periods will be calculated with start and end dates inclusive;
- Changed education program offering form to add 1 day in the calculated value for study break days;
- Added unit tests to check the calculation results for `getCalculatedStudyBreaksAndWeeks` method:
    √ Should calculate funded study period and total days when study start and end study dates are available. (4 ms)                                                                      
    √ Should not calculate funded study period days and total days when study start date is not available.                                                                                
    √ Should not calculate funded study period days and total days when study end date is not available. (1 ms)                                                                           
    √ Should calculate study breaks when start and end study break dates available. (1 ms)                                                                                                
    √ Should not calculate study breaks when start study break date is not available.                                                                                                     
    √ Should not calculate study breaks when end study break date is not available.                                                                                                       
    √ Should calculate eligible break days as a maximum of 21 days when a study break exceeds it.     