### PR TITLE
#2287 - Fix forms PodHorizontalAutoscaler

### DIFF
--- a/devops/openshift/forms-deploy.yml
+++ b/devops/openshift/forms-deploy.yml
@@ -160,10 +160,12 @@ objects:
   - apiVersion: autoscaling/v1
     kind: HorizontalPodAutoscaler
     metadata:
+      labels:
+        app: ${NAME}
       name: ${NAME}-hpa
     spec:
       scaleTargetRef:
-        apiVersion: apps/v1
+        apiVersion: apps.openshift.io/v1
         kind: DeploymentConfig
         name: ${NAME}
       minReplicas: "${{REPLICAS}}"


### PR DESCRIPTION
- Added missing label to be aligned with the other template items.
- Changed the apiVersion that was failing. `apps/v1` is for `kind: Deployment` while `apps.openshift.io/v1` is for `DeploymentConfig` (the one that we use).