### PR TITLE
#2349 - Clicking institution name in offering change request view should navigate to institution profile

### DIFF
--- a/sources/packages/backend/apps/api/src/route-controllers/education-program-offering/education-program-offering.controller.service.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/education-program-offering/education-program-offering.controller.service.ts
@@ -334,6 +334,7 @@ export class EducationProgramOfferingControllerService {
       precedingOfferingId: offering.precedingOffering?.id,
       offeringType: offering.offeringType,
       locationName: offering.institutionLocation.name,
+      institutionId: offering.institutionLocation.institution.id,
       institutionName: offering.institutionLocation.institution.operatingName,
       assessedBy: getUserFullName(offering.assessedBy),
       assessedDate: offering.assessedDate,

--- a/sources/packages/backend/apps/api/src/route-controllers/education-program-offering/models/education-program-offering.dto.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/education-program-offering/models/education-program-offering.dto.ts
@@ -125,8 +125,9 @@ export class EducationProgramOfferingAPIOutDTO {
   submittedDate: Date;
   courseLoad?: number;
   hasExistingApplication?: boolean;
-  locationName?: string;
-  institutionName?: string;
+  locationName: string;
+  institutionId: number;
+  institutionName: string;
   validationWarnings: string[];
   validationInfos: string[];
 }

--- a/sources/packages/web/src/services/http/dto/EducationProgramOffering.dto.ts
+++ b/sources/packages/web/src/services/http/dto/EducationProgramOffering.dto.ts
@@ -132,8 +132,9 @@ export interface EducationProgramOfferingAPIOutDTO {
   submittedDate: Date;
   courseLoad?: number;
   hasExistingApplication?: boolean;
-  locationName?: string;
-  institutionName?: string;
+  locationName: string;
+  institutionId: number;
+  institutionName: string;
   validationWarnings: string[];
   validationInfos: string[];
 }

--- a/sources/packages/web/src/types/contracts/EducationProgram.ts
+++ b/sources/packages/web/src/types/contracts/EducationProgram.ts
@@ -50,14 +50,14 @@ export class EntranceRequirements {
 }
 
 export interface ProgramOfferingHeader {
-  institutionId?: number;
-  institutionName?: string;
+  institutionId: number;
+  institutionName: string;
   submittedDate: Date;
   status: ProgramStatus | OfferingStatus;
   assessedBy?: string;
   assessedDate?: Date;
   effectiveEndDate?: Date; // This field is only for programs.
-  locationName?: string; // This field is offering specific.
+  locationName: string; // This field is offering specific.
 }
 
 export interface ProgramOfferingApprovalLabels {

--- a/sources/packages/web/src/views/aest/institution/ProgramDetails.vue
+++ b/sources/packages/web/src/views/aest/institution/ProgramDetails.vue
@@ -35,7 +35,6 @@
       class="m-4"
       :headerDetails="{
         ...educationProgram,
-        institutionId: institutionId,
         status: educationProgram.programStatus,
       }"
     />

--- a/sources/packages/web/src/views/aest/institution/ViewOffering.vue
+++ b/sources/packages/web/src/views/aest/institution/ViewOffering.vue
@@ -36,7 +36,6 @@
         :headerDetails="{
           ...initialData,
           status: initialData.offeringStatus,
-          institutionId: institutionId,
         }"
       />
     </template>

--- a/sources/packages/web/src/views/aest/institution/ViewOfferingChangeRequest.vue
+++ b/sources/packages/web/src/views/aest/institution/ViewOfferingChangeRequest.vue
@@ -114,6 +114,7 @@ export default defineComponent({
           props.offeringId,
         );
       headerDetails.value = {
+        institutionId: offering.value.institutionId,
         institutionName: offering.value.institutionName,
         submittedDate: offering.value.submittedDate,
         status: offering.value.offeringStatus,

--- a/sources/packages/web/src/views/aest/institution/ViewOfferingChangeRequestComplete.vue
+++ b/sources/packages/web/src/views/aest/institution/ViewOfferingChangeRequestComplete.vue
@@ -71,6 +71,7 @@ export default defineComponent({
           props.offeringId,
         );
       headerDetails.value = {
+        institutionId: offering.institutionId,
         institutionName: offering.institutionName,
         submittedDate: offering.submittedDate,
         status: offering.offeringStatus,

--- a/sources/packages/web/src/views/institution/locations/offerings/OfferingEdit.vue
+++ b/sources/packages/web/src/views/institution/locations/offerings/OfferingEdit.vue
@@ -56,7 +56,6 @@
         :headerDetails="{
           ...initialData,
           status: initialData.offeringStatus,
-          institutionId: institutionId,
         }"
       />
     </template>

--- a/sources/packages/web/src/views/institution/locations/offerings/OfferingRequestChange.vue
+++ b/sources/packages/web/src/views/institution/locations/offerings/OfferingRequestChange.vue
@@ -12,7 +12,6 @@
         :headerDetails="{
           ...initialData,
           status: initialData.offeringStatus,
-          institutionId: institutionId,
         }"
       />
     </template>

--- a/sources/packages/web/src/views/institution/locations/programs/LocationProgramView.vue
+++ b/sources/packages/web/src/views/institution/locations/programs/LocationProgramView.vue
@@ -15,7 +15,6 @@
       <program-offering-detail-header
         :headerDetails="{
           ...educationProgram,
-          institutionId: institutionId,
           status: educationProgram.programStatus,
         }"
       />


### PR DESCRIPTION
As a part of this PR, the following bug was fixed:

- [x] Clicking on the Institution Name does not navigate to the Institution Profile
- [x] Changed `institutionId`, `institutionName` and `locationName` properties from optional to mandatory in the DTOs.

**Issue:** The institution id was not being returned by the API and therefore clicking on the Institution Name did not navigate to the Institution Profile

**Fix:** The institution id was added to the `EducationProgramAPIOutDTO` and the web was adjusted to fix the issue.

Screenshot:

<img width="1920" alt="image" src="https://github.com/bcgov/SIMS/assets/7859295/bcc5b276-22fd-4c15-bbf2-2ec80f3fb2cb">

Clicking on the above highlighted Institution Name link takes to the below shown Institution Profile view.

<img width="1920" alt="image" src="https://github.com/bcgov/SIMS/assets/7859295/2aa44f11-897b-4fae-8492-cddba6f11167">
