### PR TITLE
#1824 - Scholastic Standing Cloning Offering 

### DIFF
--- a/sources/packages/backend/apps/api/src/services/education-program-offering/_tests_/unit/education-program-offering.service-adjustStudyBreaks.spec.ts
+++ b/sources/packages/backend/apps/api/src/services/education-program-offering/_tests_/unit/education-program-offering.service-adjustStudyBreaks.spec.ts
@@ -1,37 +1,11 @@
 import { StudyBreak } from "@sims/sims-db";
-import {
-  StudentRestrictionService,
-  StudentScholasticStandingsService,
-} from "../../..";
-import {
-  NotificationActionsService,
-  StudentRestrictionSharedService,
-} from "@sims/services";
-import { DataSource } from "typeorm";
-import { createMock } from "@golevelup/ts-jest";
+import { EducationProgramOfferingService } from "../../..";
 import { dateDifference } from "@sims/utilities";
 import { OFFERING_STUDY_BREAK_MAX_DAYS } from "../../../../utilities";
 
-class PublicClassToTestAdjustStudyBreak extends StudentScholasticStandingsService {
-  public adjustStudyBreaks(
-    studyBreaks: StudyBreak[],
-    newStudyEndDate: string,
-  ): StudyBreak[] {
-    return super.adjustStudyBreaks(studyBreaks, newStudyEndDate);
-  }
-}
-
-describe("StudentScholasticStandingsService-adjustStudyBreaks", () => {
+describe("EducationProgramOfferingService-adjustStudyBreaks", () => {
   let studyBreaks: StudyBreak[];
-  let publicClassToTestAdjustStudyBreak: PublicClassToTestAdjustStudyBreak;
-
   beforeAll(() => {
-    publicClassToTestAdjustStudyBreak = new PublicClassToTestAdjustStudyBreak(
-      createMock<DataSource>(),
-      createMock<StudentRestrictionService>(),
-      createMock<NotificationActionsService>(),
-      createMock<StudentRestrictionSharedService>(),
-    );
     studyBreaks = [
       {
         breakDays: 16,
@@ -49,7 +23,7 @@ describe("StudentScholasticStandingsService-adjustStudyBreaks", () => {
 
     // Act
     const adjustedStudyBreaks =
-      publicClassToTestAdjustStudyBreak.adjustStudyBreaks(
+      EducationProgramOfferingService.adjustStudyBreaks(
         studyBreaks,
         newStudyEndDate,
       );
@@ -58,13 +32,13 @@ describe("StudentScholasticStandingsService-adjustStudyBreaks", () => {
     expect(adjustedStudyBreaks).toStrictEqual(studyBreaks);
   });
 
-  it("Should ignore the study break return empty array when new study end date is less than the break start date.", () => {
+  it("Should ignore the study break and return empty array when new study end date is less than the break start date.", () => {
     // Arrange
     const newStudyEndDate = "2023-11-01";
 
     // Act
     const adjustedStudyBreaks =
-      publicClassToTestAdjustStudyBreak.adjustStudyBreaks(
+      EducationProgramOfferingService.adjustStudyBreaks(
         studyBreaks,
         newStudyEndDate,
       );
@@ -79,7 +53,7 @@ describe("StudentScholasticStandingsService-adjustStudyBreaks", () => {
 
     // Act
     const adjustedStudyBreaks =
-      publicClassToTestAdjustStudyBreak.adjustStudyBreaks(
+      EducationProgramOfferingService.adjustStudyBreaks(
         studyBreaks,
         newStudyEndDate,
       );

--- a/sources/packages/backend/apps/api/src/services/education-program-offering/education-program-offering.service.ts
+++ b/sources/packages/backend/apps/api/src/services/education-program-offering/education-program-offering.service.ts
@@ -21,6 +21,7 @@ import {
   PostgresDriverError,
   mapFromRawAndEntities,
   StudentAssessmentStatus,
+  StudyBreaksAndWeeks,
 } from "@sims/sims-db";
 import {
   DataSource,
@@ -427,22 +428,8 @@ export class EducationProgramOfferingService extends RecordDataModelService<Educ
       EducationProgramOfferingService.getCalculatedStudyBreaksAndWeeks(
         educationProgramOffering,
       );
-    // Ensures that no additional properties will be assigned to studyBreaks
-    // since calculatedStudyBreaks could received extra properties that are
-    // not required to be saved to the database.
-    programOffering.studyBreaks = {
-      fundedStudyPeriodDays: calculatedBreaks.fundedStudyPeriodDays,
-      totalDays: calculatedBreaks.totalDays,
-      totalFundedWeeks: calculatedBreaks.totalFundedWeeks,
-      unfundedStudyPeriodDays: calculatedBreaks.unfundedStudyPeriodDays,
-      studyBreaks: calculatedBreaks.studyBreaks?.map((studyBreak) => ({
-        breakStartDate: studyBreak.breakStartDate,
-        breakEndDate: studyBreak.breakEndDate,
-        breakDays: studyBreak.breakDays,
-        eligibleBreakDays: studyBreak.eligibleBreakDays,
-        ineligibleBreakDays: studyBreak.ineligibleBreakDays,
-      })),
-    };
+    programOffering.studyBreaks =
+      EducationProgramOfferingService.assignStudyBreaks(calculatedBreaks);
 
     return programOffering;
   }
@@ -1193,7 +1180,33 @@ export class EducationProgramOfferingService extends RecordDataModelService<Educ
   }
 
   /**
-   * study break calculations needed for validations and definitions
+   * Calculate and assign study breaks.
+   * @param calculatedBreaks newly calculated breaks.
+   * @returns adjusted study break as per the calculatedBreaks.
+   */
+  static assignStudyBreaks(
+    calculatedBreaks: CalculatedStudyBreaksAndWeeks,
+  ): StudyBreaksAndWeeks {
+    // Ensures that no additional properties will be assigned to studyBreaks
+    // since calculatedStudyBreaks could received extra properties that are
+    // not required to be saved to the database.
+    return {
+      fundedStudyPeriodDays: calculatedBreaks.fundedStudyPeriodDays,
+      totalDays: calculatedBreaks.totalDays,
+      totalFundedWeeks: calculatedBreaks.totalFundedWeeks,
+      unfundedStudyPeriodDays: calculatedBreaks.unfundedStudyPeriodDays,
+      studyBreaks: calculatedBreaks.studyBreaks?.map((studyBreak) => ({
+        breakStartDate: studyBreak.breakStartDate,
+        breakEndDate: studyBreak.breakEndDate,
+        breakDays: studyBreak.breakDays,
+        eligibleBreakDays: studyBreak.eligibleBreakDays,
+        ineligibleBreakDays: studyBreak.ineligibleBreakDays,
+      })),
+    };
+  }
+
+  /**
+   * Study break calculations needed for validations and definitions
    * like the total weeks of study for an offering.
    * @param offering offering to have the calculation executed.
    * @returns calculated offering information.

--- a/sources/packages/backend/apps/api/src/services/education-program-offering/education-program-offering.service.ts
+++ b/sources/packages/backend/apps/api/src/services/education-program-offering/education-program-offering.service.ts
@@ -1286,7 +1286,7 @@ export class EducationProgramOfferingService extends RecordDataModelService<Educ
    * Adjust the study breaks when there is a change in study end date
    * during scholastic standing.
    * * This method is used when there is a change in study end date, which,
-   * * will effect the study break period, which will not respect the basic
+   * * will affect the study break period, which will not respect the basic
    * * offering validations like min study break period etc.
    * @param studyBreaks current offering study break.
    * @param newStudyEndDate newly changed/updated study end date.

--- a/sources/packages/backend/apps/api/src/services/student-scholastic-standings/_tests_/unit/student-scholastic-standings.service.adjustStudyBreaks.spec.ts
+++ b/sources/packages/backend/apps/api/src/services/student-scholastic-standings/_tests_/unit/student-scholastic-standings.service.adjustStudyBreaks.spec.ts
@@ -81,10 +81,10 @@ describe("StudentScholasticStandingsService-adjustStudyBreaks", () => {
       newStudyEndDate,
       studyBreak.breakStartDate,
     );
-    const eligibleBreakDays =
-      breakDays > OFFERING_STUDY_BREAK_MAX_DAYS
-        ? OFFERING_STUDY_BREAK_MAX_DAYS
-        : breakDays;
+    const eligibleBreakDays = Math.min(
+      breakDays,
+      OFFERING_STUDY_BREAK_MAX_DAYS,
+    );
 
     expect(adjustedStudyBreaks).toStrictEqual([
       {

--- a/sources/packages/backend/apps/api/src/services/student-scholastic-standings/_tests_/unit/student-scholastic-standings.service.adjustStudyBreaks.spec.ts
+++ b/sources/packages/backend/apps/api/src/services/student-scholastic-standings/_tests_/unit/student-scholastic-standings.service.adjustStudyBreaks.spec.ts
@@ -1,0 +1,99 @@
+import { StudyBreak } from "@sims/sims-db";
+import {
+  StudentRestrictionService,
+  StudentScholasticStandingsService,
+} from "../../..";
+import {
+  NotificationActionsService,
+  StudentRestrictionSharedService,
+} from "@sims/services";
+import { DataSource } from "typeorm";
+import { createMock } from "@golevelup/ts-jest";
+import { dateDifference } from "@sims/utilities";
+import { OFFERING_STUDY_BREAK_MAX_DAYS } from "../../../../utilities";
+
+describe("StudentScholasticStandingsService-adjustStudyBreaks", () => {
+  let studyBreaks: StudyBreak[];
+  let studentScholasticStandingsService: StudentScholasticStandingsService;
+
+  beforeAll(() => {
+    studentScholasticStandingsService = new StudentScholasticStandingsService(
+      createMock<DataSource>(),
+      createMock<StudentRestrictionService>(),
+      createMock<NotificationActionsService>(),
+      createMock<StudentRestrictionSharedService>(),
+    );
+    studyBreaks = [
+      {
+        breakDays: 16,
+        breakEndDate: "2023-12-16",
+        breakStartDate: "2023-12-01",
+        eligibleBreakDays: 16,
+        ineligibleBreakDays: 0,
+      },
+    ];
+  });
+
+  it("Should return the same study break when new study end date is greater than the break end date.", () => {
+    // Arrange
+    const newStudyEndDate = "2023-12-30";
+
+    // Act
+    const adjustedStudyBreaks =
+      studentScholasticStandingsService.adjustStudyBreaks(
+        studyBreaks,
+        newStudyEndDate,
+      );
+
+    // Assert
+    expect(adjustedStudyBreaks).toStrictEqual(studyBreaks);
+  });
+
+  it("Should ignore the study break return empty array when new study end date is less than the break start date.", () => {
+    // Arrange
+    const newStudyEndDate = "2023-11-01";
+
+    // Act
+    const adjustedStudyBreaks =
+      studentScholasticStandingsService.adjustStudyBreaks(
+        studyBreaks,
+        newStudyEndDate,
+      );
+
+    // Assert
+    expect(adjustedStudyBreaks).toStrictEqual([]);
+  });
+
+  it("Should adjust the study break as when new study end date is in between the study break(inclusive).", () => {
+    // Arrange
+    const newStudyEndDate = "2023-12-05";
+
+    // Act
+    const adjustedStudyBreaks =
+      studentScholasticStandingsService.adjustStudyBreaks(
+        studyBreaks,
+        newStudyEndDate,
+      );
+
+    // Assert
+    const [studyBreak] = studyBreaks;
+    const breakDays = dateDifference(
+      newStudyEndDate,
+      studyBreak.breakStartDate,
+    );
+    const eligibleBreakDays =
+      breakDays > OFFERING_STUDY_BREAK_MAX_DAYS
+        ? OFFERING_STUDY_BREAK_MAX_DAYS
+        : breakDays;
+
+    expect(adjustedStudyBreaks).toStrictEqual([
+      {
+        breakStartDate: studyBreak.breakStartDate,
+        breakEndDate: newStudyEndDate,
+        breakDays: breakDays,
+        eligibleBreakDays: eligibleBreakDays,
+        ineligibleBreakDays: breakDays - eligibleBreakDays,
+      },
+    ]);
+  });
+});

--- a/sources/packages/backend/apps/api/src/services/student-scholastic-standings/_tests_/unit/student-scholastic-standings.service.adjustStudyBreaks.spec.ts
+++ b/sources/packages/backend/apps/api/src/services/student-scholastic-standings/_tests_/unit/student-scholastic-standings.service.adjustStudyBreaks.spec.ts
@@ -64,7 +64,7 @@ describe("StudentScholasticStandingsService-adjustStudyBreaks", () => {
     expect(adjustedStudyBreaks).toStrictEqual([]);
   });
 
-  it("Should adjust the study break as when new study end date is in between the study break(inclusive).", () => {
+  it("Should adjust the study break when new study end date is in between the study break(inclusive).", () => {
     // Arrange
     const newStudyEndDate = "2023-12-05";
 

--- a/sources/packages/backend/apps/api/src/services/student-scholastic-standings/_tests_/unit/student-scholastic-standings.service.adjustStudyBreaks.spec.ts
+++ b/sources/packages/backend/apps/api/src/services/student-scholastic-standings/_tests_/unit/student-scholastic-standings.service.adjustStudyBreaks.spec.ts
@@ -12,12 +12,21 @@ import { createMock } from "@golevelup/ts-jest";
 import { dateDifference } from "@sims/utilities";
 import { OFFERING_STUDY_BREAK_MAX_DAYS } from "../../../../utilities";
 
+class PublicClassToTestAdjustStudyBreak extends StudentScholasticStandingsService {
+  public adjustStudyBreaks(
+    studyBreaks: StudyBreak[],
+    newStudyEndDate: string,
+  ): StudyBreak[] {
+    return super.adjustStudyBreaks(studyBreaks, newStudyEndDate);
+  }
+}
+
 describe("StudentScholasticStandingsService-adjustStudyBreaks", () => {
   let studyBreaks: StudyBreak[];
-  let studentScholasticStandingsService: StudentScholasticStandingsService;
+  let publicClassToTestAdjustStudyBreak: PublicClassToTestAdjustStudyBreak;
 
   beforeAll(() => {
-    studentScholasticStandingsService = new StudentScholasticStandingsService(
+    publicClassToTestAdjustStudyBreak = new PublicClassToTestAdjustStudyBreak(
       createMock<DataSource>(),
       createMock<StudentRestrictionService>(),
       createMock<NotificationActionsService>(),
@@ -40,7 +49,7 @@ describe("StudentScholasticStandingsService-adjustStudyBreaks", () => {
 
     // Act
     const adjustedStudyBreaks =
-      studentScholasticStandingsService.adjustStudyBreaks(
+      publicClassToTestAdjustStudyBreak.adjustStudyBreaks(
         studyBreaks,
         newStudyEndDate,
       );
@@ -55,7 +64,7 @@ describe("StudentScholasticStandingsService-adjustStudyBreaks", () => {
 
     // Act
     const adjustedStudyBreaks =
-      studentScholasticStandingsService.adjustStudyBreaks(
+      publicClassToTestAdjustStudyBreak.adjustStudyBreaks(
         studyBreaks,
         newStudyEndDate,
       );
@@ -70,7 +79,7 @@ describe("StudentScholasticStandingsService-adjustStudyBreaks", () => {
 
     // Act
     const adjustedStudyBreaks =
-      studentScholasticStandingsService.adjustStudyBreaks(
+      publicClassToTestAdjustStudyBreak.adjustStudyBreaks(
         studyBreaks,
         newStudyEndDate,
       );

--- a/sources/packages/backend/apps/api/src/services/student-scholastic-standings/student-scholastic-standings.service.ts
+++ b/sources/packages/backend/apps/api/src/services/student-scholastic-standings/student-scholastic-standings.service.ts
@@ -217,16 +217,18 @@ export class StudentScholasticStandingsService extends RecordDataModelService<St
           existingOffering.exceptionalExpenses;
 
         offering.offeringType = OfferingTypes.ScholasticStanding;
-        // Study Breaks calculation.
-        const adjustedStudyBreak = this.adjustStudyBreaks(
-          offering.studyBreaks.studyBreaks,
-          offering.studyEndDate,
-        );
-        // Assigning newly adjusted study breaks to the offering.
-        offering.studyBreaks = {
-          ...offering.studyBreaks,
-          studyBreaks: adjustedStudyBreak,
-        };
+        if (offering.studyBreaks?.studyBreaks) {
+          // Study Breaks calculation.
+          const adjustedStudyBreak = this.adjustStudyBreaks(
+            offering.studyBreaks.studyBreaks,
+            offering.studyEndDate,
+          );
+          // Assigning newly adjusted study breaks to the offering.
+          offering.studyBreaks = {
+            ...offering.studyBreaks,
+            studyBreaks: adjustedStudyBreak,
+          };
+        }
         const calculatedBreaks =
           EducationProgramOfferingService.getCalculatedStudyBreaksAndWeeks({
             studyEndDate: offering.studyEndDate,
@@ -345,10 +347,10 @@ export class StudentScholasticStandingsService extends RecordDataModelService<St
             newStudyEndDate,
             studyBreak.breakStartDate,
           );
-          const eligibleBreakDays =
-            breakDays > OFFERING_STUDY_BREAK_MAX_DAYS
-              ? OFFERING_STUDY_BREAK_MAX_DAYS
-              : breakDays;
+          const eligibleBreakDays = Math.min(
+            breakDays,
+            OFFERING_STUDY_BREAK_MAX_DAYS,
+          );
           return {
             breakStartDate: studyBreak.breakStartDate,
             breakEndDate: newStudyEndDate,

--- a/sources/packages/backend/apps/api/src/services/student-scholastic-standings/student-scholastic-standings.service.ts
+++ b/sources/packages/backend/apps/api/src/services/student-scholastic-standings/student-scholastic-standings.service.ts
@@ -235,22 +235,8 @@ export class StudentScholasticStandingsService extends RecordDataModelService<St
             studyStartDate: offering.studyStartDate,
             studyBreaks: offering.studyBreaks.studyBreaks,
           });
-        // Ensures that no additional properties will be assigned to studyBreaks
-        // since calculatedStudyBreaks could received extra properties that are
-        // not required to be saved to the database.
-        offering.studyBreaks = {
-          fundedStudyPeriodDays: calculatedBreaks.fundedStudyPeriodDays,
-          totalDays: calculatedBreaks.totalDays,
-          totalFundedWeeks: calculatedBreaks.totalFundedWeeks,
-          unfundedStudyPeriodDays: calculatedBreaks.unfundedStudyPeriodDays,
-          studyBreaks: calculatedBreaks.studyBreaks?.map((studyBreak) => ({
-            breakStartDate: studyBreak.breakStartDate,
-            breakEndDate: studyBreak.breakEndDate,
-            breakDays: studyBreak.breakDays,
-            eligibleBreakDays: studyBreak.eligibleBreakDays,
-            ineligibleBreakDays: studyBreak.ineligibleBreakDays,
-          })),
-        };
+        offering.studyBreaks =
+          EducationProgramOfferingService.assignStudyBreaks(calculatedBreaks);
         // Save new offering.
         const savedOffering = await transactionalEntityManager
           .getRepository(EducationProgramOffering)
@@ -326,7 +312,7 @@ export class StudentScholasticStandingsService extends RecordDataModelService<St
    * @param newStudyEndDate newly changed/updated study end date.
    * @returns adjusted study breaks.
    */
-  adjustStudyBreaks(
+  protected adjustStudyBreaks(
     studyBreaks: StudyBreak[],
     newStudyEndDate: string,
   ): StudyBreak[] {

--- a/sources/packages/backend/apps/api/src/services/student-scholastic-standings/student-scholastic-standings.service.ts
+++ b/sources/packages/backend/apps/api/src/services/student-scholastic-standings/student-scholastic-standings.service.ts
@@ -331,7 +331,7 @@ export class StudentScholasticStandingsService extends RecordDataModelService<St
     newStudyEndDate: string,
   ): StudyBreak[] {
     return studyBreaks
-      ?.map((studyBreak) => {
+      .map((studyBreak) => {
         if (isBeforeDate(newStudyEndDate, studyBreak.breakStartDate)) {
           // Ignore the study break.
           return;
@@ -362,7 +362,7 @@ export class StudentScholasticStandingsService extends RecordDataModelService<St
         // Consider the study break as it is.
         return studyBreak;
       })
-      ?.filter((studyBreak) => !!studyBreak);
+      .filter((studyBreak) => !!studyBreak);
   }
 
   /**


### PR DESCRIPTION
- `study_breaks` column will be updated using the `EducationProgramOfferingService.getCalculatedStudyBreaksAndWeeks`
-  If the change in study end date overlaps/crosses any study breaks, the below logics are followed:

> If new study end date =< break start date, ignore study break

> If new study end date => break end date, include study break as is.

> If break start date < new study end date < break end date, update break end date with new study end date

- During an offering creation when the break period is less than 6 days, offering is not allowed to create, In Scholastic standing, we do the above 3 steps and ignore all the validations(even if the new study break period is less than 6 days, we don't care, we still clone the offering with above-mentioned logic)
- created unit test for the newly created function `adjustStudyBreaks`
![image](https://github.com/bcgov/SIMS/assets/77353155/7cfc93cd-38fe-41ff-9a28-557e3644f48d)
