### PR TITLE
#1997 - Fix camunda deployments

### DIFF
--- a/sources/packages/backend/workflow/src/deploy.ts
+++ b/sources/packages/backend/workflow/src/deploy.ts
@@ -125,6 +125,6 @@ import {
     console.error(error);
     throw error;
   } finally {
-    zeebeClient.close();
+    await zeebeClient.close();
   }
 })();

--- a/sources/packages/backend/workflow/src/deploy.ts
+++ b/sources/packages/backend/workflow/src/deploy.ts
@@ -124,5 +124,7 @@ import {
     console.error("Error while executing the deployment.");
     console.error(error);
     throw error;
+  } finally {
+    zeebeClient.close();
   }
 })();


### PR DESCRIPTION
## Close Zeebe connection on camunda deployments

We have an ongoing issue on camunda definition deployments when deploying to camunda SaaS not in local.

The deployment gets executed but the command does not terminate(happens in local and github actions as well). 

`zeebeClient.close()` has been added to code and tested that it fixes the issue.