### PR TITLE
#2112 - Business Validations: Application Bulk Withdrawal: Bug Fix

### DIFF
--- a/sources/packages/web/src/views/institution/WithdrawalUpload.vue
+++ b/sources/packages/web/src/views/institution/WithdrawalUpload.vue
@@ -225,7 +225,7 @@ export default defineComponent({
           );
         if (uploadResults.length) {
           // Check for any errors. If no errors found (only warnings found), show success message.
-          if (!validationResults.value.some((result) => result.errors.length)) {
+          if (!uploadResults.some((result) => result.errors.length)) {
             snackBar.success("Success! File validated.");
           }
           validationResults.value = uploadResults;


### PR DESCRIPTION
### As a part of this PR, the following bug is fixed:

**Bug:** UI shows success message in the snackbar when there are validation errors for one or more application bulk withdrawal errors. 

**Fix:** This is fixed to show no success message when there are one or more validation errors.

### Bug:

<img width="1918" alt="image" src="https://github.com/bcgov/SIMS/assets/7859295/a4b95895-4250-4a40-abf4-07a97c0dd1a2">

### Fix:

<img width="1915" alt="image" src="https://github.com/bcgov/SIMS/assets/7859295/4b9a230a-adf0-4b96-bc03-251fc12edac4">
