### PR TITLE
#2664 - Fix the DB migration revert script

### DIFF
--- a/sources/packages/backend/apps/db-migrations/src/sql/StudentAssessments/Rollback-add-calculation-start-date.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/StudentAssessments/Rollback-add-calculation-start-date.sql
@@ -1,2 +1,2 @@
 ALTER TABLE
-    sims.students DROP COLUMN calculation_start_date;
+    sims.student_assessments DROP COLUMN calculation_start_date;


### PR DESCRIPTION
## The rollback file in DB migrations had wrong table name

- The file `Rollback-add-calculation-start-date.sql` updated to have the table name `sims.student_assessments`. Issue found by @sh16011993 