### PR TITLE
#2112 - Application Bulk Withdrawal: Business Validation - Bug Fix

### DIFF
--- a/sources/packages/backend/apps/api/src/services/application-bulk-withdrawal/application-bulk-withdrawal-validation.models.ts
+++ b/sources/packages/backend/apps/api/src/services/application-bulk-withdrawal/application-bulk-withdrawal-validation.models.ts
@@ -81,10 +81,10 @@ export class ApplicationBulkWithdrawalValidationModel {
    */
   @ValidateIf(
     (object: ApplicationBulkWithdrawalValidationModel) =>
-      object.applicationFound && !object.hasPreviouslyBeenWithdrawn,
+      object.applicationFound,
   )
   @IsIn([false], {
-    message: `Application is already archived and cannot be withdrawn.`,
+    message: "Application is already archived and cannot be withdrawn.",
   })
   isArchived?: boolean;
   /**

--- a/sources/packages/backend/apps/api/src/services/application-bulk-withdrawal/application-bulk-withdrawal-validation.models.ts
+++ b/sources/packages/backend/apps/api/src/services/application-bulk-withdrawal/application-bulk-withdrawal-validation.models.ts
@@ -4,7 +4,6 @@ import {
   IsNumberString,
   Length,
   ValidateIf,
-  ValidationArguments,
 } from "class-validator";
 import { APPLICATION_NUMBER_LENGTH, ApplicationStatus } from "@sims/sims-db";
 import {
@@ -82,7 +81,7 @@ export class ApplicationBulkWithdrawalValidationModel {
    */
   @ValidateIf(
     (object: ApplicationBulkWithdrawalValidationModel) =>
-      object.applicationFound,
+      object.applicationFound && !object.hasPreviouslyBeenWithdrawn,
   )
   @IsIn([false], {
     message: `Application is already archived and cannot be withdrawn.`,
@@ -96,8 +95,8 @@ export class ApplicationBulkWithdrawalValidationModel {
       object.applicationFound,
   )
   @IsIn([false], {
-    message: (validationArguments: ValidationArguments) =>
-      `The application is already withdrawn with the date: ${validationArguments.object["withdrawalDate"]} and is going to be skipped.`,
+    message:
+      "This application is already withdrawn and is going to be skipped.",
     context: ValidationContext.CreateWarning(
       ApplicationWithdrawalValidationWarnings.HasPreviouslyBeenWithdrawn,
     ),

--- a/sources/packages/backend/apps/api/src/services/application-bulk-withdrawal/application-bulk-withdrawal-validation.models.ts
+++ b/sources/packages/backend/apps/api/src/services/application-bulk-withdrawal/application-bulk-withdrawal-validation.models.ts
@@ -81,7 +81,7 @@ export class ApplicationBulkWithdrawalValidationModel {
    */
   @ValidateIf(
     (object: ApplicationBulkWithdrawalValidationModel) =>
-      object.applicationFound,
+      object.applicationFound && !object.hasPreviouslyBeenWithdrawn,
   )
   @IsIn([false], {
     message: "Application is already archived and cannot be withdrawn.",


### PR DESCRIPTION
### As a part of this PR, the following is fixed:

**Bug:** If the application is withdrawn due to the **student withdrew from program (this very specific type of scholastic standing only)**, then the error message resulting from the application getting archived shows up.

**[Bug Screenshot]**

<img width="1920" alt="image" src="https://github.com/bcgov/SIMS/assets/7859295/ff5bb5ee-dbea-4c09-8d72-847b17fb1e61">

**Fix:** If the application is withdrawn due to student withdrew from program, then the error message resulting from the application getting archived shouldn't be shown. Only the warning message: "This application is already withdrawn and going to be skipped." is shown.

As per the new message request in the story, the withdrawal date is also not shown in the UI.

**[Fix Screenshot]**

The application in the below screenshot has scholastic standing: Student withdrew from program.  Hence, only the warning message "This application is already withdrawn and going to be skipped." is shown.

<img width="1918" alt="image" src="https://github.com/bcgov/SIMS/assets/7859295/9a2c5b34-f894-473f-be49-bcfc500291e3">
