### PR TITLE
#1791 - Enable Assessments tab view and NOA view for Public Institution Users - Part 4 

### DIFF
--- a/sources/packages/backend/apps/api/src/route-controllers/assessment/_tests_/e2e/assessment.institutions.controller.getAssessmentAwardDetails.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/assessment/_tests_/e2e/assessment.institutions.controller.getAssessmentAwardDetails.e2e-spec.ts
@@ -96,11 +96,11 @@ describe("AssessmentInstitutionsController(e2e)-getAssessmentAwardDetails", () =
         disbursement.valueAmount;
       disbursementReceiptsValues.push(
         createFakeDisbursementReceiptValue(
-          { disbursementReceipt },
           {
             grantType: disbursement.valueCode,
             grantAmount: disbursement.valueAmount,
           },
+          { disbursementReceipt },
         ),
       );
     });

--- a/sources/packages/backend/apps/api/src/route-controllers/assessment/_tests_/e2e/assessment.institutions.controller.getRequestedAssessmentSummary.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/assessment/_tests_/e2e/assessment.institutions.controller.getRequestedAssessmentSummary.e2e-spec.ts
@@ -157,7 +157,7 @@ describe("AssessmentInstitutionsController(e2e)-getRequestedAssessmentSummary", 
         .expect(HttpStatus.OK)
         .expect([]);
 
-      // Checking the same scenario with the ministry user, to make sure that a fake offering change was created.
+      // Checking the same scenario with the ministry endpoint with a ministry user, to make sure that a fake offering change was created.
       // Arrange.
       const ministryEndpoint = `/aest/assessment/application/${application.id}/requests`;
       const ministryToken = await getAESTToken(

--- a/sources/packages/backend/apps/api/src/route-controllers/assessment/_tests_/e2e/assessment.institutions.controller.getRequestedAssessmentSummary.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/assessment/_tests_/e2e/assessment.institutions.controller.getRequestedAssessmentSummary.e2e-spec.ts
@@ -140,7 +140,6 @@ describe("AssessmentInstitutionsController(e2e)-getRequestedAssessmentSummary", 
       const offeringRequestOfferings = createFakeOfferingRequestChange({
         currentOffering: application.currentAssessment.offering,
       });
-      application.currentAssessment.offering = offeringRequestOfferings[0];
       await db.educationProgramOffering.save(offeringRequestOfferings);
       const endpoint = `/institutions/assessment/student/${student.id}/application/${application.id}/requests`;
       const institutionUserToken = await getInstitutionToken(

--- a/sources/packages/backend/apps/api/src/route-controllers/assessment/_tests_/e2e/assessment.institutions.controller.getRequestedAssessmentSummary.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/assessment/_tests_/e2e/assessment.institutions.controller.getRequestedAssessmentSummary.e2e-spec.ts
@@ -166,7 +166,7 @@ describe("AssessmentInstitutionsController(e2e)-getRequestedAssessmentSummary", 
 
       // Act/Assert
       await request(app.getHttpServer())
-        .get(ministryEndpoint)git add 
+        .get(ministryEndpoint)
         .auth(ministryToken, BEARER_AUTH_TYPE)
         .expect(HttpStatus.OK)
         .expect([

--- a/sources/packages/backend/apps/api/src/route-controllers/assessment/_tests_/e2e/assessment.institutions.controller.getRequestedAssessmentSummary.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/assessment/_tests_/e2e/assessment.institutions.controller.getRequestedAssessmentSummary.e2e-spec.ts
@@ -24,7 +24,6 @@ import {
 import {
   ApplicationStatus,
   AssessmentTriggerType,
-  EducationProgramOffering,
   Institution,
   InstitutionLocation,
   StudentAppealStatus,
@@ -108,7 +107,7 @@ describe("AssessmentInstitutionsController(e2e)-getRequestedAssessmentSummary", 
       ]);
   });
 
-  it.only(
+  it(
     "Should not get the 'offering change' assessment requests details in the request summary " +
       "for an eligible application when an eligible public institution user tries to access it and " +
       "student offering change is pending with the ministry.",

--- a/sources/packages/backend/apps/api/src/route-controllers/assessment/_tests_/e2e/assessment.institutions.controller.getRequestedAssessmentSummary.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/assessment/_tests_/e2e/assessment.institutions.controller.getRequestedAssessmentSummary.e2e-spec.ts
@@ -163,9 +163,10 @@ describe("AssessmentInstitutionsController(e2e)-getRequestedAssessmentSummary", 
       const ministryToken = await getAESTToken(
         AESTGroups.BusinessAdministrators,
       );
+
       // Act/Assert
       await request(app.getHttpServer())
-        .get(ministryEndpoint)
+        .get(ministryEndpoint)git add 
         .auth(ministryToken, BEARER_AUTH_TYPE)
         .expect(HttpStatus.OK)
         .expect([

--- a/sources/packages/backend/apps/api/src/route-controllers/assessment/assessment.aest.controller.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/assessment/assessment.aest.controller.ts
@@ -40,6 +40,9 @@ export class AssessmentAESTController extends BaseController {
   ): Promise<RequestAssessmentSummaryAPIOutDTO[]> {
     return this.assessmentControllerService.requestedStudentAssessmentSummary(
       applicationId,
+      {
+        showOfferingChange: true,
+      },
     );
   }
 

--- a/sources/packages/backend/apps/api/src/route-controllers/assessment/assessment.aest.controller.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/assessment/assessment.aest.controller.ts
@@ -41,7 +41,7 @@ export class AssessmentAESTController extends BaseController {
     return this.assessmentControllerService.requestedStudentAssessmentSummary(
       applicationId,
       {
-        showOfferingChange: true,
+        includeOfferingChanges: true,
       },
     );
   }

--- a/sources/packages/backend/apps/api/src/route-controllers/assessment/assessment.controller.service.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/assessment/assessment.controller.service.ts
@@ -322,7 +322,7 @@ export class AssessmentControllerService {
    * @param applicationId application id.
    * @param options options for request assessments,
    * - `studentId` student id.
-   * - `showOfferingChange` will decide weather to show assessment
+   * - `includeOfferingChanges` will decide whether to include assessment
    * request for offering change.
    * @returns assessment requests or exceptions for the student application.
    */
@@ -330,12 +330,11 @@ export class AssessmentControllerService {
     applicationId: number,
     options?: {
       studentId?: number;
-      showOfferingChange?: boolean;
+      includeOfferingChanges?: boolean;
     },
   ): Promise<RequestAssessmentSummaryAPIOutDTO[]> {
-    const showOfferingChange = options?.showOfferingChange ? true : false;
     const requestAssessmentSummary: RequestAssessmentSummaryAPIOutDTO[] = [];
-    if (showOfferingChange) {
+    if (options?.includeOfferingChanges) {
       const offeringChange =
         await this.educationProgramOfferingService.getOfferingRequestsByApplicationId(
           applicationId,

--- a/sources/packages/backend/apps/api/src/route-controllers/assessment/assessment.controller.service.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/assessment/assessment.controller.service.ts
@@ -320,32 +320,41 @@ export class AssessmentControllerService {
    * Get all pending and declined requests related to an application which would result
    * a new assessment when that request is approved.
    * @param applicationId application id.
-   * @param studentId student id.
+   * @param options options for request assessments,
+   * - `studentId` student id.
+   * - `showOfferingChange` will decide weather to show assessment
+   * request for offering change.
    * @returns assessment requests or exceptions for the student application.
    */
   async requestedStudentAssessmentSummary(
     applicationId: number,
-    studentId?: number,
+    options?: {
+      studentId?: number;
+      showOfferingChange?: boolean;
+    },
   ): Promise<RequestAssessmentSummaryAPIOutDTO[]> {
+    const showOfferingChange = options?.showOfferingChange ? true : false;
     const requestAssessmentSummary: RequestAssessmentSummaryAPIOutDTO[] = [];
-    const offeringChange =
-      await this.educationProgramOfferingService.getOfferingRequestsByApplicationId(
-        applicationId,
-        studentId,
-      );
-    if (offeringChange) {
-      requestAssessmentSummary.push({
-        id: offeringChange.id,
-        submittedDate: offeringChange.submittedDate,
-        status: offeringChange.offeringStatus,
-        requestType: RequestAssessmentTypeAPIOutDTO.OfferingRequest,
-        programId: offeringChange.educationProgram.id,
-      });
+    if (showOfferingChange) {
+      const offeringChange =
+        await this.educationProgramOfferingService.getOfferingRequestsByApplicationId(
+          applicationId,
+          options?.studentId,
+        );
+      if (offeringChange) {
+        requestAssessmentSummary.push({
+          id: offeringChange.id,
+          submittedDate: offeringChange.submittedDate,
+          status: offeringChange.offeringStatus,
+          requestType: RequestAssessmentTypeAPIOutDTO.OfferingRequest,
+          programId: offeringChange.educationProgram.id,
+        });
+      }
     }
     const applicationExceptions =
       await this.applicationExceptionService.getExceptionsByApplicationId(
         applicationId,
-        studentId,
+        options?.studentId,
         ApplicationExceptionStatus.Pending,
         ApplicationExceptionStatus.Declined,
       );
@@ -363,7 +372,7 @@ export class AssessmentControllerService {
     }
     const appeals = await this.getPendingAndDeniedAppeals(
       applicationId,
-      studentId,
+      options?.studentId,
     );
     return requestAssessmentSummary.concat(appeals);
   }

--- a/sources/packages/backend/apps/api/src/route-controllers/assessment/assessment.institutions.controller.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/assessment/assessment.institutions.controller.ts
@@ -49,7 +49,7 @@ export class AssessmentInstitutionsController extends BaseController {
   ): Promise<RequestAssessmentSummaryAPIOutDTO[]> {
     return this.assessmentControllerService.requestedStudentAssessmentSummary(
       applicationId,
-      studentId,
+      { studentId },
     );
   }
 

--- a/sources/packages/backend/libs/test-utils/src/factories/disbursement-receipt-value.ts
+++ b/sources/packages/backend/libs/test-utils/src/factories/disbursement-receipt-value.ts
@@ -1,26 +1,29 @@
 import { DisbursementReceipt, DisbursementReceiptValue } from "@sims/sims-db";
+import faker from "faker";
 
 /**
  * Create fake disbursement receipt value.
+ * @param initialValues initial values that need to assigned
+ * while creating a disbursement receipt value.
  * @param relations dependencies.
  * - `disbursementReceipt` related disbursement receipt.
- * @param options options
- * - `grantType` type of grant to be created.
- * - `grantAmount` grant amount to be created.
  * @returns disbursement receipt value.
  */
 export function createFakeDisbursementReceiptValue(
+  initialValues: Partial<DisbursementReceiptValue>,
   relations: {
     disbursementReceipt: DisbursementReceipt;
   },
-  options: {
-    grantType: string;
-    grantAmount: number;
-  },
 ): DisbursementReceiptValue {
   const disbursementReceiptValue = new DisbursementReceiptValue();
-  disbursementReceiptValue.grantType = options.grantType;
-  disbursementReceiptValue.grantAmount = options.grantAmount;
+  disbursementReceiptValue.grantType =
+    initialValues.grantType ?? faker.random.alpha({ count: 4 });
+  disbursementReceiptValue.grantAmount =
+    initialValues.grantAmount ??
+    faker.random.number({
+      min: 1000,
+      max: 9999,
+    });
   disbursementReceiptValue.disbursementReceipt = relations.disbursementReceipt;
   return disbursementReceiptValue;
 }

--- a/sources/packages/backend/libs/test-utils/src/factories/disbursement-receipt-value.ts
+++ b/sources/packages/backend/libs/test-utils/src/factories/disbursement-receipt-value.ts
@@ -3,8 +3,8 @@ import faker from "faker";
 
 /**
  * Create fake disbursement receipt value.
- * @param initialValues initial values that need to assigned
- * while creating a disbursement receipt value.
+ * @param initialValues initial values that need to be assigned
+ * while creating a fake disbursement receipt value.
  * @param relations dependencies.
  * - `disbursementReceipt` related disbursement receipt.
  * @returns disbursement receipt value.

--- a/sources/packages/backend/libs/test-utils/src/factories/offering-change-request.ts
+++ b/sources/packages/backend/libs/test-utils/src/factories/offering-change-request.ts
@@ -1,0 +1,32 @@
+import { EducationProgramOffering, OfferingStatus } from "@sims/sims-db";
+
+/**
+ * Create a fake offering request change.
+ * @param relations dependencies:
+ *  - `currentOffering` current offering, which is requested for the changed.
+ * @returns the current and requested offering.
+ */
+export function createFakeOfferingRequestChange(relations: {
+  currentOffering: EducationProgramOffering;
+}): EducationProgramOffering[] {
+  const now = new Date();
+  const requestedOfferingId = relations.currentOffering.id;
+  let requestedOffering = new EducationProgramOffering();
+  requestedOffering = relations.currentOffering;
+  delete requestedOffering.id;
+  requestedOffering.offeringStatus = OfferingStatus.ChangeAwaitingApproval;
+  requestedOffering.parentOffering =
+    relations.currentOffering.parentOffering ??
+    ({ id: requestedOfferingId } as EducationProgramOffering);
+  requestedOffering.precedingOffering = {
+    id: requestedOfferingId,
+  } as EducationProgramOffering;
+  requestedOffering.createdAt = now;
+
+  // Update the status and audit details of current offering.
+  const precedingOffering = new EducationProgramOffering();
+  precedingOffering.id = requestedOfferingId;
+  precedingOffering.offeringStatus = OfferingStatus.ChangeUnderReview;
+  precedingOffering.updatedAt = now;
+  return [precedingOffering, requestedOffering];
+}

--- a/sources/packages/backend/libs/test-utils/src/factories/offering-change-request.ts
+++ b/sources/packages/backend/libs/test-utils/src/factories/offering-change-request.ts
@@ -11,8 +11,7 @@ export function createFakeOfferingRequestChange(relations: {
 }): EducationProgramOffering[] {
   const now = new Date();
   const requestedOfferingId = relations.currentOffering.id;
-  let requestedOffering = new EducationProgramOffering();
-  requestedOffering = relations.currentOffering;
+  const requestedOffering = relations.currentOffering;
   delete requestedOffering.id;
   requestedOffering.offeringStatus = OfferingStatus.ChangeAwaitingApproval;
   requestedOffering.parentOffering =

--- a/sources/packages/backend/libs/test-utils/src/factories/offering-change-request.ts
+++ b/sources/packages/backend/libs/test-utils/src/factories/offering-change-request.ts
@@ -2,25 +2,27 @@ import { EducationProgramOffering, OfferingStatus } from "@sims/sims-db";
 
 /**
  * Create a fake offering request change.
- * @param relations dependencies:
- *  - `currentOffering` current offering, which is requested for the changed.
+ * @param options dependencies:
+ *  - `currentOffering` current offering, which is requested for the changed, which is
+ * already saved in the DB.
  * @returns the current and requested offering.
  */
-export function createFakeOfferingRequestChange(relations: {
+export function createFakeOfferingRequestChange(options: {
   currentOffering: EducationProgramOffering;
 }): EducationProgramOffering[] {
   const now = new Date();
-  const requestedOfferingId = relations.currentOffering.id;
-  const requestedOffering = relations.currentOffering;
+  const requestedOfferingId = options.currentOffering.id;
+  const requestedOffering = options.currentOffering;
   delete requestedOffering.id;
   requestedOffering.offeringStatus = OfferingStatus.ChangeAwaitingApproval;
   requestedOffering.parentOffering =
-    relations.currentOffering.parentOffering ??
+    options.currentOffering.parentOffering ??
     ({ id: requestedOfferingId } as EducationProgramOffering);
   requestedOffering.precedingOffering = {
     id: requestedOfferingId,
   } as EducationProgramOffering;
   requestedOffering.createdAt = now;
+  requestedOffering.submittedDate = now;
 
   // Update the status and audit details of current offering.
   const precedingOffering = new EducationProgramOffering();

--- a/sources/packages/backend/libs/test-utils/src/factories/offering-change-request.ts
+++ b/sources/packages/backend/libs/test-utils/src/factories/offering-change-request.ts
@@ -2,7 +2,7 @@ import { EducationProgramOffering, OfferingStatus } from "@sims/sims-db";
 
 /**
  * Create a fake offering request change.
- * @param options dependencies:
+ * @param options options:
  *  - `currentOffering` current offering, which is requested for the changed, which is
  * already saved in the DB.
  * @returns the current and requested offering.

--- a/sources/packages/web/src/views/institution/student/applicationDetails/InstitutionAssessmentsSummary.vue
+++ b/sources/packages/web/src/views/institution/student/applicationDetails/InstitutionAssessmentsSummary.vue
@@ -17,7 +17,7 @@
     <history-assessment
       :applicationId="applicationId"
       :studentId="studentId"
-      :viewRequestTypes="assessmentRequestTypes"
+      :viewRequestTypes="assessmentRequestViewTypes"
       @viewStudentAppeal="goToStudentAppeal"
       @viewAssessment="gotToViewAssessment"
       @viewApplicationException="goToApplicationException"
@@ -51,10 +51,8 @@ export default defineComponent({
   setup(props) {
     const router = useRouter();
     // The assessment trigger types for which the request form must be visible by default.
-    const assessmentRequestTypes = [
+    const assessmentRequestViewTypes = [
       AssessmentTriggerType.StudentAppeal,
-      AssessmentTriggerType.OfferingChange,
-      AssessmentTriggerType.ScholasticStandingChange,
       AssessmentTriggerType.OriginalAssessment,
     ];
 
@@ -103,7 +101,7 @@ export default defineComponent({
       goToStudentAppeal,
       gotToViewAssessment,
       goToApplicationException,
-      assessmentRequestTypes,
+      assessmentRequestViewTypes,
       backRoute,
     };
   },


### PR DESCRIPTION
1 - Offering change and scholastic change related changes and related e2e
2 -  @andrewsignori-aot comment from my previous is addressed, https://github.com/bcgov/SIMS/pull/1952#discussion_r1207267373\
Screenshots:
1. Ministry view with offering change,
![image](https://github.com/bcgov/SIMS/assets/77353155/71721e6b-2a95-44eb-be56-153159e7cace)
Institutions view with offering change
![image](https://github.com/bcgov/SIMS/assets/77353155/a032921d-8ae8-4001-b153-4b168f56d763)
2-  Ministry view with scholastic standing.
![image](https://github.com/bcgov/SIMS/assets/77353155/c05034b5-66fb-499d-90d6-3a281b62d549)
Institutions view scholastic standing, 
![image](https://github.com/bcgov/SIMS/assets/77353155/ce0948b1-5837-42a2-9733-9d32b60ccc7c)
3- new TC,
![image](https://github.com/bcgov/SIMS/assets/77353155/ee41ef98-3c73-4564-8eca-f8b6b298bdcf)

Next PR:
1. I will be addressing @dheepak-aot comment added in my last PR, https://github.com/bcgov/SIMS/pull/1952#discussion_r1207444962