### PR TITLE
#2688 - Bug in submitting application when total income has non integer values

### DIFF
--- a/sources/packages/forms/src/form-definitions/sfaa2021-22.json
+++ b/sources/packages/forms/src/form-definitions/sfaa2021-22.json
@@ -16589,7 +16589,7 @@
               "inputFormat": "plain",
               "validate": {
                 "required": true,
-                "custom": "",
+                "custom": "valid = (input >= 0 && input < 100000000) ? true : 'The number you have entered is not an acceptable value.'",
                 "customPrivate": false,
                 "strictDateValidation": false,
                 "multiple": false,
@@ -16601,7 +16601,7 @@
               },
               "key": "estimatedSpouseIncome",
               "conditional": {
-                "show": true,
+                "show": "true",
                 "when": "isYourSpouseACanadianCitizen",
                 "eq": "no"
               },
@@ -16655,8 +16655,9 @@
               "id": "e9yrlbn",
               "inputType": "text",
               "inputMask": "",
-              "decimalLimit": 2,
-              "requireDecimal": true
+              "decimalLimit": 0,
+              "requireDecimal": false,
+              "tags": []
             },
             {
               "label": "<strong>Will your partner be employed full-time or part-time during your study period</strong>",
@@ -17335,7 +17336,7 @@
                   "inputFormat": "plain",
                   "validate": {
                     "required": true,
-                    "custom": "",
+                    "custom": "valid = (input >= 0 && input < 100000000) ? true : 'The number you have entered is not an acceptable value.'",
                     "customPrivate": false,
                     "strictDateValidation": false,
                     "multiple": false,
@@ -17347,7 +17348,7 @@
                   },
                   "key": "partnertotalincomeAssistance",
                   "conditional": {
-                    "show": true,
+                    "show": "true",
                     "when": "partnerrecieveIncomeAssistance",
                     "eq": "yes"
                   },
@@ -17402,8 +17403,9 @@
                   "id": "eyn3uvta",
                   "inputType": "text",
                   "inputMask": "",
-                  "decimalLimit": 2,
-                  "requireDecimal": true
+                  "decimalLimit": 0,
+                  "requireDecimal": false,
+                  "tags": []
                 }
               ],
               "allowPrevious": false,
@@ -19642,7 +19644,7 @@
                   "truncateMultipleSpaces": false,
                   "validate": {
                     "required": true,
-                    "custom": "",
+                    "custom": "valid = (input >= 0 && input < 100000000) ? true : 'The number you have entered is not an acceptable value.'",
                     "customPrivate": false,
                     "strictDateValidation": false,
                     "multiple": false,
@@ -19688,7 +19690,7 @@
                   "attributes": {},
                   "validateOn": "change",
                   "conditional": {
-                    "show": null,
+                    "show": "",
                     "when": null,
                     "eq": ""
                   },
@@ -19709,8 +19711,9 @@
                   "id": "et8xql",
                   "inputType": "text",
                   "inputMask": "",
-                  "decimalLimit": 2,
-                  "requireDecimal": true
+                  "decimalLimit": 0,
+                  "requireDecimal": false,
+                  "tags": []
                 },
                 {
                   "label": "Enter the total net value of all your parents Canadian and foreign assets (do not include RRSPs, principal residence or business). Enter ‘0’ if none.",
@@ -23343,7 +23346,7 @@
               "inputFormat": "plain",
               "validate": {
                 "required": true,
-                "custom": "",
+                "custom": "valid = (input >= 0 && input < 100000000) ? true : 'The number you have entered is not an acceptable value.'",
                 "customPrivate": false,
                 "strictDateValidation": false,
                 "multiple": false,
@@ -23388,7 +23391,7 @@
               "attributes": {},
               "validateOn": "change",
               "conditional": {
-                "show": null,
+                "show": "",
                 "when": null,
                 "eq": ""
               },
@@ -23409,9 +23412,10 @@
               "addons": [],
               "inputType": "text",
               "inputMask": "",
-              "decimalLimit": 2,
-              "requireDecimal": true,
-              "tags": []
+              "decimalLimit": 0,
+              "requireDecimal": false,
+              "tags": [],
+              "isNew": false
             },
             {
               "title": "CRA consent panel",
@@ -24513,7 +24517,7 @@
                   "inputFormat": "plain",
                   "validate": {
                     "required": true,
-                    "custom": "",
+                    "custom": "valid = (input >= 0 && input < 100000000) ? true : 'The number you have entered is not an acceptable value.'",
                     "customPrivate": false,
                     "strictDateValidation": false,
                     "multiple": false,
@@ -24525,7 +24529,7 @@
                   },
                   "key": "myTotalCurrentYearIncomeIs",
                   "conditional": {
-                    "show": true,
+                    "show": "true",
                     "when": "hasSignificantDegreeOfIncome",
                     "eq": "yes"
                   },
@@ -24579,8 +24583,9 @@
                   "addons": [],
                   "inputType": "text",
                   "inputMask": "",
-                  "decimalLimit": 2,
-                  "requireDecimal": true
+                  "decimalLimit": 0,
+                  "requireDecimal": false,
+                  "tags": []
                 },
                 {
                   "label": "<strong>Select the reason for your significant decrease in income.</strong>",

--- a/sources/packages/forms/src/form-definitions/sfaa2021-22.json
+++ b/sources/packages/forms/src/form-definitions/sfaa2021-22.json
@@ -16589,7 +16589,7 @@
               "inputFormat": "plain",
               "validate": {
                 "required": true,
-                "custom": "valid = (input >= 0 && input < 100000000) ? true : 'The number you have entered is not an acceptable value.'",
+                "custom": "",
                 "customPrivate": false,
                 "strictDateValidation": false,
                 "multiple": false,
@@ -16601,7 +16601,7 @@
               },
               "key": "estimatedSpouseIncome",
               "conditional": {
-                "show": "true",
+                "show": true,
                 "when": "isYourSpouseACanadianCitizen",
                 "eq": "no"
               },
@@ -16655,9 +16655,8 @@
               "id": "e9yrlbn",
               "inputType": "text",
               "inputMask": "",
-              "decimalLimit": 0,
-              "requireDecimal": false,
-              "tags": []
+              "decimalLimit": 2,
+              "requireDecimal": true
             },
             {
               "label": "<strong>Will your partner be employed full-time or part-time during your study period</strong>",
@@ -17336,7 +17335,7 @@
                   "inputFormat": "plain",
                   "validate": {
                     "required": true,
-                    "custom": "valid = (input >= 0 && input < 100000000) ? true : 'The number you have entered is not an acceptable value.'",
+                    "custom": "",
                     "customPrivate": false,
                     "strictDateValidation": false,
                     "multiple": false,
@@ -17348,7 +17347,7 @@
                   },
                   "key": "partnertotalincomeAssistance",
                   "conditional": {
-                    "show": "true",
+                    "show": true,
                     "when": "partnerrecieveIncomeAssistance",
                     "eq": "yes"
                   },
@@ -17403,9 +17402,8 @@
                   "id": "eyn3uvta",
                   "inputType": "text",
                   "inputMask": "",
-                  "decimalLimit": 0,
-                  "requireDecimal": false,
-                  "tags": []
+                  "decimalLimit": 2,
+                  "requireDecimal": true
                 }
               ],
               "allowPrevious": false,
@@ -19644,7 +19642,7 @@
                   "truncateMultipleSpaces": false,
                   "validate": {
                     "required": true,
-                    "custom": "valid = (input >= 0 && input < 100000000) ? true : 'The number you have entered is not an acceptable value.'",
+                    "custom": "",
                     "customPrivate": false,
                     "strictDateValidation": false,
                     "multiple": false,
@@ -19690,7 +19688,7 @@
                   "attributes": {},
                   "validateOn": "change",
                   "conditional": {
-                    "show": "",
+                    "show": null,
                     "when": null,
                     "eq": ""
                   },
@@ -19711,9 +19709,8 @@
                   "id": "et8xql",
                   "inputType": "text",
                   "inputMask": "",
-                  "decimalLimit": 0,
-                  "requireDecimal": false,
-                  "tags": []
+                  "decimalLimit": 2,
+                  "requireDecimal": true
                 },
                 {
                   "label": "Enter the total net value of all your parents Canadian and foreign assets (do not include RRSPs, principal residence or business). Enter ‘0’ if none.",
@@ -23346,7 +23343,7 @@
               "inputFormat": "plain",
               "validate": {
                 "required": true,
-                "custom": "valid = (input >= 0 && input < 100000000) ? true : 'The number you have entered is not an acceptable value.'",
+                "custom": "valid = (input >= 0 && input < data.maxIncome) ? true : 'The number you have entered is outside the expected range.';",
                 "customPrivate": false,
                 "strictDateValidation": false,
                 "multiple": false,
@@ -23414,8 +23411,7 @@
               "inputMask": "",
               "decimalLimit": 0,
               "requireDecimal": false,
-              "tags": [],
-              "isNew": false
+              "tags": []
             },
             {
               "title": "CRA consent panel",
@@ -24517,7 +24513,7 @@
                   "inputFormat": "plain",
                   "validate": {
                     "required": true,
-                    "custom": "valid = (input >= 0 && input < 100000000) ? true : 'The number you have entered is not an acceptable value.'",
+                    "custom": "valid = (input >= 0 && input < data.maxIncome) ? true : 'The number you have entered is outside the expected range.';",
                     "customPrivate": false,
                     "strictDateValidation": false,
                     "multiple": false,
@@ -31968,6 +31964,25 @@
             }
           ],
           "id": "emvzoox"
+        },
+        {
+          "input": true,
+          "tableView": false,
+          "key": "maxIncome",
+          "label": "Max Income",
+          "protected": false,
+          "unique": false,
+          "persistent": true,
+          "type": "hidden",
+          "tags": [],
+          "conditional": {
+            "show": "",
+            "when": null,
+            "eq": ""
+          },
+          "properties": {},
+          "defaultValue": "100000000",
+          "lockKey": true
         },
         {
           "input": true,

--- a/sources/packages/forms/src/form-definitions/sfaa2022-23.json
+++ b/sources/packages/forms/src/form-definitions/sfaa2022-23.json
@@ -16589,7 +16589,7 @@
               "inputFormat": "plain",
               "validate": {
                 "required": true,
-                "custom": "",
+                "custom": "valid = (input >= 0 && input < 100000000) ? true : 'The number you have entered is not an acceptable value.'",
                 "customPrivate": false,
                 "strictDateValidation": false,
                 "multiple": false,
@@ -16601,7 +16601,7 @@
               },
               "key": "estimatedSpouseIncome",
               "conditional": {
-                "show": true,
+                "show": "true",
                 "when": "isYourSpouseACanadianCitizen",
                 "eq": "no"
               },
@@ -16655,8 +16655,9 @@
               "id": "e9yrlbn",
               "inputType": "text",
               "inputMask": "",
-              "decimalLimit": 2,
-              "requireDecimal": true
+              "decimalLimit": 0,
+              "requireDecimal": false,
+              "tags": []
             },
             {
               "label": "<strong>Will your partner be employed full-time or part-time during your study period</strong>",
@@ -17335,7 +17336,7 @@
                   "inputFormat": "plain",
                   "validate": {
                     "required": true,
-                    "custom": "",
+                    "custom": "valid = (input >= 0 && input < 100000000) ? true : 'The number you have entered is not an acceptable value.'",
                     "customPrivate": false,
                     "strictDateValidation": false,
                     "multiple": false,
@@ -17347,7 +17348,7 @@
                   },
                   "key": "partnertotalincomeAssistance",
                   "conditional": {
-                    "show": true,
+                    "show": "true",
                     "when": "partnerrecieveIncomeAssistance",
                     "eq": "yes"
                   },
@@ -17402,8 +17403,9 @@
                   "id": "eyn3uvta",
                   "inputType": "text",
                   "inputMask": "",
-                  "decimalLimit": 2,
-                  "requireDecimal": true
+                  "decimalLimit": 0,
+                  "requireDecimal": false,
+                  "tags": []
                 }
               ],
               "allowPrevious": false,
@@ -19642,7 +19644,7 @@
                   "truncateMultipleSpaces": false,
                   "validate": {
                     "required": true,
-                    "custom": "",
+                    "custom": "valid = (input >= 0 && input < 100000000) ? true : 'The number you have entered is not an acceptable value.'",
                     "customPrivate": false,
                     "strictDateValidation": false,
                     "multiple": false,
@@ -19688,7 +19690,7 @@
                   "attributes": {},
                   "validateOn": "change",
                   "conditional": {
-                    "show": null,
+                    "show": "",
                     "when": null,
                     "eq": ""
                   },
@@ -19709,8 +19711,9 @@
                   "id": "et8xql",
                   "inputType": "text",
                   "inputMask": "",
-                  "decimalLimit": 2,
-                  "requireDecimal": true
+                  "decimalLimit": 0,
+                  "requireDecimal": false,
+                  "tags": []
                 },
                 {
                   "label": "Enter the total net value of all your parents Canadian and foreign assets (do not include RRSPs, principal residence or business). Enter ‘0’ if none.",
@@ -23343,7 +23346,7 @@
               "inputFormat": "plain",
               "validate": {
                 "required": true,
-                "custom": "",
+                "custom": "valid = (input >= 0 && input < 100000000) ? true : 'The number you have entered is not an acceptable value.'",
                 "customPrivate": false,
                 "strictDateValidation": false,
                 "multiple": false,
@@ -23388,7 +23391,7 @@
               "attributes": {},
               "validateOn": "change",
               "conditional": {
-                "show": null,
+                "show": "",
                 "when": null,
                 "eq": ""
               },
@@ -23409,8 +23412,8 @@
               "addons": [],
               "inputType": "text",
               "inputMask": "",
-              "decimalLimit": 2,
-              "requireDecimal": true,
+              "decimalLimit": 0,
+              "requireDecimal": false,
               "tags": []
             },
             {
@@ -24513,7 +24516,7 @@
                   "inputFormat": "plain",
                   "validate": {
                     "required": true,
-                    "custom": "",
+                    "custom": "valid = (input >= 0 && input < 100000000) ? true : 'The number you have entered is not an acceptable value.'",
                     "customPrivate": false,
                     "strictDateValidation": false,
                     "multiple": false,
@@ -24525,7 +24528,7 @@
                   },
                   "key": "myTotalCurrentYearIncomeIs",
                   "conditional": {
-                    "show": true,
+                    "show": "true",
                     "when": "hasSignificantDegreeOfIncome",
                     "eq": "yes"
                   },
@@ -24579,8 +24582,9 @@
                   "addons": [],
                   "inputType": "text",
                   "inputMask": "",
-                  "decimalLimit": 2,
-                  "requireDecimal": true
+                  "decimalLimit": 0,
+                  "requireDecimal": false,
+                  "tags": []
                 },
                 {
                   "label": "<strong>Select the reason for your significant decrease in income.</strong>",

--- a/sources/packages/forms/src/form-definitions/sfaa2022-23.json
+++ b/sources/packages/forms/src/form-definitions/sfaa2022-23.json
@@ -16589,7 +16589,7 @@
               "inputFormat": "plain",
               "validate": {
                 "required": true,
-                "custom": "valid = (input >= 0 && input < 100000000) ? true : 'The number you have entered is not an acceptable value.'",
+                "custom": "",
                 "customPrivate": false,
                 "strictDateValidation": false,
                 "multiple": false,
@@ -16601,7 +16601,7 @@
               },
               "key": "estimatedSpouseIncome",
               "conditional": {
-                "show": "true",
+                "show": true,
                 "when": "isYourSpouseACanadianCitizen",
                 "eq": "no"
               },
@@ -16655,9 +16655,8 @@
               "id": "e9yrlbn",
               "inputType": "text",
               "inputMask": "",
-              "decimalLimit": 0,
-              "requireDecimal": false,
-              "tags": []
+              "decimalLimit": 2,
+              "requireDecimal": true
             },
             {
               "label": "<strong>Will your partner be employed full-time or part-time during your study period</strong>",
@@ -17336,7 +17335,7 @@
                   "inputFormat": "plain",
                   "validate": {
                     "required": true,
-                    "custom": "valid = (input >= 0 && input < 100000000) ? true : 'The number you have entered is not an acceptable value.'",
+                    "custom": "",
                     "customPrivate": false,
                     "strictDateValidation": false,
                     "multiple": false,
@@ -17348,7 +17347,7 @@
                   },
                   "key": "partnertotalincomeAssistance",
                   "conditional": {
-                    "show": "true",
+                    "show": true,
                     "when": "partnerrecieveIncomeAssistance",
                     "eq": "yes"
                   },
@@ -17403,9 +17402,8 @@
                   "id": "eyn3uvta",
                   "inputType": "text",
                   "inputMask": "",
-                  "decimalLimit": 0,
-                  "requireDecimal": false,
-                  "tags": []
+                  "decimalLimit": 2,
+                  "requireDecimal": true
                 }
               ],
               "allowPrevious": false,
@@ -19644,7 +19642,7 @@
                   "truncateMultipleSpaces": false,
                   "validate": {
                     "required": true,
-                    "custom": "valid = (input >= 0 && input < 100000000) ? true : 'The number you have entered is not an acceptable value.'",
+                    "custom": "",
                     "customPrivate": false,
                     "strictDateValidation": false,
                     "multiple": false,
@@ -19690,7 +19688,7 @@
                   "attributes": {},
                   "validateOn": "change",
                   "conditional": {
-                    "show": "",
+                    "show": null,
                     "when": null,
                     "eq": ""
                   },
@@ -19711,9 +19709,8 @@
                   "id": "et8xql",
                   "inputType": "text",
                   "inputMask": "",
-                  "decimalLimit": 0,
-                  "requireDecimal": false,
-                  "tags": []
+                  "decimalLimit": 2,
+                  "requireDecimal": true
                 },
                 {
                   "label": "Enter the total net value of all your parents Canadian and foreign assets (do not include RRSPs, principal residence or business). Enter ‘0’ if none.",
@@ -23346,7 +23343,7 @@
               "inputFormat": "plain",
               "validate": {
                 "required": true,
-                "custom": "valid = (input >= 0 && input < 100000000) ? true : 'The number you have entered is not an acceptable value.'",
+                "custom": "valid = (input >= 0 && input < data.maxIncome) ? true : 'The number you have entered is outside the expected range.';",
                 "customPrivate": false,
                 "strictDateValidation": false,
                 "multiple": false,
@@ -24516,7 +24513,7 @@
                   "inputFormat": "plain",
                   "validate": {
                     "required": true,
-                    "custom": "valid = (input >= 0 && input < 100000000) ? true : 'The number you have entered is not an acceptable value.'",
+                    "custom": "valid = (input >= 0 && input < data.maxIncome) ? true : 'The number you have entered is outside the expected range.';",
                     "customPrivate": false,
                     "strictDateValidation": false,
                     "multiple": false,
@@ -31967,6 +31964,25 @@
             }
           ],
           "id": "emvzoox"
+        },
+        {
+          "input": true,
+          "tableView": false,
+          "key": "maxIncome",
+          "label": "Max Income",
+          "protected": false,
+          "unique": false,
+          "persistent": true,
+          "type": "hidden",
+          "tags": [],
+          "conditional": {
+            "show": "",
+            "when": null,
+            "eq": ""
+          },
+          "properties": {},
+          "defaultValue": "100000000",
+          "lockKey": true
         },
         {
           "input": true,

--- a/sources/packages/forms/src/form-definitions/sfaa2023-24.json
+++ b/sources/packages/forms/src/form-definitions/sfaa2023-24.json
@@ -5463,8 +5463,7 @@
           "properties": {},
           "lockKey": true,
           "calculateValue": "/**\n * Maximum number of days past the study period end date\n * beyond when an application will require StudentAid BC\n * approval for funding.\n */\n \nvalue = 42;",
-          "calculateServer": true,
-          "isNew": false
+          "calculateServer": true
         },
         {
           "input": true,
@@ -7396,8 +7395,7 @@
                       "addons": [],
                       "inputType": "hidden",
                       "id": "ej3ulok",
-                      "lockKey": true,
-                      "isNew": false
+                      "lockKey": true
                     },
                     {
                       "label": "HTML",
@@ -16594,7 +16592,7 @@
               "inputFormat": "plain",
               "validate": {
                 "required": true,
-                "custom": "",
+                "custom": "valid = (input >= 0 && input < 100000000) ? true : 'The number you have entered is not an acceptable value.'",
                 "customPrivate": false,
                 "strictDateValidation": false,
                 "multiple": false,
@@ -16606,7 +16604,7 @@
               },
               "key": "estimatedSpouseIncome",
               "conditional": {
-                "show": true,
+                "show": "true",
                 "when": "isYourSpouseACanadianCitizen",
                 "eq": "no"
               },
@@ -16660,8 +16658,9 @@
               "id": "e9yrlbn",
               "inputType": "text",
               "inputMask": "",
-              "decimalLimit": 2,
-              "requireDecimal": true
+              "decimalLimit": 0,
+              "requireDecimal": false,
+              "tags": []
             },
             {
               "label": "<strong>Will your partner be employed full-time or part-time during your study period</strong>",
@@ -17340,7 +17339,7 @@
                   "inputFormat": "plain",
                   "validate": {
                     "required": true,
-                    "custom": "",
+                    "custom": "valid = (input >= 0 && input < 100000000) ? true : 'The number you have entered is not an acceptable value.'",
                     "customPrivate": false,
                     "strictDateValidation": false,
                     "multiple": false,
@@ -17352,7 +17351,7 @@
                   },
                   "key": "partnertotalincomeAssistance",
                   "conditional": {
-                    "show": true,
+                    "show": "true",
                     "when": "partnerrecieveIncomeAssistance",
                     "eq": "yes"
                   },
@@ -17407,8 +17406,9 @@
                   "id": "eyn3uvta",
                   "inputType": "text",
                   "inputMask": "",
-                  "decimalLimit": 2,
-                  "requireDecimal": true
+                  "decimalLimit": 0,
+                  "requireDecimal": false,
+                  "tags": []
                 }
               ],
               "allowPrevious": false,
@@ -19647,7 +19647,7 @@
                   "truncateMultipleSpaces": false,
                   "validate": {
                     "required": true,
-                    "custom": "",
+                    "custom": "valid = (input >= 0 && input < 100000000) ? true : 'The number you have entered is not an acceptable value.'",
                     "customPrivate": false,
                     "strictDateValidation": false,
                     "multiple": false,
@@ -19693,7 +19693,7 @@
                   "attributes": {},
                   "validateOn": "change",
                   "conditional": {
-                    "show": null,
+                    "show": "",
                     "when": null,
                     "eq": ""
                   },
@@ -19714,8 +19714,9 @@
                   "id": "et8xql",
                   "inputType": "text",
                   "inputMask": "",
-                  "decimalLimit": 2,
-                  "requireDecimal": true
+                  "decimalLimit": 0,
+                  "requireDecimal": false,
+                  "tags": []
                 },
                 {
                   "label": "Enter the total net value of all your parents Canadian and foreign assets (do not include RRSPs, principal residence or business). Enter ‘0’ if none.",
@@ -23348,7 +23349,7 @@
               "inputFormat": "plain",
               "validate": {
                 "required": true,
-                "custom": "",
+                "custom": "valid = (input >= 0 && input < 100000000) ? true : 'The number you have entered is not an acceptable value.'",
                 "customPrivate": false,
                 "strictDateValidation": false,
                 "multiple": false,
@@ -23393,7 +23394,7 @@
               "attributes": {},
               "validateOn": "change",
               "conditional": {
-                "show": null,
+                "show": "",
                 "when": null,
                 "eq": ""
               },
@@ -23414,8 +23415,8 @@
               "addons": [],
               "inputType": "text",
               "inputMask": "",
-              "decimalLimit": 2,
-              "requireDecimal": true,
+              "decimalLimit": 0,
+              "requireDecimal": false,
               "tags": []
             },
             {
@@ -24518,7 +24519,7 @@
                   "inputFormat": "plain",
                   "validate": {
                     "required": true,
-                    "custom": "",
+                    "custom": "valid = (input >= 0 && input < 100000000) ? true : 'The number you have entered is not an acceptable value.'",
                     "customPrivate": false,
                     "strictDateValidation": false,
                     "multiple": false,
@@ -24530,7 +24531,7 @@
                   },
                   "key": "myTotalCurrentYearIncomeIs",
                   "conditional": {
-                    "show": true,
+                    "show": "true",
                     "when": "hasSignificantDegreeOfIncome",
                     "eq": "yes"
                   },
@@ -24584,8 +24585,9 @@
                   "addons": [],
                   "inputType": "text",
                   "inputMask": "",
-                  "decimalLimit": 2,
-                  "requireDecimal": true
+                  "decimalLimit": 0,
+                  "requireDecimal": false,
+                  "tags": []
                 },
                 {
                   "label": "<strong>Select the reason for your significant decrease in income.</strong>",
@@ -33120,6 +33122,16 @@
       "allowMultipleMasks": false,
       "inputType": "hidden",
       "id": "e6z1qd9"
+    }
+  ],
+  "access": [
+    {
+      "type": "read_all",
+      "roles": [
+        "645d5647ef9573d50776ce00",
+        "645d5647ef9573d50776ce06",
+        "645d5647ef9573d50776ce0a"
+      ]
     }
   ]
 }

--- a/sources/packages/forms/src/form-definitions/sfaa2023-24.json
+++ b/sources/packages/forms/src/form-definitions/sfaa2023-24.json
@@ -16592,7 +16592,7 @@
               "inputFormat": "plain",
               "validate": {
                 "required": true,
-                "custom": "valid = (input >= 0 && input < 100000000) ? true : 'The number you have entered is not an acceptable value.'",
+                "custom": "",
                 "customPrivate": false,
                 "strictDateValidation": false,
                 "multiple": false,
@@ -16604,7 +16604,7 @@
               },
               "key": "estimatedSpouseIncome",
               "conditional": {
-                "show": "true",
+                "show": true,
                 "when": "isYourSpouseACanadianCitizen",
                 "eq": "no"
               },
@@ -16658,9 +16658,8 @@
               "id": "e9yrlbn",
               "inputType": "text",
               "inputMask": "",
-              "decimalLimit": 0,
-              "requireDecimal": false,
-              "tags": []
+              "decimalLimit": 2,
+              "requireDecimal": true
             },
             {
               "label": "<strong>Will your partner be employed full-time or part-time during your study period</strong>",
@@ -17339,7 +17338,7 @@
                   "inputFormat": "plain",
                   "validate": {
                     "required": true,
-                    "custom": "valid = (input >= 0 && input < 100000000) ? true : 'The number you have entered is not an acceptable value.'",
+                    "custom": "",
                     "customPrivate": false,
                     "strictDateValidation": false,
                     "multiple": false,
@@ -17351,7 +17350,7 @@
                   },
                   "key": "partnertotalincomeAssistance",
                   "conditional": {
-                    "show": "true",
+                    "show": true,
                     "when": "partnerrecieveIncomeAssistance",
                     "eq": "yes"
                   },
@@ -17406,9 +17405,8 @@
                   "id": "eyn3uvta",
                   "inputType": "text",
                   "inputMask": "",
-                  "decimalLimit": 0,
-                  "requireDecimal": false,
-                  "tags": []
+                  "decimalLimit": 2,
+                  "requireDecimal": true
                 }
               ],
               "allowPrevious": false,
@@ -19647,7 +19645,7 @@
                   "truncateMultipleSpaces": false,
                   "validate": {
                     "required": true,
-                    "custom": "valid = (input >= 0 && input < 100000000) ? true : 'The number you have entered is not an acceptable value.'",
+                    "custom": "",
                     "customPrivate": false,
                     "strictDateValidation": false,
                     "multiple": false,
@@ -19693,7 +19691,7 @@
                   "attributes": {},
                   "validateOn": "change",
                   "conditional": {
-                    "show": "",
+                    "show": null,
                     "when": null,
                     "eq": ""
                   },
@@ -19714,9 +19712,8 @@
                   "id": "et8xql",
                   "inputType": "text",
                   "inputMask": "",
-                  "decimalLimit": 0,
-                  "requireDecimal": false,
-                  "tags": []
+                  "decimalLimit": 2,
+                  "requireDecimal": true
                 },
                 {
                   "label": "Enter the total net value of all your parents Canadian and foreign assets (do not include RRSPs, principal residence or business). Enter ‘0’ if none.",
@@ -23349,7 +23346,7 @@
               "inputFormat": "plain",
               "validate": {
                 "required": true,
-                "custom": "valid = (input >= 0 && input < 100000000) ? true : 'The number you have entered is not an acceptable value.'",
+                "custom": "valid = (input >= 0 && input < data.maxIncome) ? true : 'The number you have entered is outside the expected range.';",
                 "customPrivate": false,
                 "strictDateValidation": false,
                 "multiple": false,
@@ -24519,7 +24516,7 @@
                   "inputFormat": "plain",
                   "validate": {
                     "required": true,
-                    "custom": "valid = (input >= 0 && input < 100000000) ? true : 'The number you have entered is not an acceptable value.'",
+                    "custom": "valid = (input >= 0 && input < data.maxIncome) ? true : 'The number you have entered is outside the expected range.';",
                     "customPrivate": false,
                     "strictDateValidation": false,
                     "multiple": false,
@@ -31974,6 +31971,25 @@
         {
           "input": true,
           "tableView": false,
+          "key": "maxIncome",
+          "label": "Max Income",
+          "protected": false,
+          "unique": false,
+          "persistent": true,
+          "type": "hidden",
+          "tags": [],
+          "conditional": {
+            "show": "",
+            "when": null,
+            "eq": ""
+          },
+          "properties": {},
+          "defaultValue": "100000000",
+          "lockKey": true
+        },
+        {
+          "input": true,
+          "tableView": false,
           "key": "dependantstatus",
           "label": "Dependant Status",
           "protected": false,
@@ -33122,16 +33138,6 @@
       "allowMultipleMasks": false,
       "inputType": "hidden",
       "id": "e6z1qd9"
-    }
-  ],
-  "access": [
-    {
-      "type": "read_all",
-      "roles": [
-        "645d5647ef9573d50776ce00",
-        "645d5647ef9573d50776ce06",
-        "645d5647ef9573d50776ce0a"
-      ]
     }
   ]
 }

--- a/sources/packages/forms/src/form-definitions/supportingusersparent2022-2023.json
+++ b/sources/packages/forms/src/form-definitions/supportingusersparent2022-2023.json
@@ -2213,7 +2213,7 @@
                   "inputFormat": "plain",
                   "validate": {
                     "required": true,
-                    "custom": "valid = (input >= 0 && input < 100000000) ? true : 'The number you have entered is not an acceptable value.'",
+                    "custom": "valid = (input >= 0 && input < data.maxIncome) ? true : 'The number you have entered is outside the expected range.';",
                     "customPrivate": false,
                     "strictDateValidation": false,
                     "multiple": false,
@@ -4393,6 +4393,25 @@
           "tree": true,
           "lazyLoad": false,
           "id": "engp8qe"
+        },
+        {
+          "input": true,
+          "tableView": false,
+          "key": "maxIncome",
+          "label": "Max Income",
+          "protected": false,
+          "unique": false,
+          "persistent": true,
+          "type": "hidden",
+          "tags": [],
+          "conditional": {
+            "show": "",
+            "when": null,
+            "eq": ""
+          },
+          "properties": {},
+          "defaultValue": "100000000",
+          "lockKey": true
         },
         {
           "label": "calculatedTaxYear",

--- a/sources/packages/forms/src/form-definitions/supportingusersparent2022-2023.json
+++ b/sources/packages/forms/src/form-definitions/supportingusersparent2022-2023.json
@@ -2197,7 +2197,11 @@
                   "properties": {},
                   "allowMultipleMasks": false,
                   "addons": [],
-                  "id": "edv1wen"
+                  "id": "edv1wen",
+                  "inputType": "text",
+                  "inputMask": "",
+                  "decimalLimit": 2,
+                  "requireDecimal": true
                 },
                 {
                   "label": "Enter your reported total income from line 15000 of your {{data.calculatedTaxYear}} income tax return. If you did not file a {{data.calculatedTaxYear}} income tax return, enter your total income from all sources both inside and outside of Canada",
@@ -2209,7 +2213,7 @@
                   "inputFormat": "plain",
                   "validate": {
                     "required": true,
-                    "custom": "",
+                    "custom": "valid = (input >= 0 && input < 100000000) ? true : 'The number you have entered is not an acceptable value.'",
                     "customPrivate": false,
                     "strictDateValidation": false,
                     "multiple": false,
@@ -2256,7 +2260,7 @@
                   "attributes": {},
                   "validateOn": "change",
                   "conditional": {
-                    "show": null,
+                    "show": "",
                     "when": null,
                     "eq": ""
                   },
@@ -2274,7 +2278,12 @@
                   "properties": {},
                   "allowMultipleMasks": false,
                   "addons": [],
-                  "id": "eiem6k2"
+                  "id": "eiem6k2",
+                  "inputType": "text",
+                  "inputMask": "",
+                  "decimalLimit": 0,
+                  "requireDecimal": false,
+                  "tags": []
                 },
                 {
                   "label": "Canada Pension Plan contributions (CPP) from line 30800 (contributions through employment). Enter ‘0’ if none.",
@@ -2351,7 +2360,11 @@
                   "properties": {},
                   "allowMultipleMasks": false,
                   "addons": [],
-                  "id": "e4zwg0t"
+                  "id": "e4zwg0t",
+                  "inputType": "text",
+                  "inputMask": "",
+                  "decimalLimit": 2,
+                  "requireDecimal": true
                 },
                 {
                   "label": "Enter the total net value of all Canadian and foreign assets (do not include RRSPs, principal residence or business). Enter ‘0’ if none.",
@@ -2428,7 +2441,11 @@
                   "properties": {},
                   "allowMultipleMasks": false,
                   "addons": [],
-                  "id": "evdk87"
+                  "id": "evdk87",
+                  "inputType": "text",
+                  "inputMask": "",
+                  "decimalLimit": 2,
+                  "requireDecimal": true
                 },
                 {
                   "label": "Canada Pension Plan contributions (CPP) from line 31000 (contributions payable on self-employment and other earnings). Enter ‘0’ if none.",
@@ -2505,7 +2522,11 @@
                   "properties": {},
                   "allowMultipleMasks": false,
                   "addons": [],
-                  "id": "ew5ec5c"
+                  "id": "ew5ec5c",
+                  "inputType": "text",
+                  "inputMask": "",
+                  "decimalLimit": 2,
+                  "requireDecimal": true
                 },
                 {
                   "label": "Total income tax from line 43500. Enter ‘0’ if none",
@@ -2582,7 +2603,11 @@
                   "properties": {},
                   "allowMultipleMasks": false,
                   "addons": [],
-                  "id": "et79a9"
+                  "id": "et79a9",
+                  "inputType": "text",
+                  "inputMask": "",
+                  "decimalLimit": 2,
+                  "requireDecimal": true
                 },
                 {
                   "label": "Employment insurance (EI) from line 31200. Enter ‘0’ if none.",
@@ -2659,7 +2684,11 @@
                   "properties": {},
                   "allowMultipleMasks": false,
                   "addons": [],
-                  "id": "esfhhsd"
+                  "id": "esfhhsd",
+                  "inputType": "text",
+                  "inputMask": "",
+                  "decimalLimit": 2,
+                  "requireDecimal": true
                 },
                 {
                   "label": "Do you have any dependant(s) other than the Student?",
@@ -3400,7 +3429,8 @@
                       "addons": [],
                       "tree": false,
                       "lazyLoad": false,
-                      "legend": ""
+                      "legend": "",
+                      "inDataGrid": true
                     }
                   ],
                   "placeholder": "",
@@ -3601,7 +3631,7 @@
                       "id": "elbt2rr"
                     },
                     {
-                      "html": "<p><strong>I. I. I/we understand that:</strong></p><ol><li>The student will have access to information provided in this appendix;</li><li>The student's school will have access to information provided in this appendix;</li><li>The information in this appendix is subject to audit, investigation and verification as defined in the current program year's StudentAid BC Policy Manual</li></ol><p><strong>II. II. I/we understand that signing this declaration means:</strong></p><ol><li>I declare that the information I have given in this appendix is correct and complete and that I have not altered or added to any of the pre-printed application and/or appendix questions.</li><li>I authorize the student to notify StudentAid BC as soon as practical of any change in my income and/or assets, as defined in the current program year's StudentAid BC Policy Manual.</li><li>For the purposes of verifying the accuracy of the personal information provided by me in this appendix, I consent to the collection, use and disclosure of my personal information between the BC Ministry of Post Secondary and Future Skills, the BC Ministry of Finance, the National Student Loans Service Centre, and any of their contractors, subcontractors or agents, each with each other, and with the following: financial institutions, lenders, educational institutions, financial aid offices, employers, credit bureaus, credit reporting agencies, Aboriginal Organizations, federal and provincial Crown corporations, and federal, provincial, municipal ministries/departments/agencies, including but not limited to: BC Ministry of Social Development and Poverty Reduction, BC Ministry of Children and Family Development, BC Ministry of Health, BC Ministry of Attorney General, BC Ministry of Education, BC Public Service Agency, RoadSafe BC, Insurance Corporation of BC (and Service BC acting in the role of ICBC), BC Assessment Authority, Land Title and Survey Authority of BC, BC Registry Services, WorkSafe BC, BC Vital Statistics Agency, the Office of the Superintendent of Bankruptcy Canada, Employment and Social Development Canada, Canada Revenue Agency, Immigration, Refugees and Citizenship Canada. This consent takes effect on the date that I make the first submission of this Appendix to StudentAid BC, regardless of whether this Appendix is in electronic or written format.</li></ol>",
+                      "html": "<p><strong>I. I. I/we understand that:</strong></p>\n\n<ol>\n\t<li>The student will have access to information provided in this appendix;</li>\n\t<li>The student&#39;s school will have access to information provided in this appendix;</li>\n\t<li>The information in this appendix is subject to audit, investigation and verification as defined in the current program year&#39;s StudentAid BC Policy Manual</li>\n</ol>\n\n<p><strong>II. II. I/we understand that signing this declaration means:</strong></p>\n\n<ol>\n\t<li>I declare that the information I have given in this appendix is correct and complete and that I have not altered or added to any of the pre-printed application and/or appendix questions.</li>\n\t<li>I authorize the student to notify StudentAid BC as soon as practical of any change in my income and/or assets, as defined in the current program year&#39;s StudentAid BC Policy Manual.</li>\n\t<li>For the purposes of verifying the accuracy of the personal information provided by me in this appendix, I consent to the collection, use and disclosure of my personal information between the BC Ministry of Post Secondary and Future Skills, the BC Ministry of Finance, the National Student Loans Service Centre, and any of their contractors, subcontractors or agents, each with each other, and with the following: financial institutions, lenders, educational institutions, financial aid offices, employers, credit bureaus, credit reporting agencies, Aboriginal Organizations, federal and provincial Crown corporations, and federal, provincial, municipal ministries/departments/agencies, including but not limited to: BC Ministry of Social Development and Poverty Reduction, BC Ministry of Children and Family Development, BC Ministry of Health, BC Ministry of Attorney General, BC Ministry of Education, BC Public Service Agency, RoadSafe BC, Insurance Corporation of BC (and Service BC acting in the role of ICBC), BC Assessment Authority, Land Title and Survey Authority of BC, BC Registry Services, WorkSafe BC, BC Vital Statistics Agency, the Office of the Superintendent of Bankruptcy Canada, Employment and Social Development Canada, Canada Revenue Agency, Immigration, Refugees and Citizenship Canada. This consent takes effect on the date that I make the first submission of this Appendix to StudentAid BC, regardless of whether this Appendix is in electronic or written format.</li>\n</ol>\n",
                       "label": "Content",
                       "refreshOnChange": false,
                       "key": "content",
@@ -3739,7 +3769,8 @@
                       "allowMultipleMasks": false,
                       "addons": [],
                       "tag": "p",
-                      "id": "el4ky9"
+                      "id": "el4ky9",
+                      "className": ""
                     }
                   ],
                   "placeholder": "",
@@ -3961,10 +3992,11 @@
                       "allowMultipleMasks": false,
                       "addons": [],
                       "tag": "p",
-                      "id": "e8aru0u"
+                      "id": "e8aru0u",
+                      "className": ""
                     },
                     {
-                      "html": "<p>For the purpose of verifying the data provided in this application for student assistance, I hereby consent to the release, by the Canada Revenue Agency, to the BC Ministry of Post Secondary and Future Skills (or a person delegated by the ministry), of taxpayer information from any portion of my income tax records that pertains to information given by me on any StudentAid BC application. The information will be used solely for the purpose of verifying information on my StudentAid BC application forms and for the general administration and enforcement of StudentAid BC policy and the Canada Student Financial Assistance Act. This authorization is valid for the two taxation years prior to the year of signature of this consent, the year of signature of this consent and for any other subsequent consecutive taxation year for which assistance is requested.</p>",
+                      "html": "<p>For the purpose of verifying the data provided in this application for student assistance, I hereby consent to the release, by the Canada Revenue Agency, to the BC Ministry of Post Secondary and Future Skills (or a person delegated by the ministry), of taxpayer information from any portion of my income tax records that pertains to information given by me on any StudentAid BC application. The information will be used solely for the purpose of verifying information on my StudentAid BC application forms and for the general administration and enforcement of StudentAid BC policy and the Canada Student Financial Assistance Act. This authorization is valid for the two taxation years prior to the year of signature of this consent, the year of signature of this consent and for any other subsequent consecutive taxation year for which assistance is requested.</p>\n",
                       "label": "Content",
                       "refreshOnChange": false,
                       "key": "content",
@@ -4102,7 +4134,8 @@
                       "allowMultipleMasks": false,
                       "addons": [],
                       "tag": "p",
-                      "id": "ems55e"
+                      "id": "ems55e",
+                      "className": ""
                     }
                   ],
                   "placeholder": "",

--- a/sources/packages/forms/src/form-definitions/supportinguserspartner2022-2023.json
+++ b/sources/packages/forms/src/form-definitions/supportinguserspartner2022-2023.json
@@ -2038,13 +2038,13 @@
                   "inputFormat": "plain",
                   "validate": {
                     "required": true,
-                    "custom": "valid = (input >= 0 && input < 100000000) ? true : 'The number you have entered is not an acceptable value.'",
+                    "custom": "valid = (input >= 0 && input < data.maxIncome) ? true : 'The number you have entered is outside the expected range.';",
                     "customPrivate": false,
                     "strictDateValidation": false,
                     "multiple": false,
                     "unique": false,
-                    "min": null,
-                    "max": null,
+                    "min": "",
+                    "max": "",
                     "step": "any",
                     "integer": ""
                   },
@@ -2752,7 +2752,7 @@
                       "inputFormat": "plain",
                       "validate": {
                         "required": true,
-                        "custom": "valid = (input >= 0 && input < 100000000) ? true : 'The number you have entered is not an acceptable value.'",
+                        "custom": "",
                         "customPrivate": false,
                         "strictDateValidation": false,
                         "multiple": false,
@@ -2798,7 +2798,7 @@
                       "attributes": {},
                       "validateOn": "change",
                       "conditional": {
-                        "show": "",
+                        "show": null,
                         "when": null,
                         "eq": ""
                       },
@@ -2819,9 +2819,8 @@
                       "id": "ew72bho",
                       "inputType": "text",
                       "inputMask": "",
-                      "decimalLimit": 0,
-                      "requireDecimal": false,
-                      "tags": []
+                      "decimalLimit": 2,
+                      "requireDecimal": true
                     }
                   ],
                   "placeholder": "",
@@ -5080,6 +5079,25 @@
           "tree": true,
           "lazyLoad": false,
           "id": "erp1v1j"
+        },
+        {
+          "input": true,
+          "tableView": false,
+          "key": "maxIncome",
+          "label": "Max Income",
+          "protected": false,
+          "unique": false,
+          "persistent": true,
+          "type": "hidden",
+          "tags": [],
+          "conditional": {
+            "show": "",
+            "when": null,
+            "eq": ""
+          },
+          "properties": {},
+          "defaultValue": "100000000",
+          "lockKey": true
         },
         {
           "label": "calculatedTaxYear",

--- a/sources/packages/forms/src/form-definitions/supportinguserspartner2022-2023.json
+++ b/sources/packages/forms/src/form-definitions/supportinguserspartner2022-2023.json
@@ -2038,13 +2038,13 @@
                   "inputFormat": "plain",
                   "validate": {
                     "required": true,
-                    "custom": "",
+                    "custom": "valid = (input >= 0 && input < 100000000) ? true : 'The number you have entered is not an acceptable value.'",
                     "customPrivate": false,
                     "strictDateValidation": false,
                     "multiple": false,
                     "unique": false,
-                    "min": "",
-                    "max": "",
+                    "min": null,
+                    "max": null,
                     "step": "any",
                     "integer": ""
                   },
@@ -2085,7 +2085,7 @@
                   "attributes": {},
                   "validateOn": "change",
                   "conditional": {
-                    "show": null,
+                    "show": "",
                     "when": null,
                     "eq": ""
                   },
@@ -2104,7 +2104,8 @@
                   "allowMultipleMasks": false,
                   "addons": [],
                   "id": "eazbh7",
-                  "inputType": "number"
+                  "inputType": "number",
+                  "tags": []
                 },
                 {
                   "label": "<strong>Will you be employed full-time or part-time during your Partner's study period</strong>",
@@ -2189,7 +2190,7 @@
                   "id": "e2j82bp"
                 },
                 {
-                  "label": "<strong>Will you be at home caring for eligible dependant children on a full-time basis during your Partner's entire study period? </strong>",
+                  "label": "<strong>Will you be at home caring for eligible dependant children on a full-time basis during your Partner's entire study period? </strong>",
                   "labelPosition": "top",
                   "labelWidth": "",
                   "labelMargin": "",
@@ -2364,7 +2365,7 @@
                   "id": "edsljuf"
                 },
                 {
-                  "label": "<strong>Will you be a full-time post-secondary student for some or all of your Partner's study period?</strong>",
+                  "label": "<strong>Will you be a full-time post-secondary student for some or all of your Partner's study period?</strong>",
                   "optionsLabelPosition": "right",
                   "inline": false,
                   "tableView": false,
@@ -2603,7 +2604,7 @@
                   "id": "eryyqjh"
                 },
                 {
-                  "label": "<strong>Will you receive income assistance/social assistance (welfare) and/or BC income assistance for persons with disabilities during your Partner's study period?</strong>",
+                  "label": "<strong>Will you receive income assistance/social assistance (welfare) and/or BC income assistance for persons with disabilities during your Partner's study period?</strong>",
                   "labelPosition": "top",
                   "labelWidth": "",
                   "labelMargin": "",
@@ -2696,7 +2697,7 @@
                   "defaultValue": ""
                 },
                 {
-                  "title": "<strong>Will you receive income assistance/social assistance (welfare) and/or BC income assistance for persons with disabilities during your Partner's study period?</strong>",
+                  "title": "<strong>Will you receive income assistance/social assistance (welfare) and/or BC income assistance for persons with disabilities during your Partner's study period?</strong>",
                   "labelWidth": "",
                   "labelMargin": "",
                   "theme": "default",
@@ -2728,7 +2729,7 @@
                     "height": ""
                   },
                   "type": "panel",
-                  "label": "<strong>Will you receive income assistance/social assistance (welfare) and/or BC income assistance for persons with disabilities during the your Partner's study period?</strong>",
+                  "label": "<strong>Will you receive income assistance/social assistance (welfare) and/or BC income assistance for persons with disabilities during the your Partner's study period?</strong>",
                   "breadcrumb": "default",
                   "buttonSettings": {
                     "previous": true,
@@ -2751,7 +2752,7 @@
                       "inputFormat": "plain",
                       "validate": {
                         "required": true,
-                        "custom": "",
+                        "custom": "valid = (input >= 0 && input < 100000000) ? true : 'The number you have entered is not an acceptable value.'",
                         "customPrivate": false,
                         "strictDateValidation": false,
                         "multiple": false,
@@ -2797,7 +2798,7 @@
                       "attributes": {},
                       "validateOn": "change",
                       "conditional": {
-                        "show": null,
+                        "show": "",
                         "when": null,
                         "eq": ""
                       },
@@ -2818,8 +2819,9 @@
                       "id": "ew72bho",
                       "inputType": "text",
                       "inputMask": "",
-                      "decimalLimit": 2,
-                      "requireDecimal": true
+                      "decimalLimit": 0,
+                      "requireDecimal": false,
+                      "tags": []
                     }
                   ],
                   "placeholder": "",
@@ -2863,7 +2865,7 @@
                   "id": "e308bl"
                 },
                 {
-                  "label": "<strong>Will you be in receipt of Employment Insurance benefits during your Partner's study period?</strong>",
+                  "label": "<strong>Will you be in receipt of Employment Insurance benefits during your Partner's study period?</strong>",
                   "labelPosition": "top",
                   "labelWidth": "",
                   "labelMargin": "",
@@ -2956,7 +2958,7 @@
                   "defaultValue": ""
                 },
                 {
-                  "title": "<strong>Will you be in receipt of Employment Insurance benefits during your Partner's study period?</strong>",
+                  "title": "<strong>Will you be in receipt of Employment Insurance benefits during your Partner's study period?</strong>",
                   "labelWidth": "",
                   "labelMargin": "",
                   "theme": "default",
@@ -2988,7 +2990,7 @@
                     "height": ""
                   },
                   "type": "panel",
-                  "label": "<strong>Will you be in receipt of Employment Insurance benefits during the your Partner's study period?</strong>",
+                  "label": "<strong>Will you be in receipt of Employment Insurance benefits during the your Partner's study period?</strong>",
                   "breadcrumb": "default",
                   "buttonSettings": {
                     "previous": true,
@@ -3120,7 +3122,7 @@
                   "id": "euq0vth"
                 },
                 {
-                  "label": "<strong>Will you be in receipt of federal or provincial permanent disability benefits during your Partner's study period?</strong>",
+                  "label": "<strong>Will you be in receipt of federal or provincial permanent disability benefits during your Partner's study period?</strong>",
                   "optionsLabelPosition": "right",
                   "inline": false,
                   "tableView": false,
@@ -3202,7 +3204,7 @@
                   "id": "egj7jpm"
                 },
                 {
-                  "title": "Will your partner be in receipt of federal or provincial permanent disability benefits during your study period Panel",
+                  "title": "Will your partner be in receipt of federal or provincial permanent disability benefits during your study period Panel",
                   "labelWidth": "",
                   "labelMargin": "",
                   "theme": "default",
@@ -3234,7 +3236,7 @@
                     "height": ""
                   },
                   "type": "panel",
-                  "label": "Will your partner be in receipt of federal or provincial permanent disability benefits during the your study period Panel",
+                  "label": "Will your partner be in receipt of federal or provincial permanent disability benefits during the your study period Panel",
                   "breadcrumb": "default",
                   "buttonSettings": {
                     "previous": true,
@@ -3369,7 +3371,7 @@
                   "id": "ednv0e"
                 },
                 {
-                  "label": "<strong>Will you be paying a Canada Student Loan and/or a provincial student loan regular scheduled payments during your Partner's study period?</strong>",
+                  "label": "<strong>Will you be paying a Canada Student Loan and/or a provincial student loan regular scheduled payments during your Partner's study period?</strong>",
                   "labelPosition": "top",
                   "labelWidth": "",
                   "labelMargin": "",
@@ -3462,7 +3464,7 @@
                   "defaultValue": ""
                 },
                 {
-                  "title": "<strong>Will you be paying a Canada Student Loan and/or a provincial student loan regular scheduled payments during your Partner's study period?</strong>",
+                  "title": "<strong>Will you be paying a Canada Student Loan and/or a provincial student loan regular scheduled payments during your Partner's study period?</strong>",
                   "labelWidth": "",
                   "labelMargin": "",
                   "theme": "default",
@@ -3494,7 +3496,7 @@
                     "height": ""
                   },
                   "type": "panel",
-                  "label": "<strong>Will you be paying a Canada Student Loan and/or a provincial student loan regular scheduled payments during the your Partner's study period?</strong>",
+                  "label": "<strong>Will you be paying a Canada Student Loan and/or a provincial student loan regular scheduled payments during the your Partner's study period?</strong>",
                   "breadcrumb": "default",
                   "buttonSettings": {
                     "previous": true,
@@ -3626,7 +3628,7 @@
                   "id": "e1cacbl"
                 },
                 {
-                  "label": "<strong>Will you be paying for child support and/or spousal support during your Partner's study period?</strong>",
+                  "label": "<strong>Will you be paying for child support and/or spousal support during your Partner's study period?</strong>",
                   "optionsLabelPosition": "right",
                   "inline": false,
                   "tableView": false,
@@ -3708,7 +3710,7 @@
                   "id": "efbnjl"
                 },
                 {
-                  "title": "Will your partner be paying for child support and/or spousal support during your study period Panel",
+                  "title": "Will your partner be paying for child support and/or spousal support during your study period Panel",
                   "labelWidth": "",
                   "labelMargin": "",
                   "theme": "default",
@@ -3740,7 +3742,7 @@
                     "height": ""
                   },
                   "type": "panel",
-                  "label": "Will your partner be paying for child support and/or spousal support during the your study period Panel",
+                  "label": "Will your partner be paying for child support and/or spousal support during the your study period Panel",
                   "breadcrumb": "default",
                   "buttonSettings": {
                     "previous": true,
@@ -4341,8 +4343,7 @@
                   "theme": "default",
                   "breadcrumb": "default",
                   "id": "e69jwa",
-                  "tags": [],
-                  "isNew": false
+                  "tags": []
                 },
                 {
                   "title": "SABC Declaration for Part Time",
@@ -4682,7 +4683,7 @@
                       "className": ""
                     },
                     {
-                      "html": "<p>I hereby consent to the disclosure of information from my income tax records, by the Canada Revenue Agency to an official of the Ministry of Post Secondary and Future Skills, that pertains to information provided on any Student Aid BC application. The information disclosed will be relevant to, and used solely for the purpose of, determining and verifying eligibility for student aid under the Canada Student Financial Assistance Act. The information disclosed by the Canada Revenue Agency to the Ministry of Post Secondary and Future Skills will be protected from unauthorized use or disclosure and will not be disclosed to any other person or organization without my approval. This authorization is valid for the two taxation years prior to the year of signature of this consent, and the year of signature.</p>",
+                      "html": "<p>I hereby consent to the disclosure of information from my income tax records, by the Canada Revenue Agency to an official of the Ministry of Post Secondary and Future Skills, that pertains to information provided on any Student Aid BC application. The information disclosed will be relevant to, and used solely for the purpose of, determining and verifying eligibility for student aid under the Canada Student Financial Assistance Act. The information disclosed by the Canada Revenue Agency to the Ministry of Post Secondary and Future Skills will be protected from unauthorized use or disclosure and will not be disclosed to any other person or organization without my approval. This authorization is valid for the two taxation years prior to the year of signature of this consent, and the year of signature.</p>\n",
                       "label": "Content",
                       "refreshOnChange": false,
                       "key": "content",


### PR DESCRIPTION
**As a part of this PR, validations (for negative and very large [> $100 million] inputs) have been added for total income reported in the application forms for all the 3 program years along with parent and partner supporting documents. Also, ability for the user to enter a decimal number has been disabled.** 

## UI Validation Screenshots:

### User enters a negative number:

<img width="1922" alt="image" src="https://github.com/bcgov/SIMS/assets/7859295/81cc61c5-f357-4927-ab19-048f77d3bf81">

### User enters a number too large (>= $100 million):

<img width="1920" alt="image" src="https://github.com/bcgov/SIMS/assets/7859295/0f762f34-22e2-448d-8e19-60a77ebe98a1">
