### PR TITLE
#1983 - Changed Redis client to ioredis for local development

### DIFF
--- a/sources/packages/backend/libs/sims-db/src/data-source.ts
+++ b/sources/packages/backend/libs/sims-db/src/data-source.ts
@@ -57,7 +57,7 @@ import { ORM_CACHE_LIFETIME } from "@sims/utilities";
 import { ConfigService } from "@sims/utilities/config";
 
 interface ORMCacheConfig {
-  type: "database" | "redis" | "ioredis/cluster";
+  type: "database" | "ioredis" | "ioredis/cluster";
   options?:
     | RedisOptions
     | {
@@ -94,7 +94,7 @@ function getORMCacheConfig(): ORMCacheConfig | false {
 
   if (config.redis.redisStandaloneMode) {
     return {
-      type: "redis",
+      type: "ioredis",
       options: {
         host: config.redis.redisHost,
         port: config.redis.redisPort,


### PR DESCRIPTION
While using the standalone mode (local development only) the configuration used was meant to be used by `ioredis` client but it was configured to use `redis` client. For reference only, this is the method on the Typeorm source code where the initialization of the specific client happens: https://github.com/typeorm/typeorm/blob/master/src/cache/RedisQueryResultCache.ts#L50
This is the Typeorm documention that states that the connection can happen using `redis` or `ioredis` client: https://orkhan.gitbook.io/typeorm/docs/caching

#### Expected by `redis` client

As shown below, the `redis` client requires a `socket` configuration. because the information about the host/port was not properly provided to `redis` client the connectivity was established on localhost:6379 by default, which explains why it was working from our localhost ad failing from the docker-compose.
`redis` client configuration options: https://github.com/redis/node-redis/blob/master/docs/client-configuration.md

```ts
 if (config.redis.redisStandaloneMode) {
  return {
    type: "redis",
    options: {
      socket: {
        host: config.redis.redisHost,
        port: config.redis.redisPort,
      },
      password: config.redis.redisPassword,
    },
    duration: ORM_CACHE_LIFETIME,
  };
}
```

#### Expected by `ioredis` client
`ioredis` configuration options: https://github.com/luin/ioredis/blob/v4/API.md#new-redisport-host-options

```ts
if (config.redis.redisStandaloneMode) {
  return {
    type: "ioredis",
    options: {
      host: config.redis.redisHost,
      port: config.redis.redisPort,
      password: config.redis.redisPassword,
    },
    duration: ORM_CACHE_LIFETIME,
  };
}
```

#### Why use `ioredis` client?

`ioredis` is also a [Bull Queue](https://www.npmjs.com/package/bull) framework [dependency](https://www.npmjs.com/package/bull?activeTab=dependencies) and it is also already used for the cluster mode, so it seems better to just use the same client for the standalone connection.