### PR TITLE
#2289 - Implement logic for Application Event Code in IER12 - code and date assignment (Part 5)

### DIFF
--- a/sources/packages/backend/libs/integrations/src/institution-integration/ier12-integration/ier12.integration.service.ts
+++ b/sources/packages/backend/libs/integrations/src/institution-integration/ier12-integration/ier12.integration.service.ts
@@ -240,6 +240,8 @@ export class IER12IntegrationService extends SFTPIntegrationBase<void> {
         ierRecord.disbursementAwards,
       );
       ierFileDetail.documentProducedDate = ierRecord.disbursementSentDate;
+      ierFileDetail.applicationEventCode = ierRecord.applicationEventCode;
+      ierFileDetail.applicationEventDate = ierRecord.applicationEventDate;
       return ierFileDetail;
     });
     ierFileLines.push(...fileRecords);


### PR DESCRIPTION
- There was a logic missing for application event code and date, due to which both fields were not showing in the file content
**_Sample file screenshot_**
![image](https://github.com/bcgov/SIMS/assets/77353155/05466872-c51e-443b-81b5-4411be59fba7)
