### PR TITLE
#2134 - Institution Search Fix

### DIFF
--- a/sources/packages/backend/libs/sims-db/src/entities/institution.model.ts
+++ b/sources/packages/backend/libs/sims-db/src/entities/institution.model.ts
@@ -17,8 +17,8 @@ import { Note } from ".";
 import { AddressInfo } from "./address.type";
 import { PrimaryContact } from "./primary-contact.type";
 
-export const OPERATING_NAME_MAX_LENGTH = 64;
-export const LEGAL_OPERATING_NAME_MAX_LENGTH = 64;
+export const OPERATING_NAME_MAX_LENGTH = 250;
+export const LEGAL_OPERATING_NAME_MAX_LENGTH = 250;
 
 export interface InstitutionAddress {
   mailingAddress: AddressInfo;

--- a/sources/packages/web/src/views/aest/SearchInstitutions.vue
+++ b/sources/packages/web/src/views/aest/SearchInstitutions.vue
@@ -49,6 +49,7 @@
           v-if="institutionsFound"
           class="mt-4"
           :autoLayout="true"
+          :scrollable="true"
           :value="institutions"
         >
           <Column


### PR DESCRIPTION
## Update institution search for ministry user to allow 250 characters on operating name and legal operating name

- [x] Update the max length constants

## The institution search result seems to be broken when the characters of operating name and legal name are lengthy

![image](https://github.com/bcgov/SIMS/assets/54600590/50f02c29-d223-4b72-a692-8357e910953b)

After enabling scrollable

![image](https://github.com/bcgov/SIMS/assets/54600590/dc1a4ee3-6bb8-4b97-9d4e-4c8a17aca3ea)

- [x] Enable scrollable as true