### PR TITLE
#2055 - Institution menus not displayed after creation (Business BCeID only)

### DIFF
--- a/sources/packages/web/src/composables/institution/useInstitutionAuth.ts
+++ b/sources/packages/web/src/composables/institution/useInstitutionAuth.ts
@@ -9,9 +9,6 @@ import { useAuth } from "..";
 export function useInstitutionAuth(rootStore?: Store<any>) {
   const store = rootStore ?? useStore();
 
-  const authorizations =
-    store.state.institution.authorizationsState?.authorizations ?? [];
-
   const { isAuthenticated } = useAuth();
   const isAuthenticatedInstitutionUser = computed(() => {
     return isAuthenticated.value && store.state.institution.userState.isActive;
@@ -21,7 +18,9 @@ export function useInstitutionAuth(rootStore?: Store<any>) {
     () => store.state.institution.userState.userFullName,
   );
   const userEmail = computed(() => store.state.institution.userState.email);
-  const userAuth = computed(() => authorizations);
+  const userAuth = computed(
+    () => store.state.institution.authorizationsState?.authorizations ?? [],
+  );
   const isLegalSigningAuthority = computed(() =>
     store.state.institution.authorizationsState?.authorizations.some(
       (auth: InstitutionUserAuthRolesAndLocation) =>

--- a/sources/packages/web/src/composables/institution/useInstitutionState.ts
+++ b/sources/packages/web/src/composables/institution/useInstitutionState.ts
@@ -14,10 +14,23 @@ export function useInstitutionState(rootStore?: Store<any>) {
     ).name;
   };
 
+  /**
+   * Get all store information needed for the institution store.
+   */
   const initialize = async () => {
     await store.dispatch("institution/initialize");
   };
 
+  /**
+   * Get institution details needed for the institution store.
+   */
+  const getInstitutionDetails = async () => {
+    await store.dispatch("institution/getInstitutionDetails");
+  };
+
+  /**
+   * Set the institution setup user property to institution user state.
+   */
   const setInstitutionSetupUser = async () => {
     await store.dispatch("institution/setInstitutionSetupUser");
   };
@@ -27,5 +40,6 @@ export function useInstitutionState(rootStore?: Store<any>) {
     getLocationName,
     setInstitutionSetupUser,
     initialize,
+    getInstitutionDetails,
   };
 }

--- a/sources/packages/web/src/store/modules/institution/actions.ts
+++ b/sources/packages/web/src/store/modules/institution/actions.ts
@@ -8,24 +8,23 @@ import {
 import { InstitutionUserService } from "@/services/InstitutionUserService";
 
 export const actions: ActionTree<InstitutionLocationState, RootState> = {
-  async initialize(context): Promise<boolean> {
-    /*
-    authHeader are only needed for initial stores, 
-    since during the first initializing token are not ready yet
-    */
+  /**
+   * Get all store information needed for the institution store.
+   * @param context store context.
+   */
+  async initialize(context): Promise<void> {
     await Promise.all([
       context.dispatch("getInstitutionDetails"),
       context.dispatch("getUserInstitutionDetails"),
       context.dispatch("getUserInstitutionLocationDetails"),
     ]);
-    return true;
   },
 
+  /**
+   * Get institution details needed for the institution store.
+   * @param context store context.
+   */
   async getInstitutionDetails(context): Promise<void> {
-    /*
-    authHeader are only needed for initial stores, 
-    since during the first initializing token are not ready yet
-    */
     const response = await InstitutionService.shared.getDetail();
     context.commit("setInstitutionDetails", {
       legalOperatingName: response.legalOperatingName,
@@ -37,22 +36,22 @@ export const actions: ActionTree<InstitutionLocationState, RootState> = {
     } as InstitutionStateForStore);
   },
 
+  /**
+   * Get institution user details needed for the institution store.
+   * @param context store context.
+   */
   async getUserInstitutionDetails(context): Promise<void> {
-    /*
-    authHeader are only needed for initial stores, 
-    since during the first initializing token are not ready yet
-    */
     const resultComment =
       await InstitutionUserService.shared.getMyInstitutionDetails();
     context.commit("setMyDetailsState", resultComment?.user);
     context.commit("setMyAuthorizationState", resultComment?.authorizations);
   },
 
+  /**
+   * Get institution location details needed for the institution store.
+   * @param context store context.
+   */
   async getUserInstitutionLocationDetails(context): Promise<void> {
-    /*
-    authHeader are only needed for initial stores, 
-    since during the first initializing token are not ready yet
-    */
     const resultComment =
       await InstitutionService.shared.getMyInstitutionLocationsDetails();
     context.commit("setMyInstitutionLocationsDetailsState", resultComment);

--- a/sources/packages/web/src/views/institution/InstitutionCreate.vue
+++ b/sources/packages/web/src/views/institution/InstitutionCreate.vue
@@ -32,7 +32,6 @@
 <script lang="ts">
 import { ref, onMounted, defineComponent } from "vue";
 import { useRouter } from "vue-router";
-import { useStore } from "vuex";
 import { UserService } from "@/services/UserService";
 import { InstitutionService } from "@/services/InstitutionService";
 import { CreateInstitutionAPIInDTO } from "@/services/http/dto";
@@ -40,6 +39,7 @@ import { InstitutionRoutesConst } from "@/constants/routes/RouteConstants";
 import {
   useFormioDropdownLoader,
   useFormioUtils,
+  useInstitutionState,
   useSnackBar,
 } from "@/composables";
 import { FormIOForm } from "@/types";
@@ -47,9 +47,9 @@ import { FormIOForm } from "@/types";
 export default defineComponent({
   setup() {
     const processing = ref(false);
-    const store = useStore();
     const snackBar = useSnackBar();
     const { excludeExtraneousValues } = useFormioUtils();
+    const { initialize } = useInstitutionState();
     const router = useRouter();
     const formioDataLoader = useFormioDropdownLoader();
     const initialData = ref({});
@@ -64,9 +64,8 @@ export default defineComponent({
         await InstitutionService.shared.createInstitutionWithAssociatedUser(
           typedData,
         );
-        await store.dispatch("institution/initialize");
+        await initialize();
         snackBar.success("Institution and User successfully created!");
-        await store.dispatch("institution/getInstitutionDetails");
         router.push({
           name: InstitutionRoutesConst.INSTITUTION_DASHBOARD,
         });

--- a/sources/packages/web/src/views/institution/InstitutionProfile.vue
+++ b/sources/packages/web/src/views/institution/InstitutionProfile.vue
@@ -34,8 +34,11 @@ import {
   InstitutionContactAPIInDTO,
 } from "@/services/http/dto";
 import { InstitutionRoutesConst } from "@/constants/routes/RouteConstants";
-import { useFormioUtils, useSnackBar } from "@/composables";
-import { useStore } from "vuex";
+import {
+  useFormioUtils,
+  useInstitutionState,
+  useSnackBar,
+} from "@/composables";
 import InstitutionProfileForm from "@/components/institutions/profile/InstitutionProfileForm.vue";
 import { BannerTypes } from "@/types";
 
@@ -43,9 +46,9 @@ export default defineComponent({
   components: { InstitutionProfileForm },
   setup() {
     // Hooks
-    const store = useStore();
     const snackBar = useSnackBar();
     const { excludeExtraneousValues } = useFormioUtils();
+    const { getInstitutionDetails } = useInstitutionState();
     const router = useRouter();
     // Data-bind
     const institutionProfileModel = ref({} as InstitutionDetailAPIOutDTO);
@@ -58,7 +61,7 @@ export default defineComponent({
         );
         await InstitutionService.shared.updateInstitution(typedData);
         snackBar.success("Institution successfully updated!");
-        await store.dispatch("institution/getInstitutionDetails");
+        await getInstitutionDetails();
         router.push({
           name: InstitutionRoutesConst.INSTITUTION_DASHBOARD,
         });


### PR DESCRIPTION
When a Business BCeID creates the institution the main applications menus are not displayed to allow the user to navigate in the application. 
The way the store was previously being accessed was apparently interrupting the reactivity, so even when the store was updated the computed properties were not broadcasting the changes.
The way it is right now is working and was the quick way to have it fixed for the upcoming release.

From Vue documentation (https://vuejs.org/guide/extras/reactivity-in-depth.html#how-reactivity-works-in-vue)
_When you assign or destructure a reactive object's property to a local variable, accessing or assigning to that variable is non-reactive because it no longer triggers the get/set proxy traps on the source object. Note this "disconnect" only affects the variable binding - if the variable points to a non-primitive value such as an object, mutating the object would still be reactive._