### PR TITLE
#1777 - Process MSFAA Cancellation and Reactivation Notification

### DIFF
--- a/sources/packages/backend/apps/db-migrations/src/migrations/1688016799148-InsertMSFAACancellationMessage.ts
+++ b/sources/packages/backend/apps/db-migrations/src/migrations/1688016799148-InsertMSFAACancellationMessage.ts
@@ -1,0 +1,24 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+import { getSQLFileData } from "../utilities/sqlLoader";
+
+export class InsertMSFAACancellationMessage1688016799148
+  implements MigrationInterface
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      getSQLFileData(
+        "Insert-msfaa-cancellation-message.sql",
+        "NotificationMessages",
+      ),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      getSQLFileData(
+        "Delete-msfaa-cancellation-message.sql",
+        "NotificationMessages",
+      ),
+    );
+  }
+}

--- a/sources/packages/backend/apps/db-migrations/src/sql/NotificationMessages/Delete-msfaa-cancellation-message.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/NotificationMessages/Delete-msfaa-cancellation-message.sql
@@ -1,0 +1,4 @@
+DELETE FROM
+  sims.notification_messages
+WHERE
+  ID = 12;

--- a/sources/packages/backend/apps/db-migrations/src/sql/NotificationMessages/Insert-msfaa-cancellation-message.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/NotificationMessages/Insert-msfaa-cancellation-message.sql
@@ -1,0 +1,8 @@
+INSERT INTO
+  sims.notification_messages(id, description, template_id)
+VALUES
+  (
+    12,
+    'MSFAA Cancellation',
+    'b3093a44-da3d-4ea5-af3a-1542535ae7e9'
+  );

--- a/sources/packages/backend/libs/integrations/src/esdc-integration/msfaa-integration/msfaa-response.processing.service.ts
+++ b/sources/packages/backend/libs/integrations/src/esdc-integration/msfaa-integration/msfaa-response.processing.service.ts
@@ -138,19 +138,11 @@ export class MSFAAResponseProcessingService {
     // The update of msfaa always comes from an external source through integration.
     // Hence the cancelled date is parsed as date object from external source as their date format
     // may not be necessarily ISO date format.
-    const updateResult =
-      await this.msfaaNumberService.updateCancelledReceivedFile(
-        cancelledRecord.msfaaNumber,
-        cancelledRecord.cancelledDate,
-        cancelledRecord.newIssuingProvince,
-      );
-
-    // Expected to update 1 and only 1 record.
-    if (updateResult.affected !== 1) {
-      throw new Error(
-        `Error while updating MSFAA number: ${cancelledRecord.msfaaNumber}. Number of affected rows was ${updateResult.affected}, expected 1.`,
-      );
-    }
+    await this.msfaaNumberService.updateCancelledReceivedFile(
+      cancelledRecord.msfaaNumber,
+      cancelledRecord.cancelledDate,
+      cancelledRecord.newIssuingProvince,
+    );
   }
 
   @InjectLogger()

--- a/sources/packages/backend/libs/integrations/src/services/msfaa-number/msfaa-number.service.ts
+++ b/sources/packages/backend/libs/integrations/src/services/msfaa-number/msfaa-number.service.ts
@@ -223,35 +223,33 @@ export class MSFAANumberService extends RecordDataModelService<MSFAANumber> {
       }
       // Only if the msfaa record was successfully cancelled, then save the msfaa cancellation notification.
       // This also takes care of the scenario where the msfaa record was already cancelled before in which case the record will not be updated and hence no notification will be saved.
-      if (updateResult.affected) {
-        // Get the student associated with the cancelled MSFAA record.
-        const msfaaRecord = await this.repo.findOne({
-          select: {
+      // Get the student associated with the cancelled MSFAA record.
+      const msfaaRecord = await this.repo.findOne({
+        select: {
+          id: true,
+          student: {
             id: true,
-            student: {
-              id: true,
-              user: { id: true, firstName: true, lastName: true, email: true },
-            },
+            user: { id: true, firstName: true, lastName: true, email: true },
           },
-          relations: {
-            student: { user: true },
-          },
-          where: {
-            msfaaNumber,
-          },
-        });
-        const systemUser = await this.systemUsersService.systemUser();
-        await this.notificationActionsService.saveMSFAACancellationNotification(
-          {
-            givenNames: msfaaRecord.student.user.firstName,
-            lastName: msfaaRecord.student.user.lastName,
-            toAddress: msfaaRecord.student.user.email,
-            userId: msfaaRecord.student.user.id,
-          },
-          systemUser.id,
-          transactionEntityManager,
-        );
-      }
+        },
+        relations: {
+          student: { user: true },
+        },
+        where: {
+          msfaaNumber,
+        },
+      });
+      const systemUser = await this.systemUsersService.systemUser();
+      await this.notificationActionsService.saveMSFAACancellationNotification(
+        {
+          givenNames: msfaaRecord.student.user.firstName,
+          lastName: msfaaRecord.student.user.lastName,
+          toAddress: msfaaRecord.student.user.email,
+          userId: msfaaRecord.student.user.id,
+        },
+        systemUser.id,
+        transactionEntityManager,
+      );
       return updateResult;
     });
   }

--- a/sources/packages/backend/libs/integrations/src/services/msfaa-number/msfaa-number.service.ts
+++ b/sources/packages/backend/libs/integrations/src/services/msfaa-number/msfaa-number.service.ts
@@ -215,16 +215,17 @@ export class MSFAANumberService extends RecordDataModelService<MSFAANumber> {
           newIssuingProvince,
         },
       );
-      // Find the student associated with the cancelled MSFAA record.
+      // Get the student associated with the cancelled MSFAA record.
       const msfaaRecord = await this.repo.findOne({
         select: {
           id: true,
           student: {
             id: true,
+            user: { id: true, firstName: true, lastName: true, email: true },
           },
         },
         relations: {
-          student: true,
+          student: { user: true },
         },
         where: {
           msfaaNumber,

--- a/sources/packages/backend/libs/integrations/src/services/msfaa-number/msfaa-number.service.ts
+++ b/sources/packages/backend/libs/integrations/src/services/msfaa-number/msfaa-number.service.ts
@@ -204,17 +204,19 @@ export class MSFAANumberService extends RecordDataModelService<MSFAANumber> {
     return this.dataSource.transaction(async (transactionEntityManager) => {
       // Keeping both MSFAA Cancellation update and saving of MSFAA Notification message as a part of the same transaction.
       // Update the MSFAA record that needs to be cancelled.
-      const updateResult = await this.repo.update(
-        {
-          msfaaNumber: msfaaNumber,
-          cancelledDate: IsNull(),
-          newIssuingProvince: IsNull(),
-        },
-        {
-          cancelledDate: getISODateOnlyString(cancelledDate),
-          newIssuingProvince,
-        },
-      );
+      const updateResult = await transactionEntityManager
+        .getRepository(MSFAANumber)
+        .update(
+          {
+            msfaaNumber: msfaaNumber,
+            cancelledDate: IsNull(),
+            newIssuingProvince: IsNull(),
+          },
+          {
+            cancelledDate: getISODateOnlyString(cancelledDate),
+            newIssuingProvince,
+          },
+        );
       // Expected to update 1 and only 1 record.
       if (updateResult.affected !== 1) {
         throw new Error(

--- a/sources/packages/backend/libs/integrations/src/services/msfaa-number/msfaa-number.service.ts
+++ b/sources/packages/backend/libs/integrations/src/services/msfaa-number/msfaa-number.service.ts
@@ -215,8 +215,8 @@ export class MSFAANumberService extends RecordDataModelService<MSFAANumber> {
           newIssuingProvince,
         },
       );
-      // In case no MSFAA record was cancelled.
-      if (!updateResult.affected) {
+      // Expected to update 1 and only 1 record.
+      if (updateResult.affected !== 1) {
         throw new Error(
           `Error while cancelling MSFAA number: ${msfaaNumber}. Number of affected rows was ${updateResult.affected}, expected 1.`,
         );

--- a/sources/packages/backend/libs/services/src/notifications/notification/notification-actions.service.ts
+++ b/sources/packages/backend/libs/services/src/notifications/notification/notification-actions.service.ts
@@ -116,7 +116,7 @@ export class NotificationActionsService {
    * Creates a notification when an MSFAA record gets cancelled.
    * @param notification input parameters to generate the notification.
    * @param auditUserId user that should be considered the one that is causing the changes.
-   * @param entityManager entity manager to execute in transaction.
+   * @param entityManager optional entity manager to execute in transaction.
    */
   async saveMSFAACancellationNotification(
     notification: MSFAACancellationNotification,

--- a/sources/packages/backend/libs/services/src/notifications/notification/notification-actions.service.ts
+++ b/sources/packages/backend/libs/services/src/notifications/notification/notification-actions.service.ts
@@ -124,20 +124,22 @@ export class NotificationActionsService {
     entityManager?: EntityManager,
   ): Promise<void> {
     const templateId = await this.notificationMessageService.getTemplateId(
-      NotificationMessageType.MSFAACancellationComplete,
+      NotificationMessageType.MSFAACancellation,
     );
+
+    const messagePayload: NotificationEmailMessage = {
+      email_address: notification.toAddress,
+      template_id: templateId,
+      personalisation: {
+        givenNames: notification.givenNames ?? "",
+        lastName: notification.lastName,
+      },
+    };
 
     const notificationToSend = {
       userId: notification.userId,
-      messageType: NotificationMessageType.MSFAACancellationComplete,
-      messagePayload: {
-        email_address: notification.toAddress,
-        template_id: templateId,
-        personalisation: {
-          givenNames: notification.givenNames ?? "",
-          lastName: notification.lastName,
-        },
-      },
+      messageType: NotificationMessageType.MSFAACancellation,
+      messagePayload: messagePayload,
     };
 
     // Save notification into notification table.

--- a/sources/packages/backend/libs/services/src/notifications/notification/notification-actions.service.ts
+++ b/sources/packages/backend/libs/services/src/notifications/notification/notification-actions.service.ts
@@ -10,6 +10,7 @@ import { NotificationMessageService } from "../notification-message/notification
 import {
   StudentRestrictionAddedNotification,
   MinistryStudentFileUploadNotification,
+  MSFAACancellationNotification,
   StudentFileUploadNotification,
   StudentNotification,
   ECEResponseFileProcessingNotification,
@@ -99,6 +100,42 @@ export class NotificationActionsService {
           givenNames: notification.firstName ?? "",
           lastName: notification.lastName,
           date: this.getDateTimeOnPSTTimeZone(),
+        },
+      },
+    };
+
+    // Save notification into notification table.
+    await this.notificationService.saveNotifications(
+      [notificationToSend],
+      auditUserId,
+      { entityManager },
+    );
+  }
+
+  /**
+   * Creates a notification when an MSFAA record gets cancelled.
+   * @param notification input parameters to generate the notification.
+   * @param auditUserId user that should be considered the one that is causing the changes.
+   * @param entityManager entity manager to execute in transaction.
+   */
+  async saveMSFAACancellationNotification(
+    notification: MSFAACancellationNotification,
+    auditUserId: number,
+    entityManager?: EntityManager,
+  ): Promise<void> {
+    const templateId = await this.notificationMessageService.getTemplateId(
+      NotificationMessageType.MSFAACancellationComplete,
+    );
+
+    const notificationToSend = {
+      userId: notification.userId,
+      messageType: NotificationMessageType.MSFAACancellationComplete,
+      messagePayload: {
+        email_address: notification.toAddress,
+        template_id: templateId,
+        personalisation: {
+          givenNames: notification.givenNames ?? "",
+          lastName: notification.lastName,
         },
       },
     };

--- a/sources/packages/backend/libs/services/src/notifications/notification/notification.model.ts
+++ b/sources/packages/backend/libs/services/src/notifications/notification/notification.model.ts
@@ -23,6 +23,13 @@ export interface MinistryStudentFileUploadNotification {
   userId: number;
 }
 
+export interface MSFAACancellationNotification {
+  givenNames: string;
+  lastName: string;
+  toAddress: string;
+  userId: number;
+}
+
 export interface StudentRestrictionAddedNotification {
   givenNames: string;
   lastName: string;

--- a/sources/packages/backend/libs/sims-db/src/entities/notification.model.ts
+++ b/sources/packages/backend/libs/sims-db/src/entities/notification.model.ts
@@ -132,4 +132,8 @@ export enum NotificationMessageType {
    * ECE response file processing details.
    */
   ECEResponseFileProcessing = 11,
+  /**
+   * MSFAA record gets cancelled.
+   */
+  MSFAACancellationComplete = 12,
 }

--- a/sources/packages/backend/libs/sims-db/src/entities/notification.model.ts
+++ b/sources/packages/backend/libs/sims-db/src/entities/notification.model.ts
@@ -135,5 +135,5 @@ export enum NotificationMessageType {
   /**
    * MSFAA record gets cancelled.
    */
-  MSFAACancellationComplete = 12,
+  MSFAACancellation = 12,
 }


### PR DESCRIPTION
**As a part of this PR:**

- Created a GC Notify template to send emails when a MSFAA record is cancelled.
- Updated msfaa-number service to save notifications on MSFAA cancellation.
- MSFAA reactivation template is not required as the federal government will send them notification. 

Screenshot of the sent notification email:

![image](https://github.com/bcgov/SIMS/assets/7859295/fb71ce15-91bc-490c-9cf7-03bb835998eb)

**To be done in a separate PR:**

- E2E tests for MSFAA Cancellation Notification.

**NOTE:** There is an update in the Acceptance Criteria (point 2) - MSFAA reactivation template is not required as the federal government will send them notification. Only MSFAA cancellation notification needs to be sent.