### PR TITLE
#2207 - Investigate Root Cause of Camunda Workers Getting Stuck

### DIFF
--- a/sources/packages/backend/apps/workers/src/controllers/application/application.controller.ts
+++ b/sources/packages/backend/apps/workers/src/controllers/application/application.controller.ts
@@ -65,6 +65,7 @@ export class ApplicationController {
         jobLogger.error(message);
         return job.error(APPLICATION_STATUS_NOT_UPDATED, message);
       }
+      jobLogger.log("Updated the application status.");
       return job.complete();
     } catch (error: unknown) {
       const errorMessage = `Unexpected error while updating the application status. ${error}`;
@@ -105,6 +106,7 @@ export class ApplicationController {
       }
       if (application.applicationException) {
         // The exceptions were already processed for this application.
+        jobLogger.log("Exceptions were already processed for the application.");
         return job.complete({
           applicationExceptionStatus:
             application.applicationException.exceptionStatus,
@@ -120,10 +122,12 @@ export class ApplicationController {
             job.variables.applicationId,
             exceptions,
           );
+        jobLogger.log("Exception created.");
         return job.complete({
           applicationExceptionStatus: createdException.exceptionStatus,
         });
       }
+      jobLogger.log("Verified application exception.");
       return job.complete({
         applicationExceptionStatus: ApplicationExceptionStatus.Approved,
       });

--- a/sources/packages/backend/apps/workers/src/controllers/application/application.controller.ts
+++ b/sources/packages/backend/apps/workers/src/controllers/application/application.controller.ts
@@ -1,4 +1,4 @@
-import { Controller } from "@nestjs/common";
+import { Controller, Logger } from "@nestjs/common";
 import { ZeebeWorker } from "../../zeebe";
 import {
   ZeebeJob,
@@ -66,9 +66,10 @@ export class ApplicationController {
       }
       return job.complete();
     } catch (error: unknown) {
-      return job.fail(
-        `Unexpected error while updating the application status. ${error}`,
-      );
+      const jobLogger = new Logger(job.type);
+      const errorMessage = `Unexpected error while updating the application status. ${error}`;
+      jobLogger.error(errorMessage);
+      return job.fail(errorMessage);
     }
   }
 
@@ -124,9 +125,10 @@ export class ApplicationController {
         applicationExceptionStatus: ApplicationExceptionStatus.Approved,
       });
     } catch (error: unknown) {
-      return job.fail(
-        `Unexpected error while verifying the application exceptions. ${error}`,
-      );
+      const jobLogger = new Logger(job.type);
+      const errorMessage = `Unexpected error while verifying the application exceptions. ${error}`;
+      jobLogger.error(errorMessage);
+      return job.fail(errorMessage);
     }
   }
 }

--- a/sources/packages/backend/apps/workers/src/controllers/application/application.controller.ts
+++ b/sources/packages/backend/apps/workers/src/controllers/application/application.controller.ts
@@ -69,8 +69,7 @@ export class ApplicationController {
       jobLogger.log("Updated the application status.");
       return job.complete();
     } catch (error: unknown) {
-      const errorMessage = `Unexpected error while updating the application status. ${error}`;
-      return createUnexpectedJobFail(errorMessage, job, jobLogger);
+      return createUnexpectedJobFail(error, job, jobLogger);
     }
   }
 
@@ -132,8 +131,7 @@ export class ApplicationController {
         applicationExceptionStatus: ApplicationExceptionStatus.Approved,
       });
     } catch (error: unknown) {
-      const errorMessage = `Unexpected error while verifying the application exceptions. ${error}`;
-      return createUnexpectedJobFail(errorMessage, job, jobLogger);
+      return createUnexpectedJobFail(error, job, jobLogger);
     }
   }
 }

--- a/sources/packages/backend/apps/workers/src/controllers/application/application.controller.ts
+++ b/sources/packages/backend/apps/workers/src/controllers/application/application.controller.ts
@@ -69,7 +69,9 @@ export class ApplicationController {
       jobLogger.log("Updated the application status.");
       return job.complete();
     } catch (error: unknown) {
-      return createUnexpectedJobFail(error, job, jobLogger);
+      return createUnexpectedJobFail(error, job, {
+        logger: jobLogger,
+      });
     }
   }
 
@@ -131,7 +133,9 @@ export class ApplicationController {
         applicationExceptionStatus: ApplicationExceptionStatus.Approved,
       });
     } catch (error: unknown) {
-      return createUnexpectedJobFail(error, job, jobLogger);
+      return createUnexpectedJobFail(error, job, {
+        logger: jobLogger,
+      });
     }
   }
 }

--- a/sources/packages/backend/apps/workers/src/controllers/application/application.controller.ts
+++ b/sources/packages/backend/apps/workers/src/controllers/application/application.controller.ts
@@ -24,6 +24,7 @@ import {
 import { APPLICATION_ID } from "@sims/services/workflow/variables/assessment-gateway";
 import { MaxJobsToActivate } from "../../types";
 import { Workers } from "@sims/services/constants";
+import { createUnexpectedJobFail } from "../../utilities";
 
 @Controller()
 export class ApplicationController {
@@ -69,8 +70,7 @@ export class ApplicationController {
       return job.complete();
     } catch (error: unknown) {
       const errorMessage = `Unexpected error while updating the application status. ${error}`;
-      jobLogger.error(errorMessage);
-      return job.fail(errorMessage);
+      return createUnexpectedJobFail(errorMessage, job, jobLogger);
     }
   }
 
@@ -133,8 +133,7 @@ export class ApplicationController {
       });
     } catch (error: unknown) {
       const errorMessage = `Unexpected error while verifying the application exceptions. ${error}`;
-      jobLogger.error(errorMessage);
-      return job.fail(errorMessage);
+      return createUnexpectedJobFail(errorMessage, job, jobLogger);
     }
   }
 }

--- a/sources/packages/backend/apps/workers/src/controllers/assessment/assessment.controller.ts
+++ b/sources/packages/backend/apps/workers/src/controllers/assessment/assessment.controller.ts
@@ -104,12 +104,15 @@ export class AssessmentController {
       ZeebeJob<AssessmentDataJobInDTO, ICustomHeaders, IOutputVariables>
     >,
   ): Promise<MustReturnJobActionAcknowledgement> {
+    const jobLogger = new Logger(job.type);
     try {
       const assessment = await this.studentAssessmentService.getById(
         job.variables.assessmentId,
       );
       if (!assessment) {
-        return job.error(ASSESSMENT_NOT_FOUND, "Assessment not found.");
+        const message = "Assessment not found.";
+        jobLogger.error(message);
+        return job.error(ASSESSMENT_NOT_FOUND, message);
       }
       const assessmentDTO = this.transformToAssessmentDTO(assessment);
       const outputVariables = filterObjectProperties(
@@ -118,7 +121,6 @@ export class AssessmentController {
       );
       return job.complete(outputVariables);
     } catch (error: unknown) {
-      const jobLogger = new Logger(job.type);
       const errorMessage = `Unexpected error while loading assessment consolidated data. ${error}`;
       jobLogger.error(errorMessage);
       return job.fail(errorMessage);

--- a/sources/packages/backend/apps/workers/src/controllers/assessment/assessment.controller.ts
+++ b/sources/packages/backend/apps/workers/src/controllers/assessment/assessment.controller.ts
@@ -60,14 +60,15 @@ export class AssessmentController {
       >
     >,
   ): Promise<MustReturnJobActionAcknowledgement> {
+    const jobLogger = new Logger(job.type);
     try {
       await this.studentAssessmentService.associateWorkflowId(
         job.variables.assessmentId,
         job.processInstanceKey,
       );
+      jobLogger.log("Associated the assessment id.");
       return job.complete();
     } catch (error: unknown) {
-      const jobLogger = new Logger(job.type);
       if (error instanceof CustomNamedError) {
         switch (error.name) {
           case ASSESSMENT_ALREADY_ASSOCIATED_TO_WORKFLOW:
@@ -119,6 +120,7 @@ export class AssessmentController {
         assessmentDTO,
         job.customHeaders,
       );
+      jobLogger.log("Assessment consolidated data loaded.");
       return job.complete(outputVariables);
     } catch (error: unknown) {
       const errorMessage = `Unexpected error while loading assessment consolidated data. ${error}`;
@@ -139,14 +141,15 @@ export class AssessmentController {
       ZeebeJob<SaveAssessmentDataJobInDTO, ICustomHeaders, IOutputVariables>
     >,
   ): Promise<MustReturnJobActionAcknowledgement> {
+    const jobLogger = new Logger(job.type);
     try {
       await this.studentAssessmentService.updateAssessmentData(
         job.variables.assessmentId,
         job.variables.assessmentData,
       );
+      jobLogger.log("Assessment data saved.");
       return job.complete();
     } catch (error: unknown) {
-      const jobLogger = new Logger(job.type);
       const errorMessage = `Unexpected error saving the assessment data. ${error}`;
       jobLogger.error(errorMessage);
       return job.fail(errorMessage);
@@ -169,14 +172,15 @@ export class AssessmentController {
       >
     >,
   ): Promise<MustReturnJobActionAcknowledgement> {
+    const jobLogger = new Logger(job.type);
     try {
       await this.studentAssessmentService.updateNOAApprovalStatus(
         job.variables.assessmentId,
         job.customHeaders.status,
       );
+      jobLogger.log("NOA status updated.");
       return job.complete();
     } catch (error: unknown) {
-      const jobLogger = new Logger(job.type);
       const errorMessage = `Unexpected error while updating the NOA status. ${error}`;
       jobLogger.error(errorMessage);
       return job.fail(errorMessage);

--- a/sources/packages/backend/apps/workers/src/controllers/assessment/assessment.controller.ts
+++ b/sources/packages/backend/apps/workers/src/controllers/assessment/assessment.controller.ts
@@ -83,8 +83,7 @@ export class AssessmentController {
             return job.error(error.name, error.message);
         }
       }
-      const errorMessage = `Not able to associate the assessment id ${job.variables.assessmentId} with the workflow instance id ${job.processInstanceKey}. ${error}`;
-      return createUnexpectedJobFail(errorMessage, job, jobLogger);
+      return createUnexpectedJobFail(error, job, jobLogger);
     }
   }
 
@@ -125,8 +124,7 @@ export class AssessmentController {
       jobLogger.log("Assessment consolidated data loaded.");
       return job.complete(outputVariables);
     } catch (error: unknown) {
-      const errorMessage = `Unexpected error while loading assessment consolidated data. ${error}`;
-      return createUnexpectedJobFail(errorMessage, job, jobLogger);
+      return createUnexpectedJobFail(error, job, jobLogger);
     }
   }
 
@@ -151,8 +149,7 @@ export class AssessmentController {
       jobLogger.log("Assessment data saved.");
       return job.complete();
     } catch (error: unknown) {
-      const errorMessage = `Unexpected error saving the assessment data. ${error}`;
-      return createUnexpectedJobFail(errorMessage, job, jobLogger);
+      return createUnexpectedJobFail(error, job, jobLogger);
     }
   }
 
@@ -181,8 +178,7 @@ export class AssessmentController {
       jobLogger.log("NOA status updated.");
       return job.complete();
     } catch (error: unknown) {
-      const errorMessage = `Unexpected error while updating the NOA status. ${error}`;
-      return createUnexpectedJobFail(errorMessage, job, jobLogger);
+      return createUnexpectedJobFail(error, job, jobLogger);
     }
   }
 

--- a/sources/packages/backend/apps/workers/src/controllers/assessment/assessment.controller.ts
+++ b/sources/packages/backend/apps/workers/src/controllers/assessment/assessment.controller.ts
@@ -101,18 +101,24 @@ export class AssessmentController {
       ZeebeJob<AssessmentDataJobInDTO, ICustomHeaders, IOutputVariables>
     >,
   ): Promise<MustReturnJobActionAcknowledgement> {
-    const assessment = await this.studentAssessmentService.getById(
-      job.variables.assessmentId,
-    );
-    if (!assessment) {
-      return job.error(ASSESSMENT_NOT_FOUND, "Assessment not found.");
+    try {
+      const assessment = await this.studentAssessmentService.getById(
+        job.variables.assessmentId,
+      );
+      if (!assessment) {
+        return job.error(ASSESSMENT_NOT_FOUND, "Assessment not found.");
+      }
+      const assessmentDTO = this.transformToAssessmentDTO(assessment);
+      const outputVariables = filterObjectProperties(
+        assessmentDTO,
+        job.customHeaders,
+      );
+      return job.complete(outputVariables);
+    } catch (error: unknown) {
+      return job.fail(
+        `Unexpected error while loading assessment consolidated data. ${error}`,
+      );
     }
-    const assessmentDTO = this.transformToAssessmentDTO(assessment);
-    const outputVariables = filterObjectProperties(
-      assessmentDTO,
-      job.customHeaders,
-    );
-    return job.complete(outputVariables);
   }
 
   /**
@@ -127,11 +133,15 @@ export class AssessmentController {
       ZeebeJob<SaveAssessmentDataJobInDTO, ICustomHeaders, IOutputVariables>
     >,
   ): Promise<MustReturnJobActionAcknowledgement> {
-    await this.studentAssessmentService.updateAssessmentData(
-      job.variables.assessmentId,
-      job.variables.assessmentData,
-    );
-    return job.complete();
+    try {
+      await this.studentAssessmentService.updateAssessmentData(
+        job.variables.assessmentId,
+        job.variables.assessmentData,
+      );
+      return job.complete();
+    } catch (error: unknown) {
+      return job.fail(`Unexpected error saving the assessment data. ${error}`);
+    }
   }
 
   /**
@@ -150,11 +160,17 @@ export class AssessmentController {
       >
     >,
   ): Promise<MustReturnJobActionAcknowledgement> {
-    await this.studentAssessmentService.updateNOAApprovalStatus(
-      job.variables.assessmentId,
-      job.customHeaders.status,
-    );
-    return job.complete();
+    try {
+      await this.studentAssessmentService.updateNOAApprovalStatus(
+        job.variables.assessmentId,
+        job.customHeaders.status,
+      );
+      return job.complete();
+    } catch (error: unknown) {
+      return job.fail(
+        `Unexpected error while updating the NOA status. ${error}`,
+      );
+    }
   }
 
   /**

--- a/sources/packages/backend/apps/workers/src/controllers/assessment/assessment.controller.ts
+++ b/sources/packages/backend/apps/workers/src/controllers/assessment/assessment.controller.ts
@@ -1,4 +1,4 @@
-import { Controller } from "@nestjs/common";
+import { Controller, Logger } from "@nestjs/common";
 import { ZeebeWorker } from "../../zeebe";
 import {
   ZeebeJob,
@@ -67,18 +67,21 @@ export class AssessmentController {
       );
       return job.complete();
     } catch (error: unknown) {
+      const jobLogger = new Logger(job.type);
       if (error instanceof CustomNamedError) {
         switch (error.name) {
           case ASSESSMENT_ALREADY_ASSOCIATED_TO_WORKFLOW:
+            jobLogger.log(`${error.name} ${error.message}`);
             return job.complete();
           case ASSESSMENT_NOT_FOUND:
           case ASSESSMENT_INVALID_OPERATION_IN_THE_CURRENT_STATE:
+            jobLogger.error(`${error.name} ${error.message}`);
             return job.error(error.name, error.message);
         }
       }
-      return job.fail(
-        `Not able to associate the assessment id ${job.variables.assessmentId} with the workflow instance id ${job.processInstanceKey}. ${error}`,
-      );
+      const errorMessage = `Not able to associate the assessment id ${job.variables.assessmentId} with the workflow instance id ${job.processInstanceKey}. ${error}`;
+      jobLogger.error(errorMessage);
+      return job.fail(errorMessage);
     }
   }
 
@@ -115,9 +118,10 @@ export class AssessmentController {
       );
       return job.complete(outputVariables);
     } catch (error: unknown) {
-      return job.fail(
-        `Unexpected error while loading assessment consolidated data. ${error}`,
-      );
+      const jobLogger = new Logger(job.type);
+      const errorMessage = `Unexpected error while loading assessment consolidated data. ${error}`;
+      jobLogger.error(errorMessage);
+      return job.fail(errorMessage);
     }
   }
 
@@ -140,7 +144,10 @@ export class AssessmentController {
       );
       return job.complete();
     } catch (error: unknown) {
-      return job.fail(`Unexpected error saving the assessment data. ${error}`);
+      const jobLogger = new Logger(job.type);
+      const errorMessage = `Unexpected error saving the assessment data. ${error}`;
+      jobLogger.error(errorMessage);
+      return job.fail(errorMessage);
     }
   }
 
@@ -167,9 +174,10 @@ export class AssessmentController {
       );
       return job.complete();
     } catch (error: unknown) {
-      return job.fail(
-        `Unexpected error while updating the NOA status. ${error}`,
-      );
+      const jobLogger = new Logger(job.type);
+      const errorMessage = `Unexpected error while updating the NOA status. ${error}`;
+      jobLogger.error(errorMessage);
+      return job.fail(errorMessage);
     }
   }
 

--- a/sources/packages/backend/apps/workers/src/controllers/assessment/assessment.controller.ts
+++ b/sources/packages/backend/apps/workers/src/controllers/assessment/assessment.controller.ts
@@ -85,7 +85,9 @@ export class AssessmentController {
             return job.error(error.name, error.message);
         }
       }
-      return createUnexpectedJobFail(error, job, jobLogger);
+      return createUnexpectedJobFail(error, job, {
+        logger: jobLogger,
+      });
     }
   }
 
@@ -126,7 +128,9 @@ export class AssessmentController {
       jobLogger.log("Assessment consolidated data loaded.");
       return job.complete(outputVariables);
     } catch (error: unknown) {
-      return createUnexpectedJobFail(error, job, jobLogger);
+      return createUnexpectedJobFail(error, job, {
+        logger: jobLogger,
+      });
     }
   }
 
@@ -151,7 +155,9 @@ export class AssessmentController {
       jobLogger.log("Assessment data saved.");
       return job.complete();
     } catch (error: unknown) {
-      return createUnexpectedJobFail(error, job, jobLogger);
+      return createUnexpectedJobFail(error, job, {
+        logger: jobLogger,
+      });
     }
   }
 
@@ -180,7 +186,9 @@ export class AssessmentController {
       jobLogger.log("NOA status updated.");
       return job.complete();
     } catch (error: unknown) {
-      return createUnexpectedJobFail(error, job, jobLogger);
+      return createUnexpectedJobFail(error, job, {
+        logger: jobLogger,
+      });
     }
   }
 
@@ -196,17 +204,18 @@ export class AssessmentController {
       ZeebeJob<WorkflowWrapUpJobInDTO, ICustomHeaders, IOutputVariables>
     >,
   ): Promise<MustReturnJobActionAcknowledgement> {
+    const jobLogger = new Logger(job.type);
     try {
       await this.studentAssessmentService.updateAssessmentStatusAndSaveWorkflowData(
         job.variables.assessmentId,
         job.variables.workflowData,
       );
+      jobLogger.log("Updated assessment status and saved the workflow data.");
       return job.complete();
     } catch (error: unknown) {
-      const jobLogger = new Logger(job.type);
-      const errorMessage = `Failed while updating assessment status and saving workflow data. ${error}`;
-      jobLogger.error(errorMessage);
-      return job.fail(errorMessage);
+      return createUnexpectedJobFail(error, job, {
+        logger: jobLogger,
+      });
     }
   }
 

--- a/sources/packages/backend/apps/workers/src/controllers/assessment/assessment.controller.ts
+++ b/sources/packages/backend/apps/workers/src/controllers/assessment/assessment.controller.ts
@@ -24,7 +24,10 @@ import {
   SupportingUser,
   SupportingUserType,
 } from "@sims/sims-db";
-import { filterObjectProperties } from "../../utilities";
+import {
+  createUnexpectedJobFail,
+  filterObjectProperties,
+} from "../../utilities";
 import {
   ASSESSMENT_ALREADY_ASSOCIATED_TO_WORKFLOW,
   ASSESSMENT_INVALID_OPERATION_IN_THE_CURRENT_STATE,
@@ -81,8 +84,7 @@ export class AssessmentController {
         }
       }
       const errorMessage = `Not able to associate the assessment id ${job.variables.assessmentId} with the workflow instance id ${job.processInstanceKey}. ${error}`;
-      jobLogger.error(errorMessage);
-      return job.fail(errorMessage);
+      return createUnexpectedJobFail(errorMessage, job, jobLogger);
     }
   }
 
@@ -124,8 +126,7 @@ export class AssessmentController {
       return job.complete(outputVariables);
     } catch (error: unknown) {
       const errorMessage = `Unexpected error while loading assessment consolidated data. ${error}`;
-      jobLogger.error(errorMessage);
-      return job.fail(errorMessage);
+      return createUnexpectedJobFail(errorMessage, job, jobLogger);
     }
   }
 
@@ -151,8 +152,7 @@ export class AssessmentController {
       return job.complete();
     } catch (error: unknown) {
       const errorMessage = `Unexpected error saving the assessment data. ${error}`;
-      jobLogger.error(errorMessage);
-      return job.fail(errorMessage);
+      return createUnexpectedJobFail(errorMessage, job, jobLogger);
     }
   }
 
@@ -182,8 +182,7 @@ export class AssessmentController {
       return job.complete();
     } catch (error: unknown) {
       const errorMessage = `Unexpected error while updating the NOA status. ${error}`;
-      jobLogger.error(errorMessage);
-      return job.fail(errorMessage);
+      return createUnexpectedJobFail(errorMessage, job, jobLogger);
     }
   }
 

--- a/sources/packages/backend/apps/workers/src/controllers/cra-integration/cra-integration.controller.ts
+++ b/sources/packages/backend/apps/workers/src/controllers/cra-integration/cra-integration.controller.ts
@@ -69,7 +69,9 @@ export class CRAIntegrationController {
       jobLogger.log("CRA income verification created.");
       return job.complete({ incomeVerificationId: identifier.id });
     } catch (error: unknown) {
-      return createUnexpectedJobFail(error, job, jobLogger);
+      return createUnexpectedJobFail(error, job, {
+        logger: jobLogger,
+      });
     }
   }
 
@@ -100,7 +102,9 @@ export class CRAIntegrationController {
       jobLogger.log("CRA income verification completed.");
       return job.complete({ incomeVerificationCompleted });
     } catch (error: unknown) {
-      return createUnexpectedJobFail(error, job, jobLogger);
+      return createUnexpectedJobFail(error, job, {
+        logger: jobLogger,
+      });
     }
   }
 }

--- a/sources/packages/backend/apps/workers/src/controllers/cra-integration/cra-integration.controller.ts
+++ b/sources/packages/backend/apps/workers/src/controllers/cra-integration/cra-integration.controller.ts
@@ -51,6 +51,7 @@ export class CRAIntegrationController {
       >
     >,
   ): Promise<MustReturnJobActionAcknowledgement> {
+    const jobLogger = new Logger(job.type);
     try {
       const incomeRequest =
         await this.incomeVerificationService.createIncomeVerification(
@@ -64,10 +65,9 @@ export class CRAIntegrationController {
       await this.incomeVerificationService.checkForCRAIncomeVerificationBypass(
         identifier.id,
       );
-
+      jobLogger.log("CRA income verification created.");
       return job.complete({ incomeVerificationId: identifier.id });
     } catch (error: unknown) {
-      const jobLogger = new Logger(job.type);
       const errorMessage = `Unexpected error while creating the CRA income verification. ${error}`;
       jobLogger.error(errorMessage);
       return job.fail(errorMessage);
@@ -92,14 +92,15 @@ export class CRAIntegrationController {
       >
     >,
   ): Promise<MustReturnJobActionAcknowledgement> {
+    const jobLogger = new Logger(job.type);
     try {
       const incomeVerificationCompleted =
         await this.incomeVerificationService.isIncomeVerificationCompleted(
           job.variables.incomeVerificationId,
         );
+      jobLogger.log("CRA income verification completed.");
       return job.complete({ incomeVerificationCompleted });
     } catch (error: unknown) {
-      const jobLogger = new Logger(job.type);
       const errorMessage = `Unexpected error while checking the CRA income verification. ${error}`;
       jobLogger.error(errorMessage);
       return job.fail(errorMessage);

--- a/sources/packages/backend/apps/workers/src/controllers/cra-integration/cra-integration.controller.ts
+++ b/sources/packages/backend/apps/workers/src/controllers/cra-integration/cra-integration.controller.ts
@@ -22,6 +22,7 @@ import {
 } from "@sims/services/workflow/variables/cra-integration-income-verification";
 import { MaxJobsToActivate } from "../../types";
 import { Workers } from "@sims/services/constants";
+import { createUnexpectedJobFail } from "../../utilities";
 
 @Controller()
 export class CRAIntegrationController {
@@ -69,8 +70,7 @@ export class CRAIntegrationController {
       return job.complete({ incomeVerificationId: identifier.id });
     } catch (error: unknown) {
       const errorMessage = `Unexpected error while creating the CRA income verification. ${error}`;
-      jobLogger.error(errorMessage);
-      return job.fail(errorMessage);
+      return createUnexpectedJobFail(errorMessage, job, jobLogger);
     }
   }
 
@@ -102,8 +102,7 @@ export class CRAIntegrationController {
       return job.complete({ incomeVerificationCompleted });
     } catch (error: unknown) {
       const errorMessage = `Unexpected error while checking the CRA income verification. ${error}`;
-      jobLogger.error(errorMessage);
-      return job.fail(errorMessage);
+      return createUnexpectedJobFail(errorMessage, job, jobLogger);
     }
   }
 }

--- a/sources/packages/backend/apps/workers/src/controllers/cra-integration/cra-integration.controller.ts
+++ b/sources/packages/backend/apps/workers/src/controllers/cra-integration/cra-integration.controller.ts
@@ -69,8 +69,7 @@ export class CRAIntegrationController {
       jobLogger.log("CRA income verification created.");
       return job.complete({ incomeVerificationId: identifier.id });
     } catch (error: unknown) {
-      const errorMessage = `Unexpected error while creating the CRA income verification. ${error}`;
-      return createUnexpectedJobFail(errorMessage, job, jobLogger);
+      return createUnexpectedJobFail(error, job, jobLogger);
     }
   }
 
@@ -101,8 +100,7 @@ export class CRAIntegrationController {
       jobLogger.log("CRA income verification completed.");
       return job.complete({ incomeVerificationCompleted });
     } catch (error: unknown) {
-      const errorMessage = `Unexpected error while checking the CRA income verification. ${error}`;
-      return createUnexpectedJobFail(errorMessage, job, jobLogger);
+      return createUnexpectedJobFail(error, job, jobLogger);
     }
   }
 }

--- a/sources/packages/backend/apps/workers/src/controllers/cra-integration/cra-integration.controller.ts
+++ b/sources/packages/backend/apps/workers/src/controllers/cra-integration/cra-integration.controller.ts
@@ -1,4 +1,4 @@
-import { Controller } from "@nestjs/common";
+import { Controller, Logger } from "@nestjs/common";
 import { ZeebeWorker } from "../../zeebe";
 import {
   ZeebeJob,
@@ -67,9 +67,10 @@ export class CRAIntegrationController {
 
       return job.complete({ incomeVerificationId: identifier.id });
     } catch (error: unknown) {
-      return job.fail(
-        `Unexpected error while creating the CRA income verification. ${error}`,
-      );
+      const jobLogger = new Logger(job.type);
+      const errorMessage = `Unexpected error while creating the CRA income verification. ${error}`;
+      jobLogger.error(errorMessage);
+      return job.fail(errorMessage);
     }
   }
 
@@ -98,9 +99,10 @@ export class CRAIntegrationController {
         );
       return job.complete({ incomeVerificationCompleted });
     } catch (error: unknown) {
-      return job.fail(
-        `Unexpected error while checking the CRA income verification. ${error}`,
-      );
+      const jobLogger = new Logger(job.type);
+      const errorMessage = `Unexpected error while checking the CRA income verification. ${error}`;
+      jobLogger.error(errorMessage);
+      return job.fail(errorMessage);
     }
   }
 }

--- a/sources/packages/backend/apps/workers/src/controllers/disbursement/disbursement.controller.ts
+++ b/sources/packages/backend/apps/workers/src/controllers/disbursement/disbursement.controller.ts
@@ -32,6 +32,7 @@ import {
   DISBURSEMENT_MSFAA_ALREADY_ASSOCIATED,
   DISBURSEMENT_NOT_FOUND,
 } from "../../constants";
+import { createUnexpectedJobFail } from "../../utilities";
 
 @Controller()
 export class DisbursementController {
@@ -77,8 +78,7 @@ export class DisbursementController {
         }
       }
       const errorMessage = `Unexpected error while creating disbursement schedules. ${error}`;
-      jobLogger.error(errorMessage);
-      return job.fail(errorMessage);
+      return createUnexpectedJobFail(errorMessage, job, jobLogger);
     }
   }
 
@@ -117,8 +117,7 @@ export class DisbursementController {
         }
       }
       const errorMessage = `Unexpected error while associating the MSFAA number to the disbursements. ${error}`;
-      jobLogger.error(errorMessage);
-      return job.fail(errorMessage);
+      return createUnexpectedJobFail(errorMessage, job, jobLogger);
     }
   }
 }

--- a/sources/packages/backend/apps/workers/src/controllers/disbursement/disbursement.controller.ts
+++ b/sources/packages/backend/apps/workers/src/controllers/disbursement/disbursement.controller.ts
@@ -56,14 +56,15 @@ export class DisbursementController {
       >
     >,
   ): Promise<MustReturnJobActionAcknowledgement> {
+    const jobLogger = new Logger(job.type);
     try {
       await this.disbursementScheduleSharedService.createDisbursementSchedules(
         job.variables.assessmentId,
         job.variables.disbursementSchedules,
       );
+      jobLogger.log("Created disbursement schedule");
       return job.complete();
     } catch (error: unknown) {
-      const jobLogger = new Logger(job.type);
       if (error instanceof CustomNamedError) {
         switch (error.name) {
           case DISBURSEMENT_SCHEDULES_ALREADY_CREATED:
@@ -95,13 +96,14 @@ export class DisbursementController {
       ZeebeJob<AssignMSFAAJobInDTO, ICustomHeaders, IOutputVariables>
     >,
   ): Promise<MustReturnJobActionAcknowledgement> {
+    const jobLogger = new Logger(job.type);
     try {
       await this.disbursementScheduleService.associateMSFAANumber(
         job.variables.assessmentId,
       );
+      jobLogger.error("Associated the MSFAA number to the disbursements.");
       return job.complete();
     } catch (error: unknown) {
-      const jobLogger = new Logger(job.type);
       if (error instanceof CustomNamedError) {
         switch (error.name) {
           case DISBURSEMENT_NOT_FOUND:

--- a/sources/packages/backend/apps/workers/src/controllers/disbursement/disbursement.controller.ts
+++ b/sources/packages/backend/apps/workers/src/controllers/disbursement/disbursement.controller.ts
@@ -77,8 +77,7 @@ export class DisbursementController {
             return job.error(error.name, error.message);
         }
       }
-      const errorMessage = `Unexpected error while creating disbursement schedules. ${error}`;
-      return createUnexpectedJobFail(errorMessage, job, jobLogger);
+      return createUnexpectedJobFail(error, job, jobLogger);
     }
   }
 
@@ -116,8 +115,7 @@ export class DisbursementController {
             return job.complete();
         }
       }
-      const errorMessage = `Unexpected error while associating the MSFAA number to the disbursements. ${error}`;
-      return createUnexpectedJobFail(errorMessage, job, jobLogger);
+      return createUnexpectedJobFail(error, job, jobLogger);
     }
   }
 }

--- a/sources/packages/backend/apps/workers/src/controllers/disbursement/disbursement.controller.ts
+++ b/sources/packages/backend/apps/workers/src/controllers/disbursement/disbursement.controller.ts
@@ -77,7 +77,9 @@ export class DisbursementController {
             return job.error(error.name, error.message);
         }
       }
-      return createUnexpectedJobFail(error, job, jobLogger);
+      return createUnexpectedJobFail(error, job, {
+        logger: jobLogger,
+      });
     }
   }
 
@@ -115,7 +117,9 @@ export class DisbursementController {
             return job.complete();
         }
       }
-      return createUnexpectedJobFail(error, job, jobLogger);
+      return createUnexpectedJobFail(error, job, {
+        logger: jobLogger,
+      });
     }
   }
 }

--- a/sources/packages/backend/apps/workers/src/controllers/program-info-request/program-info-request.controller.ts
+++ b/sources/packages/backend/apps/workers/src/controllers/program-info-request/program-info-request.controller.ts
@@ -66,7 +66,9 @@ export class ProgramInfoRequestController {
         programInfoStatus: job.customHeaders.programInfoStatus,
       });
     } catch (error: unknown) {
-      return createUnexpectedJobFail(error, job, jobLogger);
+      return createUnexpectedJobFail(error, job, {
+        logger: jobLogger,
+      });
     }
   }
 }

--- a/sources/packages/backend/apps/workers/src/controllers/program-info-request/program-info-request.controller.ts
+++ b/sources/packages/backend/apps/workers/src/controllers/program-info-request/program-info-request.controller.ts
@@ -37,16 +37,16 @@ export class ProgramInfoRequestController {
       >
     >,
   ): Promise<MustReturnJobActionAcknowledgement> {
+    const jobLogger = new Logger(job.type);
     try {
       const application = await this.applicationService.getApplicationById(
         job.variables.applicationId,
         { loadDynamicData: false },
       );
       if (!application) {
-        return job.error(
-          APPLICATION_NOT_FOUND,
-          "Application not found while verifying the PIR.",
-        );
+        const message = "Application not found while verifying the PIR.";
+        jobLogger.error(message);
+        return job.error(APPLICATION_NOT_FOUND, message);
       }
       if (application.pirStatus) {
         // PIR status was already set, just return it.
@@ -63,7 +63,6 @@ export class ProgramInfoRequestController {
         programInfoStatus: job.customHeaders.programInfoStatus,
       });
     } catch (error: unknown) {
-      const jobLogger = new Logger(job.type);
       const errorMessage = `Unexpected error while setting the PIR status. ${error}`;
       jobLogger.error(errorMessage);
       return job.fail(errorMessage);

--- a/sources/packages/backend/apps/workers/src/controllers/program-info-request/program-info-request.controller.ts
+++ b/sources/packages/backend/apps/workers/src/controllers/program-info-request/program-info-request.controller.ts
@@ -14,6 +14,7 @@ import {
 } from "@sims/services/workflow/variables/assessment-gateway";
 import { MaxJobsToActivate } from "../../types";
 import { Workers } from "@sims/services/constants";
+import { createUnexpectedJobFail } from "../../utilities";
 
 @Controller()
 export class ProgramInfoRequestController {
@@ -66,8 +67,7 @@ export class ProgramInfoRequestController {
       });
     } catch (error: unknown) {
       const errorMessage = `Unexpected error while setting the PIR status. ${error}`;
-      jobLogger.error(errorMessage);
-      return job.fail(errorMessage);
+      return createUnexpectedJobFail(errorMessage, job, jobLogger);
     }
   }
 }

--- a/sources/packages/backend/apps/workers/src/controllers/program-info-request/program-info-request.controller.ts
+++ b/sources/packages/backend/apps/workers/src/controllers/program-info-request/program-info-request.controller.ts
@@ -50,6 +50,7 @@ export class ProgramInfoRequestController {
       }
       if (application.pirStatus) {
         // PIR status was already set, just return it.
+        jobLogger.log("PIR status was already set.");
         return job.complete({
           programInfoStatus: application.pirStatus,
         });
@@ -59,6 +60,7 @@ export class ProgramInfoRequestController {
         job.customHeaders.programInfoStatus,
         job.variables.studentDataSelectedProgram,
       );
+      jobLogger.log("PIR status updated.");
       return job.complete({
         programInfoStatus: job.customHeaders.programInfoStatus,
       });

--- a/sources/packages/backend/apps/workers/src/controllers/program-info-request/program-info-request.controller.ts
+++ b/sources/packages/backend/apps/workers/src/controllers/program-info-request/program-info-request.controller.ts
@@ -66,8 +66,7 @@ export class ProgramInfoRequestController {
         programInfoStatus: job.customHeaders.programInfoStatus,
       });
     } catch (error: unknown) {
-      const errorMessage = `Unexpected error while setting the PIR status. ${error}`;
-      return createUnexpectedJobFail(errorMessage, job, jobLogger);
+      return createUnexpectedJobFail(error, job, jobLogger);
     }
   }
 }

--- a/sources/packages/backend/apps/workers/src/controllers/program-info-request/program-info-request.controller.ts
+++ b/sources/packages/backend/apps/workers/src/controllers/program-info-request/program-info-request.controller.ts
@@ -1,4 +1,4 @@
-import { Controller } from "@nestjs/common";
+import { Controller, Logger } from "@nestjs/common";
 import { ZeebeWorker } from "../../zeebe";
 import { ZeebeJob, MustReturnJobActionAcknowledgement } from "zeebe-node";
 import { ApplicationService } from "../../services";
@@ -63,7 +63,10 @@ export class ProgramInfoRequestController {
         programInfoStatus: job.customHeaders.programInfoStatus,
       });
     } catch (error: unknown) {
-      return job.fail(`Unexpected error while seting the PIR status. ${error}`);
+      const jobLogger = new Logger(job.type);
+      const errorMessage = `Unexpected error while setting the PIR status. ${error}`;
+      jobLogger.error(errorMessage);
+      return job.fail(errorMessage);
     }
   }
 }

--- a/sources/packages/backend/apps/workers/src/controllers/supporting-user/supporting-user.controller.ts
+++ b/sources/packages/backend/apps/workers/src/controllers/supporting-user/supporting-user.controller.ts
@@ -63,7 +63,9 @@ export class SupportingUserController {
       jobLogger.log("Created supporting users.");
       return job.complete({ createdSupportingUsersIds });
     } catch (error: unknown) {
-      return createUnexpectedJobFail(error, job, jobLogger);
+      return createUnexpectedJobFail(error, job, {
+        logger: jobLogger,
+      });
     }
   }
 
@@ -99,7 +101,9 @@ export class SupportingUserController {
       jobLogger.log("Supporting user data loaded.");
       return job.complete(outputVariables);
     } catch (error: unknown) {
-      return createUnexpectedJobFail(error, job, jobLogger);
+      return createUnexpectedJobFail(error, job, {
+        logger: jobLogger,
+      });
     }
   }
 }

--- a/sources/packages/backend/apps/workers/src/controllers/supporting-user/supporting-user.controller.ts
+++ b/sources/packages/backend/apps/workers/src/controllers/supporting-user/supporting-user.controller.ts
@@ -63,8 +63,7 @@ export class SupportingUserController {
       jobLogger.log("Created supporting users.");
       return job.complete({ createdSupportingUsersIds });
     } catch (error: unknown) {
-      const errorMessage = `Unexpected error while creating supporting users. ${error}`;
-      return createUnexpectedJobFail(errorMessage, job, jobLogger);
+      return createUnexpectedJobFail(error, job, jobLogger);
     }
   }
 
@@ -100,8 +99,7 @@ export class SupportingUserController {
       jobLogger.log("Supporting user data loaded.");
       return job.complete(outputVariables);
     } catch (error: unknown) {
-      const errorMessage = `Unexpected error while loading supporting user data. ${error}`;
-      return createUnexpectedJobFail(errorMessage, job, jobLogger);
+      return createUnexpectedJobFail(error, job, jobLogger);
     }
   }
 }

--- a/sources/packages/backend/apps/workers/src/controllers/supporting-user/supporting-user.controller.ts
+++ b/sources/packages/backend/apps/workers/src/controllers/supporting-user/supporting-user.controller.ts
@@ -1,4 +1,4 @@
-import { Controller } from "@nestjs/common";
+import { Controller, Logger } from "@nestjs/common";
 import { ZeebeWorker } from "../../zeebe";
 import {
   ZeebeJob,
@@ -57,7 +57,10 @@ export class SupportingUserController {
       );
       return job.complete({ createdSupportingUsersIds });
     } catch (error: unknown) {
-      return job.fail(`Unexpected error creating supporting users. ${error}`);
+      const jobLogger = new Logger(job.type);
+      const errorMessage = `Unexpected error while creating supporting users. ${error}`;
+      jobLogger.error(errorMessage);
+      return job.fail(errorMessage);
     }
   }
 
@@ -91,9 +94,10 @@ export class SupportingUserController {
       );
       return job.complete(outputVariables);
     } catch (error: unknown) {
-      return job.fail(
-        `Unexpected error while loading supporting user data. ${error}`,
-      );
+      const jobLogger = new Logger(job.type);
+      const errorMessage = `Unexpected error while loading supporting user data. ${error}`;
+      jobLogger.error(errorMessage);
+      return job.fail(errorMessage);
     }
   }
 }

--- a/sources/packages/backend/apps/workers/src/controllers/supporting-user/supporting-user.controller.ts
+++ b/sources/packages/backend/apps/workers/src/controllers/supporting-user/supporting-user.controller.ts
@@ -12,7 +12,10 @@ import {
   CreateSupportingUsersJobInDTO,
   CreateSupportingUsersJobOutDTO,
 } from "..";
-import { filterObjectProperties } from "../../utilities";
+import {
+  createUnexpectedJobFail,
+  filterObjectProperties,
+} from "../../utilities";
 import { SUPPORTING_USER_NOT_FOUND } from "../../constants";
 import { APPLICATION_ID } from "@sims/services/workflow/variables/assessment-gateway";
 import {
@@ -61,8 +64,7 @@ export class SupportingUserController {
       return job.complete({ createdSupportingUsersIds });
     } catch (error: unknown) {
       const errorMessage = `Unexpected error while creating supporting users. ${error}`;
-      jobLogger.error(errorMessage);
-      return job.fail(errorMessage);
+      return createUnexpectedJobFail(errorMessage, job, jobLogger);
     }
   }
 
@@ -99,8 +101,7 @@ export class SupportingUserController {
       return job.complete(outputVariables);
     } catch (error: unknown) {
       const errorMessage = `Unexpected error while loading supporting user data. ${error}`;
-      jobLogger.error(errorMessage);
-      return job.fail(errorMessage);
+      return createUnexpectedJobFail(errorMessage, job, jobLogger);
     }
   }
 }

--- a/sources/packages/backend/apps/workers/src/controllers/supporting-user/supporting-user.controller.ts
+++ b/sources/packages/backend/apps/workers/src/controllers/supporting-user/supporting-user.controller.ts
@@ -39,12 +39,14 @@ export class SupportingUserController {
       >
     >,
   ): Promise<MustReturnJobActionAcknowledgement> {
+    const jobLogger = new Logger(job.type);
     try {
       const hasSupportingUsers =
         await this.supportingUserService.hasSupportingUsers(
           job.variables.applicationId,
         );
       if (hasSupportingUsers) {
+        jobLogger.log("Supporting users already exists.");
         return job.complete();
       }
       const supportingUsers =
@@ -55,9 +57,9 @@ export class SupportingUserController {
       const createdSupportingUsersIds = supportingUsers.map(
         (supportingUser) => supportingUser.id,
       );
+      jobLogger.log("Created supporting users.");
       return job.complete({ createdSupportingUsersIds });
     } catch (error: unknown) {
-      const jobLogger = new Logger(job.type);
       const errorMessage = `Unexpected error while creating supporting users. ${error}`;
       jobLogger.error(errorMessage);
       return job.fail(errorMessage);
@@ -93,6 +95,7 @@ export class SupportingUserController {
         supportingUser.supportingData,
         job.customHeaders,
       );
+      jobLogger.log("Supporting user data loaded.");
       return job.complete(outputVariables);
     } catch (error: unknown) {
       const errorMessage = `Unexpected error while loading supporting user data. ${error}`;

--- a/sources/packages/backend/apps/workers/src/controllers/supporting-user/supporting-user.controller.ts
+++ b/sources/packages/backend/apps/workers/src/controllers/supporting-user/supporting-user.controller.ts
@@ -77,16 +77,17 @@ export class SupportingUserController {
       >
     >,
   ): Promise<MustReturnJobActionAcknowledgement> {
+    const jobLogger = new Logger(job.type);
     try {
       const supportingUser =
         await this.supportingUserService.getSupportingUserById(
           job.variables.supportingUserId,
         );
       if (!supportingUser) {
-        job.error(
-          SUPPORTING_USER_NOT_FOUND,
-          "Supporting user not found while checking for supporting user response.",
-        );
+        const message =
+          "Supporting user not found while checking for supporting user response.";
+        jobLogger.error(message);
+        job.error(SUPPORTING_USER_NOT_FOUND, message);
       }
       const outputVariables = filterObjectProperties(
         supportingUser.supportingData,
@@ -94,7 +95,6 @@ export class SupportingUserController {
       );
       return job.complete(outputVariables);
     } catch (error: unknown) {
-      const jobLogger = new Logger(job.type);
       const errorMessage = `Unexpected error while loading supporting user data. ${error}`;
       jobLogger.error(errorMessage);
       return job.fail(errorMessage);

--- a/sources/packages/backend/apps/workers/src/utilities/error-handler.ts
+++ b/sources/packages/backend/apps/workers/src/utilities/error-handler.ts
@@ -24,6 +24,10 @@ export function createUnexpectedJobFail(
   return job.fail(errorMessage);
 }
 
+/**
+ * Parse the error in a prettier format for better
+ * readability.
+ */
 function parseException(error: unknown): string {
   return JSON.stringify(error, null, 2);
 }

--- a/sources/packages/backend/apps/workers/src/utilities/error-handler.ts
+++ b/sources/packages/backend/apps/workers/src/utilities/error-handler.ts
@@ -1,0 +1,29 @@
+import { Logger } from "@nestjs/common";
+import { ZeebeJob, MustReturnJobActionAcknowledgement } from "zeebe-node";
+
+/**
+ * Takes care of log and will acknowledge worker,
+ * in case any unexpected job failure.
+ * @param error error message to be logged.
+ * @param job zeebe job.
+ * @param logger logger object if any,
+ * else a new logger instance will be created.
+ * @returns a job fail acknowledgement to the worker.
+ */
+export function createUnexpectedJobFail(
+  error: unknown,
+  job: ZeebeJob,
+  logger?: Logger,
+): MustReturnJobActionAcknowledgement {
+  const jobLogger = logger ?? new Logger(job.type);
+  const errorMessage = `Unexpected error while processing job. ${parseException(
+    error,
+  )}`;
+  jobLogger.error(job);
+  jobLogger.error(errorMessage);
+  return job.fail(errorMessage);
+}
+
+function parseException(error: unknown): string {
+  return JSON.stringify(error, null, 2);
+}

--- a/sources/packages/backend/apps/workers/src/utilities/error-handler.ts
+++ b/sources/packages/backend/apps/workers/src/utilities/error-handler.ts
@@ -7,16 +7,19 @@ import { ZeebeJob, MustReturnJobActionAcknowledgement } from "zeebe-node";
  * in case any unexpected job failure.
  * @param error error message to be logged.
  * @param job zeebe job.
- * @param logger logger object if any,
+ * @param options options,
+ * - "logger" logger object if any,
  * else a new logger instance will be created.
  * @returns a job fail acknowledgement to the worker.
  */
 export function createUnexpectedJobFail(
   error: unknown,
   job: ZeebeJob,
-  logger?: Logger,
+  options?: {
+    logger?: Logger;
+  },
 ): MustReturnJobActionAcknowledgement {
-  const jobLogger = logger ?? new Logger(job.type);
+  const jobLogger = options?.logger ?? new Logger(job.type);
   const errorMessage = `Unexpected error while processing job. ${parseJSONError(
     error,
   )}`;

--- a/sources/packages/backend/apps/workers/src/utilities/error-handler.ts
+++ b/sources/packages/backend/apps/workers/src/utilities/error-handler.ts
@@ -1,4 +1,5 @@
 import { Logger } from "@nestjs/common";
+import { parseJSONError } from "@sims/utilities";
 import { ZeebeJob, MustReturnJobActionAcknowledgement } from "zeebe-node";
 
 /**
@@ -16,18 +17,10 @@ export function createUnexpectedJobFail(
   logger?: Logger,
 ): MustReturnJobActionAcknowledgement {
   const jobLogger = logger ?? new Logger(job.type);
-  const errorMessage = `Unexpected error while processing job. ${parseException(
+  const errorMessage = `Unexpected error while processing job. ${parseJSONError(
     error,
   )}`;
   jobLogger.error(job);
   jobLogger.error(errorMessage);
   return job.fail(errorMessage);
-}
-
-/**
- * Parse the error in a prettier format for better
- * readability.
- */
-function parseException(error: unknown): string {
-  return JSON.stringify(error, null, 2);
 }

--- a/sources/packages/backend/apps/workers/src/utilities/index.ts
+++ b/sources/packages/backend/apps/workers/src/utilities/index.ts
@@ -1,2 +1,2 @@
 export * from "./jsonpath/jsonpath-utils";
-export * from "./error-handler"
+export * from "./error-handler";

--- a/sources/packages/backend/apps/workers/src/utilities/index.ts
+++ b/sources/packages/backend/apps/workers/src/utilities/index.ts
@@ -1,1 +1,2 @@
 export * from "./jsonpath/jsonpath-utils";
+export * from "./error-handler"

--- a/sources/packages/backend/apps/workers/src/zeebe/zeebe-transport-strategy.ts
+++ b/sources/packages/backend/apps/workers/src/zeebe/zeebe-transport-strategy.ts
@@ -64,12 +64,18 @@ export class ZeebeTransportStrategy
       `Starting job for processInstanceKey ${job.processInstanceKey}. Retries left: ${job.retries}.`,
     );
     try {
-      // The return is an `Observable`for a jobHandler, which needs to be awaits.
-      // The lastValueFrom is almost exactly the same as toPromise()
-      // meaning that it will resolve with the last value that has arrived
-      // when the Observable completes.
+      // The jobHandler can potentially return a Promise or
+      // an Observable. The Promise will be returned from a
+      // controller when it finishes as expected returning
+      // some value. The Observable will be returned as a
+      // result of an unhandled exception when a RpcExecption
+      // will be generated and the RpcExpectionHandler will
+      // wrap this exception as an Observable object.
       const jobResult = await jobHandler(job);
       if (isObservable(jobResult)) {
+        // The lastValueFrom is almost exactly the same as toPromise()
+        // meaning that it will resolve with the last value that has arrived
+        // when the Observable completes.
         await lastValueFrom(jobResult);
       }
       return jobResult;

--- a/sources/packages/backend/libs/utilities/src/index.ts
+++ b/sources/packages/backend/libs/utilities/src/index.ts
@@ -9,3 +9,4 @@ export * from "./sqlLoader";
 export * from "./parallel-processing-utils";
 export * from "./datatable-config";
 export * from "./base64-utils";
+export * from "./parse-json";

--- a/sources/packages/backend/libs/utilities/src/parse-json.ts
+++ b/sources/packages/backend/libs/utilities/src/parse-json.ts
@@ -1,0 +1,9 @@
+/**
+ * Parse the json error in a prettier format for better
+ * readability.
+ * @param value to be parsed.
+ * @returns stringify JSON object is a prettier format.
+ */
+export function parseJSONError(value: unknown): string {
+  return JSON.stringify(value, null, 2);
+}

--- a/sources/packages/backend/libs/utilities/src/parse-json.ts
+++ b/sources/packages/backend/libs/utilities/src/parse-json.ts
@@ -2,7 +2,7 @@
  * Parse the json error in a prettier format for better
  * readability.
  * @param value to be parsed.
- * @returns stringify JSON object is a prettier format.
+ * @returns json string in a prettier format.
  */
 export function parseJSONError(value: unknown): string {
   return JSON.stringify(value, null, 2);


### PR DESCRIPTION
- The issue was able to replicate in one of the workers when we submitted an application with a long income, which was an error in the worker logic during the assessment. However, the worker is not getting any acknowledgment from the code and it is waiting
- So, the next time a new assessment comes, it gets stuck in the same worker for an infinite time.
- checked our worker global error handle in https://vscode.dev/github/bcgov/SIMS/blob/fix/sims-%232207/sources/packages/backend/apps/workers/src/zeebe/zeebe-transport-strategy.ts#L57
![image](https://github.com/bcgov/SIMS/assets/77353155/0e091620-683d-4a4a-a0a8-8ee31e42baba)
and found that, the `return await jobHandler(job);` is not throwing any error, when there is an error, as a result, the `catch` is not invoked and the worker is not getting the acknowledgment. 
- fixed the global handler, the jobhandler is returning an observable, so, added a logic to await for it when the return type is observable, 
![image](https://github.com/bcgov/SIMS/assets/77353155/fd834315-b22e-495c-a92c-a79123740b7e)

- And added try-catch, and if there is any error in the controller level, the code acknowledges the worker as a failed job, so that the worker is free and can focus on the next jobs.
- This causes an incident in the Camunda, Which developers can take a look at (Before this fix, Camunda never caused an incident for these scenarios).


-**Replicate**
1. To replicate the issue, I decreased the `maxJobsToActivate: ` to `1` and decreased the `timeout` to `10`.
![image](https://github.com/bcgov/SIMS/assets/77353155/5b652817-3115-423c-86f9-a9e2829cddb5)
2. And created/edited 2 applications with a lengthy income,
![image](https://github.com/bcgov/SIMS/assets/77353155/3a202c02-a105-4f73-8dc6-014a38d95a73)
3.  which made the `create income verification` worker stuck in both the case
![image](https://github.com/bcgov/SIMS/assets/77353155/b4c0daa2-45d3-4f2e-99a4-4ab92c4b4f34)
4.  And then, when you submit an application with a proper income, the new assessment is also stuck in the same worker.
5.  After the fix, step 2 will create incidents in Camunda, and step 4, will work as expected.
Step 2, after the fix
![image](https://github.com/bcgov/SIMS/assets/77353155/86f53df7-78b8-4c22-9350-6ae8650343e8)
![image](https://github.com/bcgov/SIMS/assets/77353155/661b0f22-3bb3-4828-aac5-a1af6ef17745)
![image](https://github.com/bcgov/SIMS/assets/77353155/c98d625d-fbda-4796-927e-c41fcb8e1c9d)
Step 4, after the fix,
![image](https://github.com/bcgov/SIMS/assets/77353155/f6a89590-cba8-4adb-a496-005cfea4fb05)

Ref: https://docs.camunda.io/docs/components/best-practices/development/writing-good-workers/#nodejs-client
