### PR TITLE
#2847 - Ensure Re-assessments Recognize Request a Change Assessments as the Relevant Baseline

### DIFF
--- a/sources/packages/backend/apps/api/src/route-controllers/application-offering-change-request/_tests_/e2e/application-offering-change-request.aest.controller.assessApplicationOfferingChangeRequest.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/application-offering-change-request/_tests_/e2e/application-offering-change-request.aest.controller.assessApplicationOfferingChangeRequest.e2e-spec.ts
@@ -9,7 +9,6 @@ import {
 import {
   E2EDataSources,
   createE2EDataSources,
-  createFakeEducationProgramOffering,
   createFakeStudentAppeal,
   saveFakeApplication,
   saveFakeApplicationOfferingRequestChange,
@@ -106,11 +105,7 @@ describe("ApplicationOfferingChangeRequestAESTController(e2e)-assessApplicationO
     const application = await saveFakeApplication(db.dataSource, undefined, {
       applicationStatus: ApplicationStatus.Completed,
     });
-    const user = application.student.user;
     const studentAppeal = createFakeStudentAppeal({ application });
-    const offering = await db.educationProgramOffering.save(
-      createFakeEducationProgramOffering({ auditUser: user }),
-    );
     const studentAssessment = application.currentAssessment;
     studentAssessment.studentAppeal = studentAppeal;
     application.currentAssessment = studentAssessment;
@@ -167,10 +162,6 @@ describe("ApplicationOfferingChangeRequestAESTController(e2e)-assessApplicationO
     expect(
       updatedApplicationOfferingChangeRequest.application.currentAssessment.id,
     ).not.toBe(studentAssessment.id);
-    expect(
-      updatedApplicationOfferingChangeRequest.application.currentAssessment
-        .offering.id,
-    ).not.toBe(offering.id);
     expect(
       updatedApplicationOfferingChangeRequest.application.currentAssessment
         .studentAppeal.id,

--- a/sources/packages/backend/apps/api/src/route-controllers/application-offering-change-request/_tests_/e2e/application-offering-change-request.aest.controller.assessApplicationOfferingChangeRequest.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/application-offering-change-request/_tests_/e2e/application-offering-change-request.aest.controller.assessApplicationOfferingChangeRequest.e2e-spec.ts
@@ -11,7 +11,6 @@ import {
   createE2EDataSources,
   createFakeEducationProgramOffering,
   createFakeStudentAppeal,
-  createFakeStudentAssessment,
   saveFakeApplication,
   saveFakeApplicationOfferingRequestChange,
 } from "@sims/test-utils";
@@ -112,12 +111,8 @@ describe("ApplicationOfferingChangeRequestAESTController(e2e)-assessApplicationO
     const offering = await db.educationProgramOffering.save(
       createFakeEducationProgramOffering({ auditUser: user }),
     );
-    const studentAssessment = createFakeStudentAssessment({
-      auditUser: user,
-      application,
-      offering,
-      studentAppeal,
-    });
+    const studentAssessment = application.currentAssessment;
+    studentAssessment.studentAppeal = studentAppeal;
     application.currentAssessment = studentAssessment;
     await db.application.save(application);
     const applicationOfferingChangeRequest =

--- a/sources/packages/backend/apps/api/src/route-controllers/education-program-offering/_tests_/e2e/education-program-offering.aest.controller.assessOfferingChangeRequest.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/education-program-offering/_tests_/e2e/education-program-offering.aest.controller.assessOfferingChangeRequest.e2e-spec.ts
@@ -1,0 +1,311 @@
+import { HttpStatus, INestApplication } from "@nestjs/common";
+import * as request from "supertest";
+import {
+  AESTGroups,
+  BEARER_AUTH_TYPE,
+  InstitutionTokenTypes,
+  authorizeUserTokenForLocation,
+  createTestingAppModule,
+  getAESTToken,
+  getAuthRelatedEntities,
+} from "../../../../testHelpers";
+import {
+  E2EDataSources,
+  createE2EDataSources,
+  createFakeEducationProgramOffering,
+  createFakeInstitutionLocation,
+  createFakeStudentAppeal,
+  createFakeUser,
+  saveFakeApplication,
+} from "@sims/test-utils";
+import {
+  ApplicationStatus,
+  AssessmentTriggerType,
+  EducationProgramOffering,
+  InstitutionLocation,
+  OfferingStatus,
+  User,
+} from "@sims/sims-db";
+import { OfferingChangeAssessmentAPIInDTO } from "apps/api/src/route-controllers/education-program-offering/models/education-program-offering.dto";
+
+describe("EducationProgramOfferingAESTController(e2e)-assessOfferingChangeRequest", () => {
+  let app: INestApplication;
+  let db: E2EDataSources;
+  let collegeFLocation: InstitutionLocation;
+  let savedUser: User;
+  let precedingOffering: EducationProgramOffering;
+  let requestedOffering: EducationProgramOffering;
+
+  beforeAll(async () => {
+    const { nestApplication, dataSource } = await createTestingAppModule();
+    app = nestApplication;
+    db = createE2EDataSources(dataSource);
+    const { institution: collegeF } = await getAuthRelatedEntities(
+      db.dataSource,
+      InstitutionTokenTypes.CollegeFUser,
+    );
+    collegeFLocation = createFakeInstitutionLocation({ institution: collegeF });
+    await authorizeUserTokenForLocation(
+      db.dataSource,
+      InstitutionTokenTypes.CollegeFUser,
+      collegeFLocation,
+    );
+    savedUser = await db.user.save(createFakeUser());
+  });
+
+  beforeEach(async () => {
+    precedingOffering = createFakeEducationProgramOffering({
+      auditUser: savedUser,
+    });
+    precedingOffering.offeringStatus = OfferingStatus.ChangeAwaitingApproval;
+    await db.educationProgramOffering.save(precedingOffering);
+    requestedOffering = createFakeEducationProgramOffering({
+      auditUser: savedUser,
+    });
+    requestedOffering.offeringStatus = OfferingStatus.ChangeAwaitingApproval;
+    requestedOffering.precedingOffering = precedingOffering;
+    await db.educationProgramOffering.save(requestedOffering);
+  });
+
+  it("Should throw unprocessable entity exception error when the offering is not found.", async () => {
+    // Arrange
+    const payload: OfferingChangeAssessmentAPIInDTO = {
+      offeringStatus: OfferingStatus.Approved,
+      assessmentNotes: "notes",
+    };
+    // Ministry token.
+    const token = await getAESTToken(AESTGroups.BusinessAdministrators);
+
+    const endpoint = `/aest/education-program-offering/000/assess-change-request`;
+
+    // Act/Assert
+    await request(app.getHttpServer())
+      .patch(endpoint)
+      .send(payload)
+      .auth(token, BEARER_AUTH_TYPE)
+      .expect(HttpStatus.UNPROCESSABLE_ENTITY)
+      .expect({
+        statusCode: HttpStatus.UNPROCESSABLE_ENTITY,
+        message:
+          "Either offering not found or the offering not in appropriate status to be approved or declined for change.",
+        error: "Unprocessable Entity",
+      });
+  });
+
+  it("Should throw unprocessable entity exception error when the offering does not have a preceding offering.", async () => {
+    // Arrange
+    const offeringNoPrecedingOffering = createFakeEducationProgramOffering({
+      auditUser: savedUser,
+    });
+    offeringNoPrecedingOffering.offeringStatus =
+      OfferingStatus.ChangeAwaitingApproval;
+    await db.educationProgramOffering.save(offeringNoPrecedingOffering);
+    const payload: OfferingChangeAssessmentAPIInDTO = {
+      offeringStatus: OfferingStatus.Approved,
+      assessmentNotes: "notes",
+    };
+    // Ministry token.
+    const token = await getAESTToken(AESTGroups.BusinessAdministrators);
+
+    const endpoint = `/aest/education-program-offering/${offeringNoPrecedingOffering.id}/assess-change-request`;
+
+    // Act/Assert
+    await request(app.getHttpServer())
+      .patch(endpoint)
+      .send(payload)
+      .auth(token, BEARER_AUTH_TYPE)
+      .expect(HttpStatus.UNPROCESSABLE_ENTITY)
+      .expect({
+        statusCode: HttpStatus.UNPROCESSABLE_ENTITY,
+        message:
+          "The offering requested for change does not have a preceding offering.",
+        error: "Unprocessable Entity",
+      });
+  });
+
+  it("Should determine both of preceding and requested offerings when the offering change is declined.", async () => {
+    // Arrange
+    const payload: OfferingChangeAssessmentAPIInDTO = {
+      offeringStatus: OfferingStatus.ChangeDeclined,
+      assessmentNotes: "offering change declined",
+    };
+    // Ministry token.
+    const token = await getAESTToken(AESTGroups.BusinessAdministrators);
+
+    const endpoint = `/aest/education-program-offering/${requestedOffering.id}/assess-change-request`;
+
+    // Act/Assert
+    await request(app.getHttpServer())
+      .patch(endpoint)
+      .send(payload)
+      .auth(token, BEARER_AUTH_TYPE)
+      .expect(HttpStatus.OK);
+
+    const queryPrecedingOffering = await db.educationProgramOffering.findOne({
+      select: {
+        id: true,
+        offeringStatus: true,
+      },
+      where: { id: precedingOffering.id },
+    });
+    const queryRequestedOffering = await db.educationProgramOffering.findOne({
+      select: {
+        id: true,
+        offeringStatus: true,
+        offeringNote: { id: true, description: true },
+      },
+      relations: { offeringNote: true },
+      where: { id: requestedOffering.id },
+    });
+    expect(queryPrecedingOffering.offeringStatus).toBe(OfferingStatus.Approved);
+    expect(queryRequestedOffering.offeringStatus).toBe(
+      OfferingStatus.ChangeDeclined,
+    );
+    expect(queryRequestedOffering.offeringNote.description).toBe(
+      "offering change declined",
+    );
+  });
+
+  it(
+    "Should determine both of preceding and requested offerings when the offering change is approved " +
+      "and there is no applications associated with the requested offering.",
+    async () => {
+      // Arrange
+      const payload: OfferingChangeAssessmentAPIInDTO = {
+        offeringStatus: OfferingStatus.Approved,
+        assessmentNotes: "offering change approved",
+      };
+      // Ministry token.
+      const token = await getAESTToken(AESTGroups.BusinessAdministrators);
+
+      const endpoint = `/aest/education-program-offering/${requestedOffering.id}/assess-change-request`;
+
+      // Act/Assert
+      await request(app.getHttpServer())
+        .patch(endpoint)
+        .send(payload)
+        .auth(token, BEARER_AUTH_TYPE)
+        .expect(HttpStatus.OK);
+
+      const queryPrecedingOffering = await db.educationProgramOffering.findOne({
+        select: {
+          id: true,
+          offeringStatus: true,
+        },
+        where: { id: precedingOffering.id },
+      });
+      const queryRequestedOffering = await db.educationProgramOffering.findOne({
+        select: {
+          id: true,
+          offeringStatus: true,
+          offeringNote: { id: true, description: true },
+        },
+        relations: { offeringNote: true },
+        where: { id: requestedOffering.id },
+      });
+      expect(queryPrecedingOffering.offeringStatus).toBe(
+        OfferingStatus.ChangeOverwritten,
+      );
+      expect(queryRequestedOffering.offeringStatus).toBe(
+        OfferingStatus.Approved,
+      );
+      expect(queryRequestedOffering.offeringNote.description).toBe(
+        "offering change approved",
+      );
+      const queryApplications = await db.application.find({
+        select: {
+          id: true,
+          currentAssessment: {
+            triggerType: true,
+            offering: { id: true },
+          },
+        },
+        relations: {
+          currentAssessment: { offering: true },
+        },
+        where: {
+          currentAssessment: {
+            offering: { id: requestedOffering.id },
+          },
+        },
+      });
+      expect(queryApplications.length).toBe(0);
+    },
+  );
+
+  it(
+    "Should determine applications for a requested offering when the offering change is approved" +
+      "and there are applications associated with the requested offering.",
+    async () => {
+      // Arrange
+      for (let i = 0; i < 2; i++) {
+        const application = await saveFakeApplication(
+          db.dataSource,
+          {
+            institution: collegeFLocation.institution,
+            institutionLocation: collegeFLocation,
+          },
+          {
+            applicationStatus: ApplicationStatus.Completed,
+          },
+        );
+        // Create a student appeal for the application and its student assessment.
+        const studentAppeal = createFakeStudentAppeal({
+          application: application,
+          studentAssessment: application.currentAssessment,
+        });
+        application.currentAssessment.studentAppeal = studentAppeal;
+        application.currentAssessment.offering = precedingOffering;
+        await db.application.save(application);
+      }
+
+      const payload: OfferingChangeAssessmentAPIInDTO = {
+        offeringStatus: OfferingStatus.Approved,
+        assessmentNotes: "offering change approved",
+      };
+      // Ministry token.
+      const token = await getAESTToken(AESTGroups.BusinessAdministrators);
+
+      const endpoint = `/aest/education-program-offering/${requestedOffering.id}/assess-change-request`;
+
+      // Act/Assert
+      await request(app.getHttpServer())
+        .patch(endpoint)
+        .send(payload)
+        .auth(token, BEARER_AUTH_TYPE)
+        .expect(HttpStatus.OK);
+
+      const queryApplications = await db.application.find({
+        select: {
+          id: true,
+          currentAssessment: {
+            triggerType: true,
+            offering: { id: true },
+            studentAppeal: { id: true },
+          },
+        },
+        relations: {
+          currentAssessment: { offering: true, studentAppeal: true },
+        },
+        where: {
+          currentAssessment: {
+            offering: { id: requestedOffering.id },
+          },
+        },
+      });
+      expect(queryApplications.length).toBe(2);
+      queryApplications.forEach((queryApplication) => {
+        expect(queryApplication.currentAssessment.triggerType).toBe(
+          AssessmentTriggerType.OfferingChange,
+        );
+        expect(
+          queryApplication.currentAssessment.studentAppeal.id,
+        ).toBeGreaterThan(0);
+      });
+    },
+  );
+
+  afterAll(async () => {
+    await app?.close();
+  });
+});

--- a/sources/packages/backend/apps/api/src/route-controllers/student-scholastic-standings/_tests_/e2e/student-scholastic-standings.institutions.controller.saveScholasticStanding.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/student-scholastic-standings/_tests_/e2e/student-scholastic-standings.institutions.controller.saveScholasticStanding.e2e-spec.ts
@@ -85,12 +85,7 @@ describe("StudentScholasticStandingsInstitutionsController(e2e)-saveScholasticSt
           StudentScholasticStandingChangeType.ChangeInIntensity,
       },
     };
-    const dryRunSubmissionMock = jest.fn().mockResolvedValue({
-      valid: false,
-      formName: FormNames.ReportScholasticStandingChange,
-      data: { data: invalidPayload.data },
-    });
-    formService.dryRunSubmission = dryRunSubmissionMock;
+    mockFormioDryRun({ validDryRun: false, payload: invalidPayload });
     // Institution token.
     const institutionUserToken = await getInstitutionToken(
       InstitutionTokenTypes.CollegeFUser,
@@ -259,10 +254,14 @@ describe("StudentScholasticStandingsInstitutionsController(e2e)-saveScholasticSt
    * Centralized method to handle the form.io mock
    * @param options method options:
    * - `validDryRun`: boolean false indicates that the form mock resolved value is invalid. Default value is true.
+   * - `payload`: payload to be sent to the form to check for validation
    */
-  function mockFormioDryRun(options?: { validDryRun?: boolean }): void {
+  function mockFormioDryRun(options?: {
+    validDryRun?: boolean;
+    payload?: ScholasticStandingAPIInDTO;
+  }): void {
     const validDryRun = options?.validDryRun ?? true;
-    payload = {
+    payload = options?.payload ?? {
       data: {
         booksAndSupplies: 1000,
         dateOfChange: getISODateOnlyString(new Date()),

--- a/sources/packages/backend/apps/api/src/route-controllers/student-scholastic-standings/_tests_/e2e/student-scholastic-standings.institutions.controller.saveScholasticStanding.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/student-scholastic-standings/_tests_/e2e/student-scholastic-standings.institutions.controller.saveScholasticStanding.e2e-spec.ts
@@ -255,6 +255,11 @@ describe("StudentScholasticStandingsInstitutionsController(e2e)-saveScholasticSt
     ).toBe(createdScholasticStandingId);
   });
 
+  /**
+   * Centralized method to handle the form.io mock
+   * @param options method options:
+   * - `validDryRun`: boolean false indicates that the form mock resolved value is invalid. Default value is true.
+   */
   function mockFormioDryRun(options?: { validDryRun?: boolean }): void {
     const validDryRun = options?.validDryRun ?? true;
     payload = {

--- a/sources/packages/backend/apps/api/src/route-controllers/student-scholastic-standings/_tests_/e2e/student-scholastic-standings.institutions.controller.saveScholasticStanding.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/student-scholastic-standings/_tests_/e2e/student-scholastic-standings.institutions.controller.saveScholasticStanding.e2e-spec.ts
@@ -251,10 +251,10 @@ describe("StudentScholasticStandingsInstitutionsController(e2e)-saveScholasticSt
   });
 
   /**
-   * Centralized method to handle the form.io mock
+   * Centralized method to handle the form.io mock.
    * @param options method options:
    * - `validDryRun`: boolean false indicates that the form mock resolved value is invalid. Default value is true.
-   * - `payload`: payload to be sent to the form to check for validation
+   * - `payload`: payload to be sent to the form to check for validation.
    */
   function mockFormioDryRun(options?: {
     validDryRun?: boolean;

--- a/sources/packages/backend/apps/api/src/route-controllers/student-scholastic-standings/_tests_/e2e/student-scholastic-standings.institutions.controller.saveScholasticStanding.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/student-scholastic-standings/_tests_/e2e/student-scholastic-standings.institutions.controller.saveScholasticStanding.e2e-spec.ts
@@ -1,0 +1,321 @@
+import { HttpStatus, INestApplication } from "@nestjs/common";
+import {
+  E2EDataSources,
+  createE2EDataSources,
+  createFakeInstitutionLocation,
+  createFakeStudentAppeal,
+  getProviderInstanceForModule,
+  saveFakeApplicationDisbursements,
+} from "@sims/test-utils";
+import {
+  BEARER_AUTH_TYPE,
+  InstitutionTokenTypes,
+  authorizeUserTokenForLocation,
+  createTestingAppModule,
+  getAuthRelatedEntities,
+  getInstitutionToken,
+} from "../../../../testHelpers";
+import * as request from "supertest";
+import {
+  ApplicationStatus,
+  AssessmentTriggerType,
+  InstitutionLocation,
+  StudentAssessmentStatus,
+  StudentScholasticStandingChangeType,
+} from "@sims/sims-db";
+import {
+  APPLICATION_NOT_FOUND,
+  FormNames,
+  FormService,
+  INVALID_OPERATION_IN_THE_CURRENT_STATUS,
+} from "../../../../services";
+import { APPLICATION_CHANGE_NOT_ELIGIBLE } from "../../../../constants";
+import { ScholasticStandingAPIInDTO } from "../../models/student-scholastic-standings.dto";
+import { addDays, getISODateOnlyString } from "@sims/utilities";
+import { AppInstitutionsModule } from "../../../../app.institutions.module";
+import { TestingModule } from "@nestjs/testing";
+
+describe("StudentScholasticStandingsInstitutionsController(e2e)-saveScholasticStanding.", () => {
+  let app: INestApplication;
+  let appModule: TestingModule;
+  let db: E2EDataSources;
+  let collegeFLocation: InstitutionLocation;
+  let institutionUserToken: string;
+  const SCHOLASTIC_STANDING_FORM_NAME =
+    FormNames.ReportScholasticStandingChange;
+
+  beforeAll(async () => {
+    const { nestApplication, module, dataSource } =
+      await createTestingAppModule();
+    app = nestApplication;
+    appModule = module;
+    db = createE2EDataSources(dataSource);
+    // College F.
+    const { institution: collegeF } = await getAuthRelatedEntities(
+      db.dataSource,
+      InstitutionTokenTypes.CollegeFUser,
+    );
+    collegeFLocation = createFakeInstitutionLocation({ institution: collegeF });
+    await authorizeUserTokenForLocation(
+      db.dataSource,
+      InstitutionTokenTypes.CollegeFUser,
+      collegeFLocation,
+    );
+    // Institution token.
+    institutionUserToken = await getInstitutionToken(
+      InstitutionTokenTypes.CollegeFUser,
+    );
+  });
+
+  it("Should throw bad request exception error when the payload is invalid for formIO dryRun test.", async () => {
+    // Arrange
+    const application = await saveFakeApplicationDisbursements(db.dataSource, {
+      institutionLocation: collegeFLocation,
+    });
+    const payload = {
+      data: {
+        booksAndSupplies: 1000,
+        scholasticStandingChangeType:
+          StudentScholasticStandingChangeType.ChangeInIntensity,
+      },
+    };
+    // Mock the form service to validate the dry-run submission result.
+    // TODO: Form service must be hosted for E2E tests to validate dry run submission
+    // and this mock must be removed.
+    const formService = await getProviderInstanceForModule(
+      appModule,
+      AppInstitutionsModule,
+      FormService,
+    );
+    const dryRunSubmissionMock = jest.fn().mockResolvedValue({
+      valid: false,
+      formName: SCHOLASTIC_STANDING_FORM_NAME,
+      data: { data: payload.data },
+    });
+    formService.dryRunSubmission = dryRunSubmissionMock;
+
+    const endpoint = `/institutions/scholastic-standing/location/${collegeFLocation.id}/application/${application.id}`;
+
+    // Act/Assert
+    await request(app.getHttpServer())
+      .post(endpoint)
+      .send(payload)
+      .auth(institutionUserToken, BEARER_AUTH_TYPE)
+      .expect(HttpStatus.BAD_REQUEST)
+      .expect({
+        statusCode: HttpStatus.BAD_REQUEST,
+        message: "Invalid submission.",
+        error: "Bad Request",
+      });
+  });
+
+  it("Should throw unprocessable entity exception error when the application is not found.", async () => {
+    // Arrange
+    const payload: ScholasticStandingAPIInDTO = {
+      data: {
+        booksAndSupplies: 1000,
+        dateOfChange: getISODateOnlyString(new Date()),
+        scholasticStandingChangeType:
+          StudentScholasticStandingChangeType.ChangeInIntensity,
+      },
+    };
+    // Mock the form service to validate the dry-run submission result.
+    // TODO: Form service must be hosted for E2E tests to validate dry run submission
+    // and this mock must be removed.
+    const formService = await getProviderInstanceForModule(
+      appModule,
+      AppInstitutionsModule,
+      FormService,
+    );
+    const dryRunSubmissionMock = jest.fn().mockResolvedValue({
+      valid: true,
+      formName: SCHOLASTIC_STANDING_FORM_NAME,
+      data: { data: payload.data },
+    });
+    formService.dryRunSubmission = dryRunSubmissionMock;
+    const endpoint = `/institutions/scholastic-standing/location/${collegeFLocation.id}/application/0000`;
+
+    // Act/Assert
+    await request(app.getHttpServer())
+      .post(endpoint)
+      .send(payload)
+      .auth(institutionUserToken, BEARER_AUTH_TYPE)
+      .expect(HttpStatus.UNPROCESSABLE_ENTITY)
+      .expect({
+        message:
+          "Application Not found or invalid current assessment or offering.",
+        errorType: APPLICATION_NOT_FOUND,
+      });
+  });
+
+  it("Should throw unprocessable entity exception error when the application is not found.", async () => {
+    // Arrange
+    const application = await saveFakeApplicationDisbursements(db.dataSource, {
+      institutionLocation: collegeFLocation,
+    });
+    application.isArchived = true;
+    await db.application.save(application);
+    const payload: ScholasticStandingAPIInDTO = {
+      data: {
+        booksAndSupplies: 1000,
+        dateOfChange: getISODateOnlyString(new Date()),
+        scholasticStandingChangeType:
+          StudentScholasticStandingChangeType.ChangeInIntensity,
+      },
+    };
+    // Mock the form service to validate the dry-run submission result.
+    // TODO: Form service must be hosted for E2E tests to validate dry run submission
+    // and this mock must be removed.
+    const formService = await getProviderInstanceForModule(
+      appModule,
+      AppInstitutionsModule,
+      FormService,
+    );
+    const dryRunSubmissionMock = jest.fn().mockResolvedValue({
+      valid: true,
+      formName: SCHOLASTIC_STANDING_FORM_NAME,
+      data: { data: payload.data },
+    });
+    formService.dryRunSubmission = dryRunSubmissionMock;
+    const endpoint = `/institutions/scholastic-standing/location/${collegeFLocation.id}/application/${application.id}`;
+
+    // Act/Assert
+    await request(app.getHttpServer())
+      .post(endpoint)
+      .send(payload)
+      .auth(institutionUserToken, BEARER_AUTH_TYPE)
+      .expect(HttpStatus.UNPROCESSABLE_ENTITY)
+      .expect({
+        message: "This application is no longer eligible to request changes.",
+        errorType: APPLICATION_CHANGE_NOT_ELIGIBLE,
+      });
+  });
+
+  it("Should throw unprocessable entity exception error when the application status is not complete.", async () => {
+    // Arrange
+    const application = await saveFakeApplicationDisbursements(db.dataSource, {
+      institutionLocation: collegeFLocation,
+    });
+    application.applicationStatus = ApplicationStatus.InProgress;
+    await db.application.save(application);
+    const payload: ScholasticStandingAPIInDTO = {
+      data: {
+        booksAndSupplies: 1000,
+        dateOfChange: getISODateOnlyString(new Date()),
+        scholasticStandingChangeType:
+          StudentScholasticStandingChangeType.ChangeInIntensity,
+      },
+    };
+    // Mock the form service to validate the dry-run submission result.
+    // TODO: Form service must be hosted for E2E tests to validate dry run submission
+    // and this mock must be removed.
+    const formService = await getProviderInstanceForModule(
+      appModule,
+      AppInstitutionsModule,
+      FormService,
+    );
+    const dryRunSubmissionMock = jest.fn().mockResolvedValue({
+      valid: true,
+      formName: SCHOLASTIC_STANDING_FORM_NAME,
+      data: { data: payload.data },
+    });
+    formService.dryRunSubmission = dryRunSubmissionMock;
+    const endpoint = `/institutions/scholastic-standing/location/${collegeFLocation.id}/application/${application.id}`;
+
+    // Act/Assert
+    await request(app.getHttpServer())
+      .post(endpoint)
+      .send(payload)
+      .auth(institutionUserToken, BEARER_AUTH_TYPE)
+      .expect(HttpStatus.UNPROCESSABLE_ENTITY)
+      .expect({
+        message:
+          "Cannot report a change for application with status other than completed.",
+        errorType: INVALID_OPERATION_IN_THE_CURRENT_STATUS,
+      });
+  });
+
+  it("Should create a new scholastic standing when the institution user requests it.", async () => {
+    // Arrange
+    const application = await saveFakeApplicationDisbursements(
+      db.dataSource,
+      {
+        institutionLocation: collegeFLocation,
+      },
+      {
+        applicationStatus: ApplicationStatus.Completed,
+        currentAssessmentInitialValues: {
+          assessmentWorkflowId: "some fake id",
+          assessmentDate: addDays(1),
+          studentAssessmentStatus: StudentAssessmentStatus.Completed,
+        },
+      },
+    );
+    // Createa student appeal for the application and its student assessment
+    const studentAppeal = await createFakeStudentAppeal({
+      application: application,
+      studentAssessment: application.currentAssessment,
+    });
+    application.currentAssessment.studentAppeal = studentAppeal;
+    await db.application.save(application);
+    const payload: ScholasticStandingAPIInDTO = {
+      data: {
+        booksAndSupplies: 1000,
+        dateOfChange: getISODateOnlyString(new Date()),
+        scholasticStandingChangeType:
+          StudentScholasticStandingChangeType.ChangeInIntensity,
+      },
+    };
+    // Mock the form service to validate the dry-run submission result.
+    // TODO: Form service must be hosted for E2E tests to validate dry run submission
+    // and this mock must be removed.
+    const formService = await getProviderInstanceForModule(
+      appModule,
+      AppInstitutionsModule,
+      FormService,
+    );
+    const dryRunSubmissionMock = jest.fn().mockResolvedValue({
+      valid: true,
+      formName: SCHOLASTIC_STANDING_FORM_NAME,
+      data: { data: payload.data },
+    });
+    formService.dryRunSubmission = dryRunSubmissionMock;
+    const endpoint = `/institutions/scholastic-standing/location/${collegeFLocation.id}/application/${application.id}`;
+
+    // Act/Assert
+    let createdScholasticStanding: number;
+    await request(app.getHttpServer())
+      .post(endpoint)
+      .send(payload)
+      .auth(institutionUserToken, BEARER_AUTH_TYPE)
+      .expect(HttpStatus.CREATED)
+      .expect((response) => {
+        console.log("response.body: ", response.body);
+        expect(response.body.id).toBeGreaterThan(0);
+        createdScholasticStanding = +response.body.id;
+      });
+    const newScholasticStanding = await db.studentScholasticStanding.findOne({
+      select: {
+        id: true,
+        application: { id: true },
+        studentAssessment: {
+          id: true,
+          triggerType: true,
+          studentAppeal: { id: true },
+        },
+      },
+      relations: {
+        application: true,
+        studentAssessment: { studentAppeal: true },
+      },
+      where: { id: createdScholasticStanding },
+    });
+    expect(newScholasticStanding.application.id).toBe(application.id);
+    expect(newScholasticStanding.studentAssessment.triggerType).toBe(
+      AssessmentTriggerType.ScholasticStandingChange,
+    );
+    expect(newScholasticStanding.studentAssessment.studentAppeal.id).toBe(
+      studentAppeal.id,
+    );
+  });
+});

--- a/sources/packages/backend/apps/api/src/route-controllers/student-scholastic-standings/_tests_/e2e/student-scholastic-standings.institutions.controller.saveScholasticStanding.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/student-scholastic-standings/_tests_/e2e/student-scholastic-standings.institutions.controller.saveScholasticStanding.e2e-spec.ts
@@ -70,20 +70,7 @@ describe("StudentScholasticStandingsInstitutionsController(e2e)-saveScholasticSt
   });
 
   beforeEach(async () => {
-    payload = {
-      data: {
-        booksAndSupplies: 1000,
-        dateOfChange: getISODateOnlyString(new Date()),
-        scholasticStandingChangeType:
-          StudentScholasticStandingChangeType.ChangeInIntensity,
-      },
-    };
-    const dryRunSubmissionMock = jest.fn().mockResolvedValue({
-      valid: true,
-      formName: FormNames.ReportScholasticStandingChange,
-      data: { data: payload.data },
-    });
-    formService.dryRunSubmission = dryRunSubmissionMock;
+    mockFormioDryRun();
   });
 
   it("Should throw bad request exception error when the payload is invalid for formIO dryRun test.", async () => {
@@ -267,4 +254,21 @@ describe("StudentScholasticStandingsInstitutionsController(e2e)-saveScholasticSt
       queryApplication.currentAssessment.studentScholasticStanding.id,
     ).toBe(createdScholasticStandingId);
   });
+
+  function mockFormioDryRun(options?: { validDryRun?: boolean }): void {
+    const validDryRun = options?.validDryRun ?? true;
+    payload = {
+      data: {
+        booksAndSupplies: 1000,
+        dateOfChange: getISODateOnlyString(new Date()),
+        scholasticStandingChangeType:
+          StudentScholasticStandingChangeType.ChangeInIntensity,
+      },
+    };
+    formService.dryRunSubmission = jest.fn().mockResolvedValue({
+      valid: validDryRun,
+      formName: FormNames.ReportScholasticStandingChange,
+      data: { data: payload.data },
+    });
+  }
 });

--- a/sources/packages/backend/apps/api/src/route-controllers/student-scholastic-standings/_tests_/e2e/student-scholastic-standings.institutions.controller.saveScholasticStanding.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/student-scholastic-standings/_tests_/e2e/student-scholastic-standings.institutions.controller.saveScholasticStanding.e2e-spec.ts
@@ -85,7 +85,7 @@ describe("StudentScholasticStandingsInstitutionsController(e2e)-saveScholasticSt
           StudentScholasticStandingChangeType.ChangeInIntensity,
       },
     };
-    mockFormioDryRun({ validDryRun: false, payload: invalidPayload });
+    mockFormioDryRun({ validDryRun: false });
     // Institution token.
     const institutionUserToken = await getInstitutionToken(
       InstitutionTokenTypes.CollegeFUser,
@@ -254,14 +254,10 @@ describe("StudentScholasticStandingsInstitutionsController(e2e)-saveScholasticSt
    * Centralized method to handle the form.io mock.
    * @param options method options:
    * - `validDryRun`: boolean false indicates that the form mock resolved value is invalid. Default value is true.
-   * - `payload`: payload to be sent to the form to check for validation.
    */
-  function mockFormioDryRun(options?: {
-    validDryRun?: boolean;
-    payload?: ScholasticStandingAPIInDTO;
-  }): void {
+  function mockFormioDryRun(options?: { validDryRun?: boolean }): void {
     const validDryRun = options?.validDryRun ?? true;
-    payload = options?.payload ?? {
+    payload = {
       data: {
         booksAndSupplies: 1000,
         dateOfChange: getISODateOnlyString(new Date()),

--- a/sources/packages/backend/apps/api/src/route-controllers/student-scholastic-standings/student-scholastic-standings.institutions.controller.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/student-scholastic-standings/student-scholastic-standings.institutions.controller.ts
@@ -103,7 +103,7 @@ export class ScholasticStandingInstitutionsController extends BaseController {
     @Param("applicationId", ParseIntPipe) applicationId: number,
     @Body() payload: ScholasticStandingAPIInDTO,
     @UserToken() userToken: IInstitutionUserToken,
-  ): Promise<void> {
+  ): Promise<PrimaryIdentifierAPIOutDTO> {
     try {
       const submissionResult =
         await this.formService.dryRunSubmission<ScholasticStanding>(
@@ -114,12 +114,14 @@ export class ScholasticStandingInstitutionsController extends BaseController {
       if (!submissionResult.valid) {
         throw new BadRequestException("Invalid submission.");
       }
-      await this.studentScholasticStandingsService.processScholasticStanding(
-        locationId,
-        applicationId,
-        userToken.userId,
-        submissionResult.data.data,
-      );
+      const newStudentScholasticStanding =
+        await this.studentScholasticStandingsService.processScholasticStanding(
+          locationId,
+          applicationId,
+          userToken.userId,
+          submissionResult.data.data,
+        );
+      return { id: newStudentScholasticStanding.id };
     } catch (error: unknown) {
       if (error instanceof CustomNamedError) {
         switch (error.name) {

--- a/sources/packages/backend/apps/api/src/services/application-offering-change-request/application-offering-change-request.service.ts
+++ b/sources/packages/backend/apps/api/src/services/application-offering-change-request/application-offering-change-request.service.ts
@@ -609,12 +609,9 @@ export class ApplicationOfferingChangeRequestService {
         } as StudentAssessment;
         // Update the student appeal record for the student assessment if it exists.
         if (studentAssessment.studentAppeal) {
-          application.currentAssessment = {
-            ...application.currentAssessment,
-            studentAppeal: {
-              id: studentAssessment.studentAppeal.id,
-            } as StudentAppeal,
-          } as StudentAssessment;
+          application.currentAssessment.studentAppeal = {
+            id: studentAssessment.studentAppeal.id,
+          } as StudentAppeal;
         }
       }
       await transactionalEntityManager

--- a/sources/packages/backend/apps/api/src/services/application-offering-change-request/application-offering-change-request.service.ts
+++ b/sources/packages/backend/apps/api/src/services/application-offering-change-request/application-offering-change-request.service.ts
@@ -306,7 +306,7 @@ export class ApplicationOfferingChangeRequestService {
               email: true,
             },
           },
-          currentAssessment: { studentAppeal: { id: true } },
+          currentAssessment: { id: true, studentAppeal: { id: true } },
         },
         assessedNote: {
           id: true,
@@ -594,6 +594,8 @@ export class ApplicationOfferingChangeRequestService {
         applicationOfferingChangeRequestStatus ===
         ApplicationOfferingChangeRequestStatus.Approved
       ) {
+        // Access the student assessment if it exists.
+        const studentAssessment = application.currentAssessment;
         // Create a new assessment if the application offering change request status is approved.
         application.currentAssessment = {
           application,
@@ -604,10 +606,16 @@ export class ApplicationOfferingChangeRequestService {
           createdAt: currentDate,
           submittedBy: auditUser,
           submittedDate: currentDate,
-          studentAppeal: {
-            id: application.currentAssessment.studentAppeal?.id,
-          } as StudentAppeal,
         } as StudentAssessment;
+        // Update the student appeal record for the student assessment if it exists.
+        if (studentAssessment?.studentAppeal) {
+          application.currentAssessment = {
+            ...application.currentAssessment,
+            studentAppeal: {
+              id: studentAssessment.studentAppeal.id,
+            } as StudentAppeal,
+          } as StudentAssessment;
+        }
       }
       await transactionalEntityManager
         .getRepository(ApplicationOfferingChangeRequest)

--- a/sources/packages/backend/apps/api/src/services/application-offering-change-request/application-offering-change-request.service.ts
+++ b/sources/packages/backend/apps/api/src/services/application-offering-change-request/application-offering-change-request.service.ts
@@ -13,6 +13,7 @@ import {
   NoteType,
   AssessmentTriggerType,
   StudentAssessment,
+  StudentAppeal,
 } from "@sims/sims-db";
 import { DataSource, Brackets, Repository, In } from "typeorm";
 import { PaginatedResults, PaginationOptions } from "../../utilities";
@@ -305,6 +306,7 @@ export class ApplicationOfferingChangeRequestService {
               email: true,
             },
           },
+          currentAssessment: { studentAppeal: { id: true } },
         },
         assessedNote: {
           id: true,
@@ -317,6 +319,7 @@ export class ApplicationOfferingChangeRequestService {
           student: {
             user: true,
           },
+          currentAssessment: { studentAppeal: true },
         },
         activeOffering: true,
         requestedOffering: {
@@ -601,6 +604,9 @@ export class ApplicationOfferingChangeRequestService {
           createdAt: currentDate,
           submittedBy: auditUser,
           submittedDate: currentDate,
+          studentAppeal: {
+            id: application.currentAssessment.studentAppeal?.id,
+          } as StudentAppeal,
         } as StudentAssessment;
       }
       await transactionalEntityManager

--- a/sources/packages/backend/apps/api/src/services/application-offering-change-request/application-offering-change-request.service.ts
+++ b/sources/packages/backend/apps/api/src/services/application-offering-change-request/application-offering-change-request.service.ts
@@ -608,7 +608,7 @@ export class ApplicationOfferingChangeRequestService {
           submittedDate: currentDate,
         } as StudentAssessment;
         // Update the student appeal record for the student assessment if it exists.
-        if (studentAssessment?.studentAppeal) {
+        if (studentAssessment.studentAppeal) {
           application.currentAssessment = {
             ...application.currentAssessment,
             studentAppeal: {

--- a/sources/packages/backend/apps/api/src/services/education-program-offering/education-program-offering.service.models.ts
+++ b/sources/packages/backend/apps/api/src/services/education-program-offering/education-program-offering.service.models.ts
@@ -48,6 +48,7 @@ export class ApplicationAssessmentSummary extends Application {
   assessmentWorkflowId: string;
   workflowName: string;
   hasAssessmentData: boolean;
+  assessmentAppealId: number;
 }
 
 /**

--- a/sources/packages/backend/apps/api/src/services/education-program-offering/education-program-offering.service.models.ts
+++ b/sources/packages/backend/apps/api/src/services/education-program-offering/education-program-offering.service.models.ts
@@ -48,7 +48,7 @@ export class ApplicationAssessmentSummary extends Application {
   assessmentWorkflowId: string;
   workflowName: string;
   hasAssessmentData: boolean;
-  assessmentAppealId: number;
+  assessmentAppealId: number | null;
 }
 
 /**

--- a/sources/packages/backend/apps/api/src/services/education-program-offering/education-program-offering.service.models.ts
+++ b/sources/packages/backend/apps/api/src/services/education-program-offering/education-program-offering.service.models.ts
@@ -48,7 +48,7 @@ export class ApplicationAssessmentSummary extends Application {
   assessmentWorkflowId: string;
   workflowName: string;
   hasAssessmentData: boolean;
-  assessmentAppealId: number | null;
+  assessmentAppealId?: number;
 }
 
 /**

--- a/sources/packages/backend/apps/api/src/services/education-program-offering/education-program-offering.service.ts
+++ b/sources/packages/backend/apps/api/src/services/education-program-offering/education-program-offering.service.ts
@@ -22,6 +22,7 @@ import {
   StudentAssessmentStatus,
   StudyBreaksAndWeeks,
   isDatabaseConstraintError,
+  StudentAppeal,
 } from "@sims/sims-db";
 import { DataSource, In, Repository, UpdateResult } from "typeorm";
 import {
@@ -1064,7 +1065,9 @@ export class EducationProgramOfferingService extends RecordDataModelService<Educ
       .addSelect("assessment.assessmentData IS NULL", "hasAssessmentData")
       .addSelect("application.data->>'workflowName'", "workflowName")
       .addSelect("assessment.assessmentWorkflowId", "assessmentWorkflowId")
+      .addSelect("studentAppeal.id", "assessmentAppealId")
       .innerJoin("application.currentAssessment", "assessment")
+      .leftJoin("assessment.studentAppeal", "studentAppeal")
       .innerJoin(
         EducationProgramOffering,
         "offering",
@@ -1087,6 +1090,7 @@ export class EducationProgramOfferingService extends RecordDataModelService<Educ
       "workflowName",
       "assessmentWorkflowId",
       "hasAssessmentData",
+      "assessmentAppealId",
     );
   }
 
@@ -1155,6 +1159,15 @@ export class EducationProgramOfferingService extends RecordDataModelService<Educ
             submittedBy: auditUser,
             submittedDate: currentDate,
           } as StudentAssessment;
+          // Update the student appeal record for the student assessment if it exists.
+          if (application.assessmentAppealId) {
+            application.currentAssessment = {
+              ...application.currentAssessment,
+              studentAppeal: {
+                id: application.assessmentAppealId,
+              } as StudentAppeal,
+            } as StudentAssessment;
+          }
         }
 
         // If the application which is affected by offering change is not completed

--- a/sources/packages/backend/apps/api/src/services/education-program-offering/education-program-offering.service.ts
+++ b/sources/packages/backend/apps/api/src/services/education-program-offering/education-program-offering.service.ts
@@ -1161,12 +1161,9 @@ export class EducationProgramOfferingService extends RecordDataModelService<Educ
           } as StudentAssessment;
           // Update the student appeal record for the student assessment if it exists.
           if (application.assessmentAppealId) {
-            application.currentAssessment = {
-              ...application.currentAssessment,
-              studentAppeal: {
-                id: application.assessmentAppealId,
-              } as StudentAppeal,
-            } as StudentAssessment;
+            application.currentAssessment.studentAppeal = {
+              id: application.assessmentAppealId,
+            } as StudentAppeal;
           }
         }
 

--- a/sources/packages/backend/apps/api/src/services/student-scholastic-standings/student-scholastic-standings.service.ts
+++ b/sources/packages/backend/apps/api/src/services/student-scholastic-standings/student-scholastic-standings.service.ts
@@ -258,12 +258,9 @@ export class StudentScholasticStandingsService extends RecordDataModelService<St
         } as StudentAssessment;
         // Update the student appeal record for the student assessment if it exists.
         if (application.currentAssessment.studentAppeal) {
-          scholasticStanding.studentAssessment = {
-            ...scholasticStanding.studentAssessment,
-            studentAppeal: {
-              id: application.currentAssessment.studentAppeal.id,
-            } as StudentAppeal,
-          } as StudentAssessment;
+          scholasticStanding.studentAssessment.studentAppeal = {
+            id: application.currentAssessment.studentAppeal.id,
+          } as StudentAppeal;
         }
       } else {
         // If unsuccessful weeks, then add to the column.

--- a/sources/packages/backend/apps/api/src/services/student-scholastic-standings/student-scholastic-standings.service.ts
+++ b/sources/packages/backend/apps/api/src/services/student-scholastic-standings/student-scholastic-standings.service.ts
@@ -255,10 +255,16 @@ export class StudentScholasticStandingsService extends RecordDataModelService<St
           submittedBy: auditUser,
           submittedDate: now,
           offering: { id: savedOffering.id } as EducationProgramOffering,
-          studentAppeal: {
-            id: application.currentAssessment.studentAppeal?.id,
-          } as StudentAppeal,
         } as StudentAssessment;
+        // Update the student appeal record for the student assessment if it exists.
+        if (application.currentAssessment?.studentAppeal) {
+          scholasticStanding.studentAssessment = {
+            ...scholasticStanding.studentAssessment,
+            studentAppeal: {
+              id: application.currentAssessment.studentAppeal.id,
+            } as StudentAppeal,
+          } as StudentAssessment;
+        }
       } else {
         // If unsuccessful weeks, then add to the column.
         // * No cloning of offering and re-assessment is required in this scenario.

--- a/sources/packages/backend/apps/api/src/services/student-scholastic-standings/student-scholastic-standings.service.ts
+++ b/sources/packages/backend/apps/api/src/services/student-scholastic-standings/student-scholastic-standings.service.ts
@@ -13,6 +13,7 @@ import {
   StudentRestriction,
   User,
   StudentScholasticStandingChangeType,
+  StudentAppeal,
 } from "@sims/sims-db";
 import { CustomNamedError } from "@sims/utilities";
 import {
@@ -79,9 +80,11 @@ export class StudentScholasticStandingsService extends RecordDataModelService<St
         "user.firstName",
         "user.lastName",
         "user.email",
+        "studentAppeal.id",
       ])
       .innerJoin("application.currentAssessment", "currentAssessment")
       .innerJoin("currentAssessment.offering", "offering")
+      .leftJoin("currentAssessment.studentAppeal", "studentAppeal")
       .innerJoin("application.location", "location")
       .innerJoin("application.student", "student")
       .innerJoin("student.user", "user")
@@ -252,6 +255,9 @@ export class StudentScholasticStandingsService extends RecordDataModelService<St
           submittedBy: auditUser,
           submittedDate: now,
           offering: { id: savedOffering.id } as EducationProgramOffering,
+          studentAppeal: {
+            id: application.currentAssessment.studentAppeal?.id,
+          } as StudentAppeal,
         } as StudentAssessment;
       } else {
         // If unsuccessful weeks, then add to the column.

--- a/sources/packages/backend/apps/api/src/services/student-scholastic-standings/student-scholastic-standings.service.ts
+++ b/sources/packages/backend/apps/api/src/services/student-scholastic-standings/student-scholastic-standings.service.ts
@@ -257,7 +257,7 @@ export class StudentScholasticStandingsService extends RecordDataModelService<St
           offering: { id: savedOffering.id } as EducationProgramOffering,
         } as StudentAssessment;
         // Update the student appeal record for the student assessment if it exists.
-        if (application.currentAssessment?.studentAppeal) {
+        if (application.currentAssessment.studentAppeal) {
           scholasticStanding.studentAssessment = {
             ...scholasticStanding.studentAssessment,
             studentAppeal: {

--- a/sources/packages/backend/apps/workers/src/controllers/assessment/_tests_/e2e/assessment.controller-workflowWrapUp.e2e-spec.ts
+++ b/sources/packages/backend/apps/workers/src/controllers/assessment/_tests_/e2e/assessment.controller-workflowWrapUp.e2e-spec.ts
@@ -1,5 +1,6 @@
 import {
   createE2EDataSources,
+  createFakeStudentAppeal,
   E2EDataSources,
   saveFakeApplication,
   saveFakeApplicationDisbursements,
@@ -136,6 +137,13 @@ describe("AssessmentController(e2e)-workflowWrapUp", () => {
         },
       },
     );
+    // Student appeal for the impacted application and its student assessment
+    const studentAppeal = await createFakeStudentAppeal({
+      application: impactedApplication,
+      studentAssessment: impactedApplication.currentAssessment,
+    });
+    impactedApplication.currentAssessment.studentAppeal = studentAppeal;
+    await db.studentAssessment.save(impactedApplication.currentAssessment);
     // Dummy workflowData to be saved during workflow wrap up.
     const workflowData = {
       studentData: {
@@ -162,10 +170,11 @@ describe("AssessmentController(e2e)-workflowWrapUp", () => {
         currentAssessment: {
           id: true,
           triggerType: true,
+          studentAppeal: { id: true },
         },
       },
       relations: {
-        currentAssessment: true,
+        currentAssessment: { studentAppeal: true },
       },
       where: {
         id: impactedApplication.id,
@@ -173,6 +182,9 @@ describe("AssessmentController(e2e)-workflowWrapUp", () => {
     });
     expect(expectedAssessment.currentAssessment.triggerType).toBe(
       AssessmentTriggerType.RelatedApplicationChanged,
+    );
+    expect(expectedAssessment.currentAssessment.studentAppeal.id).toBe(
+      studentAppeal.id,
     );
   });
 

--- a/sources/packages/backend/apps/workers/src/controllers/assessment/_tests_/e2e/assessment.controller-workflowWrapUp.e2e-spec.ts
+++ b/sources/packages/backend/apps/workers/src/controllers/assessment/_tests_/e2e/assessment.controller-workflowWrapUp.e2e-spec.ts
@@ -140,7 +140,6 @@ describe("AssessmentController(e2e)-workflowWrapUp", () => {
     impactedApplication.currentAssessment.studentAppeal =
       createFakeStudentAppeal({
         application: impactedApplication,
-        studentAssessment: impactedApplication.currentAssessment,
       });
     await db.studentAssessment.save(impactedApplication.currentAssessment);
     // Dummy workflowData to be saved during workflow wrap up.

--- a/sources/packages/backend/apps/workers/src/controllers/assessment/_tests_/e2e/assessment.controller-workflowWrapUp.e2e-spec.ts
+++ b/sources/packages/backend/apps/workers/src/controllers/assessment/_tests_/e2e/assessment.controller-workflowWrapUp.e2e-spec.ts
@@ -137,12 +137,11 @@ describe("AssessmentController(e2e)-workflowWrapUp", () => {
         },
       },
     );
-    // Student appeal for the impacted application and its student assessment.
-    const studentAppeal = createFakeStudentAppeal({
-      application: impactedApplication,
-      studentAssessment: impactedApplication.currentAssessment,
-    });
-    impactedApplication.currentAssessment.studentAppeal = studentAppeal;
+    impactedApplication.currentAssessment.studentAppeal =
+      createFakeStudentAppeal({
+        application: impactedApplication,
+        studentAssessment: impactedApplication.currentAssessment,
+      });
     await db.studentAssessment.save(impactedApplication.currentAssessment);
     // Dummy workflowData to be saved during workflow wrap up.
     const workflowData = {
@@ -184,7 +183,7 @@ describe("AssessmentController(e2e)-workflowWrapUp", () => {
       AssessmentTriggerType.RelatedApplicationChanged,
     );
     expect(expectedAssessment.currentAssessment.studentAppeal.id).toBe(
-      studentAppeal.id,
+      impactedApplication.currentAssessment.studentAppeal.id,
     );
   });
 

--- a/sources/packages/backend/apps/workers/src/controllers/assessment/_tests_/e2e/assessment.controller-workflowWrapUp.e2e-spec.ts
+++ b/sources/packages/backend/apps/workers/src/controllers/assessment/_tests_/e2e/assessment.controller-workflowWrapUp.e2e-spec.ts
@@ -137,8 +137,8 @@ describe("AssessmentController(e2e)-workflowWrapUp", () => {
         },
       },
     );
-    // Student appeal for the impacted application and its student assessment
-    const studentAppeal = await createFakeStudentAppeal({
+    // Student appeal for the impacted application and its student assessment.
+    const studentAppeal = createFakeStudentAppeal({
       application: impactedApplication,
       studentAssessment: impactedApplication.currentAssessment,
     });

--- a/sources/packages/backend/libs/services/src/students-assessments/assessment-sequential-processing.service.models.ts
+++ b/sources/packages/backend/libs/services/src/students-assessments/assessment-sequential-processing.service.models.ts
@@ -28,6 +28,10 @@ export interface SequentialApplication {
    * is still in progress.
    */
   currentAssessmentOfferingId?: number;
+  /**
+   * Current student appeal id associated to the current assessment of the active application.
+   */
+  currentAssessmentAppealId?: number;
 }
 
 /**

--- a/sources/packages/backend/libs/services/src/students-assessments/assessment-sequential-processing.service.ts
+++ b/sources/packages/backend/libs/services/src/students-assessments/assessment-sequential-processing.service.ts
@@ -110,12 +110,9 @@ export class AssessmentSequentialProcessingService {
     } as StudentAssessment;
     // Update the student appeal record for the student assessment if it exists.
     if (futureSequencedApplication.currentAssessmentAppealId) {
-      impactedApplication.currentAssessment = {
-        ...impactedApplication.currentAssessment,
-        studentAppeal: {
-          id: futureSequencedApplication.currentAssessmentAppealId,
-        } as StudentAppeal,
-      } as StudentAssessment;
+      impactedApplication.currentAssessment.studentAppeal = {
+        id: futureSequencedApplication.currentAssessmentAppealId,
+      } as StudentAppeal;
     }
     return applicationRepo.save(impactedApplication);
   }

--- a/sources/packages/backend/libs/services/src/students-assessments/assessment-sequential-processing.service.ts
+++ b/sources/packages/backend/libs/services/src/students-assessments/assessment-sequential-processing.service.ts
@@ -9,6 +9,7 @@ import {
   DisbursementScheduleStatus,
   DisbursementValueType,
   OfferingIntensity,
+  StudentAppeal,
   StudentAssessment,
   StudentAssessmentStatus,
   User,
@@ -53,10 +54,14 @@ export class AssessmentSequentialProcessingService {
         student: {
           id: true,
         },
+        currentAssessment: {
+          studentAppeal: { id: true },
+        },
       },
       relations: {
         student: true,
         programYear: true,
+        currentAssessment: { studentAppeal: true },
       },
       where: {
         applicationStatus: Not(ApplicationStatus.Overwritten),
@@ -101,6 +106,9 @@ export class AssessmentSequentialProcessingService {
       createdAt: now,
       submittedBy: auditUser,
       submittedDate: now,
+      studentAppeal: {
+        id: application.currentAssessment.studentAppeal?.id,
+      } as StudentAppeal,
     } as StudentAssessment;
     return applicationRepo.save(impactedApplication);
   }

--- a/sources/packages/backend/libs/test-utils/src/factories/student-assessment.ts
+++ b/sources/packages/backend/libs/test-utils/src/factories/student-assessment.ts
@@ -5,6 +5,7 @@ import {
   Assessment,
   AssessmentTriggerType,
   EducationProgramOffering,
+  StudentAppeal,
   StudentAssessment,
   StudentAssessmentStatus,
   User,
@@ -15,6 +16,7 @@ export function createFakeStudentAssessment(
     auditUser: User;
     application?: Application;
     offering?: EducationProgramOffering;
+    studentAppeal?: StudentAppeal;
   },
   options?: { initialValue?: Partial<StudentAssessment> },
 ): StudentAssessment {
@@ -34,7 +36,7 @@ export function createFakeStudentAssessment(
   assessment.offering =
     relations?.offering ??
     createFakeEducationProgramOffering({ auditUser: relations?.auditUser });
-  assessment.studentAppeal = null;
+  assessment.studentAppeal = relations?.studentAppeal ?? null;
   assessment.studentScholasticStanding = null;
   assessment.noaApprovalStatus = null;
   assessment.disbursementSchedules = [];


### PR DESCRIPTION
**Rephrase of the AC**
Update any student appeal record (Request a Change) for the current student re-assessment for an application when the re-assessment takes place in offering change, scholastic standing, automatic re-assessment, etc.. That is, modify places where re-assessments occur for all assessment trigger type other than the "original assessment". This story will be a preparation story for a later story, where application data used for Camunda reassessment calculation will be updated with student appeal data.

- Updated one place for `AssessmentTriggerType.ScholasticStandingChange`.
- Updated one place for `AssessmentTriggerType.ApplicationOfferingChange`.
- Updated one place for `AssessmentTriggerType.RelatedApplicationChanged`.
- Updated one place for `AssessmentTriggerType.OfferingChange`.
- Added E2E tests to accommodate the endpoint changes and failed E2E tests.

**Note**
- `AssessmentTriggerType.ProgramChange` has no reference.
- Reference to `AssessmentTriggerType.StudentAppeal` doesn't need modifications.

Screenshot of failed E2E tests for the solution in the initial commit
![image](https://github.com/bcgov/SIMS/assets/148148914/de2c4d5c-420a-47b8-8946-0456ed9fe1ff)

