### PR TITLE
#2180 - Assessment Workflow Enqueuer Scheduler - Start Assessment (Part 1) - DB migration fix

### DIFF
--- a/sources/packages/backend/apps/db-migrations/src/sql/StudentAssessments/Update-student-assessment-status.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/StudentAssessments/Update-student-assessment-status.sql
@@ -1,7 +1,5 @@
 /**
  Updates all assessments associated with active applications.
- By default all records were created with 'Submitted' hence there is
- no need to have it added to below CASE conditions.
  */
 UPDATE
   sims.student_assessments sa
@@ -11,6 +9,7 @@ SET
       WHEN sa.assessment_data IS NOT NULL THEN 'Completed'
       WHEN sa.assessment_workflow_id IS NOT NULL
       AND sa.assessment_data IS NULL THEN 'In progress'
+      ELSE 'Submitted'
     END
   ) :: sims.student_assessment_status
 FROM


### PR DESCRIPTION
A missing CASE condition was causing an attempt to set null the student assessment status: "QueryFailedError: null value in column "student_assessment_status" violates not-null constraint".