### PR TITLE
#1964 - Added role to restrict MSFAA reissue

### DIFF
--- a/sources/packages/backend/apps/api/src/auth/roles.enum.ts
+++ b/sources/packages/backend/apps/api/src/auth/roles.enum.ts
@@ -30,5 +30,5 @@ export enum Role {
   InstitutionCreateNote = "institution-create-note",
   InstitutionApproveDeclineDesignation = "institution-approve-decline-designation",
   InstitutionApproveDeclineOfferingChanges = "institution-approve-decline-offering-changes",
-  RestrictMSFAAReissue = "restrict-msfaa-reissue",
+  StudentReissueMSFAA = "student-reissue-msfaa",
 }

--- a/sources/packages/backend/apps/api/src/auth/roles.enum.ts
+++ b/sources/packages/backend/apps/api/src/auth/roles.enum.ts
@@ -30,4 +30,5 @@ export enum Role {
   InstitutionCreateNote = "institution-create-note",
   InstitutionApproveDeclineDesignation = "institution-approve-decline-designation",
   InstitutionApproveDeclineOfferingChanges = "institution-approve-decline-offering-changes",
+  RestrictMSFAAReissue = "restrict-msfaa-reissue",
 }

--- a/sources/packages/backend/apps/api/src/route-controllers/application/_tests_/application.aest.reissueMSFAA.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/application/_tests_/application.aest.reissueMSFAA.e2e-spec.ts
@@ -316,6 +316,7 @@ describe("ApplicationAESTController(e2e)-reissueMSFAA", () => {
     // Arrange
     const endpoint = `/aest/application/9999/reissue-msfaa`;
     const token = await getAESTToken(AESTGroups.BusinessAdministrators);
+
     // Act/Assert
     await request(app.getHttpServer())
       .post(endpoint)
@@ -349,26 +350,9 @@ describe("ApplicationAESTController(e2e)-reissueMSFAA", () => {
     }
   }
 
-  it("Should not reissue an MSFAA when user is not a business administrator.", async () => {
+  it.only("Should not reissue an MSFAA when user is not a business administrator.", async () => {
     // Arrange
-    const student = await saveFakeStudent(db.dataSource);
-    const currentMSFAA = createFakeMSFAANumber(
-      { student },
-      {
-        state: MSFAAStates.Signed | MSFAAStates.CancelledOtherProvince,
-      },
-    );
-    await db.msfaaNumber.save(currentMSFAA);
-    const application = await saveFakeApplicationDisbursements(
-      db.dataSource,
-      { student, msfaaNumber: currentMSFAA },
-      {
-        applicationStatus: ApplicationStatus.Completed,
-        createSecondDisbursement: true,
-      },
-    );
-
-    const endpoint = `/aest/application/${application.id}/reissue-msfaa`;
+    const endpoint = "/aest/application/123/reissue-msfaa";
     const token = await getAESTToken(AESTGroups.OperationsAdministrators);
 
     // Act/Assert

--- a/sources/packages/backend/apps/api/src/route-controllers/application/_tests_/application.aest.reissueMSFAA.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/application/_tests_/application.aest.reissueMSFAA.e2e-spec.ts
@@ -350,7 +350,7 @@ describe("ApplicationAESTController(e2e)-reissueMSFAA", () => {
     }
   }
 
-  it.only("Should not reissue an MSFAA when user is not a business administrator.", async () => {
+  it("Should not reissue an MSFAA when user is not a business administrator.", async () => {
     // Arrange
     const endpoint = "/aest/application/123/reissue-msfaa";
     const token = await getAESTToken(AESTGroups.OperationsAdministrators);

--- a/sources/packages/backend/apps/api/src/route-controllers/application/application.aest.controller.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/application/application.aest.controller.ts
@@ -10,7 +10,12 @@ import {
 import { ApplicationService } from "../../services";
 import BaseController from "../BaseController";
 import { ApplicationBaseAPIOutDTO } from "./models/application.dto";
-import { AllowAuthorizedParty, Groups, UserToken } from "../../auth/decorators";
+import {
+  AllowAuthorizedParty,
+  Groups,
+  Roles,
+  UserToken,
+} from "../../auth/decorators";
 import { AuthorizedParties } from "../../auth/authorized-parties.enum";
 import { UserGroups } from "../../auth/user-groups.enum";
 import {
@@ -28,7 +33,7 @@ import {
   APPLICATION_NOT_FOUND,
   INVALID_OPERATION_IN_THE_CURRENT_STATUS,
 } from "@sims/services/constants";
-import { IUserToken } from "../../auth";
+import { IUserToken, Role } from "../../auth";
 
 @AllowAuthorizedParty(AuthorizedParties.aest)
 @Groups(UserGroups.AESTUser)
@@ -80,6 +85,7 @@ export class ApplicationAESTController extends BaseController {
    * @param applicationId reference application id.
    * @returns the newly created MSFAA.
    */
+  @Roles(Role.StudentReissueMSFAA)
   @Post(":applicationId/reissue-msfaa")
   @ApiNotFoundResponse({ description: "Application id not found." })
   @ApiUnprocessableEntityResponse({

--- a/sources/packages/backend/apps/api/src/testHelpers/auth/_tests_/e2e/aest-token-helpers.getAESTToken.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/testHelpers/auth/_tests_/e2e/aest-token-helpers.getAESTToken.e2e-spec.ts
@@ -1,10 +1,10 @@
 import { JwtService } from "@nestjs/jwt";
-import { IUserToken, Role } from "../src/auth";
-import { AESTGroups, getAESTToken } from "../src/testHelpers";
+import { IUserToken, Role } from "../../../../auth";
+import { AESTGroups, getAESTToken } from "../../..";
 
 const jwtService = new JwtService();
 
-describe("Auth Ministry", () => {
+describe("(e2e)-getAESTToken()", () => {
   it("Should have all roles when ministry user is a business administrator.", async () => {
     //Act
     const token = await getAESTToken(AESTGroups.BusinessAdministrators);

--- a/sources/packages/backend/apps/api/src/testHelpers/auth/_tests_/e2e/aest-token-helpers.getAESTToken.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/testHelpers/auth/_tests_/e2e/aest-token-helpers.getAESTToken.e2e-spec.ts
@@ -4,15 +4,15 @@ import { AESTGroups, getAESTToken } from "../../..";
 
 const jwtService = new JwtService();
 
-describe("(e2e)-getAESTToken()", () => {
+describe("Auth(e2e)-getAESTToken()", () => {
   it("Should have all roles when ministry user is a business administrator.", async () => {
-    //Act
+    // Act
     const token = await getAESTToken(AESTGroups.BusinessAdministrators);
     const decodedToken = jwtService.decode(token) as IUserToken;
     decodedToken.resource_access.aest.roles.sort((a, b) => a.localeCompare(b));
     const allAESTRoles = Object.values(Role).sort((a, b) => a.localeCompare(b));
 
-    //Assert
+    // Assert
     expect(decodedToken.resource_access.aest.roles).toEqual(allAESTRoles);
   });
 });

--- a/sources/packages/backend/apps/api/test/auth.aest.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/test/auth.aest.e2e-spec.ts
@@ -1,5 +1,5 @@
 import { JwtService } from "@nestjs/jwt";
-import { Role } from "../src/auth";
+import { IUserToken, Role } from "../src/auth";
 import { AESTGroups, getAESTToken } from "../src/testHelpers";
 
 const jwtService = new JwtService();
@@ -10,9 +10,9 @@ describe("Auth Ministry", () => {
     const token = await getAESTToken(AESTGroups.BusinessAdministrators);
 
     //Assert
-    const decodedToken = jwtService.decode(token);
+    const decodedToken = jwtService.decode(token) as IUserToken;
     expect(
-      decodedToken["resource_access"].aest.roles.sort((a, b) =>
+      decodedToken.resource_access.aest.roles.sort((a, b) =>
         a.localeCompare(b),
       ),
     ).toEqual(Object.values(Role).sort((a, b) => a.localeCompare(b)));

--- a/sources/packages/backend/apps/api/test/auth.aest.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/test/auth.aest.e2e-spec.ts
@@ -8,13 +8,13 @@ describe("Auth Ministry", () => {
   it("Should have all roles when ministry user is a business administrator.", async () => {
     //Act
     const token = await getAESTToken(AESTGroups.BusinessAdministrators);
+    const decodedToken = jwtService.decode(token) as IUserToken;
+    const expectedRoles = decodedToken.resource_access.aest.roles.sort((a, b) =>
+      a.localeCompare(b),
+    );
+    const allAESTRoles = Object.values(Role).sort((a, b) => a.localeCompare(b));
 
     //Assert
-    const decodedToken = jwtService.decode(token) as IUserToken;
-    expect(
-      decodedToken.resource_access.aest.roles.sort((a, b) =>
-        a.localeCompare(b),
-      ),
-    ).toEqual(Object.values(Role).sort((a, b) => a.localeCompare(b)));
+    expect(expectedRoles).toEqual(allAESTRoles);
   });
 });

--- a/sources/packages/backend/apps/api/test/auth.aest.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/test/auth.aest.e2e-spec.ts
@@ -11,8 +11,10 @@ describe("Auth Ministry", () => {
 
     //Assert
     const decodedToken = jwtService.decode(token);
-    expect(decodedToken["resource_access"].aest.roles.sort()).toEqual(
-      Object.values(Role).sort(),
-    );
+    expect(
+      decodedToken["resource_access"].aest.roles.sort((a, b) =>
+        a.localeCompare(b),
+      ),
+    ).toEqual(Object.values(Role).sort((a, b) => a.localeCompare(b)));
   });
 });

--- a/sources/packages/backend/apps/api/test/auth.aest.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/test/auth.aest.e2e-spec.ts
@@ -5,7 +5,7 @@ import { AESTGroups, getAESTToken } from "../src/testHelpers";
 const jwtService = new JwtService();
 
 describe("Auth Ministry", () => {
-  it("Should have specific roles when ministry user is a business administrator.", async () => {
+  it("Should have all roles when ministry user is a business administrator.", async () => {
     //Act
     const token = await getAESTToken(AESTGroups.BusinessAdministrators);
 

--- a/sources/packages/backend/apps/api/test/auth.aest.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/test/auth.aest.e2e-spec.ts
@@ -9,12 +9,10 @@ describe("Auth Ministry", () => {
     //Act
     const token = await getAESTToken(AESTGroups.BusinessAdministrators);
     const decodedToken = jwtService.decode(token) as IUserToken;
-    const expectedRoles = decodedToken.resource_access.aest.roles.sort((a, b) =>
-      a.localeCompare(b),
-    );
+    decodedToken.resource_access.aest.roles.sort((a, b) => a.localeCompare(b));
     const allAESTRoles = Object.values(Role).sort((a, b) => a.localeCompare(b));
 
     //Assert
-    expect(expectedRoles).toEqual(allAESTRoles);
+    expect(decodedToken.resource_access.aest.roles).toEqual(allAESTRoles);
   });
 });

--- a/sources/packages/backend/apps/api/test/auth.aest.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/test/auth.aest.e2e-spec.ts
@@ -1,0 +1,18 @@
+import { JwtService } from "@nestjs/jwt";
+import { Role } from "../src/auth";
+import { AESTGroups, getAESTToken } from "../src/testHelpers";
+
+const jwtService = new JwtService();
+
+describe("Auth Ministry", () => {
+  it("Should have specific roles when ministry user is a business administrator.", async () => {
+    //Act
+    const token = await getAESTToken(AESTGroups.BusinessAdministrators);
+
+    //Assert
+    const decodedToken = jwtService.decode(token);
+    expect(decodedToken["resource_access"].aest.roles.sort()).toEqual(
+      Object.values(Role).sort(),
+    );
+  });
+});

--- a/sources/packages/web/src/types/contracts/aest/roles.ts
+++ b/sources/packages/web/src/types/contracts/aest/roles.ts
@@ -30,5 +30,5 @@ export enum Role {
   InstitutionCreateNote = "institution-create-note",
   InstitutionApproveDeclineDesignation = "institution-approve-decline-designation",
   InstitutionApproveDeclineOfferingChanges = "institution-approve-decline-offering-changes",
-  RestrictMSFAAReissue = "restrict-msfaa-reissue",
+  StudentReissueMSFAA = "student-reissue-msfaa",
 }

--- a/sources/packages/web/src/types/contracts/aest/roles.ts
+++ b/sources/packages/web/src/types/contracts/aest/roles.ts
@@ -30,4 +30,5 @@ export enum Role {
   InstitutionCreateNote = "institution-create-note",
   InstitutionApproveDeclineDesignation = "institution-approve-decline-designation",
   InstitutionApproveDeclineOfferingChanges = "institution-approve-decline-offering-changes",
+  RestrictMSFAAReissue = "restrict-msfaa-reissue",
 }

--- a/sources/packages/web/src/views/aest/student/applicationDetails/NoticeOfAssessment.vue
+++ b/sources/packages/web/src/views/aest/student/applicationDetails/NoticeOfAssessment.vue
@@ -12,7 +12,7 @@
     </template>
     <notice-of-assessment-form-view
       :assessment-id="assessmentId"
-      :can-reissue-m-s-f-a-a="true"
+      :can-reissue-m-s-f-a-a="hasStudentReissueMSFAARole"
       @reissue-m-s-f-a-a="reissueMSFAA"
     />
   </full-page-container>
@@ -23,7 +23,8 @@ import { defineComponent } from "vue";
 import NoticeOfAssessmentFormView from "@/components/common/NoticeOfAssessmentFormView.vue";
 import { AESTRoutesConst } from "@/constants/routes/RouteConstants";
 import { ApplicationService } from "@/services/ApplicationService";
-import { useSnackBar } from "@/composables";
+import { useAuth, useSnackBar } from "@/composables";
+import { Role } from "@/types";
 
 export default defineComponent({
   components: {
@@ -45,6 +46,8 @@ export default defineComponent({
   },
   setup() {
     const snackBar = useSnackBar();
+    const { hasRole } = useAuth();
+    const hasStudentReissueMSFAARole = hasRole(Role.StudentReissueMSFAA);
     const reissueMSFAA = async (
       applicationId: number,
       reloadNOA: () => Promise<void>,
@@ -62,7 +65,7 @@ export default defineComponent({
       }
     };
 
-    return { reissueMSFAA, AESTRoutesConst };
+    return { reissueMSFAA, AESTRoutesConst, hasStudentReissueMSFAARole };
   },
 });
 </script>


### PR DESCRIPTION
- Added role to aest-business-administrators group on DEV and TEST;
- Added role to enums;
- Added decorator on the api call to restrict only to business administrator role;
- Passed value to hide button when user has not business administrator role;
- Updated User profile matrix spreadsheet;
- Added the following tests:
  Auth Ministry
      √ Should have specific roles when ministry user is a business administrator. (400 ms)
  ApplicationAESTController(e2e)-reissueMSFAA
      √ Should not reissue an MSFAA when user is not a business administrator.