### PR TITLE
#2074 - Fix the store reference

### DIFF
--- a/sources/packages/web/src/composables/institution/useInstitutionAuth.ts
+++ b/sources/packages/web/src/composables/institution/useInstitutionAuth.ts
@@ -49,7 +49,9 @@ export function useInstitutionAuth(rootStore?: Store<any>) {
     return userAuthorization?.userType;
   });
 
-  const isBCPublic = computed(() => store.state.institutionState?.isBCPublic);
+  const isBCPublic = computed(
+    () => store.state.institution.institutionState?.isBCPublic,
+  );
 
   return {
     isAdmin,


### PR DESCRIPTION
The store reference was wrong at this part of the code and due to the same, useInstitutionAuth was always returning undefined for isBCPublic.

![image](https://github.com/bcgov/SIMS/assets/54600590/2ffef871-e6f0-4eb0-ba41-b1bc6321f50e)

It has been fixed and it is working now.

![image](https://github.com/bcgov/SIMS/assets/54600590/f4d71890-5c73-4601-9f24-0811a0384765)
