### PR TITLE
2283 - HTTP server for nest

### DIFF
--- a/sources/packages/backend/apps/api/src/main.ts
+++ b/sources/packages/backend/apps/api/src/main.ts
@@ -25,18 +25,10 @@ async function bootstrap() {
   // Setting global prefix
   app.setGlobalPrefix("api");
 
-  // Using helmet
-  app.use(
-    helmet({
-      strictTransportSecurity: {
-        maxAge: 31536000,
-        includeSubDomains: true,
-        preload: true,
-      },
-    }),
-  );
+  // Using helmet.
+  app.use(helmet());
 
-  // Adding headers not covered by helmet
+  // Adding headers not covered by helmet.
   app.use((_, res, next) => {
     res.setHeader("Cache-Control", "no-store");
     res.setHeader("Pragma", "no-cache");

--- a/sources/packages/backend/apps/api/src/main.ts
+++ b/sources/packages/backend/apps/api/src/main.ts
@@ -30,8 +30,7 @@ async function bootstrap() {
 
   // Adding headers not covered by helmet.
   app.use((_, res, next) => {
-    res.setHeader("Cache-Control", "no-store");
-    res.setHeader("Pragma", "no-cache");
+    res.setHeader("Cache-Control", "no-cache");
     next();
   });
 

--- a/sources/packages/backend/apps/api/src/main.ts
+++ b/sources/packages/backend/apps/api/src/main.ts
@@ -10,6 +10,7 @@ import { setGlobalPipes } from "./utilities/auth-utils";
 import { DocumentBuilder, SwaggerModule } from "@nestjs/swagger";
 import { Request, Response } from "express";
 import { KeycloakConfig } from "@sims/auth/config";
+import helmet from "helmet";
 
 async function bootstrap() {
   await KeycloakConfig.load();
@@ -23,6 +24,22 @@ async function bootstrap() {
 
   // Setting global prefix
   app.setGlobalPrefix("api");
+
+  app.use(
+    helmet({
+      noSniff: true, // X-Content-Type-Options
+      contentSecurityPolicy: {
+        directives: {
+          defaultSrc: ["'self'"],
+        },
+      },
+      strictTransportSecurity: {
+        maxAge: 31536000,
+        includeSubDomains: true,
+        preload: true,
+      },
+    }),
+  );
 
   // Exception filter
   const { httpAdapter } = app.get(HttpAdapterHost);

--- a/sources/packages/backend/apps/api/src/main.ts
+++ b/sources/packages/backend/apps/api/src/main.ts
@@ -25,14 +25,9 @@ async function bootstrap() {
   // Setting global prefix
   app.setGlobalPrefix("api");
 
+  // Using helmet
   app.use(
     helmet({
-      noSniff: true, // X-Content-Type-Options
-      contentSecurityPolicy: {
-        directives: {
-          defaultSrc: ["'self'"],
-        },
-      },
       strictTransportSecurity: {
         maxAge: 31536000,
         includeSubDomains: true,
@@ -40,6 +35,13 @@ async function bootstrap() {
       },
     }),
   );
+
+  // Adding headers not covered by helmet
+  app.use((_, res, next) => {
+    res.setHeader("Cache-Control", "no-store");
+    res.setHeader("Pragma", "no-cache");
+    next();
+  });
 
   // Exception filter
   const { httpAdapter } = app.get(HttpAdapterHost);

--- a/sources/packages/backend/package-lock.json
+++ b/sources/packages/backend/package-lock.json
@@ -32,6 +32,7 @@
         "dayjs": "^1.10.4",
         "dotenv": "^8.2.0",
         "express-basic-auth": "^1.2.1",
+        "helmet": "^7.1.0",
         "ioredis": "^5.2.4",
         "jsonpath": "^1.1.1",
         "jwt-decode": "^3.1.2",
@@ -6576,6 +6577,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/helmet": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-7.1.0.tgz",
+      "integrity": "sha512-g+HZqgfbpXdCkme/Cd/mZkV0aV3BZZZSugecH03kl38m/Kmdx8jKjBikpDj2cr+Iynv4KpYEviojNdTJActJAg==",
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/hexoid": {
@@ -17063,6 +17072,11 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
       "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A=="
+    },
+    "helmet": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-7.1.0.tgz",
+      "integrity": "sha512-g+HZqgfbpXdCkme/Cd/mZkV0aV3BZZZSugecH03kl38m/Kmdx8jKjBikpDj2cr+Iynv4KpYEviojNdTJActJAg=="
     },
     "hexoid": {
       "version": "1.0.0",

--- a/sources/packages/backend/package.json
+++ b/sources/packages/backend/package.json
@@ -65,6 +65,7 @@
     "dayjs": "^1.10.4",
     "dotenv": "^8.2.0",
     "express-basic-auth": "^1.2.1",
+    "helmet": "^7.1.0",
     "ioredis": "^5.2.4",
     "jsonpath": "^1.1.1",
     "jwt-decode": "^3.1.2",


### PR DESCRIPTION
## Context

The SIMS API needs to have security HTTP headers set for the endpoint responses to satisfy some security issues raised by the WAVA scans. Among the alternatives to achieve that, two of them can be highlighted as most common: 
  1. Configure and set headers through the API itself;
  2. Configure a reverse proxy to receive the client requests, redirect to the API and change the response headers to the client.

## Configure and set headers through the API itself

Helmet.js is the middleware module recommended by [Nest.js](https://docs.nestjs.com/security/helmet) and [Express.js](https://expressjs.com/en/advanced/best-practice-security.html#use-helmet). As its documentation mentions, we can achieve something similar [without Helmet.js](https://helmetjs.github.io/faq/you-might-not-need-helmet/). The middleware will set some headers by default and allow the developer to customize it. Besides, it will organize it in a programmatically [way](https://helmetjs.github.io/faq/conditional-options/). 

Other  middleware options:
- Lusca
- Security-Headers
- CSP-Header
- Express-Secure-Headers

It's also possible to set headers for the API responses without any additional module by adding a middleware function: 
```js
  app.use((_, res, next) => {
    res.setHeader("Cache-Control", "no-cache");
    next();
  });
```

## Configure a reverse proxy to receive the client requests, redirect to the API and change the response headers to the client.

In the existing architecture, the existing Nginx server used for the web module could also be configured as a reverse proxy for the API, adding headers to the API requests.

![image](https://github.com/bcgov/SIMS/assets/78114138/f4e8520e-6f5f-4768-9616-15f05f5231e5)

Sample Nginx configuration:
```
location /api/ {
    proxy_pass http://dev-api-sims:3000;
    proxy_set_header Host $host;
    proxy_set_header X-Content-Type-Options nosniff;
    ...
}
```

Although the Nginx configuration is not complex, having this redirection of requests to the Nginx server would imply in changing API OpenShift route to the Nginx Server, new log messages would be logged to Nginx regarding the API requests and a new point of failure would be added.

Also, a reverse proxy is usually used to help us solve issues like CORS configuration, Load Balancing, SSL/TLS Termination, Request Rate limiting, Scalability, among others issues. In our architecture hosted on OpenShift these issues are already or can be addressed either by configuring OpenShift features or by setting in the API through Express.js. For this reason this option was not chosen to be implemented now.

## Implementation

In this PR it was added Helmet.js npm package and addressed some of the issues presented by the Wava scan for the institution module. Some headers were added without using Helmet because the Helmet module itself doesn't support them. There's an additional module called [nocache](https://github.com/helmetjs/nocache) that would be supposed to deal with "Cache-Control" header but is not worth it to add a new npm package just to add a [small middleware function](https://github.com/helmetjs/nocache/blob/main/index.js).

### New Headers
![image](https://github.com/bcgov/SIMS/assets/78114138/c8d7e74f-65b4-4aa6-b8b1-ee582bd14723)

## References

- https://docs.nestjs.com/security/helmet
- https://expressjs.com/en/advanced/best-practice-security.html#use-helmet
- https://helmetjs.github.io/
- https://docs.nginx.com/nginx/admin-guide/web-server/reverse-proxy/
- https://www.theserverside.com/blog/Coffee-Talk-Java-News-Stories-and-Opinions/How-to-setup-Nginx-reverse-proxy-servers-by-example