### PR TITLE
#2373 - IER fix allow zero grants

### DIFF
--- a/sources/packages/backend/libs/integrations/src/institution-integration/ier12-integration/ier12.integration.service.ts
+++ b/sources/packages/backend/libs/integrations/src/institution-integration/ier12-integration/ier12.integration.service.ts
@@ -361,7 +361,7 @@ export class IER12IntegrationService extends SFTPIntegrationBase<void> {
             !options.awardTypeExclusions.includes(award.valueType)),
       )
       .map((disbursementValue) => disbursementValue.valueAmount)
-      .reduce((accumulator, currentValue) => accumulator + currentValue);
+      .reduce((accumulator, currentValue) => accumulator + currentValue, 0);
 
     return combineDecimalPlaces(totalAwardsAmount);
   }


### PR DESCRIPTION
## IER Fix allow zero grants
 - [x] Add initial value to reduce function
 - [x] Test the fix by creating an application submitted for `BC Private` (any non BC Public institution) and applicant income as $100000
![image](https://github.com/bcgov/SIMS/assets/54600590/1717638a-fce7-435c-a3ff-de4d20e99a56)
