### PR TITLE
#2044 Add Ignore errors and timeout for ORM Cache

### DIFF
--- a/sources/packages/backend/libs/sims-db/src/data-source.ts
+++ b/sources/packages/backend/libs/sims-db/src/data-source.ts
@@ -54,7 +54,10 @@ import {
   ApplicationOfferingChangeRequest,
 } from "./entities";
 import { ClusterNode, ClusterOptions, RedisOptions } from "ioredis";
-import { ORM_CACHE_LIFETIME } from "@sims/utilities";
+import {
+  ORM_CACHE_LIFETIME,
+  ORM_CACHE_REDIS_COMMAND_TIMEOUT,
+} from "@sims/utilities";
 import { ConfigService } from "@sims/utilities/config";
 
 interface ORMCacheConfig {
@@ -100,7 +103,9 @@ function getORMCacheConfig(): ORMCacheConfig | false {
         host: config.redis.redisHost,
         port: config.redis.redisPort,
         password: config.redis.redisPassword,
+        commandTimeout: ORM_CACHE_REDIS_COMMAND_TIMEOUT,
       },
+      ignoreErrors: true,
       duration: ORM_CACHE_LIFETIME,
     };
   }
@@ -113,9 +118,11 @@ function getORMCacheConfig(): ORMCacheConfig | false {
       options: {
         redisOptions: {
           password: config.redis.redisPassword,
+          commandTimeout: ORM_CACHE_REDIS_COMMAND_TIMEOUT,
         },
       },
     },
+    ignoreErrors: true,
     duration: ORM_CACHE_LIFETIME,
   };
 }

--- a/sources/packages/backend/libs/sims-db/src/data-source.ts
+++ b/sources/packages/backend/libs/sims-db/src/data-source.ts
@@ -57,6 +57,7 @@ import { ClusterNode, ClusterOptions, RedisOptions } from "ioredis";
 import {
   ORM_CACHE_LIFETIME,
   ORM_CACHE_REDIS_COMMAND_TIMEOUT,
+  ORM_CACHE_REDIS_RETRY_INTERVAL,
 } from "@sims/utilities";
 import { ConfigService } from "@sims/utilities/config";
 
@@ -104,6 +105,7 @@ function getORMCacheConfig(): ORMCacheConfig | false {
         port: config.redis.redisPort,
         password: config.redis.redisPassword,
         commandTimeout: ORM_CACHE_REDIS_COMMAND_TIMEOUT,
+        retryStrategy: () => ORM_CACHE_REDIS_RETRY_INTERVAL,
       },
       ignoreErrors: true,
       duration: ORM_CACHE_LIFETIME,
@@ -120,6 +122,7 @@ function getORMCacheConfig(): ORMCacheConfig | false {
           password: config.redis.redisPassword,
           commandTimeout: ORM_CACHE_REDIS_COMMAND_TIMEOUT,
         },
+        clusterRetryStrategy: () => ORM_CACHE_REDIS_RETRY_INTERVAL,
       },
     },
     ignoreErrors: true,

--- a/sources/packages/backend/libs/sims-db/src/data-source.ts
+++ b/sources/packages/backend/libs/sims-db/src/data-source.ts
@@ -97,6 +97,11 @@ function getORMCacheConfig(): ORMCacheConfig | false {
     return false;
   }
 
+  const retryStrategy = (times: number) => {
+    const delay = Math.min(times * 100, ORM_CACHE_REDIS_RETRY_INTERVAL);
+    return delay;
+  };
+
   if (config.redis.redisStandaloneMode) {
     return {
       type: "ioredis",
@@ -105,7 +110,7 @@ function getORMCacheConfig(): ORMCacheConfig | false {
         port: config.redis.redisPort,
         password: config.redis.redisPassword,
         commandTimeout: ORM_CACHE_REDIS_COMMAND_TIMEOUT,
-        retryStrategy: () => ORM_CACHE_REDIS_RETRY_INTERVAL,
+        retryStrategy,
       },
       ignoreErrors: true,
       duration: ORM_CACHE_LIFETIME,

--- a/sources/packages/backend/libs/sims-db/src/data-source.ts
+++ b/sources/packages/backend/libs/sims-db/src/data-source.ts
@@ -127,7 +127,7 @@ function getORMCacheConfig(): ORMCacheConfig | false {
           password: config.redis.redisPassword,
           commandTimeout: ORM_CACHE_REDIS_COMMAND_TIMEOUT,
         },
-        clusterRetryStrategy: () => ORM_CACHE_REDIS_RETRY_INTERVAL,
+        clusterRetryStrategy: retryStrategy,
       },
     },
     ignoreErrors: true,

--- a/sources/packages/backend/libs/utilities/src/system-configurations-constants.ts
+++ b/sources/packages/backend/libs/utilities/src/system-configurations-constants.ts
@@ -28,7 +28,7 @@ export const ORM_CACHE_LIFETIME = 10 * 60 * 1000;
 /**
  * Redis command timeout of the ORM cache in milliseconds.
  */
-export const ORM_CACHE_REDIS_COMMAND_TIMEOUT = 60 * 1000;
+export const ORM_CACHE_REDIS_COMMAND_TIMEOUT = 5 * 1000;
 
 /**
  * Redis retry interval to retry connection

--- a/sources/packages/backend/libs/utilities/src/system-configurations-constants.ts
+++ b/sources/packages/backend/libs/utilities/src/system-configurations-constants.ts
@@ -24,6 +24,12 @@ export const MIN_CANADA_LOAN_OVERAWARD = 250;
  * Default lifetime of ORM cache in milliseconds.
  */
 export const ORM_CACHE_LIFETIME = 10 * 60 * 1000;
+
+/**
+ * Redis command timeout of the ORM cache in milliseconds.
+ */
+export const ORM_CACHE_REDIS_COMMAND_TIMEOUT = 10 * 60 * 1000;
+
 /**
  * Minimum number of days from COE approval date to the disbursement date.
  */

--- a/sources/packages/backend/libs/utilities/src/system-configurations-constants.ts
+++ b/sources/packages/backend/libs/utilities/src/system-configurations-constants.ts
@@ -28,7 +28,17 @@ export const ORM_CACHE_LIFETIME = 10 * 60 * 1000;
 /**
  * Redis command timeout of the ORM cache in milliseconds.
  */
-export const ORM_CACHE_REDIS_COMMAND_TIMEOUT = 10 * 60 * 1000;
+export const ORM_CACHE_REDIS_COMMAND_TIMEOUT = 60 * 1000;
+
+/**
+ * Redis retry interval to retry connection
+ * when a connection cannot be established to redis.
+ *
+ * Ref for standalone: https://github.com/redis/ioredis/tree/v4#auto-reconnect
+ *
+ * Ref for cluster: https://github.com/redis/ioredis/tree/v4#cluster
+ */
+export const ORM_CACHE_REDIS_RETRY_INTERVAL = 60 * 1000;
 
 /**
  * Minimum number of days from COE approval date to the disbursement date.


### PR DESCRIPTION
## Ignore Errors and add timeout 
- [x] Added `ignoreErrors: true` to the orm cache config.
 - [x] Set `commandTimeout` of redis to 60 seconds in cache config which is infinite by default.

## Retry Strategy (https://github.com/redis/ioredis/tree/v4#auto-reconnect)
When `ignoreErrors: true` is set, errors are ignored and the typeorm works normally but the redis client(ioredis and ioredis/cluster) does retry every 2 seconds to connect again to redis server and creates log for every retry.

This is due to the default implementation of `retryStrategy` and `clusterRetryStrategy`.

![image](https://github.com/bcgov/SIMS/assets/54600590/1362a3cb-7eff-4be2-b692-278dc5c07267)

![image](https://github.com/bcgov/SIMS/assets/54600590/47319be5-f4be-4564-9a33-dedc8bb3b3aa)

- [x] Hence the connection retry interval has been set to 60 seconds for orm config.
