### PR TITLE
#2880 - PT Award Configuration BCAG

### DIFF
--- a/sources/packages/backend/workflow/BPMN/camunda-8/parttime-assessment-2021-2022.bpmn
+++ b/sources/packages/backend/workflow/BPMN/camunda-8/parttime-assessment-2021-2022.bpmn
@@ -760,7 +760,7 @@
       <bpmn:extensionElements>
         <zeebe:ioMapping>
           <zeebe:output source="=  if (calculatedDataTotalFamilyIncome &#60;= dmnPartTimeAwardFamilySizeVariables.limitAwardBCAGIncomeCap)&#10;then dmnPartTimeAwardAllowableLimits.limitAwardBCAGAmount&#10;else&#10;  max(dmnPartTimeAwardAllowableLimits.limitAwardBCAGAmount - ((calculatedDataTotalFamilyIncome - dmnPartTimeAwardFamilySizeVariables.limitAwardBCAGIncomeCap) * dmnPartTimeAwardFamilySizeVariables.limitAwardBCAGSlope),&#10;     100&#10;  )" target="federalAwardBCAGAmount" />
-          <zeebe:output source="=if ((awardEligibilityBCAG = true) and (federalAwardBCAGAmount &#62;= 100))&#10;then&#10;  min(&#10;     calculatedDataTotalRemainingNeed3,&#10;     min(dmnPartTimeAwardAllowableLimits.limitAwardBCAGAmount, federalAwardBCAGAmount)&#10;  )&#10;else&#10;0" target="provincialAwardNetBCAGAmount" />
+          <zeebe:output source="=if ((awardEligibilityBCAG = true) and (federalAwardBCAGAmount &#62;= 100))&#10;then&#10;  min(&#10;     calculatedDataTotalRemainingNeed3,&#10;     min(dmnPartTimeAwardAllowableLimits.limitAwardBCAGAmount - programYearTotalPartTimeBCAG, federalAwardBCAGAmount)&#10;  )&#10;else&#10;0" target="provincialAwardNetBCAGAmount" />
           <zeebe:output source="=calculatedDataTotalRemainingNeed3 - provincialAwardNetBCAGAmount" target="calculatedDataTotalRemainingNeed4" />
         </zeebe:ioMapping>
       </bpmn:extensionElements>
@@ -1551,10 +1551,6 @@ studentCalculatedTotalIncome</bpmn:text>
         <di:waypoint x="5797" y="2254" />
         <di:waypoint x="5823" y="2200" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Association_1mm3xop_di" bpmnElement="Association_1mm3xop">
-        <di:waypoint x="5700" y="2252" />
-        <di:waypoint x="5700" y="2200" />
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="Group_1a4vdzr_di" bpmnElement="Group_1a4vdzr">
         <dc:Bounds x="1535" y="660" width="90" height="230" />
       </bpmndi:BPMNShape>
@@ -1601,6 +1597,10 @@ studentCalculatedTotalIncome</bpmn:text>
         <dc:Bounds x="4497" y="1250" width="458" height="30" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="TextAnnotation_1oinrrh_di" bpmnElement="TextAnnotation_1oinrrh">
+        <dc:Bounds x="5650" y="2170" width="100" height="30" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
       <bpmndi:BPMNEdge id="Association_1vdevsr_di" bpmnElement="Association_1vdevsr">
         <di:waypoint x="5151" y="2256" />
         <di:waypoint x="5198" y="2200" />
@@ -1637,10 +1637,10 @@ studentCalculatedTotalIncome</bpmn:text>
         <di:waypoint x="4388" y="1279" />
         <di:waypoint x="4497" y="1260" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNShape id="TextAnnotation_1oinrrh_di" bpmnElement="TextAnnotation_1oinrrh">
-        <dc:Bounds x="5650" y="2170" width="100" height="30" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Association_1mm3xop_di" bpmnElement="Association_1mm3xop">
+        <di:waypoint x="5700" y="2252" />
+        <di:waypoint x="5700" y="2200" />
+      </bpmndi:BPMNEdge>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>
 </bpmn:definitions>

--- a/sources/packages/backend/workflow/BPMN/camunda-8/parttime-assessment-2022-2023.bpmn
+++ b/sources/packages/backend/workflow/BPMN/camunda-8/parttime-assessment-2022-2023.bpmn
@@ -437,7 +437,7 @@
       <bpmn:extensionElements>
         <zeebe:ioMapping>
           <zeebe:output source="=  if (calculatedDataTotalFamilyIncome &#60;= dmnPartTimeAwardFamilySizeVariables.limitAwardBCAGIncomeCap)&#10;then dmnPartTimeAwardAllowableLimits.limitAwardBCAGAmount&#10;else&#10;  max(dmnPartTimeAwardAllowableLimits.limitAwardBCAGAmount - ((calculatedDataTotalFamilyIncome - dmnPartTimeAwardFamilySizeVariables.limitAwardBCAGIncomeCap) * dmnPartTimeAwardFamilySizeVariables.limitAwardBCAGSlope),&#10;     100&#10;  )" target="federalAwardBCAGAmount" />
-          <zeebe:output source="=if ((awardEligibilityBCAG = true) and (federalAwardBCAGAmount &#62;= 100))&#10;then&#10;  min(&#10;     calculatedDataTotalRemainingNeed3,&#10;     min(dmnPartTimeAwardAllowableLimits.limitAwardBCAGAmount, federalAwardBCAGAmount)&#10;  )&#10;else&#10;0" target="provincialAwardNetBCAGAmount" />
+          <zeebe:output source="=if ((awardEligibilityBCAG = true) and (federalAwardBCAGAmount &#62;= 100))&#10;then&#10;  min(&#10;     calculatedDataTotalRemainingNeed3,&#10;     min(dmnPartTimeAwardAllowableLimits.limitAwardBCAGAmount - programYearTotalPartTimeBCAG, federalAwardBCAGAmount)&#10;  )&#10;else&#10;0" target="provincialAwardNetBCAGAmount" />
           <zeebe:output source="=calculatedDataTotalRemainingNeed3 - provincialAwardNetBCAGAmount" target="calculatedDataTotalRemainingNeed4" />
         </zeebe:ioMapping>
       </bpmn:extensionElements>
@@ -1551,10 +1551,6 @@ studentCalculatedTotalIncome</bpmn:text>
         <di:waypoint x="5303" y="2258" />
         <di:waypoint x="5373" y="2200" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Association_160cvbz_di" bpmnElement="Association_160cvbz">
-        <di:waypoint x="5700" y="2252" />
-        <di:waypoint x="5700" y="2200" />
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="Group_1a4vdzr_di" bpmnElement="Group_1a4vdzr">
         <dc:Bounds x="1535" y="660" width="90" height="230" />
       </bpmndi:BPMNShape>
@@ -1601,6 +1597,10 @@ studentCalculatedTotalIncome</bpmn:text>
         <dc:Bounds x="6139" y="2330" width="100" height="30" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="TextAnnotation_18wu29l_di" bpmnElement="TextAnnotation_18wu29l">
+        <dc:Bounds x="5650" y="2170" width="100" height="30" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
       <bpmndi:BPMNEdge id="Association_0k52tdi_di" bpmnElement="Association_0k52tdi">
         <di:waypoint x="4407" y="1356" />
         <di:waypoint x="4522" y="1330" />
@@ -1637,10 +1637,10 @@ studentCalculatedTotalIncome</bpmn:text>
         <di:waypoint x="6124" y="2398" />
         <di:waypoint x="6168" y="2360" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNShape id="TextAnnotation_18wu29l_di" bpmnElement="TextAnnotation_18wu29l">
-        <dc:Bounds x="5650" y="2170" width="100" height="30" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Association_160cvbz_di" bpmnElement="Association_160cvbz">
+        <di:waypoint x="5700" y="2252" />
+        <di:waypoint x="5700" y="2200" />
+      </bpmndi:BPMNEdge>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>
 </bpmn:definitions>

--- a/sources/packages/backend/workflow/BPMN/camunda-8/parttime-assessment-2023-2024.bpmn
+++ b/sources/packages/backend/workflow/BPMN/camunda-8/parttime-assessment-2023-2024.bpmn
@@ -760,7 +760,7 @@
       <bpmn:extensionElements>
         <zeebe:ioMapping>
           <zeebe:output source="=  if (calculatedDataTotalFamilyIncome &#60;= dmnPartTimeAwardFamilySizeVariables.limitAwardBCAGIncomeCap)&#10;then dmnPartTimeAwardAllowableLimits.limitAwardBCAGAmount&#10;else&#10;  max(dmnPartTimeAwardAllowableLimits.limitAwardBCAGAmount - ((calculatedDataTotalFamilyIncome - dmnPartTimeAwardFamilySizeVariables.limitAwardBCAGIncomeCap) * dmnPartTimeAwardFamilySizeVariables.limitAwardBCAGSlope),&#10;     100&#10;  )" target="federalAwardBCAGAmount" />
-          <zeebe:output source="=if ((awardEligibilityBCAG = true) and (federalAwardBCAGAmount &#62;= 100))&#10;then&#10;  min(&#10;     calculatedDataTotalRemainingNeed3,&#10;     min(dmnPartTimeAwardAllowableLimits.limitAwardBCAGAmount, federalAwardBCAGAmount)&#10;  )&#10;else&#10;0" target="provincialAwardNetBCAGAmount" />
+          <zeebe:output source="=if ((awardEligibilityBCAG = true) and (federalAwardBCAGAmount &#62;= 100))&#10;then&#10;  min(&#10;     calculatedDataTotalRemainingNeed3,&#10;     min(dmnPartTimeAwardAllowableLimits.limitAwardBCAGAmount - programYearTotalPartTimeBCAG, federalAwardBCAGAmount)&#10;  )&#10;else&#10;0" target="provincialAwardNetBCAGAmount" />
           <zeebe:output source="=calculatedDataTotalRemainingNeed3 - provincialAwardNetBCAGAmount" target="calculatedDataTotalRemainingNeed4" />
         </zeebe:ioMapping>
       </bpmn:extensionElements>
@@ -1551,10 +1551,6 @@ dmnX (comes from dmn)</bpmn:text>
         <di:waypoint x="5827" y="2254" />
         <di:waypoint x="5853" y="2200" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Association_0gzo1wo_di" bpmnElement="Association_0gzo1wo">
-        <di:waypoint x="5740" y="2252" />
-        <di:waypoint x="5740" y="2180" />
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="Group_1a4vdzr_di" bpmnElement="Group_1a4vdzr">
         <dc:Bounds x="1535" y="660" width="90" height="230" />
       </bpmndi:BPMNShape>
@@ -1601,6 +1597,10 @@ dmnX (comes from dmn)</bpmn:text>
         <dc:Bounds x="4532" y="1304" width="398" height="41" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="TextAnnotation_13w21u1_di" bpmnElement="TextAnnotation_13w21u1">
+        <dc:Bounds x="5690" y="2150" width="100" height="30" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
       <bpmndi:BPMNEdge id="Association_1gi7mg0_di" bpmnElement="Association_1gi7mg0">
         <di:waypoint x="6134" y="2398" />
         <di:waypoint x="6178" y="2360" />
@@ -1637,10 +1637,10 @@ dmnX (comes from dmn)</bpmn:text>
         <di:waypoint x="4417" y="1356" />
         <di:waypoint x="4532" y="1330" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNShape id="TextAnnotation_13w21u1_di" bpmnElement="TextAnnotation_13w21u1">
-        <dc:Bounds x="5690" y="2150" width="100" height="30" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Association_0gzo1wo_di" bpmnElement="Association_0gzo1wo">
+        <di:waypoint x="5740" y="2252" />
+        <di:waypoint x="5740" y="2180" />
+      </bpmndi:BPMNEdge>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>
 </bpmn:definitions>

--- a/sources/packages/backend/workflow/test/2021-2022/parttime-assessment/awards-amounts/parttime-assessment-2021-2022-awards-amount-BCAG.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2021-2022/parttime-assessment/awards-amounts/parttime-assessment-2021-2022-awards-amount-BCAG.e2e-spec.ts
@@ -37,6 +37,9 @@ describe(`E2E Test Workflow parttime-assessment-${PROGRAM_YEAR}-awards-amount-BC
         .limitAwardBCAGAmount,
     );
     expect(calculatedAssessment.variables.federalAwardBCAGAmount).toBe(1000);
+    expect(calculatedAssessment.variables.provincialAwardNetBCAGAmount).toBe(
+      800,
+    );
   });
 
   it("Should determine federalAwardBCAGAmount when calculatedDataTotalFamilyIncome > limitAwardBCAGIncomeCap", async () => {
@@ -115,7 +118,7 @@ describe(`E2E Test Workflow parttime-assessment-${PROGRAM_YEAR}-awards-amount-BC
       ),
     );
     expect(calculatedAssessment.variables.provincialAwardNetBCAGAmount).toBe(
-      1000,
+      800,
     );
   });
 

--- a/sources/packages/backend/workflow/test/2021-2022/parttime-assessment/awards-amounts/parttime-assessment-2021-2022-awards-amount-BCAG.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2021-2022/parttime-assessment/awards-amounts/parttime-assessment-2021-2022-awards-amount-BCAG.e2e-spec.ts
@@ -7,7 +7,7 @@ import { InstitutionTypes } from "../../../models";
 import { YesNoOptions } from "@sims/test-utils";
 
 describe(`E2E Test Workflow parttime-assessment-${PROGRAM_YEAR}-awards-amount-BCAG.`, () => {
-  it("Should determine federalAwardBCAGAmount when calculatedDataTotalFamilyIncome <= limitAwardBCAGIncomeCap", async () => {
+  it("Should determine federalAwardBCAGAmount, provincialAwardNetBCAGAmount when calculatedDataTotalFamilyIncome <= limitAwardBCAGIncomeCap", async () => {
     // Arrange
     const assessmentConsolidatedData =
       createFakeConsolidatedPartTimeData(PROGRAM_YEAR);
@@ -101,22 +101,9 @@ describe(`E2E Test Workflow parttime-assessment-${PROGRAM_YEAR}-awards-amount-BC
       assessmentConsolidatedData,
     );
     // Assert
-    // awardEligibilityBCAG is true
-    // provincialAwardNetBCAGAmount is greater than 0
+    // awardEligibilityBCAG is true.
+    // provincialAwardNetBCAGAmount is 800.
     expect(calculatedAssessment.variables.awardEligibilityBCAG).toBe(true);
-    expect(
-      calculatedAssessment.variables.federalAwardBCAGAmount,
-    ).toBeGreaterThan(100);
-    expect(calculatedAssessment.variables.provincialAwardNetBCAGAmount).toBe(
-      Math.min(
-        calculatedAssessment.variables.calculatedDataTotalRemainingNeed3,
-        Math.min(
-          calculatedAssessment.variables.dmnPartTimeAwardAllowableLimits
-            .limitAwardBCAGAmount,
-          calculatedAssessment.variables.federalAwardBCAGAmount,
-        ),
-      ),
-    );
     expect(calculatedAssessment.variables.provincialAwardNetBCAGAmount).toBe(
       800,
     );

--- a/sources/packages/backend/workflow/test/2021-2022/parttime-assessment/awards-amounts/parttime-assessment-2021-2022-awards-amount-BCAG.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2021-2022/parttime-assessment/awards-amounts/parttime-assessment-2021-2022-awards-amount-BCAG.e2e-spec.ts
@@ -38,7 +38,7 @@ describe(`E2E Test Workflow parttime-assessment-${PROGRAM_YEAR}-awards-amount-BC
     );
     expect(calculatedAssessment.variables.federalAwardBCAGAmount).toBe(1000);
     expect(calculatedAssessment.variables.provincialAwardNetBCAGAmount).toBe(
-      800,
+      700,
     );
   });
 
@@ -102,10 +102,10 @@ describe(`E2E Test Workflow parttime-assessment-${PROGRAM_YEAR}-awards-amount-BC
     );
     // Assert
     // awardEligibilityBCAG is true.
-    // provincialAwardNetBCAGAmount is 800.
+    // provincialAwardNetBCAGAmount is 700.
     expect(calculatedAssessment.variables.awardEligibilityBCAG).toBe(true);
     expect(calculatedAssessment.variables.provincialAwardNetBCAGAmount).toBe(
-      800,
+      700,
     );
   });
 

--- a/sources/packages/backend/workflow/test/2022-2023/parttime-assessment/awards-amounts/parttime-assessment-2022-2023-awards-amount-BCAG.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2022-2023/parttime-assessment/awards-amounts/parttime-assessment-2022-2023-awards-amount-BCAG.e2e-spec.ts
@@ -38,7 +38,7 @@ describe(`E2E Test Workflow parttime-assessment-${PROGRAM_YEAR}-awards-amount-BC
     );
     expect(calculatedAssessment.variables.federalAwardBCAGAmount).toBe(1000);
     expect(calculatedAssessment.variables.provincialAwardNetBCAGAmount).toBe(
-      800,
+      700,
     );
   });
 
@@ -102,13 +102,13 @@ describe(`E2E Test Workflow parttime-assessment-${PROGRAM_YEAR}-awards-amount-BC
     );
     // Assert
     // awardEligibilityBCAG is true.
-    // provincialAwardNetBCAGAmount is 800.
+    // provincialAwardNetBCAGAmount is 700.
     expect(calculatedAssessment.variables.awardEligibilityBCAG).toBe(true);
     expect(
       calculatedAssessment.variables.federalAwardBCAGAmount,
     ).toBeGreaterThan(100);
     expect(calculatedAssessment.variables.provincialAwardNetBCAGAmount).toBe(
-      800,
+      700,
     );
   });
 

--- a/sources/packages/backend/workflow/test/2022-2023/parttime-assessment/awards-amounts/parttime-assessment-2022-2023-awards-amount-BCAG.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2022-2023/parttime-assessment/awards-amounts/parttime-assessment-2022-2023-awards-amount-BCAG.e2e-spec.ts
@@ -37,6 +37,9 @@ describe(`E2E Test Workflow parttime-assessment-${PROGRAM_YEAR}-awards-amount-BC
         .limitAwardBCAGAmount,
     );
     expect(calculatedAssessment.variables.federalAwardBCAGAmount).toBe(1000);
+    expect(calculatedAssessment.variables.provincialAwardNetBCAGAmount).toBe(
+      800,
+    );
   });
 
   it("Should determine federalAwardBCAGAmount when calculatedDataTotalFamilyIncome > limitAwardBCAGIncomeCap", async () => {
@@ -115,7 +118,7 @@ describe(`E2E Test Workflow parttime-assessment-${PROGRAM_YEAR}-awards-amount-BC
       ),
     );
     expect(calculatedAssessment.variables.provincialAwardNetBCAGAmount).toBe(
-      1000,
+      800,
     );
   });
 

--- a/sources/packages/backend/workflow/test/2022-2023/parttime-assessment/awards-amounts/parttime-assessment-2022-2023-awards-amount-BCAG.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2022-2023/parttime-assessment/awards-amounts/parttime-assessment-2022-2023-awards-amount-BCAG.e2e-spec.ts
@@ -7,7 +7,7 @@ import { InstitutionTypes } from "../../../models";
 import { YesNoOptions } from "@sims/test-utils";
 
 describe(`E2E Test Workflow parttime-assessment-${PROGRAM_YEAR}-awards-amount-BCAG.`, () => {
-  it("Should determine federalAwardBCAGAmount when calculatedDataTotalFamilyIncome <= limitAwardBCAGIncomeCap", async () => {
+  it("Should determine federalAwardBCAGAmount, provincialAwardNetBCAGAmount when calculatedDataTotalFamilyIncome <= limitAwardBCAGIncomeCap", async () => {
     // Arrange
     const assessmentConsolidatedData =
       createFakeConsolidatedPartTimeData(PROGRAM_YEAR);
@@ -101,22 +101,12 @@ describe(`E2E Test Workflow parttime-assessment-${PROGRAM_YEAR}-awards-amount-BC
       assessmentConsolidatedData,
     );
     // Assert
-    // awardEligibilityBCAG is true
-    // provincialAwardNetBCAGAmount is greater than 0
+    // awardEligibilityBCAG is true.
+    // provincialAwardNetBCAGAmount is 800.
     expect(calculatedAssessment.variables.awardEligibilityBCAG).toBe(true);
     expect(
       calculatedAssessment.variables.federalAwardBCAGAmount,
     ).toBeGreaterThan(100);
-    expect(calculatedAssessment.variables.provincialAwardNetBCAGAmount).toBe(
-      Math.min(
-        calculatedAssessment.variables.calculatedDataTotalRemainingNeed3,
-        Math.min(
-          calculatedAssessment.variables.dmnPartTimeAwardAllowableLimits
-            .limitAwardBCAGAmount,
-          calculatedAssessment.variables.federalAwardBCAGAmount,
-        ),
-      ),
-    );
     expect(calculatedAssessment.variables.provincialAwardNetBCAGAmount).toBe(
       800,
     );

--- a/sources/packages/backend/workflow/test/2023-2024/parttime-assessment/awards-amounts/parttime-assessment-2023-2024-awards-amount-BCAG.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2023-2024/parttime-assessment/awards-amounts/parttime-assessment-2023-2024-awards-amount-BCAG.e2e-spec.ts
@@ -42,7 +42,7 @@ describe(`E2E Test Workflow parttime-assessment-${PROGRAM_YEAR}-awards-amount-BC
     );
   });
 
-  it("Should determine federalAwardBCAGAmount when calculatedDataTotalFamilyIncome > limitAwardBCAGIncomeCap", async () => {
+  it("Should determine federalAwardBCAGAmount, provincialAwardNetBCAGAmount when calculatedDataTotalFamilyIncome > limitAwardBCAGIncomeCap", async () => {
     // Arrange
     const assessmentConsolidatedData =
       createFakeConsolidatedPartTimeData(PROGRAM_YEAR);
@@ -101,22 +101,12 @@ describe(`E2E Test Workflow parttime-assessment-${PROGRAM_YEAR}-awards-amount-BC
       assessmentConsolidatedData,
     );
     // Assert
-    // awardEligibilityBCAG is true
-    // provincialAwardNetBCAGAmount is greater than 0
+    // awardEligibilityBCAG is true.
+    // provincialAwardNetBCAGAmount is 800.
     expect(calculatedAssessment.variables.awardEligibilityBCAG).toBe(true);
     expect(
       calculatedAssessment.variables.federalAwardBCAGAmount,
     ).toBeGreaterThan(100);
-    expect(calculatedAssessment.variables.provincialAwardNetBCAGAmount).toBe(
-      Math.min(
-        calculatedAssessment.variables.calculatedDataTotalRemainingNeed3,
-        Math.min(
-          calculatedAssessment.variables.dmnPartTimeAwardAllowableLimits
-            .limitAwardBCAGAmount,
-          calculatedAssessment.variables.federalAwardBCAGAmount,
-        ),
-      ),
-    );
     expect(calculatedAssessment.variables.provincialAwardNetBCAGAmount).toBe(
       800,
     );

--- a/sources/packages/backend/workflow/test/2023-2024/parttime-assessment/awards-amounts/parttime-assessment-2023-2024-awards-amount-BCAG.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2023-2024/parttime-assessment/awards-amounts/parttime-assessment-2023-2024-awards-amount-BCAG.e2e-spec.ts
@@ -38,7 +38,7 @@ describe(`E2E Test Workflow parttime-assessment-${PROGRAM_YEAR}-awards-amount-BC
     );
     expect(calculatedAssessment.variables.federalAwardBCAGAmount).toBe(1000);
     expect(calculatedAssessment.variables.provincialAwardNetBCAGAmount).toBe(
-      800,
+      700,
     );
   });
 
@@ -102,13 +102,13 @@ describe(`E2E Test Workflow parttime-assessment-${PROGRAM_YEAR}-awards-amount-BC
     );
     // Assert
     // awardEligibilityBCAG is true.
-    // provincialAwardNetBCAGAmount is 800.
+    // provincialAwardNetBCAGAmount is 700.
     expect(calculatedAssessment.variables.awardEligibilityBCAG).toBe(true);
     expect(
       calculatedAssessment.variables.federalAwardBCAGAmount,
     ).toBeGreaterThan(100);
     expect(calculatedAssessment.variables.provincialAwardNetBCAGAmount).toBe(
-      800,
+      700,
     );
   });
 

--- a/sources/packages/backend/workflow/test/2023-2024/parttime-assessment/awards-amounts/parttime-assessment-2023-2024-awards-amount-BCAG.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2023-2024/parttime-assessment/awards-amounts/parttime-assessment-2023-2024-awards-amount-BCAG.e2e-spec.ts
@@ -37,6 +37,9 @@ describe(`E2E Test Workflow parttime-assessment-${PROGRAM_YEAR}-awards-amount-BC
         .limitAwardBCAGAmount,
     );
     expect(calculatedAssessment.variables.federalAwardBCAGAmount).toBe(1000);
+    expect(calculatedAssessment.variables.provincialAwardNetBCAGAmount).toBe(
+      800,
+    );
   });
 
   it("Should determine federalAwardBCAGAmount when calculatedDataTotalFamilyIncome > limitAwardBCAGIncomeCap", async () => {
@@ -115,7 +118,7 @@ describe(`E2E Test Workflow parttime-assessment-${PROGRAM_YEAR}-awards-amount-BC
       ),
     );
     expect(calculatedAssessment.variables.provincialAwardNetBCAGAmount).toBe(
-      1000,
+      800,
     );
   });
 

--- a/sources/packages/backend/workflow/test/test-utils/factories/assessment-consolidated-data.ts
+++ b/sources/packages/backend/workflow/test/test-utils/factories/assessment-consolidated-data.ts
@@ -89,6 +89,7 @@ export function createFakePartTimeAssessmentConsolidatedData(
     studentDataCRAReportedIncome: 10001,
     partner1CRAReportedIncome: 15001,
     programYearTotalPartTimeCSGD: 200,
+    programYearTotalPartTimeBCAG: 200,
   };
 }
 /**

--- a/sources/packages/backend/workflow/test/test-utils/factories/assessment-consolidated-data.ts
+++ b/sources/packages/backend/workflow/test/test-utils/factories/assessment-consolidated-data.ts
@@ -89,7 +89,7 @@ export function createFakePartTimeAssessmentConsolidatedData(
     studentDataCRAReportedIncome: 10001,
     partner1CRAReportedIncome: 15001,
     programYearTotalPartTimeCSGD: 200,
-    programYearTotalPartTimeBCAG: 200,
+    programYearTotalPartTimeBCAG: 300,
   };
 }
 /**


### PR DESCRIPTION
Updated part time assessment bpmn's on the calculate BCAG Event to consider programYearTotalPartTimeBCAG

<img width="1127" alt="image" src="https://github.com/bcgov/SIMS/assets/62901416/5cfb521f-2f2a-416e-9c92-f8a8aaf3b99f">

e2e Test cases updated
parttime-assessment-2021-2022-awards-amount-BCAG.e2e-spec.ts
parttime-assessment-2022-2023-awards-amount-BCAG.e2e-spec.ts
parttime-assessment-2023-2024-awards-amount-BCAG.e2e-spec.ts

