### PR TITLE
#2305 - Nginx - change configuration to output logs to stdout

### DIFF
--- a/sources/packages/web/default.conf.template
+++ b/sources/packages/web/default.conf.template
@@ -7,10 +7,6 @@ log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
 server {
   # Log to stdout
   access_log /dev/stdout main;
-  
-  # Log to a file
-  access_log /var/log/nginx/access.log main;
-  
   listen       ${PORT};
   location / {
     root   /opt/app-root/src;

--- a/sources/packages/web/default.conf.template
+++ b/sources/packages/web/default.conf.template
@@ -1,5 +1,16 @@
 # nginx default configuration.
+
+log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                  '$status $body_bytes_sent "$http_referer" '
+                  '"$http_user_agent" "$http_x_forwarded_for"';
+
 server {
+  # Log to stdout
+  access_log /dev/stdout main;
+  
+  # Log to a file
+  access_log /var/log/nginx/access.log main;
+  
   listen       ${PORT};
   location / {
     root   /opt/app-root/src;

--- a/sources/packages/web/nginx.conf
+++ b/sources/packages/web/nginx.conf
@@ -3,9 +3,6 @@ worker_processes  auto;
 # Log to stdout
 error_log  /dev/stdout info;
 
-# Log to a file
-error_log  /var/log/nginx/error.log info;
-
 pid        /tmp/nginx.pid;
 events {
   worker_connections  1024;

--- a/sources/packages/web/nginx.conf
+++ b/sources/packages/web/nginx.conf
@@ -1,5 +1,11 @@
 worker_processes  auto;
-error_log  /var/log/nginx/error.log warn;
+
+# Log to stdout
+error_log  /dev/stdout info;
+
+# Log to a file
+error_log  /var/log/nginx/error.log info;
+
 pid        /tmp/nginx.pid;
 events {
   worker_connections  1024;
@@ -8,10 +14,6 @@ http {
   include       /etc/nginx/mime.types;
   include       /etc/nginx/conf.d/default.conf;
   default_type  application/octet-stream;
-  log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
-                    '$status $body_bytes_sent "$http_referer" '
-                    '"$http_user_agent" "$http_x_forwarded_for"';
-  access_log  /var/log/nginx/access.log  main;
   sendfile        on;
   keepalive_timeout  65;
 }


### PR DESCRIPTION
- Configured error_log and access_log to be redirected only to stdout. Kibana should be responsible for capturing the logs output on stdout.

Notice that error_log is now configured to "info" log level which means that all the higher [log levels](https://www.keycdn.com/support/nginx-error-log#nginx-error-log-severity-levels) will be also logged.