### PR TITLE
#2067 - Patroni creds change from Superuser to Databaseuser in DB Backup

### DIFF
--- a/devops/Makefile
+++ b/devops/Makefile
@@ -543,7 +543,7 @@ db-backup-deploy-patroni:
 		-p DATABASE_USER_KEY_NAME=database-user \
 		-p DATABASE_PASSWORD_KEY_NAME=database-password \
   	-p ENVIRONMENT_FRIENDLY_NAME='SIMS $(NAMESPACE) POSTGRESQL DB Backups' \
-		-p TABLE_SCHEMA='sims'
+		-p TABLE_SCHEMA='sims' \
 		| oc -n $(NAMESPACE) apply -f -	                                                                       
 
 db-backup-deploy-patroni-delete:

--- a/devops/Makefile
+++ b/devops/Makefile
@@ -540,9 +540,10 @@ db-backup-deploy-patroni:
 		-p CUSTOM_CONFIG_FILE_NAME=$(PATRONI_SIMSDB_BACKUP_CONFIG_FILE_NAME) \
 		-p VERIFICATION_VOLUME_NAME=$(PATRONI_SIMSDB_BACKUP_APP_NAME)-verification-pvc \
 		-p DATABASE_DEPLOYMENT_NAME=patroni-creds \
-		-p DATABASE_USER_KEY_NAME=superuser-username \
-		-p DATABASE_PASSWORD_KEY_NAME=superuser-password \
+		-p DATABASE_USER_KEY_NAME=database-user \
+		-p DATABASE_PASSWORD_KEY_NAME=database-password \
   	-p ENVIRONMENT_FRIENDLY_NAME='SIMS $(NAMESPACE) POSTGRESQL DB Backups' \
+		-p TABLE_SCHEMA='sims'
 		| oc -n $(NAMESPACE) apply -f -	                                                                       
 
 db-backup-deploy-patroni-delete:

--- a/devops/openshift/database-backup/patroni-simsdb-backup.conf
+++ b/devops/openshift/database-backup/patroni-simsdb-backup.conf
@@ -2,3 +2,5 @@ postgres=patroni-master:5432/SIMSDB
 
 # Run a backup at 1am Pacific every day.
 0 1 * * * default ./backup.sh -s
+# Run verification at 4am Pacific every day.
+0 4 * * * default ./backup.sh -s -v all

--- a/devops/openshift/database/patroni-pre-req.yml
+++ b/devops/openshift/database/patroni-pre-req.yml
@@ -16,7 +16,7 @@ objects:
       superuser-username: ${PATRONI_SUPERUSER_USERNAME}
       superuser-password: ${PATRONI_SUPERUSER_PASSWORD}
       database-name: ${APP_DB_NAME}
-      database-user: app_api_user
+      database-user: app_database_user
       database-password: ${APP_DB_PASSWORD}
   - apiVersion: v1
     kind: ServiceAccount

--- a/devops/openshift/database/patroni-pre-req.yml
+++ b/devops/openshift/database/patroni-pre-req.yml
@@ -16,7 +16,7 @@ objects:
       superuser-username: ${PATRONI_SUPERUSER_USERNAME}
       superuser-password: ${PATRONI_SUPERUSER_PASSWORD}
       database-name: ${APP_DB_NAME}
-      database-user: app_api_${APP_DB_USERNAME}
+      database-user: app_api_user
       database-password: ${APP_DB_PASSWORD}
   - apiVersion: v1
     kind: ServiceAccount
@@ -113,9 +113,6 @@ parameters:
     displayName: Replication Password
     generate: expression
     from: "[a-zA-Z0-9]{32}"
-  - name: APP_DB_USERNAME
-    generate: expression
-    from: "[a-zA-Z0-9]{8}"
   - name: APP_DB_NAME
     value: SIMSDB
   - name: APP_DB_PASSWORD


### PR DESCRIPTION
- Patroni creds change from Superuser to Databaseuser in DB Backup
- The scripts to assign the privileges for the Databaseuser is updated in wiki 
https://github.com/bcgov/SIMS/wiki/DevOps-and-Running-the-Application#assign-privileges-for-database-user-for-backup-and-restore
https://github.com/bcgov/SIMS/wiki/DevOps-and-Running-the-Application#revoke-privileges-for-database-user-for-backup-and-restore