### PR TITLE
#2086 - Enhance regulatory body dropdown

### DIFF
--- a/sources/packages/forms/src/form-definitions/educationprogram.json
+++ b/sources/packages/forms/src/form-definitions/educationprogram.json
@@ -2820,219 +2820,191 @@
                     "showWordCount": false,
                     "allowMultipleMasks": false,
                     "addons": [],
-                    "id": "eug8su"
+                    "id": "eug8su",
+                    "isNew": false
                 },
                 {
-                    "clearOnHide": false,
-                    "label": "Columns",
-                    "input": false,
-                    "tableView": false,
-                    "key": "panel1Columns",
-                    "columns": [
-                        {
-                            "components": [
-                                {
-                                    "label": "Which regulatory body does this program belong to?",
-                                    "labelPosition": "top",
-                                    "widget": "html5",
-                                    "labelWidth": "",
-                                    "labelMargin": "",
-                                    "placeholder": "",
-                                    "description": "",
-                                    "tooltip": "",
-                                    "customClass": "",
-                                    "tabindex": "",
-                                    "hidden": false,
-                                    "uniqueOptions": false,
-                                    "autofocus": false,
-                                    "disabled": false,
-                                    "tableView": true,
-                                    "modalEdit": false,
-                                    "multiple": false,
-                                    "dataSrc": "values",
-                                    "data": {
-                                        "values": [
-                                            {
-                                                "label": "PTIB",
-                                                "value": "ptib"
-                                            },
-                                            {
-                                                "label": "DQAB",
-                                                "value": "dqab"
-                                            },
-                                            {
-                                                "label": "Private Act of B.C. Legislature",
-                                                "value": "privateActLegislature"
-                                            },
-                                            {
-                                                "label": "Skilled Trades BC",
-                                                "value": "skilledTradesBC"
-                                            },
-                                            {
-                                                "label": "ICBC",
-                                                "value": "icbc"
-                                            },
-                                            {
-                                                "value": "other",
-                                                "label": "Other"
-                                            }
-                                        ],
-                                        "resource": "",
-                                        "json": "",
-                                        "url": "",
-                                        "custom": ""
-                                    },
-                                    "dataType": "",
-                                    "idPath": "id",
-                                    "valueProperty": "",
-                                    "limit": 100,
-                                    "template": "<span>{{ item.label }}</span>",
-                                    "refreshOn": "",
-                                    "refreshOnBlur": "",
-                                    "clearOnRefresh": false,
-                                    "searchEnabled": true,
-                                    "selectThreshold": 0.3,
-                                    "readOnlyValue": false,
-                                    "customOptions": {},
-                                    "useExactSearch": false,
-                                    "persistent": true,
-                                    "protected": false,
-                                    "dbIndex": false,
-                                    "encrypted": false,
-                                    "clearOnHide": true,
-                                    "customDefaultValue": "",
-                                    "calculateValue": "",
-                                    "calculateServer": false,
-                                    "allowCalculateOverride": false,
-                                    "validateOn": "change",
-                                    "validate": {
-                                        "required": true,
-                                        "onlyAvailableItems": false,
-                                        "customMessage": "",
-                                        "custom": "",
-                                        "customPrivate": false,
-                                        "json": "",
-                                        "strictDateValidation": false,
-                                        "multiple": false,
-                                        "unique": false
-                                    },
-                                    "unique": false,
-                                    "errorLabel": "",
-                                    "errors": "",
-                                    "key": "regulatoryBody",
-                                    "tags": [],
-                                    "properties": {},
-                                    "conditional": {
-                                        "show": "",
-                                        "when": null,
-                                        "eq": "",
-                                        "json": ""
-                                    },
-                                    "customConditional": "",
-                                    "logic": [],
-                                    "attributes": {
-                                        "data-cy": "regulatoryBody"
-                                    },
-                                    "overlay": {
-                                        "style": "",
-                                        "page": "",
-                                        "left": "",
-                                        "top": "",
-                                        "width": "",
-                                        "height": ""
-                                    },
-                                    "type": "select",
-                                    "indexeddb": {
-                                        "filter": {}
-                                    },
-                                    "selectFields": "",
-                                    "searchField": "",
-                                    "searchDebounce": 0.3,
-                                    "minSearch": 0,
-                                    "filter": "",
-                                    "redrawOn": "",
-                                    "input": true,
-                                    "searchThreshold": 0.3,
-                                    "prefix": "",
-                                    "suffix": "",
-                                    "dataGridLabel": false,
-                                    "showCharCount": false,
-                                    "showWordCount": false,
-                                    "allowMultipleMasks": false,
-                                    "addons": [],
-                                    "lazyLoad": true,
-                                    "authenticate": false,
-                                    "ignoreCache": false,
-                                    "fuseOptions": {
-                                        "include": "score",
-                                        "threshold": 0.3
-                                    },
-                                    "id": "e7o9328",
-                                    "defaultValue": ""
-                                }
-                            ],
-                            "width": 6,
-                            "offset": 0,
-                            "push": 0,
-                            "pull": 0
-                        },
-                        {
-                            "components": [
-                                {
-                                    "autofocus": false,
-                                    "input": true,
-                                    "tableView": true,
-                                    "inputType": "text",
-                                    "inputMask": "",
-                                    "label": "Other institution regulatory body",
-                                    "key": "otherRegulatoryBody",
-                                    "placeholder": "",
-                                    "prefix": "",
-                                    "suffix": "",
-                                    "multiple": false,
-                                    "defaultValue": "",
-                                    "protected": false,
-                                    "unique": false,
-                                    "persistent": true,
-                                    "hidden": false,
-                                    "clearOnHide": true,
-                                    "spellcheck": true,
-                                    "validate": {
-                                        "required": true,
-                                        "minLength": 1,
-                                        "maxLength": 100,
-                                        "pattern": "",
-                                        "custom": "",
-                                        "customPrivate": false
-                                    },
-                                    "conditional": {
-                                        "show": "true",
-                                        "when": "regulatoryBody",
-                                        "eq": "other"
-                                    },
-                                    "type": "textfield",
-                                    "labelPosition": "top",
-                                    "inputFormat": "plain",
-                                    "tags": [],
-                                    "properties": {},
-                                    "lockKey": true
-                                }
-                            ],
-                            "width": 6,
-                            "offset": 0,
-                            "push": 0,
-                            "pull": 0
-                        }
-                    ],
-                    "type": "columns",
-                    "hideLabel": true,
+                    "label": "Which regulatory body does this program belong to?",
+                    "labelPosition": "top",
+                    "widget": "html5",
+                    "labelWidth": "",
+                    "labelMargin": "",
+                    "placeholder": "",
+                    "description": "",
+                    "tooltip": "",
+                    "customClass": "",
+                    "tabindex": "",
+                    "hidden": false,
+                    "uniqueOptions": false,
+                    "autofocus": false,
+                    "disabled": false,
+                    "tableView": true,
+                    "modalEdit": false,
+                    "multiple": false,
+                    "dataSrc": "values",
+                    "data": {
+                        "values": [
+                            {
+                                "label": "PTIB",
+                                "value": "ptib"
+                            },
+                            {
+                                "label": "DQAB",
+                                "value": "dqab"
+                            },
+                            {
+                                "label": "Private Act of B.C. Legislature",
+                                "value": "privateActLegislature"
+                            },
+                            {
+                                "label": "Skilled Trades BC",
+                                "value": "skilledTradesBC"
+                            },
+                            {
+                                "label": "ICBC",
+                                "value": "icbc"
+                            },
+                            {
+                                "value": "senateOrEducationCouncil",
+                                "label": "Senate, Academic Council, Education Council, and/or Program Council and Board of Governors"
+                            },
+                            {
+                                "value": "other",
+                                "label": "Other"
+                            }
+                        ],
+                        "resource": "",
+                        "json": "",
+                        "url": "",
+                        "custom": ""
+                    },
+                    "dataType": "",
+                    "idPath": "id",
+                    "valueProperty": "",
+                    "limit": 100,
+                    "template": "<span>{{ item.label }}</span>",
+                    "refreshOn": "",
+                    "refreshOnBlur": "",
+                    "clearOnRefresh": false,
+                    "searchEnabled": true,
+                    "selectThreshold": 0.3,
+                    "readOnlyValue": false,
+                    "customOptions": {},
+                    "useExactSearch": false,
+                    "persistent": true,
+                    "protected": false,
+                    "dbIndex": false,
+                    "encrypted": false,
+                    "clearOnHide": true,
+                    "customDefaultValue": "",
+                    "calculateValue": "",
+                    "calculateServer": false,
+                    "allowCalculateOverride": false,
+                    "validateOn": "change",
+                    "validate": {
+                        "required": true,
+                        "onlyAvailableItems": false,
+                        "customMessage": "",
+                        "custom": "",
+                        "customPrivate": false,
+                        "json": "",
+                        "strictDateValidation": false,
+                        "multiple": false,
+                        "unique": false
+                    },
+                    "unique": false,
+                    "errorLabel": "",
+                    "errors": "",
+                    "key": "regulatoryBody",
                     "tags": [],
+                    "properties": {},
                     "conditional": {
                         "show": "",
                         "when": null,
-                        "eq": ""
+                        "eq": "",
+                        "json": ""
                     },
-                    "properties": {}
+                    "customConditional": "",
+                    "logic": [],
+                    "attributes": {
+                        "data-cy": "regulatoryBody"
+                    },
+                    "overlay": {
+                        "style": "",
+                        "page": "",
+                        "left": "",
+                        "top": "",
+                        "width": "",
+                        "height": ""
+                    },
+                    "type": "select",
+                    "indexeddb": {
+                        "filter": {}
+                    },
+                    "selectFields": "",
+                    "searchField": "",
+                    "searchDebounce": 0.3,
+                    "minSearch": 0,
+                    "filter": "",
+                    "redrawOn": "",
+                    "input": true,
+                    "searchThreshold": 0.3,
+                    "prefix": "",
+                    "suffix": "",
+                    "dataGridLabel": false,
+                    "showCharCount": false,
+                    "showWordCount": false,
+                    "allowMultipleMasks": false,
+                    "addons": [],
+                    "lazyLoad": true,
+                    "authenticate": false,
+                    "ignoreCache": false,
+                    "fuseOptions": {
+                        "include": "score",
+                        "threshold": 0.3
+                    },
+                    "id": "e7o9328",
+                    "defaultValue": ""
+                },
+                {
+                    "autofocus": false,
+                    "input": true,
+                    "tableView": true,
+                    "inputType": "text",
+                    "inputMask": "",
+                    "label": "Other institution regulatory body",
+                    "key": "otherRegulatoryBody",
+                    "placeholder": "",
+                    "prefix": "",
+                    "suffix": "",
+                    "multiple": false,
+                    "defaultValue": "",
+                    "protected": false,
+                    "unique": false,
+                    "persistent": true,
+                    "hidden": false,
+                    "clearOnHide": true,
+                    "spellcheck": true,
+                    "validate": {
+                        "required": true,
+                        "minLength": 1,
+                        "maxLength": 100,
+                        "pattern": "",
+                        "custom": "",
+                        "customPrivate": false
+                    },
+                    "conditional": {
+                        "show": "true",
+                        "when": "regulatoryBody",
+                        "eq": "other"
+                    },
+                    "type": "textfield",
+                    "labelPosition": "top",
+                    "inputFormat": "plain",
+                    "tags": [],
+                    "properties": {},
+                    "lockKey": true,
+                    "isNew": false
                 }
             ],
             "placeholder": "",

--- a/sources/packages/forms/src/form-definitions/institutionprofile.json
+++ b/sources/packages/forms/src/form-definitions/institutionprofile.json
@@ -562,216 +562,186 @@
           "defaultValue": null
         },
         {
+          "label": "Institution regulating body",
+          "labelPosition": "top",
+          "widget": "choicesjs",
+          "labelWidth": "",
+          "labelMargin": "",
+          "placeholder": "",
+          "description": "",
+          "tooltip": "",
+          "customClass": "",
+          "tabindex": "",
+          "hidden": false,
+          "uniqueOptions": false,
+          "autofocus": false,
+          "disabled": false,
+          "tableView": true,
+          "modalEdit": false,
+          "multiple": false,
+          "dataSrc": "values",
+          "data": {
+            "values": [
+              {
+                "label": "Private Act of BC Legislature",
+                "value": "private-act"
+              },
+              {
+                "label": "ICBC",
+                "value": "icbc"
+              },
+              {
+                "label": "DQAB",
+                "value": "dqab"
+              },
+              {
+                "label": "PTIB",
+                "value": "ptib"
+              },
+              {
+                "label": "Skilled Trades BC",
+                "value": "skilledTradesBC"
+              },
+              {
+                "value": "senateOrEducationCouncil",
+                "label": "Senate, Academic Council, Education Council, and/or Program Council and Board of Governors"
+              },
+              {
+                "value": "other",
+                "label": "Other"
+              }
+            ],
+            "resource": "",
+            "json": "",
+            "url": "",
+            "custom": ""
+          },
+          "dataType": "",
+          "idPath": "id",
+          "valueProperty": "",
+          "limit": 100,
+          "template": "<span>{{ item.label }}</span>",
+          "refreshOn": "",
+          "refreshOnBlur": "",
+          "clearOnRefresh": false,
+          "searchEnabled": true,
+          "selectThreshold": 0.3,
+          "readOnlyValue": false,
+          "customOptions": {},
+          "useExactSearch": false,
+          "persistent": true,
+          "protected": false,
+          "dbIndex": false,
+          "encrypted": false,
           "clearOnHide": false,
-          "label": "Columns",
-          "input": false,
-          "tableView": false,
-          "key": "institutionDetailsPanelColumns",
-          "columns": [
-            {
-              "components": [
-                {
-                  "label": "Institution regulating body",
-                  "labelPosition": "top",
-                  "widget": "choicesjs",
-                  "labelWidth": "",
-                  "labelMargin": "",
-                  "placeholder": "",
-                  "description": "",
-                  "tooltip": "",
-                  "customClass": "",
-                  "tabindex": "",
-                  "hidden": false,
-                  "uniqueOptions": false,
-                  "autofocus": false,
-                  "disabled": false,
-                  "tableView": true,
-                  "modalEdit": false,
-                  "multiple": false,
-                  "dataSrc": "values",
-                  "data": {
-                    "values": [
-                      {
-                        "label": "Private Act of BC Legislature",
-                        "value": "private-act"
-                      },
-                      {
-                        "label": "ICBC",
-                        "value": "icbc"
-                      },
-                      {
-                        "label": "DQAB",
-                        "value": "dqab"
-                      },
-                      {
-                        "label": "PTIB",
-                        "value": "ptib"
-                      },
-                      {
-                        "label": "Skilled Trades BC",
-                        "value": "skilledTradesBC"
-                      },
-                      {
-                        "value": "other",
-                        "label": "Other"
-                      }
-                    ],
-                    "resource": "",
-                    "json": "",
-                    "url": "",
-                    "custom": ""
-                  },
-                  "dataType": "",
-                  "idPath": "id",
-                  "valueProperty": "",
-                  "limit": 100,
-                  "template": "<span>{{ item.label }}</span>",
-                  "refreshOn": "",
-                  "refreshOnBlur": "",
-                  "clearOnRefresh": false,
-                  "searchEnabled": true,
-                  "selectThreshold": 0.3,
-                  "readOnlyValue": false,
-                  "customOptions": {},
-                  "useExactSearch": false,
-                  "persistent": true,
-                  "protected": false,
-                  "dbIndex": false,
-                  "encrypted": false,
-                  "clearOnHide": false,
-                  "customDefaultValue": "",
-                  "calculateValue": "",
-                  "calculateServer": false,
-                  "allowCalculateOverride": false,
-                  "validateOn": "change",
-                  "validate": {
-                    "required": true,
-                    "onlyAvailableItems": true,
-                    "customMessage": "",
-                    "custom": "",
-                    "customPrivate": false,
-                    "json": "",
-                    "strictDateValidation": false,
-                    "multiple": false,
-                    "unique": false
-                  },
-                  "unique": false,
-                  "errorLabel": "",
-                  "errors": "",
-                  "key": "regulatingBody",
-                  "tags": [],
-                  "properties": {},
-                  "conditional": {
-                    "show": "",
-                    "when": null,
-                    "eq": "",
-                    "json": ""
-                  },
-                  "customConditional": "",
-                  "logic": [],
-                  "attributes": {
-                    "data-cy": "regulatingBody"
-                  },
-                  "overlay": {
-                    "style": "",
-                    "page": "",
-                    "left": "",
-                    "top": "",
-                    "width": "",
-                    "height": ""
-                  },
-                  "type": "select",
-                  "indexeddb": {
-                    "filter": {}
-                  },
-                  "selectFields": "",
-                  "searchField": "",
-                  "searchDebounce": 0.3,
-                  "minSearch": 0,
-                  "filter": "",
-                  "redrawOn": "",
-                  "input": true,
-                  "searchThreshold": 0.3,
-                  "prefix": "",
-                  "suffix": "",
-                  "dataGridLabel": false,
-                  "showCharCount": false,
-                  "showWordCount": false,
-                  "allowMultipleMasks": false,
-                  "addons": [],
-                  "lazyLoad": true,
-                  "authenticate": false,
-                  "ignoreCache": false,
-                  "fuseOptions": {
-                    "include": "score",
-                    "threshold": 0.3
-                  },
-                  "id": "e5eqny",
-                  "defaultValue": ""
-                }
-              ],
-              "width": 6,
-              "offset": 0,
-              "push": 0,
-              "pull": 0
-            },
-            {
-              "components": [
-                {
-                  "autofocus": false,
-                  "input": true,
-                  "tableView": true,
-                  "inputType": "text",
-                  "inputMask": "",
-                  "label": "Other institution regulating body",
-                  "key": "otherRegulatingBody",
-                  "placeholder": "",
-                  "prefix": "",
-                  "suffix": "",
-                  "multiple": false,
-                  "defaultValue": "",
-                  "protected": false,
-                  "unique": false,
-                  "persistent": true,
-                  "hidden": false,
-                  "clearOnHide": true,
-                  "spellcheck": true,
-                  "validate": {
-                    "required": true,
-                    "minLength": 1,
-                    "maxLength": 100,
-                    "pattern": "",
-                    "custom": "",
-                    "customPrivate": false
-                  },
-                  "conditional": {
-                    "show": "true",
-                    "when": "regulatingBody",
-                    "eq": "other"
-                  },
-                  "type": "textfield",
-                  "labelPosition": "top",
-                  "inputFormat": "plain",
-                  "tags": [],
-                  "properties": {},
-                  "lockKey": true
-                }
-              ],
-              "width": 6,
-              "offset": 0,
-              "push": 0,
-              "pull": 0
-            }
-          ],
-          "type": "columns",
-          "hideLabel": true,
+          "customDefaultValue": "",
+          "calculateValue": "",
+          "calculateServer": false,
+          "allowCalculateOverride": false,
+          "validateOn": "change",
+          "validate": {
+            "required": true,
+            "onlyAvailableItems": true,
+            "customMessage": "",
+            "custom": "",
+            "customPrivate": false,
+            "json": "",
+            "strictDateValidation": false,
+            "multiple": false,
+            "unique": false
+          },
+          "unique": false,
+          "errorLabel": "",
+          "errors": "",
+          "key": "regulatingBody",
           "tags": [],
+          "properties": {},
           "conditional": {
             "show": "",
             "when": null,
-            "eq": ""
+            "eq": "",
+            "json": ""
           },
-          "properties": {}
+          "customConditional": "",
+          "logic": [],
+          "attributes": {
+            "data-cy": "regulatingBody"
+          },
+          "overlay": {
+            "style": "",
+            "page": "",
+            "left": "",
+            "top": "",
+            "width": "",
+            "height": ""
+          },
+          "type": "select",
+          "indexeddb": {
+            "filter": {}
+          },
+          "selectFields": "",
+          "searchField": "",
+          "searchDebounce": 0.3,
+          "minSearch": 0,
+          "filter": "",
+          "redrawOn": "",
+          "input": true,
+          "searchThreshold": 0.3,
+          "prefix": "",
+          "suffix": "",
+          "dataGridLabel": false,
+          "showCharCount": false,
+          "showWordCount": false,
+          "allowMultipleMasks": false,
+          "addons": [],
+          "lazyLoad": true,
+          "authenticate": false,
+          "ignoreCache": false,
+          "fuseOptions": {
+            "include": "score",
+            "threshold": 0.3
+          },
+          "id": "e5eqny",
+          "defaultValue": ""
+        },
+        {
+          "autofocus": false,
+          "input": true,
+          "tableView": true,
+          "inputType": "text",
+          "inputMask": "",
+          "label": "Other institution regulating body",
+          "key": "otherRegulatingBody",
+          "placeholder": "",
+          "prefix": "",
+          "suffix": "",
+          "multiple": false,
+          "defaultValue": "",
+          "protected": false,
+          "unique": false,
+          "persistent": true,
+          "hidden": false,
+          "clearOnHide": true,
+          "spellcheck": true,
+          "validate": {
+            "required": true,
+            "minLength": 1,
+            "maxLength": 100,
+            "pattern": "",
+            "custom": "",
+            "customPrivate": false
+          },
+          "conditional": {
+            "show": "true",
+            "when": "regulatingBody",
+            "eq": "other"
+          },
+          "type": "textfield",
+          "labelPosition": "top",
+          "inputFormat": "plain",
+          "tags": [],
+          "properties": {},
+          "lockKey": true
         },
         {
           "label": "Established date",

--- a/sources/packages/forms/src/form-definitions/institutionprofile.json
+++ b/sources/packages/forms/src/form-definitions/institutionprofile.json
@@ -562,7 +562,7 @@
           "defaultValue": null
         },
         {
-          "label": "Institution regulating body",
+          "label": "Institution regulatory body",
           "labelPosition": "top",
           "widget": "choicesjs",
           "labelWidth": "",
@@ -710,7 +710,7 @@
           "tableView": true,
           "inputType": "text",
           "inputMask": "",
-          "label": "Other institution regulating body",
+          "label": "Other regulatory body",
           "key": "otherRegulatingBody",
           "placeholder": "",
           "prefix": "",

--- a/sources/packages/forms/src/form-definitions/institutionprofilecreation.json
+++ b/sources/packages/forms/src/form-definitions/institutionprofilecreation.json
@@ -1025,7 +1025,7 @@
           "defaultValue": null
         },
         {
-          "label": "Institution regulating body",
+          "label": "Institution regulatory body",
           "labelPosition": "top",
           "widget": "choicesjs",
           "labelWidth": "",
@@ -1174,7 +1174,7 @@
           "tableView": true,
           "inputType": "text",
           "inputMask": "",
-          "label": "Other regulating body",
+          "label": "Other regulatory body",
           "key": "otherRegulatingBody",
           "placeholder": "",
           "prefix": "",

--- a/sources/packages/forms/src/form-definitions/institutionprofilecreation.json
+++ b/sources/packages/forms/src/form-definitions/institutionprofilecreation.json
@@ -1025,217 +1025,188 @@
           "defaultValue": null
         },
         {
-          "clearOnHide": false,
-          "label": "Columns",
-          "input": false,
-          "tableView": false,
-          "key": "institutionRegulatingBodyColumns",
-          "columns": [
-            {
-              "components": [
-                {
-                  "label": "Institution regulating body",
-                  "labelPosition": "top",
-                  "widget": "choicesjs",
-                  "labelWidth": "",
-                  "labelMargin": "",
-                  "placeholder": "",
-                  "description": "",
-                  "tooltip": "",
-                  "customClass": "",
-                  "tabindex": "",
-                  "hidden": false,
-                  "uniqueOptions": false,
-                  "autofocus": false,
-                  "disabled": false,
-                  "tableView": true,
-                  "modalEdit": false,
-                  "multiple": false,
-                  "dataSrc": "values",
-                  "data": {
-                    "values": [
-                      {
-                        "label": "Private Act of BC Legislature",
-                        "value": "private-act"
-                      },
-                      {
-                        "label": "ICBC",
-                        "value": "icbc"
-                      },
-                      {
-                        "label": "DQAB",
-                        "value": "dqab"
-                      },
-                      {
-                        "label": "PTIB",
-                        "value": "ptib"
-                      },
-                      {
-                        "label": "Skilled Trades BC",
-                        "value": "skilledTradesBC"
-                      },
-                      {
-                        "value": "other",
-                        "label": "Other"
-                      }
-                    ],
-                    "resource": "",
-                    "json": "",
-                    "url": "",
-                    "custom": ""
-                  },
-                  "dataType": "",
-                  "idPath": "id",
-                  "valueProperty": "",
-                  "limit": 100,
-                  "template": "<span>{{ item.label }}</span>",
-                  "refreshOn": "",
-                  "refreshOnBlur": "",
-                  "clearOnRefresh": false,
-                  "searchEnabled": true,
-                  "selectThreshold": 0.3,
-                  "readOnlyValue": false,
-                  "customOptions": {},
-                  "useExactSearch": false,
-                  "persistent": true,
-                  "protected": false,
-                  "dbIndex": false,
-                  "encrypted": false,
-                  "clearOnHide": true,
-                  "customDefaultValue": "",
-                  "calculateValue": "",
-                  "calculateServer": false,
-                  "allowCalculateOverride": false,
-                  "validateOn": "change",
-                  "validate": {
-                    "required": true,
-                    "onlyAvailableItems": true,
-                    "customMessage": "",
-                    "custom": "",
-                    "customPrivate": false,
-                    "json": "",
-                    "strictDateValidation": false,
-                    "multiple": false,
-                    "unique": false
-                  },
-                  "unique": false,
-                  "errorLabel": "",
-                  "errors": "",
-                  "key": "regulatingBody",
-                  "tags": [],
-                  "properties": {},
-                  "conditional": {
-                    "show": "",
-                    "when": null,
-                    "eq": "",
-                    "json": ""
-                  },
-                  "customConditional": "",
-                  "logic": [],
-                  "attributes": {
-                    "data-cy": "regulatingBody"
-                  },
-                  "overlay": {
-                    "style": "",
-                    "page": "",
-                    "left": "",
-                    "top": "",
-                    "width": "",
-                    "height": ""
-                  },
-                  "type": "select",
-                  "indexeddb": {
-                    "filter": {}
-                  },
-                  "selectFields": "",
-                  "searchField": "",
-                  "searchDebounce": 0.3,
-                  "minSearch": 0,
-                  "filter": "",
-                  "redrawOn": "",
-                  "input": true,
-                  "searchThreshold": 0.3,
-                  "prefix": "",
-                  "suffix": "",
-                  "dataGridLabel": false,
-                  "showCharCount": false,
-                  "showWordCount": false,
-                  "allowMultipleMasks": false,
-                  "addons": [],
-                  "lazyLoad": true,
-                  "authenticate": false,
-                  "ignoreCache": false,
-                  "fuseOptions": {
-                    "include": "score",
-                    "threshold": 0.3
-                  },
-                  "id": "eu71knzh",
-                  "defaultValue": ""
-                }
-              ],
-              "width": 6,
-              "offset": 0,
-              "push": 0,
-              "pull": 0
-            },
-            {
-              "components": [
-                {
-                  "autofocus": false,
-                  "input": true,
-                  "tableView": true,
-                  "inputType": "text",
-                  "inputMask": "",
-                  "label": "Other regulating body",
-                  "key": "otherRegulatingBody",
-                  "placeholder": "",
-                  "prefix": "",
-                  "suffix": "",
-                  "multiple": false,
-                  "defaultValue": "",
-                  "protected": false,
-                  "unique": false,
-                  "persistent": true,
-                  "hidden": false,
-                  "clearOnHide": true,
-                  "spellcheck": true,
-                  "validate": {
-                    "required": true,
-                    "minLength": 1,
-                    "maxLength": 100,
-                    "pattern": "",
-                    "custom": "",
-                    "customPrivate": false
-                  },
-                  "conditional": {
-                    "show": "true",
-                    "when": "regulatingBody",
-                    "eq": "other"
-                  },
-                  "type": "textfield",
-                  "labelPosition": "top",
-                  "inputFormat": "plain",
-                  "tags": [],
-                  "properties": {},
-                  "lockKey": true
-                }
-              ],
-              "width": 6,
-              "offset": 0,
-              "push": 0,
-              "pull": 0
-            }
-          ],
-          "type": "columns",
-          "hideLabel": true,
+          "label": "Institution regulating body",
+          "labelPosition": "top",
+          "widget": "choicesjs",
+          "labelWidth": "",
+          "labelMargin": "",
+          "placeholder": "",
+          "description": "",
+          "tooltip": "",
+          "customClass": "",
+          "tabindex": "",
+          "hidden": false,
+          "uniqueOptions": false,
+          "autofocus": false,
+          "disabled": false,
+          "tableView": true,
+          "modalEdit": false,
+          "multiple": false,
+          "dataSrc": "values",
+          "data": {
+            "values": [
+              {
+                "label": "Private Act of BC Legislature",
+                "value": "private-act"
+              },
+              {
+                "label": "ICBC",
+                "value": "icbc"
+              },
+              {
+                "label": "DQAB",
+                "value": "dqab"
+              },
+              {
+                "label": "PTIB",
+                "value": "ptib"
+              },
+              {
+                "label": "Skilled Trades BC",
+                "value": "skilledTradesBC"
+              },
+              {
+                "value": "senateOrEducationCouncil",
+                "label": "Senate, Academic Council, Education Council, and/or Program Council and Board of Governors"
+              },
+              {
+                "value": "other",
+                "label": "Other"
+              }
+            ],
+            "resource": "",
+            "json": "",
+            "url": "",
+            "custom": ""
+          },
+          "dataType": "",
+          "idPath": "id",
+          "valueProperty": "",
+          "limit": 100,
+          "template": "<span>{{ item.label }}</span>",
+          "refreshOn": "",
+          "refreshOnBlur": "",
+          "clearOnRefresh": false,
+          "searchEnabled": true,
+          "selectThreshold": 0.3,
+          "readOnlyValue": false,
+          "customOptions": {},
+          "useExactSearch": false,
+          "persistent": true,
+          "protected": false,
+          "dbIndex": false,
+          "encrypted": false,
+          "clearOnHide": true,
+          "customDefaultValue": "",
+          "calculateValue": "",
+          "calculateServer": false,
+          "allowCalculateOverride": false,
+          "validateOn": "change",
+          "validate": {
+            "required": true,
+            "onlyAvailableItems": true,
+            "customMessage": "",
+            "custom": "",
+            "customPrivate": false,
+            "json": "",
+            "strictDateValidation": false,
+            "multiple": false,
+            "unique": false
+          },
+          "unique": false,
+          "errorLabel": "",
+          "errors": "",
+          "key": "regulatingBody",
           "tags": [],
+          "properties": {},
           "conditional": {
             "show": "",
             "when": null,
-            "eq": ""
+            "eq": "",
+            "json": ""
           },
+          "customConditional": "",
+          "logic": [],
+          "attributes": {
+            "data-cy": "regulatingBody"
+          },
+          "overlay": {
+            "style": "",
+            "page": "",
+            "left": "",
+            "top": "",
+            "width": "",
+            "height": ""
+          },
+          "type": "select",
+          "indexeddb": {
+            "filter": {}
+          },
+          "selectFields": "",
+          "searchField": "",
+          "searchDebounce": 0.3,
+          "minSearch": 0,
+          "filter": "",
+          "redrawOn": "",
+          "input": true,
+          "searchThreshold": 0.3,
+          "prefix": "",
+          "suffix": "",
+          "dataGridLabel": false,
+          "showCharCount": false,
+          "showWordCount": false,
+          "allowMultipleMasks": false,
+          "addons": [],
+          "lazyLoad": true,
+          "authenticate": false,
+          "ignoreCache": false,
+          "fuseOptions": {
+            "include": "score",
+            "threshold": 0.3
+          },
+          "id": "eu71knzh",
+          "defaultValue": "",
+          "isNew": false
+        },
+        {
+          "autofocus": false,
+          "input": true,
+          "tableView": true,
+          "inputType": "text",
+          "inputMask": "",
+          "label": "Other regulating body",
+          "key": "otherRegulatingBody",
+          "placeholder": "",
+          "prefix": "",
+          "suffix": "",
+          "multiple": false,
+          "defaultValue": "",
+          "protected": false,
+          "unique": false,
+          "persistent": true,
+          "hidden": false,
+          "clearOnHide": true,
+          "spellcheck": true,
+          "validate": {
+            "required": true,
+            "minLength": 1,
+            "maxLength": 100,
+            "pattern": "",
+            "custom": "",
+            "customPrivate": false
+          },
+          "conditional": {
+            "show": "true",
+            "when": "regulatingBody",
+            "eq": "other"
+          },
+          "type": "textfield",
+          "labelPosition": "top",
+          "inputFormat": "plain",
+          "tags": [],
           "properties": {},
-          "lockKey": true
+          "lockKey": true,
+          "isNew": false
         },
         {
           "label": "Established date",

--- a/sources/packages/web/src/views/aest/institution/Profile.vue
+++ b/sources/packages/web/src/views/aest/institution/Profile.vue
@@ -56,12 +56,12 @@
               :propertyValue="institutionProfileDetail.institutionTypeName"
             />
             <title-value
-              propertyTitle="Regulating body"
+              propertyTitle="Regulatory body"
               :propertyValue="institutionProfileDetail.regulatingBody"
             />
             <title-value
               v-if="institutionProfileDetail.regulatingBody === 'other'"
-              propertyTitle="Other regulating body"
+              propertyTitle="Other regulatory body"
               :propertyValue="institutionProfileDetail.otherRegulatingBody"
             />
           </v-col>


### PR DESCRIPTION
## New dropdown item Senate, Academic Council, Education Council, and/or Program Council and Board of Governors

- [x] Add a new dropdown item called "Senate, Academic Council, Education Council, and/or Program Council and Board of Governors". Add the dropdown item to institution profile and program both.
- [x] Define the option code as senateOrEducationCouncil.
- [x] In case of other regulatory body is selected, the text input to enter other regulatory body has been moved under the regulatory body dropdown.

### Create/Edit Program

![image](https://github.com/bcgov/SIMS/assets/54600590/69efff75-06bd-4221-9ae8-d7ada9f7f7e2)

Other
![image](https://github.com/bcgov/SIMS/assets/54600590/422dd245-9096-4d6f-a762-b7361bbc1b4b)

### Institution Profile (Edit from ministry)
![image](https://github.com/bcgov/SIMS/assets/54600590/cf40bdd3-a117-49d1-ba05-92990d3d3eda)


![image](https://github.com/bcgov/SIMS/assets/54600590/3918d8d9-c99b-4acf-b06e-3070b68d36cb)


![image](https://github.com/bcgov/SIMS/assets/54600590/376cf0e0-aa33-46ee-959f-5ef6d0e74855)

###  Institution Setup (Ignore the label)
![image](https://github.com/bcgov/SIMS/assets/54600590/36e5faa3-cbf6-4da3-bc6b-ff70a0b15034)

![image](https://github.com/bcgov/SIMS/assets/54600590/6d182567-e661-4e29-97a0-3730a87495d8)


