### PR TITLE
#2058 - Add new program regulatory option

### DIFF
--- a/sources/packages/forms/src/form-definitions/educationprogram.json
+++ b/sources/packages/forms/src/form-definitions/educationprogram.json
@@ -816,8 +816,7 @@
                     "addons": [],
                     "inputType": "text",
                     "id": "e7oydq",
-                    "defaultValue": "",
-                    "isNew": false
+                    "defaultValue": ""
                 },
                 {
                     "label": "Field of study code",
@@ -2864,6 +2863,10 @@
                             {
                                 "label": "ICBC",
                                 "value": "icbc"
+                            },
+                            {
+                                "value": "senateOrEducationCouncil",
+                                "label": "Senate, Academic Council, Education Council, and/or Program Council and Board of Governors"
                             }
                         ],
                         "resource": "",
@@ -2912,7 +2915,7 @@
                     "tags": [],
                     "properties": {},
                     "conditional": {
-                        "show": null,
+                        "show": "",
                         "when": null,
                         "eq": "",
                         "json": ""


### PR DESCRIPTION
- Added new entry to the program's regulatory options.
    - Label: Senate, Academic Council, Education Council, and/or Program Council and Board of Governors
    - Value: senateOrEducationCouncil
    
![image](https://github.com/bcgov/SIMS/assets/61259237/0557507b-cde3-470d-a633-8fdec331de78)
