### PR TITLE
#2530 - Rename Upcoming Enrollment Tab Within Institution Account

### DIFF
--- a/sources/packages/web/src/components/generic/BodyHeader.vue
+++ b/sources/packages/web/src/components/generic/BodyHeader.vue
@@ -12,7 +12,7 @@
   </v-row>
   <v-row no-gutters class="mb-2">
     <v-col>
-      <slot name="subtitle">{{ subTitle }}</slot>
+      <slot name="subtitle"><span v-html="subTitle" /></slot>
     </v-col>
   </v-row>
 </template>

--- a/sources/packages/web/src/components/generic/BodyHeader.vue
+++ b/sources/packages/web/src/components/generic/BodyHeader.vue
@@ -12,7 +12,7 @@
   </v-row>
   <v-row no-gutters class="mb-2">
     <v-col>
-      <slot name="subtitle"><span v-html="subTitle" /></slot>
+      <slot name="subtitle">{{ subTitle }}</slot>
     </v-col>
   </v-row>
 </template>

--- a/sources/packages/web/src/views/institution/locations/confirmation-of-enrollment/COESummaryData.vue
+++ b/sources/packages/web/src/views/institution/locations/confirmation-of-enrollment/COESummaryData.vue
@@ -3,11 +3,10 @@
     <v-container :fluid="true">
       <body-header
         :title="header"
-        :subTitle="subTitle"
         :recordsCount="disbursements.results?.length"
       >
         <template #subtitle>
-          <slot name="coeSummarySubtitle" />
+          <slot name="coeSummarySubtitle">{{ coeSummarySubtitle }}</slot>
         </template>
         <template #actions>
           <v-text-field
@@ -112,9 +111,9 @@ export default defineComponent({
       type: String,
       required: true,
     },
-    subTitle: {
+    coeSummarySubtitle: {
       type: String,
-      required: true,
+      required: false,
     },
     enrollmentPeriod: {
       type: String as PropType<EnrollmentPeriod>,

--- a/sources/packages/web/src/views/institution/locations/confirmation-of-enrollment/COESummaryData.vue
+++ b/sources/packages/web/src/views/institution/locations/confirmation-of-enrollment/COESummaryData.vue
@@ -6,6 +6,9 @@
         :subTitle="subTitle"
         :recordsCount="disbursements.results?.length"
       >
+        <template #subtitle>
+          <slot name="coeSummarySubtitle">{{ subTitle }}</slot>
+        </template>
         <template #actions>
           <v-text-field
             density="compact"

--- a/sources/packages/web/src/views/institution/locations/confirmation-of-enrollment/COESummaryData.vue
+++ b/sources/packages/web/src/views/institution/locations/confirmation-of-enrollment/COESummaryData.vue
@@ -7,7 +7,7 @@
         :recordsCount="disbursements.results?.length"
       >
         <template #subtitle>
-          <slot name="coeSummarySubtitle">{{ subTitle }}</slot>
+          <slot name="coeSummarySubtitle" />
         </template>
         <template #actions>
           <v-text-field

--- a/sources/packages/web/src/views/institution/locations/confirmation-of-enrollment/LocationCOESummary.vue
+++ b/sources/packages/web/src/views/institution/locations/confirmation-of-enrollment/LocationCOESummary.vue
@@ -48,11 +48,11 @@
             <span>This page contains two types of records:</span>
             <ul>
               <li>
-                disbursements requests which are upcoming and will be required
+                Disbursements requests which are upcoming and will be required
                 at a later date. These are indicated by a 'Required' status.
               </li>
               <li>
-                previously actioned Confirmation of Enrolment Requests which can
+                Previously actioned Confirmation of Enrolment Requests which can
                 no longer be actioned. These are indicated by a 'Completed'
                 status.
               </li>

--- a/sources/packages/web/src/views/institution/locations/confirmation-of-enrollment/LocationCOESummary.vue
+++ b/sources/packages/web/src/views/institution/locations/confirmation-of-enrollment/LocationCOESummary.vue
@@ -22,7 +22,7 @@
           <div>
             <v-icon start icon="fa:far fa-folder-open" class="px-1"></v-icon>
             <span class="label-bold" data-cy="upcomingEnrolmentTab">
-              Upcoming enrolment
+              Upcoming and Previous Enrolments
             </span>
           </div>
         </v-tab>
@@ -41,8 +41,14 @@
         <c-o-e-summary-data
           :locationId="locationId"
           :enrollmentPeriod="EnrollmentPeriod.Upcoming"
-          header="Upcoming enrolment"
-          subTitle="These applications are still outside of the 21 days of the study start date."
+          header="Upcoming and
+        Previous Enrolments"
+          subTitle="This page contains two types of
+        records: <br />
+        i. disbursements requests which are upcoming and will be required at a
+        later date. These are indicated by a 'Required' status. <br />
+        ii. previously actioned Confirmation of Enrolment Requests which can no
+        longer be actioned. These are indicated by a 'Completed' status."
         />
       </v-window-item>
     </v-window>

--- a/sources/packages/web/src/views/institution/locations/confirmation-of-enrollment/LocationCOESummary.vue
+++ b/sources/packages/web/src/views/institution/locations/confirmation-of-enrollment/LocationCOESummary.vue
@@ -49,12 +49,13 @@
             <ul>
               <li>
                 Disbursements requests which are upcoming and will be required
-                at a later date. These are indicated by a 'Required' status.
+                at a later date. These are indicated by a
+                <strong>Required</strong> status.
               </li>
               <li>
                 Previously actioned Confirmation of Enrolment Requests which can
-                no longer be actioned. These are indicated by a 'Completed'
-                status.
+                no longer be actioned. These are indicated by a
+                <strong>Completed</strong> status.
               </li>
             </ul>
           </template>

--- a/sources/packages/web/src/views/institution/locations/confirmation-of-enrollment/LocationCOESummary.vue
+++ b/sources/packages/web/src/views/institution/locations/confirmation-of-enrollment/LocationCOESummary.vue
@@ -43,13 +43,22 @@
           :enrollmentPeriod="EnrollmentPeriod.Upcoming"
           header="Upcoming and
         Previous Enrolments"
-          subTitle="This page contains two types of
-        records: <br />
-        i. disbursements requests which are upcoming and will be required at a
-        later date. These are indicated by a 'Required' status. <br />
-        ii. previously actioned Confirmation of Enrolment Requests which can no
-        longer be actioned. These are indicated by a 'Completed' status."
-        />
+        >
+          <template #coeSummarySubtitle>
+            <span>This page contains two types of records:</span>
+            <ul>
+              <li>
+                disbursements requests which are upcoming and will be required
+                at a later date. These are indicated by a 'Required' status.
+              </li>
+              <li>
+                previously actioned Confirmation of Enrolment Requests which can
+                no longer be actioned. These are indicated by a 'Completed'
+                status.
+              </li>
+            </ul>
+          </template>
+        </c-o-e-summary-data>
       </v-window-item>
     </v-window>
   </full-page-container>

--- a/sources/packages/web/src/views/institution/locations/confirmation-of-enrollment/LocationCOESummary.vue
+++ b/sources/packages/web/src/views/institution/locations/confirmation-of-enrollment/LocationCOESummary.vue
@@ -50,12 +50,12 @@
               <li>
                 Disbursements requests which are upcoming and will be required
                 at a later date. These are indicated by a
-                <strong>Required</strong> status.
+                <span class="font-bold">Required</span> status.
               </li>
               <li>
                 Previously actioned Confirmation of Enrolment Requests which can
                 no longer be actioned. These are indicated by a
-                <strong>Completed</strong> status.
+                <span class="font-bold">Completed</span> status.
               </li>
             </ul>
           </template>

--- a/sources/packages/web/src/views/institution/locations/confirmation-of-enrollment/LocationCOESummary.vue
+++ b/sources/packages/web/src/views/institution/locations/confirmation-of-enrollment/LocationCOESummary.vue
@@ -41,8 +41,7 @@
         <c-o-e-summary-data
           :locationId="locationId"
           :enrollmentPeriod="EnrollmentPeriod.Upcoming"
-          header="Upcoming and
-        Previous Enrolments"
+          header="Upcoming and Previous Enrolments"
         >
           <template #coeSummarySubtitle>
             <span>This page contains two types of records:</span>


### PR DESCRIPTION
## As a part of this PR, completed the following:

1. Revised the tab name from "Upcoming Enrolment" to: "Upcoming and Previous Enrolments"
2. Within the 'upcoming and previous enrolment' tab, added wording beneath the header which reads: "This page contains two types of records:
    - disbursements requests which are upcoming and will be required at a later date. These are indicated by a 'Required' status.
    - previously actioned Confirmation of Enrolment Requests which can no longer be actioned. These are indicated by a 'Completed' status.

### Screenshot

<img width="1920" alt="image" src="https://github.com/bcgov/SIMS/assets/7859295/9875e123-de30-4e36-b96d-ca779900f406">