### PR TITLE
#2112 - Application Bulk Withdrawal: Business Validations - Bug Fix

### DIFF
--- a/sources/packages/backend/apps/api/src/services/application-bulk-withdrawal/application-bulk-withdrawal-import-text.service.ts
+++ b/sources/packages/backend/apps/api/src/services/application-bulk-withdrawal/application-bulk-withdrawal-import-text.service.ts
@@ -177,10 +177,11 @@ export class ApplicationWithdrawalImportTextService {
         textValidation.textModel.applicationNumber;
       validationModel.withdrawalDate = textValidation.textModel.withdrawalDate;
       validationModel.applicationFound = false;
-      if (applicationData) {
+      if (
+        applicationData &&
+        textValidation.textModel.sin === applicationData.sin
+      ) {
         validationModel.applicationFound = true;
-        validationModel.studentSINMatch =
-          textValidation.textModel.sin === applicationData.sin;
         validationModel.isArchived = applicationData.isArchived;
         validationModel.applicationStatus = applicationData.applicationStatus;
         validationModel.hasPreviouslyBeenWithdrawn =

--- a/sources/packages/backend/apps/api/src/services/application-bulk-withdrawal/application-bulk-withdrawal-validation.models.ts
+++ b/sources/packages/backend/apps/api/src/services/application-bulk-withdrawal/application-bulk-withdrawal-validation.models.ts
@@ -67,20 +67,6 @@ export class ApplicationBulkWithdrawalValidationModel {
   })
   applicationFound: boolean;
   /**
-   * Valid SIN.
-   */
-  @ValidateIf(
-    (object: ApplicationBulkWithdrawalValidationModel) =>
-      object.applicationFound,
-  )
-  @IsIn([true], {
-    message: "The record was not found and will be skipped.",
-    context: ValidationContext.CreateWarning(
-      ApplicationWithdrawalValidationWarnings.NoMatchingRecordFound,
-    ),
-  })
-  studentSINMatch?: boolean;
-  /**
    * Application Status.
    */
   @ValidateIf(


### PR DESCRIPTION
## As a part of this PR, the following is fixed:

**Bug:** When an application record in the bulk withdrawal file where the student has previously withdrawn from the program (scholastic standing) is processed and the same record in the file also has an incorrect value of SIN:
 
### The below errors and warnings are shown:

<img width="1918" alt="image" src="https://github.com/bcgov/SIMS/assets/7859295/a485250e-395d-4552-8bc1-18f5b43836f2">

### **[Fix]** Instead the following errors and warnings must be shown:

<img width="1920" alt="image" src="https://github.com/bcgov/SIMS/assets/7859295/7df329e7-7660-424b-a2fc-c0f92115508d">
