### PR TITLE
#1978 - Request Offering Change - Student View Request (Bug fix)

### DIFF
--- a/sources/packages/web/src/components/students/modals/ApproveApplicationOfferingChangeRequestModal.vue
+++ b/sources/packages/web/src/components/students/modals/ApproveApplicationOfferingChangeRequestModal.vue
@@ -70,7 +70,6 @@ export default defineComponent({
     );
     const approveApplicationOfferingChangeRequest = ref({} as VForm);
     const cancel = () => {
-      approveApplicationOfferingChangeRequest.value.reset();
       approveApplicationOfferingChangeRequestModal.value.studentConsent = false;
       approveApplicationOfferingChangeRequest.value.resetValidation();
       resolvePromise(false);

--- a/sources/packages/web/src/components/students/modals/ApproveApplicationOfferingChangeRequestModal.vue
+++ b/sources/packages/web/src/components/students/modals/ApproveApplicationOfferingChangeRequestModal.vue
@@ -50,7 +50,7 @@
 </template>
 <script lang="ts">
 import ModalDialogBase from "@/components/generic/ModalDialogBase.vue";
-import { ref, defineComponent } from "vue";
+import { ref, defineComponent, reactive } from "vue";
 import { useModalDialog } from "@/composables";
 import { StudentApplicationOfferingChangeRequestAPIInDTO } from "@/services/http/dto";
 import { ApplicationOfferingChangeRequestStatus, VForm } from "@/types";
@@ -65,12 +65,12 @@ export default defineComponent({
     const { showDialog, showModal, resolvePromise } = useModalDialog<
       StudentApplicationOfferingChangeRequestAPIInDTO | boolean
     >();
-    const approveApplicationOfferingChangeRequestModal = ref(
+    const approveApplicationOfferingChangeRequestModal = reactive(
       {} as StudentApplicationOfferingChangeRequestAPIInDTO,
     );
     const approveApplicationOfferingChangeRequest = ref({} as VForm);
     const cancel = () => {
-      approveApplicationOfferingChangeRequestModal.value.studentConsent = false;
+      approveApplicationOfferingChangeRequestModal.studentConsent = false;
       approveApplicationOfferingChangeRequest.value.resetValidation();
       resolvePromise(false);
     };
@@ -80,9 +80,9 @@ export default defineComponent({
       if (!validationResult.valid) {
         return;
       }
-      approveApplicationOfferingChangeRequestModal.value.applicationOfferingChangeRequestStatus =
+      approveApplicationOfferingChangeRequestModal.applicationOfferingChangeRequestStatus =
         ApplicationOfferingChangeRequestStatus.InProgressWithSABC;
-      const payload = { ...approveApplicationOfferingChangeRequestModal.value };
+      const payload = { ...approveApplicationOfferingChangeRequestModal };
       resolvePromise(payload);
       approveApplicationOfferingChangeRequest.value.reset();
     };

--- a/sources/packages/web/src/components/students/modals/ApproveApplicationOfferingChangeRequestModal.vue
+++ b/sources/packages/web/src/components/students/modals/ApproveApplicationOfferingChangeRequestModal.vue
@@ -31,7 +31,7 @@
             ></title-value
           ></content-group-info
         ><v-checkbox
-          v-model="formModel.studentConsent"
+          v-model="approveApplicationOfferingChangeRequestModal.studentConsent"
           label="I agree to the terms and conditions of the StudentAid BC Declaration
           form"
           hide-details="auto"
@@ -50,7 +50,7 @@
 </template>
 <script lang="ts">
 import ModalDialogBase from "@/components/generic/ModalDialogBase.vue";
-import { ref, defineComponent, reactive } from "vue";
+import { ref, defineComponent } from "vue";
 import { useModalDialog } from "@/composables";
 import { StudentApplicationOfferingChangeRequestAPIInDTO } from "@/services/http/dto";
 import { ApplicationOfferingChangeRequestStatus, VForm } from "@/types";
@@ -69,12 +69,9 @@ export default defineComponent({
       {} as StudentApplicationOfferingChangeRequestAPIInDTO,
     );
     const approveApplicationOfferingChangeRequest = ref({} as VForm);
-    const formModel = reactive(
-      {} as StudentApplicationOfferingChangeRequestAPIInDTO,
-    );
     const cancel = () => {
       approveApplicationOfferingChangeRequest.value.reset();
-      formModel.studentConsent = false;
+      approveApplicationOfferingChangeRequestModal.value.studentConsent = false;
       approveApplicationOfferingChangeRequest.value.resetValidation();
       resolvePromise(false);
     };
@@ -86,7 +83,7 @@ export default defineComponent({
       }
       approveApplicationOfferingChangeRequestModal.value.applicationOfferingChangeRequestStatus =
         ApplicationOfferingChangeRequestStatus.InProgressWithSABC;
-      const payload = { ...formModel };
+      const payload = { ...approveApplicationOfferingChangeRequestModal.value };
       resolvePromise(payload);
       approveApplicationOfferingChangeRequest.value.reset();
     };
@@ -95,7 +92,6 @@ export default defineComponent({
       showModal,
       cancel,
       allowChange,
-      formModel,
       approveApplicationOfferingChangeRequest,
       approveApplicationOfferingChangeRequestModal,
     };

--- a/sources/packages/web/src/views/student/application-offering-change-request/tabs/RequestedApplicationOfferingDetails.vue
+++ b/sources/packages/web/src/views/student/application-offering-change-request/tabs/RequestedApplicationOfferingDetails.vue
@@ -15,7 +15,7 @@
       </template>
       <hr class="horizontal-divider" />
       <h2 class="category-header-large primary-color">Application Details</h2>
-      <p v-if="changeRequestNotApproved">
+      <p v-if="changeRequestInProgressWithStudent">
         Below displays the requested changes from your institution. You can
         compare your
         <span class="font-bold">active application details</span> by switching
@@ -24,7 +24,7 @@
       <offering-view :offeringId="changeRequest.requestedOfferingId" />
       <hr class="horizontal-divider" />
       <h2 class="category-header-large primary-color">Request details</h2>
-      <p v-if="changeRequestNotApproved">
+      <p v-if="changeRequestInProgressWithStudent">
         Contact your institution for more information if there are no
         differences in the requested change above. There may be proposed changes
         that aren't displayed such as study costs.
@@ -80,17 +80,17 @@ export default defineComponent({
           Location: changeRequest.value.locationName,
         } as Record<string, string>),
     );
-    const changeRequestNotApproved = computed(() => {
+    const changeRequestInProgressWithStudent = computed(() => {
       return (
-        changeRequest.value.status !==
-        ApplicationOfferingChangeRequestStatus.Approved
+        changeRequest.value.status ===
+        ApplicationOfferingChangeRequestStatus.InProgressWithStudent
       );
     });
     return {
       changeRequest,
       studentFullName,
       headerDetailsData,
-      changeRequestNotApproved,
+      changeRequestInProgressWithStudent,
       ApplicationOfferingChangeRequestStatus,
     };
   },


### PR DESCRIPTION
The following two scenarios are fixed:

-  **Problem:** Application Offering Change Request Status was not sent in payload. 
   **Fix:** Application Offering Change Request Status is being set to `InProgressWithSABC` in the payload.

- **Problem:** Text under the Application Details and Request Details headings was only omitted when the application offering change request was approved by the ministry. 
  **Fix** As per the requirement, text under the Application Details and Request Details headings is only displayed when "In progress with student." They are omitted after the student approves or declines.