### PR TITLE
#2510 - Full-time and Part-Time Schedulers Centralization Refactor

### DIFF
--- a/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/esdc-integration/ecert-integration/_tests_/ecert-full-time-process-integration.scheduler.e2e-spec.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/esdc-integration/ecert-integration/_tests_/ecert-full-time-process-integration.scheduler.e2e-spec.ts
@@ -139,7 +139,7 @@ describe(
       const { job } = mockBullJob<void>();
 
       // Act
-      const result = await processor.processFullTimeECert(job);
+      const result = await processor.processECert(job);
 
       // Assert
       expect(result).toStrictEqual(["Process finalized with success."]);
@@ -367,7 +367,7 @@ describe(
       const mockedJob = mockBullJob<void>();
 
       // Act
-      const result = await processor.processFullTimeECert(mockedJob.job);
+      const result = await processor.processECert(mockedJob.job);
 
       // Assert
       expect(result).toStrictEqual(["Process finalized with success."]);

--- a/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/esdc-integration/ecert-integration/_tests_/ecert-full-time-process-integration.scheduler.e2e-spec.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/esdc-integration/ecert-integration/_tests_/ecert-full-time-process-integration.scheduler.e2e-spec.ts
@@ -142,9 +142,17 @@ describe(
       const result = await processor.processECert(job);
 
       // Assert
-      expect(result).toStrictEqual(["Process finalized with success."]);
 
-      // Assert
+      // Assert uploaded file.
+      const uploadedFile = getUploadedFile(sftpClientMock);
+      const fileDate = dayjs().format("YYYYMMDD");
+      const uploadedFileName = `MSFT-Request\\DPBC.EDU.FTECERTS.${fileDate}.001`;
+      expect(uploadedFile.remoteFilePath).toBe(uploadedFileName);
+      expect(result).toStrictEqual([
+        "Process finalized with success.",
+        `Generated file: ${uploadedFileName}`,
+        "Uploaded records: 1",
+      ]);
 
       // Assert Canada Loan overawards were deducted.
       const hasCanadaLoanOverawardDeduction =
@@ -370,7 +378,6 @@ describe(
       const result = await processor.processECert(mockedJob.job);
 
       // Assert
-      expect(result).toStrictEqual(["Process finalized with success."]);
       expect(
         mockedJob.containLogMessages([
           "New BCLM restriction was added to the student account.",
@@ -386,6 +393,14 @@ describe(
         `MSFT-Request\\DPBC.EDU.FTECERTS.${fileDate}.001`,
       );
       expect(uploadedFile.fileLines).toHaveLength(5);
+      const uploadedFileName = `MSFT-Request\\DPBC.EDU.FTECERTS.${fileDate}.001`;
+      expect(uploadedFile.remoteFilePath).toBe(uploadedFileName);
+      expect(result).toStrictEqual([
+        "Process finalized with success.",
+        `Generated file: ${uploadedFileName}`,
+        "Uploaded records: 3",
+      ]);
+
       const [header, record1, record2, record3, footer] =
         uploadedFile.fileLines;
       // Validate header.

--- a/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/esdc-integration/ecert-integration/_tests_/ecert-part-time-process-integration.scheduler.e2e-spec.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/esdc-integration/ecert-integration/_tests_/ecert-part-time-process-integration.scheduler.e2e-spec.ts
@@ -107,14 +107,18 @@ describe(
       const result = await processor.processECert(job);
 
       // Assert
-      expect(result).toStrictEqual(["Process finalized with success."]);
 
       // Assert uploaded file.
       const uploadedFile = getUploadedFile(sftpClientMock);
       const fileDate = dayjs().format("YYYYMMDD");
-      expect(uploadedFile.remoteFilePath).toBe(
-        `MSFT-Request\\DPBC.EDU.PTCERTS.D${fileDate}.001`,
-      );
+      const uploadedFileName = `MSFT-Request\\DPBC.EDU.PTCERTS.D${fileDate}.001`;
+      expect(uploadedFile.remoteFilePath).toBe(uploadedFileName);
+      expect(result).toStrictEqual([
+        "Process finalized with success.",
+        `Generated file: ${uploadedFileName}`,
+        "Uploaded records: 1",
+      ]);
+
       expect(uploadedFile.fileLines).toHaveLength(3);
       const [header, record, footer] = uploadedFile.fileLines;
       // Validate header.
@@ -233,14 +237,18 @@ describe(
       const result = await processor.processECert(job);
 
       // Assert
-      expect(result).toStrictEqual(["Process finalized with success."]);
 
       // Assert uploaded file.
       const uploadedFile = getUploadedFile(sftpClientMock);
       const fileDate = dayjs().format("YYYYMMDD");
-      expect(uploadedFile.remoteFilePath).toBe(
-        `MSFT-Request\\DPBC.EDU.PTCERTS.D${fileDate}.001`,
-      );
+      const uploadedFileName = `MSFT-Request\\DPBC.EDU.PTCERTS.D${fileDate}.001`;
+      expect(uploadedFile.remoteFilePath).toBe(uploadedFileName);
+      expect(result).toStrictEqual([
+        "Process finalized with success.",
+        `Generated file: ${uploadedFileName}`,
+        "Uploaded records: 3",
+      ]);
+
       expect(uploadedFile.fileLines).toHaveLength(5);
       const [header, record1, record2, record3, footer] =
         uploadedFile.fileLines;

--- a/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/esdc-integration/ecert-integration/_tests_/ecert-part-time-process-integration.scheduler.e2e-spec.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/esdc-integration/ecert-integration/_tests_/ecert-part-time-process-integration.scheduler.e2e-spec.ts
@@ -104,7 +104,7 @@ describe(
       const { job } = mockBullJob<void>();
 
       // Act
-      const result = await processor.processPartTimeECert(job);
+      const result = await processor.processECert(job);
 
       // Assert
       expect(result).toStrictEqual(["Process finalized with success."]);
@@ -230,7 +230,7 @@ describe(
       const { job } = mockBullJob<void>();
 
       // Act
-      const result = await processor.processPartTimeECert(job);
+      const result = await processor.processECert(job);
 
       // Assert
       expect(result).toStrictEqual(["Process finalized with success."]);

--- a/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/esdc-integration/ecert-integration/ecert-full-time-feedback-integration.scheduler.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/esdc-integration/ecert-integration/ecert-full-time-feedback-integration.scheduler.ts
@@ -1,5 +1,5 @@
 import { InjectQueue, Process, Processor } from "@nestjs/bull";
-import { ECertFileHandler } from "@sims/integrations/esdc-integration";
+import { FullTimeECertFileHandler } from "@sims/integrations/esdc-integration";
 import { QueueService } from "@sims/services/queue";
 import { QueueNames } from "@sims/utilities";
 import { Job, Queue } from "bull";
@@ -13,7 +13,7 @@ export class FullTimeECertFeedbackIntegrationScheduler extends BaseScheduler<voi
     @InjectQueue(QueueNames.FullTimeFeedbackIntegration)
     schedulerQueue: Queue<void>,
     queueService: QueueService,
-    private readonly eCertFileHandler: ECertFileHandler,
+    private readonly eCertFileHandler: FullTimeECertFileHandler,
   ) {
     super(schedulerQueue, queueService);
   }
@@ -32,8 +32,7 @@ export class FullTimeECertFeedbackIntegrationScheduler extends BaseScheduler<voi
     await summary.info(
       `Processing E-Cert Full-time integration job ${job.id} of type ${job.name}.`,
     );
-    const fullTimeResults =
-      await this.eCertFileHandler.processFullTimeResponses();
+    const fullTimeResults = await this.eCertFileHandler.processECertResponses();
     await this.cleanSchedulerQueueHistory();
     await summary.info(
       `Completed E-Cert Full-time integration job ${job.id} of type ${job.name}.`,

--- a/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/esdc-integration/ecert-integration/ecert-full-time-feedback-integration.scheduler.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/esdc-integration/ecert-integration/ecert-full-time-feedback-integration.scheduler.ts
@@ -13,7 +13,7 @@ export class FullTimeECertFeedbackIntegrationScheduler extends BaseScheduler<voi
     @InjectQueue(QueueNames.FullTimeFeedbackIntegration)
     schedulerQueue: Queue<void>,
     queueService: QueueService,
-    private readonly eCertFileHandler: FullTimeECertFileHandler,
+    private readonly fullTimeECertFileHandler: FullTimeECertFileHandler,
   ) {
     super(schedulerQueue, queueService);
   }
@@ -32,7 +32,8 @@ export class FullTimeECertFeedbackIntegrationScheduler extends BaseScheduler<voi
     await summary.info(
       `Processing E-Cert Full-time integration job ${job.id} of type ${job.name}.`,
     );
-    const fullTimeResults = await this.eCertFileHandler.processECertResponses();
+    const fullTimeResults =
+      await this.fullTimeECertFileHandler.processECertResponses();
     await this.cleanSchedulerQueueHistory();
     await summary.info(
       `Completed E-Cert Full-time integration job ${job.id} of type ${job.name}.`,

--- a/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/esdc-integration/ecert-integration/ecert-full-time-process-integration.scheduler.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/esdc-integration/ecert-integration/ecert-full-time-process-integration.scheduler.ts
@@ -1,67 +1,27 @@
-import { InjectQueue, Process, Processor } from "@nestjs/bull";
-import { ECertFileHandler } from "@sims/integrations/esdc-integration";
+import { InjectQueue, Processor } from "@nestjs/bull";
+import { FullTimeECertFileHandler } from "@sims/integrations/esdc-integration";
 import { QueueService } from "@sims/services/queue";
 import { QueueNames } from "@sims/utilities";
-import { Job, Queue } from "bull";
-import { BaseScheduler } from "../../base-scheduler";
+import { Queue } from "bull";
 import { FullTimeCalculationProcess } from "@sims/integrations/services/disbursement-schedule/e-cert-calculation";
-import {
-  InjectLogger,
-  LoggerService,
-  ProcessSummary,
-} from "@sims/utilities/logger";
-import {
-  getSuccessMessageWithAttentionCheck,
-  logProcessSummaryToJobLogger,
-} from "../../../../utilities";
+import { InjectLogger, LoggerService } from "@sims/utilities/logger";
+import { ECertProcessIntegrationBaseScheduler } from "./ecert-process-integration-base.scheduler";
 
 @Processor(QueueNames.FullTimeECertIntegration)
-export class FullTimeECertProcessIntegrationScheduler extends BaseScheduler<void> {
+export class FullTimeECertProcessIntegrationScheduler extends ECertProcessIntegrationBaseScheduler {
   constructor(
     @InjectQueue(QueueNames.FullTimeECertIntegration)
     schedulerQueue: Queue<void>,
     queueService: QueueService,
-    private readonly fullTimeCalculationProcess: FullTimeCalculationProcess,
-    private readonly eCertFileHandler: ECertFileHandler,
+    fullTimeCalculationProcess: FullTimeCalculationProcess,
+    fullTimeECertFileHandler: FullTimeECertFileHandler,
   ) {
-    super(schedulerQueue, queueService);
-  }
-
-  /**
-   * Process full-time disbursements available to be sent to ESDC.
-   * Consider any record that is scheduled in upcoming days or in the past.
-   * @params job job details.
-   * @returns result of the file upload with the file generated and the
-   * amount of records added to the file.
-   */
-  @Process()
-  async processFullTimeECert(job: Job<void>): Promise<string[]> {
-    const processSummary = new ProcessSummary();
-    try {
-      processSummary.info("Processing full-time e-Cert.");
-      processSummary.info(
-        "Executing e-Cert calculations for all eligible disbursements.",
-      );
-      // e-Cert calculations.
-      await this.fullTimeCalculationProcess.executeCalculations(processSummary);
-      // e-Cert file generation.
-      processSummary.info("Sending full-time e-Cert file.");
-      const uploadResult = await this.eCertFileHandler.generateFullTimeECert();
-      processSummary.info(`Generated file: ${uploadResult.generatedFile}`);
-      processSummary.info(`Uploaded records: ${uploadResult.uploadedRecords}`);
-      return getSuccessMessageWithAttentionCheck(
-        "Process finalized with success.",
-        processSummary,
-      );
-    } catch (error: unknown) {
-      const errorMessage = "Unexpected error while executing the job.";
-      processSummary.error(errorMessage, error);
-      return [errorMessage];
-    } finally {
-      this.logger.logProcessSummary(processSummary);
-      await logProcessSummaryToJobLogger(processSummary, job);
-      await this.cleanSchedulerQueueHistory();
-    }
+    super(
+      schedulerQueue,
+      queueService,
+      fullTimeCalculationProcess,
+      fullTimeECertFileHandler,
+    );
   }
 
   @InjectLogger()

--- a/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/esdc-integration/ecert-integration/ecert-part-time-feedback-integration.scheduler.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/esdc-integration/ecert-integration/ecert-part-time-feedback-integration.scheduler.ts
@@ -1,5 +1,5 @@
 import { InjectQueue, Process, Processor } from "@nestjs/bull";
-import { ECertFileHandler } from "@sims/integrations/esdc-integration";
+import { PartTimeECertFileHandler } from "@sims/integrations/esdc-integration";
 import { QueueService } from "@sims/services/queue";
 import { QueueNames } from "@sims/utilities";
 import { Job, Queue } from "bull";
@@ -13,7 +13,7 @@ export class PartTimeECertFeedbackIntegrationScheduler extends BaseScheduler<voi
     @InjectQueue(QueueNames.PartTimeFeedbackIntegration)
     schedulerQueue: Queue<void>,
     queueService: QueueService,
-    private readonly eCertFileHandler: ECertFileHandler,
+    private readonly eCertFileHandler: PartTimeECertFileHandler,
   ) {
     super(schedulerQueue, queueService);
   }
@@ -32,8 +32,7 @@ export class PartTimeECertFeedbackIntegrationScheduler extends BaseScheduler<voi
     await summary.info(
       `Processing e-Cert part-time feedback integration job ${job.id} of type ${job.name}.`,
     );
-    const partTimeResults =
-      await this.eCertFileHandler.processPartTimeResponses();
+    const partTimeResults = await this.eCertFileHandler.processECertResponses();
     await this.cleanSchedulerQueueHistory();
     await summary.info(
       `Completed e-Cert part-time feedback integration job ${job.id} of type ${job.name}.`,

--- a/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/esdc-integration/ecert-integration/ecert-part-time-feedback-integration.scheduler.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/esdc-integration/ecert-integration/ecert-part-time-feedback-integration.scheduler.ts
@@ -13,7 +13,7 @@ export class PartTimeECertFeedbackIntegrationScheduler extends BaseScheduler<voi
     @InjectQueue(QueueNames.PartTimeFeedbackIntegration)
     schedulerQueue: Queue<void>,
     queueService: QueueService,
-    private readonly eCertFileHandler: PartTimeECertFileHandler,
+    private readonly partTimeECertFileHandler: PartTimeECertFileHandler,
   ) {
     super(schedulerQueue, queueService);
   }
@@ -32,7 +32,8 @@ export class PartTimeECertFeedbackIntegrationScheduler extends BaseScheduler<voi
     await summary.info(
       `Processing e-Cert part-time feedback integration job ${job.id} of type ${job.name}.`,
     );
-    const partTimeResults = await this.eCertFileHandler.processECertResponses();
+    const partTimeResults =
+      await this.partTimeECertFileHandler.processECertResponses();
     await this.cleanSchedulerQueueHistory();
     await summary.info(
       `Completed e-Cert part-time feedback integration job ${job.id} of type ${job.name}.`,

--- a/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/esdc-integration/ecert-integration/ecert-process-integration-base.scheduler.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/esdc-integration/ecert-integration/ecert-process-integration-base.scheduler.ts
@@ -43,11 +43,19 @@ export abstract class ECertProcessIntegrationBaseScheduler extends BaseScheduler
       await this.eCertCalculationProcess.executeCalculations(processSummary);
       // e-Cert file generation.
       processSummary.info("Sending e-Cert file.");
-      const uploadResult = await this.eCertFileHandler.generateECert();
-      processSummary.info(`Generated file: ${uploadResult.generatedFile}`);
-      processSummary.info(`Uploaded records: ${uploadResult.uploadedRecords}`);
+      const uploadResult = await this.eCertFileHandler.generateECert(
+        processSummary,
+      );
+      const generatedFileMessage = `Generated file: ${uploadResult.generatedFile}`;
+      const uploadedRecordsMessage = `Uploaded records: ${uploadResult.uploadedRecords}`;
+      processSummary.info(generatedFileMessage);
+      processSummary.info(uploadedRecordsMessage);
       return getSuccessMessageWithAttentionCheck(
-        "Process finalized with success.",
+        [
+          "Process finalized with success.",
+          generatedFileMessage,
+          uploadedRecordsMessage,
+        ],
         processSummary,
       );
     } catch (error: unknown) {

--- a/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/esdc-integration/ecert-integration/ecert-process-integration-base.scheduler.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/esdc-integration/ecert-integration/ecert-process-integration-base.scheduler.ts
@@ -1,0 +1,66 @@
+import { Process } from "@nestjs/bull";
+import { ECertFileHandler } from "@sims/integrations/esdc-integration";
+import { QueueService } from "@sims/services/queue";
+import { Job, Queue } from "bull";
+import { BaseScheduler } from "../../base-scheduler";
+import { ECertCalculationProcess } from "@sims/integrations/services/disbursement-schedule/e-cert-calculation";
+import {
+  InjectLogger,
+  LoggerService,
+  ProcessSummary,
+} from "@sims/utilities/logger";
+import {
+  getSuccessMessageWithAttentionCheck,
+  logProcessSummaryToJobLogger,
+} from "../../../../utilities";
+
+export abstract class ECertProcessIntegrationBaseScheduler extends BaseScheduler<void> {
+  constructor(
+    schedulerQueue: Queue<void>,
+    queueService: QueueService,
+    private readonly eCertCalculationProcess: ECertCalculationProcess,
+    private readonly eCertFileHandler: ECertFileHandler,
+  ) {
+    super(schedulerQueue, queueService);
+  }
+
+  /**
+   * Process disbursements available to be sent to ESDC.
+   * Consider any record that is scheduled in upcoming days or in the past.
+   * @params job job details.
+   * @returns result of the file upload with the file generated and the
+   * amount of records added to the file.
+   */
+  @Process()
+  async processECert(job: Job<void>): Promise<string[]> {
+    const processSummary = new ProcessSummary();
+    try {
+      processSummary.info("Processing e-Cert.");
+      processSummary.info(
+        "Executing e-Cert calculations for all eligible disbursements.",
+      );
+      // e-Cert calculations.
+      await this.eCertCalculationProcess.executeCalculations(processSummary);
+      // e-Cert file generation.
+      processSummary.info("Sending e-Cert file.");
+      const uploadResult = await this.eCertFileHandler.generateECert();
+      processSummary.info(`Generated file: ${uploadResult.generatedFile}`);
+      processSummary.info(`Uploaded records: ${uploadResult.uploadedRecords}`);
+      return getSuccessMessageWithAttentionCheck(
+        "Process finalized with success.",
+        processSummary,
+      );
+    } catch (error: unknown) {
+      const errorMessage = "Unexpected error while executing the job.";
+      processSummary.error(errorMessage, error);
+      return [errorMessage];
+    } finally {
+      this.logger.logProcessSummary(processSummary);
+      await logProcessSummaryToJobLogger(processSummary, job);
+      await this.cleanSchedulerQueueHistory();
+    }
+  }
+
+  @InjectLogger()
+  logger: LoggerService;
+}

--- a/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/workflow/assessment-workflow-enqueuer.scheduler.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/workflow/assessment-workflow-enqueuer.scheduler.ts
@@ -56,7 +56,7 @@ export class AssessmentWorkflowEnqueuerScheduler extends BaseScheduler<void> {
         ),
       );
       return getSuccessMessageWithAttentionCheck(
-        "Process finalized with success.",
+        ["Process finalized with success."],
         processSummary,
       );
     } catch (error: unknown) {

--- a/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/workflow/assessment-workflow-queue-retry.scheduler.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/workflow/assessment-workflow-queue-retry.scheduler.ts
@@ -59,7 +59,7 @@ export class WorkflowQueueRetryScheduler extends BaseScheduler<AssessmentWorkflo
         ),
       );
       return getSuccessMessageWithAttentionCheck(
-        "Process finalized with success.",
+        ["Process finalized with success."],
         processSummary,
       );
     } catch (error: unknown) {

--- a/sources/packages/backend/apps/queue-consumers/src/utilities/log-utils.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/utilities/log-utils.ts
@@ -38,18 +38,18 @@ export async function logProcessSummaryToJobLogger(
 /**
  * Takes a regular success messages and append possible
  * attention messages if there are errors or warnings.
- * @param successMessage generic success message.
+ * @param successMessages generic success message.
  * @param processSummary processSummary to check if an
  * attention message is required.
  * @returns generic success message or success message with
  * attention messages appended.
  */
 export function getSuccessMessageWithAttentionCheck(
-  successMessage: string,
+  successMessages: string[],
   processSummary: ProcessSummary,
 ): string[] {
   const message: string[] = [];
-  message.push(successMessage);
+  message.push(...successMessages);
   const logsSum = processSummary.getLogLevelSum();
   if (logsSum.error || logsSum.warn) {
     message.push(

--- a/sources/packages/backend/libs/integrations/src/esdc-integration/e-cert-integration/e-cert-file-handler.ts
+++ b/sources/packages/backend/libs/integrations/src/esdc-integration/e-cert-integration/e-cert-file-handler.ts
@@ -1,4 +1,8 @@
-import { LoggerService, InjectLogger } from "@sims/utilities/logger";
+import {
+  LoggerService,
+  InjectLogger,
+  ProcessSummary,
+} from "@sims/utilities/logger";
 import {
   DisbursementSchedule,
   DisbursementScheduleStatus,
@@ -28,7 +32,6 @@ import { ECertFullTimeResponseRecord } from "./e-cert-full-time-integration/e-ce
 import { ProcessSFTPResponseResult } from "../models/esdc-integration.model";
 import { ConfigService, ESDCIntegrationConfig } from "@sims/utilities/config";
 import { ECertGenerationService } from "@sims/integrations/services";
-import { ProcessSummary } from "@sims/utilities/logger";
 
 /**
  * Used to abort the e-Cert generation process, cancel the current transaction,

--- a/sources/packages/backend/libs/integrations/src/esdc-integration/e-cert-integration/e-cert-file-handler.ts
+++ b/sources/packages/backend/libs/integrations/src/esdc-integration/e-cert-integration/e-cert-file-handler.ts
@@ -64,7 +64,6 @@ export abstract class ECertFileHandler extends ESDCFileHandler {
 
   /**
    * Method to call the e-cert feedback file processing and the list of all errors, if any.
-
    * @returns result of the file upload with the file generated and the
    * amount of records added to the file.
    */

--- a/sources/packages/backend/libs/integrations/src/esdc-integration/e-cert-integration/e-cert-integration.module.ts
+++ b/sources/packages/backend/libs/integrations/src/esdc-integration/e-cert-integration/e-cert-integration.module.ts
@@ -8,7 +8,6 @@ import {
   DisbursementScheduleSharedService,
   RestrictionSharedService,
 } from "@sims/services";
-import { ECertFileHandler } from "./e-cert-file-handler";
 import { ECertFullTimeFileFooter } from "./e-cert-full-time-integration/e-cert-files/e-cert-file-footer";
 import { ECertFullTimeFileHeader } from "./e-cert-full-time-integration/e-cert-files/e-cert-file-header";
 import { ECertFullTimeIntegrationService } from "./e-cert-full-time-integration/e-cert-full-time.integration.service";
@@ -39,6 +38,8 @@ import {
   FullTimeCalculationProcess,
   PartTimeCalculationProcess,
 } from "@sims/integrations/services/disbursement-schedule/e-cert-calculation";
+import { FullTimeECertFileHandler } from "./full-time-e-cert-file-handler";
+import { PartTimeECertFileHandler } from "./part-time-e-cert-file-handler";
 
 @Module({
   imports: [ConfigModule, SystemUserModule],
@@ -48,7 +49,8 @@ import {
     ECertPartTimeIntegrationService,
     SequenceControlService,
     DisbursementScheduleService,
-    ECertFileHandler,
+    FullTimeECertFileHandler,
+    PartTimeECertFileHandler,
     ECertPartTimeFileHeader,
     ECertPartTimeFileFooter,
     ECertFullTimeFileHeader,
@@ -76,7 +78,8 @@ import {
     PartTimeCalculationProcess,
   ],
   exports: [
-    ECertFileHandler,
+    FullTimeECertFileHandler,
+    PartTimeECertFileHandler,
     FullTimeCalculationProcess,
     PartTimeCalculationProcess,
   ],

--- a/sources/packages/backend/libs/integrations/src/esdc-integration/e-cert-integration/full-time-e-cert-file-handler.ts
+++ b/sources/packages/backend/libs/integrations/src/esdc-integration/e-cert-integration/full-time-e-cert-file-handler.ts
@@ -1,0 +1,70 @@
+import { OfferingIntensity } from "@sims/sims-db";
+import {
+  DisbursementScheduleErrorsService,
+  DisbursementScheduleService,
+} from "../../services";
+import { SequenceControlService, SystemUsersService } from "@sims/services";
+import {
+  ECERT_FULL_TIME_FILE_CODE,
+  ECERT_FULL_TIME_FEEDBACK_FILE_CODE,
+} from "@sims/services/constants";
+import {
+  ECertUploadResult,
+  ESDCFileResponse,
+} from "./models/e-cert-integration-model";
+import { Injectable } from "@nestjs/common";
+import { ConfigService, ESDCIntegrationConfig } from "@sims/utilities/config";
+import { ECertGenerationService } from "@sims/integrations/services";
+import { ECertFileHandler } from "./e-cert-file-handler";
+import { ECertFullTimeIntegrationService } from "./e-cert-full-time-integration/e-cert-full-time.integration.service";
+
+const ECERT_FULL_TIME_SENT_FILE_SEQUENCE_GROUP = "ECERT_FT_SENT_FILE";
+
+@Injectable()
+export class FullTimeECertFileHandler extends ECertFileHandler {
+  esdcConfig: ESDCIntegrationConfig;
+  constructor(
+    configService: ConfigService,
+    sequenceService: SequenceControlService,
+    disbursementScheduleService: DisbursementScheduleService,
+    eCertGenerationService: ECertGenerationService,
+    disbursementScheduleErrorsService: DisbursementScheduleErrorsService,
+    systemUserService: SystemUsersService,
+    private readonly eCertIntegrationService: ECertFullTimeIntegrationService,
+  ) {
+    super(
+      configService,
+      sequenceService,
+      disbursementScheduleService,
+      eCertGenerationService,
+      disbursementScheduleErrorsService,
+      systemUserService,
+    );
+  }
+
+  /**
+   * Method to call the Full-time disbursements available to be sent to ESDC.
+   * @returns result of the file upload with the file generated and the
+   * amount of records added to the file.
+   */
+  async generateECert(): Promise<ECertUploadResult> {
+    return this.eCertGeneration(
+      this.eCertIntegrationService,
+      OfferingIntensity.fullTime,
+      ECERT_FULL_TIME_FILE_CODE,
+      ECERT_FULL_TIME_SENT_FILE_SEQUENCE_GROUP,
+    );
+  }
+
+  /**
+   * Method to call the Full-time feedback file processing and the list of all errors, if any.
+   * @returns result of the file upload with the file generated and the
+   * amount of records added to the file.
+   */
+  async processECertResponses(): Promise<ESDCFileResponse[]> {
+    return this.processResponses(
+      this.eCertIntegrationService,
+      ECERT_FULL_TIME_FEEDBACK_FILE_CODE,
+    );
+  }
+}

--- a/sources/packages/backend/libs/integrations/src/esdc-integration/e-cert-integration/full-time-e-cert-file-handler.ts
+++ b/sources/packages/backend/libs/integrations/src/esdc-integration/e-cert-integration/full-time-e-cert-file-handler.ts
@@ -17,6 +17,7 @@ import { ConfigService, ESDCIntegrationConfig } from "@sims/utilities/config";
 import { ECertGenerationService } from "@sims/integrations/services";
 import { ECertFileHandler } from "./e-cert-file-handler";
 import { ECertFullTimeIntegrationService } from "./e-cert-full-time-integration/e-cert-full-time.integration.service";
+import { ProcessSummary } from "@sims/utilities/logger";
 
 const ECERT_FULL_TIME_SENT_FILE_SEQUENCE_GROUP = "ECERT_FT_SENT_FILE";
 
@@ -44,15 +45,17 @@ export class FullTimeECertFileHandler extends ECertFileHandler {
 
   /**
    * Method to call the Full-time disbursements available to be sent to ESDC.
+   * @param log cumulative process log.
    * @returns result of the file upload with the file generated and the
    * amount of records added to the file.
    */
-  async generateECert(): Promise<ECertUploadResult> {
+  async generateECert(log: ProcessSummary): Promise<ECertUploadResult> {
     return this.eCertGeneration(
       this.eCertIntegrationService,
       OfferingIntensity.fullTime,
       ECERT_FULL_TIME_FILE_CODE,
       ECERT_FULL_TIME_SENT_FILE_SEQUENCE_GROUP,
+      log,
     );
   }
 

--- a/sources/packages/backend/libs/integrations/src/esdc-integration/e-cert-integration/part-time-e-cert-file-handler.ts
+++ b/sources/packages/backend/libs/integrations/src/esdc-integration/e-cert-integration/part-time-e-cert-file-handler.ts
@@ -17,6 +17,7 @@ import { ConfigService, ESDCIntegrationConfig } from "@sims/utilities/config";
 import { ECertGenerationService } from "@sims/integrations/services";
 import { ECertFileHandler } from "./e-cert-file-handler";
 import { ECertPartTimeIntegrationService } from "./e-cert-part-time-integration/e-cert-part-time.integration.service";
+import { ProcessSummary } from "@sims/utilities/logger";
 
 const ECERT_PART_TIME_SENT_FILE_SEQUENCE_GROUP = "ECERT_PT_SENT_FILE";
 
@@ -44,15 +45,17 @@ export class PartTimeECertFileHandler extends ECertFileHandler {
 
   /**
    * Method to call the Part-time disbursements available to be sent to ESDC.
+   * @param log cumulative process log.
    * @returns result of the file upload with the file generated and the
    * amount of records added to the file.
    */
-  async generateECert(): Promise<ECertUploadResult> {
+  async generateECert(log: ProcessSummary): Promise<ECertUploadResult> {
     return this.eCertGeneration(
       this.eCertIntegrationService,
       OfferingIntensity.partTime,
       ECERT_PART_TIME_FILE_CODE,
       ECERT_PART_TIME_SENT_FILE_SEQUENCE_GROUP,
+      log,
     );
   }
 

--- a/sources/packages/backend/libs/integrations/src/esdc-integration/e-cert-integration/part-time-e-cert-file-handler.ts
+++ b/sources/packages/backend/libs/integrations/src/esdc-integration/e-cert-integration/part-time-e-cert-file-handler.ts
@@ -1,0 +1,70 @@
+import { OfferingIntensity } from "@sims/sims-db";
+import {
+  DisbursementScheduleErrorsService,
+  DisbursementScheduleService,
+} from "../../services";
+import { SequenceControlService, SystemUsersService } from "@sims/services";
+import {
+  ECERT_PART_TIME_FEEDBACK_FILE_CODE,
+  ECERT_PART_TIME_FILE_CODE,
+} from "@sims/services/constants";
+import {
+  ECertUploadResult,
+  ESDCFileResponse,
+} from "./models/e-cert-integration-model";
+import { Injectable } from "@nestjs/common";
+import { ConfigService, ESDCIntegrationConfig } from "@sims/utilities/config";
+import { ECertGenerationService } from "@sims/integrations/services";
+import { ECertFileHandler } from "./e-cert-file-handler";
+import { ECertPartTimeIntegrationService } from "./e-cert-part-time-integration/e-cert-part-time.integration.service";
+
+const ECERT_PART_TIME_SENT_FILE_SEQUENCE_GROUP = "ECERT_PT_SENT_FILE";
+
+@Injectable()
+export class PartTimeECertFileHandler extends ECertFileHandler {
+  esdcConfig: ESDCIntegrationConfig;
+  constructor(
+    configService: ConfigService,
+    sequenceService: SequenceControlService,
+    disbursementScheduleService: DisbursementScheduleService,
+    eCertGenerationService: ECertGenerationService,
+    disbursementScheduleErrorsService: DisbursementScheduleErrorsService,
+    systemUserService: SystemUsersService,
+    private readonly eCertIntegrationService: ECertPartTimeIntegrationService,
+  ) {
+    super(
+      configService,
+      sequenceService,
+      disbursementScheduleService,
+      eCertGenerationService,
+      disbursementScheduleErrorsService,
+      systemUserService,
+    );
+  }
+
+  /**
+   * Method to call the Part-time disbursements available to be sent to ESDC.
+   * @returns result of the file upload with the file generated and the
+   * amount of records added to the file.
+   */
+  async generateECert(): Promise<ECertUploadResult> {
+    return this.eCertGeneration(
+      this.eCertIntegrationService,
+      OfferingIntensity.partTime,
+      ECERT_PART_TIME_FILE_CODE,
+      ECERT_PART_TIME_SENT_FILE_SEQUENCE_GROUP,
+    );
+  }
+
+  /**
+   * Method to call the Part-time feedback file processing and the list of all errors, if any.
+   * @returns result of the file upload with the file generated and the
+   * amount of records added to the file.
+   */
+  async processECertResponses(): Promise<ESDCFileResponse[]> {
+    return this.processResponses(
+      this.eCertIntegrationService,
+      ECERT_PART_TIME_FEEDBACK_FILE_CODE,
+    );
+  }
+}

--- a/sources/packages/backend/libs/integrations/src/esdc-integration/index.ts
+++ b/sources/packages/backend/libs/integrations/src/esdc-integration/index.ts
@@ -8,6 +8,8 @@ export * from "./disbursement-receipt-integration/disbursement-receipt.processin
 export * from "./disbursement-receipt-integration/daily-disbursement-receipt.processing.service";
 export * from "./disbursement-receipt-integration/models/disbursement-receipt-integration.model";
 export * from "./e-cert-integration/e-cert-file-handler";
+export * from "./e-cert-integration/full-time-e-cert-file-handler";
+export * from "./e-cert-integration/part-time-e-cert-file-handler";
 export * from "./e-cert-integration/e-cert-files/e-cert-file-footer";
 export * from "./e-cert-integration/e-cert-files/e-cert-file-header";
 export * from "./e-cert-integration/e-cert-files/e-cert-file-record";


### PR DESCRIPTION
- Created the new based class `ECertProcessIntegrationBaseScheduler` to be shared by the full-time and part-time e-Cert schedulers.
- Created also the base class `ECertFileHandler` to support the above-mentioned change.
- Changed the e-Cert file generation to also use the `ProcessSummary` logs.

_Please note that refactors for the e-Cert feedback are out of the scope of this effort._