### PR TITLE
#1934 - Finastra Part-time File Review Changes

### DIFF
--- a/sources/packages/backend/libs/integrations/src/esdc-integration/e-cert-integration/e-cert-part-time-integration/_tests_/unit/e-cert-part-time-integration.service.spec.ts
+++ b/sources/packages/backend/libs/integrations/src/esdc-integration/e-cert-integration/e-cert-part-time-integration/_tests_/unit/e-cert-part-time-integration.service.spec.ts
@@ -103,26 +103,6 @@ describe("ECertPartTimeIntegrationService-createRequestContent", () => {
         ],
       },
     ];
-
-    const [ecertRecord] = ecertRecords;
-    const disbursementAmount = ecertRecord.awards.filter(
-      (award) => award.valueCode === "CSLP",
-    )[0].effectiveAmount;
-    const totalBCGrantAmount = ecertRecord.awards.filter(
-      (award) => award.valueCode === "BCSG",
-    )[0].effectiveAmount;
-    const csgpPTAmount = ecertRecord.awards.filter(
-      (award) => award.valueCode === "CSPT",
-    )[0].effectiveAmount;
-    const csgpPDAmount = ecertRecord.awards.filter(
-      (award) => award.valueCode === "CSGP",
-    )[0].effectiveAmount;
-    const csgpPTDEPAmount = ecertRecord.awards.filter(
-      (award) => award.valueCode === "CSGD",
-    )[0].effectiveAmount;
-    const totalCanadaAndProvincialGrantsAmount =
-      totalBCGrantAmount + csgpPTAmount + csgpPDAmount + csgpPTDEPAmount;
-
     // Act
     const fileLines = eCertPartTimeIntegrationService.createRequestContent(
       ecertRecords,
@@ -130,6 +110,7 @@ describe("ECertPartTimeIntegrationService-createRequestContent", () => {
     );
 
     // Assert
+    const [ecertRecord] = ecertRecords;
     expect(fileLines).toEqual([
       {
         recordTypeCode: "01",
@@ -143,7 +124,7 @@ describe("ECertPartTimeIntegrationService-createRequestContent", () => {
         certNumber: ecertRecord.documentNumber,
         disbursementDate: ecertRecord.disbursementDate,
         documentProducedDate: ecertRecord.documentProducedDate,
-        disbursementAmount,
+        disbursementAmount: 6554,
         schoolAmount: ecertRecord.schoolAmount,
         educationalStartDate: ecertRecord.educationalStartDate,
         educationalEndDate: ecertRecord.educationalEndDate,
@@ -166,15 +147,15 @@ describe("ECertPartTimeIntegrationService-createRequestContent", () => {
         maritalStatus: getPartTimeMaritalStatusCode(ecertRecord.maritalStatus),
         studentNumber: ecertRecord.studentNumber,
         ppdFlag: getPPDFlag(ecertRecord.ppdFlag),
-        totalCanadaAndProvincialGrantsAmount,
-        totalBCGrantAmount,
-        csgpPTAmount,
-        csgpPDAmount,
-        csgpPTDEPAmount,
+        totalCanadaAndProvincialGrantsAmount: 3909,
+        totalBCGrantAmount: 333,
+        csgpPTAmount: 1800,
+        csgpPDAmount: 999,
+        csgpPTDEPAmount: 777,
       },
       {
         recordTypeCode: "99",
-        totalAmountDisbursed: disbursementAmount,
+        totalAmountDisbursed: 6554,
         recordCount: 1,
       },
     ]);

--- a/sources/packages/backend/libs/integrations/src/esdc-integration/e-cert-integration/e-cert-part-time-integration/_tests_/unit/e-cert-part-time-integration.service.spec.ts
+++ b/sources/packages/backend/libs/integrations/src/esdc-integration/e-cert-integration/e-cert-part-time-integration/_tests_/unit/e-cert-part-time-integration.service.spec.ts
@@ -1,0 +1,163 @@
+import { createMock } from "@golevelup/ts-jest";
+import { SshService } from "@sims/integrations/services";
+import { DisbursementValueType, RelationshipStatus } from "@sims/sims-db";
+import { ConfigService } from "@sims/utilities/config";
+import { ECertPartTimeFileFooter } from "../../e-cert-files/e-cert-file-footer";
+import { ECertPartTimeFileHeader } from "../../e-cert-files/e-cert-file-header";
+import { ECertPartTimeIntegrationService } from "../../e-cert-part-time.integration.service";
+
+describe("ECertPartTimeIntegrationService-createRequestContent", () => {
+  let eCertPartTimeIntegrationService: ECertPartTimeIntegrationService;
+  let eCertPartTimeFileHeader: ECertPartTimeFileHeader;
+  let eCertPartTimeFileFooter: ECertPartTimeFileFooter;
+  let configService: ConfigService;
+  let sshService: SshService;
+
+  beforeAll(() => {
+    configService = createMock<ConfigService>();
+    sshService = createMock<SshService>();
+    eCertPartTimeFileHeader = new ECertPartTimeFileHeader();
+    eCertPartTimeFileFooter = new ECertPartTimeFileFooter();
+    eCertPartTimeIntegrationService = new ECertPartTimeIntegrationService(
+      eCertPartTimeFileHeader,
+      eCertPartTimeFileFooter,
+      configService,
+      sshService,
+    );
+  });
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it(`Should create content for part time E-CERT file when requested providing E-CERT records.`, async () => {
+    // Arrange
+    const ecertRecords = [
+      {
+        sin: "445966120",
+        stopFullTimeBCFunding: false,
+        courseLoad: 20,
+        applicationNumber: "2023000009",
+        documentNumber: 28,
+        disbursementDate: new Date("2023-11-03T00:00:00.000Z"),
+        documentProducedDate: new Date("2023-11-03T20:37:58.422Z"),
+        negotiatedExpiryDate: new Date("2023-11-03T00:00:00.000Z"),
+        schoolAmount: 0,
+        educationalStartDate: new Date("2023-09-15T00:00:00.000Z"),
+        educationalEndDate: new Date("2024-08-30T00:00:00.000Z"),
+        federalInstitutionCode: "DDDD",
+        weeksOfStudy: 51,
+        fieldOfStudy: 15,
+        yearOfStudy: 1,
+        completionYears: "12WeeksToLessThan1Year",
+        enrollmentConfirmationDate: new Date("2023-11-03T19:59:44.913Z"),
+        dateOfBirth: new Date("1973-01-31T00:00:00.000Z"),
+        lastName: "SHAH",
+        firstName: "RAM DEV",
+        addressLine1: "123 Gorge Rd E",
+        addressLine2: "",
+        city: "Victoria",
+        country: "Canada",
+        provinceState: "BC",
+        postalCode: "V1V1V1",
+        email: "simsthree@test.ca",
+        gender: "male",
+        ppdFlag: null,
+        maritalStatus: RelationshipStatus.Other,
+        studentNumber: "",
+        awards: [
+          {
+            valueType: DisbursementValueType.CanadaLoan,
+            valueCode: "CSLP",
+            valueAmount: 6554,
+            effectiveAmount: 6554,
+          },
+          {
+            valueType: DisbursementValueType.CanadaGrant,
+            valueCode: "CSGP",
+            valueAmount: 999,
+            effectiveAmount: 999,
+          },
+          {
+            valueType: DisbursementValueType.CanadaGrant,
+            valueCode: "CSPT",
+            valueAmount: 1800,
+            effectiveAmount: 1800,
+          },
+          {
+            valueType: DisbursementValueType.CanadaGrant,
+            valueCode: "CSGD",
+            valueAmount: 777,
+            effectiveAmount: 777,
+          },
+          {
+            valueType: DisbursementValueType.BCTotalGrant,
+            valueCode: "BCSG",
+            valueAmount: 333,
+            effectiveAmount: 333,
+          },
+        ],
+      },
+    ];
+    // Act
+    const fileLines = eCertPartTimeIntegrationService.createRequestContent(
+      ecertRecords,
+      1,
+    );
+
+    // Assert
+    expect(fileLines).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          recordTypeCode: "01",
+          sequence: 1,
+        }),
+        expect.objectContaining({
+          recordType: "02",
+          sin: "445966120",
+          courseLoad: 20,
+          certNumber: 28,
+          disbursementDate: new Date("2023-11-03T00:00:00.000Z"),
+          documentProducedDate: new Date("2023-11-03T20:37:58.422Z"),
+          disbursementAmount: 6554,
+          schoolAmount: 0,
+          educationalStartDate: new Date("2023-09-15T00:00:00.000Z"),
+          educationalEndDate: new Date("2024-08-30T00:00:00.000Z"),
+          federalInstitutionCode: "DDDD",
+          weeksOfStudy: 51,
+          fieldOfStudy: 15,
+          yearOfStudy: 1,
+          enrollmentConfirmationDate: new Date("2023-11-03T19:59:44.913Z"),
+          dateOfBirth: new Date("1973-01-31T00:00:00.000Z"),
+          lastName: "SHAH",
+          firstName: "RAM DEV",
+          addressLine1: "123 Gorge Rd E",
+          addressLine2: "",
+          city: "Victoria",
+          country: "CAN",
+          provinceState: "BC",
+          postalCode: "V1V1V1",
+          emailAddress: "simsthree@test.ca",
+          gender: "M",
+          maritalStatus: "SP",
+          studentNumber: "",
+          ppdFlag: "N",
+          totalCanadaGrantAmount: 3909,
+          totalBCGrantAmount: 333,
+          CSGPPTAmount: 1800,
+          CSGPPDAmount: 999,
+          CSGPPTDEPAmount: 777,
+        }),
+        expect.objectContaining({
+          recordTypeCode: "99",
+          totalAmountDisbursed: 6554,
+          recordCount: 1,
+        }),
+      ]),
+    );
+
+    for (const line of fileLines) {
+      expect(line.getFixedFormat().length).toBe(756);
+    }
+  });
+});

--- a/sources/packages/backend/libs/integrations/src/esdc-integration/e-cert-integration/e-cert-part-time-integration/_tests_/unit/e-cert-part-time-integration.service.spec.ts
+++ b/sources/packages/backend/libs/integrations/src/esdc-integration/e-cert-integration/e-cert-part-time-integration/_tests_/unit/e-cert-part-time-integration.service.spec.ts
@@ -144,9 +144,9 @@ describe("ECertPartTimeIntegrationService-createRequestContent", () => {
           ppdFlag: "N",
           totalCanadaGrantAmount: 3909,
           totalBCGrantAmount: 333,
-          CSGPPTAmount: 1800,
-          CSGPPDAmount: 999,
-          CSGPPTDEPAmount: 777,
+          csgpPTAmount: 1800,
+          csgpPDAmount: 999,
+          csgpPTDEPAmount: 777,
         }),
         expect.objectContaining({
           recordTypeCode: "99",

--- a/sources/packages/backend/libs/integrations/src/esdc-integration/e-cert-integration/e-cert-part-time-integration/e-cert-files/e-cert-file-header.ts
+++ b/sources/packages/backend/libs/integrations/src/esdc-integration/e-cert-integration/e-cert-part-time-integration/e-cert-files/e-cert-file-header.ts
@@ -25,7 +25,7 @@ export class ECertPartTimeFileHeader extends ECertFileHeader {
     header.appendDate(this.processDate, DATE_FORMAT);
     header.appendDate(this.processDate, TIME_FORMAT);
     header.appendWithStartFiller(this.sequence, 6, NUMBER_FILLER);
-    header.repeatAppend(SPACE_FILLER, 698); // Trailing space.
+    header.repeatAppend(SPACE_FILLER, 692); // Trailing space.
     return header.toString();
   }
 

--- a/sources/packages/backend/libs/integrations/src/esdc-integration/e-cert-integration/e-cert-part-time-integration/e-cert-files/e-cert-file-record.ts
+++ b/sources/packages/backend/libs/integrations/src/esdc-integration/e-cert-integration/e-cert-part-time-integration/e-cert-files/e-cert-file-record.ts
@@ -134,15 +134,15 @@ export class ECertPartTimeFileRecord extends ECertFileRecord {
   /**
    * Amount of Grant for Part-time Studies (CSGP-PT) at the study start.
    */
-  CSGPPTAmount: number;
+  csgpPTAmount: number;
   /**
    * Amount of Grant for Students with Permanent Disabilities (CSGP-PD) at the study start.
    */
-  CSGPPDAmount: number;
+  csgpPDAmount: number;
   /**
    * Amount Grant for Part-time Students with Dependants (CSGP-PTDEP) at the study start.
    */
-  CSGPPTDEPAmount: number;
+  csgpPTDEPAmount: number;
   /**
    * CourseLoad for the PartTime course.
    */
@@ -198,10 +198,10 @@ export class ECertPartTimeFileRecord extends ECertFileRecord {
         5,
         NUMBER_FILLER,
       );
-      record.appendWithStartFiller(this.CSGPPTAmount, 5, NUMBER_FILLER);
+      record.appendWithStartFiller(this.csgpPTAmount, 5, NUMBER_FILLER);
       record.repeatAppend(NUMBER_FILLER, 5); // CSGP NBD MI Amt, No longer used.
-      record.appendWithStartFiller(this.CSGPPDAmount, 5, NUMBER_FILLER);
-      record.appendWithStartFiller(this.CSGPPTDEPAmount, 5, NUMBER_FILLER);
+      record.appendWithStartFiller(this.csgpPDAmount, 5, NUMBER_FILLER);
+      record.appendWithStartFiller(this.csgpPTDEPAmount, 5, NUMBER_FILLER);
       record.repeatAppend(NUMBER_FILLER, 5); // Amount of Grant for Services and Equipment for Students with Permanent Disabilities (CSGP-PDSE) at the study start, No longer used.
       record.appendWithStartFiller(this.totalBCGrantAmount, 5, NUMBER_FILLER);
       record.repeatAppend(NUMBER_FILLER, 5); // BC Part-time grant amount 2 - Reserved for future use

--- a/sources/packages/backend/libs/integrations/src/esdc-integration/e-cert-integration/e-cert-part-time-integration/e-cert-files/e-cert-file-record.ts
+++ b/sources/packages/backend/libs/integrations/src/esdc-integration/e-cert-integration/e-cert-part-time-integration/e-cert-files/e-cert-file-record.ts
@@ -122,7 +122,7 @@ export class ECertPartTimeFileRecord extends ECertFileRecord {
   /**
    * Sum of all CSGP grants + BC Provincial Part-time grants from this certificate.
    */
-  totalGrantAmount: number;
+  totalCanadaGrantAmount: number;
   /**
    * Certificate number, the generated sequence number for the file.
    */
@@ -130,19 +130,19 @@ export class ECertPartTimeFileRecord extends ECertFileRecord {
   /**
    * BC Part-time grant amount 1.
    */
-  totalBCSGAmount: number;
+  totalBCGrantAmount: number;
   /**
    * Amount of Grant for Part-time Studies (CSGP-PT) at the study start.
    */
-  totalCSGPPTAmount: number;
+  CSGPPTAmount: number;
   /**
    * Amount of Grant for Students with Permanent Disabilities (CSGP-PD) at the study start.
    */
-  totalCSGPPDAmount: number;
+  CSGPPDAmount: number;
   /**
    * Amount Grant for Part-time Students with Dependants (CSGP-PTDEP) at the study start.
    */
-  totalCSGPPTDEPAmount: number;
+  CSGPPTDEPAmount: number;
   /**
    * CourseLoad for the PartTime course.
    */
@@ -186,20 +186,24 @@ export class ECertPartTimeFileRecord extends ECertFileRecord {
       record.appendDate(this.educationalStartDate, DATE_FORMAT);
       record.appendDate(this.educationalEndDate, DATE_FORMAT);
       record.appendWithEndFiller(this.federalInstitutionCode, 4, SPACE_FILLER);
-      record.appendWithStartFiller(this.fieldOfStudy, 4, NUMBER_FILLER);
+      record.appendWithEndFiller(this.fieldOfStudy.toString(), 4, SPACE_FILLER);
       record.append(this.yearOfStudy.toString(), 1);
       record.appendWithStartFiller(this.weeksOfStudy, 3, NUMBER_FILLER);
       record.appendDate(this.documentProducedDate, DATE_FORMAT);
       record.repeatAppend(SPACE_FILLER, 8); // TODO Cancel Date, E-cert cancellation date.
       record.repeatAppend(NUMBER_FILLER, 9); // CAG PD Amt, no longer used.
       record.repeatAppend(NUMBER_FILLER, 9); // CAG LI Amt, no longer used.
-      record.appendWithStartFiller(this.totalGrantAmount, 5, NUMBER_FILLER);
-      record.appendWithStartFiller(this.totalCSGPPTAmount, 5, NUMBER_FILLER);
+      record.appendWithStartFiller(
+        this.totalCanadaGrantAmount,
+        5,
+        NUMBER_FILLER,
+      ); //39
+      record.appendWithStartFiller(this.CSGPPTAmount, 5, NUMBER_FILLER);
       record.repeatAppend(NUMBER_FILLER, 5); // CSGP NBD MI Amt, No longer used.
-      record.appendWithStartFiller(this.totalCSGPPDAmount, 5, NUMBER_FILLER);
-      record.appendWithStartFiller(this.totalCSGPPTDEPAmount, 5, NUMBER_FILLER);
+      record.appendWithStartFiller(this.CSGPPDAmount, 5, NUMBER_FILLER); //42
+      record.appendWithStartFiller(this.CSGPPTDEPAmount, 5, NUMBER_FILLER);
       record.repeatAppend(NUMBER_FILLER, 5); // Amount of Grant for Services and Equipment for Students with Permanent Disabilities (CSGP-PDSE) at the study start, No longer used.
-      record.appendWithStartFiller(this.totalBCSGAmount, 5, NUMBER_FILLER);
+      record.appendWithStartFiller(this.totalBCGrantAmount, 5, NUMBER_FILLER);
       record.repeatAppend(NUMBER_FILLER, 5); // BC Part-time grant amount 2 - Reserved for future use
       record.repeatAppend(SPACE_FILLER, 10); // Space filler.
       record.repeatAppend(SPACE_FILLER, 8); // CSGP MP Date, No longer used.
@@ -215,7 +219,7 @@ export class ECertPartTimeFileRecord extends ECertFileRecord {
       record.appendWithStartFiller(this.schoolAmount, 7, NUMBER_FILLER);
       record.appendWithStartFiller(this.courseLoad, 2, NUMBER_FILLER);
       record.append(this.ppdFlag, 1);
-      record.repeatAppend(SPACE_FILLER, 25); // Space filler.
+      record.repeatAppend(SPACE_FILLER, 24); // Space filler.
       return record.toString();
     } catch (error: unknown) {
       throw new Error(

--- a/sources/packages/backend/libs/integrations/src/esdc-integration/e-cert-integration/e-cert-part-time-integration/e-cert-files/e-cert-file-record.ts
+++ b/sources/packages/backend/libs/integrations/src/esdc-integration/e-cert-integration/e-cert-part-time-integration/e-cert-files/e-cert-file-record.ts
@@ -197,10 +197,10 @@ export class ECertPartTimeFileRecord extends ECertFileRecord {
         this.totalCanadaGrantAmount,
         5,
         NUMBER_FILLER,
-      ); //39
+      );
       record.appendWithStartFiller(this.CSGPPTAmount, 5, NUMBER_FILLER);
       record.repeatAppend(NUMBER_FILLER, 5); // CSGP NBD MI Amt, No longer used.
-      record.appendWithStartFiller(this.CSGPPDAmount, 5, NUMBER_FILLER); //42
+      record.appendWithStartFiller(this.CSGPPDAmount, 5, NUMBER_FILLER);
       record.appendWithStartFiller(this.CSGPPTDEPAmount, 5, NUMBER_FILLER);
       record.repeatAppend(NUMBER_FILLER, 5); // Amount of Grant for Services and Equipment for Students with Permanent Disabilities (CSGP-PDSE) at the study start, No longer used.
       record.appendWithStartFiller(this.totalBCGrantAmount, 5, NUMBER_FILLER);

--- a/sources/packages/backend/libs/integrations/src/esdc-integration/e-cert-integration/e-cert-part-time-integration/e-cert-files/e-cert-file-record.ts
+++ b/sources/packages/backend/libs/integrations/src/esdc-integration/e-cert-integration/e-cert-part-time-integration/e-cert-files/e-cert-file-record.ts
@@ -122,13 +122,13 @@ export class ECertPartTimeFileRecord extends ECertFileRecord {
   /**
    * Sum of all CSGP grants + BC Provincial Part-time grants from this certificate.
    */
-  totalCanadaGrantAmount: number;
+  totalCanadaAndProvincialGrantsAmount: number;
   /**
    * Certificate number, the generated sequence number for the file.
    */
   certNumber: number;
   /**
-   * BC Part-time grant amount 1.
+   * BC Part-time grant amount.
    */
   totalBCGrantAmount: number;
   /**
@@ -194,7 +194,7 @@ export class ECertPartTimeFileRecord extends ECertFileRecord {
       record.repeatAppend(NUMBER_FILLER, 9); // CAG PD Amt, no longer used.
       record.repeatAppend(NUMBER_FILLER, 9); // CAG LI Amt, no longer used.
       record.appendWithStartFiller(
-        this.totalCanadaGrantAmount,
+        this.totalCanadaAndProvincialGrantsAmount,
         5,
         NUMBER_FILLER,
       );

--- a/sources/packages/backend/libs/integrations/src/esdc-integration/e-cert-integration/e-cert-part-time-integration/e-cert-part-time.integration.service.ts
+++ b/sources/packages/backend/libs/integrations/src/esdc-integration/e-cert-integration/e-cert-part-time-integration/e-cert-part-time.integration.service.ts
@@ -69,7 +69,7 @@ export class ECertPartTimeIntegrationService extends ECertIntegrationService {
         ecertRecord.awards,
         CSGP,
       );
-      const CSGPPTDEPAmount = getDisbursementEffectiveAmountByValueCode(
+      const csgpPTDEPAmount = getDisbursementEffectiveAmountByValueCode(
         ecertRecord.awards,
         CSGD,
       );
@@ -124,7 +124,7 @@ export class ECertPartTimeIntegrationService extends ECertIntegrationService {
       record.totalBCGrantAmount = totalBCGrantAmount;
       record.csgpPTAmount = csgpPTAmount;
       record.csgpPDAmount = csgpPDAmount;
-      record.csgpPTDEPAmount = CSGPPTDEPAmount;
+      record.csgpPTDEPAmount = csgpPTDEPAmount;
       return record;
     });
     fileLines.push(...fileRecords);

--- a/sources/packages/backend/libs/integrations/src/esdc-integration/e-cert-integration/e-cert-part-time-integration/e-cert-part-time.integration.service.ts
+++ b/sources/packages/backend/libs/integrations/src/esdc-integration/e-cert-integration/e-cert-part-time-integration/e-cert-part-time.integration.service.ts
@@ -3,8 +3,8 @@ import {
   RecordTypeCodes,
   CSGD,
   CSGP,
-  CSGPT,
   ECertRecord,
+  CSPT,
 } from "../models/e-cert-integration-model";
 import { ECertPartTimeFileHeader } from "./e-cert-files/e-cert-file-header";
 import { ECertPartTimeFileFooter } from "./e-cert-files/e-cert-file-footer";
@@ -61,28 +61,28 @@ export class ECertPartTimeIntegrationService extends ECertIntegrationService {
     // Detail records
     // Calculated values
     const fileRecords = ecertRecords.map((ecertRecord) => {
-      const totalCSGPPTAmount = getDisbursementEffectiveAmountByValueCode(
+      const CSGPPTAmount = getDisbursementEffectiveAmountByValueCode(
         ecertRecord.awards,
-        CSGD,
+        CSPT,
       );
-      const totalCSGPPDAmount = getDisbursementEffectiveAmountByValueCode(
+      const CSGPPDAmount = getDisbursementEffectiveAmountByValueCode(
         ecertRecord.awards,
         CSGP,
       );
-      const totalCSGPPTDEPAmount = getDisbursementEffectiveAmountByValueCode(
+      const CSGPPTDEPAmount = getDisbursementEffectiveAmountByValueCode(
         ecertRecord.awards,
-        CSGPT,
+        CSGD,
       );
 
       const disbursementAmount = getTotalDisbursementEffectiveAmount(
         ecertRecord.awards,
         [DisbursementValueType.CanadaLoan],
       );
-      const totalGrantAmount = getTotalDisbursementEffectiveAmount(
+      const totalCanadaGrantAmount = getTotalDisbursementEffectiveAmount(
         ecertRecord.awards,
         [DisbursementValueType.CanadaGrant, DisbursementValueType.BCTotalGrant],
       );
-      const totalBCSGAmount = getTotalDisbursementEffectiveAmount(
+      const totalBCGrantAmount = getTotalDisbursementEffectiveAmount(
         ecertRecord.awards,
         [DisbursementValueType.BCTotalGrant],
       );
@@ -120,11 +120,11 @@ export class ECertPartTimeIntegrationService extends ECertIntegrationService {
       );
       record.studentNumber = ecertRecord.studentNumber;
       record.ppdFlag = getPPDFlag(ecertRecord.ppdFlag);
-      record.totalGrantAmount = totalGrantAmount;
-      record.totalBCSGAmount = totalBCSGAmount;
-      record.totalCSGPPTAmount = totalCSGPPTAmount;
-      record.totalCSGPPDAmount = totalCSGPPDAmount;
-      record.totalCSGPPTDEPAmount = totalCSGPPTDEPAmount;
+      record.totalCanadaGrantAmount = totalCanadaGrantAmount;
+      record.totalBCGrantAmount = totalBCGrantAmount;
+      record.CSGPPTAmount = CSGPPTAmount;
+      record.CSGPPDAmount = CSGPPDAmount;
+      record.CSGPPTDEPAmount = CSGPPTDEPAmount;
       return record;
     });
     fileLines.push(...fileRecords);

--- a/sources/packages/backend/libs/integrations/src/esdc-integration/e-cert-integration/e-cert-part-time-integration/e-cert-part-time.integration.service.ts
+++ b/sources/packages/backend/libs/integrations/src/esdc-integration/e-cert-integration/e-cert-part-time-integration/e-cert-part-time.integration.service.ts
@@ -61,11 +61,11 @@ export class ECertPartTimeIntegrationService extends ECertIntegrationService {
     // Detail records
     // Calculated values
     const fileRecords = ecertRecords.map((ecertRecord) => {
-      const CSGPPTAmount = getDisbursementEffectiveAmountByValueCode(
+      const csgpPTAmount = getDisbursementEffectiveAmountByValueCode(
         ecertRecord.awards,
         CSPT,
       );
-      const CSGPPDAmount = getDisbursementEffectiveAmountByValueCode(
+      const csgpPDAmount = getDisbursementEffectiveAmountByValueCode(
         ecertRecord.awards,
         CSGP,
       );
@@ -122,9 +122,9 @@ export class ECertPartTimeIntegrationService extends ECertIntegrationService {
       record.ppdFlag = getPPDFlag(ecertRecord.ppdFlag);
       record.totalCanadaGrantAmount = totalCanadaGrantAmount;
       record.totalBCGrantAmount = totalBCGrantAmount;
-      record.CSGPPTAmount = CSGPPTAmount;
-      record.CSGPPDAmount = CSGPPDAmount;
-      record.CSGPPTDEPAmount = CSGPPTDEPAmount;
+      record.csgpPTAmount = csgpPTAmount;
+      record.csgpPDAmount = csgpPDAmount;
+      record.csgpPTDEPAmount = CSGPPTDEPAmount;
       return record;
     });
     fileLines.push(...fileRecords);

--- a/sources/packages/backend/libs/integrations/src/esdc-integration/e-cert-integration/e-cert-part-time-integration/e-cert-part-time.integration.service.ts
+++ b/sources/packages/backend/libs/integrations/src/esdc-integration/e-cert-integration/e-cert-part-time-integration/e-cert-part-time.integration.service.ts
@@ -78,10 +78,11 @@ export class ECertPartTimeIntegrationService extends ECertIntegrationService {
         ecertRecord.awards,
         [DisbursementValueType.CanadaLoan],
       );
-      const totalCanadaGrantAmount = getTotalDisbursementEffectiveAmount(
-        ecertRecord.awards,
-        [DisbursementValueType.CanadaGrant, DisbursementValueType.BCTotalGrant],
-      );
+      const totalCanadaAndProvincialGrantsAmount =
+        getTotalDisbursementEffectiveAmount(ecertRecord.awards, [
+          DisbursementValueType.CanadaGrant,
+          DisbursementValueType.BCTotalGrant,
+        ]);
       const totalBCGrantAmount = getTotalDisbursementEffectiveAmount(
         ecertRecord.awards,
         [DisbursementValueType.BCTotalGrant],
@@ -120,7 +121,8 @@ export class ECertPartTimeIntegrationService extends ECertIntegrationService {
       );
       record.studentNumber = ecertRecord.studentNumber;
       record.ppdFlag = getPPDFlag(ecertRecord.ppdFlag);
-      record.totalCanadaGrantAmount = totalCanadaGrantAmount;
+      record.totalCanadaAndProvincialGrantsAmount =
+        totalCanadaAndProvincialGrantsAmount;
       record.totalBCGrantAmount = totalBCGrantAmount;
       record.csgpPTAmount = csgpPTAmount;
       record.csgpPDAmount = csgpPDAmount;

--- a/sources/packages/backend/libs/integrations/src/esdc-integration/e-cert-integration/models/e-cert-integration-model.ts
+++ b/sources/packages/backend/libs/integrations/src/esdc-integration/e-cert-integration/models/e-cert-integration-model.ts
@@ -6,7 +6,7 @@ export const ECERT_PT_SENT_TITLE = "NEW PT ENTITLEMENT";
 /**
  * Amount of Grant for Part-time Studies (CSGP-PT) at the study start.
  */
-export const CSGD = "CSGD";
+export const CSPT = "CSPT";
 /**
  * Amount of Grant for Students with Permanent Disabilities (CSGP-PD) at the study start.
  */
@@ -14,7 +14,7 @@ export const CSGP = "CSGP";
 /**
  * Amount Grant for Part-time Students with Dependants (CSGP-PTDEP) at the study start.
  */
-export const CSGPT = "CSGPT";
+export const CSGD = "CSGD";
 export interface ECertRecord {
   sin: string;
   applicationNumber: string;

--- a/sources/packages/backend/libs/integrations/src/services/disbursement-schedule/e-cert-generation.service.ts
+++ b/sources/packages/backend/libs/integrations/src/services/disbursement-schedule/e-cert-generation.service.ts
@@ -621,12 +621,16 @@ export class ECertGenerationService {
     disbursements: ECertDisbursementSchedule[],
   ) {
     for (const disbursement of disbursements) {
-      disbursement.tuitionRemittanceEffectiveAmount =
+      const maxTuitionRemittance =
         this.confirmationOfEnrollmentService.getMaxTuitionRemittance(
           disbursement.disbursementValues,
           disbursement.studentAssessment.application.currentAssessment.offering,
           MaxTuitionRemittanceTypes.Effective,
         );
+      disbursement.tuitionRemittanceEffectiveAmount =
+        disbursement.tuitionRemittanceRequestedAmount > maxTuitionRemittance
+          ? maxTuitionRemittance
+          : disbursement.tuitionRemittanceRequestedAmount;
     }
   }
 }

--- a/sources/packages/backend/libs/integrations/src/services/disbursement-schedule/e-cert-generation.service.ts
+++ b/sources/packages/backend/libs/integrations/src/services/disbursement-schedule/e-cert-generation.service.ts
@@ -627,10 +627,10 @@ export class ECertGenerationService {
           disbursement.studentAssessment.application.currentAssessment.offering,
           MaxTuitionRemittanceTypes.Effective,
         );
-      disbursement.tuitionRemittanceEffectiveAmount =
-        disbursement.tuitionRemittanceRequestedAmount > maxTuitionRemittance
-          ? maxTuitionRemittance
-          : disbursement.tuitionRemittanceRequestedAmount;
+      disbursement.tuitionRemittanceEffectiveAmount = Math.min(
+        disbursement.tuitionRemittanceRequestedAmount,
+        maxTuitionRemittance,
+      );
     }
   }
 }

--- a/sources/packages/backend/libs/services/src/constants/system-configurations-constants.ts
+++ b/sources/packages/backend/libs/services/src/constants/system-configurations-constants.ts
@@ -24,7 +24,7 @@ export const ECERT_PART_TIME_FILE_CODE = "PBC.EDU.PTCERTS.D";
  * created for Full-Time/ Part-Time feedback file.
  */
 export const ECERT_FULL_TIME_FEEDBACK_FILE_CODE = "EDU.PBC.FTECERTSFB.*";
-export const ECERT_PART_TIME_FEEDBACK_FILE_CODE = "EDU.PBC.ECERTSFB.PT.*";
+export const ECERT_PART_TIME_FEEDBACK_FILE_CODE = "TEDU.PBC.NEW.ECERTSFB.PT.*";
 
 /**
  * Amount of days before a disbursement schedule date is due that

--- a/sources/packages/backend/libs/services/src/constants/system-configurations-constants.ts
+++ b/sources/packages/backend/libs/services/src/constants/system-configurations-constants.ts
@@ -24,7 +24,7 @@ export const ECERT_PART_TIME_FILE_CODE = "PBC.EDU.PTCERTS.D";
  * created for Full-Time/ Part-Time feedback file.
  */
 export const ECERT_FULL_TIME_FEEDBACK_FILE_CODE = "EDU.PBC.FTECERTSFB.*";
-export const ECERT_PART_TIME_FEEDBACK_FILE_CODE = "TEDU.PBC.NEW.ECERTSFB.PT.*";
+export const ECERT_PART_TIME_FEEDBACK_FILE_CODE = "EDU.PBC.NEW.ECERTSFB.PT.*";
 
 /**
  * Amount of days before a disbursement schedule date is due that

--- a/sources/packages/backend/libs/sims-db/src/entities/disbursement-value-type.ts
+++ b/sources/packages/backend/libs/sims-db/src/entities/disbursement-value-type.ts
@@ -9,7 +9,7 @@ export enum DisbursementValueType {
   CanadaLoan = "Canada Loan",
   /**
    * Represents different types of federal grants
-   * that will be reported to ESDC (e.g. CSGP, CSGD, CSGT).
+   * that will be reported to ESDC (e.g. CSGP, CSGD, CSPT).
    */
   CanadaGrant = "Canada Grant",
   /**

--- a/sources/packages/backend/libs/utilities/src/disbursements-utils.ts
+++ b/sources/packages/backend/libs/utilities/src/disbursements-utils.ts
@@ -67,7 +67,7 @@ export function getTotalDisbursementEffectiveAmount(
 }
 
 /**
- * Get the award effective amount by the award value code (e.g. CSGD, CSGP, CSGPT).
+ * Get the award effective amount by the award value code (e.g. CSGD, CSGP, CSPT).
  * !Effective award value is available only after the e-Cert is generated
  * !and the overaward deductions or possible restrictions are applied.
  * @param awards list of awards (disbursement values).


### PR DESCRIPTION
- e-Cert tuition remittance should be the minimum value between `tuition_remittance_requested_amount` and `max calculated tuition remittance`:
https://github.com/bcgov/SIMS/blob/0aea33c42854e25ebf4a5afba8621ae3e0aa3997/sources/packages/backend/libs/integrations/src/services/disbursement-schedule/e-cert-generation.service.ts#L623-L636
- File name change
	- Moved to another ticket: https://app.zenhub.com/workspaces/student-information-management-system-5fce9df5aa1b45000e937014/issues/gh/bcgov/sims/2479
- Fixed file max line length;
- Changed field of study to be string with trailing spaces;
- Grants
	- Renamed CSGPT to CSPT;
	- Renamed some variables removing the "total" in the name because they don't represent a total value.
	- Fixed grant types (order);
	- Confirmed that CSGP Total Amount is the sum of all Canada Grants + BC Total Grant (BCSG);
- Changed pattern for the Feedback file;
- Added a unit test to validate the fixes in the file. The test increased the coverage in 2%):
Before:
![image](https://github.com/bcgov/SIMS/assets/78114138/929d1831-b41a-437e-8dcb-f684e751b61e)
After: 
![image](https://github.com/bcgov/SIMS/assets/78114138/792ab2d9-da68-46c2-a027-d69ad17d00a7)

