### PR TITLE
#2582 - PT Remove child care cost spilt in half 

### DIFF
--- a/sources/packages/backend/workflow/BPMN/camunda-8/parttime-assessment-2021-2022.bpmn
+++ b/sources/packages/backend/workflow/BPMN/camunda-8/parttime-assessment-2021-2022.bpmn
@@ -205,17 +205,16 @@
     <bpmn:intermediateThrowEvent id="Event_1j6ep9h" name="calculatedDataTotalAssessedNeed">
       <bpmn:extensionElements>
         <zeebe:ioMapping>
-          <zeebe:output source="=sum([&#10;  calculatedDataActualTuitionCosts,&#10;  calculatedDataMandatoryFees,&#10;  calculatedDataProgramRelatedCosts,&#10;  calculatedDataTransportationAllownace,&#10;  calculatedDataMiscellaneousAllowance,&#10;  calculatedDataTotalChildCareCost&#10;][item != null])" target="calculatedDataTotalAssessedNeed" />
+          <zeebe:output source="=sum([&#10;  calculatedDataActualTuitionCosts,&#10;  calculatedDataMandatoryFees,&#10;  calculatedDataProgramRelatedCosts,&#10;  calculatedDataTransportationAllownace,&#10;  calculatedDataMiscellaneousAllowance,&#10;  calculatedDataChildCareCost&#10;][item != null])" target="calculatedDataTotalAssessedNeed" />
         </zeebe:ioMapping>
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_0temot0</bpmn:incoming>
       <bpmn:outgoing>Flow_0jntyac</bpmn:outgoing>
     </bpmn:intermediateThrowEvent>
-    <bpmn:intermediateThrowEvent id="Event_0re3zsg" name="Calculate calculatedDataTotalChildCareCost">
+    <bpmn:intermediateThrowEvent id="Event_0re3zsg" name="Calculate calculatedDataChildCareCost">
       <bpmn:extensionElements>
         <zeebe:ioMapping>
           <zeebe:output source="=if &#10;  dmnPartTimeProgramYearMaximums.limitWeeklyChildCare * offeringWeeks &#60; studentDataDaycareCosts11YearsOrUnder + studentDataDaycareCosts12YearsOrOver&#10;then&#10;  dmnPartTimeProgramYearMaximums.limitWeeklyChildCare * offeringWeeks&#10;else&#10;  studentDataDaycareCosts11YearsOrUnder + studentDataDaycareCosts12YearsOrOver" target="calculatedDataChildCareCost" />
-          <zeebe:output source="=if &#10;  studentDataRelationshipStatus = &#34;married&#34; &#10;  and&#10;  calculatedDataPartnerStudentStudyWeeks &#62;=12 &#10;then&#10;  calculatedDataChildCareCost / 2 &#10;else&#10;  calculatedDataChildCareCost" target="calculatedDataTotalChildCareCost" />
         </zeebe:ioMapping>
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_0lp9mvw</bpmn:incoming>
@@ -758,7 +757,7 @@ dmnX (comes from dmn)</bpmn:text>
       <bpmndi:BPMNShape id="Event_0re3zsg_di" bpmnElement="Event_0re3zsg">
         <dc:Bounds x="3312" y="1122" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="3289" y="1165" width="85" height="40" />
+          <dc:Bounds x="3289" y="1165" width="87" height="40" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="BPMNShape_1pcjqq6" bpmnElement="Event_10tndoy">

--- a/sources/packages/backend/workflow/BPMN/camunda-8/parttime-assessment-2022-2023.bpmn
+++ b/sources/packages/backend/workflow/BPMN/camunda-8/parttime-assessment-2022-2023.bpmn
@@ -205,17 +205,16 @@
     <bpmn:intermediateThrowEvent id="Event_1j6ep9h" name="calculatedDataTotalAssessedNeed">
       <bpmn:extensionElements>
         <zeebe:ioMapping>
-          <zeebe:output source="=sum([&#10;  calculatedDataActualTuitionCosts,&#10;  calculatedDataMandatoryFees,&#10;  calculatedDataProgramRelatedCosts,&#10;  calculatedDataTransportationAllownace,&#10;  calculatedDataMiscellaneousAllowance,&#10;  calculatedDataTotalChildCareCost&#10;][item != null])" target="calculatedDataTotalAssessedNeed" />
+          <zeebe:output source="=sum([&#10;  calculatedDataActualTuitionCosts,&#10;  calculatedDataMandatoryFees,&#10;  calculatedDataProgramRelatedCosts,&#10;  calculatedDataTransportationAllownace,&#10;  calculatedDataMiscellaneousAllowance,&#10;  calculatedDataChildCareCost&#10;][item != null])" target="calculatedDataTotalAssessedNeed" />
         </zeebe:ioMapping>
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_0temot0</bpmn:incoming>
       <bpmn:outgoing>Flow_0jntyac</bpmn:outgoing>
     </bpmn:intermediateThrowEvent>
-    <bpmn:intermediateThrowEvent id="Event_0re3zsg" name="Calculate calculatedDataTotalChildCareCost">
+    <bpmn:intermediateThrowEvent id="Event_0re3zsg" name="Calculate calculatedDataChildCareCost">
       <bpmn:extensionElements>
         <zeebe:ioMapping>
           <zeebe:output source="=if &#10;  dmnPartTimeProgramYearMaximums.limitWeeklyChildCare * offeringWeeks &#60; studentDataDaycareCosts11YearsOrUnder + studentDataDaycareCosts12YearsOrOver&#10;then&#10;  dmnPartTimeProgramYearMaximums.limitWeeklyChildCare * offeringWeeks&#10;else&#10;  studentDataDaycareCosts11YearsOrUnder + studentDataDaycareCosts12YearsOrOver" target="calculatedDataChildCareCost" />
-          <zeebe:output source="=if &#10;  studentDataRelationshipStatus = &#34;married&#34; &#10;  and&#10;  calculatedDataPartnerStudentStudyWeeks &#62;=12 &#10;then&#10;  calculatedDataChildCareCost / 2 &#10;else&#10;  calculatedDataChildCareCost" target="calculatedDataTotalChildCareCost" />
         </zeebe:ioMapping>
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_0lp9mvw</bpmn:incoming>
@@ -758,7 +757,7 @@ dmnX (comes from dmn)</bpmn:text>
       <bpmndi:BPMNShape id="Event_0re3zsg_di" bpmnElement="Event_0re3zsg">
         <dc:Bounds x="3312" y="1122" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="3289" y="1165" width="85" height="40" />
+          <dc:Bounds x="3289" y="1165" width="87" height="40" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="BPMNShape_1pcjqq6" bpmnElement="Event_10tndoy">

--- a/sources/packages/backend/workflow/BPMN/camunda-8/parttime-assessment-2023-2024.bpmn
+++ b/sources/packages/backend/workflow/BPMN/camunda-8/parttime-assessment-2023-2024.bpmn
@@ -205,17 +205,16 @@
     <bpmn:intermediateThrowEvent id="Event_1j6ep9h" name="calculatedDataTotalAssessedNeed">
       <bpmn:extensionElements>
         <zeebe:ioMapping>
-          <zeebe:output source="=sum([&#10;  calculatedDataActualTuitionCosts,&#10;  calculatedDataMandatoryFees,&#10;  calculatedDataProgramRelatedCosts,&#10;  calculatedDataTransportationAllownace,&#10;  calculatedDataMiscellaneousAllowance,&#10;  calculatedDataTotalChildCareCost&#10;][item != null])" target="calculatedDataTotalAssessedNeed" />
+          <zeebe:output source="=sum([&#10;  calculatedDataActualTuitionCosts,&#10;  calculatedDataMandatoryFees,&#10;  calculatedDataProgramRelatedCosts,&#10;  calculatedDataTransportationAllownace,&#10;  calculatedDataMiscellaneousAllowance,&#10;  calculatedDataChildCareCost&#10;][item != null])" target="calculatedDataTotalAssessedNeed" />
         </zeebe:ioMapping>
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_0temot0</bpmn:incoming>
       <bpmn:outgoing>Flow_0jntyac</bpmn:outgoing>
     </bpmn:intermediateThrowEvent>
-    <bpmn:intermediateThrowEvent id="Event_0re3zsg" name="Calculate calculatedDataTotalChildCareCost">
+    <bpmn:intermediateThrowEvent id="Event_0re3zsg" name="Calculate calculatedDataChildCareCost">
       <bpmn:extensionElements>
         <zeebe:ioMapping>
           <zeebe:output source="=if &#10;  dmnPartTimeProgramYearMaximums.limitWeeklyChildCare * offeringWeeks &#60; studentDataDaycareCosts11YearsOrUnder + studentDataDaycareCosts12YearsOrOver&#10;then&#10;  dmnPartTimeProgramYearMaximums.limitWeeklyChildCare * offeringWeeks&#10;else&#10;  studentDataDaycareCosts11YearsOrUnder + studentDataDaycareCosts12YearsOrOver" target="calculatedDataChildCareCost" />
-          <zeebe:output source="=if &#10;  studentDataRelationshipStatus = &#34;married&#34; &#10;  and&#10;  calculatedDataPartnerStudentStudyWeeks &#62;=12 &#10;then&#10;  calculatedDataChildCareCost / 2 &#10;else&#10;  calculatedDataChildCareCost" target="calculatedDataTotalChildCareCost" />
         </zeebe:ioMapping>
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_0lp9mvw</bpmn:incoming>
@@ -758,7 +757,7 @@ dmnX (comes from dmn)</bpmn:text>
       <bpmndi:BPMNShape id="Event_0re3zsg_di" bpmnElement="Event_0re3zsg">
         <dc:Bounds x="3312" y="1122" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="3289" y="1165" width="85" height="40" />
+          <dc:Bounds x="3288" y="1165" width="87" height="40" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="BPMNShape_1pcjqq6" bpmnElement="Event_10tndoy">


### PR DESCRIPTION
# PT Remove child care cost spilt in half 

- [x] Removed total child care split in half for PT only. This value is calculated as `calculatedDataTotalChildCareCost`.
![image](https://github.com/bcgov/SIMS/assets/54600590/e97ca4b9-8393-4459-96d9-31a8c5a51698)

- [x] In the total assessed need calculation used `calculatedDataChildCareCost` instead of `calculatedDataTotalChildCareCost`.

![image](https://github.com/bcgov/SIMS/assets/54600590/63d69c3e-0d05-4fdb-8594-8670ab398f14)

- [x] Update all parttime-assessment-*.bpmn