### PR TITLE
#1807 - Fix css style for dividers (<hr />)

### DIFF
--- a/sources/packages/web/src/components/aest/institution/modals/ApproveDenyDesignationModal.vue
+++ b/sources/packages/web/src/components/aest/institution/modals/ApproveDenyDesignationModal.vue
@@ -26,7 +26,7 @@
                 variant="outlined"
                 :rules="[checkStringDateFormatRule]"
                 hide-details="auto" /></v-col></v-row
-          ><v-divider></v-divider>
+          ><v-divider class="border-opacity-100" :thickness="2" />
           <h4 class="label-bold color-blue">Designate locations</h4>
           <v-row
             v-for="(item, index) in formModel.locationsDesignations"

--- a/sources/packages/web/src/components/common/restriction/ViewRestriction.vue
+++ b/sources/packages/web/src/components/common/restriction/ViewRestriction.vue
@@ -38,7 +38,7 @@
           ></v-row>
         </content-group>
         <template v-if="showResolution">
-          <v-divider></v-divider>
+          <v-divider class="border-opacity-100" :thickness="2" />
           <h3 class="category-header-medium mb-5">Resolution</h3>
           <v-textarea
             v-if="allowUserToEdit"

--- a/sources/packages/web/src/components/generic/ModalDialogBase.vue
+++ b/sources/packages/web/src/components/generic/ModalDialogBase.vue
@@ -19,12 +19,13 @@
           </h2>
         </slot>
       </v-card-title>
-      <v-divider class="mx-6 mt-1 mb-4"></v-divider>
+      <v-divider class="border-opacity-100" :thickness="2" inset />
       <v-card-text class="pt-0">
         <div class="pb-2" v-if="subTitle">{{ subTitle }}</div>
         <slot name="content">Please add the modal content here!</slot>
       </v-card-text>
-      <hr class="mx-6 mt-0 horizontal-divider" />
+      <v-divider class="border-opacity-100" :thickness="2" inset />
+
       <v-card-actions>
         <v-spacer></v-spacer>
         <div class="mx-4 mb-2">

--- a/sources/packages/web/src/views/aest/institution/Profile.vue
+++ b/sources/packages/web/src/views/aest/institution/Profile.vue
@@ -41,7 +41,7 @@
               :propertyValue="institutionProfileDetail.establishedDate"
             />
           </v-col>
-          <v-divider class="mx-4" vertical></v-divider>
+          <v-divider :thickness="2" vertical />
           <v-col>
             <title-value
               propertyTitle="Legal operating name"

--- a/sources/packages/web/src/views/institution/OfferingsUpload.vue
+++ b/sources/packages/web/src/views/institution/OfferingsUpload.vue
@@ -53,7 +53,7 @@
           to "{{ OfferingStatus.Approved }}"
         </li>
       </ul>
-      <v-divider />
+      <v-divider class="border-opacity-100" :thickness="2" />
       <v-form ref="uploadForm">
         <v-row class="m-0 p-0">
           <v-file-input

--- a/sources/packages/web/src/views/institution/WithdrawalUpload.vue
+++ b/sources/packages/web/src/views/institution/WithdrawalUpload.vue
@@ -47,7 +47,7 @@
           When clicking "Validate" any warnings will produce a list below.
         </li>
       </ul>
-      <v-divider />
+      <v-divider class="border-opacity-100" :thickness="2" />
       <v-form ref="uploadForm">
         <v-row class="m-0 p-0">
           <v-file-input

--- a/sources/packages/web/src/views/institution/locations/confirmation-of-enrollment/ApplicationDetailsForCOE.vue
+++ b/sources/packages/web/src/views/institution/locations/confirmation-of-enrollment/ApplicationDetailsForCOE.vue
@@ -36,6 +36,8 @@
                   </v-list-item-title>
                 </v-list-item>
                 <v-divider
+                  class="border-opacity-100"
+                  :thickness="2"
                   v-if="index < items.length - 1"
                   :key="index"
                   inset

--- a/sources/packages/web/src/views/institution/locations/offerings/OfferingEdit.vue
+++ b/sources/packages/web/src/views/institution/locations/offerings/OfferingEdit.vue
@@ -31,6 +31,8 @@
                     </v-list-item-title>
                   </v-list-item>
                   <v-divider
+                    class="border-opacity-100"
+                    :thickness="2"
                     v-if="index < items.length - 1"
                     :key="index"
                     inset

--- a/sources/packages/web/src/views/student/AppStudent.vue
+++ b/sources/packages/web/src/views/student/AppStudent.vue
@@ -79,6 +79,8 @@
                 </v-list-item-title>
               </v-list-item>
               <v-divider
+                class="border-opacity-100"
+                :thickness="2"
                 v-if="index < menuItems.length - 1"
                 :key="index"
                 inset

--- a/sources/packages/web/src/views/student/StudentApplicationDetails.vue
+++ b/sources/packages/web/src/views/student/StudentApplicationDetails.vue
@@ -34,6 +34,8 @@
                   </v-list-item-title>
                 </v-list-item>
                 <v-divider
+                  class="border-opacity-100"
+                  :thickness="2"
                   v-if="index < items.length - 1"
                   :key="index"
                   inset


### PR DESCRIPTION
- There were some new properties and classes for v-divider in Vuetify 3, added those properties for all `v-divider` for the fix. 
- The default opacity of the divider is `--v-border-opacity: 0.12;` updated it to `--v-border-opacity: 1 `
- Tried to make it as close to Figma
![image](https://github.com/bcgov/SIMS/assets/77353155/fbebb8d4-5ac1-4d7e-b25c-639c755e8314)
https://vuetifyjs.com/en/components/dividers/
**Screenshots**
![image](https://github.com/bcgov/SIMS/assets/77353155/a6a79eca-0ec4-4d42-88a2-deabec1025d9)
![image](https://github.com/bcgov/SIMS/assets/77353155/7a1c4182-4c51-42e7-ac3f-2982601c670a)
![image](https://github.com/bcgov/SIMS/assets/77353155/23e47017-eacb-4cd4-98b1-d720398e00c1)
![image](https://github.com/bcgov/SIMS/assets/77353155/a878cf81-060a-48af-94d0-dca8740305d8)
![image](https://github.com/bcgov/SIMS/assets/77353155/268e16a6-5b43-47b4-9b95-af6ece43fd30)
![image](https://github.com/bcgov/SIMS/assets/77353155/c7e04720-d8bf-4be8-9da9-8349400cbc82)
![image](https://github.com/bcgov/SIMS/assets/77353155/50bdb5b8-a52b-45af-9ed6-c5540f97d438)
![image](https://github.com/bcgov/SIMS/assets/77353155/77d1bf03-d18c-4f77-94a5-69a9830612ce)
![image](https://github.com/bcgov/SIMS/assets/77353155/2f761e39-4314-4da4-97e9-234b9d5e4706)
