### PR TITLE
#2685 - Import Provincial Restrictions from SFAS into SIMS [Bug Fix 2]

### DIFF
--- a/sources/packages/backend/libs/src-sql/sfas-restrictions/Bulk-insert-sfas-mapped-restrictions.sql
+++ b/sources/packages/backend/libs/src-sql/sfas-restrictions/Bulk-insert-sfas-mapped-restrictions.sql
@@ -11,7 +11,7 @@ INSERT INTO
 SELECT
   sfas_individuals.student_id,
   restrictions.id,
-  $ 1
+  $1
 FROM
   (
     -- select sfas_restrictions records with mapped restriction (from SFAS to SIMS) codes

--- a/sources/packages/backend/libs/src-sql/sfas-restrictions/Bulk-insert-sfas-mapped-restrictions.sql
+++ b/sources/packages/backend/libs/src-sql/sfas-restrictions/Bulk-insert-sfas-mapped-restrictions.sql
@@ -38,6 +38,22 @@ FROM
 WHERE
   sfas_individuals.student_id IS NOT NULL
   AND (
-    student_restrictions.is_active = false
-    OR student_restrictions.restriction_id IS NULL
+    student_restrictions.restriction_id IS NULL
+    OR (
+      -- if the restriction is found in the student_restrictions table
+      -- but is inactive, the below condition checks that there are no 
+      -- other entries of this same restriction for this particular student 
+      -- present in the student_restrictions table that are currently active.
+      student_restrictions.is_active = false
+      AND NOT EXISTS (
+        SELECT
+          1
+        FROM
+          sims.student_restrictions student_restrictions
+        WHERE
+          student_restrictions.student_id = sfas_individuals.student_id
+          AND student_restrictions.restriction_id = restrictions.id
+          AND student_restrictions.is_active = true
+      )
+    )
   );

--- a/sources/packages/backend/libs/src-sql/sfas-restrictions/Bulk-insert-sfas-mapped-restrictions.sql
+++ b/sources/packages/backend/libs/src-sql/sfas-restrictions/Bulk-insert-sfas-mapped-restrictions.sql
@@ -11,7 +11,7 @@ INSERT INTO
 SELECT
   sfas_individuals.student_id,
   restrictions.id,
-  $1
+  $ 1
 FROM
   (
     -- select sfas_restrictions records with mapped restriction (from SFAS to SIMS) codes
@@ -35,25 +35,7 @@ FROM
   INNER JOIN sims.restrictions restrictions ON mapped_restrictions.mapped_code = restrictions.restriction_code
   LEFT JOIN sims.student_restrictions student_restrictions ON student_restrictions.student_id = sfas_individuals.student_id
   AND student_restrictions.restriction_id = restrictions.id
+  AND student_restrictions.is_active = true
 WHERE
   sfas_individuals.student_id IS NOT NULL
-  AND (
-    student_restrictions.restriction_id IS NULL
-    OR (
-      -- if the restriction is found in the student_restrictions table
-      -- but is inactive, the below condition checks that there are no 
-      -- other entries of this same restriction for this particular student 
-      -- present in the student_restrictions table that are currently active.
-      student_restrictions.is_active = false
-      AND NOT EXISTS (
-        SELECT
-          1
-        FROM
-          sims.student_restrictions student_restrictions
-        WHERE
-          student_restrictions.student_id = sfas_individuals.student_id
-          AND student_restrictions.restriction_id = restrictions.id
-          AND student_restrictions.is_active = true
-      )
-    )
-  );
+  AND student_restrictions.restriction_id IS NULL;

--- a/sources/packages/web/src/components/common/students/StudentRestrictions.vue
+++ b/sources/packages/web/src/components/common/students/StudentRestrictions.vue
@@ -48,7 +48,7 @@
           <Column field="updatedAt" header="Resolved">
             <template #body="slotProps">{{
               conditionalEmptyStringFiller(
-                slotProps.data.isActive,
+                !slotProps.data.isActive,
                 dateOnlyLongString(slotProps.data.updatedAt),
               )
             }}</template></Column


### PR DESCRIPTION
### As a part of this PR, the following two bugs were fixed:
-----------------------------------------------------------------------
- **Bug:** The Resolved Column was not showing the date for Resolved restrictions and was instead showing a Date for the Active Restrictions.
  **Fix:** It has been fixed to show the resolved date for the Resolved restrictions and not show a date under the Resolved column for the currently active restrictions.
<img width="1918" alt="image" src="https://github.com/bcgov/SIMS/assets/7859295/cd74f2bd-f32b-4f91-8858-3d7d45062e93">

---------------------------------------------------------------------
- **Bug:** The `Bulk-insert-sfas-mapped-restrictions.sql` query was not checking for the scenario when a specific restriction for a student mapped from SFAS is inactive is SIMS and at the same time, the same restriction has entries as an active restriction. If this situation was there, the query was still allowing for this restriction to be inserted.

  **Fix:** This query was adjusted to make sure that if a restriction is found in the `student_restrictions` table that was mapped from the `sfas_restrictions` table but is inactive, then the query now checks that there are no other entries of this same restriction for this particular student that are present in the `student_restrictions` table that are currently active. If active restriction entries are found, then this restriction won't be inserted.
<img width="1080" alt="image" src="https://github.com/bcgov/SIMS/assets/7859295/f80c7720-a502-46eb-af86-5fad111e6aea">
