### PR TITLE
#2299 - Adjust Maximum Allowable Tuition Remittance

### DIFF
--- a/sources/packages/backend/apps/api/src/route-controllers/confirmation-of-enrollment/_tests_/e2e/confirmation-of-enrollment.institutions.confirmEnrollment.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/confirmation-of-enrollment/_tests_/e2e/confirmation-of-enrollment.institutions.confirmEnrollment.e2e-spec.ts
@@ -295,6 +295,7 @@ describe("ConfirmationOfEnrollmentInstitutionsController(e2e)-confirmEnrollment"
     // Adjust offering values for maxTuitionRemittanceAllowed.
     application.currentAssessment.offering.actualTuitionCosts = 500;
     application.currentAssessment.offering.programRelatedCosts = 500;
+    application.currentAssessment.offering.mandatoryFees = 100;
     await offeringRepo.save(application.currentAssessment.offering);
     const endpoint = `/institutions/location/${collegeCLocation.id}/confirmation-of-enrollment/disbursement-schedule/${firstDisbursementSchedule.id}/confirm`;
     // Act/Assert
@@ -308,7 +309,7 @@ describe("ConfirmationOfEnrollmentInstitutionsController(e2e)-confirmEnrollment"
       .expect(HttpStatus.UNPROCESSABLE_ENTITY)
       .expect({
         message:
-          "Tuition amount provided should be lesser than both (Actual tuition + Program related costs) and (Canada grants + Canada Loan + BC Loan).",
+          "Tuition amount provided should be lesser than both (Actual tuition + Program related costs + Mandatory fees) and (Canada grants + Canada Loan + BC Loan).",
         errorType: "INVALID_TUITION_REMITTANCE_AMOUNT",
       });
   });

--- a/sources/packages/backend/apps/api/src/route-controllers/confirmation-of-enrollment/confirmation-of-enrollment.institutions.controller.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/confirmation-of-enrollment/confirmation-of-enrollment.institutions.controller.ts
@@ -248,7 +248,7 @@ export class ConfirmationOfEnrollmentInstitutionsController extends BaseControll
       "Enrolment already completed and can neither be confirmed nor declined " +
       "or enrolment cannot be confirmed as application is not in a valid status " +
       "or enrolment cannot be confirmed as enrolment confirmation date is not within the valid approval period " +
-      "or tuition amount provided should be lesser than both (actual tuition + program related costs) and (Canada grants + Canada Loan + BC Loan) " +
+      "or tuition amount provided should be lesser than both (actual tuition + program related costs + mandatory fees) and (Canada grants + Canada Loan + BC Loan) " +
       "or first disbursement(COE) is not completed and it must be completed.",
   })
   @Patch(

--- a/sources/packages/backend/libs/integrations/src/services/disbursement-schedule/disbursement-schedule.models.ts
+++ b/sources/packages/backend/libs/integrations/src/services/disbursement-schedule/disbursement-schedule.models.ts
@@ -150,7 +150,11 @@ export interface StudentActiveRestriction {
  */
 export type EligibleECertOffering = Pick<
   EducationProgramOffering,
-  "id" | "offeringIntensity" | "actualTuitionCosts" | "programRelatedCosts"
+  | "id"
+  | "offeringIntensity"
+  | "actualTuitionCosts"
+  | "programRelatedCosts"
+  | "mandatoryFees"
 >;
 
 /**

--- a/sources/packages/backend/libs/services/src/confirmation-of-enrollment/_tests_/unit/confirmation-of-enrollment.getMaxTuitionRemittance.spec.ts
+++ b/sources/packages/backend/libs/services/src/confirmation-of-enrollment/_tests_/unit/confirmation-of-enrollment.getMaxTuitionRemittance.spec.ts
@@ -53,6 +53,7 @@ describe("ConfirmationOfEnrollmentService-getMaxTuitionRemittance", () => {
     const offeringCosts = {
       actualTuitionCosts: Number.MAX_SAFE_INTEGER,
       programRelatedCosts: Number.MAX_SAFE_INTEGER,
+      mandatoryFees: Number.MAX_SAFE_INTEGER,
     };
     // Act
     const total = service.getMaxTuitionRemittance(
@@ -75,6 +76,7 @@ describe("ConfirmationOfEnrollmentService-getMaxTuitionRemittance", () => {
     const offeringCosts = {
       actualTuitionCosts: 100,
       programRelatedCosts: 300,
+      mandatoryFees: 50,
     };
     // Act
     const total = service.getMaxTuitionRemittance(
@@ -83,7 +85,7 @@ describe("ConfirmationOfEnrollmentService-getMaxTuitionRemittance", () => {
       MaxTuitionRemittanceTypes.Estimated,
     );
     // Assert
-    expect(total).toBe(400);
+    expect(total).toBe(450);
   });
 
   it("Should calculate total effective value from awards when awards are lesser than offering costs", () => {
@@ -108,6 +110,7 @@ describe("ConfirmationOfEnrollmentService-getMaxTuitionRemittance", () => {
     const offeringCosts = {
       actualTuitionCosts: Number.MAX_SAFE_INTEGER,
       programRelatedCosts: Number.MAX_SAFE_INTEGER,
+      mandatoryFees: Number.MAX_SAFE_INTEGER,
     };
     // Act
     const total = service.getMaxTuitionRemittance(
@@ -131,6 +134,7 @@ describe("ConfirmationOfEnrollmentService-getMaxTuitionRemittance", () => {
     const offeringCosts = {
       actualTuitionCosts: 25,
       programRelatedCosts: 75,
+      mandatoryFees: 15,
     };
     // Act
     const total = service.getMaxTuitionRemittance(
@@ -139,6 +143,6 @@ describe("ConfirmationOfEnrollmentService-getMaxTuitionRemittance", () => {
       MaxTuitionRemittanceTypes.Effective,
     );
     // Assert
-    expect(total).toBe(100);
+    expect(total).toBe(115);
   });
 });

--- a/sources/packages/backend/libs/services/src/confirmation-of-enrollment/confirmation-of-enrollment.service.ts
+++ b/sources/packages/backend/libs/services/src/confirmation-of-enrollment/confirmation-of-enrollment.service.ts
@@ -138,7 +138,9 @@ export class ConfirmationOfEnrollmentService {
       );
     }
     const offeringTotalCosts =
-      offeringCosts.actualTuitionCosts + offeringCosts.programRelatedCosts;
+      offeringCosts.actualTuitionCosts +
+      offeringCosts.programRelatedCosts +
+      offeringCosts.mandatoryFees;
     return Math.min(offeringTotalCosts, totalAwards);
   }
 

--- a/sources/packages/backend/libs/services/src/confirmation-of-enrollment/confirmation-of-enrollment.service.ts
+++ b/sources/packages/backend/libs/services/src/confirmation-of-enrollment/confirmation-of-enrollment.service.ts
@@ -78,6 +78,7 @@ export class ConfirmationOfEnrollmentService {
               id: true,
               actualTuitionCosts: true,
               programRelatedCosts: true,
+              mandatoryFees: true,
             },
           },
         },
@@ -654,7 +655,7 @@ export class ConfirmationOfEnrollmentService {
 
     if (tuitionRemittanceAmount > maxTuitionAllowed) {
       throw new CustomNamedError(
-        "Tuition amount provided should be lesser than both (Actual tuition + Program related costs) and (Canada grants + Canada Loan + BC Loan).",
+        "Tuition amount provided should be lesser than both (Actual tuition + Program related costs + Mandatory fees) and (Canada grants + Canada Loan + BC Loan).",
         INVALID_TUITION_REMITTANCE_AMOUNT,
       );
     }

--- a/sources/packages/backend/libs/services/src/confirmation-of-enrollment/models/confirmation-of-enrollment.models.ts
+++ b/sources/packages/backend/libs/services/src/confirmation-of-enrollment/models/confirmation-of-enrollment.models.ts
@@ -13,7 +13,7 @@ export type Award = Pick<
  */
 export type OfferingCosts = Pick<
   EducationProgramOffering,
-  "actualTuitionCosts" | "programRelatedCosts"
+  "actualTuitionCosts" | "programRelatedCosts" | "mandatoryFees"
 >;
 
 /**


### PR DESCRIPTION
As a part of this PR, the following was done:

- Mandatory fees is incorporated into the allowable maximum (i.e. tuition+books and supplies+mandatory fees.)
- Unit tests were updated