### PR TITLE
#2150 - TESTING BUG - Unable to search student in the Support user portal (Parent/partner declaration portal)

### DIFF
--- a/sources/packages/web/src/services/http/dto/SupportingUser.dto.ts
+++ b/sources/packages/web/src/services/http/dto/SupportingUser.dto.ts
@@ -1,30 +1,42 @@
 import { SupportingUserType } from "@/types";
 import { ContactInformationAPIOutDTO } from "./Address.dto";
+import { Expose } from "class-transformer";
 
 /**
  * Information used to uniquely identify a Student Application.
  * The application must be search using at least 3 criteria as
  * per defined by the Ministry policies.
  */
-export interface ApplicationIdentifierAPIInDTO {
+export class ApplicationIdentifierAPIInDTO {
+  @Expose()
   applicationNumber: string;
+  @Expose()
   studentsDateOfBirth: string;
+  @Expose()
   studentsLastName: string;
 }
 
 /**
  * Data send to api to update a supporting user.
  */
-export interface UpdateSupportingUserAPIInDTO
-  extends ApplicationIdentifierAPIInDTO {
+export class UpdateSupportingUserAPIInDTO extends ApplicationIdentifierAPIInDTO {
+  @Expose()
   addressLine1: string;
+  @Expose()
   addressLine2?: string;
+  @Expose()
   city: string;
+  @Expose()
   country: string;
+  @Expose()
   phone: string;
+  @Expose()
   postalCode: string;
+  @Expose()
   provinceState?: string;
+  @Expose()
   sin: string;
+  @Expose()
   supportingData: unknown;
 }
 

--- a/sources/packages/web/src/views/supporting-user/SupportingInformation.vue
+++ b/sources/packages/web/src/views/supporting-user/SupportingInformation.vue
@@ -121,6 +121,7 @@ import {
   VForm,
   ApiProcessError,
 } from "@/types";
+import { UpdateSupportingUserAPIInDTO } from "@/services/http/dto";
 
 export default defineComponent({
   props: {
@@ -140,7 +141,7 @@ export default defineComponent({
     const studentsLastName = ref("");
     const studentsDateOfBirth = ref();
     const initialData = ref();
-    const formioUtils = useFormioUtils();
+    const { disableWizardButtons, excludeExtraneousValues } = useFormioUtils();
     const isFirstPage = ref(true);
     const isLastPage = ref(false);
     const showNav = ref(false);
@@ -156,7 +157,7 @@ export default defineComponent({
       showNav.value = true;
       formInstance = form;
       // Disable internal submit button.
-      formioUtils.disableWizardButtons(formInstance);
+      disableWizardButtons(formInstance);
       formInstance.options.buttonSettings.showSubmit = false;
       // Handle the navigation using the breadcrumbs.
       formInstance.on(
@@ -233,12 +234,16 @@ export default defineComponent({
       }
     };
 
-    const submitted = async (formData: any) => {
+    const submitted = async (formData: unknown) => {
       submitting.value = true;
       try {
+        const typedData = excludeExtraneousValues(
+          UpdateSupportingUserAPIInDTO,
+          formData,
+        );
         await SupportingUsersService.shared.updateSupportingInformation(
           props.supportingUserType,
-          { ...formData, ...getIdentifiedApplication() },
+          { ...typedData, ...getIdentifiedApplication() },
         );
 
         snackBar.success("Supporting data submitted with success.");

--- a/sources/packages/web/src/views/supporting-user/SupportingInformation.vue
+++ b/sources/packages/web/src/views/supporting-user/SupportingInformation.vue
@@ -198,6 +198,7 @@ export default defineComponent({
     });
 
     const applicationSearch = async () => {
+      showNav.value = false;
       const validationResult = await searchApplicationsForm.value.validate();
       if (!validationResult.valid) {
         return;


### PR DESCRIPTION
- Partner and partner When searching for the student application, I couldn't find any issue in my local, As discussed in the call, look like the loading issue mentioned in the ticket was due to point 4.
- Supporting partner data submission was failing - fixed
- Did an overall smoke test in the supporting user portal - everything looks fine.
- Supporting user form was not correct in TEST db, updated it
![image](https://github.com/bcgov/SIMS/assets/77353155/374ef8ea-98d8-4062-8c8e-053a14c0ee14)
- Fixed a small UI issue - Once you search for an existing application and then try to search for a nonexisting application the form's Next step  and back btn was still visible
**Issue**
![image](https://github.com/bcgov/SIMS/assets/77353155/de9d3971-382a-45ac-aabe-6b2e4b43043b)
**Fix**
![image](https://github.com/bcgov/SIMS/assets/77353155/ea516359-641d-4b90-9bc0-7e34c8563dd6)

**Screenshots**
![image](https://github.com/bcgov/SIMS/assets/77353155/e20a66ee-5105-411e-8285-c7ee247f3334)
![image](https://github.com/bcgov/SIMS/assets/77353155/770fbc12-1961-4cd8-a3ab-87b4ae50cef5)
