### PR TITLE
#2382 - Redis recovery command

### DIFF
--- a/.github/workflows/env-setup-deploy-secrets.yml
+++ b/.github/workflows/env-setup-deploy-secrets.yml
@@ -56,7 +56,7 @@ jobs:
           ref: ${{ inputs.gitRef }}
       - name: Log in to OpenShift
         run: |
-          oc login --token=${{ secrets.SA_TOKEN }} --server=https://api.silver.devops.gov.bc.ca:6443
+          oc login --token=${{ secrets.SA_TOKEN }} --server=${{ vars.OPENSHIFT_CLUSTER_URL }}
       - name: Update secrets
         working-directory: "./devops/"
         run: |

--- a/.github/workflows/env-setup-deploy-secrets.yml
+++ b/.github/workflows/env-setup-deploy-secrets.yml
@@ -47,9 +47,6 @@ jobs:
       ZEEBE_CLIENT_SECRET: ${{ secrets.ZEEBE_CLIENT_SECRET }}
       ZEEBE_AUTHORIZATION_SERVER_URL: ${{ secrets.ZEEBE_AUTHORIZATION_SERVER_URL }}
     steps:
-      - name: Print env
-        run: |
-          echo NAMESPACE: $NAMESPACE
       - name: Checkout Target Branch
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/env-setup-redis-recovery.yml
+++ b/.github/workflows/env-setup-redis-recovery.yml
@@ -1,5 +1,5 @@
-name: Redis recovery in Openshift
-run-name: Redis recovery in Openshift from ${{ inputs.gitRef }} to ${{ inputs.environment }}
+name: Env Setup - Redis recovery in Openshift
+run-name: Env Setup - Redis recovery in Openshift from ${{ inputs.gitRef }} to ${{ inputs.environment }}
 
 on:
   workflow_dispatch:
@@ -21,16 +21,13 @@ jobs:
     env:
       NAMESPACE: ${{ secrets.OPENSHIFT_ENV_NAMESPACE }}
     steps:
-      - name: Print env
-        run: |
-          echo NAMESPACE: $NAMESPACE
       - name: Checkout Target Branch
         uses: actions/checkout@v3
         with:
           ref: ${{ inputs.gitRef }}
       - name: Log in to OpenShift
         run: |
-          oc login --token=${{ secrets.SA_TOKEN }} --server=https://api.silver.devops.gov.bc.ca:6443
+          oc login --token=${{ secrets.SA_TOKEN }} --server=${{ vars.OPENSHIFT_CLUSTER_URL }}
       - name: Redis cluster meet
         working-directory: "./devops/"
         run: |

--- a/.github/workflows/redis-recovery.yml
+++ b/.github/workflows/redis-recovery.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   recoverRedis:
-    name: Deploy secrets to Openshift
+    name: Redis recovery in Openshift
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment }}
     env:
@@ -31,7 +31,7 @@ jobs:
       - name: Log in to OpenShift
         run: |
           oc login --token=${{ secrets.SA_TOKEN }} --server=https://api.silver.devops.gov.bc.ca:6443
-      - name: Update secrets
+      - name: Redis cluster meet
         working-directory: "./devops/"
         run: |
           make redis-cluster-meet

--- a/.github/workflows/redis-recovery.yml
+++ b/.github/workflows/redis-recovery.yml
@@ -1,5 +1,5 @@
-name: Redis recovery to Openshift
-run-name: Redis recovery to Openshift from ${{ inputs.gitRef }} to ${{ inputs.environment }}
+name: Redis recovery in Openshift
+run-name: Redis recovery in Openshift from ${{ inputs.gitRef }} to ${{ inputs.environment }}
 
 on:
   workflow_dispatch:

--- a/.github/workflows/redis-recovery.yml
+++ b/.github/workflows/redis-recovery.yml
@@ -14,7 +14,7 @@ on:
         default: ""
 
 jobs:
-  updateSecrets:
+  recoverRedis:
     name: Deploy secrets to Openshift
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment }}

--- a/.github/workflows/redis-recovery.yml
+++ b/.github/workflows/redis-recovery.yml
@@ -1,0 +1,37 @@
+name: Redis recovery to Openshift
+run-name: Redis recovery to Openshift from ${{ inputs.gitRef }} to ${{ inputs.environment }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: "Environment"
+        required: true
+        type: environment
+      gitRef:
+        description: "Build Ref"
+        required: true
+        default: ""
+
+jobs:
+  updateSecrets:
+    name: Deploy secrets to Openshift
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
+    env:
+      NAMESPACE: ${{ secrets.OPENSHIFT_ENV_NAMESPACE }}
+    steps:
+      - name: Print env
+        run: |
+          echo NAMESPACE: $NAMESPACE
+      - name: Checkout Target Branch
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.gitRef }}
+      - name: Log in to OpenShift
+        run: |
+          oc login --token=${{ secrets.SA_TOKEN }} --server=https://api.silver.devops.gov.bc.ca:6443
+      - name: Update secrets
+        working-directory: "./devops/"
+        run: |
+          make redis-cluster-meet

--- a/devops/Makefile
+++ b/devops/Makefile
@@ -22,6 +22,7 @@ export BYPASS_CRA_INCOME_VERIFICATION := $(or $(BYPASS_CRA_INCOME_VERIFICATION),
 export BYPASS_APPLICATION_SUBMIT_VALIDATIONS := $(or $(BYPASS_APPLICATION_SUBMIT_VALIDATIONS), false)
 export SWAGGER_ENABLED := $(or ${SWAGGER_ENABLED}, true)
 export APPLICATION_ARCHIVE_DAYS := $(or ${APPLICATION_ARCHIVE_DAYS}, 43)
+export REDIS_PORT := $(or ${REDIS_PORT}, 6379)
 export API_PORT := $(or ${API_PORT}, 7070)
 export QUEUE_CONSUMERS_PORT := $(or ${QUEUE_CONSUMERS_PORT}, 7000)
 export WEB_PORT := $(or ${WEB_PORT}, 3030)
@@ -288,14 +289,14 @@ deploy-redis:
 # Make sure that all the redis pods are up and running before initializing the cluster.
 init-redis-cluster:
 	REDIS_PASSWORD=$$(oc get secret -n $(NAMESPACE) redis-creds -o jsonpath='{.data.password}' | base64 -d); \
-	REDIS_NODES=$$(oc get pods -n $(NAMESPACE) -l app=redis -o jsonpath='{range .items[*]}{.status.podIP}:6379 ' | sed 's/ :6379 $$/ /'); \
+	REDIS_NODES=$$(oc get pods -n $(NAMESPACE) -l app=redis -o jsonpath='{range .items[*]}{.status.podIP}:$(REDIS_PORT) ' | sed 's/ :$(REDIS_PORT) $$/ /'); \
 	oc exec -n $(NAMESPACE) -it redis-0 -- redis-cli -a $$REDIS_PASSWORD --cluster create $$REDIS_NODES --cluster-replicas 1
 
 # Command to tell one Redis node to connect to another node and join the cluster. 
 # This is typically done when you are setting up a Redis Cluster or adding new nodes to an existing cluster to ensure they are aware of each other and can communicate effectively.
 redis-cluster-meet:
 	REDIS_PASSWORD=$$(oc get secret -n $(NAMESPACE) redis-creds -o jsonpath='{.data.password}' | base64 -d); \
-  oc get pods -n $(NAMESPACE) -l app=redis -o jsonpath='{range.items[*]}{.status.podIP} 6379 {end}' | xargs -n2 oc exec -n $(NAMESPACE) -it redis-0 -- redis-cli -a $$REDIS_PASSWORD -c CLUSTER MEET
+  oc get pods -n $(NAMESPACE) -l app=redis -o jsonpath='{range.items[*]}{.status.podIP} $(REDIS_PORT) {end}' | xargs -n2 oc exec -n $(NAMESPACE) -it redis-0 -- redis-cli -a $$REDIS_PASSWORD -c CLUSTER MEET
 
 create-db:
 	test -n $(DB_NAME)

--- a/devops/Makefile
+++ b/devops/Makefile
@@ -291,6 +291,12 @@ init-redis-cluster:
 	REDIS_NODES=$$(oc get pods -n $(NAMESPACE) -l app=redis -o jsonpath='{range .items[*]}{.status.podIP}:6379 ' | sed 's/ :6379 $$/ /'); \
 	oc exec -n $(NAMESPACE) -it redis-0 -- redis-cli -a $$REDIS_PASSWORD --cluster create $$REDIS_NODES --cluster-replicas 1
 
+# Command to tell one Redis node to connect to another node and join the cluster. 
+# This is typically done when you are setting up a Redis Cluster or adding new nodes to an existing cluster to ensure they are aware of each other and can communicate effectively.
+redis-cluster-meet:
+	REDIS_PASSWORD=$$(oc get secret -n $(NAMESPACE) redis-creds -o jsonpath='{.data.password}' | base64 -d); \
+  oc get pods -n $(NAMESPACE) -l app=redis -o jsonpath='{range.items[*]}{.status.podIP} 6379 {end}' | xargs -n2 oc exec -n $(NAMESPACE) -it redis-0 -- redis-cli -a $$REDIS_PASSWORD -c CLUSTER MEET
+
 create-db:
 	test -n $(DB_NAME)
 	test -n $(NAMESPACE)


### PR DESCRIPTION
Created a make command from the below recommendation from the Redis channel in rocket chat and it seems to recover our Redis without deleting it completely in the environment and creating them again.

![image](https://github.com/bcgov/SIMS/assets/62901416/0dc17383-c929-4224-85eb-23c586a94a1e)

Note: This command had to be run every time, when we put down the Redis manually or any disruptions that restart the Redis pods. Parallel to this, if we have a Sysdig alert which checks the health of the Redis pods in the environment, would help us in any delays to the application queues processing.

Also wiki has been appropriately updated
https://github.com/bcgov/SIMS/wiki/DevOps-and-Running-the-Application#redis-cluster-failing-to-recover