### PR TITLE
#2489 - Worker and ORM changes based on load test results

### DIFF
--- a/sources/packages/backend/apps/load-test-gateway/src/constants/system-configurations-constants.ts
+++ b/sources/packages/backend/apps/load-test-gateway/src/constants/system-configurations-constants.ts
@@ -5,4 +5,4 @@ export const HTTP_SERVICE_TIMEOUT = 30000;
 /**
  * Timeout for zeebe client to wait for process instance completion.
  */
-export const ZEEBE_PROCESS_INSTANCE_COMPLETE_TIMEOUT = 90000;
+export const ZEEBE_PROCESS_INSTANCE_COMPLETE_TIMEOUT = 120000;

--- a/sources/packages/backend/apps/workers/src/controllers/application/application.controller.ts
+++ b/sources/packages/backend/apps/workers/src/controllers/application/application.controller.ts
@@ -42,7 +42,7 @@ export class ApplicationController {
    */
   @ZeebeWorker(Workers.UpdateApplicationStatus, {
     fetchVariable: [APPLICATION_ID],
-    maxJobsToActivate: MaxJobsToActivate.Maximum,
+    maxJobsToActivate: MaxJobsToActivate.High,
   })
   async updateApplicationStatus(
     job: Readonly<

--- a/sources/packages/backend/apps/workers/src/controllers/assessment/assessment.controller.ts
+++ b/sources/packages/backend/apps/workers/src/controllers/assessment/assessment.controller.ts
@@ -88,6 +88,14 @@ export class AssessmentController {
           case INVALID_OPERATION_IN_THE_CURRENT_STATUS:
           case ASSESSMENT_ALREADY_ASSOCIATED_WITH_DIFFERENT_WORKFLOW:
             logger.warn(error.getSummaryMessage());
+            // The below method also returns JOB_ACTION_ACKNOWLEDGEMENT ideally
+            // considered sufficient to acknowledge that the job is completed.
+            // But during the load test it has been identified that calling `job.cancelWorkflow()`
+            // was not acknowledging that job is complete after the instance was cancelled.
+            // At this moment, it proves to be bug in the framework and hence the approach of calling `job.complete()`
+            // was followed.
+            // TODO: Raise the issue regarding the bug to zeebe-node community and modify
+            // the code if required based on their response or solution.
             await job.cancelWorkflow();
             return job.complete();
         }

--- a/sources/packages/backend/apps/workers/src/controllers/assessment/assessment.controller.ts
+++ b/sources/packages/backend/apps/workers/src/controllers/assessment/assessment.controller.ts
@@ -55,7 +55,7 @@ export class AssessmentController {
    */
   @ZeebeWorker(Workers.AssociateWorkflowInstance, {
     fetchVariable: [ASSESSMENT_ID],
-    maxJobsToActivate: MaxJobsToActivate.Normal,
+    maxJobsToActivate: MaxJobsToActivate.Medium,
   })
   async associateWorkflowInstance(
     job: Readonly<
@@ -87,8 +87,9 @@ export class AssessmentController {
             return job.error(error.name, error.message);
           case INVALID_OPERATION_IN_THE_CURRENT_STATUS:
           case ASSESSMENT_ALREADY_ASSOCIATED_WITH_DIFFERENT_WORKFLOW:
-            logger.error(error.getSummaryMessage());
-            return job.cancelWorkflow();
+            logger.warn(error.getSummaryMessage());
+            await job.cancelWorkflow();
+            return job.complete();
         }
       }
       return createUnexpectedJobFail(error, job, { logger });
@@ -170,7 +171,7 @@ export class AssessmentController {
    */
   @ZeebeWorker(Workers.UpdateNOAStatus, {
     fetchVariable: [ASSESSMENT_ID],
-    maxJobsToActivate: MaxJobsToActivate.Maximum,
+    maxJobsToActivate: MaxJobsToActivate.High,
   })
   async updateNOAStatus(
     job: Readonly<

--- a/sources/packages/backend/apps/workers/src/controllers/cra-integration/cra-integration.controller.ts
+++ b/sources/packages/backend/apps/workers/src/controllers/cra-integration/cra-integration.controller.ts
@@ -82,7 +82,7 @@ export class CRAIntegrationController {
    */
   @ZeebeWorker(Workers.CheckIncomeRequest, {
     fetchVariable: [INCOME_VERIFICATION_ID],
-    maxJobsToActivate: MaxJobsToActivate.Maximum,
+    maxJobsToActivate: MaxJobsToActivate.High,
   })
   async checkIncomeRequest(
     job: Readonly<

--- a/sources/packages/backend/apps/workers/src/controllers/disbursement/disbursement.controller.ts
+++ b/sources/packages/backend/apps/workers/src/controllers/disbursement/disbursement.controller.ts
@@ -46,7 +46,7 @@ export class DisbursementController {
    */
   @ZeebeWorker(Workers.SaveDisbursementSchedules, {
     fetchVariable: [ASSESSMENT_ID, DISBURSEMENT_SCHEDULES],
-    maxJobsToActivate: MaxJobsToActivate.Normal,
+    maxJobsToActivate: MaxJobsToActivate.Medium,
   })
   async saveDisbursementSchedules(
     job: Readonly<

--- a/sources/packages/backend/libs/utilities/src/system-configurations-constants.ts
+++ b/sources/packages/backend/libs/utilities/src/system-configurations-constants.ts
@@ -34,7 +34,7 @@ export const ORM_CACHE_REDIS_COMMAND_TIMEOUT = 5 * 1000;
  * Maximum number of open connections that
  * are allowed for connection pool.
  */
-export const CONNECTION_POOL_MAX_CONNECTIONS = 20;
+export const CONNECTION_POOL_MAX_CONNECTIONS = 10;
 /**
  * Maximum time that a connection request can wait
  * to get the database connection.


### PR DESCRIPTION
## Worker and ORM Changes based on load test results

**Background:** 
While load testing the workers with a chunk of 5000 assessments with different worker configuration scenarios, It has been observed that, when the pods are auto-scaling and going at and beyond 6 pods for workers, an immense load has been put on the patroni db and the patroni db was going to recovery state for few seconds and then became functional without any issues. 

As a side effect of patroni db going to recovery state, the inference proves that  the worker `associate-workflow-instance` was executed twice for the same assessment, during such an occurrence it is expected that second workflow instance must be cancelled and it must not raise an incident. The workflow instance was getting cancelled but the code to cancel workflow was not terminating/conveying the terminal state of the job and the job keeps waiting forever. Due to this the worker `associate-workflow-instance` does not process any jobs which keeps all the assessment gateway instances waiting forever once after this error occurred. 

![image](https://github.com/bcgov/SIMS/assets/54600590/fbf32d6f-22e8-4405-b931-d2a95a8977be)
 
**_Solution for worker issue:_** Updated the worker code which cancel the workflow to await for cancellation and send complete status.

**_Solution for DB going to recovery state:_** Updated the connection pool property and worker configuration to control the load on database and the configuration provided in this PR has been tested to make sure it did not make the database enter recovery mode
**Note: This is not a final solution for the database. There will be an upcoming ticket for the analysis and stabilization of DB.

- [x] Updated the worker code which cancel the workflow to await for cancellation and send complete status.
- [x] As we are not raising incident in the event of `INVALID_OPERATION_IN_THE_CURRENT_STATUS` or `ASSESSMENT_ALREADY_ASSOCIATED_WITH_DIFFERENT_WORKFLOW` in the worker `associate-workflow-instance` changed the log type to warn from error
- [x] Reduced the quota of `maxJobsToActivate` for `associate-workflow-instance` to medium to control the load applied to patroni db
- [x] Reduced the  `maxJobsToActivate` to High for all workers which had Maximumto control the load applied to patroni db
- [x] Set the connection pool to default value 10. Still have the property explicitly defined for better understanding from code.