### PR TITLE
#2488 - Ensure offering parent id is always present- build fix

### DIFF
--- a/sources/packages/web/src/types/contracts/EducationProgram.ts
+++ b/sources/packages/web/src/types/contracts/EducationProgram.ts
@@ -58,7 +58,7 @@ export interface ProgramOfferingHeader {
   assessedDate?: Date;
   effectiveEndDate?: Date; // This field is only for programs.
   locationName: string; // This field is offering specific.
-  parentOfferingId: number;
+  parentOfferingId?: number;
 }
 
 export interface ProgramOfferingApprovalLabels {


### PR DESCRIPTION
There was a build failure, because of the below issue,
`ProgramOfferingHeader` is a shared interface, the certain components don't need the `parentofferingid`, so, I made the `parentofferingid` as optional,