### PR TITLE
#88 - Change to allow multi staged builds and continue using artifacts repo

### DIFF
--- a/devops/Makefile
+++ b/devops/Makefile
@@ -263,7 +263,7 @@ build-web:
 	test -n "$(BUILD_REF)"
 	test -n "$(WEB_BUILD_REF)"
 	@echo "+\n++ BUILDING WEB with tag: $(BUILD_REF)\n+"
-	@oc -n $(BUILD_NAMESPACE) process -f $(BUILD_TEMPLATE_PATH) -p TAG=$(BUILD_REF) -p SOURCE_REPOSITORY_REF=$(BUILD_REF) -p BASE_IMAGE_NAME="nginx-120" -p BASE_IMAGE_TAG="1" -p BASE_IMAGE_REPO="artifacts.developer.gov.bc.ca/redhat-access-docker-remote/ubi8/" -p SOURCE_CONTEXT_DIR=$(SOURCE_CONTEXT_DIR)web -p NAME=$(WEB_BUILD_REF) | oc -n $(BUILD_NAMESPACE) apply -f -
+	@oc -n $(BUILD_NAMESPACE) process -f $(BUILD_TEMPLATE_PATH) -p TAG=$(BUILD_REF) -p SOURCE_REPOSITORY_REF=$(BUILD_REF) -p BASE_IMAGE_NAME="nginx-122" -p BASE_IMAGE_TAG="1" -p BASE_IMAGE_REPO="artifacts.developer.gov.bc.ca/redhat-access-docker-remote/ubi8/" -p SOURCE_CONTEXT_DIR=$(SOURCE_CONTEXT_DIR)web -p NAME=$(WEB_BUILD_REF) | oc -n $(BUILD_NAMESPACE) apply -f -
 	@oc -n $(BUILD_NAMESPACE) start-build bc/$(WEB_BUILD_REF) --wait
 
 init-patroni:

--- a/devops/Makefile
+++ b/devops/Makefile
@@ -263,7 +263,7 @@ build-web:
 	test -n "$(BUILD_REF)"
 	test -n "$(WEB_BUILD_REF)"
 	@echo "+\n++ BUILDING WEB with tag: $(BUILD_REF)\n+"
-	@oc -n $(BUILD_NAMESPACE) process -f $(BUILD_TEMPLATE_PATH) -p TAG=$(BUILD_REF) -p SOURCE_REPOSITORY_REF=$(BUILD_REF) -p BASE_IMAGE_NAME="nodejs-16" -p BASE_IMAGE_TAG="1" -p BASE_IMAGE_REPO="artifacts.developer.gov.bc.ca/redhat-access-docker-remote/ubi8/" -p SOURCE_CONTEXT_DIR=$(SOURCE_CONTEXT_DIR)web -p NAME=$(WEB_BUILD_REF) | oc -n $(BUILD_NAMESPACE) apply -f -
+	@oc -n $(BUILD_NAMESPACE) process -f $(BUILD_TEMPLATE_PATH) -p TAG=$(BUILD_REF) -p SOURCE_REPOSITORY_REF=$(BUILD_REF) -p BASE_IMAGE_NAME="nginx-120" -p BASE_IMAGE_TAG="1" -p BASE_IMAGE_REPO="artifacts.developer.gov.bc.ca/redhat-access-docker-remote/ubi8/" -p SOURCE_CONTEXT_DIR=$(SOURCE_CONTEXT_DIR)web -p NAME=$(WEB_BUILD_REF) | oc -n $(BUILD_NAMESPACE) apply -f -
 	@oc -n $(BUILD_NAMESPACE) start-build bc/$(WEB_BUILD_REF) --wait
 
 init-patroni:

--- a/devops/openshift/docker-build.yml
+++ b/devops/openshift/docker-build.yml
@@ -62,9 +62,6 @@ objects:
           dockerfilePath: "${DOCKER_FILE_PATH}"
           pullSecret:
             name: artifactory-secret-credential
-          from:
-            kind: ImageStreamTag
-            name: ${BASE_IMAGE_NAME}:${BASE_IMAGE_TAG}
           buildArgs:
             - name: ${ARG_KEY_1}
               value: ${ARG_VAL_1}

--- a/sources/packages/backend/apps/api/Dockerfile
+++ b/sources/packages/backend/apps/api/Dockerfile
@@ -1,5 +1,5 @@
 # Base Image
-FROM registry.access.redhat.com/ubi8/nodejs-16:1-5
+FROM artifacts.developer.gov.bc.ca/redhat-access-docker-remote/ubi8/nodejs-16:1-5
 
 LABEL maintainer="BC GOV"
 

--- a/sources/packages/backend/apps/db-migrations/Dockerfile
+++ b/sources/packages/backend/apps/db-migrations/Dockerfile
@@ -1,5 +1,5 @@
 # Base Image
-FROM registry.access.redhat.com/ubi8/nodejs-16:1-5
+FROM artifacts.developer.gov.bc.ca/redhat-access-docker-remote/ubi8/nodejs-16:1-5
 
 LABEL maintainer="BC GOV"
 

--- a/sources/packages/backend/apps/queue-consumers/Dockerfile
+++ b/sources/packages/backend/apps/queue-consumers/Dockerfile
@@ -1,5 +1,5 @@
 # Base Image
-FROM registry.access.redhat.com/ubi8/nodejs-16:1-5
+FROM artifacts.developer.gov.bc.ca/redhat-access-docker-remote/ubi8/nodejs-16:1-5
 
 LABEL maintainer="BC GOV"
 

--- a/sources/packages/backend/apps/workers/Dockerfile
+++ b/sources/packages/backend/apps/workers/Dockerfile
@@ -1,5 +1,5 @@
 # Base Image
-FROM registry.access.redhat.com/ubi8/nodejs-16:1-5
+FROM artifacts.developer.gov.bc.ca/redhat-access-docker-remote/ubi8/nodejs-16:1-5
 
 LABEL maintainer="BC GOV"
 

--- a/sources/packages/web/Dockerfile
+++ b/sources/packages/web/Dockerfile
@@ -12,7 +12,7 @@ RUN sed 's/${PORT}/'"${PORT}"'/g' default.conf.template > default.conf
 
 RUN npm run build
 
-FROM registry.access.redhat.com/ubi8/nginx-120 AS deployer
+FROM registry.access.redhat.com/ubi8/nginx-122 AS deployer
 
 USER default
 

--- a/sources/packages/web/Dockerfile
+++ b/sources/packages/web/Dockerfile
@@ -12,7 +12,7 @@ RUN sed 's/${PORT}/'"${PORT}"'/g' default.conf.template > default.conf
 
 RUN npm run build
 
-FROM registry.access.redhat.com/ubi8/nginx-122 AS deployer
+FROM registry.access.redhat.com/ubi8/nginx-120 AS deployer
 
 USER default
 

--- a/sources/packages/web/Dockerfile
+++ b/sources/packages/web/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/nodejs-16:1-5 AS builder
+FROM artifacts.developer.gov.bc.ca/redhat-access-docker-remote/ubi8/nodejs-16:1-5 AS builder
 
 # Application Port.
 ENV PORT 3030
@@ -12,7 +12,7 @@ RUN sed 's/${PORT}/'"${PORT}"'/g' default.conf.template > default.conf
 
 RUN npm run build
 
-FROM registry.access.redhat.com/ubi8/nginx-122 AS deployer
+FROM artifacts.developer.gov.bc.ca/redhat-access-docker-remote/ubi8/nginx-122 AS deployer
 
 USER default
 


### PR DESCRIPTION
- Modified docker-build.yml to allow multi stage builds. docker-build.yml was forcing the base images to be the one passed as argument to the oc command. Now, the image used will be the one in the Dockerfiles.
- Modified Dockerfiles to use artifacts.developer.gov.bc.ca images.