### PR TITLE
#2033 - Validating FT and PT offering minimum length

### DIFF
--- a/sources/packages/backend/apps/api/src/services/education-program-offering/custom-validators/has-valid-offering-period-for-funded-days.ts
+++ b/sources/packages/backend/apps/api/src/services/education-program-offering/custom-validators/has-valid-offering-period-for-funded-days.ts
@@ -20,8 +20,7 @@ class HasValidOfferingPeriodForFundedDaysConstraint
   implements ValidatorConstraintInterface
 {
   validate(studyBreaks: StudyBreak[], args: ValidationArguments): boolean {
-    const [, , offeringMinDaysAllowed] = args.constraints;
-    const offeringMinDaysAllowedValue = offeringMinDaysAllowed(args.object);
+    const offeringMinDaysAllowedValue = this.getOfferingMinAllowedDays(args);
     const calculatedStudyBreaksAndWeeks = this.getCalculatedStudyBreaks(
       studyBreaks,
       args,
@@ -35,9 +34,18 @@ class HasValidOfferingPeriodForFundedDaysConstraint
   }
 
   defaultMessage(args: ValidationArguments) {
-    const [, , minDaysAllowed] = args.constraints;
-    const minDaysAllowedValue = minDaysAllowed(args.object);
-    return `The funded study amount of days is ineligible for StudentAid BC funding. Your dates must be between ${minDaysAllowedValue} to ${OFFERING_STUDY_PERIOD_MAX_DAYS} days.`;
+    const offeringMinDaysAllowedValue = this.getOfferingMinAllowedDays(args);
+    return `The funded study amount of days is ineligible for StudentAid BC funding. Your dates must be between ${offeringMinDaysAllowedValue} to ${OFFERING_STUDY_PERIOD_MAX_DAYS} days.`;
+  }
+
+  /**
+   * Get offering minimum allowed days from args
+   * @param args validation arguments.
+   * @returns minimum allowed days.
+   */
+  private getOfferingMinAllowedDays(args: ValidationArguments): number {
+    const [, , offeringMinDaysAllowed] = args.constraints;
+    return offeringMinDaysAllowed(args.object) as number;
   }
 }
 

--- a/sources/packages/backend/apps/api/src/services/education-program-offering/custom-validators/has-valid-offering-period-for-funded-days.ts
+++ b/sources/packages/backend/apps/api/src/services/education-program-offering/custom-validators/has-valid-offering-period-for-funded-days.ts
@@ -39,7 +39,7 @@ class HasValidOfferingPeriodForFundedDaysConstraint
   }
 
   /**
-   * Get offering minimum allowed days from args
+   * Get offering minimum allowed days from args.
    * @param args validation arguments.
    * @returns minimum allowed days.
    */

--- a/sources/packages/backend/apps/api/src/services/education-program-offering/custom-validators/has-valid-offering-period-for-funded-days.ts
+++ b/sources/packages/backend/apps/api/src/services/education-program-offering/custom-validators/has-valid-offering-period-for-funded-days.ts
@@ -55,8 +55,8 @@ class HasValidOfferingPeriodForFundedDaysConstraint
  * allowed study period amount of days.
  * @param startPeriodProperty property of the model that identifies the offering start date.
  * @param endPeriodProperty property of the model that identifies the offering end date.
- * @param validationOptions validations options.
  * @param offeringMinDaysAllowed study period minimum length in number of days.
+ * @param validationOptions validations options.
  * @returns true if the study period is valid, otherwise, false.
  */
 export function HasValidOfferingPeriodForFundedDays(

--- a/sources/packages/backend/apps/api/src/services/education-program-offering/education-program-offering-validation.models.ts
+++ b/sources/packages/backend/apps/api/src/services/education-program-offering/education-program-offering-validation.models.ts
@@ -46,7 +46,8 @@ import {
   OFFERING_STUDY_BREAK_MAX_DAYS,
   OFFERING_STUDY_BREAK_MIN_DAYS,
   OFFERING_STUDY_PERIOD_MAX_DAYS,
-  OFFERING_STUDY_PERIOD_MIN_DAYS,
+  FT_OFFERING_STUDY_PERIOD_MIN_DAYS,
+  PT_OFFERING_STUDY_PERIOD_MIN_DAYS,
   OFFERING_YEAR_OF_STUDY_MAX_VALUE,
   OFFERING_YEAR_OF_STUDY_MIN_VALUE,
 } from "../../utilities";
@@ -320,6 +321,18 @@ const studyEndDateProperty = (offering: OfferingValidationModel) =>
   offering.studyEndDate;
 
 /**
+ * Get study period minimum length based on offering intensity.
+ * @param offering offering.
+ * @returns minimum study period length in number of days.
+ */
+const studyPeriodMinLength = (offering: OfferingValidationModel) => {
+  if (offering.offeringIntensity === OfferingIntensity.fullTime) {
+    return FT_OFFERING_STUDY_PERIOD_MIN_DAYS;
+  }
+  return PT_OFFERING_STUDY_PERIOD_MIN_DAYS;
+};
+
+/**
  * Complete offering data with all validations needed to ensure data
  * consistency. Program data and locations data need to be present to
  * ensure a successfully validation.
@@ -353,7 +366,7 @@ export class OfferingValidationModel {
   @IsDateAfter(studyStartDateProperty, userFriendlyNames.studyEndDate)
   @PeriodMinLength(
     studyStartDateProperty,
-    OFFERING_STUDY_PERIOD_MIN_DAYS,
+    studyPeriodMinLength,
     userFriendlyNames.studyEndDate,
     {
       context: ValidationContext.CreateWarning(
@@ -595,6 +608,7 @@ export class OfferingValidationModel {
   @HasValidOfferingPeriodForFundedDays(
     studyStartDateProperty,
     studyEndDateProperty,
+    studyPeriodMinLength,
     {
       context: ValidationContext.CreateWarning(
         OfferingValidationWarnings.InvalidStudyDatesPeriodLength,

--- a/sources/packages/backend/apps/api/src/services/education-program-offering/education-program-offering-validation.models.ts
+++ b/sources/packages/backend/apps/api/src/services/education-program-offering/education-program-offering-validation.models.ts
@@ -46,8 +46,8 @@ import {
   OFFERING_STUDY_BREAK_MAX_DAYS,
   OFFERING_STUDY_BREAK_MIN_DAYS,
   OFFERING_STUDY_PERIOD_MAX_DAYS,
-  FT_OFFERING_STUDY_PERIOD_MIN_DAYS,
-  PT_OFFERING_STUDY_PERIOD_MIN_DAYS,
+  OFFERING_STUDY_PERIOD_MIN_DAYS_FULL_TIME,
+  OFFERING_STUDY_PERIOD_MIN_DAYS_PART_TIME,
   OFFERING_YEAR_OF_STUDY_MAX_VALUE,
   OFFERING_YEAR_OF_STUDY_MIN_VALUE,
 } from "../../utilities";
@@ -327,9 +327,9 @@ const studyEndDateProperty = (offering: OfferingValidationModel) =>
  */
 const studyPeriodMinLength = (offering: OfferingValidationModel) => {
   if (offering.offeringIntensity === OfferingIntensity.fullTime) {
-    return FT_OFFERING_STUDY_PERIOD_MIN_DAYS;
+    return OFFERING_STUDY_PERIOD_MIN_DAYS_FULL_TIME;
   }
-  return PT_OFFERING_STUDY_PERIOD_MIN_DAYS;
+  return OFFERING_STUDY_PERIOD_MIN_DAYS_PART_TIME;
 };
 
 /**

--- a/sources/packages/backend/apps/api/src/utilities/class-validation/custom-validators/period-min-length.ts
+++ b/sources/packages/backend/apps/api/src/utilities/class-validation/custom-validators/period-min-length.ts
@@ -36,8 +36,8 @@ class PeriodMinLengthConstraint implements ValidatorConstraintInterface {
   }
 
   /**
-   * Get minimum allowed days from args
-   * @param args
+   * Get minimum allowed days from args.
+   * @param args validation arguments.
    * @returns minimum allowed days.
    */
   private getMinAllowedDays(args: ValidationArguments): number {
@@ -57,6 +57,7 @@ class PeriodMinLengthConstraint implements ValidatorConstraintInterface {
  * @param startDateProperty indicates the property that define the
  * start of a period.
  * @param minDaysAllowed min allowed days to the period be considered valid.
+ * This could be a value or a function that returns a value of minimum allowed days.
  * @param propertyDisplayName user-friendly property name to be added to the
  * validation message.
  * @param validationOptions validations options.

--- a/sources/packages/backend/apps/api/src/utilities/class-validation/custom-validators/period-min-length.ts
+++ b/sources/packages/backend/apps/api/src/utilities/class-validation/custom-validators/period-min-length.ts
@@ -57,7 +57,7 @@ class PeriodMinLengthConstraint implements ValidatorConstraintInterface {
  * @param startDateProperty indicates the property that define the
  * start of a period.
  * @param minDaysAllowed min allowed days to the period be considered valid.
- * This could be a value or a function that returns a value of minimum allowed days.
+ * This could be a number or a function that returns a value of minimum allowed days.
  * @param propertyDisplayName user-friendly property name to be added to the
  * validation message.
  * @param validationOptions validations options.

--- a/sources/packages/backend/apps/api/src/utilities/class-validation/custom-validators/period-min-length.ts
+++ b/sources/packages/backend/apps/api/src/utilities/class-validation/custom-validators/period-min-length.ts
@@ -16,12 +16,16 @@ import { dateDifference, getDateOnlyFormat } from "@sims/utilities";
 class PeriodMinLengthConstraint implements ValidatorConstraintInterface {
   validate(value: Date | string, args: ValidationArguments): boolean {
     const [startDateProperty, minDaysAllowed] = args.constraints;
+    const minDaysAllowedValue =
+      minDaysAllowed instanceof Function
+        ? minDaysAllowed(args.object)
+        : minDaysAllowed;
     const periodStartDate = startDateProperty(args.object);
     if (!periodStartDate) {
       // The related property does not exists in the provided object to be compared.
       return false;
     }
-    return dateDifference(value, periodStartDate) >= minDaysAllowed;
+    return dateDifference(value, periodStartDate) >= minDaysAllowedValue;
   }
 
   defaultMessage(args: ValidationArguments) {
@@ -49,7 +53,7 @@ class PeriodMinLengthConstraint implements ValidatorConstraintInterface {
  */
 export function PeriodMinLength(
   startDateProperty: (targetObject: unknown) => Date | string,
-  minDaysAllowed: number,
+  minDaysAllowed: ((targetObject: unknown) => number) | number,
   propertyDisplayName?: string,
   validationOptions?: ValidationOptions,
 ) {

--- a/sources/packages/backend/apps/api/src/utilities/class-validation/custom-validators/period-min-length.ts
+++ b/sources/packages/backend/apps/api/src/utilities/class-validation/custom-validators/period-min-length.ts
@@ -44,7 +44,7 @@ class PeriodMinLengthConstraint implements ValidatorConstraintInterface {
     const [, minDaysAllowed] = args.constraints;
     const minDaysAllowedValue =
       minDaysAllowed instanceof Function
-        ? (minDaysAllowed(args.object) as number)
+        ? minDaysAllowed(args.object)
         : minDaysAllowed;
     return minDaysAllowedValue as number;
   }

--- a/sources/packages/backend/apps/api/src/utilities/class-validation/custom-validators/period-min-length.ts
+++ b/sources/packages/backend/apps/api/src/utilities/class-validation/custom-validators/period-min-length.ts
@@ -15,11 +15,8 @@ import { dateDifference, getDateOnlyFormat } from "@sims/utilities";
 @ValidatorConstraint()
 class PeriodMinLengthConstraint implements ValidatorConstraintInterface {
   validate(value: Date | string, args: ValidationArguments): boolean {
-    const [startDateProperty, minDaysAllowed] = args.constraints;
-    const minDaysAllowedValue =
-      minDaysAllowed instanceof Function
-        ? minDaysAllowed(args.object)
-        : minDaysAllowed;
+    const [startDateProperty] = args.constraints;
+    const minDaysAllowedValue = this.getMinAllowedDays(args);
     const periodStartDate = startDateProperty(args.object);
     if (!periodStartDate) {
       // The related property does not exists in the provided object to be compared.
@@ -29,13 +26,27 @@ class PeriodMinLengthConstraint implements ValidatorConstraintInterface {
   }
 
   defaultMessage(args: ValidationArguments) {
-    const [startDateProperty, minDaysAllowed, propertyDisplayName] =
-      args.constraints;
+    const [startDateProperty, , propertyDisplayName] = args.constraints;
     const startDate = getDateOnlyFormat(startDateProperty(args.object));
     const endDate = getDateOnlyFormat(args.value);
+    const minDaysAllowedValue = this.getMinAllowedDays(args);
     return `${
       propertyDisplayName ?? args.property
-    }, the number of day(s) between ${startDate} and ${endDate} must be at least ${minDaysAllowed}.`;
+    }, the number of day(s) between ${startDate} and ${endDate} must be at least ${minDaysAllowedValue}.`;
+  }
+
+  /**
+   * Get minimum allowed days from args
+   * @param args
+   * @returns minimum allowed days.
+   */
+  private getMinAllowedDays(args: ValidationArguments): number {
+    const [, minDaysAllowed] = args.constraints;
+    const minDaysAllowedValue =
+      minDaysAllowed instanceof Function
+        ? (minDaysAllowed(args.object) as number)
+        : minDaysAllowed;
+    return minDaysAllowedValue as number;
   }
 }
 

--- a/sources/packages/backend/apps/api/src/utilities/system-configurations-constants.ts
+++ b/sources/packages/backend/apps/api/src/utilities/system-configurations-constants.ts
@@ -60,9 +60,15 @@ export const OFFERING_COURSE_LOAD_MIN_VALUE = 20;
  */
 export const OFFERING_COURSE_LOAD_MAX_VALUE = 59;
 /**
- * Minimum amount of days to an offering study period.
+ * Minimum amount of days to a full time offering study period.
  */
-export const OFFERING_STUDY_PERIOD_MIN_DAYS = 42;
+export const FT_OFFERING_STUDY_PERIOD_MIN_DAYS = 84;
+
+/**
+ * Minimum amount of days to a part time offering study period.
+ */
+export const PT_OFFERING_STUDY_PERIOD_MIN_DAYS = 42;
+
 /**
  * Maximum amount of days to an offering study period.
  */

--- a/sources/packages/backend/apps/api/src/utilities/system-configurations-constants.ts
+++ b/sources/packages/backend/apps/api/src/utilities/system-configurations-constants.ts
@@ -60,12 +60,12 @@ export const OFFERING_COURSE_LOAD_MIN_VALUE = 20;
  */
 export const OFFERING_COURSE_LOAD_MAX_VALUE = 59;
 /**
- * Minimum amount of days to a full time offering study period.
+ * Minimum amount of days required for a full time offering study period.
  */
 export const FT_OFFERING_STUDY_PERIOD_MIN_DAYS = 84;
 
 /**
- * Minimum amount of days to a part time offering study period.
+ * Minimum amount of days required for a part time offering study period.
  */
 export const PT_OFFERING_STUDY_PERIOD_MIN_DAYS = 42;
 

--- a/sources/packages/backend/apps/api/src/utilities/system-configurations-constants.ts
+++ b/sources/packages/backend/apps/api/src/utilities/system-configurations-constants.ts
@@ -62,12 +62,12 @@ export const OFFERING_COURSE_LOAD_MAX_VALUE = 59;
 /**
  * Minimum amount of days required for a full time offering study period.
  */
-export const FT_OFFERING_STUDY_PERIOD_MIN_DAYS = 84;
+export const OFFERING_STUDY_PERIOD_MIN_DAYS_FULL_TIME = 84;
 
 /**
  * Minimum amount of days required for a part time offering study period.
  */
-export const PT_OFFERING_STUDY_PERIOD_MIN_DAYS = 42;
+export const OFFERING_STUDY_PERIOD_MIN_DAYS_PART_TIME = 42;
 
 /**
  * Maximum amount of days to an offering study period.

--- a/sources/packages/forms/src/form-definitions/educationprogramoffering.json
+++ b/sources/packages/forms/src/form-definitions/educationprogramoffering.json
@@ -1,12 +1,13 @@
 {
   "title": "Education Program Offering",
-  "display": "form",
-  "type": "form",
   "name": "educationprogramoffering",
   "path": "educationprogramoffering",
+  "type": "form",
+  "display": "form",
   "tags": [
     "common"
   ],
+  "owner": "63e3d91e5df786ce7093da47",
   "components": [
     {
       "label": "HTML",
@@ -170,7 +171,8 @@
       "showWordCount": false,
       "allowMultipleMasks": false,
       "addons": [],
-      "id": "ec8hh1"
+      "id": "ec8hh1",
+      "isNew": false
     },
     {
       "label": "HTML",
@@ -836,7 +838,8 @@
               "inputType": "radio",
               "fieldSet": false,
               "id": "epwmfzr",
-              "defaultValue": ""
+              "defaultValue": "",
+              "lockKey": true
             },
             {
               "label": "Study period intensity popup",
@@ -1022,7 +1025,8 @@
                   "allowMultipleMasks": false,
                   "addons": [],
                   "id": "emuvfb",
-                  "defaultValue": ""
+                  "defaultValue": "",
+                  "inputType": "number"
                 }
               ],
               "placeholder": "",
@@ -2085,7 +2089,7 @@
                       "value": ""
                     }
                   ],
-                  "content": "<strong class=\"ml-2\">This study period is ineligible for StudentAid BC funding</strong>\n<br>\n<span>Your dates must be between 42 to 365 days.</span>",
+                  "content": "<strong class=\"ml-2\">This study period is ineligible for StudentAid BC funding</strong>\n<br>\n<span>Your dates must be between {{data.studyPeriodMinDays}} to {{data.studyPeriodMaxDays}} days.</span>",
                   "refreshOnChange": true,
                   "customClass": "banner-warning ",
                   "hidden": false,
@@ -2094,7 +2098,7 @@
                   "tags": [],
                   "properties": {},
                   "conditional": {
-                    "show": null,
+                    "show": "",
                     "when": null,
                     "eq": "",
                     "json": ""
@@ -2153,7 +2157,8 @@
                   "showWordCount": false,
                   "allowMultipleMasks": false,
                   "addons": [],
-                  "id": "ebhbfou"
+                  "id": "ebhbfou",
+                  "isNew": false
                 }
               ],
               "placeholder": "",
@@ -2375,7 +2380,8 @@
                   "allowMultipleMasks": false,
                   "addons": [],
                   "tag": "p",
-                  "id": "eity25i"
+                  "id": "eity25i",
+                  "className": ""
                 },
                 {
                   "label": "No study breaks",
@@ -2650,7 +2656,8 @@
                       "addons": [],
                       "inputType": "text",
                       "id": "eufdf4l0000000",
-                      "defaultValue": ""
+                      "defaultValue": "",
+                      "inDataGrid": true
                     },
                     {
                       "label": "Break end date",
@@ -2760,7 +2767,8 @@
                       "addons": [],
                       "inputType": "text",
                       "id": "endqveo000000",
-                      "defaultValue": ""
+                      "defaultValue": "",
+                      "inDataGrid": true
                     },
                     {
                       "label": "Total break days",
@@ -2837,7 +2845,9 @@
                       "showWordCount": false,
                       "properties": {},
                       "allowMultipleMasks": false,
-                      "addons": []
+                      "addons": [],
+                      "inDataGrid": true,
+                      "inputType": "number"
                     },
                     {
                       "label": "Total eligible break days",
@@ -2913,7 +2923,9 @@
                       "showWordCount": false,
                       "properties": {},
                       "allowMultipleMasks": false,
-                      "addons": []
+                      "addons": [],
+                      "inDataGrid": true,
+                      "inputType": "number"
                     },
                     {
                       "label": "Total ineligible break days",
@@ -2989,7 +3001,9 @@
                       "showWordCount": false,
                       "properties": {},
                       "allowMultipleMasks": false,
-                      "addons": []
+                      "addons": [],
+                      "inDataGrid": true,
+                      "inputType": "number"
                     }
                   ],
                   "placeholder": "",
@@ -4169,7 +4183,8 @@
               "allowMultipleMasks": false,
               "addons": [],
               "tag": "p",
-              "id": "e6zws5q"
+              "id": "e6zws5q",
+              "className": ""
             },
             {
               "collapsible": false,
@@ -4264,7 +4279,8 @@
                           "properties": {},
                           "allowMultipleMasks": false,
                           "addons": [],
-                          "id": "ey5wqhj"
+                          "id": "ey5wqhj",
+                          "inputType": "number"
                         }
                       ],
                       "width": 6,
@@ -4355,7 +4371,8 @@
                           "properties": {},
                           "allowMultipleMasks": false,
                           "addons": [],
-                          "id": "ezezla"
+                          "id": "ezezla",
+                          "inputType": "number"
                         }
                       ],
                       "width": 6,
@@ -4520,7 +4537,8 @@
                           "properties": {},
                           "allowMultipleMasks": false,
                           "addons": [],
-                          "id": "eont0uf"
+                          "id": "eont0uf",
+                          "inputType": "number"
                         }
                       ],
                       "width": 6,
@@ -4611,7 +4629,8 @@
                           "properties": {},
                           "allowMultipleMasks": false,
                           "addons": [],
-                          "id": "esc41a"
+                          "id": "esc41a",
+                          "inputType": "number"
                         }
                       ],
                       "width": 6,
@@ -5184,7 +5203,8 @@
               "allowMultipleMasks": false,
               "addons": [],
               "tag": "p",
-              "id": "e7678z"
+              "id": "e7678z",
+              "className": ""
             },
             {
               "label": "I confirm this study period offering meets the policies outlined in the StudentAid BC policy manual.",
@@ -5725,6 +5745,46 @@
       "addons": [],
       "inputType": "hidden",
       "id": "ejidpjh"
+    },
+    {
+      "input": true,
+      "tableView": true,
+      "key": "studyPeriodMinDays",
+      "label": "Study period minimum days",
+      "protected": false,
+      "unique": false,
+      "persistent": true,
+      "type": "hidden",
+      "tags": [],
+      "conditional": {
+        "show": "",
+        "when": null,
+        "eq": ""
+      },
+      "properties": {},
+      "lockKey": true,
+      "customDefaultValue": "",
+      "calculateValue": "value = data.offeringIntensity === 'Full Time' ? 84 : 42;"
+    },
+    {
+      "input": true,
+      "tableView": true,
+      "key": "studyPeriodMaxDays",
+      "label": "Study period maximum days",
+      "protected": false,
+      "unique": false,
+      "persistent": true,
+      "type": "hidden",
+      "tags": [],
+      "conditional": {
+        "show": "",
+        "when": null,
+        "eq": ""
+      },
+      "properties": {},
+      "defaultValue": "365",
+      "lockKey": true,
+      "isNew": false
     }
   ]
 }

--- a/sources/packages/forms/src/form-definitions/educationprogramoffering.json
+++ b/sources/packages/forms/src/form-definitions/educationprogramoffering.json
@@ -7,7 +7,6 @@
   "tags": [
     "common"
   ],
-  "owner": "63e3d91e5df786ce7093da47",
   "components": [
     {
       "label": "HTML",


### PR DESCRIPTION
## Update the minimum offering length validation as per offering intensity

- [x] Updated `@PeriodMinLength` decorator to accept either a function or a value for `minDaysAllowed`.
   When the same decorator is used for offering validation, the function `studyPeriodMinLength` is assigned to minAllowedDays which calculates minAllowedDays based on offering intensity.
- [x] Updated `@HasValidOfferingPeriodForFundedDays` decorator to have an additional argument to get the minimum allowed days for offering and not use a direct value from  constant. The third argument is a function which provides the minimum allowed days based on the offering intensity.
- [x] Updated `educationprogramoffering` form to have client side hidden variables to get minimum and maximum days for study period length and display the banner messaged using the variables.

Full Time

![image](https://github.com/bcgov/SIMS/assets/54600590/0ebf9e52-c6ad-42f2-839c-0cfb2db1d4ad)

Part Time 

![image](https://github.com/bcgov/SIMS/assets/54600590/6c6492d2-531b-46a2-bb89-d42ac1931b06)



### Bulk offering upload testing

- [x] Tested for offering period less the minimum days for _Full Time_

![image](https://github.com/bcgov/SIMS/assets/54600590/5c0cf65d-d117-4b3c-bf9c-bf2717907879)

- [x] Tested for offering period less the minimum days for _Part Time_

![image](https://github.com/bcgov/SIMS/assets/54600590/18fdb7c3-4f6f-4642-8fb1-0fff749607d9)

- [x] Tested with valid minimum days for _Full Time_

![image](https://github.com/bcgov/SIMS/assets/54600590/0839692e-59e0-4c68-b8b5-03414b3c1c88)

