### PR TITLE
#2665 - Added Missing Assessment for Queue Processing

### DIFF
--- a/sources/packages/backend/apps/queue-consumers/src/services/application/application.service.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/services/application/application.service.ts
@@ -101,6 +101,7 @@ export class ApplicationService {
           status: [
             ApplicationStatus.Submitted,
             ApplicationStatus.InProgress,
+            ApplicationStatus.Assessment,
             ApplicationStatus.Enrolment,
             ApplicationStatus.Completed,
           ],


### PR DESCRIPTION
Added the missing `ApplicationStatus.Assessment` to allow the queue processing before the student even accepts the assessment.