### PR TITLE
#2307 - WAVA scan headers update

### DIFF
--- a/sources/packages/web/nginx.conf
+++ b/sources/packages/web/nginx.conf
@@ -18,6 +18,6 @@ http {
       add_header 'Content-Security-Policy' "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'";
       add_header 'Strict-Transport-Security' "max-age=31536000; includeSubDomains; preload";
       add_header 'Referrer-Policy' "same-origin";
-      add_header 'X-Frame-Options' 'sameorigin';
+      add_header 'X-Frame-Options' "sameorigin";
   }
 }

--- a/sources/packages/web/nginx.conf
+++ b/sources/packages/web/nginx.conf
@@ -15,7 +15,7 @@ http {
   keepalive_timeout  65;
   server {
       add_header 'X-Content-Type-Options'  "nosniff";
-      add_header 'Content-Security-Policy' "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'";
+      add_header 'Content-Security-Policy' "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'";
       add_header 'Strict-Transport-Security' "max-age=31536000; includeSubDomains; preload";
       add_header 'Referrer-Policy' "same-origin";
       add_header 'X-Frame-Options' "sameorigin";

--- a/sources/packages/web/nginx.conf
+++ b/sources/packages/web/nginx.conf
@@ -18,5 +18,6 @@ http {
       add_header 'Content-Security-Policy' "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'";
       add_header 'Strict-Transport-Security' "max-age=31536000; includeSubDomains; preload";
       add_header 'Referrer-Policy' "same-origin";
+      add_header 'X-Frame-Options' 'sameorigin';
   }
 }

--- a/sources/packages/web/nginx.conf
+++ b/sources/packages/web/nginx.conf
@@ -13,4 +13,10 @@ http {
   default_type  application/octet-stream;
   sendfile        on;
   keepalive_timeout  65;
+  server {
+      add_header 'X-Content-Type-Options'  "nosniff";
+      add_header 'Content-Security-Policy' "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'";
+      add_header 'Strict-Transport-Security' "max-age=31536000; includeSubDomains; preload";
+      add_header 'Referrer-Policy' "same-origin";
+  }
 }


### PR DESCRIPTION
![image](https://github.com/bcgov/SIMS/assets/62901416/2f5e55ff-082e-4664-8cd0-4e4d785849a2)

- [x] Missing or insecure "X-Content-Type-Options" header
> add_header 'X-Content-Type-Options'  "nosniff";

- [x] Missing "Content-Security-Policy" header
> add_header 'Content-Security-Policy' "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'";

- [x] Missing or insecure HTTP Strict-Transport-Security Header
> add_header 'Strict-Transport-Security' "max-age=31536000; includeSubDomains; preload";

- [x] Missing "Referrer policy" Security Header
> add_header 'Referrer-Policy' "same-origin";

As we are not setting any cookie our application, we are not fixing the "Cookie with Insecure or Improper or Missing SameSite attribute" issue.