### PR TITLE
#1981 - Request Offering Change: Ministry View [Approve / Deny Request] - Part 3

### DIFF
--- a/sources/packages/backend/apps/api/src/route-controllers/application-offering-change-request/_tests_/e2e/application-offering-change-request.aest.controller.assessApplicationOfferingChangeRequest.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/application-offering-change-request/_tests_/e2e/application-offering-change-request.aest.controller.assessApplicationOfferingChangeRequest.e2e-spec.ts
@@ -19,7 +19,7 @@ import {
 } from "@sims/sims-db";
 import { Repository } from "typeorm";
 
-describe("ApplicationOfferingChangeRequestAESTController(e2e)-getAllInProgressApplications", () => {
+describe("ApplicationOfferingChangeRequestAESTController(e2e)-assessApplicationOfferingChangeRequest", () => {
   let app: INestApplication;
   let db: E2EDataSources;
   let applicationOfferingChangeRequestRepo: Repository<ApplicationOfferingChangeRequest>;

--- a/sources/packages/backend/apps/api/src/route-controllers/application-offering-change-request/_tests_/e2e/application-offering-change-request.aest.controller.assessApplicationOfferingChangeRequest.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/application-offering-change-request/_tests_/e2e/application-offering-change-request.aest.controller.assessApplicationOfferingChangeRequest.e2e-spec.ts
@@ -64,7 +64,7 @@ describe("ApplicationOfferingChangeRequestAESTController(e2e)-assessApplicationO
         select: {
           id: true,
           applicationOfferingChangeRequestStatus: true,
-          assessedNote: { id: true, description: true },
+          assessedNote: { description: true },
         },
         relations: { assessedNote: true },
         where: { id: applicationOfferingChangeRequest.id },

--- a/sources/packages/backend/apps/api/src/route-controllers/application-offering-change-request/_tests_/e2e/application-offering-change-request.aest.controller.assessApplicationOfferingChangeRequest.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/application-offering-change-request/_tests_/e2e/application-offering-change-request.aest.controller.assessApplicationOfferingChangeRequest.e2e-spec.ts
@@ -1,0 +1,198 @@
+import { HttpStatus, INestApplication } from "@nestjs/common";
+import * as request from "supertest";
+import {
+  AESTGroups,
+  BEARER_AUTH_TYPE,
+  createTestingAppModule,
+  getAESTToken,
+} from "../../../../testHelpers";
+import {
+  E2EDataSources,
+  createE2EDataSources,
+  saveFakeApplication,
+  saveFakeApplicationOfferingRequestChange,
+} from "@sims/test-utils";
+import {
+  ApplicationOfferingChangeRequest,
+  ApplicationOfferingChangeRequestStatus,
+  ApplicationStatus,
+} from "@sims/sims-db";
+import { Repository } from "typeorm";
+
+describe("ApplicationOfferingChangeRequestAESTController(e2e)-getAllInProgressApplications", () => {
+  let app: INestApplication;
+  let db: E2EDataSources;
+  let applicationOfferingChangeRequestRepo: Repository<ApplicationOfferingChangeRequest>;
+
+  beforeAll(async () => {
+    const { nestApplication, dataSource } = await createTestingAppModule();
+    app = nestApplication;
+    db = createE2EDataSources(dataSource);
+    applicationOfferingChangeRequestRepo = dataSource.getRepository(
+      ApplicationOfferingChangeRequest,
+    );
+  });
+
+  it("Should assess the application offering change request for the provided application offering change request id.", async () => {
+    // Arrange
+    const application = await saveFakeApplication(db.dataSource, undefined, {
+      applicationStatus: ApplicationStatus.Completed,
+    });
+    const applicationOfferingChangeRequest =
+      await saveFakeApplicationOfferingRequestChange(
+        db,
+        {
+          application,
+        },
+        {
+          initialValues: {
+            applicationOfferingChangeRequestStatus:
+              ApplicationOfferingChangeRequestStatus.InProgressWithSABC,
+          } as ApplicationOfferingChangeRequest,
+        },
+      );
+    const note = "Some dummy note.";
+    const token = await getAESTToken(AESTGroups.BusinessAdministrators);
+    const endpoint = `/aest/application-offering-change-request/${applicationOfferingChangeRequest.id}`;
+    // Act/Assert
+    await request(app.getHttpServer())
+      .patch(endpoint)
+      .send({
+        note,
+        applicationOfferingChangeRequestStatus:
+          ApplicationOfferingChangeRequestStatus.Approved,
+      })
+      .auth(token, BEARER_AUTH_TYPE)
+      .expect(HttpStatus.OK);
+    // Check if the application offering change request was assessed as expected.
+    const updatedApplicationOfferingChangeRequest =
+      await applicationOfferingChangeRequestRepo.findOne({
+        select: {
+          id: true,
+          applicationOfferingChangeRequestStatus: true,
+          assessedNote: { id: true, description: true },
+        },
+        relations: { assessedNote: true },
+        where: { id: applicationOfferingChangeRequest.id },
+      });
+    expect(
+      updatedApplicationOfferingChangeRequest.applicationOfferingChangeRequestStatus,
+    ).toBe(ApplicationOfferingChangeRequestStatus.Approved);
+    expect(
+      updatedApplicationOfferingChangeRequest.assessedNote.description,
+    ).toBe(note);
+  });
+
+  it("Should throw a HttpStatus Not Found (404) error when an application offering change is assessed for an application not in completed state.", async () => {
+    // Arrange
+    const application = await saveFakeApplication(db.dataSource, undefined, {
+      applicationStatus: ApplicationStatus.Overwritten,
+    });
+    const applicationOfferingChangeRequest =
+      await saveFakeApplicationOfferingRequestChange(db, {
+        application,
+      });
+    const note = "Some dummy note.";
+    const token = await getAESTToken(AESTGroups.BusinessAdministrators);
+    const endpoint = `/aest/application-offering-change-request/${applicationOfferingChangeRequest.id}`;
+    // Act/Assert
+    await request(app.getHttpServer())
+      .patch(endpoint)
+      .send({
+        note,
+        applicationOfferingChangeRequestStatus:
+          ApplicationOfferingChangeRequestStatus.DeclinedBySABC,
+      })
+      .auth(token, BEARER_AUTH_TYPE)
+      .expect(HttpStatus.NOT_FOUND)
+      .expect({
+        statusCode: HttpStatus.NOT_FOUND,
+        message:
+          "Application offering change not found or not in valid status to be approved/declined.",
+        error: "Not Found",
+      });
+  });
+
+  it("Should throw a HttpStatus Not Found (404) error when an application offering change is not in a valid status to be assessed.", async () => {
+    // Arrange
+    const application = await saveFakeApplication(db.dataSource, undefined, {
+      applicationStatus: ApplicationStatus.Completed,
+    });
+    const applicationOfferingChangeRequest =
+      await saveFakeApplicationOfferingRequestChange(
+        db,
+        {
+          application,
+        },
+        {
+          initialValues: {
+            applicationOfferingChangeRequestStatus:
+              ApplicationOfferingChangeRequestStatus.InProgressWithStudent,
+          },
+        },
+      );
+    const note = "Some dummy note.";
+    const token = await getAESTToken(AESTGroups.BusinessAdministrators);
+    const endpoint = `/aest/application-offering-change-request/${applicationOfferingChangeRequest.id}`;
+    // Act/Assert
+    await request(app.getHttpServer())
+      .patch(endpoint)
+      .send({
+        note,
+        applicationOfferingChangeRequestStatus:
+          ApplicationOfferingChangeRequestStatus.Approved,
+      })
+      .auth(token, BEARER_AUTH_TYPE)
+      .expect(HttpStatus.NOT_FOUND)
+      .expect({
+        statusCode: HttpStatus.NOT_FOUND,
+        message:
+          "Application offering change not found or not in valid status to be approved/declined.",
+        error: "Not Found",
+      });
+  });
+
+  it("Should throw a HttpStatus Bad Request (400) error when an invalid application offering change request status is provided.", async () => {
+    // Arrange
+    const application = await saveFakeApplication(db.dataSource, undefined, {
+      applicationStatus: ApplicationStatus.Completed,
+    });
+    const applicationOfferingChangeRequest =
+      await saveFakeApplicationOfferingRequestChange(
+        db,
+        {
+          application,
+        },
+        {
+          initialValues: {
+            applicationOfferingChangeRequestStatus:
+              ApplicationOfferingChangeRequestStatus.InProgressWithSABC,
+          },
+        },
+      );
+    const note = "Some dummy note.";
+    const token = await getAESTToken(AESTGroups.BusinessAdministrators);
+    const endpoint = `/aest/application-offering-change-request/${applicationOfferingChangeRequest.id}`;
+    // Act/Assert
+    await request(app.getHttpServer())
+      .patch(endpoint)
+      .send({
+        note,
+        applicationOfferingChangeRequestStatus:
+          ApplicationOfferingChangeRequestStatus.InProgressWithStudent,
+      })
+      .auth(token, BEARER_AUTH_TYPE)
+      .expect(HttpStatus.BAD_REQUEST)
+      .expect({
+        statusCode: HttpStatus.BAD_REQUEST,
+        message: [
+          "applicationOfferingChangeRequestStatus must be one of the following values: Approved, Declined by SABC",
+        ],
+        error: "Bad Request",
+      });
+  });
+
+  afterAll(async () => {
+    await app?.close();
+  });
+});

--- a/sources/packages/backend/apps/api/src/route-controllers/application-offering-change-request/_tests_/e2e/application-offering-change-request.aest.controller.assessApplicationOfferingChangeRequest.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/application-offering-change-request/_tests_/e2e/application-offering-change-request.aest.controller.assessApplicationOfferingChangeRequest.e2e-spec.ts
@@ -13,24 +13,18 @@ import {
   saveFakeApplicationOfferingRequestChange,
 } from "@sims/test-utils";
 import {
-  ApplicationOfferingChangeRequest,
   ApplicationOfferingChangeRequestStatus,
   ApplicationStatus,
 } from "@sims/sims-db";
-import { Repository } from "typeorm";
 
 describe("ApplicationOfferingChangeRequestAESTController(e2e)-assessApplicationOfferingChangeRequest", () => {
   let app: INestApplication;
   let db: E2EDataSources;
-  let applicationOfferingChangeRequestRepo: Repository<ApplicationOfferingChangeRequest>;
 
   beforeAll(async () => {
     const { nestApplication, dataSource } = await createTestingAppModule();
     app = nestApplication;
     db = createE2EDataSources(dataSource);
-    applicationOfferingChangeRequestRepo = dataSource.getRepository(
-      ApplicationOfferingChangeRequest,
-    );
   });
 
   it("Should assess the application offering change request for the provided application offering change request id.", async () => {
@@ -48,7 +42,7 @@ describe("ApplicationOfferingChangeRequestAESTController(e2e)-assessApplicationO
           initialValues: {
             applicationOfferingChangeRequestStatus:
               ApplicationOfferingChangeRequestStatus.InProgressWithSABC,
-          } as ApplicationOfferingChangeRequest,
+          },
         },
       );
     const note = "Some dummy note.";
@@ -66,7 +60,7 @@ describe("ApplicationOfferingChangeRequestAESTController(e2e)-assessApplicationO
       .expect(HttpStatus.OK);
     // Check if the application offering change request was assessed as expected.
     const updatedApplicationOfferingChangeRequest =
-      await applicationOfferingChangeRequestRepo.findOne({
+      await db.applicationOfferingChangeRequest.findOne({
         select: {
           id: true,
           applicationOfferingChangeRequestStatus: true,
@@ -81,36 +75,6 @@ describe("ApplicationOfferingChangeRequestAESTController(e2e)-assessApplicationO
     expect(
       updatedApplicationOfferingChangeRequest.assessedNote.description,
     ).toBe(note);
-  });
-
-  it("Should throw a HttpStatus Not Found (404) error when an application offering change is assessed for an application not in completed state.", async () => {
-    // Arrange
-    const application = await saveFakeApplication(db.dataSource, undefined, {
-      applicationStatus: ApplicationStatus.Overwritten,
-    });
-    const applicationOfferingChangeRequest =
-      await saveFakeApplicationOfferingRequestChange(db, {
-        application,
-      });
-    const note = "Some dummy note.";
-    const token = await getAESTToken(AESTGroups.BusinessAdministrators);
-    const endpoint = `/aest/application-offering-change-request/${applicationOfferingChangeRequest.id}`;
-    // Act/Assert
-    await request(app.getHttpServer())
-      .patch(endpoint)
-      .send({
-        note,
-        applicationOfferingChangeRequestStatus:
-          ApplicationOfferingChangeRequestStatus.DeclinedBySABC,
-      })
-      .auth(token, BEARER_AUTH_TYPE)
-      .expect(HttpStatus.NOT_FOUND)
-      .expect({
-        statusCode: HttpStatus.NOT_FOUND,
-        message:
-          "Application offering change not found or not in valid status to be approved/declined.",
-        error: "Not Found",
-      });
   });
 
   it("Should throw a HttpStatus Not Found (404) error when an application offering change is not in a valid status to be assessed.", async () => {
@@ -154,25 +118,9 @@ describe("ApplicationOfferingChangeRequestAESTController(e2e)-assessApplicationO
 
   it("Should throw a HttpStatus Bad Request (400) error when an invalid application offering change request status is provided.", async () => {
     // Arrange
-    const application = await saveFakeApplication(db.dataSource, undefined, {
-      applicationStatus: ApplicationStatus.Completed,
-    });
-    const applicationOfferingChangeRequest =
-      await saveFakeApplicationOfferingRequestChange(
-        db,
-        {
-          application,
-        },
-        {
-          initialValues: {
-            applicationOfferingChangeRequestStatus:
-              ApplicationOfferingChangeRequestStatus.InProgressWithSABC,
-          },
-        },
-      );
     const note = "Some dummy note.";
     const token = await getAESTToken(AESTGroups.BusinessAdministrators);
-    const endpoint = `/aest/application-offering-change-request/${applicationOfferingChangeRequest.id}`;
+    const endpoint = "/aest/application-offering-change-request/9999";
     // Act/Assert
     await request(app.getHttpServer())
       .patch(endpoint)

--- a/sources/packages/backend/apps/api/src/route-controllers/application-offering-change-request/_tests_/e2e/application-offering-change-request.aest.controller.assessApplicationOfferingChangeRequest.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/application-offering-change-request/_tests_/e2e/application-offering-change-request.aest.controller.assessApplicationOfferingChangeRequest.e2e-spec.ts
@@ -15,6 +15,7 @@ import {
 import {
   ApplicationOfferingChangeRequestStatus,
   ApplicationStatus,
+  AssessmentTriggerType,
 } from "@sims/sims-db";
 
 describe("ApplicationOfferingChangeRequestAESTController(e2e)-assessApplicationOfferingChangeRequest", () => {
@@ -66,8 +67,19 @@ describe("ApplicationOfferingChangeRequestAESTController(e2e)-assessApplicationO
           id: true,
           applicationOfferingChangeRequestStatus: true,
           assessedNote: { description: true },
+          application: {
+            id: true,
+            currentAssessment: {
+              id: true,
+              triggerType: true,
+              offering: { id: true },
+            },
+          },
         },
-        relations: { assessedNote: true },
+        relations: {
+          assessedNote: true,
+          application: { currentAssessment: { offering: true } },
+        },
         where: { id: applicationOfferingChangeRequest.id },
       });
     expect(
@@ -76,6 +88,14 @@ describe("ApplicationOfferingChangeRequestAESTController(e2e)-assessApplicationO
     expect(
       updatedApplicationOfferingChangeRequest.assessedNote.description,
     ).toBe(note);
+    expect(
+      updatedApplicationOfferingChangeRequest.application.currentAssessment
+        .triggerType,
+    ).toBe(AssessmentTriggerType.ApplicationOfferingChange);
+    expect(
+      updatedApplicationOfferingChangeRequest.application.currentAssessment
+        .offering.id,
+    ).toBe(applicationOfferingChangeRequest.requestedOffering.id);
   });
 
   it("Should throw a HttpStatus Not Found (404) error when an application offering change is not in a valid status to be assessed.", async () => {

--- a/sources/packages/backend/apps/api/src/route-controllers/application-offering-change-request/_tests_/e2e/application-offering-change-request.aest.controller.assessApplicationOfferingChangeRequest.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/application-offering-change-request/_tests_/e2e/application-offering-change-request.aest.controller.assessApplicationOfferingChangeRequest.e2e-spec.ts
@@ -16,18 +16,15 @@ import {
   ApplicationOfferingChangeRequestStatus,
   ApplicationStatus,
 } from "@sims/sims-db";
-import { SystemUsersService } from "@sims/services";
 
 describe("ApplicationOfferingChangeRequestAESTController(e2e)-assessApplicationOfferingChangeRequest", () => {
   let app: INestApplication;
   let db: E2EDataSources;
-  let systemUsersService: SystemUsersService;
 
   beforeAll(async () => {
     const { nestApplication, dataSource } = await createTestingAppModule();
     app = nestApplication;
     db = createE2EDataSources(dataSource);
-    systemUsersService = nestApplication.get(SystemUsersService);
   });
 
   it("Should assess the application offering change request for the provided application offering change request id.", async () => {

--- a/sources/packages/backend/apps/api/src/route-controllers/application-offering-change-request/_tests_/e2e/application-offering-change-request.aest.controller.assessApplicationOfferingChangeRequest.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/application-offering-change-request/_tests_/e2e/application-offering-change-request.aest.controller.assessApplicationOfferingChangeRequest.e2e-spec.ts
@@ -73,15 +73,12 @@ describe("ApplicationOfferingChangeRequestAESTController(e2e)-assessApplicationO
         relations: { assessedNote: true },
         where: { id: applicationOfferingChangeRequest.id },
       });
-    const auditUser = await systemUsersService.systemUser();
     expect(
       updatedApplicationOfferingChangeRequest.applicationOfferingChangeRequestStatus,
     ).toBe(ApplicationOfferingChangeRequestStatus.Approved);
     expect(
       updatedApplicationOfferingChangeRequest.assessedNote.description,
     ).toBe(note);
-    expect(updatedApplicationOfferingChangeRequest.modifier).toBe(auditUser);
-    expect(updatedApplicationOfferingChangeRequest.assessedBy).toBe(auditUser);
   });
 
   it("Should throw a HttpStatus Not Found (404) error when an application offering change is not in a valid status to be assessed.", async () => {

--- a/sources/packages/backend/apps/api/src/services/application-offering-change-request/application-offering-change-request.service.ts
+++ b/sources/packages/backend/apps/api/src/services/application-offering-change-request/application-offering-change-request.service.ts
@@ -505,7 +505,7 @@ export class ApplicationOfferingChangeRequestService {
         .getRepository(ApplicationOfferingChangeRequest)
         .save(newRequest);
       const systemUser = await this.systemUsersService.systemUser();
-      await this.notificationActionsService.saveApplicationOfferingChangeRequestInProgressWithStudent(
+      await this.notificationActionsService.saveApplicationOfferingChangeRequestInProgressWithStudentNotification(
         {
           givenNames: application.student.user.firstName,
           lastName: application.student.user.lastName,
@@ -608,15 +608,13 @@ export class ApplicationOfferingChangeRequestService {
         .save(applicationOfferingChangeRequest);
       // Send the application offering change request completed notification.
       const systemUser = await this.systemUsersService.systemUser();
-      await this.notificationActionsService.saveApplicationOfferingChangeRequestCompletedByMinistry(
+      const user = applicationOfferingChangeRequest.application.student.user;
+      await this.notificationActionsService.saveApplicationOfferingChangeRequestCompleteNotification(
         {
-          givenNames:
-            applicationOfferingChangeRequest.application.student.user.firstName,
-          lastName:
-            applicationOfferingChangeRequest.application.student.user.lastName,
-          toAddress:
-            applicationOfferingChangeRequest.application.student.user.email,
-          userId: applicationOfferingChangeRequest.application.student.user.id,
+          givenNames: user.firstName,
+          lastName: user.lastName,
+          toAddress: user.email,
+          userId: user.id,
         },
         systemUser.id,
         transactionalEntityManager,

--- a/sources/packages/backend/apps/api/src/services/application-offering-change-request/application-offering-change-request.service.ts
+++ b/sources/packages/backend/apps/api/src/services/application-offering-change-request/application-offering-change-request.service.ts
@@ -302,6 +302,7 @@ export class ApplicationOfferingChangeRequestService {
               id: true,
               firstName: true,
               lastName: true,
+              email: true,
             },
           },
         },
@@ -548,7 +549,7 @@ export class ApplicationOfferingChangeRequestService {
   }
 
   /**
-   * Assess the application offering change request status for the given application offering change request id for the ministry user.
+   * Assess the application offering change request status for the given application offering change request id for the ministry user and create a notification for the same.
    * @param applicationOfferingChangeRequestId application offering change request id for which to update the status.
    * @param applicationOfferingChangeRequestStatus the application offering change request status to be updated.
    * @param assessmentNote note added while updating the application offering change request.
@@ -605,6 +606,21 @@ export class ApplicationOfferingChangeRequestService {
       await transactionalEntityManager
         .getRepository(ApplicationOfferingChangeRequest)
         .save(applicationOfferingChangeRequest);
+      // Send the application offering change request completed notification.
+      const systemUser = await this.systemUsersService.systemUser();
+      await this.notificationActionsService.saveApplicationOfferingChangeRequestCompletedByMinistry(
+        {
+          givenNames:
+            applicationOfferingChangeRequest.application.student.user.firstName,
+          lastName:
+            applicationOfferingChangeRequest.application.student.user.lastName,
+          toAddress:
+            applicationOfferingChangeRequest.application.student.user.email,
+          userId: applicationOfferingChangeRequest.application.student.user.id,
+        },
+        systemUser.id,
+        transactionalEntityManager,
+      );
     });
   }
 }

--- a/sources/packages/backend/apps/db-migrations/src/migrations/1697055771725-InsertApplicationOfferingChangeRequestCompletedByMinistryMessage.ts
+++ b/sources/packages/backend/apps/db-migrations/src/migrations/1697055771725-InsertApplicationOfferingChangeRequestCompletedByMinistryMessage.ts
@@ -1,0 +1,24 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+import { getSQLFileData } from "../utilities/sqlLoader";
+
+export class InsertApplicationOfferingChangeRequestCompletedByMinistryMessage1697055771725
+  implements MigrationInterface
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      getSQLFileData(
+        "Insert-application-offering-change-request-completed-by-ministry-message.sql",
+        "NotificationMessages",
+      ),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      getSQLFileData(
+        "Delete-application-offering-change-request-completed-by-ministry-message.sql",
+        "NotificationMessages",
+      ),
+    );
+  }
+}

--- a/sources/packages/backend/apps/db-migrations/src/sql/NotificationMessages/Delete-application-offering-change-request-completed-by-ministry-message.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/NotificationMessages/Delete-application-offering-change-request-completed-by-ministry-message.sql
@@ -1,0 +1,4 @@
+DELETE FROM
+  sims.notification_messages
+WHERE
+  ID = 14;

--- a/sources/packages/backend/apps/db-migrations/src/sql/NotificationMessages/Insert-application-offering-change-request-completed-by-ministry-message.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/NotificationMessages/Insert-application-offering-change-request-completed-by-ministry-message.sql
@@ -1,0 +1,8 @@
+INSERT INTO
+  sims.notification_messages(id, description, template_id)
+VALUES
+  (
+    14,
+    'Application Offering Change Request Completed By Ministry',
+    '24ea085b-c7b3-4ef4-8627-3d6bdd1e62cb'
+  );

--- a/sources/packages/backend/libs/services/src/notifications/notification/notification-actions.service.ts
+++ b/sources/packages/backend/libs/services/src/notifications/notification/notification-actions.service.ts
@@ -16,7 +16,7 @@ import {
   ECEResponseFileProcessingNotification,
   NotificationEmailMessage,
   ApplicationOfferingChangeRequestInProgressWithStudentNotification,
-  ApplicationOfferingChangeRequestCompletedByMinistryNotification,
+  ApplicationOfferingChangeRequestCompleteNotification,
 } from "..";
 import { GCNotifyService } from "./gc-notify.service";
 import { NotificationService } from "./notification.service";
@@ -158,7 +158,7 @@ export class NotificationActionsService {
    * @param auditUserId user that should be considered the one that is causing the changes.
    * @param entityManager optional entity manager to execute in transaction.
    */
-  async saveApplicationOfferingChangeRequestInProgressWithStudent(
+  async saveApplicationOfferingChangeRequestInProgressWithStudentNotification(
     notification: ApplicationOfferingChangeRequestInProgressWithStudentNotification,
     auditUserId: number,
     entityManager?: EntityManager,
@@ -194,10 +194,10 @@ export class NotificationActionsService {
    * @param auditUserId user that should be considered the one that is causing the changes.
    * @param entityManager optional entity manager to execute in transaction.
    */
-  async saveApplicationOfferingChangeRequestCompletedByMinistry(
-    notification: ApplicationOfferingChangeRequestCompletedByMinistryNotification,
+  async saveApplicationOfferingChangeRequestCompleteNotification(
+    notification: ApplicationOfferingChangeRequestCompleteNotification,
     auditUserId: number,
-    entityManager?: EntityManager,
+    entityManager: EntityManager,
   ): Promise<void> {
     const templateId = await this.notificationMessageService.getTemplateId(
       NotificationMessageType.ApplicationOfferingChangeRequestCompletedByMinistry,

--- a/sources/packages/backend/libs/services/src/notifications/notification/notification-actions.service.ts
+++ b/sources/packages/backend/libs/services/src/notifications/notification/notification-actions.service.ts
@@ -16,6 +16,7 @@ import {
   ECEResponseFileProcessingNotification,
   NotificationEmailMessage,
   ApplicationOfferingChangeRequestInProgressWithStudentNotification,
+  ApplicationOfferingChangeRequestCompletedByMinistryNotification,
 } from "..";
 import { GCNotifyService } from "./gc-notify.service";
 import { NotificationService } from "./notification.service";
@@ -177,6 +178,42 @@ export class NotificationActionsService {
       userId: notification.userId,
       messageType:
         NotificationMessageType.ApplicationOfferingChangeRequestInProgressWithStudent,
+      messagePayload: messagePayload,
+    };
+    // Save notification into notification table.
+    await this.notificationService.saveNotifications(
+      [notificationToSend],
+      auditUserId,
+      { entityManager },
+    );
+  }
+
+  /**
+   * Creates a notification when an Application Offering Change Request is completed by the ministry.
+   * @param notification input parameters to generate the notification.
+   * @param auditUserId user that should be considered the one that is causing the changes.
+   * @param entityManager optional entity manager to execute in transaction.
+   */
+  async saveApplicationOfferingChangeRequestCompletedByMinistry(
+    notification: ApplicationOfferingChangeRequestCompletedByMinistryNotification,
+    auditUserId: number,
+    entityManager?: EntityManager,
+  ): Promise<void> {
+    const templateId = await this.notificationMessageService.getTemplateId(
+      NotificationMessageType.ApplicationOfferingChangeRequestCompletedByMinistry,
+    );
+    const messagePayload: NotificationEmailMessage = {
+      email_address: notification.toAddress,
+      template_id: templateId,
+      personalisation: {
+        givenNames: notification.givenNames ?? "",
+        lastName: notification.lastName,
+      },
+    };
+    const notificationToSend = {
+      userId: notification.userId,
+      messageType:
+        NotificationMessageType.ApplicationOfferingChangeRequestCompletedByMinistry,
       messagePayload: messagePayload,
     };
     // Save notification into notification table.

--- a/sources/packages/backend/libs/services/src/notifications/notification/notification.model.ts
+++ b/sources/packages/backend/libs/services/src/notifications/notification/notification.model.ts
@@ -37,6 +37,13 @@ export interface ApplicationOfferingChangeRequestInProgressWithStudentNotificati
   userId: number;
 }
 
+export interface ApplicationOfferingChangeRequestCompletedByMinistryNotification {
+  givenNames: string;
+  lastName: string;
+  toAddress: string;
+  userId: number;
+}
+
 export interface StudentRestrictionAddedNotification {
   givenNames: string;
   lastName: string;

--- a/sources/packages/backend/libs/services/src/notifications/notification/notification.model.ts
+++ b/sources/packages/backend/libs/services/src/notifications/notification/notification.model.ts
@@ -37,7 +37,7 @@ export interface ApplicationOfferingChangeRequestInProgressWithStudentNotificati
   userId: number;
 }
 
-export interface ApplicationOfferingChangeRequestCompletedByMinistryNotification {
+export interface ApplicationOfferingChangeRequestCompleteNotification {
   givenNames: string;
   lastName: string;
   toAddress: string;

--- a/sources/packages/backend/libs/sims-db/src/entities/notification.model.ts
+++ b/sources/packages/backend/libs/sims-db/src/entities/notification.model.ts
@@ -140,4 +140,8 @@ export enum NotificationMessageType {
    *  An Application Offering Change Request is in progress with the student.
    */
   ApplicationOfferingChangeRequestInProgressWithStudent = 13,
+  /**
+   * An Application Offering Change Request completed by ministry.
+   */
+  ApplicationOfferingChangeRequestCompletedByMinistry = 14,
 }


### PR DESCRIPTION
## As a part of this PR, the following tasks were completed:

- [x]  **Added an email notification for the scenario: offering change request approved or declined by SABC**: This task involves DB migration to add the new notification type.

Screenshot:

<img width="1925" alt="image" src="https://github.com/bcgov/SIMS/assets/7859295/edab5cdf-f84a-464f-8410-e265b1b455ba">

##  

- [x]  **e2e tests**

ApplicationOfferingChangeRequestAESTController(e2e)-assessApplicationOfferingChangeRequest
    √ Should assess the application offering change request for the provided application offering change request id.
    √ Should not create a new assessment when the application offering change request has been declined by the ministry user.
    √ Should throw a HttpStatus Not Found (404) error when an application offering change is not in a valid status to be assessed.
    √ Should throw a HttpStatus Bad Request (400) error when an invalid application offering change request status is provided.
    √ Should throw a HttpStatus Forbidden (403) error when an unauthorized AEST user tries to assess the application offering change request.