### PR TITLE
#2233 - Unable to view files Uploaded within App (Through Exception Path)

### DIFF
--- a/sources/packages/backend/apps/api/src/route-controllers/student/student.controller.service.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/student/student.controller.service.ts
@@ -65,7 +65,7 @@ export class StudentControllerService {
     return {
       fileName: createdFile.fileName,
       uniqueFileName: createdFile.uniqueFileName,
-      url: `students/files/${createdFile.uniqueFileName}`,
+      url: `student/files/${createdFile.uniqueFileName}`,
       size: createdFile.fileContent.length,
       mimetype: createdFile.mimeType,
     };


### PR DESCRIPTION
-  Allow Ministry users to open files embedded within Student App
-  Allow students to view uploaded files
