### PR TITLE
#2043 - Remove cache for institution type

### DIFF
--- a/sources/packages/backend/apps/api/src/services/institution/institution.service.ts
+++ b/sources/packages/backend/apps/api/src/services/institution/institution.service.ts
@@ -717,7 +717,7 @@ export class InstitutionService extends RecordDataModelService<Institution> {
       where: {
         id: institutionId,
       },
-      cache: true,
+      // TODO:Implement the cache again after updating cache eviction strategy.
     });
   }
 


### PR DESCRIPTION
## Remove cache for institution type

Currently `getInstitutionTypeById()` in the institution.service.ts is cached at ORM level. 
Due to this, if the cache provider(Redis) is not working properly this method could wait indefinitely for a response and eventually it causes issues which currently could affect the areas of release testing.

Hence as a temporary measure, the cache is being disabled to not affect the release.

Once #1927 is completed, the cache will be enabled again.