### PR TITLE
#1989 -  Prune images

### DIFF
--- a/.github/workflows/prune-images.yml
+++ b/.github/workflows/prune-images.yml
@@ -1,5 +1,5 @@
 name: Prune Images
-description: Prune old images from OpenShift
+run-name: Prune old images from OpenShift
 
 on:
   workflow_dispatch:

--- a/.github/workflows/prune-images.yml
+++ b/.github/workflows/prune-images.yml
@@ -1,0 +1,63 @@
+name: Prune Images
+description: Prune old images from OpenShift
+
+on:
+  workflow_dispatch:
+    inputs:
+      applications:
+        description: 'Applications to prune'
+        required: true
+        default: 'web-sims, api-sims'
+      licensePlate:
+        description: 'License Plate'
+        required: true
+        default: '0c27fb'
+      environment:
+        description: 'Environment (dev, test, prod)'
+        required: true
+        default: 'dev'
+      prefix:
+        description: 'Prefix'
+        required: false
+        default: 'main'
+      minTags:
+        description: 'Minimum number of Tags to keep'
+        required: false
+        default: '10'
+  schedule:
+    - cron: '0 6 * * *' # Runs at 6 AM every day
+
+jobs:
+  prune-images:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Print env
+        run: |
+          echo "License Plate: ${{ inputs.licensePlate }}"
+          echo "Environment: ${{ inputs.environment }}"
+          echo "Prefix: ${{ inputs.prefix }}"
+          echo "Minimum Tags: ${{ inputs.minTags }}"
+      
+      - name: Checkout source code
+        uses: actions/checkout@v3
+      
+      - name: Login to OpenShift
+        run: |
+          oc login --token=${{ secrets.SA_TOKEN }} --server=${{ vars.OPENSHIFT_CLUSTER_URL }}
+      
+      - name: Prune Images
+        run: |
+          IFS=',' read -r -a apps <<< ${{ inputs.applications }}
+          for app in "${apps[@]}"
+          do
+            # Trim spaces
+            trimmed_app=$(echo "$app" | xargs)
+            ./fetchOldTags.sh \
+              --license_plate=${{ inputs.licensePlate }} \
+              --env=${{ inputs.environment }} \
+              --app_name=$app \
+              --prefix=${{ inputs.prefix }} | \
+              xargs -I {} echo "oc tag ${{ inputs.licensePlate }}-tools/$app:{}' --delete"
+          done
+    
+          

--- a/.github/workflows/prune-images.yml
+++ b/.github/workflows/prune-images.yml
@@ -52,7 +52,7 @@ jobs:
           do
             # Trim spaces
             trimmed_app=$(echo "$app" | xargs)
-            ./fetchOldTags.sh \
+            devops/scripts/fetchOldTags.sh \
               --license_plate=${{ inputs.licensePlate }} \
               --env=${{ inputs.environment }} \
               --app_name=$app \

--- a/devops/scripts/fetchOldTags.sh
+++ b/devops/scripts/fetchOldTags.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+
+# Usage: $0 --license_plate=VALUE --env=VALUE --app_name=VALUE [--prefix=VALUE] [--min_tags=VALUE]
+
+# Initialize default values
+LICENSE_PLATE=""
+ENV=""
+APP_NAME=""
+PREFIX=""
+MIN_TAGS=10  # Default to keeping all tags if MIN_TAGS is not specified
+
+# Parse named arguments
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --license_plate=*)
+      LICENSE_PLATE="${1#*=}"
+      ;;
+    --env=*)
+      ENV="${1#*=}"
+      ;;
+    --app_name=*)
+      APP_NAME="${1#*=}"
+      ;;
+    --prefix=*)
+      PREFIX="${1#*=}"
+      ;;
+    --min_tags=*)
+      MIN_TAGS="${1#*=}"
+      ;;
+    *)
+      echo "Invalid argument: $1"
+      echo "Usage: $0 --license_plate=VALUE --env=VALUE --app_name=VALUE [--prefix=VALUE] [--min_tags=VALUE]"
+      exit 1
+  esac
+  shift
+done
+
+# Validation of required arguments and env values
+if [ -z "$LICENSE_PLATE" ] || [ -z "$ENV" ] || [ -z "$APP_NAME" ]; then
+  echo "License plate, environment, and app name are required."
+  echo "Usage: $0 --license_plate=VALUE --env=VALUE --app_name=VALUE [--prefix=VALUE] [--min_tags=VALUE]"
+  exit 1
+fi
+
+# Check if env value is allowed
+case "$ENV" in
+  dev|test|prod)
+    # All good, continue
+    ;;
+  *)
+    echo "The --env parameter must be one of: dev, test, prod."
+    exit 1
+    ;;
+esac
+
+# Setup internal variables
+DC_NAMESPACE="${LICENSE_PLATE}-${ENV}"
+IS_NAMESPACE="${LICENSE_PLATE}-tools"
+DC_NAME="${ENV}-${APP_NAME}"
+
+# Lookup the dc to get the deployed container image tag
+DC_IMAGE=$(oc get dc/$DC_NAME -n $DC_NAMESPACE -o json | jq -r '.spec.template.spec.containers[].image')
+if [ -z "$DC_IMAGE" ]; then
+  echo "DeploymentConfig image tag not found." >&2
+  exit 1
+fi
+
+# Extract the GitHub run number from the DC Image
+DC_BUILD_ID=$(echo "$DC_IMAGE" | grep -oE '[0-9]+$')
+if [ -z "$DC_BUILD_ID" ]; then
+  echo "No GitHub run number found in DC image tag." >&2
+  exit 1
+fi
+
+# Process ImageStream Tags and output those prior to the deployed version
+oc get is/$APP_NAME -n $IS_NAMESPACE -o json | jq -r --arg DC_BUILD_ID "$DC_BUILD_ID" --arg PREFIX "$PREFIX" --argjson MIN_TAGS "$MIN_TAGS" '
+  .status.tags
+  | map(select(.tag | startswith($PREFIX) and test(".*-[0-9]+$")))
+  | map(.tag)
+  | map(select(capture(".*-(?<id>[0-9]+)$").id | tonumber < ($DC_BUILD_ID | tonumber)))
+  | sort_by(capture(".*-(?<id>[0-9]+)$").id | tonumber)
+  | if $MIN_TAGS > 0 then .[:-$MIN_TAGS] else . end
+  | .[]
+'


### PR DESCRIPTION
Created a new script to determine ImageStream tags that can be safely removed for a given environment.  The intended usage would be to run the script against prod and set min_tags to a number like 3 for rollback.  This would list all tags newer than prod + include 3 tags that are older than prod.

After speaking with Guru, I added the ability to prefix a branch which then only targets those tags.

The script itself only dumps a list which then must be used by a command to do something.  For this, I've created a new GitHub Action which calls the fetchOldTags.sh against dev with a min_tags to set at 10.  This is the behaviour that has been run manually.  Ideally in the future we could target Prod but this requires timely releases.  

NOTE:  Currently the script simply echo's the OC commands that should be run, once merged I will test and resubmit.