### PR TITLE
#1910 - Student profile returns SIN

### DIFF
--- a/sources/packages/backend/apps/api/src/route-controllers/student/_tests_/e2e/student.students.controller.getStudentProfile.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/student/_tests_/e2e/student.students.controller.getStudentProfile.e2e-spec.ts
@@ -64,7 +64,6 @@ describe("StudentInstitutionsController(e2e)-getStudentProfile", () => {
         },
         disabilityStatus: student.disabilityStatus,
         validSin: student.sinValidation.isValidSIN,
-        sin: student.sinValidation.sin,
       });
   });
 

--- a/sources/packages/backend/apps/api/src/route-controllers/student/models/student.dto.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/student/models/student.dto.ts
@@ -181,10 +181,13 @@ export class StudentProfileAPIOutDTO {
   contact: ContactInformationAPIOutDTO;
   validSin: boolean;
   disabilityStatus: DisabilityStatus;
+}
+
+export class SensitiveDataStudentProfileAPIOutDTO extends StudentProfileAPIOutDTO {
   sin: string;
 }
 
-export class AESTStudentProfileAPIOutDTO extends StudentProfileAPIOutDTO {
+export class AESTStudentProfileAPIOutDTO extends SensitiveDataStudentProfileAPIOutDTO {
   hasRestriction: boolean;
 }
 

--- a/sources/packages/backend/apps/api/src/route-controllers/student/models/student.dto.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/student/models/student.dto.ts
@@ -183,9 +183,11 @@ export class StudentProfileAPIOutDTO {
   disabilityStatus: DisabilityStatus;
 }
 
-export class SensitiveDataStudentProfileAPIOutDTO extends StudentProfileAPIOutDTO {
+class SensitiveDataStudentProfileAPIOutDTO extends StudentProfileAPIOutDTO {
   sin: string;
 }
+
+export class InstitutionStudentProfileAPIOutDTO extends SensitiveDataStudentProfileAPIOutDTO {}
 
 export class AESTStudentProfileAPIOutDTO extends SensitiveDataStudentProfileAPIOutDTO {
   hasRestriction: boolean;

--- a/sources/packages/backend/apps/api/src/route-controllers/student/models/student.dto.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/student/models/student.dto.ts
@@ -183,13 +183,11 @@ export class StudentProfileAPIOutDTO {
   disabilityStatus: DisabilityStatus;
 }
 
-class SensitiveDataStudentProfileAPIOutDTO extends StudentProfileAPIOutDTO {
+export class InstitutionStudentProfileAPIOutDTO extends StudentProfileAPIOutDTO {
   sin: string;
 }
 
-export class InstitutionStudentProfileAPIOutDTO extends SensitiveDataStudentProfileAPIOutDTO {}
-
-export class AESTStudentProfileAPIOutDTO extends SensitiveDataStudentProfileAPIOutDTO {
+export class AESTStudentProfileAPIOutDTO extends InstitutionStudentProfileAPIOutDTO {
   hasRestriction: boolean;
 }
 

--- a/sources/packages/backend/apps/api/src/route-controllers/student/student.aest.controller.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/student/student.aest.controller.ts
@@ -48,7 +48,6 @@ import {
   SINValidationsAPIOutDTO,
   UniqueFileNameParamAPIInDTO,
   UpdateSINValidationAPIInDTO,
-  SensitiveDataStudentProfileAPIOutDTO,
 } from "./models/student.dto";
 import { Response } from "express";
 import { FileInterceptor } from "@nestjs/platform-express";

--- a/sources/packages/backend/apps/api/src/route-controllers/student/student.aest.controller.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/student/student.aest.controller.ts
@@ -48,6 +48,7 @@ import {
   SINValidationsAPIOutDTO,
   UniqueFileNameParamAPIInDTO,
   UpdateSINValidationAPIInDTO,
+  SensitiveDataStudentProfileAPIOutDTO,
 } from "./models/student.dto";
 import { Response } from "express";
 import { FileInterceptor } from "@nestjs/platform-express";
@@ -242,13 +243,18 @@ export class StudentAESTController extends BaseController {
     @Param("studentId", ParseIntPipe) studentId: number,
   ): Promise<AESTStudentProfileAPIOutDTO> {
     const [student, studentRestrictions] = await Promise.all([
-      this.studentControllerService.getStudentProfile(studentId),
+      this.studentControllerService.getStudentProfile(studentId, {
+        withSensitiveData: true,
+      }),
       this.studentRestrictionService.getStudentRestrictionsById(studentId, {
         onlyActive: true,
       }),
     ]);
 
-    return { ...student, hasRestriction: !!studentRestrictions.length };
+    return {
+      ...(student as SensitiveDataStudentProfileAPIOutDTO),
+      hasRestriction: !!studentRestrictions.length,
+    };
   }
 
   /**

--- a/sources/packages/backend/apps/api/src/route-controllers/student/student.aest.controller.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/student/student.aest.controller.ts
@@ -252,7 +252,7 @@ export class StudentAESTController extends BaseController {
     ]);
 
     return {
-      ...(student as SensitiveDataStudentProfileAPIOutDTO),
+      ...student,
       hasRestriction: !!studentRestrictions.length,
     };
   }

--- a/sources/packages/backend/apps/api/src/route-controllers/student/student.controller.service.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/student/student.controller.service.ts
@@ -20,7 +20,7 @@ import {
   StudentProfileAPIOutDTO,
   StudentFileDetailsAPIOutDTO,
   StudentUploadFileAPIOutDTO,
-  SensitiveDataStudentProfileAPIOutDTO,
+  InstitutionStudentProfileAPIOutDTO,
 } from "./models/student.dto";
 import { transformAddressDetailsForAddressBlockForm } from "../utils/address-utils";
 
@@ -125,7 +125,7 @@ export class StudentControllerService {
   async getStudentProfile(
     studentId: number,
     options: { withSensitiveData: true },
-  ): Promise<SensitiveDataStudentProfileAPIOutDTO>;
+  ): Promise<InstitutionStudentProfileAPIOutDTO>;
   /**
    * Get the student information that represents the profile.
    * @param studentId student id to retrieve the data.
@@ -136,7 +136,7 @@ export class StudentControllerService {
   async getStudentProfile(
     studentId: number,
     options?: { withSensitiveData: true },
-  ): Promise<StudentProfileAPIOutDTO | SensitiveDataStudentProfileAPIOutDTO> {
+  ): Promise<StudentProfileAPIOutDTO | InstitutionStudentProfileAPIOutDTO> {
     const student = await this.studentService.getStudentById(studentId);
     if (!student) {
       throw new NotFoundException("Student not found.");

--- a/sources/packages/backend/apps/api/src/route-controllers/student/student.controller.service.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/student/student.controller.service.ts
@@ -20,6 +20,7 @@ import {
   StudentProfileAPIOutDTO,
   StudentFileDetailsAPIOutDTO,
   StudentUploadFileAPIOutDTO,
+  SensitiveDataStudentProfileAPIOutDTO,
 } from "./models/student.dto";
 import { transformAddressDetailsForAddressBlockForm } from "../utils/address-utils";
 
@@ -113,14 +114,17 @@ export class StudentControllerService {
    * @param studentId student id to retrieve the data.
    * @returns student profile details.
    */
-  async getStudentProfile(studentId: number): Promise<StudentProfileAPIOutDTO> {
+  async getStudentProfile(
+    studentId: number,
+    options?: { withSensitiveData: boolean },
+  ): Promise<StudentProfileAPIOutDTO | SensitiveDataStudentProfileAPIOutDTO> {
     const student = await this.studentService.getStudentById(studentId);
     if (!student) {
       throw new NotFoundException("Student not found.");
     }
 
     const address = student.contactInfo.address ?? ({} as AddressInfo);
-    return {
+    const studentProfile = {
       firstName: student.user.firstName,
       lastName: student.user.lastName,
       fullName: getUserFullName(student.user),
@@ -133,8 +137,12 @@ export class StudentControllerService {
       },
       disabilityStatus: student.disabilityStatus,
       validSin: student.sinValidation.isValidSIN,
-      sin: student.sinValidation.sin,
     };
+
+    if (options?.withSensitiveData) {
+      return { ...studentProfile, sin: student.sinValidation.sin };
+    }
+    return studentProfile;
   }
 
   /**

--- a/sources/packages/backend/apps/api/src/route-controllers/student/student.controller.service.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/student/student.controller.service.ts
@@ -112,6 +112,8 @@ export class StudentControllerService {
   /**
    * Get the student information that represents the profile.
    * @param studentId student id to retrieve the data.
+   * @param options options:
+   * - `withSensitiveData` boolean option to return sensitive data such as SIN.
    * @returns student profile details.
    */
   async getStudentProfile(

--- a/sources/packages/backend/apps/api/src/route-controllers/student/student.controller.service.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/student/student.controller.service.ts
@@ -124,7 +124,7 @@ export class StudentControllerService {
    */
   async getStudentProfile(
     studentId: number,
-    options: { withSensitiveData: boolean },
+    options: { withSensitiveData: true },
   ): Promise<SensitiveDataStudentProfileAPIOutDTO>;
   /**
    * Get the student information that represents the profile.
@@ -135,7 +135,7 @@ export class StudentControllerService {
    */
   async getStudentProfile(
     studentId: number,
-    options?: { withSensitiveData: boolean },
+    options?: { withSensitiveData: true },
   ): Promise<StudentProfileAPIOutDTO | SensitiveDataStudentProfileAPIOutDTO> {
     const student = await this.studentService.getStudentById(studentId);
     if (!student) {

--- a/sources/packages/backend/apps/api/src/route-controllers/student/student.controller.service.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/student/student.controller.service.ts
@@ -112,6 +112,23 @@ export class StudentControllerService {
   /**
    * Get the student information that represents the profile.
    * @param studentId student id to retrieve the data.
+   * @returns student profile details.
+   */
+  async getStudentProfile(studentId: number): Promise<StudentProfileAPIOutDTO>;
+  /**
+   * Get the student information that represents the profile.
+   * @param studentId student id to retrieve the data.
+   * @param options options:
+   * - `withSensitiveData` boolean option to return sensitive data such as SIN.
+   * @returns student profile details.
+   */
+  async getStudentProfile(
+    studentId: number,
+    options: { withSensitiveData: boolean },
+  ): Promise<SensitiveDataStudentProfileAPIOutDTO>;
+  /**
+   * Get the student information that represents the profile.
+   * @param studentId student id to retrieve the data.
    * @param options options:
    * - `withSensitiveData` boolean option to return sensitive data such as SIN.
    * @returns student profile details.

--- a/sources/packages/backend/apps/api/src/route-controllers/student/student.institutions.controller.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/student/student.institutions.controller.ts
@@ -82,7 +82,9 @@ export class StudentInstitutionsController extends BaseController {
   async getStudentProfile(
     @Param("studentId", ParseIntPipe) studentId: number,
   ): Promise<StudentProfileAPIOutDTO> {
-    return this.studentControllerService.getStudentProfile(studentId);
+    return this.studentControllerService.getStudentProfile(studentId, {
+      withSensitiveData: true,
+    });
   }
 
   /**

--- a/sources/packages/web/src/components/common/students/StudentProfile.vue
+++ b/sources/packages/web/src/components/common/students/StudentProfile.vue
@@ -98,8 +98,15 @@
 import { onMounted, ref, defineComponent } from "vue";
 import { StudentService } from "@/services/StudentService";
 import { useFormatters } from "@/composables";
-import { StudentProfile } from "@/types";
 import { AddressAPIOutDTO } from "@/services/http/dto";
+import { StudentProfile } from "@/types";
+
+/**
+ *  Used to combine institution and ministry DTOs and make SIN explicitly mandatory.
+ */
+interface SharedStudentProfile extends Omit<StudentProfile, "sin"> {
+  sin: string;
+}
 
 export default defineComponent({
   props: {
@@ -109,13 +116,13 @@ export default defineComponent({
     },
   },
   setup(props) {
-    const studentDetail = ref({} as StudentProfile);
+    const studentDetail = ref({} as SharedStudentProfile);
     const address = ref({} as AddressAPIOutDTO);
     const { sinDisplayFormat, emptyStringFiller } = useFormatters();
     onMounted(async () => {
-      studentDetail.value = await StudentService.shared.getStudentProfile(
+      studentDetail.value = (await StudentService.shared.getStudentProfile(
         props.studentId,
-      );
+      )) as SharedStudentProfile;
       address.value = studentDetail.value.contact.address;
     });
     return {

--- a/sources/packages/web/src/services/http/StudentApi.ts
+++ b/sources/packages/web/src/services/http/StudentApi.ts
@@ -12,6 +12,8 @@ import {
   CreateSINValidationAPIInDTO,
   UpdateSINValidationAPIInDTO,
   SearchStudentAPIInDTO,
+  InstitutionStudentProfileAPIOutDTO,
+  AESTStudentProfileAPIOutDTO,
 } from "@/services/http/dto";
 
 export class StudentApi extends HttpBaseClient {
@@ -45,10 +47,12 @@ export class StudentApi extends HttpBaseClient {
    */
   async getStudentProfile(
     studentId?: number,
-  ): Promise<StudentProfileAPIOutDTO> {
-    return this.getCall<StudentProfileAPIOutDTO>(
-      this.addClientRoot(`student/${studentId ?? ""}`),
-    );
+  ): Promise<
+    | StudentProfileAPIOutDTO
+    | InstitutionStudentProfileAPIOutDTO
+    | AESTStudentProfileAPIOutDTO
+  > {
+    return this.getCall(this.addClientRoot(`student/${studentId ?? ""}`));
   }
 
   /**

--- a/sources/packages/web/src/services/http/dto/Student.dto.ts
+++ b/sources/packages/web/src/services/http/dto/Student.dto.ts
@@ -44,9 +44,17 @@ export interface StudentProfileAPIOutDTO {
   contact: ContactInformationAPIOutDTO;
   validSin: boolean;
   disabilityStatus: DisabilityStatus;
-  sin: string;
   sinConsent: boolean;
-  hasRestriction?: boolean;
+}
+
+export interface InstitutionStudentProfileAPIOutDTO
+  extends StudentProfileAPIOutDTO {
+  sin: string;
+}
+
+export interface AESTStudentProfileAPIOutDTO
+  extends InstitutionStudentProfileAPIOutDTO {
+  hasRestriction: boolean;
 }
 
 /**

--- a/sources/packages/web/src/types/contracts/StudentContract.ts
+++ b/sources/packages/web/src/types/contracts/StudentContract.ts
@@ -1,13 +1,20 @@
 import {
   AddressDetailsFormAPIDTO,
+  AESTStudentProfileAPIOutDTO,
+  InstitutionStudentProfileAPIOutDTO,
   SINValidationsAPIOutDTO,
   StudentProfileAPIOutDTO,
 } from "@/services/http/dto";
 import { IdentityProviders } from "@/types";
 
-export interface StudentProfile extends StudentProfileAPIOutDTO {
-  birthDateFormatted: string;
-}
+export type StudentProfile =
+  | (
+      | StudentProfileAPIOutDTO
+      | InstitutionStudentProfileAPIOutDTO
+      | AESTStudentProfileAPIOutDTO
+    ) & {
+      birthDateFormatted: string;
+    };
 
 /**
  * Disability status of student.

--- a/sources/packages/web/src/views/aest/student/StudentDetails.vue
+++ b/sources/packages/web/src/views/aest/student/StudentDetails.vue
@@ -40,7 +40,8 @@ import { onMounted, ref, defineComponent } from "vue";
 import { StudentService } from "@/services/StudentService";
 import { AESTRoutesConst } from "@/constants/routes/RouteConstants";
 import StudentRestrictionChip from "@/components/generic/StudentRestrictionChip.vue";
-import { StudentRestrictionStatus, StudentProfile } from "@/types";
+import { StudentRestrictionStatus } from "@/types";
+import { AESTStudentProfileAPIOutDTO } from "@/services/http/dto";
 
 export default defineComponent({
   components: { StudentRestrictionChip },
@@ -51,7 +52,7 @@ export default defineComponent({
     },
   },
   setup(props) {
-    const studentDetails = ref({} as StudentProfile);
+    const studentDetails = ref({} as AESTStudentProfileAPIOutDTO);
     const items = ref([
       {
         label: "Profile",
@@ -112,9 +113,9 @@ export default defineComponent({
     ]);
 
     onMounted(async () => {
-      studentDetails.value = await StudentService.shared.getStudentProfile(
+      studentDetails.value = (await StudentService.shared.getStudentProfile(
         props.studentId,
-      );
+      )) as AESTStudentProfileAPIOutDTO;
     });
 
     return {


### PR DESCRIPTION
- Added a new DTO to contain sensitive data and changed the logic to make the student api to not bring the SIN data.
- Removed the SIN property from the student profile retrieved by the student.

## Student view
![image](https://github.com/bcgov/SIMS/assets/78114138/2c09f546-1ccb-4994-bd9a-e6f68cc95e01)

## Institution view
![image](https://github.com/bcgov/SIMS/assets/78114138/8e689189-672a-4eaa-9383-0a14d8bf0df1)

## Ministry view
![image](https://github.com/bcgov/SIMS/assets/78114138/db71230f-4d84-4530-8bea-1cb38aa1a5e7)
