### PR TITLE
#2544 - Patroni Recovery mode resolution

### DIFF
--- a/devops/openshift/api-deploy.yml
+++ b/devops/openshift/api-deploy.yml
@@ -290,9 +290,9 @@ parameters:
   - name: DB_SECRET_NAME
     value: patroni-creds
   - name: DB_USERNAME_KEY
-    value: superuser-username
+    value: database-user
   - name: DB_PASSWORD_KEY
-    value: superuser-password
+    value: database-password
   - name: IMAGE_STREAM_TAG
     required: true
   - name: BUILD_NAMESPACE

--- a/devops/openshift/load-test-gateway-deploy.yml
+++ b/devops/openshift/load-test-gateway-deploy.yml
@@ -132,9 +132,9 @@ parameters:
   - name: DB_SECRET_NAME
     value: patroni-creds
   - name: DB_USERNAME_KEY
-    value: superuser-username
+    value: database-user
   - name: DB_PASSWORD_KEY
-    value: superuser-password
+    value: database-password
   - name: SIMS_DB_NAME
     value: sims-db-name
   - name: DISABLE_ORM_CACHE

--- a/devops/openshift/queue-consumers-deploy.yml
+++ b/devops/openshift/queue-consumers-deploy.yml
@@ -310,9 +310,9 @@ parameters:
   - name: DB_SECRET_NAME
     value: patroni-creds
   - name: DB_USERNAME_KEY
-    value: superuser-username
+    value: database-user
   - name: DB_PASSWORD_KEY
-    value: superuser-password
+    value: database-password
   - name: SIMS_DB_NAME
     value: sims-db-name
   - name: IMAGE_STREAM_TAG

--- a/devops/openshift/workers-deploy.yml
+++ b/devops/openshift/workers-deploy.yml
@@ -160,9 +160,9 @@ parameters:
   - name: DB_SECRET_NAME
     value: patroni-creds
   - name: DB_USERNAME_KEY
-    value: superuser-username
+    value: database-user
   - name: DB_PASSWORD_KEY
-    value: superuser-password
+    value: database-password
   - name: SIMS_DB_NAME
     value: sims-db-name
   - name: IMAGE_STREAM_TAG


### PR DESCRIPTION
Analysis and troubleshooting on patroni going to recovery mode on load test
- [x] Patroni convert the user from superuser to database user

Tested the simple workflow in our application after changing the database user to non super user with the minimal permissions and it seems to work well.

Also the release notes will be updated to grant the non super user permissions to do application operations.

GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA sims TO "app_database_user";