### PR TITLE
#2379 - Fix computer multiplication in combine decimal places

### DIFF
--- a/sources/packages/backend/libs/utilities/src/math-utils.ts
+++ b/sources/packages/backend/libs/utilities/src/math-utils.ts
@@ -31,7 +31,5 @@ export function combineDecimalPlaces(
 ): number {
   const multiplier = Math.pow(10, decimalPlaces);
   // Round the number up to the number of decimal places.
-  const roundedValue = Math.round(decimalNumber * multiplier) / multiplier;
-  // Combine the decimals into the integer part before returning.
-  return roundedValue * multiplier;
+  return Math.round(decimalNumber * multiplier);
 }


### PR DESCRIPTION
## Floating point arithmetic issue in programming languages

![image](https://github.com/bcgov/SIMS/assets/54600590/2402b2f7-7766-4fcf-afab-a9d709c655f4)

https://stackoverflow.com/questions/45221535/javascript-floating-point-multiply-by-100-still-has-errors

## Issue and fix

Certain decimal numbers when multiplied by 100 may not return precise mathematical result as we expect

![image](https://github.com/bcgov/SIMS/assets/54600590/88da4c76-1974-43a1-af64-6073b8fe13dc)

`Math.round()` seems to be one of the solutions to handle this issue.

But in the `combineDecimalPlaces` method we are dividing and then multiplying by 100 again, which re-creates the same issue which was fixed by `Math.round()`

![image](https://github.com/bcgov/SIMS/assets/54600590/65f7f7f9-75e7-4e03-a3c9-5bfa4a5a8e82)


Hence: Divide and multiply of the rounded value by multiplier is removed.

### File output
![image](https://github.com/bcgov/SIMS/assets/54600590/601b94f1-15be-43cb-ab3b-1d53d421b4f3)
