### PR TITLE
#2546 - Readiness and Liveliness Probe for workers and Queue consumers

### DIFF
--- a/devops/openshift/api-deploy.yml
+++ b/devops/openshift/api-deploy.yml
@@ -169,7 +169,8 @@ objects:
                   cpu: ${CPU_REQUEST}
                   memory: ${MEMORY_REQUEST}
               readinessProbe:
-                failureThreshold: 10
+                failureThreshold: 3
+                successThreshold: 1
                 httpGet:
                   path: /api/
                   port: "${{PORT}}"
@@ -177,7 +178,8 @@ objects:
                 periodSeconds: 30
                 timeoutSeconds: 30
               livenessProbe:
-                failureThreshold: 10
+                failureThreshold: 3
+                successThreshold: 1
                 httpGet:
                   path: /api/
                   port: "${{PORT}}"

--- a/devops/openshift/queue-consumers-deploy.yml
+++ b/devops/openshift/queue-consumers-deploy.yml
@@ -213,6 +213,7 @@ objects:
                   memory: ${MEMORY_REQUEST}
               readinessProbe:
                 failureThreshold: 3
+                successThreshold: 1
                 httpGet:
                   path: /health/
                   port: "${{PORT}}"
@@ -221,6 +222,7 @@ objects:
                 timeoutSeconds: 1
               livenessProbe:
                 failureThreshold: 3
+                successThreshold: 1
                 httpGet:
                   path: /health/
                   port: "${{PORT}}"

--- a/devops/openshift/queue-consumers-deploy.yml
+++ b/devops/openshift/queue-consumers-deploy.yml
@@ -211,6 +211,23 @@ objects:
                 requests:
                   cpu: ${CPU_REQUEST}
                   memory: ${MEMORY_REQUEST}
+              readinessProbe:
+                failureThreshold: 3
+                httpGet:
+                  path: /health/
+                  port: "${{PORT}}"
+                initialDelaySeconds: 10
+                periodSeconds: 10
+                timeoutSeconds: 1
+              livenessProbe:
+                failureThreshold: 3
+                httpGet:
+                  path: /health/
+                  port: "${{PORT}}"
+                  scheme: HTTP
+                initialDelaySeconds: 30
+                periodSeconds: 30
+                timeoutSeconds: 1
   - apiVersion: v1
     kind: Service
     metadata:

--- a/devops/openshift/web-deploy.yml
+++ b/devops/openshift/web-deploy.yml
@@ -41,7 +41,8 @@ objects:
                   cpu: ${CPU_REQUEST}
                   memory: ${MEMORY_REQUEST}
               readinessProbe:
-                failureThreshold: 5
+                failureThreshold: 3
+                successThreshold: 1
                 httpGet:
                   path: /
                   port: "${{PORT}}"
@@ -49,7 +50,8 @@ objects:
                 periodSeconds: 30
                 timeoutSeconds: 15
               livenessProbe:
-                failureThreshold: 10
+                failureThreshold: 3
+                successThreshold: 1
                 httpGet:
                   path: /
                   port: "${{PORT}}"

--- a/devops/openshift/workers-deploy.yml
+++ b/devops/openshift/workers-deploy.yml
@@ -88,6 +88,7 @@ objects:
                   memory: ${MEMORY_REQUEST}
               readinessProbe:
                 failureThreshold: 3
+                successThreshold: 1
                 httpGet:
                   path: /health/
                   port: "${{PORT}}"
@@ -96,6 +97,7 @@ objects:
                 timeoutSeconds: 1
               livenessProbe:
                 failureThreshold: 3
+                successThreshold: 1
                 httpGet:
                   path: /health/
                   port: "${{PORT}}"

--- a/devops/openshift/workers-deploy.yml
+++ b/devops/openshift/workers-deploy.yml
@@ -86,6 +86,23 @@ objects:
                 requests:
                   cpu: ${CPU_REQUEST}
                   memory: ${MEMORY_REQUEST}
+              readinessProbe:
+                failureThreshold: 3
+                httpGet:
+                  path: /health/
+                  port: "${{PORT}}"
+                initialDelaySeconds: 10
+                periodSeconds: 10
+                timeoutSeconds: 1
+              livenessProbe:
+                failureThreshold: 3
+                httpGet:
+                  path: /health/
+                  port: "${{PORT}}"
+                  scheme: HTTP
+                initialDelaySeconds: 30
+                periodSeconds: 30
+                timeoutSeconds: 1
   - apiVersion: autoscaling/v2
     kind: HorizontalPodAutoscaler
     metadata:


### PR DESCRIPTION
- [x] Have the implemented health check created from #1580 and create readiness and liveliness probe for queue consumers
- [x] Have the implemented health check created from #1580 and create readiness and liveliness probe for workers

Tested the scenarios with the setting mentioned in the PR for Workers and queue consumers in dev by manually setting the liveliness and readiness probe. Tested by making redis and/or postgres down, both the pods restarted after the recovery successfully.