### PR TITLE
#1997 - Upgrade Zeebe node version

### DIFF
--- a/sources/packages/backend/package-lock.json
+++ b/sources/packages/backend/package-lock.json
@@ -47,7 +47,7 @@
         "ssh2-sftp-client": "^7.1.0",
         "swagger-ui-express": "^4.3.0",
         "typeorm": "^0.3.14",
-        "zeebe-node": "^8.1.4"
+        "zeebe-node": "^8.2.4"
       },
       "devDependencies": {
         "@golevelup/ts-jest": "^0.3.5",
@@ -5738,18 +5738,24 @@
       "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA=="
     },
     "node_modules/fast-xml-parser": {
-      "version": "3.21.1",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-3.21.1.tgz",
-      "integrity": "sha512-FTFVjYoBOZTJekiUsawGsSYV9QL0A+zDYCRj7y34IO6Jg+2IMYEtQa+bbictpdpV8dHxXywqU7C0gRDEOFtBFg==",
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.2.4.tgz",
+      "integrity": "sha512-fbfMDvgBNIdDJLdLOwacjFAPYt67tr31H9ZhWSm45CDAxvd0I6WTlSOUo7K2P/K5sA5JgMKG64PI3DMcaFdWpQ==",
+      "funding": [
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/naturalintelligence"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
       "dependencies": {
-        "strnum": "^1.0.4"
+        "strnum": "^1.0.5"
       },
       "bin": {
-        "xml2js": "cli.js"
-      },
-      "funding": {
-        "type": "paypal",
-        "url": "https://paypal.me/naturalintelligence"
+        "fxparser": "src/cli/cli.js"
       }
     },
     "node_modules/fastq": {
@@ -11551,9 +11557,9 @@
       }
     },
     "node_modules/zeebe-node": {
-      "version": "8.1.4",
-      "resolved": "https://registry.npmjs.org/zeebe-node/-/zeebe-node-8.1.4.tgz",
-      "integrity": "sha512-8JLeRUk62JycVzTFDKv/OgCyGWlNIYCd+JxwKFoEtddNx0/Reazgj/fACVGLmT+xOTYtUaAFsBxbxuklgZRh7w==",
+      "version": "8.2.4",
+      "resolved": "https://registry.npmjs.org/zeebe-node/-/zeebe-node-8.2.4.tgz",
+      "integrity": "sha512-AFrmPhlp7uYhnCW5Yo6kTaJOkU8Pa26XvtxnRxbg1HcSeKlnIoO0R117aYbSgSKcjHog7zWgSiYnARJMREkyPQ==",
       "dependencies": {
         "@grpc/grpc-js": "1.8.7",
         "@grpc/proto-loader": "0.7.4",
@@ -11561,14 +11567,14 @@
         "console-stamp": "^3.0.2",
         "dayjs": "^1.8.15",
         "debug": "^4.2.0",
-        "fast-xml-parser": "^3.12.12",
+        "fast-xml-parser": "^4.1.3",
         "fp-ts": "^2.5.1",
         "got": "^11.8.5",
         "long": "^4.0.0",
         "promise-retry": "^1.1.1",
         "stack-trace": "0.0.10",
         "typed-duration": "^1.0.12",
-        "uuid": "^3.3.2"
+        "uuid": "^7.0.3"
       },
       "bin": {
         "zeebe-node": "bin/zeebe-node"
@@ -11680,12 +11686,11 @@
       }
     },
     "node_modules/zeebe-node/node_modules/uuid": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-7.0.3.tgz",
+      "integrity": "sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==",
       "bin": {
-        "uuid": "bin/uuid"
+        "uuid": "dist/bin/uuid"
       }
     }
   },
@@ -15942,11 +15947,11 @@
       "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA=="
     },
     "fast-xml-parser": {
-      "version": "3.21.1",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-3.21.1.tgz",
-      "integrity": "sha512-FTFVjYoBOZTJekiUsawGsSYV9QL0A+zDYCRj7y34IO6Jg+2IMYEtQa+bbictpdpV8dHxXywqU7C0gRDEOFtBFg==",
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.2.4.tgz",
+      "integrity": "sha512-fbfMDvgBNIdDJLdLOwacjFAPYt67tr31H9ZhWSm45CDAxvd0I6WTlSOUo7K2P/K5sA5JgMKG64PI3DMcaFdWpQ==",
       "requires": {
-        "strnum": "^1.0.4"
+        "strnum": "^1.0.5"
       }
     },
     "fastq": {
@@ -20186,9 +20191,9 @@
       "dev": true
     },
     "zeebe-node": {
-      "version": "8.1.4",
-      "resolved": "https://registry.npmjs.org/zeebe-node/-/zeebe-node-8.1.4.tgz",
-      "integrity": "sha512-8JLeRUk62JycVzTFDKv/OgCyGWlNIYCd+JxwKFoEtddNx0/Reazgj/fACVGLmT+xOTYtUaAFsBxbxuklgZRh7w==",
+      "version": "8.2.4",
+      "resolved": "https://registry.npmjs.org/zeebe-node/-/zeebe-node-8.2.4.tgz",
+      "integrity": "sha512-AFrmPhlp7uYhnCW5Yo6kTaJOkU8Pa26XvtxnRxbg1HcSeKlnIoO0R117aYbSgSKcjHog7zWgSiYnARJMREkyPQ==",
       "requires": {
         "@grpc/grpc-js": "1.8.7",
         "@grpc/proto-loader": "0.7.4",
@@ -20196,14 +20201,14 @@
         "console-stamp": "^3.0.2",
         "dayjs": "^1.8.15",
         "debug": "^4.2.0",
-        "fast-xml-parser": "^3.12.12",
+        "fast-xml-parser": "^4.1.3",
         "fp-ts": "^2.5.1",
         "got": "^11.8.5",
         "long": "^4.0.0",
         "promise-retry": "^1.1.1",
         "stack-trace": "0.0.10",
         "typed-duration": "^1.0.12",
-        "uuid": "^3.3.2"
+        "uuid": "^7.0.3"
       },
       "dependencies": {
         "ansi-styles": {
@@ -20283,9 +20288,9 @@
           }
         },
         "uuid": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-7.0.3.tgz",
+          "integrity": "sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg=="
         }
       }
     }

--- a/sources/packages/backend/package-lock.json
+++ b/sources/packages/backend/package-lock.json
@@ -47,7 +47,7 @@
         "ssh2-sftp-client": "^7.1.0",
         "swagger-ui-express": "^4.3.0",
         "typeorm": "^0.3.14",
-        "zeebe-node": "^8.2.4"
+        "zeebe-node": "^8.2.3"
       },
       "devDependencies": {
         "@golevelup/ts-jest": "^0.3.5",

--- a/sources/packages/backend/package.json
+++ b/sources/packages/backend/package.json
@@ -78,7 +78,7 @@
     "ssh2-sftp-client": "^7.1.0",
     "swagger-ui-express": "^4.3.0",
     "typeorm": "^0.3.14",
-    "zeebe-node": "^8.2.4"
+    "zeebe-node": "^8.2.3"
   },
   "devDependencies": {
     "@golevelup/ts-jest": "^0.3.5",

--- a/sources/packages/backend/package.json
+++ b/sources/packages/backend/package.json
@@ -78,7 +78,7 @@
     "ssh2-sftp-client": "^7.1.0",
     "swagger-ui-express": "^4.3.0",
     "typeorm": "^0.3.14",
-    "zeebe-node": "^8.1.4"
+    "zeebe-node": "^8.2.4"
   },
   "devDependencies": {
     "@golevelup/ts-jest": "^0.3.5",

--- a/sources/packages/backend/workflow/test/models/assessment.model.ts
+++ b/sources/packages/backend/workflow/test/models/assessment.model.ts
@@ -4,8 +4,9 @@ import {
   YesNoOptions,
   OfferingDeliveryOptions,
 } from "@sims/test-utils";
+import { JSONDoc } from "zeebe-node";
 
-export interface StudentDependent {
+export interface StudentDependent extends JSONDoc {
   dateOfBirth: string;
   attendingPostSecondarySchool: YesNoOptions;
   declaredOnTaxes: YesNoOptions;
@@ -43,7 +44,7 @@ export enum InstitutionTypes {
 /**
  * Data required to calculate the assessment data of an application.
  */
-export interface AssessmentConsolidatedData {
+export interface AssessmentConsolidatedData extends JSONDoc {
   studentDataDependantstatus: "dependant" | "independant";
   programYear: string;
   programYearStartDate: string;
@@ -71,8 +72,8 @@ export interface AssessmentConsolidatedData {
   offeringStudyEndDate?: string;
   offeringStudyStartDate?: string;
   assessmentTriggerType?: AssessmentTriggerType;
-  appealsStudentIncomeAppealData?: unknown;
-  appealsPartnerIncomeAppealData?: unknown;
+  appealsStudentIncomeAppealData?: JSONDoc;
+  appealsPartnerIncomeAppealData?: JSONDoc;
   studentDataIsYourSpouseACanadianCitizen?: YesNoOptions;
   studentDataParentValidSinNumber?: YesNoOptions;
   studentDataNumberOfParents?: 1 | 2;
@@ -86,7 +87,7 @@ export interface AssessmentConsolidatedData {
   studentDataPartnerStudyWeeks?: number;
   studentDataPartnerEmploymentInsurance?: YesNoOptions;
   studentDataPartnerFedralProvincialPDReceiptCost?: number;
-  studentDataParentDependentTable?: unknown;
+  studentDataParentDependentTable?: JSONDoc;
   studentDataStudentParentNetAssests?: number;
   studentDataStudentParentNetContribution?: number;
   studentDataPartnerTotalIncomeAssistance?: number;


### PR DESCRIPTION
## Update Zeebe node version

 - [x] Updated to zeebe node version 8.2.3
 - [x] Updated the workflow test-util models to extend JSONDoc to be compliant with `createProcessInstanceWithResult()` of Zeebe client.
 
### Note
Initial effort was to upgrade to Zeebe 8.2.4 latest version of zeebe node (https://www.npmjs.com/package/zeebe-node?activeTab=versions) but upgrading to latest version brought back the GRPC resource exhausted error logs. 
Hence upgrading with second latest/penultimate version 8.2.3.