### PR TITLE
#2087 - Ministry Add New Note for Institution Account 

### DIFF
--- a/sources/packages/web/src/views/aest/institution/InstitutionNotes.vue
+++ b/sources/packages/web/src/views/aest/institution/InstitutionNotes.vue
@@ -39,6 +39,7 @@
         :notes="notes"
         @submitData="addNote"
         :allowedRole="Role.InstitutionCreateNote"
+        :allowAddingNotes="true"
       ></notes>
     </body-header-container>
   </tab-container>


### PR DESCRIPTION
-  `Create new note` button was missing in the institution note, fixed the issue.
![image](https://github.com/bcgov/SIMS/assets/77353155/61b3564d-c5a6-43c7-be42-4bd335a3cee1)
![image](https://github.com/bcgov/SIMS/assets/77353155/5ce8a6c7-5e57-4bc6-a409-e8fc7e28ab24)
![image](https://github.com/bcgov/SIMS/assets/77353155/b84c244a-e74d-479d-b019-17d5f7851c21)
