### PR TITLE
#2180 - Assessment Workflow Enqueuer Scheduler - Start Assessment - E2E tests

### DIFF
--- a/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/workflow/_tests_/assessment-workflow-enqueuer.scheduler.e2e-spec.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/workflow/_tests_/assessment-workflow-enqueuer.scheduler.e2e-spec.ts
@@ -1,0 +1,220 @@
+import { Job, Queue } from "bull";
+import { createMock } from "@golevelup/ts-jest";
+import { INestApplication } from "@nestjs/common";
+import { QueueNames, addDays } from "@sims/utilities";
+import {
+  createTestingAppModule,
+  describeProcessorRootTest,
+} from "../../../../../test/helpers";
+import { AssessmentWorkflowEnqueuerScheduler } from "../assessment-workflow-enqueuer.scheduler";
+import {
+  E2EDataSources,
+  createE2EDataSources,
+  createFakeStudentAssessment,
+  createFakeUser,
+  getQueueProviderName,
+  saveFakeApplication,
+} from "@sims/test-utils";
+import { Not } from "typeorm";
+import {
+  Application,
+  AssessmentTriggerType,
+  StudentAssessmentStatus,
+  User,
+} from "@sims/sims-db";
+import { StartAssessmentQueueInDTO } from "@sims/services/queue";
+
+describe(
+  describeProcessorRootTest(QueueNames.AssessmentWorkflowEnqueuer),
+  () => {
+    let app: INestApplication;
+    let db: E2EDataSources;
+    let processor: AssessmentWorkflowEnqueuerScheduler;
+    let startApplicationAssessmentQueueMock: Queue<StartAssessmentQueueInDTO>;
+    let auditUser: User;
+
+    beforeAll(async () => {
+      const { nestApplication, dataSource } = await createTestingAppModule();
+      app = nestApplication;
+      db = createE2EDataSources(dataSource);
+      auditUser = await db.user.save(createFakeUser());
+      // Mocked StartApplicationAssessment queue.
+      startApplicationAssessmentQueueMock = app.get(
+        getQueueProviderName(QueueNames.StartApplicationAssessment),
+      );
+      // Processor under test.
+      processor = app.get(AssessmentWorkflowEnqueuerScheduler);
+    });
+
+    beforeEach(async () => {
+      jest.resetAllMocks();
+      // Ensure that all assessments will be cancelled.
+      await db.studentAssessment.update(
+        {
+          studentAssessmentStatus: Not(StudentAssessmentStatus.Cancelled),
+        },
+        { studentAssessmentStatus: StudentAssessmentStatus.Cancelled },
+      );
+    });
+
+    it(`Should queue an assessment when an active application has only the original assessment and it is in '${StudentAssessmentStatus.Submitted}' state.`, async () => {
+      // Arrange
+
+      // Application submitted with original assessment.
+      const application = await createDefaultApplication();
+      // Queued job.
+      const job = createMock<Job<void>>();
+
+      // Act
+      await processor.enqueueAssessmentOperations(job);
+
+      // Assert
+      // Load application and related assessments for assertion.
+      const updatedApplication = await db.application.findOne({
+        select: {
+          id: true,
+          currentAssessment: {
+            id: true,
+          },
+          currentProcessingAssessment: {
+            id: true,
+            studentAssessmentStatus: true,
+          },
+        },
+        relations: {
+          currentAssessment: true,
+          currentProcessingAssessment: true,
+        },
+        where: { id: application.id },
+      });
+      // Assert item was added to the queue.
+      const queueData = {
+        assessmentId: updatedApplication.currentProcessingAssessment.id,
+      } as StartAssessmentQueueInDTO;
+      expect(startApplicationAssessmentQueueMock.add).toBeCalledWith(queueData);
+      // currentProcessingAssessment must be updated with the queued assessment.
+      expect(updatedApplication.currentAssessment.id).toBe(
+        updatedApplication.currentProcessingAssessment.id,
+      );
+      expect(
+        updatedApplication.currentProcessingAssessment.studentAssessmentStatus,
+      ).toBe(StudentAssessmentStatus.Queued);
+    });
+
+    it("Should queue the oldest pending reassessment when an active application has one completed original assessment and multiple submitted reassessments queued.", async () => {
+      // Arrange
+
+      // Application submitted with original assessment and completed assessment.
+      const application = await createDefaultApplication(
+        StudentAssessmentStatus.Completed,
+      );
+      // Oldest submitted assessment (the original one should be ignored because it is set as Completed.).
+      const oldestAssessment = createFakeStudentAssessment({
+        application,
+        auditUser,
+      });
+      oldestAssessment.triggerType = AssessmentTriggerType.OfferingChange;
+      oldestAssessment.createdAt = addDays(-1);
+      // Newest assessment that will be saved with current date and time.
+      const newestAssessment = createFakeStudentAssessment({
+        application,
+        auditUser,
+      });
+      newestAssessment.triggerType = AssessmentTriggerType.OfferingChange;
+      // Save all assessments.
+      await db.studentAssessment.save([oldestAssessment, newestAssessment]);
+      // Updates the current assessment to the newest one.
+      application.currentAssessment = newestAssessment;
+      await db.application.save(application);
+      // Queued job.
+      const job = createMock<Job<void>>();
+
+      // Act
+      await processor.enqueueAssessmentOperations(job);
+
+      // Assert
+      // Load application and related assessments for assertion.
+      const updatedApplication = await db.application.findOne({
+        select: {
+          id: true,
+          currentAssessment: {
+            id: true,
+          },
+          currentProcessingAssessment: {
+            id: true,
+            studentAssessmentStatus: true,
+          },
+        },
+        relations: {
+          currentAssessment: true,
+          currentProcessingAssessment: true,
+          studentAssessments: true,
+        },
+        where: { id: application.id },
+      });
+      // Assert oldest submitted assessment was added to the queue.
+      const queueData = {
+        assessmentId: oldestAssessment.id,
+      } as StartAssessmentQueueInDTO;
+      expect(startApplicationAssessmentQueueMock.add).toBeCalledWith(queueData);
+      // currentProcessingAssessment must be updated with the oldest assessment
+      // and currentAssessment and currentProcessingAssessment must be different.
+      expect(updatedApplication.currentProcessingAssessment.id).toBe(
+        oldestAssessment.id,
+      );
+      expect(
+        updatedApplication.currentProcessingAssessment.studentAssessmentStatus,
+      ).toBe(StudentAssessmentStatus.Queued);
+      // Current assessment should not be updated.
+      expect(updatedApplication.currentAssessment.id).toBe(newestAssessment.id);
+    });
+
+    [
+      StudentAssessmentStatus.Queued,
+      StudentAssessmentStatus.InProgress,
+    ].forEach((status) => {
+      it(`Should not queue a '${StudentAssessmentStatus.Submitted}' assessment if the another assessment has its status as '${status}'`, async () => {
+        // Arrange
+
+        // Application submitted with original assessment.
+        const application = await createDefaultApplication(status);
+        const submittedAssessment = createFakeStudentAssessment({
+          application,
+          auditUser,
+        });
+        submittedAssessment.triggerType = AssessmentTriggerType.OfferingChange;
+        await db.studentAssessment.save(submittedAssessment);
+
+        // Queued job.
+        const job = createMock<Job<void>>();
+
+        // Act
+        await processor.enqueueAssessmentOperations(job);
+
+        // Assert
+        expect(startApplicationAssessmentQueueMock.add).not.toBeCalled();
+      });
+    });
+
+    /**
+     * Get a default application with only one original assessment to test
+     * multiple positive and negative scenarios ensuring that the only variant
+     * would be the assessment status.
+     * @param assessmentStatus assessment status. When not provided it will
+     * be set with its default value 'Submitted'.
+     * @returns application with the current assessment configured with
+     * the provided student assessment.
+     */
+    const createDefaultApplication = async (
+      assessmentStatus?: StudentAssessmentStatus,
+    ): Promise<Application> => {
+      const application = await saveFakeApplication(db.dataSource);
+      if (assessmentStatus) {
+        application.currentAssessment.studentAssessmentStatus =
+          assessmentStatus;
+        await db.studentAssessment.save(application.currentAssessment);
+      }
+      return application;
+    };
+  },
+);

--- a/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/workflow/_tests_/assessment-workflow-enqueuer.scheduler.e2e-spec.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/workflow/_tests_/assessment-workflow-enqueuer.scheduler.e2e-spec.ts
@@ -70,23 +70,9 @@ describe(
 
       // Assert
       // Load application and related assessments for assertion.
-      const updatedApplication = await db.application.findOne({
-        select: {
-          id: true,
-          currentAssessment: {
-            id: true,
-          },
-          currentProcessingAssessment: {
-            id: true,
-            studentAssessmentStatus: true,
-          },
-        },
-        relations: {
-          currentAssessment: true,
-          currentProcessingAssessment: true,
-        },
-        where: { id: application.id },
-      });
+      const updatedApplication = await loadApplicationDataForAssertions(
+        application.id,
+      );
       // Assert item was added to the queue.
       const queueData = {
         assessmentId: updatedApplication.currentProcessingAssessment.id,
@@ -134,24 +120,9 @@ describe(
 
       // Assert
       // Load application and related assessments for assertion.
-      const updatedApplication = await db.application.findOne({
-        select: {
-          id: true,
-          currentAssessment: {
-            id: true,
-          },
-          currentProcessingAssessment: {
-            id: true,
-            studentAssessmentStatus: true,
-          },
-        },
-        relations: {
-          currentAssessment: true,
-          currentProcessingAssessment: true,
-          studentAssessments: true,
-        },
-        where: { id: application.id },
-      });
+      const updatedApplication = await loadApplicationDataForAssertions(
+        application.id,
+      );
       // Assert oldest submitted assessment was added to the queue.
       const queueData = {
         assessmentId: oldestAssessment.id,
@@ -215,6 +186,33 @@ describe(
         await db.studentAssessment.save(application.currentAssessment);
       }
       return application;
+    };
+
+    /**
+     * Load application and assessment data needed to execute the assert operations.
+     * @param applicationId application id.
+     * @returns application with related assessments (currentAssessment and currentProcessingAssessment).
+     */
+    const loadApplicationDataForAssertions = (
+      applicationId: number,
+    ): Promise<Application> => {
+      return db.application.findOne({
+        select: {
+          id: true,
+          currentAssessment: {
+            id: true,
+          },
+          currentProcessingAssessment: {
+            id: true,
+            studentAssessmentStatus: true,
+          },
+        },
+        relations: {
+          currentAssessment: true,
+          currentProcessingAssessment: true,
+        },
+        where: { id: applicationId },
+      });
     };
   },
 );

--- a/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/workflow/_tests_/assessment-workflow-enqueuer.scheduler.e2e-spec.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/workflow/_tests_/assessment-workflow-enqueuer.scheduler.e2e-spec.ts
@@ -167,6 +167,25 @@ describe(
       });
     });
 
+    it(`Should not queue a '${StudentAssessmentStatus.Submitted}' assessment if currentAssessment and currentProcessingAssessment are the same already.`, async () => {
+      // Arrange
+
+      // Application submitted with original assessment.
+      const application = await createDefaultApplication();
+      // Force currentAssessment and currentProcessingAssessment to be the same to test the SQL condition.
+      application.currentProcessingAssessment = application.currentAssessment;
+      await db.application.save(application);
+
+      // Queued job.
+      const job = createMock<Job<void>>();
+
+      // Act
+      await processor.enqueueAssessmentOperations(job);
+
+      // Assert
+      expect(startApplicationAssessmentQueueMock.add).not.toBeCalled();
+    });
+
     /**
      * Get a default application with only one original assessment to test
      * multiple positive and negative scenarios ensuring that the only variant

--- a/sources/packages/backend/libs/test-utils/src/mocks/queue-module-mock.ts
+++ b/sources/packages/backend/libs/test-utils/src/mocks/queue-module-mock.ts
@@ -25,7 +25,17 @@ function getMockedQueueProviders(): Provider[] {
   // The 'BullQueue_' suffix is needed to properly mock the expected
   // symbol used by the @InjectQueue decorator.
   return Object.values(QueueNames).map<Provider>((queue) => ({
-    provide: `BullQueue_${queue}`,
+    provide: getQueueProviderName(queue),
     useValue: createMock<Queue>({ name: queue }),
   }));
+}
+
+/**
+ * Get the unique mock name for a queue that can be used to retrieve
+ * the mocked object for later jest operations and checks.
+ * @param queueName queue to create the name.
+ * @returns queue mock name.
+ */
+export function getQueueProviderName(queueName: QueueNames): string {
+  return `BullQueue_${queueName}`;
 }


### PR DESCRIPTION
- Create a  few E2E tests for the new schedler.
  - Should queue an assessment when an active application has only the original assessment and it is in 'Submitted' state. (119 ms)
  - Should queue the oldest pending reassessment when an active application has one completed original assessment and multiple submitted reassessments queued. (145 ms)                          
  - Should not queue a 'Submitted' assessment if the another assessment has its status as 'Queued' (99 ms)
  - Should not queue a 'Submitted' assessment if the another assessment has its status as 'In progress' (101 ms)
  - Should not queue a 'Submitted' assessment if currentAssessment and currentProcessingAssessment are the same already. (96 ms)

- Created a method to centralize the mock name creation and allow retrieve the mock to execute tests like `toBeCalledWith`.
```ts
startApplicationAssessmentQueueMock = app.get(
    getQueueProviderName(QueueNames.StartApplicationAssessment),
);
```
```ts
expect(startApplicationAssessmentQueueMock.add).toBeCalledWith(queueData);
```
