### PR TITLE
#1981 - Request Offering Change: Ministry View/Approve/Deny (UI only) - Part 1

### DIFF
--- a/sources/packages/backend/apps/api/src/route-controllers/application-offering-change-request/application-offering-change-request.aest.controller.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/application-offering-change-request/application-offering-change-request.aest.controller.ts
@@ -1,4 +1,12 @@
-import { Controller, Get, Param, ParseIntPipe, Query } from "@nestjs/common";
+import {
+  Body,
+  Controller,
+  Get,
+  Param,
+  ParseIntPipe,
+  Patch,
+  Query,
+} from "@nestjs/common";
 import { ApiNotFoundResponse, ApiTags } from "@nestjs/swagger";
 import { AuthorizedParties } from "../../auth/authorized-parties.enum";
 import { AllowAuthorizedParty, Groups } from "../../auth/decorators";
@@ -9,6 +17,7 @@ import {
   AllInProgressOfferingChangePaginationOptionsAPIInDTO,
   AllInProgressApplicationOfferingChangesAPIOutDTO,
   ApplicationOfferingChangeDetailsAPIOutDTO,
+  ApplicationOfferingChangeAssessmentAPIInDTO,
 } from "./models/application-offering-change-request.dto";
 import { ApplicationOfferingChangeRequestService } from "../../services";
 import { ApplicationOfferingChangeRequestStatus } from "@sims/sims-db";
@@ -90,5 +99,21 @@ export class ApplicationOfferingChangeRequestAESTController extends BaseControll
       applicationOfferingChangeRequestId,
       { hasAuditAndNoteDetails: true },
     );
+  }
+
+  /**
+   * Updates an application offering change request.
+   * @param applicationOfferingChangeRequestId application offering change request id.
+   * @param payload information to update the application offering change request.
+   */
+  @Patch(":applicationOfferingChangeRequestId")
+  async updateApplicationOfferingChangeRequest(
+    @Param("applicationOfferingChangeRequestId", ParseIntPipe)
+    applicationOfferingChangeRequestId: number,
+    @Body()
+    payload: ApplicationOfferingChangeAssessmentAPIInDTO,
+  ): Promise<void> {
+    // TODO: API to be done in the next PR.
+    console.log(applicationOfferingChangeRequestId, payload);
   }
 }

--- a/sources/packages/backend/apps/api/src/route-controllers/application-offering-change-request/application-offering-change-request.aest.controller.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/application-offering-change-request/application-offering-change-request.aest.controller.ts
@@ -114,6 +114,5 @@ export class ApplicationOfferingChangeRequestAESTController extends BaseControll
     payload: ApplicationOfferingChangeAssessmentAPIInDTO,
   ): Promise<void> {
     // TODO: API to be done in the next PR.
-    console.log(applicationOfferingChangeRequestId, payload);
   }
 }

--- a/sources/packages/backend/apps/api/src/route-controllers/application-offering-change-request/application-offering-change-request.aest.controller.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/application-offering-change-request/application-offering-change-request.aest.controller.ts
@@ -102,7 +102,7 @@ export class ApplicationOfferingChangeRequestAESTController extends BaseControll
   }
 
   /**
-   * Updates an application offering change request.
+   * Approves or declines an application offering change request.
    * @param applicationOfferingChangeRequestId application offering change request id.
    * @param payload information to update the application offering change request.
    */
@@ -113,6 +113,6 @@ export class ApplicationOfferingChangeRequestAESTController extends BaseControll
     @Body()
     payload: ApplicationOfferingChangeAssessmentAPIInDTO,
   ): Promise<void> {
-    // TODO: API to be done in the next PR.
+    // TODO: API including the addition of ministry role to be done in the next PR.
   }
 }

--- a/sources/packages/backend/apps/api/src/route-controllers/application-offering-change-request/models/application-offering-change-request.dto.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/application-offering-change-request/models/application-offering-change-request.dto.ts
@@ -1,5 +1,6 @@
 import {
   ApplicationOfferingChangeRequestStatus,
+  NOTE_MAX_LENGTH,
   OfferingIntensity,
   REASON_MAX_LENGTH,
 } from "@sims/sims-db";
@@ -169,6 +170,14 @@ export class StudentApplicationOfferingChangeRequestAPIInDTO {
       ApplicationOfferingChangeRequestStatus.InProgressWithSABC,
   )
   studentConsent: boolean;
+  @IsEnum(ApplicationOfferingChangeRequestStatus)
+  applicationOfferingChangeRequestStatus: ApplicationOfferingChangeRequestStatus;
+}
+
+export class ApplicationOfferingChangeAssessmentAPIInDTO {
+  @IsNotEmpty()
+  @MaxLength(NOTE_MAX_LENGTH)
+  note: string;
   @IsEnum(ApplicationOfferingChangeRequestStatus)
   applicationOfferingChangeRequestStatus: ApplicationOfferingChangeRequestStatus;
 }

--- a/sources/packages/backend/apps/api/src/route-controllers/application-offering-change-request/models/application-offering-change-request.dto.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/application-offering-change-request/models/application-offering-change-request.dto.ts
@@ -1,6 +1,6 @@
 import {
   ApplicationOfferingChangeRequestStatus,
-  NOTE_MAX_LENGTH,
+  NOTE_DESCRIPTION_MAX_LENGTH,
   OfferingIntensity,
   REASON_MAX_LENGTH,
 } from "@sims/sims-db";
@@ -176,9 +176,12 @@ export class StudentApplicationOfferingChangeRequestAPIInDTO {
 
 export class ApplicationOfferingChangeAssessmentAPIInDTO {
   @IsNotEmpty()
-  @MaxLength(NOTE_MAX_LENGTH)
+  @MaxLength(NOTE_DESCRIPTION_MAX_LENGTH)
   note: string;
-  @IsEnum(ApplicationOfferingChangeRequestStatus)
+  @IsIn([
+    ApplicationOfferingChangeRequestStatus.Approved,
+    ApplicationOfferingChangeRequestStatus.DeclinedBySABC,
+  ])
   applicationOfferingChangeRequestStatus: ApplicationOfferingChangeRequestStatus;
 }
 

--- a/sources/packages/backend/libs/sims-db/src/entities/application-offering-change-request.model.ts
+++ b/sources/packages/backend/libs/sims-db/src/entities/application-offering-change-request.model.ts
@@ -15,6 +15,7 @@ import { Note } from "./note.model";
 import { ApplicationOfferingChangeRequestStatus } from "./application-offering-change-request-status.type";
 
 export const REASON_MAX_LENGTH = 500;
+export const NOTE_MAX_LENGTH = 500;
 /**
  * Represents the list of application specific offering change request,
  * which is requested by institution.

--- a/sources/packages/backend/libs/sims-db/src/entities/application-offering-change-request.model.ts
+++ b/sources/packages/backend/libs/sims-db/src/entities/application-offering-change-request.model.ts
@@ -15,7 +15,6 @@ import { Note } from "./note.model";
 import { ApplicationOfferingChangeRequestStatus } from "./application-offering-change-request-status.type";
 
 export const REASON_MAX_LENGTH = 500;
-export const NOTE_MAX_LENGTH = 500;
 /**
  * Represents the list of application specific offering change request,
  * which is requested by institution.

--- a/sources/packages/web/src/components/aest/AssessApplicationOfferingChangeRequestModal.vue
+++ b/sources/packages/web/src/components/aest/AssessApplicationOfferingChangeRequestModal.vue
@@ -1,6 +1,6 @@
 <template>
   <v-form ref="assessApplicationOfferingChangeRequestForm">
-    <modal-dialog-base :showDialog="showDialog" :title="title" :max-width="780">
+    <modal-dialog-base :showDialog="showDialog" :title="title">
       <template #content
         ><error-summary
           :errors="assessApplicationOfferingChangeRequestForm.errors"

--- a/sources/packages/web/src/components/aest/AssessApplicationOfferingChangeRequestModal.vue
+++ b/sources/packages/web/src/components/aest/AssessApplicationOfferingChangeRequestModal.vue
@@ -29,7 +29,7 @@
           :rules="[checkNotesLengthRule]"
           required
         />
-        <p class="pt-1">
+        <p class="pt-1 brand-gray-text">
           Notes will be visible to StudentAid staff and institutions. This will
           not be shown to students.
         </p>

--- a/sources/packages/web/src/components/aest/AssessApplicationOfferingChangeRequestModal.vue
+++ b/sources/packages/web/src/components/aest/AssessApplicationOfferingChangeRequestModal.vue
@@ -87,12 +87,16 @@ export default defineComponent({
       if (!validationResult.valid) {
         return;
       }
-      showParameter.value ===
-      ApplicationOfferingChangeRequestStatus.DeclinedBySABC
-        ? (assessApplicationOfferingChangeRequestModal.value.applicationOfferingChangeRequestStatus =
-            ApplicationOfferingChangeRequestStatus.DeclinedBySABC)
-        : (assessApplicationOfferingChangeRequestModal.value.applicationOfferingChangeRequestStatus =
-            ApplicationOfferingChangeRequestStatus.Approved);
+      if (
+        showParameter.value ===
+        ApplicationOfferingChangeRequestStatus.DeclinedBySABC
+      ) {
+        assessApplicationOfferingChangeRequestModal.value.applicationOfferingChangeRequestStatus =
+          ApplicationOfferingChangeRequestStatus.DeclinedBySABC;
+      } else {
+        assessApplicationOfferingChangeRequestModal.value.applicationOfferingChangeRequestStatus =
+          ApplicationOfferingChangeRequestStatus.Approved;
+      }
       assessApplicationOfferingChangeRequestModal.value.note = note.value;
       resolvePromise(assessApplicationOfferingChangeRequestModal.value);
       assessApplicationOfferingChangeRequestForm.value.reset();

--- a/sources/packages/web/src/components/aest/AssessApplicationOfferingChangeRequestModal.vue
+++ b/sources/packages/web/src/components/aest/AssessApplicationOfferingChangeRequestModal.vue
@@ -46,9 +46,8 @@ export default defineComponent({
     const note = ref("");
     const { showDialog, showModal, resolvePromise, showParameter } =
       useModalDialog<ApplicationOfferingChangeAssessmentAPIInDTO | boolean>();
-    const assessApplicationOfferingChangeRequestModal = ref(
-      {} as ApplicationOfferingChangeAssessmentAPIInDTO,
-    );
+    const assessApplicationOfferingChangeRequestModal =
+      {} as ApplicationOfferingChangeAssessmentAPIInDTO;
     const assessApplicationOfferingChangeRequestForm = ref({} as VForm);
     const { checkNotesLengthRule } = useRules();
     const title = computed(() =>
@@ -79,10 +78,10 @@ export default defineComponent({
       if (!validationResult.valid) {
         return;
       }
-      assessApplicationOfferingChangeRequestModal.value.applicationOfferingChangeRequestStatus =
+      assessApplicationOfferingChangeRequestModal.applicationOfferingChangeRequestStatus =
         showParameter.value;
-      assessApplicationOfferingChangeRequestModal.value.note = note.value;
-      resolvePromise(assessApplicationOfferingChangeRequestModal.value);
+      assessApplicationOfferingChangeRequestModal.note = note.value;
+      resolvePromise(assessApplicationOfferingChangeRequestModal);
       assessApplicationOfferingChangeRequestForm.value.reset();
     };
     return {

--- a/sources/packages/web/src/components/aest/AssessApplicationOfferingChangeRequestModal.vue
+++ b/sources/packages/web/src/components/aest/AssessApplicationOfferingChangeRequestModal.vue
@@ -9,7 +9,7 @@
         ><error-summary
           :errors="assessApplicationOfferingChangeRequestForm.errors"
         />
-        <p class="mt-4">
+        <p class="my-4">
           Outline the reasoning for
           <span
             v-if="
@@ -20,11 +20,10 @@
           ><span v-else>approving</span>
           this request. Please add the application number.
         </p>
-        <p class="label-bold my-2">Notes</p>
+        <p class="label-bold mb-1">Notes</p>
         <v-textarea
           variant="outlined"
           hide-details="auto"
-          class="my-2"
           v-model="note"
           :rules="[checkNotesLengthRule]"
           required

--- a/sources/packages/web/src/components/aest/AssessApplicationOfferingChangeRequestModal.vue
+++ b/sources/packages/web/src/components/aest/AssessApplicationOfferingChangeRequestModal.vue
@@ -1,0 +1,116 @@
+<template>
+  <v-form ref="assessApplicationOfferingChangeRequestForm">
+    <modal-dialog-base
+      :showDialog="showDialog"
+      :title="getTitle"
+      :max-width="780"
+    >
+      <template #content
+        ><error-summary
+          :errors="assessApplicationOfferingChangeRequestForm.errors"
+        />
+        <p class="mt-4">
+          Outline the reasoning for
+          <span
+            v-if="
+              showParameter ===
+              ApplicationOfferingChangeRequestStatus.DeclinedBySABC
+            "
+            >declining</span
+          ><span v-else>approving</span>
+          this request. Please add the application number.
+        </p>
+        <p class="label-bold my-2">Notes</p>
+        <v-textarea
+          variant="outlined"
+          hide-details="auto"
+          class="my-2"
+          v-model="note"
+          :rules="[checkNotesLengthRule]"
+          required
+        />
+        <p class="pt-1">
+          Notes will be visible to StudentAid staff and institutions. This will
+          not be shown to students.
+        </p>
+      </template>
+      <template #footer>
+        <footer-buttons
+          :primaryLabel="getPrimaryLabel"
+          @secondaryClick="cancel"
+          @primaryClick="assessChange"
+        />
+      </template>
+    </modal-dialog-base>
+  </v-form>
+</template>
+<script lang="ts">
+import ModalDialogBase from "@/components/generic/ModalDialogBase.vue";
+import { ref, defineComponent, computed } from "vue";
+import { useModalDialog, useRules } from "@/composables";
+import { ApplicationOfferingChangeAssessmentAPIInDTO } from "@/services/http/dto";
+import { ApplicationOfferingChangeRequestStatus, VForm } from "@/types";
+
+export default defineComponent({
+  components: {
+    ModalDialogBase,
+  },
+  setup() {
+    const note = ref("");
+    const { showDialog, showModal, resolvePromise, showParameter } =
+      useModalDialog<ApplicationOfferingChangeAssessmentAPIInDTO | boolean>();
+    const assessApplicationOfferingChangeRequestModal = ref(
+      {} as ApplicationOfferingChangeAssessmentAPIInDTO,
+    );
+    const assessApplicationOfferingChangeRequestForm = ref({} as VForm);
+    const { checkNotesLengthRule } = useRules();
+    const getTitle = computed(() =>
+      showParameter.value ===
+      ApplicationOfferingChangeRequestStatus.DeclinedBySABC
+        ? "Decline for reassessment"
+        : "Approve for reassessment",
+    );
+    const getPrimaryLabel = computed(() =>
+      showParameter.value ===
+      ApplicationOfferingChangeRequestStatus.DeclinedBySABC
+        ? "Decline now"
+        : "Approve now",
+    );
+    const cancel = () => {
+      assessApplicationOfferingChangeRequestForm.value.reset();
+      assessApplicationOfferingChangeRequestForm.value.resetValidation();
+      resolvePromise(false);
+    };
+    const assessChange = async () => {
+      const validationResult =
+        await assessApplicationOfferingChangeRequestForm.value.validate();
+      if (!validationResult.valid) {
+        return;
+      }
+      showParameter.value ===
+      ApplicationOfferingChangeRequestStatus.DeclinedBySABC
+        ? (assessApplicationOfferingChangeRequestModal.value.applicationOfferingChangeRequestStatus =
+            ApplicationOfferingChangeRequestStatus.DeclinedBySABC)
+        : (assessApplicationOfferingChangeRequestModal.value.applicationOfferingChangeRequestStatus =
+            ApplicationOfferingChangeRequestStatus.Approved);
+      assessApplicationOfferingChangeRequestModal.value.note = note.value;
+      resolvePromise(assessApplicationOfferingChangeRequestModal.value);
+      assessApplicationOfferingChangeRequestForm.value.reset();
+    };
+    return {
+      showDialog,
+      showModal,
+      showParameter,
+      cancel,
+      assessChange,
+      note,
+      getTitle,
+      getPrimaryLabel,
+      checkNotesLengthRule,
+      ApplicationOfferingChangeRequestStatus,
+      assessApplicationOfferingChangeRequestForm,
+      assessApplicationOfferingChangeRequestModal,
+    };
+  },
+});
+</script>

--- a/sources/packages/web/src/components/aest/AssessApplicationOfferingChangeRequestModal.vue
+++ b/sources/packages/web/src/components/aest/AssessApplicationOfferingChangeRequestModal.vue
@@ -1,27 +1,15 @@
 <template>
   <v-form ref="assessApplicationOfferingChangeRequestForm">
-    <modal-dialog-base
-      :showDialog="showDialog"
-      :title="getTitle"
-      :max-width="780"
-    >
+    <modal-dialog-base :showDialog="showDialog" :title="title" :max-width="780">
       <template #content
         ><error-summary
           :errors="assessApplicationOfferingChangeRequestForm.errors"
         />
         <p class="my-4">
-          Outline the reasoning for
-          <span
-            v-if="
-              showParameter ===
-              ApplicationOfferingChangeRequestStatus.DeclinedBySABC
-            "
-            >declining</span
-          ><span v-else>approving</span>
-          this request. Please add the application number.
+          {{ subject }}
         </p>
-        <p class="label-bold mb-1">Notes</p>
         <v-textarea
+          label="Notes"
           variant="outlined"
           hide-details="auto"
           v-model="note"
@@ -35,7 +23,7 @@
       </template>
       <template #footer>
         <footer-buttons
-          :primaryLabel="getPrimaryLabel"
+          :primaryLabel="primaryLabel"
           @secondaryClick="cancel"
           @primaryClick="assessChange"
         />
@@ -63,13 +51,18 @@ export default defineComponent({
     );
     const assessApplicationOfferingChangeRequestForm = ref({} as VForm);
     const { checkNotesLengthRule } = useRules();
-    const getTitle = computed(() =>
+    const title = computed(() =>
       showParameter.value ===
       ApplicationOfferingChangeRequestStatus.DeclinedBySABC
         ? "Decline for reassessment"
         : "Approve for reassessment",
     );
-    const getPrimaryLabel = computed(() =>
+    const subject = computed(() =>
+      showParameter.value === ApplicationOfferingChangeRequestStatus.Approved
+        ? "Outline the reasoning for approving this request. Please add the application number."
+        : "Outline the reasoning for declining this request. Please add the application number.",
+    );
+    const primaryLabel = computed(() =>
       showParameter.value ===
       ApplicationOfferingChangeRequestStatus.DeclinedBySABC
         ? "Decline now"
@@ -86,16 +79,8 @@ export default defineComponent({
       if (!validationResult.valid) {
         return;
       }
-      if (
-        showParameter.value ===
-        ApplicationOfferingChangeRequestStatus.DeclinedBySABC
-      ) {
-        assessApplicationOfferingChangeRequestModal.value.applicationOfferingChangeRequestStatus =
-          ApplicationOfferingChangeRequestStatus.DeclinedBySABC;
-      } else {
-        assessApplicationOfferingChangeRequestModal.value.applicationOfferingChangeRequestStatus =
-          ApplicationOfferingChangeRequestStatus.Approved;
-      }
+      assessApplicationOfferingChangeRequestModal.value.applicationOfferingChangeRequestStatus =
+        showParameter.value;
       assessApplicationOfferingChangeRequestModal.value.note = note.value;
       resolvePromise(assessApplicationOfferingChangeRequestModal.value);
       assessApplicationOfferingChangeRequestForm.value.reset();
@@ -107,12 +92,12 @@ export default defineComponent({
       cancel,
       assessChange,
       note,
-      getTitle,
-      getPrimaryLabel,
+      title,
+      subject,
+      primaryLabel,
       checkNotesLengthRule,
       ApplicationOfferingChangeRequestStatus,
       assessApplicationOfferingChangeRequestForm,
-      assessApplicationOfferingChangeRequestModal,
     };
   },
 });

--- a/sources/packages/web/src/components/generic/ModalDialogBase.vue
+++ b/sources/packages/web/src/components/generic/ModalDialogBase.vue
@@ -14,17 +14,17 @@
     >
       <v-card-title>
         <slot name="header">
-          <h2 v-if="title" class="category-header-large primary-color">
+          <h2 v-if="title" class="category-header-large primary-color mt-3">
             {{ title }}
           </h2>
         </slot>
       </v-card-title>
-      <v-divider class="border-opacity-100" :thickness="2" inset />
-      <v-card-text class="pt-0">
+      <v-divider class="border-opacity-100 my-0" :thickness="2" inset />
+      <v-card-text class="pt-0 pb-1">
         <div class="pb-2" v-if="subTitle">{{ subTitle }}</div>
         <slot name="content">Please add the modal content here!</slot>
       </v-card-text>
-      <v-divider class="border-opacity-100" :thickness="2" inset />
+      <v-divider class="border-opacity-100 my-0" :thickness="2" inset />
 
       <v-card-actions>
         <v-spacer></v-spacer>

--- a/sources/packages/web/src/components/generic/ModalDialogBase.vue
+++ b/sources/packages/web/src/components/generic/ModalDialogBase.vue
@@ -19,12 +19,12 @@
           </h2>
         </slot>
       </v-card-title>
-      <v-divider class="border-opacity-100 my-0" :thickness="2" inset />
-      <v-card-text class="pt-0 pb-1">
+      <v-divider class="border-opacity-100 my-1" :thickness="2" inset />
+      <v-card-text class="pt-0">
         <div class="pb-2" v-if="subTitle">{{ subTitle }}</div>
         <slot name="content">Please add the modal content here!</slot>
       </v-card-text>
-      <v-divider class="border-opacity-100 my-0" :thickness="2" inset />
+      <v-divider class="border-opacity-100 my-1" :thickness="2" inset />
 
       <v-card-actions>
         <v-spacer></v-spacer>

--- a/sources/packages/web/src/services/ApplicationOfferingChangeRequestService.ts
+++ b/sources/packages/web/src/services/ApplicationOfferingChangeRequestService.ts
@@ -12,6 +12,7 @@ import {
   ApplicationOfferingDetailsAPIOutDTO,
   ApplicationOfferingChangeRequestStatusAPIOutDTO,
   ApplicationOfferingChangeDetailsAPIOutDTO,
+  ApplicationOfferingChangeAssessmentAPIInDTO,
 } from "@/services/http/dto";
 
 export class ApplicationOfferingChangeRequestService {
@@ -190,7 +191,9 @@ export class ApplicationOfferingChangeRequestService {
    */
   async updateApplicationOfferingChangeRequestStatus(
     applicationOfferingChangeRequestId: number,
-    payload: StudentApplicationOfferingChangeRequestAPIInDTO,
+    payload:
+      | StudentApplicationOfferingChangeRequestAPIInDTO
+      | ApplicationOfferingChangeAssessmentAPIInDTO,
   ): Promise<void> {
     await ApiClient.ApplicationOfferingChangeRequestApi.updateApplicationOfferingChangeRequestStatus(
       applicationOfferingChangeRequestId,

--- a/sources/packages/web/src/services/ApplicationOfferingChangeRequestService.ts
+++ b/sources/packages/web/src/services/ApplicationOfferingChangeRequestService.ts
@@ -204,11 +204,11 @@ export class ApplicationOfferingChangeRequestService {
    * @param applicationOfferingChangeRequestId application offering change request id.
    * @param payload information to update the application offering change request.
    */
-  async updateAESTApplicationOfferingChangeRequestStatus(
+  async assessApplicationOfferingChangeRequest(
     applicationOfferingChangeRequestId: number,
     payload: ApplicationOfferingChangeAssessmentAPIInDTO,
   ): Promise<void> {
-    await ApiClient.ApplicationOfferingChangeRequestApi.updateAESTApplicationOfferingChangeRequestStatus(
+    await ApiClient.ApplicationOfferingChangeRequestApi.assessApplicationOfferingChangeRequest(
       applicationOfferingChangeRequestId,
       payload,
     );

--- a/sources/packages/web/src/services/ApplicationOfferingChangeRequestService.ts
+++ b/sources/packages/web/src/services/ApplicationOfferingChangeRequestService.ts
@@ -208,7 +208,7 @@ export class ApplicationOfferingChangeRequestService {
     applicationOfferingChangeRequestId: number,
     payload: ApplicationOfferingChangeAssessmentAPIInDTO,
   ): Promise<void> {
-    await ApiClient.ApplicationOfferingChangeRequestApi.updateApplicationOfferingChangeRequestStatus(
+    await ApiClient.ApplicationOfferingChangeRequestApi.updateAESTApplicationOfferingChangeRequestStatus(
       applicationOfferingChangeRequestId,
       payload,
     );

--- a/sources/packages/web/src/services/ApplicationOfferingChangeRequestService.ts
+++ b/sources/packages/web/src/services/ApplicationOfferingChangeRequestService.ts
@@ -191,9 +191,22 @@ export class ApplicationOfferingChangeRequestService {
    */
   async updateApplicationOfferingChangeRequestStatus(
     applicationOfferingChangeRequestId: number,
-    payload:
-      | StudentApplicationOfferingChangeRequestAPIInDTO
-      | ApplicationOfferingChangeAssessmentAPIInDTO,
+    payload: StudentApplicationOfferingChangeRequestAPIInDTO,
+  ): Promise<void> {
+    await ApiClient.ApplicationOfferingChangeRequestApi.updateApplicationOfferingChangeRequestStatus(
+      applicationOfferingChangeRequestId,
+      payload,
+    );
+  }
+
+  /**
+   * Approves or declines the application offering change request status.
+   * @param applicationOfferingChangeRequestId application offering change request id.
+   * @param payload information to update the application offering change request.
+   */
+  async updateAESTApplicationOfferingChangeRequestStatus(
+    applicationOfferingChangeRequestId: number,
+    payload: ApplicationOfferingChangeAssessmentAPIInDTO,
   ): Promise<void> {
     await ApiClient.ApplicationOfferingChangeRequestApi.updateApplicationOfferingChangeRequestStatus(
       applicationOfferingChangeRequestId,

--- a/sources/packages/web/src/services/http/ApplicationOfferingChangeRequestApi.ts
+++ b/sources/packages/web/src/services/http/ApplicationOfferingChangeRequestApi.ts
@@ -12,6 +12,7 @@ import {
   ApplicationOfferingDetailsAPIOutDTO,
   ApplicationOfferingChangeRequestStatusAPIOutDTO,
   ApplicationOfferingChangeDetailsAPIOutDTO,
+  ApplicationOfferingChangeAssessmentAPIInDTO,
 } from "@/services/http/dto";
 import { getPaginationQueryString } from "@/helpers";
 
@@ -192,7 +193,9 @@ export class ApplicationOfferingChangeRequestApi extends HttpBaseClient {
    */
   async updateApplicationOfferingChangeRequestStatus(
     applicationOfferingChangeRequestId: number,
-    payload: StudentApplicationOfferingChangeRequestAPIInDTO,
+    payload:
+      | StudentApplicationOfferingChangeRequestAPIInDTO
+      | ApplicationOfferingChangeAssessmentAPIInDTO,
   ): Promise<void> {
     const url = `application-offering-change-request/${applicationOfferingChangeRequestId}`;
     await this.patchCall(this.addClientRoot(url), payload);

--- a/sources/packages/web/src/services/http/ApplicationOfferingChangeRequestApi.ts
+++ b/sources/packages/web/src/services/http/ApplicationOfferingChangeRequestApi.ts
@@ -193,9 +193,20 @@ export class ApplicationOfferingChangeRequestApi extends HttpBaseClient {
    */
   async updateApplicationOfferingChangeRequestStatus(
     applicationOfferingChangeRequestId: number,
-    payload:
-      | StudentApplicationOfferingChangeRequestAPIInDTO
-      | ApplicationOfferingChangeAssessmentAPIInDTO,
+    payload: StudentApplicationOfferingChangeRequestAPIInDTO,
+  ): Promise<void> {
+    const url = `application-offering-change-request/${applicationOfferingChangeRequestId}`;
+    await this.patchCall(this.addClientRoot(url), payload);
+  }
+
+  /**
+   * Approve or decline the application offering change request status.
+   * @param applicationOfferingChangeRequestId application offering change request id.
+   * @param payload information to update the application offering change request status and save the declaration.
+   */
+  async updateAESTApplicationOfferingChangeRequestStatus(
+    applicationOfferingChangeRequestId: number,
+    payload: ApplicationOfferingChangeAssessmentAPIInDTO,
   ): Promise<void> {
     const url = `application-offering-change-request/${applicationOfferingChangeRequestId}`;
     await this.patchCall(this.addClientRoot(url), payload);

--- a/sources/packages/web/src/services/http/ApplicationOfferingChangeRequestApi.ts
+++ b/sources/packages/web/src/services/http/ApplicationOfferingChangeRequestApi.ts
@@ -204,7 +204,7 @@ export class ApplicationOfferingChangeRequestApi extends HttpBaseClient {
    * @param applicationOfferingChangeRequestId application offering change request id.
    * @param payload information to update the application offering change request status and save the declaration.
    */
-  async updateAESTApplicationOfferingChangeRequestStatus(
+  async assessApplicationOfferingChangeRequest(
     applicationOfferingChangeRequestId: number,
     payload: ApplicationOfferingChangeAssessmentAPIInDTO,
   ): Promise<void> {

--- a/sources/packages/web/src/services/http/dto/ApplicationOfferingChangeRequest.dto.ts
+++ b/sources/packages/web/src/services/http/dto/ApplicationOfferingChangeRequest.dto.ts
@@ -127,3 +127,8 @@ export interface StudentApplicationOfferingChangeRequestAPIInDTO {
   studentConsent: boolean;
   applicationOfferingChangeRequestStatus: ApplicationOfferingChangeRequestStatus;
 }
+
+export interface ApplicationOfferingChangeAssessmentAPIInDTO {
+  note: string;
+  applicationOfferingChangeRequestStatus: ApplicationOfferingChangeRequestStatus;
+}

--- a/sources/packages/web/src/views/aest/institution/ApplicationOfferingChangeRequestForm.vue
+++ b/sources/packages/web/src/views/aest/institution/ApplicationOfferingChangeRequestForm.vue
@@ -187,16 +187,16 @@ export default defineComponent({
         );
       if (responseData) {
         try {
-          await ApplicationOfferingChangeRequestService.shared.updateApplicationOfferingChangeRequestStatus(
+          await ApplicationOfferingChangeRequestService.shared.updateAESTApplicationOfferingChangeRequestStatus(
             props.applicationOfferingChangeRequestId,
             responseData as ApplicationOfferingChangeAssessmentAPIInDTO,
           );
           router.push({
             name: AESTRoutesConst.ASSESSMENTS_SUMMARY,
           });
-          const snackbarMessage =
-            "Your decision was submitted. You can refer to the outcome below.";
-          snackBar.success(snackbarMessage);
+          snackBar.success(
+            "Your decision was submitted. You can refer to the outcome below.",
+          );
         } catch {
           snackBar.error(
             "Unexpected error while submitting application offering change request.",

--- a/sources/packages/web/src/views/aest/institution/ApplicationOfferingChangeRequestForm.vue
+++ b/sources/packages/web/src/views/aest/institution/ApplicationOfferingChangeRequestForm.vue
@@ -135,7 +135,7 @@ export default defineComponent({
       {} as ApplicationOfferingDetails,
     );
     const assessApplicationOfferingChangeRequestModal = ref(
-      {} as ModalDialog<ApplicationOfferingChangeAssessmentAPIInDTO>,
+      {} as ModalDialog<ApplicationOfferingChangeAssessmentAPIInDTO | boolean>,
     );
     const snackBar = useSnackBar();
     const router = useRouter();

--- a/sources/packages/web/src/views/aest/institution/ApplicationOfferingChangeRequestForm.vue
+++ b/sources/packages/web/src/views/aest/institution/ApplicationOfferingChangeRequestForm.vue
@@ -187,7 +187,7 @@ export default defineComponent({
         );
       if (responseData) {
         try {
-          await ApplicationOfferingChangeRequestService.shared.updateAESTApplicationOfferingChangeRequestStatus(
+          await ApplicationOfferingChangeRequestService.shared.assessApplicationOfferingChangeRequest(
             props.applicationOfferingChangeRequestId,
             responseData as ApplicationOfferingChangeAssessmentAPIInDTO,
           );


### PR DESCRIPTION
## As a part of this PR, the following tasks were completed:

- [x] Created the models for Approve and Decline the application offering change request by the ministry.

Reason for modifying the base component (ModalDialogBase.vue): `<hr>` tag was changed to `<v-divider>` component. This v-divider component by default adds a significant amount of vertical whitespace. As a result, the margin for `v-divider` in this component is changed to reduce the whitespace.
 
Please note: Placeholder added for the API endpoint.

## Screenshots:

### Decline Application Offering Change Request Modal

<img width="1920" alt="image" src="https://github.com/bcgov/SIMS/assets/7859295/35d1e87a-16e5-4ab4-a9a3-38e1a56fa871">

### Approve Application Offering Change Request Modal

<img width="1920" alt="image" src="https://github.com/bcgov/SIMS/assets/7859295/489fdd8d-3682-4b5b-ba1b-f036b625f6a3">
