### PR TITLE
#1791 - Enable Assessments tab view and NOA view for Public Institution Users - Part 5

### DIFF
--- a/sources/packages/backend/apps/api/src/auth/decorators/institution/institution-student-data-access.decorator.ts
+++ b/sources/packages/backend/apps/api/src/auth/decorators/institution/institution-student-data-access.decorator.ts
@@ -22,5 +22,5 @@ export const HasStudentDataAccess = (
 
 export interface HasStudentDataAccessParam {
   studentIdParamName: string;
-  applicationIdParamName: string;
+  applicationIdParamName?: string;
 }

--- a/sources/packages/backend/apps/api/src/auth/decorators/institution/institution-student-data-access.decorator.ts
+++ b/sources/packages/backend/apps/api/src/auth/decorators/institution/institution-student-data-access.decorator.ts
@@ -8,13 +8,19 @@ export const INSTITUTION_HAS_STUDENT_DATA_ACCESS_KEY =
 
 /**
  * Provide context that it's consumer must be
- * validated to have access to data of given student.
+ * validated to have access to the student
+ * and their application if present.
  */
 export const HasStudentDataAccess = (
   studentIdParamName: string,
   applicationIdParamName?: string,
 ) =>
-  SetMetadata(INSTITUTION_HAS_STUDENT_DATA_ACCESS_KEY, [
+  SetMetadata(INSTITUTION_HAS_STUDENT_DATA_ACCESS_KEY, {
     studentIdParamName,
     applicationIdParamName,
-  ]);
+  });
+
+export interface HasStudentDataAccessParam {
+  studentIdParamName: string;
+  applicationIdParamName: string;
+}

--- a/sources/packages/backend/apps/api/src/auth/decorators/institution/institution-student-data-access.decorator.ts
+++ b/sources/packages/backend/apps/api/src/auth/decorators/institution/institution-student-data-access.decorator.ts
@@ -10,5 +10,11 @@ export const INSTITUTION_HAS_STUDENT_DATA_ACCESS_KEY =
  * Provide context that it's consumer must be
  * validated to have access to data of given student.
  */
-export const HasStudentDataAccess = (studentIdParamName: string) =>
-  SetMetadata(INSTITUTION_HAS_STUDENT_DATA_ACCESS_KEY, studentIdParamName);
+export const HasStudentDataAccess = (
+  studentIdParamName: string,
+  applicationIdParamName?: string,
+) =>
+  SetMetadata(INSTITUTION_HAS_STUDENT_DATA_ACCESS_KEY, [
+    studentIdParamName,
+    applicationIdParamName,
+  ]);

--- a/sources/packages/backend/apps/api/src/auth/guards/institution/institution-student-data-access.guard.ts
+++ b/sources/packages/backend/apps/api/src/auth/guards/institution/institution-student-data-access.guard.ts
@@ -3,6 +3,7 @@ import {
   CanActivate,
   ExecutionContext,
   ForbiddenException,
+  BadRequestException,
 } from "@nestjs/common";
 import { Reflector } from "@nestjs/core";
 import { IInstitutionUserToken } from "../..";
@@ -37,8 +38,22 @@ export class InstitutionStudentDataAccessGuard implements CanActivate {
       params: Record<string, string>;
     } = context.switchToHttp().getRequest();
     if (user?.isActive) {
-      const studentId = +params.studentId;
-      const applicationId = +params.applicationId;
+      let applicationId = undefined;
+      const studentId =
+        +params[institutionStudentDataAccessParam.studentIdParamName];
+      if (!studentId) {
+        // Student id not found in the url.
+        throw new BadRequestException("Student id not found in the url.");
+      }
+      if (institutionStudentDataAccessParam.applicationIdParamName) {
+        applicationId =
+          +params[institutionStudentDataAccessParam.applicationIdParamName];
+        if (!applicationId) {
+          // Application id not found in the url.
+          throw new BadRequestException("Application id not found in the url.");
+        }
+      }
+
       const hasStudentDataAccess =
         await this.institutionService.hasStudentDataAccess(
           user.authorizations.institutionId,

--- a/sources/packages/backend/apps/api/src/auth/guards/institution/institution-student-data-access.guard.ts
+++ b/sources/packages/backend/apps/api/src/auth/guards/institution/institution-student-data-access.guard.ts
@@ -6,7 +6,10 @@ import {
 } from "@nestjs/common";
 import { Reflector } from "@nestjs/core";
 import { IInstitutionUserToken } from "../..";
-import { INSTITUTION_HAS_STUDENT_DATA_ACCESS_KEY } from "../../decorators";
+import {
+  HasStudentDataAccessParam,
+  INSTITUTION_HAS_STUDENT_DATA_ACCESS_KEY,
+} from "../../decorators";
 import { InstitutionService } from "../../../services";
 
 @Injectable()
@@ -17,13 +20,12 @@ export class InstitutionStudentDataAccessGuard implements CanActivate {
   ) {}
 
   async canActivate(context: ExecutionContext): Promise<boolean> {
-    const institutionStudentDataAccessParam = this.reflector.getAllAndOverride<
-      string[]
-    >(INSTITUTION_HAS_STUDENT_DATA_ACCESS_KEY, [
-      context.getHandler(),
-      context.getClass(),
-    ]);
-    if (!institutionStudentDataAccessParam?.length) {
+    const institutionStudentDataAccessParam =
+      this.reflector.getAllAndOverride<HasStudentDataAccessParam>(
+        INSTITUTION_HAS_STUDENT_DATA_ACCESS_KEY,
+        [context.getHandler(), context.getClass()],
+      );
+    if (!institutionStudentDataAccessParam) {
       return true;
     }
 

--- a/sources/packages/backend/apps/api/src/auth/guards/institution/institution-student-data-access.guard.ts
+++ b/sources/packages/backend/apps/api/src/auth/guards/institution/institution-student-data-access.guard.ts
@@ -17,13 +17,13 @@ export class InstitutionStudentDataAccessGuard implements CanActivate {
   ) {}
 
   async canActivate(context: ExecutionContext): Promise<boolean> {
-    const institutionStudentDataAccessParam =
-      this.reflector.getAllAndOverride<string>(
-        INSTITUTION_HAS_STUDENT_DATA_ACCESS_KEY,
-        [context.getHandler(), context.getClass()],
-      );
-
-    if (!institutionStudentDataAccessParam) {
+    const institutionStudentDataAccessParam = this.reflector.getAllAndOverride<
+      string[]
+    >(INSTITUTION_HAS_STUDENT_DATA_ACCESS_KEY, [
+      context.getHandler(),
+      context.getClass(),
+    ]);
+    if (!institutionStudentDataAccessParam?.length) {
       return true;
     }
 
@@ -34,14 +34,16 @@ export class InstitutionStudentDataAccessGuard implements CanActivate {
       user: IInstitutionUserToken;
       params: Record<string, string>;
     } = context.switchToHttp().getRequest();
-
     if (user?.isActive) {
-      const studentId = +params[institutionStudentDataAccessParam];
+      const studentId = +params.studentId;
+      const applicationId = +params.applicationId;
       const hasStudentDataAccess =
         await this.institutionService.hasStudentDataAccess(
           user.authorizations.institutionId,
           studentId,
+          { applicationId },
         );
+
       if (hasStudentDataAccess) {
         return true;
       }

--- a/sources/packages/backend/apps/api/src/route-controllers/application-exception/_tests_/e2e/application-exception.institution.controller.getException.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/application-exception/_tests_/e2e/application-exception.institution.controller.getException.e2e-spec.ts
@@ -54,7 +54,7 @@ describe("ApplicationExceptionInstitutionsController(e2e)-getException", () => {
       );
       const applicationException = application.applicationException;
 
-      const endpoint = `/institutions/application-exception/student/${application.student.id}/exception/${applicationException.id}`;
+      const endpoint = `/institutions/application-exception/student/${application.student.id}/application/${application.id}/exception/${applicationException.id}`;
       const institutionUserToken = await getInstitutionToken(
         InstitutionTokenTypes.CollegeFUser,
       );
@@ -96,7 +96,7 @@ describe("ApplicationExceptionInstitutionsController(e2e)-getException", () => {
         { applicationExceptionStatus: ApplicationExceptionStatus.Approved },
       );
 
-    const endpoint = `/institutions/application-exception/student/${application.student.id}/exception/${collegeCApplication.applicationException.id}`;
+    const endpoint = `/institutions/application-exception/student/${application.student.id}/application/${application.id}/exception/${collegeCApplication.applicationException.id}`;
     const institutionUserToken = await getInstitutionToken(
       InstitutionTokenTypes.CollegeFUser,
     );
@@ -129,7 +129,7 @@ describe("ApplicationExceptionInstitutionsController(e2e)-getException", () => {
     const collegeCInstitutionUserToken = await getInstitutionToken(
       InstitutionTokenTypes.CollegeCUser,
     );
-    const endpoint = `/institutions/application-exception/student/${student.id}/exception/9999999`;
+    const endpoint = `/institutions/application-exception/student/${student.id}/application/${collegeCApplication.id}/exception/9999999`;
 
     // Act/Assert
     await request(app.getHttpServer())
@@ -152,7 +152,7 @@ describe("ApplicationExceptionInstitutionsController(e2e)-getException", () => {
       InstitutionTokenTypes.CollegeFUser,
     );
 
-    const endpoint = `/institutions/application-exception/student/${student.id}/exception/9999999`;
+    const endpoint = `/institutions/application-exception/student/${student.id}/application/9999999/exception/9999999`;
 
     // Act/Assert
     await request(app.getHttpServer())

--- a/sources/packages/backend/apps/api/src/route-controllers/application-exception/application-exception.controller.service.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/application-exception/application-exception.controller.service.ts
@@ -18,6 +18,7 @@ export class ApplicationExceptionControllerService {
    * @param exceptionId exception to be retrieved.
    * @param options options
    * - `studentId` student id.
+   * - `applicationId` application id.
    * - `assessDetails`, if true, will return access details.
    * @returns student application exception information.
    */
@@ -29,6 +30,7 @@ export class ApplicationExceptionControllerService {
     exceptionId: number,
     options?: {
       studentId?: number;
+      applicationId?: number;
       assessDetails?: boolean;
     },
   ): Promise<T> {
@@ -36,6 +38,7 @@ export class ApplicationExceptionControllerService {
       await this.applicationExceptionService.getExceptionDetails(
         exceptionId,
         options?.studentId,
+        options?.applicationId,
       );
     if (!applicationException) {
       throw new NotFoundException("Student application exception not found.");

--- a/sources/packages/backend/apps/api/src/route-controllers/application-exception/application-exception.controller.service.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/application-exception/application-exception.controller.service.ts
@@ -35,11 +35,10 @@ export class ApplicationExceptionControllerService {
     },
   ): Promise<T> {
     const applicationException =
-      await this.applicationExceptionService.getExceptionDetails(
-        exceptionId,
-        options?.studentId,
-        options?.applicationId,
-      );
+      await this.applicationExceptionService.getExceptionDetails(exceptionId, {
+        studentId: options?.studentId,
+        applicationId: options?.applicationId,
+      });
     if (!applicationException) {
       throw new NotFoundException("Student application exception not found.");
     }

--- a/sources/packages/backend/apps/api/src/route-controllers/application-exception/application-exception.institutions.controller.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/application-exception/application-exception.institutions.controller.ts
@@ -17,7 +17,7 @@ import { ApplicationExceptionControllerService } from "./application-exception.c
 @AllowAuthorizedParty(AuthorizedParties.institution)
 @Controller("application-exception")
 @IsBCPublicInstitution()
-@HasStudentDataAccess("studentId")
+@HasStudentDataAccess("studentId", "applicationId")
 @ApiTags(`${ClientTypeBaseRoute.Institution}-application-exception`)
 export class ApplicationExceptionInstitutionsController extends BaseController {
   constructor(
@@ -29,20 +29,22 @@ export class ApplicationExceptionInstitutionsController extends BaseController {
   /**
    * Get a student application exception of a student.
    * @param studentId student id.
+   * @param applicationId application id.
    * @param exceptionId exception to be retrieved.
    * @returns student application exception information.
    */
-  @Get("student/:studentId/exception/:exceptionId")
+  @Get("student/:studentId/applicationId/:applicationId/exception/:exceptionId")
   @ApiNotFoundResponse({
     description: "Student application exception not found.",
   })
   async getException(
     @Param("studentId", ParseIntPipe) studentId: number,
+    @Param("applicationId", ParseIntPipe) applicationId: number,
     @Param("exceptionId", ParseIntPipe) exceptionId: number,
   ): Promise<ApplicationExceptionAPIOutDTO> {
     return this.applicationExceptionControllerService.getExceptionDetails<ApplicationExceptionAPIOutDTO>(
       exceptionId,
-      { studentId },
+      { studentId, applicationId },
     );
   }
 }

--- a/sources/packages/backend/apps/api/src/route-controllers/application-exception/application-exception.institutions.controller.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/application-exception/application-exception.institutions.controller.ts
@@ -33,7 +33,7 @@ export class ApplicationExceptionInstitutionsController extends BaseController {
    * @param exceptionId exception to be retrieved.
    * @returns student application exception information.
    */
-  @Get("student/:studentId/applicationId/:applicationId/exception/:exceptionId")
+  @Get("student/:studentId/application/:applicationId/exception/:exceptionId")
   @ApiNotFoundResponse({
     description: "Student application exception not found.",
   })

--- a/sources/packages/backend/apps/api/src/route-controllers/assessment/_tests_/e2e/assessment.institutions.controller.getAssessmentAwardDetails.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/assessment/_tests_/e2e/assessment.institutions.controller.getAssessmentAwardDetails.e2e-spec.ts
@@ -115,7 +115,7 @@ describe("AssessmentInstitutionsController(e2e)-getAssessmentAwardDetails", () =
       ] = disbursementReceiptsValue.grantAmount;
     });
 
-    const endpoint = `/institutions/assessment/student/${student.id}/assessment/${assessment.id}/award`;
+    const endpoint = `/institutions/assessment/student/${student.id}/application/${application.id}/assessment/${assessment.id}/award`;
     const institutionUserToken = await getInstitutionToken(
       InstitutionTokenTypes.CollegeFUser,
     );
@@ -172,7 +172,7 @@ describe("AssessmentInstitutionsController(e2e)-getAssessmentAwardDetails", () =
       },
     );
     await db.msfaaNumber.save(currentMSFAA);
-    await saveFakeApplicationDisbursements(db.dataSource, {
+    const application = await saveFakeApplicationDisbursements(db.dataSource, {
       institution: collegeF,
       institutionLocation: collegeFLocation,
       student,
@@ -183,7 +183,7 @@ describe("AssessmentInstitutionsController(e2e)-getAssessmentAwardDetails", () =
       InstitutionTokenTypes.CollegeFUser,
     );
 
-    const endpoint = `/institutions/assessment/student/${student.id}/assessment/9999999/award`;
+    const endpoint = `/institutions/assessment/student/${student.id}/application/${application.id}/assessment/9999999/award`;
 
     // Act/Assert
     await request(app.getHttpServer())
@@ -213,7 +213,7 @@ describe("AssessmentInstitutionsController(e2e)-getAssessmentAwardDetails", () =
     const collegeCInstitutionUserToken = await getInstitutionToken(
       InstitutionTokenTypes.CollegeCUser,
     );
-    const endpoint = `/institutions/assessment/student/${student.id}/assessment/9999999/award`;
+    const endpoint = `/institutions/assessment/student/${student.id}/application/${collegeCApplication.id}/assessment/9999999/award`;
 
     // Act/Assert
     await request(app.getHttpServer())
@@ -236,7 +236,7 @@ describe("AssessmentInstitutionsController(e2e)-getAssessmentAwardDetails", () =
       InstitutionTokenTypes.CollegeFUser,
     );
 
-    const endpoint = `/institutions/assessment/student/${student.id}/assessment/9999999/award`;
+    const endpoint = `/institutions/assessment/student/${student.id}/application/9999999/assessment/9999999/award`;
 
     // Act/Assert
     await request(app.getHttpServer())

--- a/sources/packages/backend/apps/api/src/route-controllers/assessment/_tests_/e2e/assessment.institutions.controller.getAssessmentNOA.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/assessment/_tests_/e2e/assessment.institutions.controller.getAssessmentNOA.e2e-spec.ts
@@ -81,7 +81,7 @@ describe("AssessmentInstitutionsController(e2e)-getAssessmentNOA", () => {
         disbursement.valueAmount;
     });
 
-    const endpoint = `/institutions/assessment/student/${student.id}/assessment/${assessment.id}/noa`;
+    const endpoint = `/institutions/assessment/student/${student.id}/application/${application.id}/assessment/${assessment.id}/noa`;
     const institutionUserToken = await getInstitutionToken(
       InstitutionTokenTypes.CollegeFUser,
     );
@@ -149,7 +149,7 @@ describe("AssessmentInstitutionsController(e2e)-getAssessmentNOA", () => {
     application.currentAssessment.noaApprovalStatus = AssessmentStatus.required;
     application.currentAssessment.assessmentData = null;
     await db.application.save(application);
-    const endpoint = `/institutions/assessment/student/${student.id}/assessment/${application.currentAssessment.id}/noa`;
+    const endpoint = `/institutions/assessment/student/${student.id}/application/${application.id}/assessment/${application.currentAssessment.id}/noa`;
     const institutionUserToken = await getInstitutionToken(
       InstitutionTokenTypes.CollegeFUser,
     );
@@ -177,14 +177,14 @@ describe("AssessmentInstitutionsController(e2e)-getAssessmentNOA", () => {
       },
     );
     await db.msfaaNumber.save(currentMSFAA);
-    await saveFakeApplicationDisbursements(db.dataSource, {
+    const application = await saveFakeApplicationDisbursements(db.dataSource, {
       institution: collegeF,
       institutionLocation: collegeFLocation,
       student,
       msfaaNumber: currentMSFAA,
     });
 
-    const endpoint = `/institutions/assessment/student/${student.id}/assessment/9999999/noa`;
+    const endpoint = `/institutions/assessment/student/${student.id}/application/${application.id}/assessment/9999999/noa`;
     const institutionUserToken = await getInstitutionToken(
       InstitutionTokenTypes.CollegeFUser,
     );
@@ -217,7 +217,7 @@ describe("AssessmentInstitutionsController(e2e)-getAssessmentNOA", () => {
     const collegeCInstitutionUserToken = await getInstitutionToken(
       InstitutionTokenTypes.CollegeCUser,
     );
-    const endpoint = `/institutions/assessment/student/${student.id}/assessment/9999999/noa`;
+    const endpoint = `/institutions/assessment/student/${student.id}/application/${collegeCApplication.id}/assessment/9999999/noa`;
 
     // Act/Assert
     await request(app.getHttpServer())
@@ -240,7 +240,7 @@ describe("AssessmentInstitutionsController(e2e)-getAssessmentNOA", () => {
       InstitutionTokenTypes.CollegeFUser,
     );
 
-    const endpoint = `/institutions/assessment/student/${student.id}/assessment/9999999/noa`;
+    const endpoint = `/institutions/assessment/student/${student.id}/application/9999999/assessment/9999999/noa`;
 
     // Act/Assert
     await request(app.getHttpServer())

--- a/sources/packages/backend/apps/api/src/route-controllers/assessment/assessment.controller.service.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/assessment/assessment.controller.service.ts
@@ -154,10 +154,11 @@ export class AssessmentControllerService {
    * Get estimated and actual(if present) award details of an assessment.
    * @param assessmentId assessment to which awards details belong to.
    * @param includeDocumentNumber when true document number is mapped
-   * to disbursement dynamic data.\
+   * to disbursement dynamic data.
    * @param options options,
    * - `studentId` studentId student to whom the award details belong to.
-   * - `applicationId` applications id.
+   * - `applicationId` application is used for authorization purposes to
+   * ensure that a user has access to the specific application data.
    * @returns estimated and actual award details.
    */
   async getAssessmentAwardDetails(

--- a/sources/packages/backend/apps/api/src/route-controllers/assessment/assessment.controller.service.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/assessment/assessment.controller.service.ts
@@ -60,8 +60,7 @@ export class AssessmentControllerService {
   ): Promise<AssessmentNOAAPIOutDTO> {
     const assessment = await this.assessmentService.getAssessmentForNOA(
       assessmentId,
-      options?.studentId,
-      options?.applicationId,
+      { studentId: options?.studentId, applicationId: options?.applicationId },
     );
 
     if (!assessment) {
@@ -171,8 +170,7 @@ export class AssessmentControllerService {
   ): Promise<AwardDetailsAPIOutDTO> {
     const assessment = await this.assessmentService.getAssessmentForNOA(
       assessmentId,
-      options?.studentId,
-      options?.applicationId,
+      options,
     );
 
     if (!assessment) {
@@ -190,8 +188,7 @@ export class AssessmentControllerService {
       const disbursementReceipts =
         await this.disbursementReceiptService.getDisbursementReceiptByAssessment(
           assessmentId,
-          options?.studentId,
-          options?.applicationId,
+          options,
         );
       if (disbursementReceipts.length) {
         finalAward = this.populateDisbursementReceiptAwardValues(

--- a/sources/packages/backend/apps/api/src/route-controllers/assessment/assessment.controller.service.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/assessment/assessment.controller.service.ts
@@ -46,6 +46,7 @@ export class AssessmentControllerService {
    * @param assessmentId assessment id to be retrieved.
    * @param options for NOA.
    * - `studentId` optional student for authorization when needed.
+   * - `applicationId` application id,
    * - `maskMSFAA` mask MSFAA or not.
    * @returns notice of assessment data.
    */
@@ -53,12 +54,14 @@ export class AssessmentControllerService {
     assessmentId: number,
     options?: {
       studentId?: number;
+      applicationId?: number;
       maskMSFAA?: boolean;
     },
   ): Promise<AssessmentNOAAPIOutDTO> {
     const assessment = await this.assessmentService.getAssessmentForNOA(
       assessmentId,
       options?.studentId,
+      options?.applicationId,
     );
 
     if (!assessment) {
@@ -151,18 +154,24 @@ export class AssessmentControllerService {
    * Get estimated and actual(if present) award details of an assessment.
    * @param assessmentId assessment to which awards details belong to.
    * @param includeDocumentNumber when true document number is mapped
-   * to disbursement dynamic data.
-   * @param studentId studentId student to whom the award details belong to.
+   * to disbursement dynamic data.\
+   * @param options options,
+   * - `studentId` studentId student to whom the award details belong to.
+   * - `applicationId` applications id.
    * @returns estimated and actual award details.
    */
   async getAssessmentAwardDetails(
     assessmentId: number,
     includeDocumentNumber = false,
-    studentId?: number,
+    options?: {
+      studentId?: number;
+      applicationId?: number;
+    },
   ): Promise<AwardDetailsAPIOutDTO> {
     const assessment = await this.assessmentService.getAssessmentForNOA(
       assessmentId,
-      studentId,
+      options?.studentId,
+      options?.applicationId,
     );
 
     if (!assessment) {
@@ -180,7 +189,8 @@ export class AssessmentControllerService {
       const disbursementReceipts =
         await this.disbursementReceiptService.getDisbursementReceiptByAssessment(
           assessmentId,
-          studentId,
+          options?.studentId,
+          options?.applicationId,
         );
       if (disbursementReceipts.length) {
         finalAward = this.populateDisbursementReceiptAwardValues(

--- a/sources/packages/backend/apps/api/src/route-controllers/assessment/assessment.institutions.controller.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/assessment/assessment.institutions.controller.ts
@@ -26,7 +26,7 @@ import { AssessmentControllerService } from "..";
 @AllowAuthorizedParty(AuthorizedParties.institution)
 @Controller("assessment")
 @IsBCPublicInstitution()
-@HasStudentDataAccess("studentId")
+@HasStudentDataAccess("studentId", "applicationId")
 @ApiTags(`${ClientTypeBaseRoute.Institution}-assessment`)
 export class AssessmentInstitutionsController extends BaseController {
   constructor(
@@ -77,10 +77,13 @@ export class AssessmentInstitutionsController extends BaseController {
   /**
    * Get the NOA values for a student application on a particular assessment.
    * @param studentId, student id.
+   * @param applicationId, application id.
    * @param assessmentId assessment id to get the NOA values.
    * @returns NOA and application data.
    */
-  @Get("student/:studentId/assessment/:assessmentId/noa")
+  @Get(
+    "student/:studentId/application/:applicationId/assessment/:assessmentId/noa",
+  )
   @ApiNotFoundResponse({
     description: "Assessment id not found.",
   })
@@ -89,31 +92,37 @@ export class AssessmentInstitutionsController extends BaseController {
   })
   async getAssessmentNOA(
     @Param("studentId", ParseIntPipe) studentId: number,
+    @Param("applicationId", ParseIntPipe) applicationId: number,
     @Param("assessmentId", ParseIntPipe) assessmentId: number,
   ): Promise<AssessmentNOAAPIOutDTO> {
     return this.assessmentControllerService.getAssessmentNOA(assessmentId, {
       studentId: studentId,
+      applicationId,
     });
   }
 
   /**
    * Get estimated and actual(if present) award details of an assessment.
    * @param studentId, student id.
+   * @param applicationId, application id.
    * @param assessmentId assessment to which awards details belong to.
    * @returns estimated and actual award details.
    */
-  @Get("student/:studentId/assessment/:assessmentId/award")
+  @Get(
+    "student/:studentId/application/:applicationId/assessment/:assessmentId/award",
+  )
   @ApiNotFoundResponse({
     description: "Assessment not found.",
   })
   async getAssessmentAwardDetails(
     @Param("studentId", ParseIntPipe) studentId: number,
+    @Param("applicationId", ParseIntPipe) applicationId: number,
     @Param("assessmentId", ParseIntPipe) assessmentId: number,
   ): Promise<AwardDetailsAPIOutDTO> {
     return this.assessmentControllerService.getAssessmentAwardDetails(
       assessmentId,
       true,
-      studentId,
+      { studentId, applicationId },
     );
   }
 }

--- a/sources/packages/backend/apps/api/src/route-controllers/assessment/assessment.students.controller.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/assessment/assessment.students.controller.ts
@@ -117,7 +117,7 @@ export class AssessmentStudentsController extends BaseController {
     return this.assessmentControllerService.getAssessmentAwardDetails(
       assessmentId,
       false,
-      userToken.studentId,
+      { studentId: userToken.studentId },
     );
   }
 

--- a/sources/packages/backend/apps/api/src/route-controllers/student-appeal/_tests_/e2e/student-appeal.institutions.controller.getStudentAppealWithRequests.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/student-appeal/_tests_/e2e/student-appeal.institutions.controller.getStudentAppealWithRequests.e2e-spec.ts
@@ -83,7 +83,7 @@ describe("StudentAppealInstitutionsController(e2e)-getStudentAppealWithRequests"
     });
     await db.studentAppeal.save(appeal);
 
-    const endpoint = `/institutions/appeal/student/${application.student.id}/appeal/${appeal.id}/requests`;
+    const endpoint = `/institutions/appeal/student/${application.student.id}/application/${application.id}/appeal/${appeal.id}/requests`;
 
     const institutionUserToken = await getInstitutionToken(
       InstitutionTokenTypes.CollegeFUser,
@@ -131,7 +131,7 @@ describe("StudentAppealInstitutionsController(e2e)-getStudentAppealWithRequests"
       { applicationStatus: ApplicationStatus.Completed },
     );
 
-    const endpoint = `/institutions/appeal/student/${application.student.id}/appeal/9999999/requests`;
+    const endpoint = `/institutions/appeal/student/${application.student.id}/application/${application.id}/appeal/9999999/requests`;
     const institutionUserToken = await getInstitutionToken(
       InstitutionTokenTypes.CollegeFUser,
     );
@@ -164,7 +164,7 @@ describe("StudentAppealInstitutionsController(e2e)-getStudentAppealWithRequests"
     const collegeCInstitutionUserToken = await getInstitutionToken(
       InstitutionTokenTypes.CollegeCUser,
     );
-    const endpoint = `/institutions/appeal/student/${student.id}/appeal/9999999/requests`;
+    const endpoint = `/institutions/appeal/student/${student.id}/application/${collegeCApplication.id}/appeal/9999999/requests`;
 
     // Act/Assert
     await request(app.getHttpServer())
@@ -187,7 +187,7 @@ describe("StudentAppealInstitutionsController(e2e)-getStudentAppealWithRequests"
       InstitutionTokenTypes.CollegeFUser,
     );
 
-    const endpoint = `/institutions/appeal/student/${student.id}/appeal/9999999/requests`;
+    const endpoint = `/institutions/appeal/student/${student.id}/application/9999999/appeal/9999999/requests`;
 
     // Act/Assert
     await request(app.getHttpServer())

--- a/sources/packages/backend/apps/api/src/route-controllers/student-appeal/student-appeal.controller.service.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/student-appeal/student-appeal.controller.service.ts
@@ -16,6 +16,7 @@ export class StudentAppealControllerService {
    * @param appealId appeal id to be retrieved.
    * @param options options
    * - `studentId` student id.
+   * - `applicationId`, application id.
    * - `assessDetails`, if true, will return access details.
    * @returns the student appeal and its requests.
    */
@@ -27,6 +28,7 @@ export class StudentAppealControllerService {
     appealId: number,
     options?: {
       studentId?: number;
+      applicationId?: number;
       assessDetails?: boolean;
     },
   ): Promise<StudentAppealAPIOutDTO<T>> {
@@ -34,6 +36,7 @@ export class StudentAppealControllerService {
       await this.studentAppealService.getAppealAndRequestsById(
         appealId,
         options?.studentId,
+        options?.applicationId,
       );
     if (!studentAppeal) {
       throw new NotFoundException("Not able to find the student appeal.");

--- a/sources/packages/backend/apps/api/src/route-controllers/student-appeal/student-appeal.controller.service.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/student-appeal/student-appeal.controller.service.ts
@@ -33,11 +33,10 @@ export class StudentAppealControllerService {
     },
   ): Promise<StudentAppealAPIOutDTO<T>> {
     const studentAppeal =
-      await this.studentAppealService.getAppealAndRequestsById(
-        appealId,
-        options?.studentId,
-        options?.applicationId,
-      );
+      await this.studentAppealService.getAppealAndRequestsById(appealId, {
+        studentId: options?.studentId,
+        applicationId: options?.applicationId,
+      });
     if (!studentAppeal) {
       throw new NotFoundException("Not able to find the student appeal.");
     }

--- a/sources/packages/backend/apps/api/src/route-controllers/student-appeal/student-appeal.institutions.controller.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/student-appeal/student-appeal.institutions.controller.ts
@@ -49,7 +49,7 @@ export class StudentAppealInstitutionsController extends BaseController {
   ): Promise<StudentAppealAPIOutDTO<StudentAppealRequestAPIOutDTO>> {
     return this.studentAppealControllerService.getStudentAppealWithRequests<StudentAppealRequestAPIOutDTO>(
       appealId,
-      { studentId: studentId, applicationId: applicationId },
+      { studentId, applicationId },
     );
   }
 }

--- a/sources/packages/backend/apps/api/src/route-controllers/student-appeal/student-appeal.institutions.controller.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/student-appeal/student-appeal.institutions.controller.ts
@@ -19,7 +19,7 @@ import { StudentAppealControllerService } from "..";
  */
 @AllowAuthorizedParty(AuthorizedParties.institution)
 @IsBCPublicInstitution()
-@HasStudentDataAccess("studentId")
+@HasStudentDataAccess("studentId", "applicationId")
 @Controller("appeal")
 @ApiTags(`${ClientTypeBaseRoute.Institution}-appeal`)
 export class StudentAppealInstitutionsController extends BaseController {
@@ -32,20 +32,24 @@ export class StudentAppealInstitutionsController extends BaseController {
   /**
    * Get the student appeal details.
    * @param studentId student id.
+   * @param applicationId application id.
    * @param appealId appeal id to be retrieved.
    * @returns the student appeal details.
    */
-  @Get("student/:studentId/appeal/:appealId/requests")
+  @Get(
+    "student/:studentId/application/:applicationId/appeal/:appealId/requests",
+  )
   @ApiNotFoundResponse({
     description: "Not able to find the student appeal.",
   })
   async getStudentAppealWithRequests(
     @Param("studentId", ParseIntPipe) studentId: number,
+    @Param("applicationId", ParseIntPipe) applicationId: number,
     @Param("appealId", ParseIntPipe) appealId: number,
   ): Promise<StudentAppealAPIOutDTO<StudentAppealRequestAPIOutDTO>> {
     return this.studentAppealControllerService.getStudentAppealWithRequests<StudentAppealRequestAPIOutDTO>(
       appealId,
-      { studentId: studentId },
+      { studentId: studentId, applicationId: applicationId },
     );
   }
 }

--- a/sources/packages/backend/apps/api/src/services/application-exception/application-exception.service.ts
+++ b/sources/packages/backend/apps/api/src/services/application-exception/application-exception.service.ts
@@ -40,11 +40,13 @@ export class ApplicationExceptionService extends RecordDataModelService<Applicat
    * submitted, for instance, when there are documents to be reviewed.
    * @param exceptionId exception to be retrieved.
    * @param studentId student id.
+   * @param applicationId application id.
    * @returns student application exception information.
    */
   async getExceptionDetails(
     exceptionId: number,
     studentId?: number,
+    applicationId?: number,
   ): Promise<ApplicationException> {
     const exception = this.repo
       .createQueryBuilder("exception")
@@ -63,11 +65,18 @@ export class ApplicationExceptionService extends RecordDataModelService<Applicat
       .leftJoin("exception.assessedBy", "assessedBy")
       .where("exception.id = :exceptionId", { exceptionId });
 
+    if (studentId || applicationId) {
+      exception.innerJoin("exception.application", "application");
+    }
+
     if (studentId) {
       exception
-        .innerJoin("exception.application", "application")
         .innerJoin("application.student", "student")
         .andWhere("student.id = :studentId", { studentId });
+    }
+
+    if (applicationId) {
+      exception.andWhere("application.id = :applicationId", { applicationId });
     }
     return exception.getOne();
   }

--- a/sources/packages/backend/apps/api/src/services/application-exception/application-exception.service.ts
+++ b/sources/packages/backend/apps/api/src/services/application-exception/application-exception.service.ts
@@ -39,14 +39,17 @@ export class ApplicationExceptionService extends RecordDataModelService<Applicat
    * Get a student application exception detected after the student application was
    * submitted, for instance, when there are documents to be reviewed.
    * @param exceptionId exception to be retrieved.
-   * @param studentId student id.
-   * @param applicationId application id.
+   * @param options options for the query:
+   * - `studentId` student id.
+   * ` `applicationId` application id.
    * @returns student application exception information.
    */
   async getExceptionDetails(
     exceptionId: number,
-    studentId?: number,
-    applicationId?: number,
+    options?: {
+      studentId?: number;
+      applicationId?: number;
+    },
   ): Promise<ApplicationException> {
     const exception = this.repo
       .createQueryBuilder("exception")
@@ -65,18 +68,20 @@ export class ApplicationExceptionService extends RecordDataModelService<Applicat
       .leftJoin("exception.assessedBy", "assessedBy")
       .where("exception.id = :exceptionId", { exceptionId });
 
-    if (studentId || applicationId) {
+    if (options?.studentId || options?.applicationId) {
       exception.innerJoin("exception.application", "application");
     }
 
-    if (studentId) {
+    if (options?.studentId) {
       exception
         .innerJoin("application.student", "student")
-        .andWhere("student.id = :studentId", { studentId });
+        .andWhere("student.id = :studentId", { studentId: options?.studentId });
     }
 
-    if (applicationId) {
-      exception.andWhere("application.id = :applicationId", { applicationId });
+    if (options?.applicationId) {
+      exception.andWhere("application.id = :applicationId", {
+        applicationId: options?.applicationId,
+      });
     }
     return exception.getOne();
   }

--- a/sources/packages/backend/apps/api/src/services/disbursement-receipt/disbursement-receipt.service.ts
+++ b/sources/packages/backend/apps/api/src/services/disbursement-receipt/disbursement-receipt.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from "@nestjs/common";
-import { DataSource, FindOptionsWhere } from "typeorm";
+import { DataSource } from "typeorm";
 import { RecordDataModelService, DisbursementReceipt } from "@sims/sims-db";
 
 /**
@@ -16,15 +16,18 @@ export class DisbursementReceiptService extends RecordDataModelService<Disbursem
    * given assessment.
    * @param assessmentId assessment to which disbursement
    * receipt belongs to.
-   * @param studentId student to whom the disbursement
+   * @param options options for the query:
+   * - `studentId` student to whom the disbursement
    * receipt belongs to.
-   * @param applicationId application id.
+   * - `applicationId` application id.
    * @returns disbursement receipt details.
    */
   async getDisbursementReceiptByAssessment(
     assessmentId: number,
-    studentId?: number,
-    applicationId?: number,
+    options?: {
+      studentId?: number;
+      applicationId?: number;
+    },
   ): Promise<DisbursementReceipt[]> {
     return this.repo.find({
       select: {
@@ -41,9 +44,9 @@ export class DisbursementReceiptService extends RecordDataModelService<Disbursem
           studentAssessment: {
             id: assessmentId,
             application: {
-              id: applicationId ?? undefined,
+              id: options?.applicationId ?? undefined,
               student: {
-                id: studentId ?? undefined,
+                id: options?.studentId ?? undefined,
               },
             },
           },

--- a/sources/packages/backend/apps/api/src/services/disbursement-receipt/disbursement-receipt.service.ts
+++ b/sources/packages/backend/apps/api/src/services/disbursement-receipt/disbursement-receipt.service.ts
@@ -26,35 +26,6 @@ export class DisbursementReceiptService extends RecordDataModelService<Disbursem
     studentId?: number,
     applicationId?: number,
   ): Promise<DisbursementReceipt[]> {
-    let findOptions: FindOptionsWhere<DisbursementReceipt> = {
-      disbursementSchedule: {
-        studentAssessment: {
-          id: assessmentId,
-          application: studentId ? { student: { id: studentId } } : undefined,
-        },
-      },
-    };
-    if (studentId && applicationId) {
-      findOptions = {
-        disbursementSchedule: {
-          studentAssessment: {
-            id: assessmentId,
-            application: { student: { id: studentId }, id: applicationId },
-          },
-        },
-      };
-    }
-    if (!studentId && applicationId) {
-      findOptions = {
-        disbursementSchedule: {
-          studentAssessment: {
-            id: assessmentId,
-            application: { id: applicationId },
-          },
-        },
-      };
-    }
-
     return this.repo.find({
       select: {
         id: true,
@@ -65,7 +36,19 @@ export class DisbursementReceiptService extends RecordDataModelService<Disbursem
         disbursementReceiptValues: true,
         disbursementSchedule: true,
       },
-      where: findOptions,
+      where: {
+        disbursementSchedule: {
+          studentAssessment: {
+            id: assessmentId,
+            application: {
+              id: applicationId ?? undefined,
+              student: {
+                id: studentId ?? undefined,
+              },
+            },
+          },
+        },
+      },
     });
   }
 }

--- a/sources/packages/backend/apps/api/src/services/disbursement-receipt/disbursement-receipt.service.ts
+++ b/sources/packages/backend/apps/api/src/services/disbursement-receipt/disbursement-receipt.service.ts
@@ -44,9 +44,9 @@ export class DisbursementReceiptService extends RecordDataModelService<Disbursem
           studentAssessment: {
             id: assessmentId,
             application: {
-              id: options?.applicationId ?? undefined,
+              id: options?.applicationId,
               student: {
-                id: options?.studentId ?? undefined,
+                id: options?.studentId,
               },
             },
           },

--- a/sources/packages/backend/apps/api/src/services/institution/institution.service.ts
+++ b/sources/packages/backend/apps/api/src/services/institution/institution.service.ts
@@ -979,22 +979,14 @@ export class InstitutionService extends RecordDataModelService<Institution> {
       applicationId?: number;
     },
   ): Promise<boolean> {
-    let findOptions: FindOptionsWhere<Application> = {
-      student: { id: studentId },
-      location: { institution: { id: institutionId } },
-      applicationStatus: Not(ApplicationStatus.Overwritten),
-    };
-    if (options?.applicationId) {
-      findOptions = {
+    const institutionStudentDataAccess = await this.applicationRepo.findOne({
+      select: { id: true },
+      where: {
         student: { id: studentId },
         location: { institution: { id: institutionId } },
         applicationStatus: Not(ApplicationStatus.Overwritten),
         id: options?.applicationId,
-      };
-    }
-    const institutionStudentDataAccess = await this.applicationRepo.findOne({
-      select: { id: true },
-      where: findOptions,
+      },
       cache: true,
     });
     return !!institutionStudentDataAccess;

--- a/sources/packages/backend/apps/api/src/services/institution/institution.service.ts
+++ b/sources/packages/backend/apps/api/src/services/institution/institution.service.ts
@@ -15,14 +15,7 @@ import {
   Application,
   ApplicationStatus,
 } from "@sims/sims-db";
-import {
-  DataSource,
-  EntityManager,
-  FindOptionsWhere,
-  IsNull,
-  Not,
-  Repository,
-} from "typeorm";
+import { DataSource, EntityManager, IsNull, Not, Repository } from "typeorm";
 import { InstitutionUserType, UserInfo } from "../../types";
 import { BCeIDService } from "../bceid/bceid.service";
 import { AccountDetails } from "../bceid/account-details.model";

--- a/sources/packages/backend/apps/api/src/services/student-appeal/student-appeal.service.ts
+++ b/sources/packages/backend/apps/api/src/services/student-appeal/student-appeal.service.ts
@@ -178,11 +178,13 @@ export class StudentAppealService extends RecordDataModelService<StudentAppeal> 
    * Get the student appeal and its requests.
    * @param appealId appeal if to be retrieved.
    * @param studentId applicant student.
+   * @param applicationId application id.
    * @returns student appeal and its requests.
    */
   async getAppealAndRequestsById(
     appealId: number,
     studentId?: number,
+    applicationId?: number,
   ): Promise<StudentAppealWithStatus> {
     const query = this.repo
       .createQueryBuilder("studentAppeal")
@@ -208,6 +210,11 @@ export class StudentAppealService extends RecordDataModelService<StudentAppeal> 
     if (studentId) {
       query.andWhere("application.student.id = :studentId", {
         studentId,
+      });
+    }
+    if (applicationId) {
+      query.andWhere("application.id = :applicationId", {
+        applicationId,
       });
     }
     const queryResult = await query.getRawAndEntities();

--- a/sources/packages/backend/apps/api/src/services/student-appeal/student-appeal.service.ts
+++ b/sources/packages/backend/apps/api/src/services/student-appeal/student-appeal.service.ts
@@ -177,14 +177,17 @@ export class StudentAppealService extends RecordDataModelService<StudentAppeal> 
   /**
    * Get the student appeal and its requests.
    * @param appealId appeal if to be retrieved.
-   * @param studentId applicant student.
-   * @param applicationId application id.
+   * @param options options for the query:
+   * - `studentId` applicant student.
+   * - `applicationId` application id.
    * @returns student appeal and its requests.
    */
   async getAppealAndRequestsById(
     appealId: number,
-    studentId?: number,
-    applicationId?: number,
+    options?: {
+      studentId?: number;
+      applicationId?: number;
+    },
   ): Promise<StudentAppealWithStatus> {
     const query = this.repo
       .createQueryBuilder("studentAppeal")
@@ -207,14 +210,14 @@ export class StudentAppealService extends RecordDataModelService<StudentAppeal> 
       .leftJoin("appealRequest.note", "note")
       .where("studentAppeal.id = :appealId", { appealId });
 
-    if (studentId) {
+    if (options?.studentId) {
       query.andWhere("application.student.id = :studentId", {
-        studentId,
+        studentId: options?.studentId,
       });
     }
-    if (applicationId) {
+    if (options?.applicationId) {
       query.andWhere("application.id = :applicationId", {
-        applicationId,
+        applicationId: options?.applicationId,
       });
     }
     const queryResult = await query.getRawAndEntities();

--- a/sources/packages/backend/apps/api/src/services/student-assessment/student-assessment.service.ts
+++ b/sources/packages/backend/apps/api/src/services/student-assessment/student-assessment.service.ts
@@ -39,15 +39,18 @@ export class StudentAssessmentService extends RecordDataModelService<StudentAsse
    * Get the assessment data to load the NOA (Notice of Assessment)
    * for a student application.
    * @param assessmentId assessment id to be retrieved.
-   * @param studentId student associated to the application. Provided
+   * @param options options for the query:
+   * - `studentId` student associated to the application. Provided
    * when an authorization check is needed.
-   * @param applicationId, application id.
+   * - `applicationId`, application id.
    * @returns assessment NOA data.
    */
   async getAssessmentForNOA(
     assessmentId: number,
-    studentId?: number,
-    applicationId?: number,
+    options?: {
+      studentId?: number;
+      applicationId?: number;
+    },
   ): Promise<StudentAssessment> {
     const query = this.repo
       .createQueryBuilder("assessment")
@@ -93,11 +96,15 @@ export class StudentAssessmentService extends RecordDataModelService<StudentAsse
       .where("assessment.id = :assessmentId", { assessmentId })
       .orderBy("disbursementSchedule.disbursementDate");
 
-    if (studentId) {
-      query.andWhere("student.id = :studentId", { studentId });
+    if (options?.studentId) {
+      query.andWhere("student.id = :studentId", {
+        studentId: options?.studentId,
+      });
     }
-    if (applicationId) {
-      query.andWhere("application.id = :applicationId", { applicationId });
+    if (options?.applicationId) {
+      query.andWhere("application.id = :applicationId", {
+        applicationId: options?.applicationId,
+      });
     }
     return query.getOne();
   }

--- a/sources/packages/backend/apps/api/src/services/student-assessment/student-assessment.service.ts
+++ b/sources/packages/backend/apps/api/src/services/student-assessment/student-assessment.service.ts
@@ -41,11 +41,13 @@ export class StudentAssessmentService extends RecordDataModelService<StudentAsse
    * @param assessmentId assessment id to be retrieved.
    * @param studentId student associated to the application. Provided
    * when an authorization check is needed.
+   * @param applicationId, application id.
    * @returns assessment NOA data.
    */
   async getAssessmentForNOA(
     assessmentId: number,
     studentId?: number,
+    applicationId?: number,
   ): Promise<StudentAssessment> {
     const query = this.repo
       .createQueryBuilder("assessment")
@@ -93,6 +95,9 @@ export class StudentAssessmentService extends RecordDataModelService<StudentAsse
 
     if (studentId) {
       query.andWhere("student.id = :studentId", { studentId });
+    }
+    if (applicationId) {
+      query.andWhere("application.id = :applicationId", { applicationId });
     }
     return query.getOne();
   }

--- a/sources/packages/web/src/components/common/NoticeOfAssessmentFormView.vue
+++ b/sources/packages/web/src/components/common/NoticeOfAssessmentFormView.vue
@@ -91,9 +91,6 @@ export default defineComponent({
     ) => {
       return !!applicationId && !!loadNOA && !!processing;
     },
-    setHideView: (value: boolean) => {
-      return value;
-    },
   },
   components: { ConfirmModal },
   props: {
@@ -148,62 +145,58 @@ export default defineComponent({
     };
 
     const loadNOA = async () => {
-      try {
-        const assessment =
-          await StudentAssessmentsService.shared.getAssessmentNOA(
-            props.assessmentId,
-            props.studentId,
-            props.applicationId,
-          );
-        const noaDisbursementSchedule =
-          assessment.disbursement as NOADisbursementSchedule;
-        // Adjust disbursement schedules.
-        // First disbursement.
-        const firstMSFAAStatus = getMSFAAStatus(
-          noaDisbursementSchedule.disbursement1MSFAADateSigned,
+      const assessment =
+        await StudentAssessmentsService.shared.getAssessmentNOA(
+          props.assessmentId,
+          props.studentId,
+          props.applicationId,
+        );
+      const noaDisbursementSchedule =
+        assessment.disbursement as NOADisbursementSchedule;
+      // Adjust disbursement schedules.
+      // First disbursement.
+      const firstMSFAAStatus = getMSFAAStatus(
+        noaDisbursementSchedule.disbursement1MSFAADateSigned,
+        noaDisbursementSchedule.disbursement1MSFAACancelledDate,
+      );
+      noaDisbursementSchedule.disbursement1MSFAAStatus = firstMSFAAStatus;
+      noaDisbursementSchedule.disbursement1MSFAACancelledDateFormatted =
+        dateOnlyLongString(
           noaDisbursementSchedule.disbursement1MSFAACancelledDate,
         );
-        noaDisbursementSchedule.disbursement1MSFAAStatus = firstMSFAAStatus;
-        noaDisbursementSchedule.disbursement1MSFAACancelledDateFormatted =
-          dateOnlyLongString(
-            noaDisbursementSchedule.disbursement1MSFAACancelledDate,
-          );
-        noaDisbursementSchedule.disbursement1MSFAAStatusClass =
-          getMSFAAStatusClass(firstMSFAAStatus);
-        // Second disbursement.
-        const secondMSFAAStatus = getMSFAAStatus(
-          noaDisbursementSchedule.disbursement2MSFAADateSigned,
+      noaDisbursementSchedule.disbursement1MSFAAStatusClass =
+        getMSFAAStatusClass(firstMSFAAStatus);
+      // Second disbursement.
+      const secondMSFAAStatus = getMSFAAStatus(
+        noaDisbursementSchedule.disbursement2MSFAADateSigned,
+        noaDisbursementSchedule.disbursement2MSFAACancelledDate,
+      );
+      noaDisbursementSchedule.disbursement2MSFAAStatus = secondMSFAAStatus;
+      noaDisbursementSchedule.disbursement2MSFAACancelledDateFormatted =
+        dateOnlyLongString(
           noaDisbursementSchedule.disbursement2MSFAACancelledDate,
         );
-        noaDisbursementSchedule.disbursement2MSFAAStatus = secondMSFAAStatus;
-        noaDisbursementSchedule.disbursement2MSFAACancelledDateFormatted =
-          dateOnlyLongString(
-            noaDisbursementSchedule.disbursement2MSFAACancelledDate,
-          );
-        noaDisbursementSchedule.disbursement2MSFAAStatusClass =
-          getMSFAAStatusClass(secondMSFAAStatus);
-        // Checks if the component allows the MSFAA reissue and if there is
-        // one pending disbursement with a cancelled MSFAA.
-        const canReissueMSFAA =
-          props.canReissueMSFAA &&
-          ((noaDisbursementSchedule.disbursement1Status ===
+      noaDisbursementSchedule.disbursement2MSFAAStatusClass =
+        getMSFAAStatusClass(secondMSFAAStatus);
+      // Checks if the component allows the MSFAA reissue and if there is
+      // one pending disbursement with a cancelled MSFAA.
+      const canReissueMSFAA =
+        props.canReissueMSFAA &&
+        ((noaDisbursementSchedule.disbursement1Status ===
+          DisbursementScheduleStatus.Pending &&
+          !!noaDisbursementSchedule.disbursement1MSFAACancelledDate) ||
+          (noaDisbursementSchedule.disbursement2Status ===
             DisbursementScheduleStatus.Pending &&
-            !!noaDisbursementSchedule.disbursement1MSFAACancelledDate) ||
-            (noaDisbursementSchedule.disbursement2Status ===
-              DisbursementScheduleStatus.Pending &&
-              !!noaDisbursementSchedule.disbursement2MSFAACancelledDate));
-        initialData.value = {
-          ...assessment,
-          canReissueMSFAA,
-        };
-        emit(
-          "assessmentDataLoaded",
-          initialData.value.applicationStatus,
-          initialData.value.noaApprovalStatus,
-        );
-      } catch {
-        emit("setHideView", true);
-      }
+            !!noaDisbursementSchedule.disbursement2MSFAACancelledDate));
+      initialData.value = {
+        ...assessment,
+        canReissueMSFAA,
+      };
+      emit(
+        "assessmentDataLoaded",
+        initialData.value.applicationStatus,
+        initialData.value.noaApprovalStatus,
+      );
     };
 
     onMounted(loadNOA);

--- a/sources/packages/web/src/components/common/NoticeOfAssessmentFormView.vue
+++ b/sources/packages/web/src/components/common/NoticeOfAssessmentFormView.vue
@@ -91,6 +91,9 @@ export default defineComponent({
     ) => {
       return !!applicationId && !!loadNOA && !!processing;
     },
+    setHideView: (value: boolean) => {
+      return value;
+    },
   },
   components: { ConfirmModal },
   props: {
@@ -103,6 +106,10 @@ export default defineComponent({
       default: false,
     },
     studentId: {
+      type: Number,
+      required: false,
+    },
+    applicationId: {
       type: Number,
       required: false,
     },
@@ -141,57 +148,62 @@ export default defineComponent({
     };
 
     const loadNOA = async () => {
-      const assessment =
-        await StudentAssessmentsService.shared.getAssessmentNOA(
-          props.assessmentId,
-          props.studentId,
-        );
-      const noaDisbursementSchedule =
-        assessment.disbursement as NOADisbursementSchedule;
-      // Adjust disbursement schedules.
-      // First disbursement.
-      const firstMSFAAStatus = getMSFAAStatus(
-        noaDisbursementSchedule.disbursement1MSFAADateSigned,
-        noaDisbursementSchedule.disbursement1MSFAACancelledDate,
-      );
-      noaDisbursementSchedule.disbursement1MSFAAStatus = firstMSFAAStatus;
-      noaDisbursementSchedule.disbursement1MSFAACancelledDateFormatted =
-        dateOnlyLongString(
+      try {
+        const assessment =
+          await StudentAssessmentsService.shared.getAssessmentNOA(
+            props.assessmentId,
+            props.studentId,
+            props.applicationId,
+          );
+        const noaDisbursementSchedule =
+          assessment.disbursement as NOADisbursementSchedule;
+        // Adjust disbursement schedules.
+        // First disbursement.
+        const firstMSFAAStatus = getMSFAAStatus(
+          noaDisbursementSchedule.disbursement1MSFAADateSigned,
           noaDisbursementSchedule.disbursement1MSFAACancelledDate,
         );
-      noaDisbursementSchedule.disbursement1MSFAAStatusClass =
-        getMSFAAStatusClass(firstMSFAAStatus);
-      // Second disbursement.
-      const secondMSFAAStatus = getMSFAAStatus(
-        noaDisbursementSchedule.disbursement2MSFAADateSigned,
-        noaDisbursementSchedule.disbursement2MSFAACancelledDate,
-      );
-      noaDisbursementSchedule.disbursement2MSFAAStatus = secondMSFAAStatus;
-      noaDisbursementSchedule.disbursement2MSFAACancelledDateFormatted =
-        dateOnlyLongString(
+        noaDisbursementSchedule.disbursement1MSFAAStatus = firstMSFAAStatus;
+        noaDisbursementSchedule.disbursement1MSFAACancelledDateFormatted =
+          dateOnlyLongString(
+            noaDisbursementSchedule.disbursement1MSFAACancelledDate,
+          );
+        noaDisbursementSchedule.disbursement1MSFAAStatusClass =
+          getMSFAAStatusClass(firstMSFAAStatus);
+        // Second disbursement.
+        const secondMSFAAStatus = getMSFAAStatus(
+          noaDisbursementSchedule.disbursement2MSFAADateSigned,
           noaDisbursementSchedule.disbursement2MSFAACancelledDate,
         );
-      noaDisbursementSchedule.disbursement2MSFAAStatusClass =
-        getMSFAAStatusClass(secondMSFAAStatus);
-      // Checks if the component allows the MSFAA reissue and if there is
-      // one pending disbursement with a cancelled MSFAA.
-      const canReissueMSFAA =
-        props.canReissueMSFAA &&
-        ((noaDisbursementSchedule.disbursement1Status ===
-          DisbursementScheduleStatus.Pending &&
-          !!noaDisbursementSchedule.disbursement1MSFAACancelledDate) ||
-          (noaDisbursementSchedule.disbursement2Status ===
+        noaDisbursementSchedule.disbursement2MSFAAStatus = secondMSFAAStatus;
+        noaDisbursementSchedule.disbursement2MSFAACancelledDateFormatted =
+          dateOnlyLongString(
+            noaDisbursementSchedule.disbursement2MSFAACancelledDate,
+          );
+        noaDisbursementSchedule.disbursement2MSFAAStatusClass =
+          getMSFAAStatusClass(secondMSFAAStatus);
+        // Checks if the component allows the MSFAA reissue and if there is
+        // one pending disbursement with a cancelled MSFAA.
+        const canReissueMSFAA =
+          props.canReissueMSFAA &&
+          ((noaDisbursementSchedule.disbursement1Status ===
             DisbursementScheduleStatus.Pending &&
-            !!noaDisbursementSchedule.disbursement2MSFAACancelledDate));
-      initialData.value = {
-        ...assessment,
-        canReissueMSFAA,
-      };
-      emit(
-        "assessmentDataLoaded",
-        initialData.value.applicationStatus,
-        initialData.value.noaApprovalStatus,
-      );
+            !!noaDisbursementSchedule.disbursement1MSFAACancelledDate) ||
+            (noaDisbursementSchedule.disbursement2Status ===
+              DisbursementScheduleStatus.Pending &&
+              !!noaDisbursementSchedule.disbursement2MSFAACancelledDate));
+        initialData.value = {
+          ...assessment,
+          canReissueMSFAA,
+        };
+        emit(
+          "assessmentDataLoaded",
+          initialData.value.applicationStatus,
+          initialData.value.noaApprovalStatus,
+        );
+      } catch {
+        emit("setHideView", true);
+      }
     };
 
     onMounted(loadNOA);

--- a/sources/packages/web/src/components/common/students/applicationDetails/ApplicationExceptionsApproval.vue
+++ b/sources/packages/web/src/components/common/students/applicationDetails/ApplicationExceptionsApproval.vue
@@ -1,5 +1,5 @@
 <template>
-  <full-page-container v-if="!hideView">
+  <full-page-container>
     <template #header>
       <header-navigator
         title="Assessments"
@@ -129,37 +129,32 @@ export default defineComponent({
     const applicationExceptions = ref({} as ApplicationExceptionFormModel);
     const submittedDate = ref("");
     const readOnly = ref(true);
-    const hideView = ref(false);
 
     onMounted(async () => {
-      try {
-        const applicationException =
-          await ApplicationExceptionService.shared.getExceptionDetails<DetailedApplicationExceptionAPIOutDTO>(
-            props.exceptionId,
-            props.studentId,
-            props.applicationId,
-          );
-        applicationExceptions.value = {
-          ...applicationException,
-          assessedDate: dateOnlyLongString(applicationException.assessedDate),
-          exceptionStatusClass: mapRequestAssessmentChipStatus(
-            applicationException.exceptionStatus,
-          ),
-          exceptionStatusOnLoad: applicationException.exceptionStatus,
-          exceptionNames: applicationException.exceptionRequests.map(
-            (exception) => exception.exceptionName,
-          ),
-          showStaffApproval: props.showStaffApproval,
-        };
-        submittedDate.value = dateOnlyLongString(
-          applicationException.submittedDate,
+      const applicationException =
+        await ApplicationExceptionService.shared.getExceptionDetails<DetailedApplicationExceptionAPIOutDTO>(
+          props.exceptionId,
+          props.studentId,
+          props.applicationId,
         );
-        readOnly.value =
-          applicationException.exceptionStatus !==
-            ApplicationExceptionStatus.Pending || props.readOnlyForm;
-      } catch (error: unknown) {
-        hideView.value = true;
-      }
+      applicationExceptions.value = {
+        ...applicationException,
+        assessedDate: dateOnlyLongString(applicationException.assessedDate),
+        exceptionStatusClass: mapRequestAssessmentChipStatus(
+          applicationException.exceptionStatus,
+        ),
+        exceptionStatusOnLoad: applicationException.exceptionStatus,
+        exceptionNames: applicationException.exceptionRequests.map(
+          (exception) => exception.exceptionName,
+        ),
+        showStaffApproval: props.showStaffApproval,
+      };
+      submittedDate.value = dateOnlyLongString(
+        applicationException.submittedDate,
+      );
+      readOnly.value =
+        applicationException.exceptionStatus !==
+          ApplicationExceptionStatus.Pending || props.readOnlyForm;
     });
 
     const gotToAssessmentsSummary = () => {
@@ -172,7 +167,6 @@ export default defineComponent({
       submittedDate,
       readOnly,
       Role,
-      hideView,
     };
   },
 });

--- a/sources/packages/web/src/components/common/students/applicationDetails/StudentAppealRequestsApproval.vue
+++ b/sources/packages/web/src/components/common/students/applicationDetails/StudentAppealRequestsApproval.vue
@@ -92,7 +92,7 @@ export default defineComponent({
       required: false,
     },
   },
-  setup(props, { emit }) {
+  setup(props) {
     const router = useRouter();
     const { dateOnlyLongString } = useFormatters();
     const studentAppealRequests = ref([] as StudentAppealRequest[]);

--- a/sources/packages/web/src/components/common/students/applicationDetails/StudentAppealRequestsApproval.vue
+++ b/sources/packages/web/src/components/common/students/applicationDetails/StudentAppealRequestsApproval.vue
@@ -58,9 +58,6 @@ export default defineComponent({
     submitted: (approvals: StudentAppealApproval[]) => {
       return !!approvals.length;
     },
-    setHideView: (value: boolean) => {
-      return value;
-    },
   },
   components: {
     AppealRequestsApprovalForm,
@@ -108,30 +105,26 @@ export default defineComponent({
     );
 
     onMounted(async () => {
-      try {
-        const appeal =
-          await StudentAppealService.shared.getStudentAppealWithRequests<DetailedStudentAppealRequestAPIOutDTO>(
-            props.appealId,
-            props.studentId,
-            props.applicationId,
-          );
-        studentAppealRequests.value = appeal.appealRequests.map((request) => ({
+      const appeal =
+        await StudentAppealService.shared.getStudentAppealWithRequests<DetailedStudentAppealRequestAPIOutDTO>(
+          props.appealId,
+          props.studentId,
+          props.applicationId,
+        );
+      studentAppealRequests.value = appeal.appealRequests.map((request) => ({
+        id: request.id,
+        data: request.submittedData,
+        formName: request.submittedFormName,
+        approval: {
           id: request.id,
-          data: request.submittedData,
-          formName: request.submittedFormName,
-          approval: {
-            id: request.id,
-            appealStatus: request.appealStatus,
-            assessedDate: dateOnlyLongString(request.assessedDate),
-            assessedByUserName: request.assessedByUserName,
-            noteDescription: request.noteDescription ?? "",
-            showAudit: request.appealStatus !== StudentAppealStatus.Pending,
-          },
-        }));
-        appealStatus.value = appeal.status;
-      } catch {
-        emit("setHideView", true);
-      }
+          appealStatus: request.appealStatus,
+          assessedDate: dateOnlyLongString(request.assessedDate),
+          assessedByUserName: request.assessedByUserName,
+          noteDescription: request.noteDescription ?? "",
+          showAudit: request.appealStatus !== StudentAppealStatus.Pending,
+        },
+      }));
+      appealStatus.value = appeal.status;
     });
 
     const gotToAssessmentsSummary = () => {

--- a/sources/packages/web/src/services/ApplicationExceptionService.ts
+++ b/sources/packages/web/src/services/ApplicationExceptionService.ts
@@ -20,16 +20,22 @@ export class ApplicationExceptionService {
    * submitted, for instance, when there are documents to be reviewed.
    * @param exceptionId exception to be retrieved.
    * @param studentId student id.
+   * @param applicationId application id.
    * @returns student application exception information.
    */
   async getExceptionDetails<
     T extends
       | DetailedApplicationExceptionAPIOutDTO
       | ApplicationExceptionAPIOutDTO,
-  >(exceptionId: number, studentId?: number): Promise<T> {
+  >(
+    exceptionId: number,
+    studentId?: number,
+    applicationId?: number,
+  ): Promise<T> {
     return ApiClient.ApplicationExceptionApi.getExceptionDetails<T>(
       exceptionId,
       studentId,
+      applicationId,
     );
   }
 

--- a/sources/packages/web/src/services/StudentAppealService.ts
+++ b/sources/packages/web/src/services/StudentAppealService.ts
@@ -41,16 +41,22 @@ export class StudentAppealService {
    * Get student application appeal.
    * @param appealId appeal id.
    * @param studentId student id.
+   * @param applicationId application id.
    * @returns student application appeal.
    */
   async getStudentAppealWithRequests<
     T extends
       | StudentAppealRequestAPIOutDTO
       | DetailedStudentAppealRequestAPIOutDTO,
-  >(appealId: number, studentId?: number): Promise<StudentAppealAPIOutDTO<T>> {
+  >(
+    appealId: number,
+    studentId?: number,
+    applicationId?: number,
+  ): Promise<StudentAppealAPIOutDTO<T>> {
     return ApiClient.StudentAppealApi.getStudentAppealWithRequests<T>(
       appealId,
       studentId,
+      applicationId,
     );
   }
 

--- a/sources/packages/web/src/services/StudentAssessmentsService.ts
+++ b/sources/packages/web/src/services/StudentAssessmentsService.ts
@@ -58,15 +58,18 @@ export class StudentAssessmentsService {
    * Get the NOA values for a student application on a particular assessment.
    * @param assessmentId assessment id to get the NOA values.
    * @param studentId student id.
+   * @param applicationId, application id.
    * @returns NOA and application data.
    */
   async getAssessmentNOA(
     assessmentId: number,
     studentId?: number,
+    applicationId?: number,
   ): Promise<AssessmentNOAAPIOutDTO> {
     return ApiClient.StudentAssessmentApi.getAssessmentNOA(
       assessmentId,
       studentId,
+      applicationId,
     );
   }
 
@@ -82,15 +85,18 @@ export class StudentAssessmentsService {
    * Get estimated and actual(if present) award details of an assessment.
    * @param assessmentId assessment to which awards details belong to.
    * @param studentId, student id.
+   * @param applicationId, application id.
    * @returns estimated and actual award details.
    */
   async getAssessmentAwardDetails(
     assessmentId: number,
     studentId?: number,
+    applicationId?: number,
   ): Promise<AwardDetailsAPIOutDTO> {
     return ApiClient.StudentAssessmentApi.getAssessmentAwardDetails(
       assessmentId,
       studentId,
+      applicationId,
     );
   }
 }

--- a/sources/packages/web/src/services/http/ApplicationExceptionApi.ts
+++ b/sources/packages/web/src/services/http/ApplicationExceptionApi.ts
@@ -33,7 +33,7 @@ export class ApplicationExceptionApi extends HttpBaseClient {
     applicationId?: number,
   ): Promise<T> {
     const endpoint = studentId
-      ? `application-exception/student/${studentId}/applicationId/${applicationId}/exception/${exceptionId}`
+      ? `application-exception/student/${studentId}/application/${applicationId}/exception/${exceptionId}`
       : `application-exception/${exceptionId}`;
     return this.getCall<T>(this.addClientRoot(endpoint));
   }

--- a/sources/packages/web/src/services/http/ApplicationExceptionApi.ts
+++ b/sources/packages/web/src/services/http/ApplicationExceptionApi.ts
@@ -20,15 +20,20 @@ export class ApplicationExceptionApi extends HttpBaseClient {
    * submitted, for instance, when there are documents to be reviewed.
    * @param exceptionId exception to be retrieved.
    * @param studentId student id.
+   * @param applicationId application id.
    * @returns student application exception information.
    */
   async getExceptionDetails<
     T extends
       | ApplicationExceptionAPIOutDTO
       | DetailedApplicationExceptionAPIOutDTO,
-  >(exceptionId: number, studentId?: number): Promise<T> {
+  >(
+    exceptionId: number,
+    studentId?: number,
+    applicationId?: number,
+  ): Promise<T> {
     const endpoint = studentId
-      ? `application-exception/student/${studentId}/exception/${exceptionId}`
+      ? `application-exception/student/${studentId}/applicationId/${applicationId}/exception/${exceptionId}`
       : `application-exception/${exceptionId}`;
     return this.getCall<T>(this.addClientRoot(endpoint));
   }

--- a/sources/packages/web/src/services/http/StudentAppealApi.ts
+++ b/sources/packages/web/src/services/http/StudentAppealApi.ts
@@ -30,15 +30,20 @@ export class StudentAppealApi extends HttpBaseClient {
    * Get student application appeal.
    * @param appealId appeal id.
    * @param studentId student id.
+   * @param applicationId application id.
    * @returns student application appeal.
    */
   async getStudentAppealWithRequests<
     T extends
       | DetailedStudentAppealRequestAPIOutDTO
       | StudentAppealRequestAPIOutDTO,
-  >(appealId: number, studentId?: number): Promise<StudentAppealAPIOutDTO<T>> {
+  >(
+    appealId: number,
+    studentId?: number,
+    applicationId?: number,
+  ): Promise<StudentAppealAPIOutDTO<T>> {
     const endpoint = studentId
-      ? `appeal/student/${studentId}/appeal/${appealId}/requests`
+      ? `appeal/student/${studentId}/application/${applicationId}/appeal/${appealId}/requests`
       : `appeal/${appealId}/requests`;
     return this.getCall<StudentAppealAPIOutDTO<T>>(
       this.addClientRoot(endpoint),

--- a/sources/packages/web/src/services/http/StudentAssessmentApi.ts
+++ b/sources/packages/web/src/services/http/StudentAssessmentApi.ts
@@ -56,14 +56,16 @@ export class StudentAssessmentApi extends HttpBaseClient {
    * Get the NOA values for a student application on a particular assessment.
    * @param assessmentId assessment id to get the NOA values.
    * @param studentId student id.
+   * @param applicationId, application id.
    * @returns NOA and application data.
    */
   async getAssessmentNOA(
     assessmentId: number,
     studentId?: number,
+    applicationId?: number,
   ): Promise<AssessmentNOAAPIOutDTO> {
     const endpoint = studentId
-      ? `assessment/student/${studentId}/assessment/${assessmentId}/noa`
+      ? `assessment/student/${studentId}/application/${applicationId}/assessment/${assessmentId}/noa`
       : `assessment/${assessmentId}/noa`;
     return this.getCall<AssessmentNOAAPIOutDTO>(this.addClientRoot(endpoint));
   }
@@ -83,14 +85,16 @@ export class StudentAssessmentApi extends HttpBaseClient {
    * Get estimated and actual(if present) award details of an assessment.
    * @param assessmentId assessment to which awards details belong to.
    * @param studentId, student id.
+   * @param applicationId, application id.
    * @returns estimated and actual award details.
    */
   async getAssessmentAwardDetails(
     assessmentId: number,
     studentId?: number,
+    applicationId?: number,
   ): Promise<AwardDetailsAPIOutDTO> {
     const endpoint = studentId
-      ? `assessment/student/${studentId}/assessment/${assessmentId}/award`
+      ? `assessment/student/${studentId}/application/${applicationId}/assessment/${assessmentId}/award`
       : `assessment/${assessmentId}/award`;
     return this.getCall<AwardDetailsAPIOutDTO>(this.addClientRoot(endpoint));
   }

--- a/sources/packages/web/src/views/institution/student/applicationDetails/ApplicationExceptions.vue
+++ b/sources/packages/web/src/views/institution/student/applicationDetails/ApplicationExceptions.vue
@@ -4,6 +4,7 @@
     :exceptionId="exceptionId"
     :backRouteLocation="assessmentsSummaryRoute"
     :readOnlyForm="true"
+    :application-id="applicationId"
   />
 </template>
 <script lang="ts">

--- a/sources/packages/web/src/views/institution/student/applicationDetails/AssessmentAward.vue
+++ b/sources/packages/web/src/views/institution/student/applicationDetails/AssessmentAward.vue
@@ -1,5 +1,5 @@
 <template>
-  <full-page-container v-if="!hideView">
+  <full-page-container>
     <template #header>
       <header-navigator
         title="Assessments"
@@ -11,7 +11,6 @@
     <assessment-award
       :assessment-award-data="assessmentAwardData"
       :notice-of-assessment-route="noticeOfAssessmentRoute"
-      @set-hide-view="setHideView"
     />
   </full-page-container>
 </template>
@@ -41,23 +40,18 @@ export default defineComponent({
     },
   },
   setup(props) {
-    const hideView = ref(false);
     const assessmentAwardData = ref<AwardDetailsAPIOutDTO>();
     const { mapAssessmentDetailHeader } = useAssessment();
     const headerMap = ref<Record<string, string>>({});
 
     const loadAssessmentAwardValues = async () => {
-      try {
-        assessmentAwardData.value =
-          await StudentAssessmentsService.shared.getAssessmentAwardDetails(
-            props.assessmentId,
-            props.studentId,
-            props.applicationId,
-          );
-        headerMap.value = mapAssessmentDetailHeader(assessmentAwardData.value);
-      } catch {
-        hideView.value = true;
-      }
+      assessmentAwardData.value =
+        await StudentAssessmentsService.shared.getAssessmentAwardDetails(
+          props.assessmentId,
+          props.studentId,
+          props.applicationId,
+        );
+      headerMap.value = mapAssessmentDetailHeader(assessmentAwardData.value);
     };
 
     onMounted(loadAssessmentAwardValues);
@@ -85,7 +79,6 @@ export default defineComponent({
       assessmentAwardData,
       headerMap,
       routeLocation,
-      hideView,
     };
   },
 });

--- a/sources/packages/web/src/views/institution/student/applicationDetails/AssessmentAward.vue
+++ b/sources/packages/web/src/views/institution/student/applicationDetails/AssessmentAward.vue
@@ -1,5 +1,5 @@
 <template>
-  <full-page-container>
+  <full-page-container v-if="!hideView">
     <template #header>
       <header-navigator
         title="Assessments"
@@ -11,6 +11,7 @@
     <assessment-award
       :assessment-award-data="assessmentAwardData"
       :notice-of-assessment-route="noticeOfAssessmentRoute"
+      @set-hide-view="setHideView"
     />
   </full-page-container>
 </template>
@@ -40,17 +41,23 @@ export default defineComponent({
     },
   },
   setup(props) {
+    const hideView = ref(false);
     const assessmentAwardData = ref<AwardDetailsAPIOutDTO>();
     const { mapAssessmentDetailHeader } = useAssessment();
     const headerMap = ref<Record<string, string>>({});
 
     const loadAssessmentAwardValues = async () => {
-      assessmentAwardData.value =
-        await StudentAssessmentsService.shared.getAssessmentAwardDetails(
-          props.assessmentId,
-          props.studentId,
-        );
-      headerMap.value = mapAssessmentDetailHeader(assessmentAwardData.value);
+      try {
+        assessmentAwardData.value =
+          await StudentAssessmentsService.shared.getAssessmentAwardDetails(
+            props.assessmentId,
+            props.studentId,
+            props.applicationId,
+          );
+        headerMap.value = mapAssessmentDetailHeader(assessmentAwardData.value);
+      } catch {
+        hideView.value = true;
+      }
     };
 
     onMounted(loadAssessmentAwardValues);
@@ -78,6 +85,7 @@ export default defineComponent({
       assessmentAwardData,
       headerMap,
       routeLocation,
+      hideView,
     };
   },
 });

--- a/sources/packages/web/src/views/institution/student/applicationDetails/NoticeOfAssessment.vue
+++ b/sources/packages/web/src/views/institution/student/applicationDetails/NoticeOfAssessment.vue
@@ -47,6 +47,7 @@ export default defineComponent({
         assessmentId: props.assessmentId,
       },
     }));
+
     return { routeLocation };
   },
 });

--- a/sources/packages/web/src/views/institution/student/applicationDetails/NoticeOfAssessment.vue
+++ b/sources/packages/web/src/views/institution/student/applicationDetails/NoticeOfAssessment.vue
@@ -1,5 +1,5 @@
 <template>
-  <full-page-container>
+  <full-page-container v-if="!hideView">
     <template #header>
       <header-navigator
         title="Assessment"
@@ -10,12 +10,14 @@
     <notice-of-assessment-form-view
       :assessment-id="assessmentId"
       :student-id="studentId"
+      :application-id="applicationId"
+      @set-hide-view="setHideView"
     />
   </full-page-container>
 </template>
 
 <script lang="ts">
-import { defineComponent, computed } from "vue";
+import { defineComponent, computed, ref } from "vue";
 import NoticeOfAssessmentFormView from "@/components/common/NoticeOfAssessmentFormView.vue";
 import { InstitutionRoutesConst } from "@/constants/routes/RouteConstants";
 
@@ -38,6 +40,7 @@ export default defineComponent({
     },
   },
   setup(props) {
+    const hideView = ref(false);
     const routeLocation = computed(() => ({
       name: InstitutionRoutesConst.ASSESSMENT_AWARD_VIEW,
       params: {
@@ -47,7 +50,10 @@ export default defineComponent({
       },
     }));
 
-    return { routeLocation };
+    const setHideView = (value: boolean) => {
+      hideView.value = value;
+    };
+    return { routeLocation, hideView, setHideView };
   },
 });
 </script>

--- a/sources/packages/web/src/views/institution/student/applicationDetails/NoticeOfAssessment.vue
+++ b/sources/packages/web/src/views/institution/student/applicationDetails/NoticeOfAssessment.vue
@@ -1,5 +1,5 @@
 <template>
-  <full-page-container v-if="!hideView">
+  <full-page-container>
     <template #header>
       <header-navigator
         title="Assessment"
@@ -11,7 +11,6 @@
       :assessment-id="assessmentId"
       :student-id="studentId"
       :application-id="applicationId"
-      @set-hide-view="setHideView"
     />
   </full-page-container>
 </template>
@@ -40,7 +39,6 @@ export default defineComponent({
     },
   },
   setup(props) {
-    const hideView = ref(false);
     const routeLocation = computed(() => ({
       name: InstitutionRoutesConst.ASSESSMENT_AWARD_VIEW,
       params: {
@@ -49,11 +47,7 @@ export default defineComponent({
         assessmentId: props.assessmentId,
       },
     }));
-
-    const setHideView = (value: boolean) => {
-      hideView.value = value;
-    };
-    return { routeLocation, hideView, setHideView };
+    return { routeLocation };
   },
 });
 </script>

--- a/sources/packages/web/src/views/institution/student/applicationDetails/NoticeOfAssessment.vue
+++ b/sources/packages/web/src/views/institution/student/applicationDetails/NoticeOfAssessment.vue
@@ -16,7 +16,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, computed, ref } from "vue";
+import { defineComponent, computed } from "vue";
 import NoticeOfAssessmentFormView from "@/components/common/NoticeOfAssessmentFormView.vue";
 import { InstitutionRoutesConst } from "@/constants/routes/RouteConstants";
 

--- a/sources/packages/web/src/views/institution/student/applicationDetails/StudentAppealRequest.vue
+++ b/sources/packages/web/src/views/institution/student/applicationDetails/StudentAppealRequest.vue
@@ -17,7 +17,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, ref } from "vue";
+import { defineComponent } from "vue";
 import { InstitutionRoutesConst } from "@/constants/routes/RouteConstants";
 import StudentAppealRequestsApproval from "@/components/common/students/applicationDetails/StudentAppealRequestsApproval.vue";
 

--- a/sources/packages/web/src/views/institution/student/applicationDetails/StudentAppealRequest.vue
+++ b/sources/packages/web/src/views/institution/student/applicationDetails/StudentAppealRequest.vue
@@ -1,5 +1,5 @@
 <template>
-  <full-page-container v-if="!hideView">
+  <full-page-container>
     <template #header>
       <header-navigator
         title="Assessment"
@@ -12,7 +12,6 @@
       :appealId="appealId"
       :readOnlyForm="true"
       :application-id="applicationId"
-      @set-hide-view="setHideView"
     />
   </full-page-container>
 </template>
@@ -39,7 +38,6 @@ export default defineComponent({
     },
   },
   setup(props) {
-    const hideView = ref(false);
     const assessmentsSummaryRoute = {
       name: InstitutionRoutesConst.ASSESSMENTS_SUMMARY,
       params: {
@@ -47,14 +45,9 @@ export default defineComponent({
         studentId: props.studentId,
       },
     };
-    const setHideView = (value: boolean) => {
-      hideView.value = value;
-    };
 
     return {
       assessmentsSummaryRoute,
-      hideView,
-      setHideView,
     };
   },
 });

--- a/sources/packages/web/src/views/institution/student/applicationDetails/StudentAppealRequest.vue
+++ b/sources/packages/web/src/views/institution/student/applicationDetails/StudentAppealRequest.vue
@@ -1,5 +1,5 @@
 <template>
-  <full-page-container>
+  <full-page-container v-if="!hideView">
     <template #header>
       <header-navigator
         title="Assessment"
@@ -11,12 +11,14 @@
       :studentId="studentId"
       :appealId="appealId"
       :readOnlyForm="true"
+      :application-id="applicationId"
+      @set-hide-view="setHideView"
     />
   </full-page-container>
 </template>
 
 <script lang="ts">
-import { defineComponent } from "vue";
+import { defineComponent, ref } from "vue";
 import { InstitutionRoutesConst } from "@/constants/routes/RouteConstants";
 import StudentAppealRequestsApproval from "@/components/common/students/applicationDetails/StudentAppealRequestsApproval.vue";
 
@@ -37,6 +39,7 @@ export default defineComponent({
     },
   },
   setup(props) {
+    const hideView = ref(false);
     const assessmentsSummaryRoute = {
       name: InstitutionRoutesConst.ASSESSMENTS_SUMMARY,
       params: {
@@ -44,8 +47,14 @@ export default defineComponent({
         studentId: props.studentId,
       },
     };
+    const setHideView = (value: boolean) => {
+      hideView.value = value;
+    };
+
     return {
       assessmentsSummaryRoute,
+      hideView,
+      setHideView,
     };
   },
 });

--- a/sources/packages/web/src/views/institution/student/applicationDetails/StudentAppealRequest.vue
+++ b/sources/packages/web/src/views/institution/student/applicationDetails/StudentAppealRequest.vue
@@ -45,7 +45,6 @@ export default defineComponent({
         studentId: props.studentId,
       },
     };
-
     return {
       assessmentsSummaryRoute,
     };


### PR DESCRIPTION
- Added application check for award, noa, exception, and appeal.
- Updated existing decorator `@HasStudentDataAccess` to accept `applicationId` as an optional parameter and it applied to requests, history,  award, noa, exception, and appeals.

