### PR TITLE
#1658 - Address fields display for institutions and ministry users

### DIFF
--- a/sources/packages/backend/apps/api/src/services/institution-location/institution-location.service.ts
+++ b/sources/packages/backend/apps/api/src/services/institution-location/institution-location.service.ts
@@ -322,7 +322,8 @@ export class InstitutionLocationService extends RecordDataModelService<Instituti
       ELSE false
     END`,
         "isDesignated",
-      );
+      )
+      .orderBy("location.name");
     if (locationId) {
       return query.where("location.id = :locationId", { locationId });
     }

--- a/sources/packages/web/src/components/common/LocationSummary.vue
+++ b/sources/packages/web/src/components/common/LocationSummary.vue
@@ -23,11 +23,12 @@
     </template>
     <content-group
       v-for="item in institutionLocationList"
+      class="mb-4"
       :key="item"
       data-cy="institutionLocation"
     >
       <v-row>
-        <v-col md="10">
+        <v-col>
           <div>
             <v-icon icon="mdi-map-marker-outline"></v-icon>
             <span data-cy="locationName" class="category-header-medium mx-1">{{
@@ -58,25 +59,18 @@
         </v-col>
       </v-row>
       <v-row>
-        <!-- Address 1 -->
+        <!-- Address -->
         <v-col>
-          <title-value propertyTitle="Address line 1" />
+          <title-value propertyTitle="Address" />
           <span
             class="label-value muted-content clearfix"
-            v-for="addressLine in addressList1(item)"
+            v-for="addressLine in addressList(item)"
             :key="addressLine"
             data-cy="institutionAddress1"
           >
             {{ addressLine }}
           </span>
         </v-col>
-
-        <!-- Address 2 -->
-        <v-col>
-          <title-value propertyTitle="Address line 2" />
-          <span data-cy="institutionAddress2">---</span>
-        </v-col>
-
         <!-- Primary contact -->
         <v-col>
           <title-value propertyTitle="Primary contact" />
@@ -129,7 +123,7 @@ export default defineComponent({
     },
   },
   setup(props) {
-    const formatter = useFormatters();
+    const { getFormattedAddressList } = useFormatters();
     const router = useRouter();
     const clientType = computed(() => AuthService.shared.authClientType);
     const goToAddNewLocation = () => {
@@ -145,13 +139,8 @@ export default defineComponent({
         );
     };
 
-    const addressList1 = (item: InstitutionLocationsDetails) => {
-      return [
-        item.data.address.addressLine1,
-        item.data.address.addressLine2,
-        formatter.getFormattedAddress(item.data.address),
-        item.data.address.country,
-      ].filter((address) => address);
+    const addressList = (item: InstitutionLocationsDetails) => {
+      return getFormattedAddressList(item.data.address);
     };
 
     const primaryContactList = (item: InstitutionLocationsDetails) => {
@@ -171,7 +160,7 @@ export default defineComponent({
       getInstitutionLocationList,
       institutionLocationList,
       ClientIdType,
-      addressList1,
+      addressList,
       primaryContactList,
       clientType,
       Role,

--- a/sources/packages/web/src/composables/useFormatters.ts
+++ b/sources/packages/web/src/composables/useFormatters.ts
@@ -136,7 +136,7 @@ export function useFormatters() {
       // Address line 2
       formattedAddress.push(address.addressLine2);
     }
-    // Country, province, postal code.
+    // City, province, and postal code.
     const cityPostalCountry: string[] = [];
     cityPostalCountry.push(address.city);
     if (address.provinceState) {

--- a/sources/packages/web/src/composables/useFormatters.ts
+++ b/sources/packages/web/src/composables/useFormatters.ts
@@ -115,6 +115,40 @@ export function useFormatters() {
     return formattedAddress.join(", ");
   };
 
+  /**
+   * Format an address in the expected order where each expected
+   * address component represents an entry in the array.
+   * @param address address to be formatted.
+   * @returns string array with ordered address components.
+   * @example
+   * [
+   *   "Address Line 1"
+   *   "Address Line 2"
+   *   "City, Province, Postal Code"
+   *   "Country"
+   * ]
+   */
+  const getFormattedAddressList = (address: Address): string[] => {
+    const formattedAddress: string[] = [];
+    // Address line 1
+    formattedAddress.push(address.addressLine1);
+    if (address.addressLine2) {
+      // Address line 2
+      formattedAddress.push(address.addressLine2);
+    }
+    // Country, province, postal code.
+    const cityPostalCountry: string[] = [];
+    cityPostalCountry.push(address.city);
+    if (address.provinceState) {
+      cityPostalCountry.push(address.provinceState);
+    }
+    cityPostalCountry.push(address.postalCode);
+    formattedAddress.push(cityPostalCountry.join(", "));
+    // Country.
+    formattedAddress.push(address.country);
+    return formattedAddress;
+  };
+
   const parseSINValidStatus = (data?: boolean): SINValidStatus => {
     if (data === null) {
       return {
@@ -247,6 +281,7 @@ export function useFormatters() {
     dateOnlyToLocalDateTimeString,
     getDatesDiff,
     getFormattedAddress,
+    getFormattedAddressList,
     timeOnlyInHoursAndMinutes,
     parseSINValidStatus,
     yesNoFlagDescription,


### PR DESCRIPTION
- Institution locations address formatted as below. The same component is shared between Mnistry and Institutions so the change affects both places.
- Removed column for address line 2.
- Added `orderBy` to the query returning locations because every time that one item was edited they kept switching orders.

![image](https://github.com/bcgov/SIMS/assets/61259237/9ba73ce3-8651-4858-adc7-ae104bd17307)
