### PR TITLE
#1707 - Application Form: Additional Transportation Cost (Bug Fix)

### DIFF
--- a/sources/packages/forms/src/form-definitions/sfaa2021-22.json
+++ b/sources/packages/forms/src/form-definitions/sfaa2021-22.json
@@ -16589,7 +16589,7 @@
               "inputFormat": "plain",
               "validate": {
                 "required": true,
-                "custom": "",
+                "custom": "valid = (input >= 0 && input < data.maxIncome) ? true : 'The number you have entered is outside the expected range.';",
                 "customPrivate": false,
                 "strictDateValidation": false,
                 "multiple": false,
@@ -16601,7 +16601,7 @@
               },
               "key": "estimatedSpouseIncome",
               "conditional": {
-                "show": true,
+                "show": "true",
                 "when": "isYourSpouseACanadianCitizen",
                 "eq": "no"
               },
@@ -16655,8 +16655,9 @@
               "id": "e9yrlbn",
               "inputType": "text",
               "inputMask": "",
-              "decimalLimit": 2,
-              "requireDecimal": true
+              "decimalLimit": 0,
+              "requireDecimal": false,
+              "tags": []
             },
             {
               "label": "<strong>Will your partner be employed full-time or part-time during your study period</strong>",
@@ -19642,7 +19643,7 @@
                   "truncateMultipleSpaces": false,
                   "validate": {
                     "required": true,
-                    "custom": "",
+                    "custom": "valid = (input >= 0 && input < data.maxIncome) ? true : 'The number you have entered is outside the expected range.';",
                     "customPrivate": false,
                     "strictDateValidation": false,
                     "multiple": false,
@@ -19688,7 +19689,7 @@
                   "attributes": {},
                   "validateOn": "change",
                   "conditional": {
-                    "show": null,
+                    "show": "",
                     "when": null,
                     "eq": ""
                   },
@@ -19709,8 +19710,9 @@
                   "id": "et8xql",
                   "inputType": "text",
                   "inputMask": "",
-                  "decimalLimit": 2,
-                  "requireDecimal": true
+                  "decimalLimit": 0,
+                  "requireDecimal": false,
+                  "tags": []
                 },
                 {
                   "label": "Enter the total net value of all your parents Canadian and foreign assets (do not include RRSPs, principal residence or business). Enter ‘0’ if none.",
@@ -31157,7 +31159,7 @@
                   "label": "Please estimate your weekly transportation costs.",
                   "key": "additionalTransportCost",
                   "placeholder": "",
-                  "prefix": "",
+                  "prefix": "$",
                   "suffix": "",
                   "defaultValue": "",
                   "protected": false,
@@ -31192,7 +31194,7 @@
                   "key": "additionalTransportKm",
                   "placeholder": "",
                   "prefix": "",
-                  "suffix": "",
+                  "suffix": "km",
                   "defaultValue": "",
                   "protected": false,
                   "persistent": true,

--- a/sources/packages/forms/src/form-definitions/sfaa2022-23.json
+++ b/sources/packages/forms/src/form-definitions/sfaa2022-23.json
@@ -16589,7 +16589,7 @@
               "inputFormat": "plain",
               "validate": {
                 "required": true,
-                "custom": "",
+                "custom": "valid = (input >= 0 && input < data.maxIncome) ? true : 'The number you have entered is outside the expected range.';",
                 "customPrivate": false,
                 "strictDateValidation": false,
                 "multiple": false,
@@ -16601,7 +16601,7 @@
               },
               "key": "estimatedSpouseIncome",
               "conditional": {
-                "show": true,
+                "show": "true",
                 "when": "isYourSpouseACanadianCitizen",
                 "eq": "no"
               },
@@ -16655,8 +16655,9 @@
               "id": "e9yrlbn",
               "inputType": "text",
               "inputMask": "",
-              "decimalLimit": 2,
-              "requireDecimal": true
+              "decimalLimit": 0,
+              "requireDecimal": false,
+              "tags": []
             },
             {
               "label": "<strong>Will your partner be employed full-time or part-time during your study period</strong>",
@@ -19642,7 +19643,7 @@
                   "truncateMultipleSpaces": false,
                   "validate": {
                     "required": true,
-                    "custom": "",
+                    "custom": "valid = (input >= 0 && input < data.maxIncome) ? true : 'The number you have entered is outside the expected range.';",
                     "customPrivate": false,
                     "strictDateValidation": false,
                     "multiple": false,
@@ -19688,7 +19689,7 @@
                   "attributes": {},
                   "validateOn": "change",
                   "conditional": {
-                    "show": null,
+                    "show": "",
                     "when": null,
                     "eq": ""
                   },
@@ -19709,8 +19710,9 @@
                   "id": "et8xql",
                   "inputType": "text",
                   "inputMask": "",
-                  "decimalLimit": 2,
-                  "requireDecimal": true
+                  "decimalLimit": 0,
+                  "requireDecimal": false,
+                  "tags": []
                 },
                 {
                   "label": "Enter the total net value of all your parents Canadian and foreign assets (do not include RRSPs, principal residence or business). Enter ‘0’ if none.",
@@ -31157,7 +31159,7 @@
                   "label": "Please estimate your weekly transportation costs.",
                   "key": "additionalTransportCost",
                   "placeholder": "",
-                  "prefix": "",
+                  "prefix": "$",
                   "suffix": "",
                   "defaultValue": "",
                   "protected": false,

--- a/sources/packages/forms/src/form-definitions/sfaa2023-24.json
+++ b/sources/packages/forms/src/form-definitions/sfaa2023-24.json
@@ -16592,7 +16592,7 @@
               "inputFormat": "plain",
               "validate": {
                 "required": true,
-                "custom": "",
+                "custom": "valid = (input >= 0 && input < data.maxIncome) ? true : 'The number you have entered is outside the expected range.';",
                 "customPrivate": false,
                 "strictDateValidation": false,
                 "multiple": false,
@@ -16604,7 +16604,7 @@
               },
               "key": "estimatedSpouseIncome",
               "conditional": {
-                "show": true,
+                "show": "true",
                 "when": "isYourSpouseACanadianCitizen",
                 "eq": "no"
               },
@@ -16658,8 +16658,10 @@
               "id": "e9yrlbn",
               "inputType": "text",
               "inputMask": "",
-              "decimalLimit": 2,
-              "requireDecimal": true
+              "decimalLimit": 0,
+              "requireDecimal": false,
+              "tags": [],
+              "isNew": false
             },
             {
               "label": "<strong>Will your partner be employed full-time or part-time during your study period</strong>",
@@ -19645,7 +19647,7 @@
                   "truncateMultipleSpaces": false,
                   "validate": {
                     "required": true,
-                    "custom": "",
+                    "custom": "valid = (input >= 0 && input < data.maxIncome) ? true : 'The number you have entered is outside the expected range.';",
                     "customPrivate": false,
                     "strictDateValidation": false,
                     "multiple": false,
@@ -19691,7 +19693,7 @@
                   "attributes": {},
                   "validateOn": "change",
                   "conditional": {
-                    "show": null,
+                    "show": "",
                     "when": null,
                     "eq": ""
                   },
@@ -19712,8 +19714,9 @@
                   "id": "et8xql",
                   "inputType": "text",
                   "inputMask": "",
-                  "decimalLimit": 2,
-                  "requireDecimal": true
+                  "decimalLimit": 0,
+                  "requireDecimal": false,
+                  "tags": []
                 },
                 {
                   "label": "Enter the total net value of all your parents Canadian and foreign assets (do not include RRSPs, principal residence or business). Enter ‘0’ if none.",
@@ -23414,7 +23417,8 @@
               "inputMask": "",
               "decimalLimit": 0,
               "requireDecimal": false,
-              "tags": []
+              "tags": [],
+              "isNew": false
             },
             {
               "title": "CRA consent panel",
@@ -31162,7 +31166,7 @@
                   "label": "Please estimate your weekly transportation costs.",
                   "key": "additionalTransportCost",
                   "placeholder": "",
-                  "prefix": "",
+                  "prefix": "$",
                   "suffix": "",
                   "defaultValue": "",
                   "protected": false,


### PR DESCRIPTION
**As a part of this PR, the following were fixed:**

The below two fixes are for the story: [Application Form - Additional Transportation Costs (FT and PT)](https://github.com/bcgov/SIMS/issues/1707)
- Added the missing `$` prefix to the weekly transportation costs to the forms for all the program years.
- Added the missing `km` suffix to the weekly transportation costs to the form for program year: 2021-22.

The below fix is for the story: [Bug in submitting application when the Total income has integers](https://github.com/bcgov/SIMS/issues/2688)
- Added the missing validation for the field: **Supporting user income, when reported by the student for all program years.**