### PR TITLE
#2006 - Remediate high risk vulnerabilities from WAVA report

### DIFF
--- a/sources/packages/backend/apps/api/src/route-controllers/confirmation-of-enrollment/_tests_/e2e/confirmation-of-enrollment.institutions.getCOESummary.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/confirmation-of-enrollment/_tests_/e2e/confirmation-of-enrollment.institutions.getCOESummary.e2e-spec.ts
@@ -128,6 +128,30 @@ describe("ConfirmationOfEnrollmentInstitutionsController(e2e)-getCOESummary", ()
       });
   });
 
+  it("Should return a BadRequest error when the page number has an invalid integer.", async () => {
+    // Arrange
+    const collegeCLocation = createFakeInstitutionLocation(collegeC);
+    await authorizeUserTokenForLocation(
+      appDataSource,
+      InstitutionTokenTypes.CollegeCUser,
+      collegeCLocation,
+    );
+    const invalidPage = Number.MAX_SAFE_INTEGER + 1;
+    const endpoint = `/institutions/location/${collegeCLocation.id}/confirmation-of-enrollment/enrollmentPeriod/${EnrollmentPeriod.Current}?page=${invalidPage}&pageLimit=10&sortField=disbursementDate&sortOrder=ASC`;
+    const token = await getInstitutionToken(InstitutionTokenTypes.CollegeCUser);
+
+    // Act/Assert
+    await request(app.getHttpServer())
+      .get(endpoint)
+      .auth(token, BEARER_AUTH_TYPE)
+      .expect(HttpStatus.BAD_REQUEST)
+      .expect({
+        statusCode: HttpStatus.BAD_REQUEST,
+        message: ["page must not be greater than 9007199254740991"],
+        error: "Bad Request",
+      });
+  });
+
   it("Should get the COE upcoming summary when there are 2 COEs available.", async () => {
     // Arrange
     const collegeCLocation = createFakeInstitutionLocation(collegeC);

--- a/sources/packages/backend/apps/api/src/route-controllers/models/pagination.dto.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/models/pagination.dto.ts
@@ -21,6 +21,7 @@ abstract class PaginationOptionsAPIInDTO {
    * Page number.
    */
   @Min(0)
+  @Max(Number.MAX_SAFE_INTEGER)
   page: number;
   /**
    * Page size or records per page.


### PR DESCRIPTION
- Added a max value to the page number that is globally used for all API endpoints that have pagination enabled. This fix the 45 issues on Wava identified in the category `Integer Overflow`.
- Added an E2E test to one of the endpoints mentioned on the Wava scan: `confirmation-of-enrollment/enrollmentPeriod/current?page=99999999999999999999&pageLimit=10`. This E2E test case file was used because it already has tests created and it was easier to have this one added.
- The issues on the category `API Mass Assignment` are not part of this PR. Further details on the associated ticket.