### PR TITLE
#2452 - IER12 File Adjustments

### DIFF
--- a/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/institution-integration/ier12-integration/_tests_/e2e/models/data-inputs/programs-inputs.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/institution-integration/ier12-integration/_tests_/e2e/models/data-inputs/programs-inputs.ts
@@ -16,7 +16,9 @@ export const PROGRAM_UNDERGRADUATE_CERTIFICATE_WITHOUT_INSTITUTION_PROGRAM_CODE:
 export const PROGRAM_GRADUATE_DIPLOMA_WITH_INSTITUTION_PROGRAM_CODE: IER12Program =
   {
     name: "Some Program With Description Too Long",
-    description: "Some program with description too long",
+    // Added new line character expecting to be replaced during
+    // file processing.
+    description: "Some program with\n description too long",
     credentialType: "graduateDiploma",
     fieldOfStudyCode: 1,
     cipCode: "12.1234",

--- a/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/institution-integration/ier12-integration/_tests_/e2e/models/data-inputs/students-inputs.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/institution-integration/ier12-integration/_tests_/e2e/models/data-inputs/students-inputs.ts
@@ -20,9 +20,7 @@ export const JANE_MONONYMOUS_FROM_OTHER_COUNTRY: IER12Student = {
   birthDate: new Date("1998-01-13"),
   sin: "242963189",
   addressInfo: {
-    // Added new line character expecting to be replaced during
-    // file processing.
-    addressLine1: "Some Foreign Street\n Address Line 1",
+    addressLine1: "Some Foreign Street Address Line 1",
     addressLine2: undefined,
     provinceState: undefined,
     city: "New York",

--- a/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/institution-integration/ier12-integration/_tests_/e2e/models/data-inputs/students-inputs.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/institution-integration/ier12-integration/_tests_/e2e/models/data-inputs/students-inputs.ts
@@ -20,10 +20,11 @@ export const JANE_MONONYMOUS_FROM_OTHER_COUNTRY: IER12Student = {
   birthDate: new Date("1998-01-13"),
   sin: "242963189",
   addressInfo: {
-    addressLine1: "Some Foreign Street Address Line 1",
+    // Added new line character expecting to be replaced during
+    // file processing.
+    addressLine1: "Some Foreign Street\n Address Line 1",
     addressLine2: undefined,
-    // TODO: set to undefined once the bug is fixed (#2452).
-    provinceState: "",
+    provinceState: undefined,
     city: "New York",
     postalCode: "SOME POSTAL CODE",
   },

--- a/sources/packages/backend/libs/integrations/src/institution-integration/ier12-integration/ier12-file-detail.ts
+++ b/sources/packages/backend/libs/integrations/src/institution-integration/ier12-integration/ier12-file-detail.ts
@@ -183,7 +183,7 @@ export class IER12FileDetail implements IER12FileLine {
     record.appendStringWithFiller(this.addressInfo.addressLine1, 25);
     record.appendOptionalStringWithFiller(this.addressInfo.addressLine2, 25);
     record.appendStringWithFiller(this.addressInfo.city, 25);
-    record.appendStringWithFiller(this.addressInfo.provinceState, 4);
+    record.appendOptionalStringWithFiller(this.addressInfo.provinceState, 4);
     record.appendStringWithFiller(this.addressInfo.postalCode, 16);
     record.appendStringWithFiller(this.programName, 25);
     record.appendStringWithFiller(this.programDescription, 50);

--- a/sources/packages/backend/libs/integrations/src/institution-integration/ier12-integration/ier12.integration.service.ts
+++ b/sources/packages/backend/libs/integrations/src/institution-integration/ier12-integration/ier12.integration.service.ts
@@ -17,7 +17,11 @@ import {
   DisbursementValueType,
   StudentScholasticStandingChangeType,
 } from "@sims/sims-db";
-import { combineDecimalPlaces, getTotalYearsOfStudy } from "@sims/utilities";
+import {
+  combineDecimalPlaces,
+  getTotalYearsOfStudy,
+  replaceLineBreaks,
+} from "@sims/utilities";
 
 /**
  * Manages the creation of the content files that needs to be sent
@@ -43,10 +47,13 @@ export class IER12IntegrationService extends SFTPIntegrationBase<void> {
       ierFileDetail.assessmentId = ierRecord.assessmentId;
       ierFileDetail.disbursementId = ierRecord.disbursementId;
       ierFileDetail.applicationNumber = ierRecord.applicationNumber;
-      ierFileDetail.institutionStudentNumber =
-        ierRecord.institutionStudentNumber;
+      ierFileDetail.institutionStudentNumber = replaceLineBreaks(
+        ierRecord.institutionStudentNumber,
+      );
       ierFileDetail.sin = ierRecord.sin;
-      ierFileDetail.studentLastName = ierRecord.studentLastName;
+      ierFileDetail.studentLastName = replaceLineBreaks(
+        ierRecord.studentLastName,
+      );
       ierFileDetail.studentGivenName = ierRecord.studentGivenName;
       ierFileDetail.studentBirthDate = ierRecord.studentBirthDate;
       ierFileDetail.studentGroupCode =

--- a/sources/packages/backend/libs/integrations/src/institution-integration/ier12-integration/ier12.integration.service.ts
+++ b/sources/packages/backend/libs/integrations/src/institution-integration/ier12-integration/ier12.integration.service.ts
@@ -47,29 +47,18 @@ export class IER12IntegrationService extends SFTPIntegrationBase<void> {
       ierFileDetail.assessmentId = ierRecord.assessmentId;
       ierFileDetail.disbursementId = ierRecord.disbursementId;
       ierFileDetail.applicationNumber = ierRecord.applicationNumber;
-      ierFileDetail.institutionStudentNumber = replaceLineBreaks(
-        ierRecord.institutionStudentNumber,
-      );
+      ierFileDetail.institutionStudentNumber =
+        ierRecord.institutionStudentNumber;
       ierFileDetail.sin = ierRecord.sin;
-      ierFileDetail.studentLastName = replaceLineBreaks(
-        ierRecord.studentLastName,
-      );
-      ierFileDetail.studentGivenName = replaceLineBreaks(
-        ierRecord.studentGivenName,
-      );
+      ierFileDetail.studentLastName = ierRecord.studentLastName;
+      ierFileDetail.studentGivenName = ierRecord.studentGivenName;
       ierFileDetail.studentBirthDate = ierRecord.studentBirthDate;
       ierFileDetail.studentGroupCode =
         ierRecord.studentDependantStatus === "dependant" ? "A" : "B";
       ierFileDetail.studentMaritalStatusCode =
         ierRecord.studentMaritalStatusCode;
-      ierFileDetail.addressInfo = {
-        provinceState: ierRecord.addressInfo.provinceState,
-        addressLine1: replaceLineBreaks(ierRecord.addressInfo.addressLine1),
-        addressLine2: replaceLineBreaks(ierRecord.addressInfo.addressLine2),
-        city: replaceLineBreaks(ierRecord.addressInfo.city),
-        postalCode: replaceLineBreaks(ierRecord.addressInfo.postalCode),
-      };
-      ierFileDetail.programName = replaceLineBreaks(ierRecord.programName);
+      ierFileDetail.addressInfo = ierRecord.addressInfo;
+      ierFileDetail.programName = ierRecord.programName;
       ierFileDetail.programDescription = replaceLineBreaks(
         ierRecord.programDescription,
       );
@@ -83,9 +72,7 @@ export class IER12IntegrationService extends SFTPIntegrationBase<void> {
       ierFileDetail.cipCode = ierRecord.cipCode.replace(".", "");
       ierFileDetail.nocCode = ierRecord.nocCode;
       ierFileDetail.sabcCode = ierRecord.sabcCode;
-      ierFileDetail.institutionProgramCode = replaceLineBreaks(
-        ierRecord.institutionProgramCode,
-      );
+      ierFileDetail.institutionProgramCode = ierRecord.institutionProgramCode;
       ierFileDetail.programLength = getTotalYearsOfStudy(
         ierRecord.programCompletionYears,
       );

--- a/sources/packages/backend/libs/integrations/src/institution-integration/ier12-integration/ier12.integration.service.ts
+++ b/sources/packages/backend/libs/integrations/src/institution-integration/ier12-integration/ier12.integration.service.ts
@@ -54,15 +54,25 @@ export class IER12IntegrationService extends SFTPIntegrationBase<void> {
       ierFileDetail.studentLastName = replaceLineBreaks(
         ierRecord.studentLastName,
       );
-      ierFileDetail.studentGivenName = ierRecord.studentGivenName;
+      ierFileDetail.studentGivenName = replaceLineBreaks(
+        ierRecord.studentGivenName,
+      );
       ierFileDetail.studentBirthDate = ierRecord.studentBirthDate;
       ierFileDetail.studentGroupCode =
         ierRecord.studentDependantStatus === "dependant" ? "A" : "B";
       ierFileDetail.studentMaritalStatusCode =
         ierRecord.studentMaritalStatusCode;
-      ierFileDetail.addressInfo = ierRecord.addressInfo;
-      ierFileDetail.programName = ierRecord.programName;
-      ierFileDetail.programDescription = ierRecord.programDescription;
+      ierFileDetail.addressInfo = {
+        provinceState: ierRecord.addressInfo.provinceState,
+        addressLine1: replaceLineBreaks(ierRecord.addressInfo.addressLine1),
+        addressLine2: replaceLineBreaks(ierRecord.addressInfo.addressLine2),
+        city: replaceLineBreaks(ierRecord.addressInfo.city),
+        postalCode: replaceLineBreaks(ierRecord.addressInfo.postalCode),
+      };
+      ierFileDetail.programName = replaceLineBreaks(ierRecord.programName);
+      ierFileDetail.programDescription = replaceLineBreaks(
+        ierRecord.programDescription,
+      );
       ierFileDetail.credentialType = ierRecord.credentialType;
       ierFileDetail.fieldOfStudyCode = ierRecord.fieldOfStudyCode;
       ierFileDetail.levelOfStudyCode = this.getLevelOfStudyCode(
@@ -73,7 +83,9 @@ export class IER12IntegrationService extends SFTPIntegrationBase<void> {
       ierFileDetail.cipCode = ierRecord.cipCode.replace(".", "");
       ierFileDetail.nocCode = ierRecord.nocCode;
       ierFileDetail.sabcCode = ierRecord.sabcCode;
-      ierFileDetail.institutionProgramCode = ierRecord.institutionProgramCode;
+      ierFileDetail.institutionProgramCode = replaceLineBreaks(
+        ierRecord.institutionProgramCode,
+      );
       ierFileDetail.programLength = getTotalYearsOfStudy(
         ierRecord.programCompletionYears,
       );

--- a/sources/packages/backend/libs/utilities/src/_tests_/unit/string-utils.replaceLineBreaks.spec.ts
+++ b/sources/packages/backend/libs/utilities/src/_tests_/unit/string-utils.replaceLineBreaks.spec.ts
@@ -2,7 +2,7 @@ import { replaceLineBreaks } from "@sims/utilities/string-utils";
 
 describe("StringUtils-replaceLineBreaks", () => {
   it("Should replace the line break with empty string value in given text when one or more line break character is present.", () => {
-    //Arrange
+    // Arrange
     const textWithLineBreaks = "Some program with\n description\r\n too long";
 
     // Act
@@ -14,7 +14,7 @@ describe("StringUtils-replaceLineBreaks", () => {
   });
 
   it("Should replace the line break with given value in given text when one or more line break character is present.", () => {
-    //Arrange
+    // Arrange
     const textWithLineBreaks = "Some program with\ndescription\r\ntoo long";
 
     // Act

--- a/sources/packages/backend/libs/utilities/src/_tests_/unit/string-utils.replaceLineBreaks.spec.ts
+++ b/sources/packages/backend/libs/utilities/src/_tests_/unit/string-utils.replaceLineBreaks.spec.ts
@@ -1,0 +1,37 @@
+import { replaceLineBreaks } from "@sims/utilities/string-utils";
+
+describe("StringUtils-replaceLineBreaks", () => {
+  it("Should replace the line break with empty string value in given text when one or more line break character is present.", () => {
+    //Arrange
+    const textWithLineBreaks = "Some program with\n description\r\n too long";
+
+    // Act
+    const sanitizedData = replaceLineBreaks(textWithLineBreaks);
+
+    // Assert
+    const expectedSanitizedData = "Some program with description too long";
+    expect(sanitizedData).toBe(expectedSanitizedData);
+  });
+
+  it("Should replace the line break with given value in given text when one or more line break character is present.", () => {
+    //Arrange
+    const textWithLineBreaks = "Some program with\ndescription\r\ntoo long";
+
+    // Act
+    const sanitizedData = replaceLineBreaks(textWithLineBreaks, {
+      replaceText: " ",
+    });
+
+    // Assert
+    const expectedSanitizedData = "Some program with description too long";
+    expect(sanitizedData).toBe(expectedSanitizedData);
+  });
+
+  it("Should return the value as is when the given text is undefined.", () => {
+    // Act
+    const sanitizedData = replaceLineBreaks();
+
+    // Assert
+    expect(sanitizedData).not.toBeDefined();
+  });
+});

--- a/sources/packages/backend/libs/utilities/src/index.ts
+++ b/sources/packages/backend/libs/utilities/src/index.ts
@@ -13,3 +13,4 @@ export * from "./parse-json";
 export * from "./integration-utils";
 export * from "./math-utils";
 export * from "./specialized-string-builder";
+export * from "./string-utils";

--- a/sources/packages/backend/libs/utilities/src/integration-utils.ts
+++ b/sources/packages/backend/libs/utilities/src/integration-utils.ts
@@ -1,3 +1,4 @@
+const REPLACE_LINE_BREAK_REGEX = /\r?\n|\r/g;
 /**
  * Express the completion years data present on educational programs as
  * an amount of years.
@@ -21,4 +22,21 @@ export function getTotalYearsOfStudy(completionYears: string): number {
     default:
       return 1;
   }
+}
+
+/**
+ * Replace the line breaks in the given text.
+ * @param data data to replace the line break.
+ * @param options replace options:
+ * - `replaceText`: text to replace the line break.
+ * @returns line break replaced string.
+ */
+export function replaceLineBreaks(
+  data?: string,
+  options?: { replaceText?: string },
+) {
+  if (!data) {
+    return data;
+  }
+  return data.replace(REPLACE_LINE_BREAK_REGEX, options?.replaceText ?? "");
 }

--- a/sources/packages/backend/libs/utilities/src/integration-utils.ts
+++ b/sources/packages/backend/libs/utilities/src/integration-utils.ts
@@ -1,4 +1,3 @@
-const REPLACE_LINE_BREAK_REGEX = /\r?\n|\r/g;
 /**
  * Express the completion years data present on educational programs as
  * an amount of years.
@@ -22,21 +21,4 @@ export function getTotalYearsOfStudy(completionYears: string): number {
     default:
       return 1;
   }
-}
-
-/**
- * Replace the line breaks in the given text.
- * @param data data to replace the line break.
- * @param options replace options:
- * - `replaceText`: text to replace the line break.
- * @returns line break replaced string.
- */
-export function replaceLineBreaks(
-  data?: string,
-  options?: { replaceText?: string },
-) {
-  if (!data) {
-    return data;
-  }
-  return data.replace(REPLACE_LINE_BREAK_REGEX, options?.replaceText ?? "");
 }

--- a/sources/packages/backend/libs/utilities/src/string-utils.ts
+++ b/sources/packages/backend/libs/utilities/src/string-utils.ts
@@ -1,0 +1,18 @@
+const REPLACE_LINE_BREAK_REGEX = /\r?\n|\r/g;
+
+/**
+ * Replace the line breaks in the given text.
+ * @param data data to replace the line break.
+ * @param options replace options:
+ * - `replaceText`: text to replace the line break.
+ * @returns line break replaced string.
+ */
+export function replaceLineBreaks(
+  data?: string,
+  options?: { replaceText?: string },
+) {
+  if (!data) {
+    return data;
+  }
+  return data.replace(REPLACE_LINE_BREAK_REGEX, options?.replaceText ?? "");
+}

--- a/sources/packages/backend/libs/utilities/src/string-utils.ts
+++ b/sources/packages/backend/libs/utilities/src/string-utils.ts
@@ -10,7 +10,7 @@ const REPLACE_LINE_BREAK_REGEX = /\r?\n|\r/g;
 export function replaceLineBreaks(
   data?: string,
   options?: { replaceText?: string },
-) {
+): string {
   if (!data) {
     return data;
   }

--- a/sources/packages/backend/package.json
+++ b/sources/packages/backend/package.json
@@ -21,7 +21,7 @@
     "docker:start:queue-consumers": "node dist/apps/queue-consumers/main.js",
     "start:prod:load-test-gateway": "node dist/apps/load-test-gateway/main.js",
     "docker:start:load-test-gateway": "node dist/apps/load-test-gateway/main.js",
-    "test": "cross-env ENVIRONMENT=test jest --forceExit",
+    "test": "cross-env ENVIRONMENT=test jest --verbose --forceExit",
     "test:watch": "jest --watch ",
     "test:cov": "cross-env ENVIRONMENT=test jest --coverage --forceExit",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",


### PR DESCRIPTION
## IER 12 File content fixes
- [x] Made the province/state as optional coming from student address as it will not be entered if the address is outside Canada
- [x] Identified the inputs coming from text-area input to IER file and sanitized them to replace the line break character with empty string.
- [x] Added unit test to util `replaceLineBreaks`
![image](https://github.com/bcgov/SIMS/assets/54600590/40271466-4523-4933-90f9-0f9308a65343)

