### PR TITLE
#1953 - Request an Offering Change - Fix

### DIFF
--- a/sources/packages/backend/apps/api/src/route-controllers/application-offering-change-request/_tests_/e2e/application-offering-change-request.institutions.controller.getCompletedApplications.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/application-offering-change-request/_tests_/e2e/application-offering-change-request.institutions.controller.getCompletedApplications.e2e-spec.ts
@@ -290,6 +290,17 @@ describe("ApplicationOfferingChangeRequestInstitutionsController(e2e)-getComplet
       applicationWithDeclinedBySABCApplicationOfferingChange.student.user,
     ]);
 
+    // Here there will be multiple search results with the default order of application number, so setting the application number in order to predict the order while assert.
+    applicationWithApprovedApplicationOfferingChange.applicationNumber =
+      "2000000000";
+    applicationWithDeclinedBySABCApplicationOfferingChange.applicationNumber =
+      "9000000000";
+
+    await db.application.save([
+      applicationWithApprovedApplicationOfferingChange,
+      applicationWithDeclinedBySABCApplicationOfferingChange,
+    ]);
+
     const searchKeyword = "TestStudent";
     const endpoint = `/institutions/location/${collegeFLocation.id}/application-offering-change-request/completed?page=0&pageLimit=10&searchCriteria=${searchKeyword}`;
     console.log(endpoint);


### PR DESCRIPTION
- In the completed search test case, there are multiple search results with the default order of application number. Did a fix to set the application number in order to predict the order while asserting.