### PR TITLE
#2348 - Removal of Part-Time Application Questions For Partner Supporting Users

### DIFF
--- a/sources/packages/forms/src/form-definitions/sfaa2021-22.json
+++ b/sources/packages/forms/src/form-definitions/sfaa2021-22.json
@@ -16752,7 +16752,8 @@
               "inputType": "radio",
               "fieldSet": false,
               "id": "enyf4g",
-              "defaultValue": ""
+              "defaultValue": "",
+              "isNew": false
             },
             {
               "label": "<strong>Will  your partner be at home caring for eligible dependent children on a full-time basis during the your entire study period? </strong>",
@@ -16811,9 +16812,9 @@
               "tags": [],
               "properties": {},
               "conditional": {
-                "show": null,
-                "when": null,
-                "eq": "",
+                "show": "true",
+                "when": "howWillYouBeAttendingTheProgram",
+                "eq": "Full Time",
                 "json": ""
               },
               "customConditional": "",
@@ -16847,7 +16848,8 @@
               "inputType": "radio",
               "fieldSet": false,
               "id": "ebw9ux",
-              "defaultValue": ""
+              "defaultValue": "",
+              "isNew": false
             },
             {
               "label": "<strong>Will your partner be living with you during the your study period?</strong>",
@@ -16906,9 +16908,9 @@
               "tags": [],
               "properties": {},
               "conditional": {
-                "show": null,
-                "when": null,
-                "eq": "",
+                "show": "true",
+                "when": "howWillYouBeAttendingTheProgram",
+                "eq": "Full Time",
                 "json": ""
               },
               "customConditional": "",
@@ -16942,7 +16944,8 @@
               "inputType": "radio",
               "fieldSet": false,
               "id": "eoxnrvc",
-              "defaultValue": ""
+              "defaultValue": "",
+              "isNew": false
             },
             {
               "label": "<strong>Will your partner be a full-time post-secondary student for some or all of your study period?</strong>",
@@ -17001,9 +17004,9 @@
               "tags": [],
               "properties": {},
               "conditional": {
-                "show": null,
-                "when": null,
-                "eq": "",
+                "show": "true",
+                "when": "howWillYouBeAttendingTheProgram",
+                "eq": "Full Time",
                 "json": ""
               },
               "customConditional": "",
@@ -17037,7 +17040,8 @@
               "inputType": "radio",
               "fieldSet": false,
               "id": "elp6tn6",
-              "defaultValue": null
+              "defaultValue": null,
+              "isNew": false
             },
             {
               "title": "If your partner will be a full-time student, how many weeks of your study period will they also be in studies Panel",
@@ -18034,9 +18038,9 @@
               "tags": [],
               "properties": {},
               "conditional": {
-                "show": null,
-                "when": null,
-                "eq": "",
+                "show": "true",
+                "when": "howWillYouBeAttendingTheProgram",
+                "eq": "Full Time",
                 "json": ""
               },
               "customConditional": "",
@@ -18070,7 +18074,8 @@
               "inputType": "radio",
               "fieldSet": false,
               "id": "eor4a75",
-              "defaultValue": ""
+              "defaultValue": "",
+              "isNew": false
             },
             {
               "title": "Will your partner be paying a Canada Student Loan and/or a provincial student loan regular scheduled payments during the your study period Panel",
@@ -18325,7 +18330,8 @@
               "inputType": "radio",
               "fieldSet": false,
               "id": "e1ja09r",
-              "defaultValue": ""
+              "defaultValue": "",
+              "isNew": false
             },
             {
               "title": "Will your partner be paying for child support and/or spousal support during the your study period Panel",
@@ -18544,9 +18550,9 @@
               "tags": [],
               "properties": {},
               "conditional": {
-                "show": null,
-                "when": null,
-                "eq": "",
+                "show": "true",
+                "when": "howWillYouBeAttendingTheProgram",
+                "eq": "Full Time",
                 "json": ""
               },
               "customConditional": "",
@@ -18639,7 +18645,9 @@
           "lazyLoad": false,
           "theme": "default",
           "breadcrumb": "default",
-          "id": "erae6ji"
+          "id": "erae6ji",
+          "isNew": false,
+          "tags": []
         }
       ],
       "placeholder": "",

--- a/sources/packages/forms/src/form-definitions/sfaa2022-23.json
+++ b/sources/packages/forms/src/form-definitions/sfaa2022-23.json
@@ -16752,7 +16752,8 @@
               "inputType": "radio",
               "fieldSet": false,
               "id": "enyf4g",
-              "defaultValue": ""
+              "defaultValue": "",
+              "isNew": false
             },
             {
               "label": "<strong>Will  your partner be at home caring for eligible dependent children on a full-time basis during the your entire study period? </strong>",
@@ -16811,9 +16812,9 @@
               "tags": [],
               "properties": {},
               "conditional": {
-                "show": null,
-                "when": null,
-                "eq": "",
+                "show": "true",
+                "when": "howWillYouBeAttendingTheProgram",
+                "eq": "Full Time",
                 "json": ""
               },
               "customConditional": "",
@@ -16906,9 +16907,9 @@
               "tags": [],
               "properties": {},
               "conditional": {
-                "show": null,
-                "when": null,
-                "eq": "",
+                "show": "true",
+                "when": "howWillYouBeAttendingTheProgram",
+                "eq": "Full Time",
                 "json": ""
               },
               "customConditional": "",
@@ -16942,7 +16943,8 @@
               "inputType": "radio",
               "fieldSet": false,
               "id": "eoxnrvc",
-              "defaultValue": ""
+              "defaultValue": "",
+              "isNew": false
             },
             {
               "label": "<strong>Will your partner be a full-time post-secondary student for some or all of your study period?</strong>",
@@ -17001,9 +17003,9 @@
               "tags": [],
               "properties": {},
               "conditional": {
-                "show": null,
-                "when": null,
-                "eq": "",
+                "show": "true",
+                "when": "howWillYouBeAttendingTheProgram",
+                "eq": "Full Time",
                 "json": ""
               },
               "customConditional": "",
@@ -17037,7 +17039,8 @@
               "inputType": "radio",
               "fieldSet": false,
               "id": "elp6tn6",
-              "defaultValue": null
+              "defaultValue": null,
+              "isNew": false
             },
             {
               "title": "If your partner will be a full-time student, how many weeks of your study period will they also be in studies Panel",
@@ -18034,9 +18037,9 @@
               "tags": [],
               "properties": {},
               "conditional": {
-                "show": null,
-                "when": null,
-                "eq": "",
+                "show": "true",
+                "when": "howWillYouBeAttendingTheProgram",
+                "eq": "Full Time",
                 "json": ""
               },
               "customConditional": "",
@@ -18325,7 +18328,8 @@
               "inputType": "radio",
               "fieldSet": false,
               "id": "e1ja09r",
-              "defaultValue": ""
+              "defaultValue": "",
+              "isNew": false
             },
             {
               "title": "Will your partner be paying for child support and/or spousal support during the your study period Panel",
@@ -18544,9 +18548,9 @@
               "tags": [],
               "properties": {},
               "conditional": {
-                "show": null,
-                "when": null,
-                "eq": "",
+                "show": "true",
+                "when": "howWillYouBeAttendingTheProgram",
+                "eq": "Full Time",
                 "json": ""
               },
               "customConditional": "",

--- a/sources/packages/forms/src/form-definitions/sfaa2023-24.json
+++ b/sources/packages/forms/src/form-definitions/sfaa2023-24.json
@@ -16756,7 +16756,8 @@
               "inputType": "radio",
               "fieldSet": false,
               "id": "enyf4g",
-              "defaultValue": ""
+              "defaultValue": "",
+              "isNew": false
             },
             {
               "label": "<strong>Will  your partner be at home caring for eligible dependent children on a full-time basis during the your entire study period? </strong>",
@@ -16815,9 +16816,9 @@
               "tags": [],
               "properties": {},
               "conditional": {
-                "show": null,
-                "when": null,
-                "eq": "",
+                "show": "true",
+                "when": "howWillYouBeAttendingTheProgram",
+                "eq": "Full Time",
                 "json": ""
               },
               "customConditional": "",
@@ -16910,9 +16911,9 @@
               "tags": [],
               "properties": {},
               "conditional": {
-                "show": null,
-                "when": null,
-                "eq": "",
+                "show": "true",
+                "when": "howWillYouBeAttendingTheProgram",
+                "eq": "Full Time",
                 "json": ""
               },
               "customConditional": "",
@@ -16946,7 +16947,8 @@
               "inputType": "radio",
               "fieldSet": false,
               "id": "eoxnrvc",
-              "defaultValue": ""
+              "defaultValue": "",
+              "isNew": false
             },
             {
               "label": "<strong>Will your partner be a full-time post-secondary student for some or all of your study period?</strong>",
@@ -17005,9 +17007,9 @@
               "tags": [],
               "properties": {},
               "conditional": {
-                "show": null,
-                "when": null,
-                "eq": "",
+                "show": "true",
+                "when": "howWillYouBeAttendingTheProgram",
+                "eq": "Full Time",
                 "json": ""
               },
               "customConditional": "",
@@ -18038,9 +18040,9 @@
               "tags": [],
               "properties": {},
               "conditional": {
-                "show": null,
-                "when": null,
-                "eq": "",
+                "show": "true",
+                "when": "howWillYouBeAttendingTheProgram",
+                "eq": "Full Time",
                 "json": ""
               },
               "customConditional": "",
@@ -18329,7 +18331,8 @@
               "inputType": "radio",
               "fieldSet": false,
               "id": "e1ja09r",
-              "defaultValue": ""
+              "defaultValue": "",
+              "isNew": false
             },
             {
               "title": "Will your partner be paying for child support and/or spousal support during the your study period Panel",
@@ -18548,9 +18551,9 @@
               "tags": [],
               "properties": {},
               "conditional": {
-                "show": null,
-                "when": null,
-                "eq": "",
+                "show": "true",
+                "when": "howWillYouBeAttendingTheProgram",
+                "eq": "Full Time",
                 "json": ""
               },
               "customConditional": "",

--- a/sources/packages/forms/src/form-definitions/supportinguserspartner2022-2023.json
+++ b/sources/packages/forms/src/form-definitions/supportinguserspartner2022-2023.json
@@ -2167,9 +2167,9 @@
                   "attributes": {},
                   "validateOn": "change",
                   "conditional": {
-                    "show": null,
-                    "when": null,
-                    "eq": ""
+                    "show": "false",
+                    "when": "offeringIntensity",
+                    "eq": "Part Time"
                   },
                   "overlay": {
                     "style": "",
@@ -2187,7 +2187,9 @@
                   "addons": [],
                   "inputType": "radio",
                   "fieldSet": false,
-                  "id": "e2j82bp"
+                  "id": "e2j82bp",
+                  "tags": [],
+                  "isNew": false
                 },
                 {
                   "label": "<strong>Will you be at home caring for eligible dependant children on a full-time basis during your Partner's entire study period? </strong>",
@@ -2246,9 +2248,9 @@
                   "tags": [],
                   "properties": {},
                   "conditional": {
-                    "show": null,
-                    "when": null,
-                    "eq": "",
+                    "show": "false",
+                    "when": "offeringIntensity",
+                    "eq": "Part Time",
                     "json": ""
                   },
                   "customConditional": "",
@@ -2280,7 +2282,8 @@
                   "inputType": "radio",
                   "fieldSet": false,
                   "id": "em0e9jr",
-                  "defaultValue": ""
+                  "defaultValue": "",
+                  "isNew": false
                 },
                 {
                   "label": "<strong>Will you be living with your Partner during your Partner's study period?</strong>",
@@ -2342,9 +2345,9 @@
                   "attributes": {},
                   "validateOn": "change",
                   "conditional": {
-                    "show": null,
-                    "when": null,
-                    "eq": ""
+                    "show": "false",
+                    "when": "offeringIntensity",
+                    "eq": "Part Time"
                   },
                   "overlay": {
                     "style": "",
@@ -2362,7 +2365,9 @@
                   "addons": [],
                   "inputType": "radio",
                   "fieldSet": false,
-                  "id": "edsljuf"
+                  "id": "edsljuf",
+                  "tags": [],
+                  "isNew": false
                 },
                 {
                   "label": "<strong>Will you be a full-time post-secondary student for some or all of your Partner's study period?</strong>",
@@ -2424,9 +2429,9 @@
                   "attributes": {},
                   "validateOn": "change",
                   "conditional": {
-                    "show": null,
-                    "when": null,
-                    "eq": ""
+                    "show": "false",
+                    "when": "offeringIntensity",
+                    "eq": "Part Time"
                   },
                   "overlay": {
                     "style": "",
@@ -2444,7 +2449,9 @@
                   "addons": [],
                   "inputType": "radio",
                   "fieldSet": false,
-                  "id": "ex27r4o"
+                  "id": "ex27r4o",
+                  "tags": [],
+                  "isNew": false
                 },
                 {
                   "title": "If your partner will be a full-time student, how many weeks of your study period will they also be in studies Panel",
@@ -2452,8 +2459,8 @@
                   "hideLabel": true,
                   "key": "ifYourPartnerWillBeAFullTimeStudentHowManyWeeksOfYourStudyPeriodWillTheyAlsoBeInStudiesPanel",
                   "conditional": {
-                    "show": true,
-                    "when": "supportingData.partnerFulltimeStudent",
+                    "show": "true",
+                    "when": "partnerFulltimeStudent",
                     "eq": "yes"
                   },
                   "type": "panel",
@@ -2524,8 +2531,8 @@
                       "attributes": {},
                       "validateOn": "change",
                       "conditional": {
-                        "show": null,
-                        "when": null,
+                        "show": "",
+                        "when": "",
                         "eq": ""
                       },
                       "overlay": {
@@ -2543,7 +2550,8 @@
                       "allowMultipleMasks": false,
                       "addons": [],
                       "id": "euxu2ql",
-                      "inputType": "number"
+                      "inputType": "number",
+                      "tags": []
                     }
                   ],
                   "placeholder": "",
@@ -2601,7 +2609,8 @@
                   "lazyLoad": false,
                   "theme": "default",
                   "breadcrumb": "default",
-                  "id": "eryyqjh"
+                  "id": "eryyqjh",
+                  "tags": []
                 },
                 {
                   "label": "<strong>Will you receive income assistance/social assistance (welfare) and/or BC income assistance for persons with disabilities during your Partner's study period?</strong>",
@@ -2861,7 +2870,8 @@
                   "addons": [],
                   "tree": false,
                   "lazyLoad": false,
-                  "id": "e308bl"
+                  "id": "e308bl",
+                  "isNew": false
                 },
                 {
                   "label": "<strong>Will you be in receipt of Employment Insurance benefits during your Partner's study period?</strong>",
@@ -3426,9 +3436,9 @@
                   "tags": [],
                   "properties": {},
                   "conditional": {
-                    "show": null,
-                    "when": null,
-                    "eq": "",
+                    "show": "false",
+                    "when": "offeringIntensity",
+                    "eq": "Part Time",
                     "json": ""
                   },
                   "customConditional": "",
@@ -3480,8 +3490,8 @@
                   "customConditional": "",
                   "conditional": {
                     "json": "",
-                    "show": true,
-                    "when": "supportingData.partnerPayStudentLoan",
+                    "show": "true",
+                    "when": "partnerPayStudentLoan",
                     "eq": "yes"
                   },
                   "logic": [],
@@ -3624,7 +3634,8 @@
                   "addons": [],
                   "tree": false,
                   "lazyLoad": false,
-                  "id": "e1cacbl"
+                  "id": "e1cacbl",
+                  "isNew": false
                 },
                 {
                   "label": "<strong>Will you be paying for child support and/or spousal support during your Partner's study period?</strong>",
@@ -3686,9 +3697,9 @@
                   "attributes": {},
                   "validateOn": "change",
                   "conditional": {
-                    "show": null,
-                    "when": null,
-                    "eq": ""
+                    "show": "false",
+                    "when": "offeringIntensity",
+                    "eq": "Part Time"
                   },
                   "overlay": {
                     "style": "",
@@ -3706,7 +3717,8 @@
                   "addons": [],
                   "inputType": "radio",
                   "fieldSet": false,
-                  "id": "efbnjl"
+                  "id": "efbnjl",
+                  "tags": []
                 },
                 {
                   "title": "Will your partner be paying for child support and/or spousal support during your study period Panel",
@@ -3726,8 +3738,8 @@
                   "customConditional": "",
                   "conditional": {
                     "json": "",
-                    "show": true,
-                    "when": "supportingData.partnerPaySupport",
+                    "show": "true",
+                    "when": "partnerPaySupport",
                     "eq": "yes"
                   },
                   "logic": [],
@@ -3932,9 +3944,9 @@
                   "attributes": {},
                   "validateOn": "change",
                   "conditional": {
-                    "show": null,
-                    "when": null,
-                    "eq": ""
+                    "show": "false",
+                    "when": "offeringIntensity",
+                    "eq": "Part Time"
                   },
                   "overlay": {
                     "style": "",
@@ -3952,7 +3964,8 @@
                   "addons": [],
                   "inputType": "radio",
                   "fieldSet": false,
-                  "id": "emhjo7h"
+                  "id": "emhjo7h",
+                  "tags": []
                 },
                 {
                   "label": "HTML",
@@ -4133,7 +4146,8 @@
                       "showWordCount": false,
                       "allowMultipleMasks": false,
                       "addons": [],
-                      "id": "elh7yc6"
+                      "id": "elh7yc6",
+                      "isNew": false
                     },
                     {
                       "html": "<p><strong>I. I understand that:</strong></p>\n\n<ol>\n\t<li>The student will have access to information provided in this appendix;</li>\n\t<li>The student&rsquo;s school will have access to information provided in this appendix;</li>\n\t<li>The information in this appendix is subject to verification and investigation, as defined in the current program year&rsquo;s StudentAid BC Policy Manual.</li>\n</ol>\n\n<p><strong>II. I understand that signing the Declaration means:</strong></p>\n\n<ol>\n\t<li>I declare that the information I have given is correct and complete and that I have not altered or added to any of the preprinted application and/or appendix questions;</li>\n\t<li>I authorize the student to notify StudentAid BC as soon as practical of any change in my total income as reported on line 15000 of my previous year&rsquo;s T1 General Income Tax and Benefit Return and/or other&ldquo;assessed resources&rdquo;, as defined in the current program year&rsquo;s StudentAid BC Policy Manual;</li>\n\t<li>For the purposes of verifying the accuracy of the personal information provided by me in this appendix, <strong>I consent to the collection, use and disclosure of my personal information</strong> between the BC Ministry of Post Secondary and Future Skills, the BC Ministry of Finance, the National Student Loans Service Centre, and any of their contractors, subcontractors or agents, each with each other, and with the following: financial institutions, lenders, educational institutions, financial aid offices, employers, credit bureaus, credit reporting agencies, Aboriginal Organizations, Federal and provincial Crown corporations, and federal, provincial, municipal ministries/departments/agencies, including but not limited to: BC Ministry of Social Development and Poverty Reduction, BC Ministry of Children and Family Development, BC Ministry of Health, BC Ministry of Attorney General, BC Ministry of Education, BC Public Service Agency, RoadSafe BC, Insurance Corporation of BC (and Service BC acting in the role of ICBC), BC Assessment Authority, Land Title and Survey Authority of BC, BC Registry Services, WorkSafe BC, BC Vital Statistics Agency, the Office of the Superintendent of Bankruptcy Canada, Employment and Social Development Canada , Canada Revenue Agency, and Immigration, Refugees and Citizenship Canada. This consent takes effect on the date that I make the first submission of this Appendix to StudentAid BC, regardless of whether this Appendix is in electronic or written format.</li>\n</ol>\n",
@@ -4519,7 +4533,8 @@
                   "theme": "default",
                   "breadcrumb": "default",
                   "id": "e69jwa",
-                  "tags": []
+                  "tags": [],
+                  "isNew": false
                 },
                 {
                   "label": "I Agree to the terms and conditions of the StudentAid BC Declaration form.",

--- a/sources/packages/forms/src/form-definitions/supportinguserspartner2022-2023.json
+++ b/sources/packages/forms/src/form-definitions/supportinguserspartner2022-2023.json
@@ -2167,9 +2167,9 @@
                   "attributes": {},
                   "validateOn": "change",
                   "conditional": {
-                    "show": "false",
+                    "show": "true",
                     "when": "offeringIntensity",
-                    "eq": "Part Time"
+                    "eq": "Full Time"
                   },
                   "overlay": {
                     "style": "",
@@ -2248,9 +2248,9 @@
                   "tags": [],
                   "properties": {},
                   "conditional": {
-                    "show": "false",
+                    "show": "true",
                     "when": "offeringIntensity",
-                    "eq": "Part Time",
+                    "eq": "Full Time",
                     "json": ""
                   },
                   "customConditional": "",
@@ -2345,9 +2345,9 @@
                   "attributes": {},
                   "validateOn": "change",
                   "conditional": {
-                    "show": "false",
+                    "show": "true",
                     "when": "offeringIntensity",
-                    "eq": "Part Time"
+                    "eq": "Full Time"
                   },
                   "overlay": {
                     "style": "",
@@ -2429,9 +2429,9 @@
                   "attributes": {},
                   "validateOn": "change",
                   "conditional": {
-                    "show": "false",
+                    "show": "true",
                     "when": "offeringIntensity",
-                    "eq": "Part Time"
+                    "eq": "Full Time"
                   },
                   "overlay": {
                     "style": "",
@@ -2610,7 +2610,8 @@
                   "theme": "default",
                   "breadcrumb": "default",
                   "id": "eryyqjh",
-                  "tags": []
+                  "tags": [],
+                  "isNew": false
                 },
                 {
                   "label": "<strong>Will you receive income assistance/social assistance (welfare) and/or BC income assistance for persons with disabilities during your Partner's study period?</strong>",
@@ -3436,9 +3437,9 @@
                   "tags": [],
                   "properties": {},
                   "conditional": {
-                    "show": "false",
+                    "show": "true",
                     "when": "offeringIntensity",
-                    "eq": "Part Time",
+                    "eq": "Full Time",
                     "json": ""
                   },
                   "customConditional": "",
@@ -3697,9 +3698,9 @@
                   "attributes": {},
                   "validateOn": "change",
                   "conditional": {
-                    "show": "false",
+                    "show": "true",
                     "when": "offeringIntensity",
-                    "eq": "Part Time"
+                    "eq": "Full Time"
                   },
                   "overlay": {
                     "style": "",
@@ -3885,7 +3886,7 @@
                   "id": "e86cscg"
                 },
                 {
-                  "label": "<strong>Will your be taking care of eligible dependants during your Partner's Study Period? </strong>",
+                  "label": "<strong>Will you be taking care of eligible dependants during your Partner's Study Period? </strong>",
                   "optionsLabelPosition": "right",
                   "inline": false,
                   "tableView": false,
@@ -3944,9 +3945,9 @@
                   "attributes": {},
                   "validateOn": "change",
                   "conditional": {
-                    "show": "false",
+                    "show": "true",
                     "when": "offeringIntensity",
-                    "eq": "Part Time"
+                    "eq": "Full Time"
                   },
                   "overlay": {
                     "style": "",


### PR DESCRIPTION
Remove the following questions from supporting users form and student form 'self-report' feature
- "Will you be employed full-time or part-time during your partner's study period"
- "Will you be at home caring for eligible dependent children on a full-time basis during your partner's entire study period?"
- "Will you be living with your partner during the study period"
- "Will you be a full-time post-secondary student for some or all of your partner's study period (remove the follow-up questions capturing weeks of study as well)"
- "Will you be paying a Canada Student Loan.."
- "Will you be paying for Child support and/or spousal support during your Partner's study period"
- "Will you be taking care of eligible dependents during your Partner's study period"
- Add to the ticket comments the removed keys and mention the workflow impact points.

Screenshot of questions for supporting user form
![image](https://github.com/bcgov/SIMS/assets/148148914/ff29aeb1-b425-41b1-b0ec-1e09f54554ca)

Screenshot of questions for student self-report form
![image](https://github.com/bcgov/SIMS/assets/148148914/9892ac23-185f-412e-a92b-0152ab47423a)
