### PR TITLE
#2179 - Queued Assessments - Create DB migrations

### DIFF
--- a/sources/packages/backend/apps/db-migrations/src/migrations/1693355224679-CreateTypeStudentAssessmentStatus.ts
+++ b/sources/packages/backend/apps/db-migrations/src/migrations/1693355224679-CreateTypeStudentAssessmentStatus.ts
@@ -1,0 +1,18 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+import { getSQLFileData } from "../utilities/sqlLoader";
+
+export class CreateTypeStudentAssessmentStatus1693355224679
+  implements MigrationInterface
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      getSQLFileData("Create-student-assessment-status.sql", "Types"),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      getSQLFileData("Drop-student-assessment-status.sql", "Types"),
+    );
+  }
+}

--- a/sources/packages/backend/apps/db-migrations/src/migrations/1693355238484-StudentAssessmentsAddStudentAssessmentStatusColumns.ts
+++ b/sources/packages/backend/apps/db-migrations/src/migrations/1693355238484-StudentAssessmentsAddStudentAssessmentStatusColumns.ts
@@ -1,0 +1,24 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+import { getSQLFileData } from "../utilities/sqlLoader";
+
+export class StudentAssessmentsAddStudentAssessmentStatusColumns1693355238484
+  implements MigrationInterface
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      getSQLFileData(
+        "Add-student-assessment-status-cols.sql",
+        "StudentAssessments",
+      ),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      getSQLFileData(
+        "Drop-student-assessment-status-cols.sql",
+        "StudentAssessments",
+      ),
+    );
+  }
+}

--- a/sources/packages/backend/apps/db-migrations/src/migrations/1693355247384-ApplicationsAddCurrentProcessingAssessmentId.ts
+++ b/sources/packages/backend/apps/db-migrations/src/migrations/1693355247384-ApplicationsAddCurrentProcessingAssessmentId.ts
@@ -1,0 +1,24 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+import { getSQLFileData } from "../utilities/sqlLoader";
+
+export class ApplicationsAddCurrentProcessingAssessmentId1693355247384
+  implements MigrationInterface
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      getSQLFileData(
+        "Add-col-current-processing-assessment-id.sql",
+        "Applications",
+      ),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      getSQLFileData(
+        "Drop-col-current-processing-assessment-id.sql",
+        "Applications",
+      ),
+    );
+  }
+}

--- a/sources/packages/backend/apps/db-migrations/src/sql/Applications/Add-col-current-processing-assessment-id.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/Applications/Add-col-current-processing-assessment-id.sql
@@ -1,0 +1,6 @@
+ALTER TABLE
+    sims.applications
+ADD
+    COLUMN current_processing_assessment_id INT REFERENCES sims.student_assessments(id);
+
+COMMENT ON COLUMN sims.applications.current_processing_assessment_id IS 'Represents the student assessment that is being processed currently. Differently from the current_assessment column, which points to the most recently created record, this column indicates the assessment currently being processed.';

--- a/sources/packages/backend/apps/db-migrations/src/sql/Applications/Drop-col-current-processing-assessment-id.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/Applications/Drop-col-current-processing-assessment-id.sql
@@ -1,0 +1,2 @@
+ALTER TABLE
+    sims.applications DROP COLUMN current_processing_assessment_id;

--- a/sources/packages/backend/apps/db-migrations/src/sql/StudentAssessments/Add-student-assessment-status-cols.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/StudentAssessments/Add-student-assessment-status-cols.sql
@@ -1,0 +1,13 @@
+ALTER TABLE
+  sims.student_assessments
+ADD
+  COLUMN student_assessment_status sims.student_assessment_status NOT NULL DEFAULT 'Created';
+
+COMMENT ON COLUMN sims.student_assessments.student_assessment_status IS 'Student assessment statuses from its creation till the workflow calculations are finalized or the workflow is cancelled.';
+
+ALTER TABLE
+  sims.student_assessments
+ADD
+  COLUMN student_assessment_status_updated_on TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW();
+
+COMMENT ON COLUMN sims.student_assessments.student_assessment_status_updated_on IS 'Date and time when the student_assessment_status column was set.';

--- a/sources/packages/backend/apps/db-migrations/src/sql/StudentAssessments/Add-student-assessment-status-cols.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/StudentAssessments/Add-student-assessment-status-cols.sql
@@ -3,7 +3,7 @@ ALTER TABLE
 ADD
   COLUMN student_assessment_status sims.student_assessment_status NOT NULL DEFAULT 'Created';
 
-COMMENT ON COLUMN sims.student_assessments.student_assessment_status IS 'Student assessment statuses from its creation till the workflow calculations are finalized or the workflow is cancelled.';
+COMMENT ON COLUMN sims.student_assessments.student_assessment_status IS 'Student assessment status from its creation till the workflow calculations are finalized or the workflow is cancelled.';
 
 ALTER TABLE
   sims.student_assessments

--- a/sources/packages/backend/apps/db-migrations/src/sql/StudentAssessments/Add-student-assessment-status-cols.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/StudentAssessments/Add-student-assessment-status-cols.sql
@@ -1,7 +1,7 @@
 ALTER TABLE
   sims.student_assessments
 ADD
-  COLUMN student_assessment_status sims.student_assessment_status NOT NULL DEFAULT 'Created';
+  COLUMN student_assessment_status sims.student_assessment_status NOT NULL DEFAULT 'Submitted';
 
 COMMENT ON COLUMN sims.student_assessments.student_assessment_status IS 'Student assessment status from its creation till the workflow calculations are finalized or the workflow is cancelled.';
 
@@ -10,4 +10,4 @@ ALTER TABLE
 ADD
   COLUMN student_assessment_status_updated_on TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW();
 
-COMMENT ON COLUMN sims.student_assessments.student_assessment_status_updated_on IS 'Date and time when the student_assessment_status column was set.';
+COMMENT ON COLUMN sims.student_assessments.student_assessment_status_updated_on IS 'Date and time when the student_assessment_status column was updated.';

--- a/sources/packages/backend/apps/db-migrations/src/sql/StudentAssessments/Drop-student-assessment-status-cols.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/StudentAssessments/Drop-student-assessment-status-cols.sql
@@ -1,0 +1,5 @@
+ALTER TABLE
+  sims.student_assessments DROP COLUMN student_assessment_status;
+
+ALTER TABLE
+  sims.student_assessments DROP COLUMN student_assessment_status_updated_on;

--- a/sources/packages/backend/apps/db-migrations/src/sql/Types/Create-student-assessment-status.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/Types/Create-student-assessment-status.sql
@@ -1,0 +1,9 @@
+CREATE TYPE sims.student_assessment_status AS ENUM (
+    'Created',
+    'Queued',
+    'In progress',
+    'Completed',
+    'Cancellation requested',
+    'Cancellation queued',
+    'Cancelled'
+);

--- a/sources/packages/backend/apps/db-migrations/src/sql/Types/Create-student-assessment-status.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/Types/Create-student-assessment-status.sql
@@ -1,5 +1,5 @@
 CREATE TYPE sims.student_assessment_status AS ENUM (
-    'Created',
+    'Submitted',
     'Queued',
     'In progress',
     'Completed',

--- a/sources/packages/backend/apps/db-migrations/src/sql/Types/Drop-student-assessment-status.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/Types/Drop-student-assessment-status.sql
@@ -1,0 +1,1 @@
+DROP TYPE sims.student_assessment_status;

--- a/sources/packages/backend/libs/sims-db/src/entities/application.model.ts
+++ b/sources/packages/backend/libs/sims-db/src/entities/application.model.ts
@@ -269,7 +269,7 @@ export class Application extends RecordDataModel {
     name: "current_processing_assessment_id",
     referencedColumnName: ColumnNames.ID,
   })
-  currentProcessingAssessmentId?: StudentAssessment;
+  currentProcessingAssessment?: StudentAssessment;
   /**
    * All supporting users related to the application.
    * These users (parents/partner) will be created as needed during

--- a/sources/packages/backend/libs/sims-db/src/entities/application.model.ts
+++ b/sources/packages/backend/libs/sims-db/src/entities/application.model.ts
@@ -255,6 +255,22 @@ export class Application extends RecordDataModel {
   })
   currentAssessment?: StudentAssessment;
   /**
+   * Represents the student assessment that is being processed currently.
+   * Differently from the current_assessment column, which points to the
+   * most recently created record, this column indicates the assessment
+   * currently being processed.
+   */
+  @ManyToOne(() => StudentAssessment, {
+    eager: false,
+    cascade: ["update"],
+    nullable: true,
+  })
+  @JoinColumn({
+    name: "current_processing_assessment_id",
+    referencedColumnName: ColumnNames.ID,
+  })
+  currentProcessingAssessmentId?: StudentAssessment;
+  /**
    * All supporting users related to the application.
    * These users (parents/partner) will be created as needed during
    * the execution of the original assessment workflow processing.

--- a/sources/packages/backend/libs/sims-db/src/entities/student-assessment-status.type.ts
+++ b/sources/packages/backend/libs/sims-db/src/entities/student-assessment-status.type.ts
@@ -4,16 +4,9 @@
  */
 export enum StudentAssessmentStatus {
   /**
-   * Student assessment status is considered submitted,
-   * when the assessmentWorkflowId is null.
-   * TODO: to be removed once the assessment queues are in place.
-   * @deprecated to be replaced by the "Created" status.
+   * Student assessment was submitted and it is waiting to be processed.
    */
   Submitted = "Submitted",
-  /**
-   * Student assessment was created.
-   */
-  Created = "Created",
   /**
    * Student assessment was selected and sent to the queue to be
    * processed by Camunda.

--- a/sources/packages/backend/libs/sims-db/src/entities/student-assessment-status.type.ts
+++ b/sources/packages/backend/libs/sims-db/src/entities/student-assessment-status.type.ts
@@ -1,23 +1,43 @@
 /**
- * Student assessment status which is dynamically determined
- * with certain logic.
+ * Student assessment statuses from its creation till the workflow
+ * calculations are finalized or the workflow is cancelled.
  */
 export enum StudentAssessmentStatus {
   /**
    * Student assessment status is considered submitted,
    * when the assessmentWorkflowId is null.
+   * TODO: to be removed once the assessment queues are in place.
+   * @deprecated to be replaced by the "Created" status.
    */
   Submitted = "Submitted",
   /**
-   * Student assessment status is considered InProgress,
-   * when the assessmentWorkflowId is not null and assessmentData
-   * is null.
+   * Student assessment was created.
    */
-  InProgress = "In Progress",
+  Created = "Created",
   /**
-   * Student assessment status is considered Completed,
-   * when the assessmentWorkflowId is not null and assessmentData
-   * is also not null.
+   * Student assessment was selected and sent to the queue to be
+   * processed by Camunda.
+   */
+  Queued = "Queued",
+  /**
+   * Assessment gateway workflow started.
+   */
+  Inprogress = "In progress",
+  /**
+   * Assessment gateway workflow completed, all calculations are done,
+   * and output data was saved.
    */
   Completed = "Completed",
+  /**
+   * A cancellation was requested.
+   */
+  CancellationRequested = "Cancellation requested",
+  /**
+   * The cancellation was queued to be processed.
+   */
+  CancellationQueued = "Cancellation queued",
+  /**
+   * All processes required to have the workflow cancelled are done.
+   */
+  Cancelled = "Cancelled",
 }

--- a/sources/packages/backend/libs/sims-db/src/entities/student-assessment-status.type.ts
+++ b/sources/packages/backend/libs/sims-db/src/entities/student-assessment-status.type.ts
@@ -22,7 +22,7 @@ export enum StudentAssessmentStatus {
   /**
    * Assessment gateway workflow started.
    */
-  Inprogress = "In progress",
+  InProgress = "In progress",
   /**
    * Assessment gateway workflow completed, all calculations are done,
    * and output data was saved.

--- a/sources/packages/backend/libs/sims-db/src/entities/student-assessment.model.ts
+++ b/sources/packages/backend/libs/sims-db/src/entities/student-assessment.model.ts
@@ -13,6 +13,7 @@ import {
   DisbursementSchedule,
   EducationProgramOffering,
   StudentAppeal,
+  StudentAssessmentStatus,
   User,
 } from ".";
 import { ColumnNames, TableNames } from "../constant";
@@ -221,6 +222,27 @@ export class StudentAssessment extends RecordDataModel {
     referencedColumnName: ColumnNames.ID,
   })
   applicationOfferingChangeRequest?: ApplicationOfferingChangeRequest;
+  /**
+   * Student assessment status from its creation till the workflow calculations are finalized
+   * or the workflow is cancelled.
+   */
+  @Column({
+    name: "student_assessment_status",
+    type: "enum",
+    enum: StudentAssessmentStatus,
+    enumName: "StudentAssessmentStatus",
+    nullable: false,
+  })
+  studentAssessmentStatus: StudentAssessmentStatus;
+  /**
+   * Date and time when the student_assessment_status column was set.
+   */
+  @Column({
+    name: "student_assessment_status_updated_on",
+    type: "timestamptz",
+    nullable: false,
+  })
+  studentAssessmentStatusUpdatedOn: Date;
 }
 
 /**

--- a/sources/packages/backend/libs/sims-db/src/entities/student-assessment.model.ts
+++ b/sources/packages/backend/libs/sims-db/src/entities/student-assessment.model.ts
@@ -246,7 +246,7 @@ export class StudentAssessment extends RecordDataModel {
   })
   studentAssessmentStatus: StudentAssessmentStatus;
   /**
-   * Date and time when the student_assessment_status column was set.
+   * Date and time when the student_assessment_status column was updated.
    */
   @Column({
     name: "student_assessment_status_updated_on",

--- a/sources/packages/web/src/types/contracts/AssessmentStatus.ts
+++ b/sources/packages/web/src/types/contracts/AssessmentStatus.ts
@@ -21,20 +21,44 @@ export enum AssessmentStatus {
 }
 
 /**
- * Assessment History Status
+ * Student assessment statuses from its creation till the
+ * assessment gateway workflow is finalized.
  */
 export enum StudentAssessmentStatus {
-  // When assessmentWorkflowId is null,
-  // then status is Submitted.
+  /**
+   * Student assessment status is considered submitted,
+   * when the assessmentWorkflowId is null.
+   * @deprecated to be replaced by "Created" status.
+   */
   Submitted = "Submitted",
-
-  // When assessmentWorkflowId is not null
-  // and assessmentData is null, then status is
-  // InProgress.
-  InProgress = "In Progress",
-
-  // When assessmentWorkflowId is not null
-  // and assessmentData is not null, then status
-  // is Completed.
+  /**
+   * Student assessment was created.
+   */
+  Created = "Created",
+  /**
+   * Student assessment was selected and sent to the queue to be
+   * processed by Camunda.
+   */
+  Queued = "Queued",
+  /**
+   * Assessment gateway workflow started.
+   */
+  Inprogress = "In progress",
+  /**
+   * Assessment gateway workflow completed, all calculations are done,
+   * and output data was saved.
+   */
   Completed = "Completed",
+  /**
+   * A cancellation was requested.
+   */
+  CancellationRequested = "Cancellation requested",
+  /**
+   * The cancellation was queued to be processed.
+   */
+  CancellationQueued = "Cancellation queued",
+  /**
+   * All processes required to have the workflow cancelled are done.
+   */
+  Cancelled = "Cancelled",
 }

--- a/sources/packages/web/src/types/contracts/AssessmentStatus.ts
+++ b/sources/packages/web/src/types/contracts/AssessmentStatus.ts
@@ -43,7 +43,7 @@ export enum StudentAssessmentStatus {
   /**
    * Assessment gateway workflow started.
    */
-  Inprogress = "In progress",
+  InProgress = "In progress",
   /**
    * Assessment gateway workflow completed, all calculations are done,
    * and output data was saved.


### PR DESCRIPTION
- Created new columns on `sims.student_assessments`.
- Created new column on `sims.applications`.
- The enum for the new type (`StudentAssessmentStatus`) was already present. The new enum items were added, and the `Submitted` type was kept for backward compatibility, ticket #2188 will be responsible for having it removed.