### PR TITLE
#2510 - e-Cert Implementation for Individual Student Processing - Fix and Investigation

### DIFF
--- a/sources/packages/backend/libs/integrations/src/esdc-integration/e-cert-integration/e-cert-full-time-integration/e-cert-files/e-cert-file-record.ts
+++ b/sources/packages/backend/libs/integrations/src/esdc-integration/e-cert-integration/e-cert-full-time-integration/e-cert-files/e-cert-file-record.ts
@@ -240,7 +240,8 @@ export class ECertFullTimeFileRecord extends ECertFileRecord {
       return record.toString();
     } catch (error: unknown) {
       throw new Error(
-        `Error while creating record with document number: ${this.documentNumber}. Error ${error}`,
+        `Error while creating record with document number: ${this.documentNumber}`,
+        { cause: error },
       );
     }
   }

--- a/sources/packages/backend/libs/integrations/src/esdc-integration/e-cert-integration/e-cert-part-time-integration/e-cert-files/e-cert-file-record.ts
+++ b/sources/packages/backend/libs/integrations/src/esdc-integration/e-cert-integration/e-cert-part-time-integration/e-cert-files/e-cert-file-record.ts
@@ -223,7 +223,8 @@ export class ECertPartTimeFileRecord extends ECertFileRecord {
       return record.toString();
     } catch (error: unknown) {
       throw new Error(
-        `Error while creating record with document number: ${this.certNumber}. Error ${error}`,
+        `Error while creating record with document number: ${this.certNumber}`,
+        { cause: error },
       );
     }
   }

--- a/sources/packages/backend/libs/integrations/src/services/disbursement-schedule/e-cert-processing-steps/assert-life-time-maximum-full-time-step.ts
+++ b/sources/packages/backend/libs/integrations/src/services/disbursement-schedule/e-cert-processing-steps/assert-life-time-maximum-full-time-step.ts
@@ -57,7 +57,7 @@ export class AssertLifeTimeMaximumFullTimeStep implements ECertProcessStep {
     );
     if (!bcLoan?.valueAmount) {
       log.info(
-        `${bcLoan.valueCode} award not found or there is no amount to be disbursed, hence skipping the check.`,
+        `${DisbursementValueType.BCLoan} award not found or there is no amount to be disbursed, hence skipping the check.`,
       );
       return true;
     }

--- a/sources/packages/backend/tsconfig.json
+++ b/sources/packages/backend/tsconfig.json
@@ -6,6 +6,7 @@
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "allowSyntheticDefaultImports": true,
+    "lib": ["ES2020", "es2022.error"],
     "target": "ES2020",
     "sourceMap": true,
     "outDir": "./dist",
@@ -13,42 +14,18 @@
     "incremental": true,
     "allowJs": true,
     "paths": {
-      "@sims/sims-db": [
-        "libs/sims-db/src"
-      ],
-      "@sims/sims-db/*": [
-        "libs/sims-db/src/*"
-      ],
-      "@sims/services": [
-        "libs/services/src"
-      ],
-      "@sims/services/*": [
-        "libs/services/src/*"
-      ],
-      "@sims/utilities": [
-        "libs/utilities/src"
-      ],
-      "@sims/utilities/*": [
-        "libs/utilities/src/*"
-      ],
-      "@sims/test-utils": [
-        "libs/test-utils/src"
-      ],
-      "@sims/test-utils/*": [
-        "libs/test-utils/src/*"
-      ],
-      "@sims/integrations": [
-        "libs/integrations/src"
-      ],
-      "@sims/integrations/*": [
-        "libs/integrations/src/*"
-      ],
-      "@sims/auth": [
-        "libs/auth/src"
-      ],
-      "@sims/auth/*": [
-        "libs/auth/src/*"
-      ]
+      "@sims/sims-db": ["libs/sims-db/src"],
+      "@sims/sims-db/*": ["libs/sims-db/src/*"],
+      "@sims/services": ["libs/services/src"],
+      "@sims/services/*": ["libs/services/src/*"],
+      "@sims/utilities": ["libs/utilities/src"],
+      "@sims/utilities/*": ["libs/utilities/src/*"],
+      "@sims/test-utils": ["libs/test-utils/src"],
+      "@sims/test-utils/*": ["libs/test-utils/src/*"],
+      "@sims/integrations": ["libs/integrations/src"],
+      "@sims/integrations/*": ["libs/integrations/src/*"],
+      "@sims/auth": ["libs/auth/src"],
+      "@sims/auth/*": ["libs/auth/src/*"]
     }
   }
 }


### PR DESCRIPTION
 - Fixed an issue for the BC `assert-life-time-maximum-full-time-step` that would fail during the log due to a null exception while accessing `bcLoan.valueCode`.
 - Added `cause` to the errors generated during e-Cert record generation for further investigation. The `cause` is present in `es2022` but only `es2022.error` was updated right now because extra changes are needed to completely update the backend to use `es2022`.