### PR TITLE
#2646 - Patroni Prod issue

### DIFF
--- a/devops/openshift/database/patroni-deploy.yml
+++ b/devops/openshift/database/patroni-deploy.yml
@@ -225,7 +225,7 @@ parameters:
     The OpenShift Namespace where the patroni and postgresql
     ImageStream resides.
   displayName: ImageStream Namespace
-  value: bcgov
+  value: bcgov-docker-local
 - name: IMAGE_NAME
   description: |
     The Patroni image stream name
@@ -233,7 +233,7 @@ parameters:
 - name: IMAGE_TAG
   description: |
     The image tag used to specify which image you would like deployed.
-  value: "12.4-latest"
+  value: "2.0.1-12.4-latest"
 - name: PVC_SIZE
   description: 
     The size of the persistent volume to create.
@@ -242,4 +242,4 @@ parameters:
 - name: STORAGE_CLASS
   value: netapp-file-standard
 - name: IMAGE_REGISTRY
-  value: image-registry.openshift-image-registry.svc:5000
+  value: artifacts.developer.gov.bc.ca


### PR DESCRIPTION
<img width="1676" src="https://api.zenhub.com/attachedFiles/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBMktxQWc9PSIsImV4cCI6bnVsbCwicHVyIjoiYmxvYl9pZCJ9fQ==--6fd72c377816898a00b7f9c0e93af9f107149f0f/image.png" alt="image.png" />


More on the failure on Rocketchat - https://chat.developer.gov.bc.ca/channel/patroni?msg=64A8yQr3KeMthqsWn

<img width="1383" src="https://api.zenhub.com/attachedFiles/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBMlNxQWc9PSIsImV4cCI6bnVsbCwicHVyIjoiYmxvYl9pZCJ9fQ==--8c3db0e0068e20f2b96666d28db40f711b513e0c/image.png" alt="image.png" />

The solution:
1. Take the current DB backup in patroni backup pod
2.  Change the image from image-registry.openshift-image-registry.svc:5000/bcgov/12.4-latest to artifacts.developer.gov.bc.ca/bcgov-docker-local/patroni-postgres:2.0.1-12.4-latest