### PR TITLE
#2167 - Change how Students Report Dependants

### DIFF
--- a/sources/packages/forms/src/form-definitions/sfaa2021-22.json
+++ b/sources/packages/forms/src/form-definitions/sfaa2021-22.json
@@ -10524,7 +10524,8 @@
               "showWordCount": false,
               "allowMultipleMasks": false,
               "addons": [],
-              "id": "e7vkza"
+              "id": "e7vkza",
+              "isNew": false
             },
             {
               "label": "<strong>In the time since you left high school to your first day of classes, have you spent two periods of 12 consecutive months each, in the full time labour force?</strong>",

--- a/sources/packages/forms/src/form-definitions/sfaa2021-22.json
+++ b/sources/packages/forms/src/form-definitions/sfaa2021-22.json
@@ -10524,7 +10524,8 @@
               "showWordCount": false,
               "allowMultipleMasks": false,
               "addons": [],
-              "id": "e7vkza"
+              "id": "e7vkza",
+              "isNew": false
             },
             {
               "label": "<strong>In the time since you left high school to your first day of classes, have you spent two periods of 12 consecutive months each, in the full time labour force?</strong>",
@@ -12571,7 +12572,7 @@
               "dataGridLabel": false,
               "labelPosition": "top",
               "description": "",
-              "tooltip": "",
+              "tooltip": "Dependants represent anyone who you support financially.",
               "hideLabel": false,
               "tabindex": "",
               "disabled": false,
@@ -12583,7 +12584,7 @@
               "widget": null,
               "validateOn": "change",
               "conditional": {
-                "show": null,
+                "show": "",
                 "when": null,
                 "eq": ""
               },
@@ -12603,7 +12604,8 @@
               "addons": [],
               "inputType": "radio",
               "fieldSet": false,
-              "id": "e2utfe"
+              "id": "e2utfe",
+              "tags": []
             },
             {
               "title": "Add Dependants Panel",
@@ -14368,7 +14370,7 @@
               "id": "esww5zq"
             },
             {
-              "label": "<strong>Do you have any dependents that you support financially but do not have sole custody of?</strong>",
+              "label": "<strong>Are any of the dependants listed above supported by you financially but not under your sole custody?</strong>",
               "optionsLabelPosition": "right",
               "inline": false,
               "tableView": false,
@@ -14429,9 +14431,9 @@
               "widget": null,
               "validateOn": "change",
               "conditional": {
-                "show": null,
-                "when": null,
-                "eq": ""
+                "show": "true",
+                "when": "hasDependents",
+                "eq": "yes"
               },
               "overlay": {
                 "style": "",
@@ -14449,7 +14451,8 @@
               "addons": [],
               "inputType": "radio",
               "fieldSet": false,
-              "id": "eftpw4a"
+              "id": "eftpw4a",
+              "tags": []
             },
             {
               "title": "Dependents that you support financially but do not have sole custody",

--- a/sources/packages/forms/src/form-definitions/sfaa2021-22.json
+++ b/sources/packages/forms/src/form-definitions/sfaa2021-22.json
@@ -10524,8 +10524,7 @@
               "showWordCount": false,
               "allowMultipleMasks": false,
               "addons": [],
-              "id": "e7vkza",
-              "isNew": false
+              "id": "e7vkza"
             },
             {
               "label": "<strong>In the time since you left high school to your first day of classes, have you spent two periods of 12 consecutive months each, in the full time labour force?</strong>",

--- a/sources/packages/forms/src/form-definitions/sfaa2022-23.json
+++ b/sources/packages/forms/src/form-definitions/sfaa2022-23.json
@@ -10524,8 +10524,7 @@
               "showWordCount": false,
               "allowMultipleMasks": false,
               "addons": [],
-              "id": "e7vkza",
-              "isNew": false
+              "id": "e7vkza"
             },
             {
               "label": "<strong>In the time since you left high school to your first day of classes, have you spent two periods of 12 consecutive months each, in the full time labour force?</strong>",
@@ -12572,7 +12571,7 @@
               "dataGridLabel": false,
               "labelPosition": "top",
               "description": "",
-              "tooltip": "",
+              "tooltip": "Dependants represent anyone who you support financially.",
               "hideLabel": false,
               "tabindex": "",
               "disabled": false,
@@ -12584,7 +12583,7 @@
               "widget": null,
               "validateOn": "change",
               "conditional": {
-                "show": null,
+                "show": "",
                 "when": null,
                 "eq": ""
               },
@@ -12604,7 +12603,8 @@
               "addons": [],
               "inputType": "radio",
               "fieldSet": false,
-              "id": "e2utfe"
+              "id": "e2utfe",
+              "tags": []
             },
             {
               "title": "Add Dependants Panel",
@@ -14369,7 +14369,7 @@
               "id": "esww5zq"
             },
             {
-              "label": "<strong>Do you have any dependents that you support financially but do not have sole custody of?</strong>",
+              "label": "<strong>Are any of the dependants listed above supported by you financially but not under your sole custody?</strong>",
               "optionsLabelPosition": "right",
               "inline": false,
               "tableView": false,
@@ -14430,9 +14430,9 @@
               "widget": null,
               "validateOn": "change",
               "conditional": {
-                "show": null,
-                "when": null,
-                "eq": ""
+                "show": "true",
+                "when": "hasDependents",
+                "eq": "yes"
               },
               "overlay": {
                 "style": "",
@@ -14450,7 +14450,8 @@
               "addons": [],
               "inputType": "radio",
               "fieldSet": false,
-              "id": "eftpw4a"
+              "id": "eftpw4a",
+              "tags": []
             },
             {
               "title": "Dependents that you support financially but do not have sole custody",

--- a/sources/packages/forms/src/form-definitions/sfaa2023-24.json
+++ b/sources/packages/forms/src/form-definitions/sfaa2023-24.json
@@ -10524,8 +10524,7 @@
               "showWordCount": false,
               "allowMultipleMasks": false,
               "addons": [],
-              "id": "e7vkza",
-              "isNew": false
+              "id": "e7vkza"
             },
             {
               "label": "<strong>In the time since you left high school to your first day of classes, have you spent two periods of 12 consecutive months each, in the full time labour force?</strong>",
@@ -12572,7 +12571,7 @@
               "dataGridLabel": false,
               "labelPosition": "top",
               "description": "",
-              "tooltip": "",
+              "tooltip": "Dependants represent anyone who you support financially.",
               "hideLabel": false,
               "tabindex": "",
               "disabled": false,
@@ -12584,7 +12583,7 @@
               "widget": null,
               "validateOn": "change",
               "conditional": {
-                "show": null,
+                "show": "",
                 "when": null,
                 "eq": ""
               },
@@ -12604,7 +12603,8 @@
               "addons": [],
               "inputType": "radio",
               "fieldSet": false,
-              "id": "e2utfe"
+              "id": "e2utfe",
+              "tags": []
             },
             {
               "title": "Add Dependants Panel",
@@ -14369,7 +14369,7 @@
               "id": "esww5zq"
             },
             {
-              "label": "<strong>Do you have any dependents that you support financially but do not have sole custody of?</strong>",
+              "label": "<strong>Are any of the dependants listed above supported by you financially but not under your sole custody?</strong>",
               "optionsLabelPosition": "right",
               "inline": false,
               "tableView": false,
@@ -14430,9 +14430,9 @@
               "widget": null,
               "validateOn": "change",
               "conditional": {
-                "show": null,
-                "when": null,
-                "eq": ""
+                "show": "true",
+                "when": "hasDependents",
+                "eq": "yes"
               },
               "overlay": {
                 "style": "",
@@ -14450,7 +14450,8 @@
               "addons": [],
               "inputType": "radio",
               "fieldSet": false,
-              "id": "eftpw4a"
+              "id": "eftpw4a",
+              "tags": []
             },
             {
               "title": "Dependents that you support financially but do not have sole custody",


### PR DESCRIPTION
- [x] Adding tooltip to question 1- "Do you have any dependants?”  Tooltip should say "Dependants represent anyone who you support financially” 
- [x] If Student Answers "yes" Display Question #2 
- [x] - New wording for question 2 “Are any of the dependants listed above supported by you financially but not under your sole custody? 
  - [x]  If ‘no’ selected is to Question 2, no further effect required.  (Same as current behaviour)
  -  [x] If ‘yes’ selected to question 2, then trigger exception path, document upload tool, etc.. (Same as current behaviour)
