### PR TITLE
#2623 - Program Validation - Online - BC Public/BC Private

### DIFF
--- a/sources/packages/backend/apps/api/src/route-controllers/education-program/education-program.controller.service.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/education-program/education-program.controller.service.ts
@@ -224,7 +224,7 @@ export class EducationProgramControllerService {
       effectiveEndDate: getISODateOnlyString(program.effectiveEndDate),
       assessedDate: program.assessedDate,
       assessedBy: getUserFullName(program.assessedBy),
-      isBCPublic: program.institution.institutionType.isBCPrivate,
+      isBCPublic: program.institution.institutionType.isBCPublic,
       isBCPrivate: program.institution.institutionType.isBCPrivate,
       hasOfferings,
     };

--- a/sources/packages/backend/apps/api/src/route-controllers/education-program/education-program.controller.service.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/education-program/education-program.controller.service.ts
@@ -25,7 +25,10 @@ import {
   EDUCATION_PROGRAM_NOT_FOUND,
   DUPLICATE_SABC_CODE,
 } from "../../constants";
-import { INSTITUTION_TYPE_BC_PRIVATE } from "@sims/sims-db/constant";
+import {
+  INSTITUTION_TYPE_BC_PUBLIC,
+  INSTITUTION_TYPE_BC_PRIVATE,
+} from "@sims/sims-db/constant";
 import { ApiProcessError } from "../../types";
 import { ApiUnprocessableEntityResponse } from "@nestjs/swagger";
 import { SaveEducationProgram } from "../../services/education-program/education-program.service.models";
@@ -213,6 +216,8 @@ export class EducationProgramControllerService {
       effectiveEndDate: getISODateOnlyString(program.effectiveEndDate),
       assessedDate: program.assessedDate,
       assessedBy: getUserFullName(program.assessedBy),
+      isBCPublic:
+        program.institution.institutionType.id === INSTITUTION_TYPE_BC_PUBLIC,
       isBCPrivate:
         program.institution.institutionType.id === INSTITUTION_TYPE_BC_PRIVATE,
       hasOfferings,

--- a/sources/packages/backend/apps/api/src/route-controllers/education-program/education-program.controller.service.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/education-program/education-program.controller.service.ts
@@ -32,6 +32,7 @@ import {
 import { ApiProcessError } from "../../types";
 import { ApiUnprocessableEntityResponse } from "@nestjs/swagger";
 import { SaveEducationProgram } from "../../services/education-program/education-program.service.models";
+import { InstitutionService } from "../../services/institution/institution.service";
 
 @Injectable()
 export class EducationProgramControllerService {
@@ -39,6 +40,7 @@ export class EducationProgramControllerService {
     private readonly programService: EducationProgramService,
     private readonly educationProgramOfferingService: EducationProgramOfferingService,
     private readonly formService: FormService,
+    private readonly institutionService: InstitutionService,
   ) {}
 
   /**
@@ -99,6 +101,12 @@ export class EducationProgramControllerService {
     auditUserId: number,
     programId?: number,
   ): Promise<EducationProgram> {
+    // Check if institution is private/public and append it to the payload.
+    const { institutionType } =
+      await this.institutionService.getInstitutionTypeById(institutionId);
+    payload.isBCPrivate = institutionType.isBCPrivate;
+    payload.isBCPublic = institutionType.isBCPublic;
+
     const submissionResult =
       await this.formService.dryRunSubmission<SaveEducationProgram>(
         FormNames.EducationProgram,

--- a/sources/packages/backend/apps/api/src/route-controllers/education-program/education-program.controller.service.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/education-program/education-program.controller.service.ts
@@ -224,10 +224,8 @@ export class EducationProgramControllerService {
       effectiveEndDate: getISODateOnlyString(program.effectiveEndDate),
       assessedDate: program.assessedDate,
       assessedBy: getUserFullName(program.assessedBy),
-      isBCPublic:
-        program.institution.institutionType.id === INSTITUTION_TYPE_BC_PUBLIC,
-      isBCPrivate:
-        program.institution.institutionType.id === INSTITUTION_TYPE_BC_PRIVATE,
+      isBCPublic: program.institution.institutionType.isBCPrivate,
+      isBCPrivate: program.institution.institutionType.isBCPrivate,
       hasOfferings,
     };
   }

--- a/sources/packages/backend/apps/api/src/route-controllers/education-program/models/education-program.dto.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/education-program/models/education-program.dto.ts
@@ -51,6 +51,7 @@ export class EducationProgramAPIOutDTO {
   hasOfferings: boolean;
   institutionId: number;
   institutionName: string;
+  isBCPublic: boolean;
   isBCPrivate: boolean;
   submittedDate: Date;
   submittedBy: string;

--- a/sources/packages/backend/apps/api/src/route-controllers/education-program/models/education-program.dto.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/education-program/models/education-program.dto.ts
@@ -153,12 +153,16 @@ export class EducationProgramAPIInDTO {
   @Allow()
   fieldOfStudyCode: number;
   /**
-   * isBCPrivate/isBCPublic are part of the form and defines if the dynamic area of the form.io definition will be visible or not.
-   * It will impact the validation using the dryrun. Since the values have the source of truth on the institution, they must be
-   * populated by the API prior to the dryrun validation and they are part of DTO to make explicit its place in the form payload
-   * submitted. They will also be ignored by Nestjs because they don't have decorators.
+   * Indicates the institution type as BC Private. isBCPrivate is part of the form and defines if the dynamic
+   * area of the form.io definition will be visible or not. It will impact the validation using the dryrun.
+   * Since this value has the source of truth on the institution, it must be populated by the API prior to
+   * the dryrun validation and it is part of DTO to make explicit its place in the form payload submitted.
+   * It will also be ignored by Nestjs because it does not have a decorator.
    */
   isBCPrivate: boolean;
+  /**
+   * Indicates the institution type as BC Public. It follows the same reasoning as isBCPrivate.
+   */
   isBCPublic: boolean;
 }
 

--- a/sources/packages/backend/apps/api/src/route-controllers/education-program/models/education-program.dto.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/education-program/models/education-program.dto.ts
@@ -152,6 +152,14 @@ export class EducationProgramAPIInDTO {
   programDeclaration: boolean;
   @Allow()
   fieldOfStudyCode: number;
+  /**
+   * isBCPrivate/isBCPublic are part of the form and defines if the dynamic area of the form.io definition will be visible or not.
+   * It will impact the validation using the dryrun. Since the values have the source of truth on the institution, they must be
+   * populated by the API prior to the dryrun validation and they are part of DTO to make explicit its place in the form payload
+   * submitted. They will also be ignored by Nestjs because they don't have decorators.
+   */
+  isBCPrivate: boolean;
+  isBCPublic: boolean;
 }
 
 export class ApproveProgramAPIInDTO {

--- a/sources/packages/forms/src/form-definitions/educationprogram.json
+++ b/sources/packages/forms/src/form-definitions/educationprogram.json
@@ -1698,7 +1698,7 @@
                         "eq": "",
                         "json": ""
                     },
-                    "customConditional": "const isBCInstitution = data.isBCPublic || data.isBCPrivate;\nshow = (isBCInstitution === false && data.programDeliveryTypes.deliveredOnline);",
+                    "customConditional": "const isBCInstitution = data.isBCPublic || data.isBCPrivate;\nshow = (!isBCInstitution && data.programDeliveryTypes.deliveredOnline);",
                     "logic": [],
                     "attributes": {
                         "data-cy": "deliveredOnlineAlsoOnsite"
@@ -1794,7 +1794,7 @@
                         "eq": "",
                         "json": ""
                     },
-                    "customConditional": "const isBCInstitution = data.isBCPublic || data.isBCPrivate;\nshow = (isBCInstitution === false && data.deliveredOnlineAlsoOnsite === \"no\");",
+                    "customConditional": "const isBCInstitution = data.isBCPublic || data.isBCPrivate;\nshow = (!isBCInstitution && data.deliveredOnlineAlsoOnsite === \"no\");",
                     "logic": [],
                     "attributes": {
                         "data-cy": "sameOnlineCreditsEarned"
@@ -1890,7 +1890,7 @@
                         "eq": "",
                         "json": ""
                     },
-                    "customConditional": "const isBCInstitution = data.isBCPublic || data.isBCPrivate;\nshow = (isBCInstitution === false && data.deliveredOnlineAlsoOnsite === \"no\" && data.sameOnlineCreditsEarned ===\"no\");",
+                    "customConditional": "const isBCInstitution = data.isBCPublic || data.isBCPrivate;\nshow = (!isBCInstitution && data.deliveredOnlineAlsoOnsite === \"no\" && data.sameOnlineCreditsEarned ===\"no\");",
                     "logic": [],
                     "attributes": {
                         "data-cy": "earnAcademicCreditsOtherInstitution"
@@ -1937,7 +1937,7 @@
                     "refreshOnChange": false,
                     "customClass": "banner-warning",
                     "key": "html4",
-                    "customConditional": "const isBCInstitution = data.isBCPublic || data.isBCPrivate;\nshow = (isBCInstitution === false && data.deliveredOnlineAlsoOnsite === \"no\" && data.sameOnlineCreditsEarned === \"no\" && data.earnAcademicCreditsOtherInstitution === \"no\");",
+                    "customConditional": "const isBCInstitution = data.isBCPublic || data.isBCPrivate;\nshow = (!isBCInstitution && data.deliveredOnlineAlsoOnsite === \"no\" && data.sameOnlineCreditsEarned === \"no\" && data.earnAcademicCreditsOtherInstitution === \"no\");",
                     "type": "htmlelement",
                     "input": false,
                     "tableView": false,

--- a/sources/packages/forms/src/form-definitions/educationprogram.json
+++ b/sources/packages/forms/src/form-definitions/educationprogram.json
@@ -1632,7 +1632,9 @@
                     "allowMultipleMasks": false,
                     "addons": [],
                     "fieldSet": false,
-                    "id": "e3tglfe"
+                    "id": "e3tglfe",
+                    "isNew": false,
+                    "lockKey": true
                 },
                 {
                     "label": "Will the program also be offered and delivered at 100% course load on site?",
@@ -1691,12 +1693,12 @@
                     "tags": [],
                     "properties": {},
                     "conditional": {
-                        "show": true,
-                        "when": "programDeliveryTypes",
-                        "eq": "deliveredOnline",
+                        "show": "",
+                        "when": null,
+                        "eq": "",
                         "json": ""
                     },
-                    "customConditional": "",
+                    "customConditional": "const isBCInstitution = data.isBCPublic || data.isBCPrivate;\nshow = (!isBCInstitution && data.programDeliveryTypes.deliveredOnSite);",
                     "logic": [],
                     "attributes": {
                         "data-cy": "deliveredOnlineAlsoOnsite"
@@ -1727,7 +1729,8 @@
                     "inputType": "radio",
                     "fieldSet": false,
                     "id": "el1u4p",
-                    "defaultValue": ""
+                    "defaultValue": "",
+                    "isNew": false
                 },
                 {
                     "label": "Will the students earn the same number of credits in the same time period as students in other StudentAid BC eligible programs delivered on site?",
@@ -1786,12 +1789,12 @@
                     "tags": [],
                     "properties": {},
                     "conditional": {
-                        "show": true,
-                        "when": "deliveredOnlineAlsoOnsite",
-                        "eq": "no",
+                        "show": "",
+                        "when": null,
+                        "eq": "",
                         "json": ""
                     },
-                    "customConditional": "",
+                    "customConditional": "const isBCInstitution = data.isBCPublic || data.isBCPrivate;\nshow = (!isBCInstitution && data.deliveredOnlineAlsoOnsite === \"no\");",
                     "logic": [],
                     "attributes": {
                         "data-cy": "sameOnlineCreditsEarned"
@@ -1822,7 +1825,8 @@
                     "inputType": "radio",
                     "fieldSet": false,
                     "id": "e6vyjtc",
-                    "defaultValue": ""
+                    "defaultValue": "",
+                    "isNew": false
                 },
                 {
                     "label": "Will they earn academic credits that are recognized at another designated institution listed in the BC Transfer Guide or other acceptable articulation agreements from other jurisdictions?",
@@ -1881,12 +1885,12 @@
                     "tags": [],
                     "properties": {},
                     "conditional": {
-                        "show": null,
+                        "show": "",
                         "when": null,
                         "eq": "",
                         "json": ""
                     },
-                    "customConditional": "show = (data.deliveredOnlineAlsoOnsite === \"no\" && data.sameOnlineCreditsEarned ===\"no\");",
+                    "customConditional": "const isBCInstitution = data.isBCPublic || data.isBCPrivate;\nshow = (!isBCInstitution && data.deliveredOnlineAlsoOnsite === \"no\" && data.sameOnlineCreditsEarned ===\"no\");",
                     "logic": [],
                     "attributes": {
                         "data-cy": "earnAcademicCreditsOtherInstitution"
@@ -1917,7 +1921,8 @@
                     "inputType": "radio",
                     "fieldSet": false,
                     "id": "e3s18a",
-                    "defaultValue": ""
+                    "defaultValue": "",
+                    "isNew": false
                 },
                 {
                     "label": "HTML",
@@ -1932,7 +1937,7 @@
                     "refreshOnChange": false,
                     "customClass": "banner-warning",
                     "key": "html4",
-                    "customConditional": "show = (data.deliveredOnlineAlsoOnsite === \"no\" && data.sameOnlineCreditsEarned === \"no\" && data.earnAcademicCreditsOtherInstitution === \"no\");",
+                    "customConditional": "const isBCInstitution = data.isBCPublic || data.isBCPrivate;\nshow = (!isBCInstitution && data.deliveredOnlineAlsoOnsite === \"no\" && data.sameOnlineCreditsEarned === \"no\" && data.earnAcademicCreditsOtherInstitution === \"no\");",
                     "type": "htmlelement",
                     "input": false,
                     "tableView": false,
@@ -1974,7 +1979,7 @@
                         "unique": false
                     },
                     "conditional": {
-                        "show": null,
+                        "show": "",
                         "when": null,
                         "eq": ""
                     },
@@ -1993,7 +1998,8 @@
                     "allowMultipleMasks": false,
                     "addons": [],
                     "tag": "p",
-                    "id": "elz5y9j"
+                    "id": "elz5y9j",
+                    "tags": []
                 },
                 {
                     "label": "HTML",
@@ -6307,7 +6313,28 @@
             "allowMultipleMasks": false,
             "inputType": "hidden",
             "id": "egqexmm",
-            "addons": []
+            "addons": [],
+            "isNew": false
+        },
+        {
+            "input": true,
+            "tableView": false,
+            "key": "isBCPublic",
+            "label": "isBCPublic",
+            "protected": false,
+            "unique": false,
+            "persistent": true,
+            "type": "hidden",
+            "tags": [],
+            "conditional": {
+                "show": "",
+                "when": null,
+                "eq": ""
+            },
+            "properties": {},
+            "lockKey": true,
+            "customDefaultValue": "",
+            "customConditional": "console.log('data: ', data);"
         },
         {
             "label": "Program Status",

--- a/sources/packages/forms/src/form-definitions/educationprogram.json
+++ b/sources/packages/forms/src/form-definitions/educationprogram.json
@@ -1698,7 +1698,7 @@
                         "eq": "",
                         "json": ""
                     },
-                    "customConditional": "const isBCInstitution = data.isBCPublic || data.isBCPrivate;\nshow = (!isBCInstitution && data.programDeliveryTypes.deliveredOnSite);",
+                    "customConditional": "const isBCInstitution = data.isBCPublic || data.isBCPrivate;\nshow = (!isBCInstitution && data.programDeliveryTypes.deliveredOnline);",
                     "logic": [],
                     "attributes": {
                         "data-cy": "deliveredOnlineAlsoOnsite"
@@ -6334,7 +6334,7 @@
             "properties": {},
             "lockKey": true,
             "customDefaultValue": "",
-            "customConditional": "console.log('data: ', data);"
+            "customConditional": ""
         },
         {
             "label": "Program Status",

--- a/sources/packages/forms/src/form-definitions/educationprogram.json
+++ b/sources/packages/forms/src/form-definitions/educationprogram.json
@@ -1698,7 +1698,7 @@
                         "eq": "",
                         "json": ""
                     },
-                    "customConditional": "const isBCInstitution = data.isBCPublic || data.isBCPrivate;\nshow = (!isBCInstitution && data.programDeliveryTypes.deliveredOnline);",
+                    "customConditional": "const isBCInstitution = data.isBCPublic || data.isBCPrivate;\nshow = (isBCInstitution === false && data.programDeliveryTypes.deliveredOnline);",
                     "logic": [],
                     "attributes": {
                         "data-cy": "deliveredOnlineAlsoOnsite"
@@ -1794,7 +1794,7 @@
                         "eq": "",
                         "json": ""
                     },
-                    "customConditional": "const isBCInstitution = data.isBCPublic || data.isBCPrivate;\nshow = (!isBCInstitution && data.deliveredOnlineAlsoOnsite === \"no\");",
+                    "customConditional": "const isBCInstitution = data.isBCPublic || data.isBCPrivate;\nshow = (isBCInstitution === false && data.deliveredOnlineAlsoOnsite === \"no\");",
                     "logic": [],
                     "attributes": {
                         "data-cy": "sameOnlineCreditsEarned"
@@ -1890,7 +1890,7 @@
                         "eq": "",
                         "json": ""
                     },
-                    "customConditional": "const isBCInstitution = data.isBCPublic || data.isBCPrivate;\nshow = (!isBCInstitution && data.deliveredOnlineAlsoOnsite === \"no\" && data.sameOnlineCreditsEarned ===\"no\");",
+                    "customConditional": "const isBCInstitution = data.isBCPublic || data.isBCPrivate;\nshow = (isBCInstitution === false && data.deliveredOnlineAlsoOnsite === \"no\" && data.sameOnlineCreditsEarned ===\"no\");",
                     "logic": [],
                     "attributes": {
                         "data-cy": "earnAcademicCreditsOtherInstitution"
@@ -1937,7 +1937,7 @@
                     "refreshOnChange": false,
                     "customClass": "banner-warning",
                     "key": "html4",
-                    "customConditional": "const isBCInstitution = data.isBCPublic || data.isBCPrivate;\nshow = (!isBCInstitution && data.deliveredOnlineAlsoOnsite === \"no\" && data.sameOnlineCreditsEarned === \"no\" && data.earnAcademicCreditsOtherInstitution === \"no\");",
+                    "customConditional": "const isBCInstitution = data.isBCPublic || data.isBCPrivate;\nshow = (isBCInstitution === false && data.deliveredOnlineAlsoOnsite === \"no\" && data.sameOnlineCreditsEarned === \"no\" && data.earnAcademicCreditsOtherInstitution === \"no\");",
                     "type": "htmlelement",
                     "input": false,
                     "tableView": false,

--- a/sources/packages/web/src/services/http/dto/EducationProgram.dto.ts
+++ b/sources/packages/web/src/services/http/dto/EducationProgram.dto.ts
@@ -144,6 +144,8 @@ export class EducationProgramAPIInDTO {
   programDeclaration: boolean;
   @Expose()
   fieldOfStudyCode: number;
+  isBCPrivate: boolean;
+  isBCPublic: boolean;
 }
 
 export interface StudentEducationProgramAPIOutDTO {

--- a/sources/packages/web/src/services/http/dto/EducationProgram.dto.ts
+++ b/sources/packages/web/src/services/http/dto/EducationProgram.dto.ts
@@ -48,6 +48,7 @@ export interface EducationProgramAPIOutDTO {
   hasOfferings: boolean;
   institutionId: number;
   institutionName: string;
+  isBCPublic: boolean;
   isBCPrivate: boolean;
   submittedDate: Date;
   submittedBy: string;

--- a/sources/packages/web/src/views/institution/locations/programs/LocationProgramAddEdit.vue
+++ b/sources/packages/web/src/views/institution/locations/programs/LocationProgramAddEdit.vue
@@ -57,6 +57,7 @@ import {
   EducationProgramAPIInDTO,
   EducationProgramAPIOutDTO,
 } from "@/services/http/dto";
+import { InstitutionService } from "@/services/InstitutionService";
 
 export default defineComponent({
   props: {
@@ -93,7 +94,12 @@ export default defineComponent({
             props.programId,
           );
       } else {
-        initNewFormData();
+        const institutionProfile = await InstitutionService.shared.getDetail();
+        programData.value = {
+          isBCPrivate: institutionProfile.isBCPrivate,
+          isBCPublic: institutionProfile.isBCPublic,
+          hasOfferings: false,
+        } as EducationProgramAPIOutDTO;
       }
     };
 
@@ -209,21 +215,12 @@ export default defineComponent({
     };
 
     const createNewProgram = () => {
-      programData.value = {} as EducationProgramAPIOutDTO;
-      initNewFormData();
       router.push({
         name: InstitutionRoutesConst.ADD_LOCATION_PROGRAMS,
         params: {
           locationId: props.locationId,
         },
       });
-    };
-
-    const initNewFormData = () => {
-      programData.value = {
-        isBCPrivate: programData.value.isBCPrivate,
-        hasOfferings: false,
-      } as EducationProgramAPIOutDTO;
     };
 
     return {

--- a/sources/packages/web/src/views/institution/locations/programs/LocationProgramAddEdit.vue
+++ b/sources/packages/web/src/views/institution/locations/programs/LocationProgramAddEdit.vue
@@ -94,6 +94,7 @@ export default defineComponent({
             props.programId,
           );
       } else {
+        // Initialize programData with institution profile data
         const institutionProfile = await InstitutionService.shared.getDetail();
         programData.value = {
           isBCPrivate: institutionProfile.isBCPrivate,

--- a/sources/packages/web/src/views/institution/locations/programs/LocationProgramAddEdit.vue
+++ b/sources/packages/web/src/views/institution/locations/programs/LocationProgramAddEdit.vue
@@ -94,7 +94,7 @@ export default defineComponent({
             props.programId,
           );
       } else {
-        // Initialize programData with institution profile data
+        // Initialize programData with institution profile data.
         const institutionProfile = await InstitutionService.shared.getDetail();
         programData.value = {
           isBCPrivate: institutionProfile.isBCPrivate,


### PR DESCRIPTION
-  Remove prompts for additional questions when "Online" program delivery is selected when being created by BC Public or BC Private institutions.
- Keep prompts when creating an "Online" program (or Online and On site) for all other institution types.
- No production adjustment is needed.

Screenshot of selection behaviors for non-BC institutions
![image](https://github.com/bcgov/SIMS/assets/148148914/9caaf7c8-f83d-496e-8193-efe7e3203174)

Screenshot of selection behaviors for BC private institutions
![image](https://github.com/bcgov/SIMS/assets/148148914/af591067-43fd-4ab1-b318-a4428ff50fda)
