### PR TITLE
#2850 - Accent characters getting translated during Institution file upload

### DIFF
--- a/sources/packages/backend/apps/api/src/route-controllers/education-program-offering/_tests_/e2e/bulk-insert/multiple-upload.csv
+++ b/sources/packages/backend/apps/api/src/route-controllers/education-program-offering/_tests_/e2e/bulk-insert/multiple-upload.csv
@@ -1,3 +1,3 @@
 Institution Location Code,SABC Program Code,Name,Year of Study,Show Year of Study,Offering Intensity,Course Load,Delivered Type,WIL Component,WIL Component Type,Start Date,End Date,Has Study Breaks,Study Break 1 - Start Date,Study Break 1 - End Date,Study Break 2 - Start Date,Study Break 2 - End Date,Study Break 3 - Start Date,Study Break 3 - End Date,Study Break 4 - Start Date,Study Break 4 - End Date,Study Break 5 - Start Date,Study Break 5 - End Date,Actual Tuition,Program Related Costs,Mandatory Fees,Exceptional Expenses,Public Offering,Consent
-YESK,SBC1,Test Γ‘Γ©Γ­Γ³ΓΊ,1,yes,Full Time,,onsite,no,,2023-09-06,2024-08-15,no,,,,,,,,,,,5000,,,,yes,yes
+YESK,SBC1,Test αινσϊ,1,yes,Full Time,,onsite,no,,2023-09-06,2024-08-15,no,,,,,,,,,,,5000,,,,yes,yes
 KSEY,SBC2,Test program 2,1,yes,Full Time,,onsite,no,,2023-09-06,2024-08-15,no,,,,,,,,,,,5000,,,,yes,yes

--- a/sources/packages/backend/apps/api/src/route-controllers/education-program-offering/_tests_/e2e/education-program-offering.institutions.controller.bulkInsert.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/education-program-offering/_tests_/e2e/education-program-offering.institutions.controller.bulkInsert.e2e-spec.ts
@@ -180,6 +180,7 @@ describe("EducationProgramOfferingInstitutionsController(e2e)-bulkInsert", () =>
         await db.educationProgramOffering.find({
           select: {
             offeringStatus: true,
+            name: true,
           },
           where: {
             id: In([responseOfferingSBC1.id, responseOfferingSBC2.id]),
@@ -191,15 +192,11 @@ describe("EducationProgramOfferingInstitutionsController(e2e)-bulkInsert", () =>
 
       // Delivery method of the program 'SBC1' in the CSV does not match with the existing program, which will
       // create an 'Creation pending' offering when inserted.
-
-      expect(offeringSBC1).toHaveProperty(
-        "offeringStatus",
-        OfferingStatus.CreationPending,
-      );
-      expect(offeringSBC2).toHaveProperty(
-        "offeringStatus",
-        OfferingStatus.Approved,
-      );
+      expect(offeringSBC1.offeringStatus).toBe(OfferingStatus.CreationPending);
+      // Ensure the offering name using extended ASCII characters were properly saved.
+      expect(offeringSBC1.name).toBe("Test áéíóú");
+      expect(offeringSBC2.offeringStatus).toBe(OfferingStatus.Approved);
+      expect(offeringSBC2.name).toBe("Test program 2");
     },
   );
 

--- a/sources/packages/backend/libs/services/src/constants/system-configurations-constants.ts
+++ b/sources/packages/backend/libs/services/src/constants/system-configurations-constants.ts
@@ -77,6 +77,10 @@ export const SFAS_IMPORT_RECORDS_PROGRESS_REPORT_PACE = 1000;
 export const HTTP_SERVICE_TIMEOUT = 30000;
 
 /**
- * ASCII default encoding for files.
+ * Default encoding for files.
+ * SFTP integrations and integration files uploaded to the system
+ * should be considered to be single byte characters and therefore
+ * latin1 (ISO8859-1) is used to include the ASCII extended
+ * characters.
  */
-export const FILE_DEFAULT_ENCODING = "ascii";
+export const FILE_DEFAULT_ENCODING = "latin1";


### PR DESCRIPTION
### Files uploaded to SIMS (`buffer.toString`)

As stated in the [nodejs documentation](https://nodejs.org/docs/latest/api/buffer.html#buffer_buffer) when the encoding is set to ASCII the most significant bit will be unset (to ensure the 7bit characteristic from ASCII) causing the characters to be changed, as per the example below.

![image](https://github.com/bcgov/SIMS/assets/61259237/40b3de94-fb07-42bf-a3bb-877db28b2b32)

The same would not happen if `latin1(ISO-8859-1)` is used as stated by the documentation and tested during the file uploads.

The requirement for files integrations, via upload or SFTP, is to use a single-byte encoding, and since UTF-8 is multibyte, `latin1(ISO-8859-1)` seems to be the only way to proceed. 

One E2E test was changed to ensure that the translation issue would be captured.

### Files generated to the SFTP (`Buffer.from`)

While creating the files to be uploaded to the SFTP both `ascii` and `latin1` resulted in the same bytes.

|Char(áéí)|Encoding|
|---|---|
|UTF-8|195, 161, 195, 169, 195, 173|
|ASCII|225, 233, 237|
|Latin1(ISO8859-1)|225, 233, 237|

#### Sample file generated with UTF8

![image](https://github.com/bcgov/SIMS/assets/61259237/9e5d0806-1da5-4bf0-b11d-8d5083b7d062)

#### Sample file generated with ASCII and Latin1(ISO8859-1) where the same result was produced

![image](https://github.com/bcgov/SIMS/assets/61259237/69b9e648-9749-4e99-b6ce-88d929658052)

#### Sample file in latin1 using UTF8 characters outside ASCII extended

![image](https://github.com/bcgov/SIMS/assets/61259237/de4bde71-29d1-4b49-8af9-8dc01c75eb07)

From the student profile below.

![image](https://github.com/bcgov/SIMS/assets/61259237/1b37d392-df5c-4643-a9d6-58b706001257)


