### PR TITLE
#1989 - Prune images

### DIFF
--- a/.github/workflows/prune-images.yml
+++ b/.github/workflows/prune-images.yml
@@ -7,7 +7,7 @@ on:
       applications:
         description: 'Comma seperated list of applications to prune'
         required: true
-        default: 'web-sims, api-sims'
+        default: 'web-sims, api-sims, queue-consumers-sims, workers-sims'
       licensePlate:
         description: 'OpenShift License Plate'
         required: true

--- a/.github/workflows/prune-images.yml
+++ b/.github/workflows/prune-images.yml
@@ -52,7 +52,7 @@ jobs:
           ./pruneImages.sh \
               --license_plate=${{ inputs.licensePlate }} \
               --env=${{ inputs.environment }} \
-              --apps='"${{ inputs.applications }}"' \
+              --apps="${{ inputs.applications }}" \
               --prefix=${{ inputs.prefix }} \
               --min_tags=${{ inputs.minTags}}
           popd

--- a/.github/workflows/prune-images.yml
+++ b/.github/workflows/prune-images.yml
@@ -4,6 +4,15 @@ run-name: Pruning all but the most recent ${{ inputs.minTags }} tags prior to wh
 on:
   workflow_dispatch:
     inputs:
+      environment:
+        type: choice
+        description: 'Environment'
+        required: true
+        options:
+          - dev
+          - test
+          - prod
+        default: 'test'
       applications:
         description: 'Comma seperated list of applications to prune'
         required: true
@@ -12,10 +21,6 @@ on:
         description: 'OpenShift License Plate'
         required: true
         default: '0c27fb'
-      environment:
-        description: 'Environment (dev, test, prod)'
-        required: true
-        default: 'dev'
       prefix:
         description: 'Branch prefix to restrict pruning to'
         required: false

--- a/.github/workflows/prune-images.yml
+++ b/.github/workflows/prune-images.yml
@@ -1,15 +1,15 @@
 name: Prune Images
-run-name: Prune old images from OpenShift
+run-name: Pruning all but the most recent ${{ inputs.minTags }} tags prior to what is deployed in ${{ inputs.environment }}
 
 on:
   workflow_dispatch:
     inputs:
       applications:
-        description: 'Applications to prune'
+        description: 'Comma seperated list of applications to prune'
         required: true
         default: 'web-sims, api-sims'
       licensePlate:
-        description: 'License Plate'
+        description: 'OpenShift License Plate'
         required: true
         default: '0c27fb'
       environment:
@@ -17,7 +17,7 @@ on:
         required: true
         default: 'dev'
       prefix:
-        description: 'Prefix'
+        description: 'Branch prefix to restrict pruning to'
         required: false
         default: 'main'
       minTags:
@@ -35,6 +35,7 @@ jobs:
         run: |
           echo "License Plate: ${{ inputs.licensePlate }}"
           echo "Environment: ${{ inputs.environment }}"
+          echo "Applications: ${{ inputs.applications }}"
           echo "Prefix: ${{ inputs.prefix }}"
           echo "Minimum Tags: ${{ inputs.minTags }}"
       
@@ -47,17 +48,13 @@ jobs:
       
       - name: Prune Images
         run: |
-          IFS=',' read -r -a apps <<< ${{ inputs.applications }}
-          for app in "${apps[@]}"
-          do
-            # Trim spaces
-            trimmed_app=$(echo "$app" | xargs)
-            devops/scripts/fetchOldTags.sh \
+          pushd devops/scripts
+          ./pruneImages.sh \
               --license_plate=${{ inputs.licensePlate }} \
               --env=${{ inputs.environment }} \
-              --app_name=$app \
-              --prefix=${{ inputs.prefix }} | \
-              xargs -I {} echo "oc tag ${{ inputs.licensePlate }}-tools/$app:{}' --delete"
-          done
+              --apps='"${{ inputs.applications }}"' \
+              --prefix=${{ inputs.prefix }} \
+              --min_tags=${{ inputs.minTags}}
+          popd
     
           

--- a/.github/workflows/prune-images.yml
+++ b/.github/workflows/prune-images.yml
@@ -17,10 +17,6 @@ on:
         description: 'Comma seperated list of applications to prune'
         required: true
         default: 'web-sims, api-sims, queue-consumers-sims, workers-sims'
-      licensePlate:
-        description: 'OpenShift License Plate'
-        required: true
-        default: '0c27fb'
       prefix:
         description: 'Branch prefix to restrict pruning to'
         required: false
@@ -38,7 +34,6 @@ jobs:
     steps:
       - name: Print env
         run: |
-          echo "License Plate: ${{ inputs.licensePlate }}"
           echo "Environment: ${{ inputs.environment }}"
           echo "Applications: ${{ inputs.applications }}"
           echo "Prefix: ${{ inputs.prefix }}"
@@ -55,7 +50,7 @@ jobs:
         run: |
           pushd devops/scripts
           ./pruneImages.sh \
-              --license_plate=${{ inputs.licensePlate }} \
+              --license_plate=${{ vars.OPENSHIFT_LICENSE_PLATE }} \
               --env=${{ inputs.environment }} \
               --apps="${{ inputs.applications }}" \
               --prefix=${{ inputs.prefix }} \

--- a/devops/scripts/fetchOldTags.sh
+++ b/devops/scripts/fetchOldTags.sh
@@ -37,8 +37,8 @@ done
 
 # Validation of required arguments and env values
 if [ -z "$LICENSE_PLATE" ] || [ -z "$ENV" ] || [ -z "$APP_NAME" ]; then
-  echo "License plate, environment, and app name are required."
   echo "Usage: $0 --license_plate=VALUE --env=VALUE --app_name=VALUE [--prefix=VALUE] [--min_tags=VALUE]"
+  echo "License plate, environment, and app name are required."
   exit 1
 fi
 

--- a/devops/scripts/pruneImages.sh
+++ b/devops/scripts/pruneImages.sh
@@ -56,7 +56,7 @@ do
             --env=${ENV} \
             --app_name=${trimmed_app} \
             --prefix=${PREFIX} | \
-            xargs -I {} echo "oc tag ${LICENSE_PLATE}-tools/${trimmed_app}:{} --delete"
+            xargs -I {} oc tag ${LICENSE_PLATE}-tools/${trimmed_app}:{} --delete
 done
 
 echo Finished Pruning Images

--- a/devops/scripts/pruneImages.sh
+++ b/devops/scripts/pruneImages.sh
@@ -28,8 +28,8 @@ while [ $# -gt 0 ]; do
       MIN_TAGS="${1#*=}"
       ;;
     *)
-      echo "Invalid argument: $1"
       echo "Usage: $0 --license_plate=VALUE --env=VALUE --apps=VALUE [--prefix=VALUE] [--min_tags=VALUE]"
+      echo "Invalid argument: $1"
       exit 1
       ;;
   esac
@@ -38,16 +38,17 @@ done
 
 # Validation for required parameters
 if [ -z "$LICENSE_PLATE" ] || [ -z "$ENV" ] || [ -z "$APPLICATIONS" ] ; then
+    echo "Usage: $0 --license_plate=VALUE --env=VALUE --apps=VALUE [--prefix=VALUE] [--min_tags=VALUE]"
     echo "License plate, environment, and apps are required."
     echo "Multiple applications can be provided as a comma-separated list."
-    echo "Usage: $0 --license_plate=VALUE --env=VALUE --apps=VALUE [--prefix=VALUE] [--min_tags=VALUE]"
     exit 1
 fi
 
-echo Starting to Prune Images
+echo Starting to Prune Images for applications ${APPLICATIONS}
 IFS=',' read -r -a apps <<< ${APPLICATIONS}
 for app in "${apps[@]}"
 do
+    echo "Trimming spaces from \"${app}\""
     # Trim spaces
     trimmed_app=$(echo "$app" | xargs)
         echo "Processing ${trimmed_app}"

--- a/devops/scripts/pruneImages.sh
+++ b/devops/scripts/pruneImages.sh
@@ -48,10 +48,9 @@ echo Starting to Prune Images for applications ${APPLICATIONS}
 IFS=',' read -r -a apps <<< ${APPLICATIONS}
 for app in "${apps[@]}"
 do
-    echo "Trimming spaces from \"${app}\""
     # Trim spaces
     trimmed_app=$(echo "$app" | xargs)
-        echo "Processing ${trimmed_app}"
+        echo "Processing \"${trimmed_app}\""
         ./fetchOldTags.sh \
             --license_plate=${LICENSE_PLATE} \
             --env=${ENV} \

--- a/devops/scripts/pruneImages.sh
+++ b/devops/scripts/pruneImages.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+
+# Usage: $0 --license_plate=VALUE --env=VALUE --apps=VALUE [--prefix=VALUE] [--min_tags=VALUE]
+
+# Initialize default values
+LICENSE_PLATE=""
+ENV=""
+APPLICATIONS=""
+PREFIX=""
+MIN_TAGS=10  # Default to keeping 10 tags if MIN_TAGS is not specified
+
+# Parse named arguments
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --license_plate=*)
+      LICENSE_PLATE="${1#*=}"
+      ;;
+    --env=*)
+      ENV="${1#*=}"
+      ;;
+    --apps=*)
+      APPLICATIONS="${1#*=}"
+      ;;
+    --prefix=*)
+      PREFIX="${1#*=}"
+      ;;
+    --min_tags=*)
+      MIN_TAGS="${1#*=}"
+      ;;
+    *)
+      echo "Invalid argument: $1"
+      echo "Usage: $0 --license_plate=VALUE --env=VALUE --apps=VALUE [--prefix=VALUE] [--min_tags=VALUE]"
+      exit 1
+      ;;
+  esac
+  shift
+done
+
+# Validation for required parameters
+if [ -z "$LICENSE_PLATE" ] || [ -z "$ENV" ] || [ -z "$APPLICATIONS" ] ; then
+    echo "License plate, environment, and apps are required."
+    echo "Multiple applications can be provided as a comma-separated list."
+    echo "Usage: $0 --license_plate=VALUE --env=VALUE --apps=VALUE [--prefix=VALUE] [--min_tags=VALUE]"
+    exit 1
+fi
+
+echo Starting to Prune Images
+IFS=',' read -r -a apps <<< ${APPLICATIONS}
+for app in "${apps[@]}"
+do
+    # Trim spaces
+    trimmed_app=$(echo "$app" | xargs)
+        echo "Processing ${trimmed_app}"
+        ./fetchOldTags.sh \
+            --license_plate=${LICENSE_PLATE} \
+            --env=${ENV} \
+            --app_name=${trimmed_app} \
+            --prefix=${PREFIX} | \
+            xargs -I {} echo "oc tag ${LICENSE_PLATE}-tools/${trimmed_app}:{} --delete"
+done
+
+echo Finished Pruning Images
+


### PR DESCRIPTION
## Overview:

These ideal method for this script would be that it would be called against the Production project and without a branch specifier and would remove all but N older images from the associated tools imagestreams.  This is not currently the practice as the deployments don't occur frequently enough to prevent a build up of old tags.

As such, the script runs against the dev environment and removing tags that are older than N versions in dev and only tagged against main.

In an even more ideal world we would use environment tags like: dev, test, staging, production which with a minor modification would allow the script to only look at the image stream tags and not have to review the deployment configs.  

## Scripts Overview

1. pruneImages.sh \
    ⚠️ This script is **destructive** and iterates over a comma seperated list of applications calling `fetchOldTags.sh` and then using that output to generate OpenShift CLI commands to remove the images.\
    Logic moved from the GH Action to make it reusable \
    \
    Example call
    ```console
    ./pruneImages.sh --license_plate=0c27fb --env=dev --apps="web-sims, api-sims, queue-consumers-sims, workers-sims" --prefix=main --min_tags=10
    ```
1. fetchOldTags.sh \
    For a given application, the script will look in the defined environment and determine what tag is being used by the OpenShift DeploymentConfig.  It then will generate a list of all tags older than that version and exclude the most recent versions up to `--min_tags`.  If a prefix is supplied those tags will be excluded from the list.

    Example call
    ```console
    ./fetchOldTags.sh --license_plate=0c27fb --app_name=api-sims --env=dev --prefix=main --min_tags=10
    ```

Questions and responses from original PR #2797 

1. Add some inputs to the run-name\
DONE

1. Why don't I use  `${{ secrets.OPENSHIFT_ENV_NAMESPACE }}`\
These appear to be fully qualified and this script needs to look at two projects the tools where the images are stored and then deployment environment.

1. For the environment input we use the specific Github type for it...\
The GitHub environment includes those that are not specific to OpenShift and are also not normalized so would cause issues

1. What is the purpose of the environment input \
It is used to determine what tag is currently deployed to that environment and only remove tags older than that

1. Getting the namespace based on `${LICENSE_PLATE}-${ENV}` would not work for staging
That is true but given the typical use case for the script should only be run against dev or prod.  




