### PR TITLE
#2639 - Award Configuration PT - CSPT

### DIFF
--- a/sources/packages/backend/workflow/BPMN/camunda-8/parttime-assessment-2021-2022.bpmn
+++ b/sources/packages/backend/workflow/BPMN/camunda-8/parttime-assessment-2021-2022.bpmn
@@ -656,7 +656,7 @@
       <bpmn:extensionElements>
         <zeebe:ioMapping>
           <zeebe:output source="=  if (calculatedDataTotalFamilyIncome &#60;= dmnPartTimeAwardFamilySizeVariables.limitAwardBCAGIncomeCap)&#10;then dmnPartTimeAwardAllowableLimits.limitAwardBCAGAmount&#10;else&#10;  max(dmnPartTimeAwardAllowableLimits.limitAwardBCAGAmount - ((calculatedDataTotalFamilyIncome - dmnPartTimeAwardFamilySizeVariables.limitAwardBCAGIncomeCap) * dmnPartTimeAwardFamilySizeVariables.limitAwardBCAGSlope),&#10;     100&#10;  )" target="federalAwardBCAGAmount" />
-          <zeebe:output source="=if ((awardEligibilityBCAG = true) and (federalAwardBCAGAmount &#62;= 100))&#10;then&#10;  min(&#10;     calculatedDataTotalRemainingNeed3,&#10;     max(min(dmnPartTimeAwardAllowableLimits.limitAwardBCAGAmount - (if (programYearTotalPartTimeBCAG = null) then 0 else programYearTotalPartTimeBCAG), federalAwardBCAGAmount),0)&#10;  )&#10;else&#10;0" target="provincialAwardNetBCAGAmount" />
+          <zeebe:output source="=if ((awardEligibilityBCAG = true) and (federalAwardBCAGAmount &#62;= 100))&#10;then&#10;  min(&#10;     calculatedDataTotalRemainingNeed3,&#10;     max(min(dmnPartTimeAwardAllowableLimits.limitAwardBCAGAmount - programYearTotalPartTimeBCAG, federalAwardBCAGAmount),0)&#10;  )&#10;else&#10;0" target="provincialAwardNetBCAGAmount" />
           <zeebe:output source="=calculatedDataTotalRemainingNeed3 - provincialAwardNetBCAGAmount" target="calculatedDataTotalRemainingNeed4" />
         </zeebe:ioMapping>
       </bpmn:extensionElements>
@@ -666,7 +666,7 @@
     <bpmn:intermediateThrowEvent id="Event_1eaa23y" name="calculate CSGD">
       <bpmn:extensionElements>
         <zeebe:ioMapping>
-          <zeebe:output source="=//Deduct the total CSGD consumed amount for current Program Year from the derived CSGD total limit.&#10;if (awardEligibilityCSGD = true)&#10;then&#10;  max(min(calculatedDataTotalRemainingNeed2, federalAwardCSGDAmount - (if (programYearTotalPartTimeCSGD = null) then 0 else programYearTotalPartTimeCSGD)),0)&#10;else&#10;0" target="federalAwardNetCSGDAmount" />
+          <zeebe:output source="=//Deduct the total CSGD consumed amount for current Program Year from the derived CSGD total limit.&#10;if (awardEligibilityCSGD = true)&#10;then&#10;  max(min(calculatedDataTotalRemainingNeed2, federalAwardCSGDAmount - programYearTotalPartTimeCSGD),0)&#10;else&#10;0" target="federalAwardNetCSGDAmount" />
           <zeebe:output source="=max(0,(calculatedDataTotalRemainingNeed2 - federalAwardNetCSGDAmount))" target="calculatedDataTotalRemainingNeed3" />
         </zeebe:ioMapping>
       </bpmn:extensionElements>
@@ -703,7 +703,7 @@
     <bpmn:intermediateThrowEvent id="Event_12swz45" name="calculate SBSD">
       <bpmn:extensionElements>
         <zeebe:ioMapping>
-          <zeebe:output source="=if awardEligibilitySBSD = true&#10;then&#10;max(dmnPartTimeAwardAllowableLimits.limitAwardSBSDUnder40CourseLoadAmount - (if (programYearTotalSBSD = null) then 0 else programYearTotalSBSD),0)&#10;else&#10;  0" target="provincialAwardNetSBSDAmount" />
+          <zeebe:output source="=if awardEligibilitySBSD = true&#10;then&#10;max(dmnPartTimeAwardAllowableLimits.limitAwardSBSDUnder40CourseLoadAmount - programYearTotalSBSD,0)&#10;else&#10;  0" target="provincialAwardNetSBSDAmount" />
         </zeebe:ioMapping>
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_0x4ck3r</bpmn:incoming>
@@ -712,15 +712,21 @@
     <bpmn:intermediateThrowEvent id="Event_14d0375" name="calculate SBSD">
       <bpmn:extensionElements>
         <zeebe:ioMapping>
-          <zeebe:output source="=if awardEligibilitySBSD = true&#10;then&#10;max(dmnPartTimeAwardAllowableLimits.limitAwardSBSD40AndUpCourseLoadAmount - (if (programYearTotalSBSD = null) then 0 else programYearTotalSBSD),0)&#10;else&#10;  0" target="provincialAwardNetSBSDAmount" />
+          <zeebe:output source="=if awardEligibilitySBSD = true&#10;then&#10;max(dmnPartTimeAwardAllowableLimits.limitAwardSBSD40AndUpCourseLoadAmount - programYearTotalSBSD,0)&#10;else&#10;  0" target="provincialAwardNetSBSDAmount" />
         </zeebe:ioMapping>
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_1kzoimw</bpmn:incoming>
       <bpmn:outgoing>Flow_10dvc27</bpmn:outgoing>
     </bpmn:intermediateThrowEvent>
-    <bpmn:intermediateThrowEvent id="Event_0irnnvd" name="Program Year Total both FT and PT">
+    <bpmn:intermediateThrowEvent id="Event_0irnnvd" name="Program Year Total Initialization">
       <bpmn:extensionElements>
         <zeebe:ioMapping>
+          <zeebe:output source="=if(programYearTotalFullTimeCSGP = null) then 0 else programYearTotalFullTimeCSGP" target="programYearTotalFullTimeCSGP" />
+          <zeebe:output source="=if(programYearTotalPartTimeCSGP = null) then 0 else programYearTotalPartTimeCSGP" target="programYearTotalPartTimeCSGP" />
+          <zeebe:output source="=if(programYearTotalFullTimeSBSD = null) then 0 else programYearTotalFullTimeSBSD" target="programYearTotalFullTimeSBSD" />
+          <zeebe:output source="=if(programYearTotalPartTimSBSD = null) then 0 else programYearTotalPartTimeSBSD" target="programYearTotalPartTimeSBSD" />
+          <zeebe:output source="=if(programYearTotalPartTimeBCAG = null) then 0 else programYearTotalPartTimeBCAG" target="programYearTotalPartTimeBCAG" />
+          <zeebe:output source="=if(programYearTotalPartTimeCSGD = null) then 0 else programYearTotalPartTimeCSGD" target="programYearTotalPartTimeCSGD" />
           <zeebe:output source="=programYearTotalFullTimeSBSD + programYearTotalPartTimeSBSD" target="programYearTotalSBSD" />
           <zeebe:output source="=programYearTotalFullTimeCSGP + programYearTotalPartTimeCSGP" target="programYearTotalCSGP" />
         </zeebe:ioMapping>
@@ -742,7 +748,7 @@
     <bpmn:intermediateThrowEvent id="Event_1h2w0hl" name="calculate CSGP">
       <bpmn:extensionElements>
         <zeebe:ioMapping>
-          <zeebe:output source="=if ((awardEligibilityCSGP = true) &#10;    and (calculatedDataTotalAssessedNeed &#62;= 1)) &#10;then max(dmnPartTimeAwardAllowableLimits.limitAwardCSGPAmount - (if (programYearTotalCSGP = null) then 0 else programYearTotalCSGP), 0)&#10;else 0" target="federalAwardNetCSGPAmount" />
+          <zeebe:output source="=if ((awardEligibilityCSGP = true) &#10;    and (calculatedDataTotalAssessedNeed &#62;= 1)) &#10;then max(dmnPartTimeAwardAllowableLimits.limitAwardCSGPAmount - programYearTotalCSGP, 0) &#10;else 0" target="federalAwardNetCSGPAmount" />
           <zeebe:output source="=max(0,(calculatedDataTotalAssessedNeed - federalAwardNetCSGPAmount))" target="calculatedDataTotalRemainingNeed1" />
         </zeebe:ioMapping>
       </bpmn:extensionElements>

--- a/sources/packages/backend/workflow/BPMN/camunda-8/parttime-assessment-2021-2022.bpmn
+++ b/sources/packages/backend/workflow/BPMN/camunda-8/parttime-assessment-2021-2022.bpmn
@@ -748,7 +748,7 @@
     <bpmn:intermediateThrowEvent id="Event_1h2w0hl" name="calculate CSGP">
       <bpmn:extensionElements>
         <zeebe:ioMapping>
-          <zeebe:output source="=if ((awardEligibilityCSGP = true) &#10;    and (calculatedDataTotalAssessedNeed &#62;= 1)) &#10;then max(dmnPartTimeAwardAllowableLimits.limitAwardCSGPAmount - programYearTotalCSGP, 0) &#10;else 0" target="federalAwardNetCSGPAmount" />
+          <zeebe:output source="=if ((awardEligibilityCSGP = true) &#10;    and (calculatedDataTotalAssessedNeed &#62;= 1)) &#10;then max(dmnPartTimeAwardAllowableLimits.limitAwardCSGPAmount - programYearTotalCSGP,0)&#10;else 0" target="federalAwardNetCSGPAmount" />
           <zeebe:output source="=max(0,(calculatedDataTotalAssessedNeed - federalAwardNetCSGPAmount))" target="calculatedDataTotalRemainingNeed1" />
         </zeebe:ioMapping>
       </bpmn:extensionElements>

--- a/sources/packages/backend/workflow/BPMN/camunda-8/parttime-assessment-2021-2022.bpmn
+++ b/sources/packages/backend/workflow/BPMN/camunda-8/parttime-assessment-2021-2022.bpmn
@@ -656,7 +656,8 @@
       <bpmn:extensionElements>
         <zeebe:ioMapping>
           <zeebe:output source="=  if (calculatedDataTotalFamilyIncome &#60;= dmnPartTimeAwardFamilySizeVariables.limitAwardBCAGIncomeCap)&#10;then dmnPartTimeAwardAllowableLimits.limitAwardBCAGAmount&#10;else&#10;  max(dmnPartTimeAwardAllowableLimits.limitAwardBCAGAmount - ((calculatedDataTotalFamilyIncome - dmnPartTimeAwardFamilySizeVariables.limitAwardBCAGIncomeCap) * dmnPartTimeAwardFamilySizeVariables.limitAwardBCAGSlope),&#10;     100&#10;  )" target="federalAwardBCAGAmount" />
-          <zeebe:output source="=if ((awardEligibilityBCAG = true) and (federalAwardBCAGAmount &#62;= 100))&#10;then&#10;  min(&#10;     calculatedDataTotalRemainingNeed3,&#10;     max(min(dmnPartTimeAwardAllowableLimits.limitAwardBCAGAmount - programYearTotalPartTimeBCAG, federalAwardBCAGAmount),0)&#10;  )&#10;else&#10;0" target="provincialAwardNetBCAGAmount" />
+          <zeebe:output source="=dmnPartTimeAwardAllowableLimits.limitAwardBCAGAmount - programYearTotalPartTimeBCAG" target="limitAwardBCAGRemaining" />
+          <zeebe:output source="=if (awardEligibilityBCAG = true and federalAwardBCAGAmount &#62;= 100 and limitAwardBCAGRemaining &#62;= 100)&#10;then&#10;  min(calculatedDataTotalRemainingNeed3, limitAwardBCAGRemaining, federalAwardBCAGAmount)&#10;else&#10;0" target="provincialAwardNetBCAGAmount" />
           <zeebe:output source="=calculatedDataTotalRemainingNeed3 - provincialAwardNetBCAGAmount" target="calculatedDataTotalRemainingNeed4" />
         </zeebe:ioMapping>
       </bpmn:extensionElements>
@@ -739,7 +740,8 @@
       <bpmn:extensionElements>
         <zeebe:ioMapping>
           <zeebe:output source="=if (calculatedDataTotalFamilyIncome &#60;= dmnPartTimeAwardFamilySizeVariables.limitAwardCSPTIncomeCap)&#10;then dmnPartTimeAwardAllowableLimits.limitAwardCSPTAmount&#10;else&#10;  max(dmnPartTimeAwardAllowableLimits.limitAwardCSPTAmount - ((calculatedDataTotalFamilyIncome - dmnPartTimeAwardFamilySizeVariables.limitAwardCSPTIncomeCap) * dmnPartTimeAwardFamilySizeVariables.limitAwardCSPTSlope),&#10;     100&#10;  )" target="federalAwardCSPTAmount" />
-          <zeebe:output source="=if (awardEligibilityCSPT = true and calculatedDataTotalRemainingNeed1 &#62;= 100)&#10;then&#10;  min(&#10;     calculatedDataTotalRemainingNeed1,&#10;     min(dmnPartTimeAwardAllowableLimits.limitAwardCSPTAmount - programYearTotalPartTimeCSPT, federalAwardCSPTAmount)&#10;  )&#10;else&#10;0" target="federalAwardNetCSPTAmount" />
+          <zeebe:output source="=dmnPartTimeAwardAllowableLimits.limitAwardCSPTAmount - programYearTotalPartTimeCSPT" target="limitAwardCSPTRemaining" />
+          <zeebe:output source="=if (awardEligibilityCSPT = true and calculatedDataTotalRemainingNeed1 &#62;= 100 and limitAwardCSPTRemaining &#62;= 100)&#10;then&#10;  min(calculatedDataTotalRemainingNeed1, limitAwardCSPTRemaining, federalAwardCSPTAmount)&#10;else&#10;0" target="federalAwardNetCSPTAmount" />
           <zeebe:output source="=max(0,(calculatedDataTotalRemainingNeed1 - federalAwardNetCSPTAmount))" target="calculatedDataTotalRemainingNeed2" />
         </zeebe:ioMapping>
       </bpmn:extensionElements>

--- a/sources/packages/backend/workflow/BPMN/camunda-8/parttime-assessment-2021-2022.bpmn
+++ b/sources/packages/backend/workflow/BPMN/camunda-8/parttime-assessment-2021-2022.bpmn
@@ -656,7 +656,7 @@
       <bpmn:extensionElements>
         <zeebe:ioMapping>
           <zeebe:output source="=  if (calculatedDataTotalFamilyIncome &#60;= dmnPartTimeAwardFamilySizeVariables.limitAwardBCAGIncomeCap)&#10;then dmnPartTimeAwardAllowableLimits.limitAwardBCAGAmount&#10;else&#10;  max(dmnPartTimeAwardAllowableLimits.limitAwardBCAGAmount - ((calculatedDataTotalFamilyIncome - dmnPartTimeAwardFamilySizeVariables.limitAwardBCAGIncomeCap) * dmnPartTimeAwardFamilySizeVariables.limitAwardBCAGSlope),&#10;     100&#10;  )" target="federalAwardBCAGAmount" />
-          <zeebe:output source="=if ((awardEligibilityBCAG = true) and (federalAwardBCAGAmount &#62;= 100))&#10;then&#10;  min(&#10;     calculatedDataTotalRemainingNeed3,&#10;     max(min(dmnPartTimeAwardAllowableLimits.limitAwardBCAGAmount - programYearTotalPartTimeBCAG, federalAwardBCAGAmount),0)&#10;  )&#10;else&#10;0" target="provincialAwardNetBCAGAmount" />
+          <zeebe:output source="=if ((awardEligibilityBCAG = true) and (federalAwardBCAGAmount &#62;= 100))&#10;then&#10;  min(&#10;     calculatedDataTotalRemainingNeed3,&#10;     max(min(dmnPartTimeAwardAllowableLimits.limitAwardBCAGAmount - (if (programYearTotalPartTimeBCAG = null) then 0 else programYearTotalPartTimeBCAG), federalAwardBCAGAmount),0)&#10;  )&#10;else&#10;0" target="provincialAwardNetBCAGAmount" />
           <zeebe:output source="=calculatedDataTotalRemainingNeed3 - provincialAwardNetBCAGAmount" target="calculatedDataTotalRemainingNeed4" />
         </zeebe:ioMapping>
       </bpmn:extensionElements>
@@ -666,7 +666,7 @@
     <bpmn:intermediateThrowEvent id="Event_1eaa23y" name="calculate CSGD">
       <bpmn:extensionElements>
         <zeebe:ioMapping>
-          <zeebe:output source="=//Deduct the total CSGD consumed amount for current Program Year from the derived CSGD total limit.&#10;if (awardEligibilityCSGD = true)&#10;then&#10;  max(min(calculatedDataTotalRemainingNeed2, federalAwardCSGDAmount - programYearTotalPartTimeCSGD),0)&#10;else&#10;0" target="federalAwardNetCSGDAmount" />
+          <zeebe:output source="=//Deduct the total CSGD consumed amount for current Program Year from the derived CSGD total limit.&#10;if (awardEligibilityCSGD = true)&#10;then&#10;  max(min(calculatedDataTotalRemainingNeed2, federalAwardCSGDAmount - (if (programYearTotalPartTimeCSGD = null) then 0 else programYearTotalPartTimeCSGD)),0)&#10;else&#10;0" target="federalAwardNetCSGDAmount" />
           <zeebe:output source="=max(0,(calculatedDataTotalRemainingNeed2 - federalAwardNetCSGDAmount))" target="calculatedDataTotalRemainingNeed3" />
         </zeebe:ioMapping>
       </bpmn:extensionElements>
@@ -703,7 +703,7 @@
     <bpmn:intermediateThrowEvent id="Event_12swz45" name="calculate SBSD">
       <bpmn:extensionElements>
         <zeebe:ioMapping>
-          <zeebe:output source="=if awardEligibilitySBSD = true&#10;then&#10;max(dmnPartTimeAwardAllowableLimits.limitAwardSBSDUnder40CourseLoadAmount - programYearTotalSBSD,0)&#10;else&#10;  0" target="provincialAwardNetSBSDAmount" />
+          <zeebe:output source="=if awardEligibilitySBSD = true&#10;then&#10;max(dmnPartTimeAwardAllowableLimits.limitAwardSBSDUnder40CourseLoadAmount - (if (programYearTotalSBSD = null) then 0 else programYearTotalSBSD),0)&#10;else&#10;  0" target="provincialAwardNetSBSDAmount" />
         </zeebe:ioMapping>
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_0x4ck3r</bpmn:incoming>
@@ -712,7 +712,7 @@
     <bpmn:intermediateThrowEvent id="Event_14d0375" name="calculate SBSD">
       <bpmn:extensionElements>
         <zeebe:ioMapping>
-          <zeebe:output source="=if awardEligibilitySBSD = true&#10;then&#10;max(dmnPartTimeAwardAllowableLimits.limitAwardSBSD40AndUpCourseLoadAmount - programYearTotalSBSD,0)&#10;else&#10;  0" target="provincialAwardNetSBSDAmount" />
+          <zeebe:output source="=if awardEligibilitySBSD = true&#10;then&#10;max(dmnPartTimeAwardAllowableLimits.limitAwardSBSD40AndUpCourseLoadAmount - (if (programYearTotalSBSD = null) then 0 else programYearTotalSBSD),0)&#10;else&#10;  0" target="provincialAwardNetSBSDAmount" />
         </zeebe:ioMapping>
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_1kzoimw</bpmn:incoming>
@@ -742,7 +742,7 @@
     <bpmn:intermediateThrowEvent id="Event_1h2w0hl" name="calculate CSGP">
       <bpmn:extensionElements>
         <zeebe:ioMapping>
-          <zeebe:output source="=if ((awardEligibilityCSGP = true) &#10;    and (calculatedDataTotalAssessedNeed &#62;= 1)) &#10;then max(dmnPartTimeAwardAllowableLimits.limitAwardCSGPAmount - programYearTotalCSGP,0)&#10;else 0" target="federalAwardNetCSGPAmount" />
+          <zeebe:output source="=if ((awardEligibilityCSGP = true) &#10;    and (calculatedDataTotalAssessedNeed &#62;= 1)) &#10;then max(dmnPartTimeAwardAllowableLimits.limitAwardCSGPAmount - (if (programYearTotalCSGP = null) then 0 else programYearTotalCSGP), 0)&#10;else 0" target="federalAwardNetCSGPAmount" />
           <zeebe:output source="=max(0,(calculatedDataTotalAssessedNeed - federalAwardNetCSGPAmount))" target="calculatedDataTotalRemainingNeed1" />
         </zeebe:ioMapping>
       </bpmn:extensionElements>

--- a/sources/packages/backend/workflow/BPMN/camunda-8/parttime-assessment-2021-2022.bpmn
+++ b/sources/packages/backend/workflow/BPMN/camunda-8/parttime-assessment-2021-2022.bpmn
@@ -724,9 +724,10 @@
           <zeebe:output source="=if(programYearTotalFullTimeCSGP = null) then 0 else programYearTotalFullTimeCSGP" target="programYearTotalFullTimeCSGP" />
           <zeebe:output source="=if(programYearTotalPartTimeCSGP = null) then 0 else programYearTotalPartTimeCSGP" target="programYearTotalPartTimeCSGP" />
           <zeebe:output source="=if(programYearTotalFullTimeSBSD = null) then 0 else programYearTotalFullTimeSBSD" target="programYearTotalFullTimeSBSD" />
-          <zeebe:output source="=if(programYearTotalPartTimSBSD = null) then 0 else programYearTotalPartTimeSBSD" target="programYearTotalPartTimeSBSD" />
+          <zeebe:output source="=if(programYearTotalPartTimeSBSD = null) then 0 else programYearTotalPartTimeSBSD" target="programYearTotalPartTimeSBSD" />
           <zeebe:output source="=if(programYearTotalPartTimeBCAG = null) then 0 else programYearTotalPartTimeBCAG" target="programYearTotalPartTimeBCAG" />
           <zeebe:output source="=if(programYearTotalPartTimeCSGD = null) then 0 else programYearTotalPartTimeCSGD" target="programYearTotalPartTimeCSGD" />
+          <zeebe:output source="=if(programYearTotalPartTimeCSPT = null) then 0 else programYearTotalPartTimeCSPT" target="programYearTotalPartTimeCSPT" />
           <zeebe:output source="=programYearTotalFullTimeSBSD + programYearTotalPartTimeSBSD" target="programYearTotalSBSD" />
           <zeebe:output source="=programYearTotalFullTimeCSGP + programYearTotalPartTimeCSGP" target="programYearTotalCSGP" />
         </zeebe:ioMapping>
@@ -738,7 +739,7 @@
       <bpmn:extensionElements>
         <zeebe:ioMapping>
           <zeebe:output source="=if (calculatedDataTotalFamilyIncome &#60;= dmnPartTimeAwardFamilySizeVariables.limitAwardCSPTIncomeCap)&#10;then dmnPartTimeAwardAllowableLimits.limitAwardCSPTAmount&#10;else&#10;  max(dmnPartTimeAwardAllowableLimits.limitAwardCSPTAmount - ((calculatedDataTotalFamilyIncome - dmnPartTimeAwardFamilySizeVariables.limitAwardCSPTIncomeCap) * dmnPartTimeAwardFamilySizeVariables.limitAwardCSPTSlope),&#10;     100&#10;  )" target="federalAwardCSPTAmount" />
-          <zeebe:output source="=if (awardEligibilityCSPT = true and calculatedDataTotalRemainingNeed1 &#62;= 100)&#10;then&#10;  min(&#10;     calculatedDataTotalRemainingNeed1,&#10;     min(dmnPartTimeAwardAllowableLimits.limitAwardCSPTAmount, federalAwardCSPTAmount)&#10;  )&#10;else&#10;0" target="federalAwardNetCSPTAmount" />
+          <zeebe:output source="=if (awardEligibilityCSPT = true and calculatedDataTotalRemainingNeed1 &#62;= 100)&#10;then&#10;  min(&#10;     calculatedDataTotalRemainingNeed1,&#10;     min(dmnPartTimeAwardAllowableLimits.limitAwardCSPTAmount - programYearTotalPartTimeCSPT, federalAwardCSPTAmount)&#10;  )&#10;else&#10;0" target="federalAwardNetCSPTAmount" />
           <zeebe:output source="=max(0,(calculatedDataTotalRemainingNeed1 - federalAwardNetCSPTAmount))" target="calculatedDataTotalRemainingNeed2" />
         </zeebe:ioMapping>
       </bpmn:extensionElements>

--- a/sources/packages/backend/workflow/BPMN/camunda-8/parttime-assessment-2022-2023.bpmn
+++ b/sources/packages/backend/workflow/BPMN/camunda-8/parttime-assessment-2022-2023.bpmn
@@ -723,7 +723,7 @@
       <bpmn:extensionElements>
         <zeebe:ioMapping>
           <zeebe:output source="=if (calculatedDataTotalFamilyIncome &#60;= dmnPartTimeAwardFamilySizeVariables.limitAwardCSPTIncomeCap)&#10;then dmnPartTimeAwardAllowableLimits.limitAwardCSPTAmount&#10;else&#10;  max(dmnPartTimeAwardAllowableLimits.limitAwardCSPTAmount - ((calculatedDataTotalFamilyIncome - dmnPartTimeAwardFamilySizeVariables.limitAwardCSPTIncomeCap) * dmnPartTimeAwardFamilySizeVariables.limitAwardCSPTSlope),&#10;     100&#10;  )" target="federalAwardCSPTAmount" />
-          <zeebe:output source="=if (awardEligibilityCSPT = true and calculatedDataTotalRemainingNeed1 &#62;= 100)&#10;then&#10;  min(&#10;     calculatedDataTotalRemainingNeed1,&#10;     min(dmnPartTimeAwardAllowableLimits.limitAwardCSPTAmount, federalAwardCSPTAmount)&#10;  )&#10;else&#10;0" target="federalAwardNetCSPTAmount" />
+          <zeebe:output source="=if (awardEligibilityCSPT = true and calculatedDataTotalRemainingNeed1 &#62;= 100)&#10;then&#10;  min(&#10;     calculatedDataTotalRemainingNeed1,&#10;     min(dmnPartTimeAwardAllowableLimits.limitAwardCSPTAmount - programYearTotalPartTimeCSPT, federalAwardCSPTAmount)&#10;  )&#10;else&#10;0" target="federalAwardNetCSPTAmount" />
           <zeebe:output source="=max(0,(calculatedDataTotalRemainingNeed1 - federalAwardNetCSPTAmount))" target="calculatedDataTotalRemainingNeed2" />
         </zeebe:ioMapping>
       </bpmn:extensionElements>
@@ -746,9 +746,10 @@
           <zeebe:output source="=if(programYearTotalFullTimeCSGP = null) then 0 else programYearTotalFullTimeCSGP" target="programYearTotalFullTimeCSGP" />
           <zeebe:output source="=if(programYearTotalPartTimeCSGP = null) then 0 else programYearTotalPartTimeCSGP" target="programYearTotalPartTimeCSGP" />
           <zeebe:output source="=if(programYearTotalFullTimeSBSD = null) then 0 else programYearTotalFullTimeSBSD" target="programYearTotalFullTimeSBSD" />
-          <zeebe:output source="=if(programYearTotalPartTimSBSD = null) then 0 else programYearTotalPartTimeSBSD" target="programYearTotalPartTimeSBSD" />
+          <zeebe:output source="=if(programYearTotalPartTimeSBSD = null) then 0 else programYearTotalPartTimeSBSD" target="programYearTotalPartTimeSBSD" />
           <zeebe:output source="=if(programYearTotalPartTimeBCAG = null) then 0 else programYearTotalPartTimeBCAG" target="programYearTotalPartTimeBCAG" />
           <zeebe:output source="=if(programYearTotalPartTimeCSGD = null) then 0 else programYearTotalPartTimeCSGD" target="programYearTotalPartTimeCSGD" />
+          <zeebe:output source="=if(programYearTotalPartTimeCSPT = null) then 0 else programYearTotalPartTimeCSPT" target="programYearTotalPartTimeCSPT" />
           <zeebe:output source="=programYearTotalFullTimeSBSD + programYearTotalPartTimeSBSD" target="programYearTotalSBSD" />
           <zeebe:output source="=programYearTotalFullTimeCSGP + programYearTotalPartTimeCSGP" target="programYearTotalCSGP" />
         </zeebe:ioMapping>

--- a/sources/packages/backend/workflow/BPMN/camunda-8/parttime-assessment-2022-2023.bpmn
+++ b/sources/packages/backend/workflow/BPMN/camunda-8/parttime-assessment-2022-2023.bpmn
@@ -429,7 +429,7 @@
       <bpmn:extensionElements>
         <zeebe:ioMapping>
           <zeebe:output source="=  if (calculatedDataTotalFamilyIncome &#60;= dmnPartTimeAwardFamilySizeVariables.limitAwardBCAGIncomeCap)&#10;then dmnPartTimeAwardAllowableLimits.limitAwardBCAGAmount&#10;else&#10;  max(dmnPartTimeAwardAllowableLimits.limitAwardBCAGAmount - ((calculatedDataTotalFamilyIncome - dmnPartTimeAwardFamilySizeVariables.limitAwardBCAGIncomeCap) * dmnPartTimeAwardFamilySizeVariables.limitAwardBCAGSlope),&#10;     100&#10;  )" target="federalAwardBCAGAmount" />
-          <zeebe:output source="=if ((awardEligibilityBCAG = true) and (federalAwardBCAGAmount &#62;= 100))&#10;then&#10;  min(&#10;     calculatedDataTotalRemainingNeed3,&#10;     max(min(dmnPartTimeAwardAllowableLimits.limitAwardBCAGAmount - (if (programYearTotalPartTimeBCAG = null) then 0 else programYearTotalPartTimeBCAG), federalAwardBCAGAmount),0)&#10;  )&#10;else&#10;0" target="provincialAwardNetBCAGAmount" />
+          <zeebe:output source="=if ((awardEligibilityBCAG = true) and (federalAwardBCAGAmount &#62;= 100))&#10;then&#10;  min(&#10;     calculatedDataTotalRemainingNeed3,&#10;     max(min(dmnPartTimeAwardAllowableLimits.limitAwardBCAGAmount - programYearTotalPartTimeBCAG, federalAwardBCAGAmount),0)&#10;  )&#10;else&#10;0" target="provincialAwardNetBCAGAmount" />
           <zeebe:output source="=calculatedDataTotalRemainingNeed3 - provincialAwardNetBCAGAmount" target="calculatedDataTotalRemainingNeed4" />
         </zeebe:ioMapping>
       </bpmn:extensionElements>
@@ -692,7 +692,7 @@
     <bpmn:intermediateThrowEvent id="Event_1eaa23y" name="calculate CSGD">
       <bpmn:extensionElements>
         <zeebe:ioMapping>
-          <zeebe:output source="=//Deduct the total CSGD consumed amount for current Program Year from the derived CSGD total limit.&#10;if (awardEligibilityCSGD = true)&#10;then&#10;  max(min(calculatedDataTotalRemainingNeed2, federalAwardCSGDAmount - (if (programYearTotalPartTimeCSGD = null) then 0 else programYearTotalPartTimeCSGD)),0)&#10;else&#10;0" target="federalAwardNetCSGDAmount" />
+          <zeebe:output source="=//Deduct the total CSGD consumed amount for current Program Year from the derived CSGD total limit.&#10;if (awardEligibilityCSGD = true)&#10;then&#10;  max(min(calculatedDataTotalRemainingNeed2, federalAwardCSGDAmount - programYearTotalPartTimeCSGD),0)&#10;else&#10;0" target="federalAwardNetCSGDAmount" />
           <zeebe:output source="=max(0,(calculatedDataTotalRemainingNeed2 - federalAwardNetCSGDAmount))" target="calculatedDataTotalRemainingNeed3" />
         </zeebe:ioMapping>
       </bpmn:extensionElements>
@@ -733,7 +733,7 @@
     <bpmn:intermediateThrowEvent id="Event_1h2w0hl" name="calculate CSGP">
       <bpmn:extensionElements>
         <zeebe:ioMapping>
-          <zeebe:output source="=if ((awardEligibilityCSGP = true) &#10;    and (calculatedDataTotalAssessedNeed &#62;= 1)) &#10;then max(dmnPartTimeAwardAllowableLimits.limitAwardCSGPAmount - (if (programYearTotalCSGP = null) then 0 else programYearTotalCSGP), 0)&#10;else 0" target="federalAwardNetCSGPAmount" />
+          <zeebe:output source="=if ((awardEligibilityCSGP = true) &#10;    and (calculatedDataTotalAssessedNeed &#62;= 1)) &#10;then max(dmnPartTimeAwardAllowableLimits.limitAwardCSGPAmount - programYearTotalCSGP,0)&#10;else 0" target="federalAwardNetCSGPAmount" />
           <zeebe:output source="=max(0,(calculatedDataTotalAssessedNeed - federalAwardNetCSGPAmount))" target="calculatedDataTotalRemainingNeed1" />
         </zeebe:ioMapping>
       </bpmn:extensionElements>
@@ -765,7 +765,7 @@
     <bpmn:intermediateThrowEvent id="Event_12swz45" name="calculate SBSD">
       <bpmn:extensionElements>
         <zeebe:ioMapping>
-          <zeebe:output source="=if awardEligibilitySBSD = true&#10;then&#10;max(dmnPartTimeAwardAllowableLimits.limitAwardSBSDUnder40CourseLoadAmount - (if (programYearTotalSBSD = null) then 0 else programYearTotalSBSD),0)&#10;else&#10;  0" target="provincialAwardNetSBSDAmount" />
+          <zeebe:output source="=if awardEligibilitySBSD = true&#10;then&#10;max(dmnPartTimeAwardAllowableLimits.limitAwardSBSDUnder40CourseLoadAmount - programYearTotalSBSD,0)&#10;else&#10;  0" target="provincialAwardNetSBSDAmount" />
         </zeebe:ioMapping>
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_0x4ck3r</bpmn:incoming>
@@ -774,7 +774,7 @@
     <bpmn:intermediateThrowEvent id="Event_14d0375" name="calculate SBSD">
       <bpmn:extensionElements>
         <zeebe:ioMapping>
-          <zeebe:output source="=if awardEligibilitySBSD = true&#10;then&#10;max(dmnPartTimeAwardAllowableLimits.limitAwardSBSD40AndUpCourseLoadAmount - (if (programYearTotalSBSD = null) then 0 else programYearTotalSBSD),0)&#10;else&#10;  0" target="provincialAwardNetSBSDAmount" />
+          <zeebe:output source="=if awardEligibilitySBSD = true&#10;then&#10;max(dmnPartTimeAwardAllowableLimits.limitAwardSBSD40AndUpCourseLoadAmount - programYearTotalSBSD,0)&#10;else&#10;  0" target="provincialAwardNetSBSDAmount" />
         </zeebe:ioMapping>
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_1kzoimw</bpmn:incoming>

--- a/sources/packages/backend/workflow/BPMN/camunda-8/parttime-assessment-2022-2023.bpmn
+++ b/sources/packages/backend/workflow/BPMN/camunda-8/parttime-assessment-2022-2023.bpmn
@@ -429,7 +429,8 @@
       <bpmn:extensionElements>
         <zeebe:ioMapping>
           <zeebe:output source="=  if (calculatedDataTotalFamilyIncome &#60;= dmnPartTimeAwardFamilySizeVariables.limitAwardBCAGIncomeCap)&#10;then dmnPartTimeAwardAllowableLimits.limitAwardBCAGAmount&#10;else&#10;  max(dmnPartTimeAwardAllowableLimits.limitAwardBCAGAmount - ((calculatedDataTotalFamilyIncome - dmnPartTimeAwardFamilySizeVariables.limitAwardBCAGIncomeCap) * dmnPartTimeAwardFamilySizeVariables.limitAwardBCAGSlope),&#10;     100&#10;  )" target="federalAwardBCAGAmount" />
-          <zeebe:output source="=if ((awardEligibilityBCAG = true) and (federalAwardBCAGAmount &#62;= 100))&#10;then&#10;  min(&#10;     calculatedDataTotalRemainingNeed3,&#10;     max(min(dmnPartTimeAwardAllowableLimits.limitAwardBCAGAmount - programYearTotalPartTimeBCAG, federalAwardBCAGAmount),0)&#10;  )&#10;else&#10;0" target="provincialAwardNetBCAGAmount" />
+          <zeebe:output source="=dmnPartTimeAwardAllowableLimits.limitAwardBCAGAmount - programYearTotalPartTimeBCAG" target="limitAwardBCAGRemaining" />
+          <zeebe:output source="=if (awardEligibilityBCAG = true and federalAwardBCAGAmount &#62;= 100 and limitAwardBCAGRemaining &#62;= 100)&#10;then&#10;  min(calculatedDataTotalRemainingNeed3, limitAwardBCAGRemaining, federalAwardBCAGAmount)&#10;else&#10;0" target="provincialAwardNetBCAGAmount" />
           <zeebe:output source="=calculatedDataTotalRemainingNeed3 - provincialAwardNetBCAGAmount" target="calculatedDataTotalRemainingNeed4" />
         </zeebe:ioMapping>
       </bpmn:extensionElements>
@@ -723,7 +724,8 @@
       <bpmn:extensionElements>
         <zeebe:ioMapping>
           <zeebe:output source="=if (calculatedDataTotalFamilyIncome &#60;= dmnPartTimeAwardFamilySizeVariables.limitAwardCSPTIncomeCap)&#10;then dmnPartTimeAwardAllowableLimits.limitAwardCSPTAmount&#10;else&#10;  max(dmnPartTimeAwardAllowableLimits.limitAwardCSPTAmount - ((calculatedDataTotalFamilyIncome - dmnPartTimeAwardFamilySizeVariables.limitAwardCSPTIncomeCap) * dmnPartTimeAwardFamilySizeVariables.limitAwardCSPTSlope),&#10;     100&#10;  )" target="federalAwardCSPTAmount" />
-          <zeebe:output source="=if (awardEligibilityCSPT = true and calculatedDataTotalRemainingNeed1 &#62;= 100)&#10;then&#10;  min(&#10;     calculatedDataTotalRemainingNeed1,&#10;     min(dmnPartTimeAwardAllowableLimits.limitAwardCSPTAmount - programYearTotalPartTimeCSPT, federalAwardCSPTAmount)&#10;  )&#10;else&#10;0" target="federalAwardNetCSPTAmount" />
+          <zeebe:output source="=dmnPartTimeAwardAllowableLimits.limitAwardCSPTAmount - programYearTotalPartTimeCSPT" target="limitAwardCSPTRemaining" />
+          <zeebe:output source="=if (awardEligibilityCSPT = true and calculatedDataTotalRemainingNeed1 &#62;= 100 and limitAwardCSPTRemaining &#62;= 100)&#10;then&#10;  min(calculatedDataTotalRemainingNeed1, limitAwardCSPTRemaining, federalAwardCSPTAmount)&#10;else&#10;0" target="federalAwardNetCSPTAmount" />
           <zeebe:output source="=max(0,(calculatedDataTotalRemainingNeed1 - federalAwardNetCSPTAmount))" target="calculatedDataTotalRemainingNeed2" />
         </zeebe:ioMapping>
       </bpmn:extensionElements>

--- a/sources/packages/backend/workflow/BPMN/camunda-8/parttime-assessment-2022-2023.bpmn
+++ b/sources/packages/backend/workflow/BPMN/camunda-8/parttime-assessment-2022-2023.bpmn
@@ -429,7 +429,7 @@
       <bpmn:extensionElements>
         <zeebe:ioMapping>
           <zeebe:output source="=  if (calculatedDataTotalFamilyIncome &#60;= dmnPartTimeAwardFamilySizeVariables.limitAwardBCAGIncomeCap)&#10;then dmnPartTimeAwardAllowableLimits.limitAwardBCAGAmount&#10;else&#10;  max(dmnPartTimeAwardAllowableLimits.limitAwardBCAGAmount - ((calculatedDataTotalFamilyIncome - dmnPartTimeAwardFamilySizeVariables.limitAwardBCAGIncomeCap) * dmnPartTimeAwardFamilySizeVariables.limitAwardBCAGSlope),&#10;     100&#10;  )" target="federalAwardBCAGAmount" />
-          <zeebe:output source="=if ((awardEligibilityBCAG = true) and (federalAwardBCAGAmount &#62;= 100))&#10;then&#10;  min(&#10;     calculatedDataTotalRemainingNeed3,&#10;     max(min(dmnPartTimeAwardAllowableLimits.limitAwardBCAGAmount - programYearTotalPartTimeBCAG, federalAwardBCAGAmount),0)&#10;  )&#10;else&#10;0" target="provincialAwardNetBCAGAmount" />
+          <zeebe:output source="=if ((awardEligibilityBCAG = true) and (federalAwardBCAGAmount &#62;= 100))&#10;then&#10;  min(&#10;     calculatedDataTotalRemainingNeed3,&#10;     max(min(dmnPartTimeAwardAllowableLimits.limitAwardBCAGAmount - (if (programYearTotalPartTimeBCAG = null) then 0 else programYearTotalPartTimeBCAG), federalAwardBCAGAmount),0)&#10;  )&#10;else&#10;0" target="provincialAwardNetBCAGAmount" />
           <zeebe:output source="=calculatedDataTotalRemainingNeed3 - provincialAwardNetBCAGAmount" target="calculatedDataTotalRemainingNeed4" />
         </zeebe:ioMapping>
       </bpmn:extensionElements>
@@ -692,7 +692,7 @@
     <bpmn:intermediateThrowEvent id="Event_1eaa23y" name="calculate CSGD">
       <bpmn:extensionElements>
         <zeebe:ioMapping>
-          <zeebe:output source="=//Deduct the total CSGD consumed amount for current Program Year from the derived CSGD total limit.&#10;if (awardEligibilityCSGD = true)&#10;then&#10;  max(min(calculatedDataTotalRemainingNeed2, federalAwardCSGDAmount - programYearTotalPartTimeCSGD),0)&#10;else&#10;0" target="federalAwardNetCSGDAmount" />
+          <zeebe:output source="=//Deduct the total CSGD consumed amount for current Program Year from the derived CSGD total limit.&#10;if (awardEligibilityCSGD = true)&#10;then&#10;  max(min(calculatedDataTotalRemainingNeed2, federalAwardCSGDAmount - (if (programYearTotalPartTimeCSGD = null) then 0 else programYearTotalPartTimeCSGD)),0)&#10;else&#10;0" target="federalAwardNetCSGDAmount" />
           <zeebe:output source="=max(0,(calculatedDataTotalRemainingNeed2 - federalAwardNetCSGDAmount))" target="calculatedDataTotalRemainingNeed3" />
         </zeebe:ioMapping>
       </bpmn:extensionElements>
@@ -733,7 +733,7 @@
     <bpmn:intermediateThrowEvent id="Event_1h2w0hl" name="calculate CSGP">
       <bpmn:extensionElements>
         <zeebe:ioMapping>
-          <zeebe:output source="=if ((awardEligibilityCSGP = true) &#10;    and (calculatedDataTotalAssessedNeed &#62;= 1)) &#10;then max(dmnPartTimeAwardAllowableLimits.limitAwardCSGPAmount - programYearTotalCSGP,0)&#10;else 0" target="federalAwardNetCSGPAmount" />
+          <zeebe:output source="=if ((awardEligibilityCSGP = true) &#10;    and (calculatedDataTotalAssessedNeed &#62;= 1)) &#10;then max(dmnPartTimeAwardAllowableLimits.limitAwardCSGPAmount - (if (programYearTotalCSGP = null) then 0 else programYearTotalCSGP), 0)&#10;else 0" target="federalAwardNetCSGPAmount" />
           <zeebe:output source="=max(0,(calculatedDataTotalAssessedNeed - federalAwardNetCSGPAmount))" target="calculatedDataTotalRemainingNeed1" />
         </zeebe:ioMapping>
       </bpmn:extensionElements>
@@ -759,7 +759,7 @@
     <bpmn:intermediateThrowEvent id="Event_12swz45" name="calculate SBSD">
       <bpmn:extensionElements>
         <zeebe:ioMapping>
-          <zeebe:output source="=if awardEligibilitySBSD = true&#10;then&#10;max(dmnPartTimeAwardAllowableLimits.limitAwardSBSDUnder40CourseLoadAmount - programYearTotalSBSD,0)&#10;else&#10;  0" target="provincialAwardNetSBSDAmount" />
+          <zeebe:output source="=if awardEligibilitySBSD = true&#10;then&#10;max(dmnPartTimeAwardAllowableLimits.limitAwardSBSDUnder40CourseLoadAmount - (if (programYearTotalSBSD = null) then 0 else programYearTotalSBSD),0)&#10;else&#10;  0" target="provincialAwardNetSBSDAmount" />
         </zeebe:ioMapping>
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_0x4ck3r</bpmn:incoming>
@@ -768,7 +768,7 @@
     <bpmn:intermediateThrowEvent id="Event_14d0375" name="calculate SBSD">
       <bpmn:extensionElements>
         <zeebe:ioMapping>
-          <zeebe:output source="=if awardEligibilitySBSD = true&#10;then&#10;max(dmnPartTimeAwardAllowableLimits.limitAwardSBSD40AndUpCourseLoadAmount - programYearTotalSBSD,0)&#10;else&#10;  0" target="provincialAwardNetSBSDAmount" />
+          <zeebe:output source="=if awardEligibilitySBSD = true&#10;then&#10;max(dmnPartTimeAwardAllowableLimits.limitAwardSBSD40AndUpCourseLoadAmount - (if (programYearTotalSBSD = null) then 0 else programYearTotalSBSD),0)&#10;else&#10;  0" target="provincialAwardNetSBSDAmount" />
         </zeebe:ioMapping>
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_1kzoimw</bpmn:incoming>

--- a/sources/packages/backend/workflow/BPMN/camunda-8/parttime-assessment-2022-2023.bpmn
+++ b/sources/packages/backend/workflow/BPMN/camunda-8/parttime-assessment-2022-2023.bpmn
@@ -740,9 +740,15 @@
       <bpmn:incoming>Flow_16epk5m</bpmn:incoming>
       <bpmn:outgoing>Flow_047qz6n</bpmn:outgoing>
     </bpmn:intermediateThrowEvent>
-    <bpmn:intermediateThrowEvent id="Event_0nkkesr" name="Program Year Total both FT and PT">
+    <bpmn:intermediateThrowEvent id="Event_0nkkesr" name="Program Year Total Initialization">
       <bpmn:extensionElements>
         <zeebe:ioMapping>
+          <zeebe:output source="=if(programYearTotalFullTimeCSGP = null) then 0 else programYearTotalFullTimeCSGP" target="programYearTotalFullTimeCSGP" />
+          <zeebe:output source="=if(programYearTotalPartTimeCSGP = null) then 0 else programYearTotalPartTimeCSGP" target="programYearTotalPartTimeCSGP" />
+          <zeebe:output source="=if(programYearTotalFullTimeSBSD = null) then 0 else programYearTotalFullTimeSBSD" target="programYearTotalFullTimeSBSD" />
+          <zeebe:output source="=if(programYearTotalPartTimSBSD = null) then 0 else programYearTotalPartTimeSBSD" target="programYearTotalPartTimeSBSD" />
+          <zeebe:output source="=if(programYearTotalPartTimeBCAG = null) then 0 else programYearTotalPartTimeBCAG" target="programYearTotalPartTimeBCAG" />
+          <zeebe:output source="=if(programYearTotalPartTimeCSGD = null) then 0 else programYearTotalPartTimeCSGD" target="programYearTotalPartTimeCSGD" />
           <zeebe:output source="=programYearTotalFullTimeSBSD + programYearTotalPartTimeSBSD" target="programYearTotalSBSD" />
           <zeebe:output source="=programYearTotalFullTimeCSGP + programYearTotalPartTimeCSGP" target="programYearTotalCSGP" />
         </zeebe:ioMapping>

--- a/sources/packages/backend/workflow/BPMN/camunda-8/parttime-assessment-2023-2024.bpmn
+++ b/sources/packages/backend/workflow/BPMN/camunda-8/parttime-assessment-2023-2024.bpmn
@@ -681,7 +681,8 @@
       <bpmn:extensionElements>
         <zeebe:ioMapping>
           <zeebe:output source="=  if (calculatedDataTotalFamilyIncome &#60;= dmnPartTimeAwardFamilySizeVariables.limitAwardBCAGIncomeCap)&#10;then dmnPartTimeAwardAllowableLimits.limitAwardBCAGAmount&#10;else&#10;  max(dmnPartTimeAwardAllowableLimits.limitAwardBCAGAmount - ((calculatedDataTotalFamilyIncome - dmnPartTimeAwardFamilySizeVariables.limitAwardBCAGIncomeCap) * dmnPartTimeAwardFamilySizeVariables.limitAwardBCAGSlope),&#10;     100&#10;  )" target="federalAwardBCAGAmount" />
-          <zeebe:output source="=if ((awardEligibilityBCAG = true) and (federalAwardBCAGAmount &#62;= 100))&#10;then&#10;  min(&#10;     calculatedDataTotalRemainingNeed3,&#10;     max(min(dmnPartTimeAwardAllowableLimits.limitAwardBCAGAmount - programYearTotalPartTimeBCAG, federalAwardBCAGAmount),0)&#10;  )&#10;else&#10;0" target="provincialAwardNetBCAGAmount" />
+          <zeebe:output source="=dmnPartTimeAwardAllowableLimits.limitAwardBCAGAmount - programYearTotalPartTimeBCAG" target="limitAwardBCAGRemaining" />
+          <zeebe:output source="=if (awardEligibilityBCAG = true and federalAwardBCAGAmount &#62;= 100 and limitAwardBCAGRemaining &#62;= 100)&#10;then&#10;  min(calculatedDataTotalRemainingNeed3, limitAwardBCAGRemaining, federalAwardBCAGAmount)&#10;else&#10;0" target="provincialAwardNetBCAGAmount" />
           <zeebe:output source="=calculatedDataTotalRemainingNeed3 - provincialAwardNetBCAGAmount" target="calculatedDataTotalRemainingNeed4" />
         </zeebe:ioMapping>
       </bpmn:extensionElements>
@@ -773,7 +774,8 @@
       <bpmn:extensionElements>
         <zeebe:ioMapping>
           <zeebe:output source="=if (calculatedDataTotalFamilyIncome &#60;= dmnPartTimeAwardFamilySizeVariables.limitAwardCSPTIncomeCap)&#10;then dmnPartTimeAwardAllowableLimits.limitAwardCSPTAmount&#10;else&#10;  max(dmnPartTimeAwardAllowableLimits.limitAwardCSPTAmount - ((calculatedDataTotalFamilyIncome - dmnPartTimeAwardFamilySizeVariables.limitAwardCSPTIncomeCap) * dmnPartTimeAwardFamilySizeVariables.limitAwardCSPTSlope),&#10;     100&#10;  )" target="federalAwardCSPTAmount" />
-          <zeebe:output source="=if (awardEligibilityCSPT = true and calculatedDataTotalRemainingNeed1 &#62;= 100)&#10;then&#10;  min(&#10;     calculatedDataTotalRemainingNeed1,&#10;     min(dmnPartTimeAwardAllowableLimits.limitAwardCSPTAmount - programYearTotalPartTimeCSPT, federalAwardCSPTAmount)&#10;  )&#10;else&#10;0" target="federalAwardNetCSPTAmount" />
+          <zeebe:output source="=dmnPartTimeAwardAllowableLimits.limitAwardCSPTAmount - programYearTotalPartTimeCSPT" target="limitAwardCSPTRemaining" />
+          <zeebe:output source="=if (awardEligibilityCSPT = true and calculatedDataTotalRemainingNeed1 &#62;= 100 and limitAwardCSPTRemaining &#62;= 100)&#10;then&#10;  min(calculatedDataTotalRemainingNeed1, limitAwardCSPTRemaining, federalAwardCSPTAmount)&#10;else&#10;0" target="federalAwardNetCSPTAmount" />
           <zeebe:output source="=max(0,(calculatedDataTotalRemainingNeed1 - federalAwardNetCSPTAmount))" target="calculatedDataTotalRemainingNeed2" />
         </zeebe:ioMapping>
       </bpmn:extensionElements>

--- a/sources/packages/backend/workflow/BPMN/camunda-8/parttime-assessment-2023-2024.bpmn
+++ b/sources/packages/backend/workflow/BPMN/camunda-8/parttime-assessment-2023-2024.bpmn
@@ -681,7 +681,7 @@
       <bpmn:extensionElements>
         <zeebe:ioMapping>
           <zeebe:output source="=  if (calculatedDataTotalFamilyIncome &#60;= dmnPartTimeAwardFamilySizeVariables.limitAwardBCAGIncomeCap)&#10;then dmnPartTimeAwardAllowableLimits.limitAwardBCAGAmount&#10;else&#10;  max(dmnPartTimeAwardAllowableLimits.limitAwardBCAGAmount - ((calculatedDataTotalFamilyIncome - dmnPartTimeAwardFamilySizeVariables.limitAwardBCAGIncomeCap) * dmnPartTimeAwardFamilySizeVariables.limitAwardBCAGSlope),&#10;     100&#10;  )" target="federalAwardBCAGAmount" />
-          <zeebe:output source="=if ((awardEligibilityBCAG = true) and (federalAwardBCAGAmount &#62;= 100))&#10;then&#10;  min(&#10;     calculatedDataTotalRemainingNeed3,&#10;     max(min(dmnPartTimeAwardAllowableLimits.limitAwardBCAGAmount - (if (programYearTotalPartTimeBCAG = null) then 0 else programYearTotalPartTimeBCAG), federalAwardBCAGAmount),0)&#10;  )&#10;else&#10;0" target="provincialAwardNetBCAGAmount" />
+          <zeebe:output source="=if ((awardEligibilityBCAG = true) and (federalAwardBCAGAmount &#62;= 100))&#10;then&#10;  min(&#10;     calculatedDataTotalRemainingNeed3,&#10;     max(min(dmnPartTimeAwardAllowableLimits.limitAwardBCAGAmount - programYearTotalPartTimeBCAG, federalAwardBCAGAmount),0)&#10;  )&#10;else&#10;0" target="provincialAwardNetBCAGAmount" />
           <zeebe:output source="=calculatedDataTotalRemainingNeed3 - provincialAwardNetBCAGAmount" target="calculatedDataTotalRemainingNeed4" />
         </zeebe:ioMapping>
       </bpmn:extensionElements>
@@ -691,7 +691,7 @@
     <bpmn:intermediateThrowEvent id="Event_1eaa23y" name="calculate CSGD">
       <bpmn:extensionElements>
         <zeebe:ioMapping>
-          <zeebe:output source="=//Deduct the total CSGD consumed amount for current Program Year from the derived CSGD total limit.&#10;if (awardEligibilityCSGD = true)&#10;then&#10;  max(min(calculatedDataTotalRemainingNeed2, federalAwardCSGDAmount - (if (programYearTotalPartTimeCSGD = null) then 0 else programYearTotalPartTimeCSGD)),0)&#10;else&#10;0" target="federalAwardNetCSGDAmount" />
+          <zeebe:output source="=//Deduct the total CSGD consumed amount for current Program Year from the derived CSGD total limit.&#10;if (awardEligibilityCSGD = true)&#10;then&#10;  max(min(calculatedDataTotalRemainingNeed2, federalAwardCSGDAmount - programYearTotalPartTimeCSGD),0)&#10;else&#10;0" target="federalAwardNetCSGDAmount" />
           <zeebe:output source="=max(0,(calculatedDataTotalRemainingNeed2 - federalAwardNetCSGDAmount))" target="calculatedDataTotalRemainingNeed3" />
         </zeebe:ioMapping>
       </bpmn:extensionElements>
@@ -716,16 +716,22 @@
     <bpmn:intermediateThrowEvent id="Event_1h2w0hl" name="calculate CSGP">
       <bpmn:extensionElements>
         <zeebe:ioMapping>
-          <zeebe:output source="=if ((awardEligibilityCSGP = true) &#10;    and (calculatedDataTotalAssessedNeed &#62;= 1)) &#10;then max(dmnPartTimeAwardAllowableLimits.limitAwardCSGPAmount - (if (programYearTotalCSGP = null) then 0 else programYearTotalCSGP), 0)&#10;else 0" target="federalAwardNetCSGPAmount" />
+          <zeebe:output source="=if ((awardEligibilityCSGP = true) &#10;    and (calculatedDataTotalAssessedNeed &#62;= 1)) &#10;then max(dmnPartTimeAwardAllowableLimits.limitAwardCSGPAmount - programYearTotalCSGP, 0)&#10;else 0" target="federalAwardNetCSGPAmount" />
           <zeebe:output source="=max(0,(calculatedDataTotalAssessedNeed - federalAwardNetCSGPAmount))" target="calculatedDataTotalRemainingNeed1" />
         </zeebe:ioMapping>
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_0apjmd6</bpmn:incoming>
       <bpmn:outgoing>Flow_047qz6n</bpmn:outgoing>
     </bpmn:intermediateThrowEvent>
-    <bpmn:intermediateThrowEvent id="Event_0nkkesr" name="Program Year Total both FT and PT">
+    <bpmn:intermediateThrowEvent id="Event_0nkkesr" name="Program Year Totals Inititalization">
       <bpmn:extensionElements>
         <zeebe:ioMapping>
+          <zeebe:output source="=if(programYearTotalFullTimeCSGP = null) then 0 else programYearTotalFullTimeCSGP" target="programYearTotalFullTimeCSGP" />
+          <zeebe:output source="=if(programYearTotalPartTimeCSGP = null) then 0 else programYearTotalPartTimeCSGP" target="programYearTotalPartTimeCSGP" />
+          <zeebe:output source="=if(programYearTotalFullTimeSBSD = null) then 0 else programYearTotalFullTimeSBSD" target="programYearTotalFullTimeSBSD" />
+          <zeebe:output source="=if(programYearTotalPartTimSBSD = null) then 0 else programYearTotalPartTimeSBSD" target="programYearTotalPartTimeSBSD" />
+          <zeebe:output source="=if(programYearTotalPartTimeBCAG = null) then 0 else programYearTotalPartTimeBCAG" target="programYearTotalPartTimeBCAG" />
+          <zeebe:output source="=if(programYearTotalPartTimeCSGD = null) then 0 else programYearTotalPartTimeCSGD" target="programYearTotalPartTimeCSGD" />
           <zeebe:output source="=programYearTotalFullTimeSBSD + programYearTotalPartTimeSBSD" target="programYearTotalSBSD" />
           <zeebe:output source="=programYearTotalFullTimeCSGP + programYearTotalPartTimeCSGP" target="programYearTotalCSGP" />
         </zeebe:ioMapping>
@@ -747,7 +753,7 @@
     <bpmn:intermediateThrowEvent id="Event_12swz45" name="calculate SBSD">
       <bpmn:extensionElements>
         <zeebe:ioMapping>
-          <zeebe:output source="=if awardEligibilitySBSD = true&#10;then&#10;max(dmnPartTimeAwardAllowableLimits.limitAwardSBSDUnder40CourseLoadAmount - (if (programYearTotalSBSD = null) then 0 else programYearTotalSBSD),0)&#10;else&#10;  0" target="provincialAwardNetSBSDAmount" />
+          <zeebe:output source="=if awardEligibilitySBSD = true&#10;then&#10;max(dmnPartTimeAwardAllowableLimits.limitAwardSBSDUnder40CourseLoadAmount - programYearTotalSBSD,0)&#10;else&#10;  0" target="provincialAwardNetSBSDAmount" />
         </zeebe:ioMapping>
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_0x4ck3r</bpmn:incoming>
@@ -756,7 +762,7 @@
     <bpmn:intermediateThrowEvent id="Event_14d0375" name="calculate SBSD">
       <bpmn:extensionElements>
         <zeebe:ioMapping>
-          <zeebe:output source="=if awardEligibilitySBSD = true&#10;then&#10;max(dmnPartTimeAwardAllowableLimits.limitAwardSBSD40AndUpCourseLoadAmount - (if (programYearTotalSBSD = null) then 0 else programYearTotalSBSD),0)&#10;else&#10;  0" target="provincialAwardNetSBSDAmount" />
+          <zeebe:output source="=if awardEligibilitySBSD = true&#10;then&#10;max(dmnPartTimeAwardAllowableLimits.limitAwardSBSD40AndUpCourseLoadAmount - programYearTotalSBSD,0)&#10;else&#10;  0" target="provincialAwardNetSBSDAmount" />
         </zeebe:ioMapping>
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_1kzoimw</bpmn:incoming>

--- a/sources/packages/backend/workflow/BPMN/camunda-8/parttime-assessment-2023-2024.bpmn
+++ b/sources/packages/backend/workflow/BPMN/camunda-8/parttime-assessment-2023-2024.bpmn
@@ -716,14 +716,14 @@
     <bpmn:intermediateThrowEvent id="Event_1h2w0hl" name="calculate CSGP">
       <bpmn:extensionElements>
         <zeebe:ioMapping>
-          <zeebe:output source="=if ((awardEligibilityCSGP = true) &#10;    and (calculatedDataTotalAssessedNeed &#62;= 1)) &#10;then max(dmnPartTimeAwardAllowableLimits.limitAwardCSGPAmount - programYearTotalCSGP, 0)&#10;else 0" target="federalAwardNetCSGPAmount" />
+          <zeebe:output source="=if ((awardEligibilityCSGP = true) &#10;    and (calculatedDataTotalAssessedNeed &#62;= 1)) &#10;then max(dmnPartTimeAwardAllowableLimits.limitAwardCSGPAmount - programYearTotalCSGP, 0) &#10;else 0" target="federalAwardNetCSGPAmount" />
           <zeebe:output source="=max(0,(calculatedDataTotalAssessedNeed - federalAwardNetCSGPAmount))" target="calculatedDataTotalRemainingNeed1" />
         </zeebe:ioMapping>
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_0apjmd6</bpmn:incoming>
       <bpmn:outgoing>Flow_047qz6n</bpmn:outgoing>
     </bpmn:intermediateThrowEvent>
-    <bpmn:intermediateThrowEvent id="Event_0nkkesr" name="Program Year Totals Inititalization">
+    <bpmn:intermediateThrowEvent id="Event_0nkkesr" name="Program Year Total Initialization">
       <bpmn:extensionElements>
         <zeebe:ioMapping>
           <zeebe:output source="=if(programYearTotalFullTimeCSGP = null) then 0 else programYearTotalFullTimeCSGP" target="programYearTotalFullTimeCSGP" />

--- a/sources/packages/backend/workflow/BPMN/camunda-8/parttime-assessment-2023-2024.bpmn
+++ b/sources/packages/backend/workflow/BPMN/camunda-8/parttime-assessment-2023-2024.bpmn
@@ -729,9 +729,10 @@
           <zeebe:output source="=if(programYearTotalFullTimeCSGP = null) then 0 else programYearTotalFullTimeCSGP" target="programYearTotalFullTimeCSGP" />
           <zeebe:output source="=if(programYearTotalPartTimeCSGP = null) then 0 else programYearTotalPartTimeCSGP" target="programYearTotalPartTimeCSGP" />
           <zeebe:output source="=if(programYearTotalFullTimeSBSD = null) then 0 else programYearTotalFullTimeSBSD" target="programYearTotalFullTimeSBSD" />
-          <zeebe:output source="=if(programYearTotalPartTimSBSD = null) then 0 else programYearTotalPartTimeSBSD" target="programYearTotalPartTimeSBSD" />
+          <zeebe:output source="=if(programYearTotalPartTimeSBSD = null) then 0 else programYearTotalPartTimeSBSD" target="programYearTotalPartTimeSBSD" />
           <zeebe:output source="=if(programYearTotalPartTimeBCAG = null) then 0 else programYearTotalPartTimeBCAG" target="programYearTotalPartTimeBCAG" />
           <zeebe:output source="=if(programYearTotalPartTimeCSGD = null) then 0 else programYearTotalPartTimeCSGD" target="programYearTotalPartTimeCSGD" />
+          <zeebe:output source="=if(programYearTotalPartTimeCSPT = null) then 0 else programYearTotalPartTimeCSPT" target="programYearTotalPartTimeCSPT" />
           <zeebe:output source="=programYearTotalFullTimeSBSD + programYearTotalPartTimeSBSD" target="programYearTotalSBSD" />
           <zeebe:output source="=programYearTotalFullTimeCSGP + programYearTotalPartTimeCSGP" target="programYearTotalCSGP" />
         </zeebe:ioMapping>
@@ -772,7 +773,7 @@
       <bpmn:extensionElements>
         <zeebe:ioMapping>
           <zeebe:output source="=if (calculatedDataTotalFamilyIncome &#60;= dmnPartTimeAwardFamilySizeVariables.limitAwardCSPTIncomeCap)&#10;then dmnPartTimeAwardAllowableLimits.limitAwardCSPTAmount&#10;else&#10;  max(dmnPartTimeAwardAllowableLimits.limitAwardCSPTAmount - ((calculatedDataTotalFamilyIncome - dmnPartTimeAwardFamilySizeVariables.limitAwardCSPTIncomeCap) * dmnPartTimeAwardFamilySizeVariables.limitAwardCSPTSlope),&#10;     100&#10;  )" target="federalAwardCSPTAmount" />
-          <zeebe:output source="=if (awardEligibilityCSPT = true and calculatedDataTotalRemainingNeed1 &#62;= 100)&#10;then&#10;  min(&#10;     calculatedDataTotalRemainingNeed1,&#10;     min(dmnPartTimeAwardAllowableLimits.limitAwardCSPTAmount, federalAwardCSPTAmount)&#10;  )&#10;else&#10;0" target="federalAwardNetCSPTAmount" />
+          <zeebe:output source="=if (awardEligibilityCSPT = true and calculatedDataTotalRemainingNeed1 &#62;= 100)&#10;then&#10;  min(&#10;     calculatedDataTotalRemainingNeed1,&#10;     min(dmnPartTimeAwardAllowableLimits.limitAwardCSPTAmount - programYearTotalPartTimeCSPT, federalAwardCSPTAmount)&#10;  )&#10;else&#10;0" target="federalAwardNetCSPTAmount" />
           <zeebe:output source="=max(0,(calculatedDataTotalRemainingNeed1 - federalAwardNetCSPTAmount))" target="calculatedDataTotalRemainingNeed2" />
         </zeebe:ioMapping>
       </bpmn:extensionElements>

--- a/sources/packages/backend/workflow/BPMN/camunda-8/parttime-assessment-2023-2024.bpmn
+++ b/sources/packages/backend/workflow/BPMN/camunda-8/parttime-assessment-2023-2024.bpmn
@@ -681,7 +681,7 @@
       <bpmn:extensionElements>
         <zeebe:ioMapping>
           <zeebe:output source="=  if (calculatedDataTotalFamilyIncome &#60;= dmnPartTimeAwardFamilySizeVariables.limitAwardBCAGIncomeCap)&#10;then dmnPartTimeAwardAllowableLimits.limitAwardBCAGAmount&#10;else&#10;  max(dmnPartTimeAwardAllowableLimits.limitAwardBCAGAmount - ((calculatedDataTotalFamilyIncome - dmnPartTimeAwardFamilySizeVariables.limitAwardBCAGIncomeCap) * dmnPartTimeAwardFamilySizeVariables.limitAwardBCAGSlope),&#10;     100&#10;  )" target="federalAwardBCAGAmount" />
-          <zeebe:output source="=if ((awardEligibilityBCAG = true) and (federalAwardBCAGAmount &#62;= 100))&#10;then&#10;  min(&#10;     calculatedDataTotalRemainingNeed3,&#10;     max(min(dmnPartTimeAwardAllowableLimits.limitAwardBCAGAmount - programYearTotalPartTimeBCAG, federalAwardBCAGAmount),0)&#10;  )&#10;else&#10;0" target="provincialAwardNetBCAGAmount" />
+          <zeebe:output source="=if ((awardEligibilityBCAG = true) and (federalAwardBCAGAmount &#62;= 100))&#10;then&#10;  min(&#10;     calculatedDataTotalRemainingNeed3,&#10;     max(min(dmnPartTimeAwardAllowableLimits.limitAwardBCAGAmount - (if (programYearTotalPartTimeBCAG = null) then 0 else programYearTotalPartTimeBCAG), federalAwardBCAGAmount),0)&#10;  )&#10;else&#10;0" target="provincialAwardNetBCAGAmount" />
           <zeebe:output source="=calculatedDataTotalRemainingNeed3 - provincialAwardNetBCAGAmount" target="calculatedDataTotalRemainingNeed4" />
         </zeebe:ioMapping>
       </bpmn:extensionElements>
@@ -691,7 +691,7 @@
     <bpmn:intermediateThrowEvent id="Event_1eaa23y" name="calculate CSGD">
       <bpmn:extensionElements>
         <zeebe:ioMapping>
-          <zeebe:output source="=//Deduct the total CSGD consumed amount for current Program Year from the derived CSGD total limit.&#10;if (awardEligibilityCSGD = true)&#10;then&#10;  max(min(calculatedDataTotalRemainingNeed2, federalAwardCSGDAmount - programYearTotalPartTimeCSGD),0)&#10;else&#10;0" target="federalAwardNetCSGDAmount" />
+          <zeebe:output source="=//Deduct the total CSGD consumed amount for current Program Year from the derived CSGD total limit.&#10;if (awardEligibilityCSGD = true)&#10;then&#10;  max(min(calculatedDataTotalRemainingNeed2, federalAwardCSGDAmount - (if (programYearTotalPartTimeCSGD = null) then 0 else programYearTotalPartTimeCSGD)),0)&#10;else&#10;0" target="federalAwardNetCSGDAmount" />
           <zeebe:output source="=max(0,(calculatedDataTotalRemainingNeed2 - federalAwardNetCSGDAmount))" target="calculatedDataTotalRemainingNeed3" />
         </zeebe:ioMapping>
       </bpmn:extensionElements>
@@ -716,7 +716,7 @@
     <bpmn:intermediateThrowEvent id="Event_1h2w0hl" name="calculate CSGP">
       <bpmn:extensionElements>
         <zeebe:ioMapping>
-          <zeebe:output source="=if ((awardEligibilityCSGP = true) &#10;    and (calculatedDataTotalAssessedNeed &#62;= 1)) &#10;then max(dmnPartTimeAwardAllowableLimits.limitAwardCSGPAmount - programYearTotalCSGP,0) &#10;else 0" target="federalAwardNetCSGPAmount" />
+          <zeebe:output source="=if ((awardEligibilityCSGP = true) &#10;    and (calculatedDataTotalAssessedNeed &#62;= 1)) &#10;then max(dmnPartTimeAwardAllowableLimits.limitAwardCSGPAmount - (if (programYearTotalCSGP = null) then 0 else programYearTotalCSGP), 0)&#10;else 0" target="federalAwardNetCSGPAmount" />
           <zeebe:output source="=max(0,(calculatedDataTotalAssessedNeed - federalAwardNetCSGPAmount))" target="calculatedDataTotalRemainingNeed1" />
         </zeebe:ioMapping>
       </bpmn:extensionElements>
@@ -747,7 +747,7 @@
     <bpmn:intermediateThrowEvent id="Event_12swz45" name="calculate SBSD">
       <bpmn:extensionElements>
         <zeebe:ioMapping>
-          <zeebe:output source="=if awardEligibilitySBSD = true&#10;then&#10;max(dmnPartTimeAwardAllowableLimits.limitAwardSBSDUnder40CourseLoadAmount - programYearTotalSBSD,0)&#10;else&#10;  0" target="provincialAwardNetSBSDAmount" />
+          <zeebe:output source="=if awardEligibilitySBSD = true&#10;then&#10;max(dmnPartTimeAwardAllowableLimits.limitAwardSBSDUnder40CourseLoadAmount - (if (programYearTotalSBSD = null) then 0 else programYearTotalSBSD),0)&#10;else&#10;  0" target="provincialAwardNetSBSDAmount" />
         </zeebe:ioMapping>
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_0x4ck3r</bpmn:incoming>
@@ -756,7 +756,7 @@
     <bpmn:intermediateThrowEvent id="Event_14d0375" name="calculate SBSD">
       <bpmn:extensionElements>
         <zeebe:ioMapping>
-          <zeebe:output source="=if awardEligibilitySBSD = true&#10;then&#10;max(dmnPartTimeAwardAllowableLimits.limitAwardSBSD40AndUpCourseLoadAmount - programYearTotalSBSD,0)&#10;else&#10;  0" target="provincialAwardNetSBSDAmount" />
+          <zeebe:output source="=if awardEligibilitySBSD = true&#10;then&#10;max(dmnPartTimeAwardAllowableLimits.limitAwardSBSD40AndUpCourseLoadAmount - (if (programYearTotalSBSD = null) then 0 else programYearTotalSBSD),0)&#10;else&#10;  0" target="provincialAwardNetSBSDAmount" />
         </zeebe:ioMapping>
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_1kzoimw</bpmn:incoming>

--- a/sources/packages/backend/workflow/BPMN/camunda-8/parttime-assessment-2023-2024.bpmn
+++ b/sources/packages/backend/workflow/BPMN/camunda-8/parttime-assessment-2023-2024.bpmn
@@ -716,7 +716,7 @@
     <bpmn:intermediateThrowEvent id="Event_1h2w0hl" name="calculate CSGP">
       <bpmn:extensionElements>
         <zeebe:ioMapping>
-          <zeebe:output source="=if ((awardEligibilityCSGP = true) &#10;    and (calculatedDataTotalAssessedNeed &#62;= 1)) &#10;then max(dmnPartTimeAwardAllowableLimits.limitAwardCSGPAmount - programYearTotalCSGP, 0) &#10;else 0" target="federalAwardNetCSGPAmount" />
+          <zeebe:output source="=if ((awardEligibilityCSGP = true) &#10;    and (calculatedDataTotalAssessedNeed &#62;= 1)) &#10;then max(dmnPartTimeAwardAllowableLimits.limitAwardCSGPAmount - programYearTotalCSGP,0) &#10;else 0" target="federalAwardNetCSGPAmount" />
           <zeebe:output source="=max(0,(calculatedDataTotalAssessedNeed - federalAwardNetCSGPAmount))" target="calculatedDataTotalRemainingNeed1" />
         </zeebe:ioMapping>
       </bpmn:extensionElements>

--- a/sources/packages/backend/workflow/test/2021-2022/parttime-assessment/awards-amounts/parttime-assessment-2021-2022-awards-amount-BCAG.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2021-2022/parttime-assessment/awards-amounts/parttime-assessment-2021-2022-awards-amount-BCAG.e2e-spec.ts
@@ -154,4 +154,30 @@ describe(`E2E Test Workflow parttime-assessment-${PROGRAM_YEAR}-awards-amount-BC
       1000,
     );
   });
+
+  it("Should determine provincialAwardNetBCAGAmount as zero when awardEligibilityBCAG is true and difference between the programYearLimits and BCAG awarded in the program year previously is less than 100", async () => {
+    // Arrange
+    const assessmentConsolidatedData =
+      createFakeConsolidatedPartTimeData(PROGRAM_YEAR);
+    assessmentConsolidatedData.studentDataCRAReportedIncome = 20001;
+    assessmentConsolidatedData.studentDataRelationshipStatus = "married";
+    assessmentConsolidatedData.studentDataIsYourSpouseACanadianCitizen =
+      YesNoOptions.Yes;
+    assessmentConsolidatedData.partner1CRAReportedIncome = 22999;
+    // Public institution
+    assessmentConsolidatedData.institutionType = InstitutionTypes.BCPublic;
+    assessmentConsolidatedData.programYearTotalPartTimeBCAG = 901;
+
+    // Act
+    const calculatedAssessment = await executePartTimeAssessmentForProgramYear(
+      PROGRAM_YEAR,
+      assessmentConsolidatedData,
+    );
+    // Assert
+    // awardEligibilityBCAG is true.
+    // provincialAwardNetBCAGAmount is 0.
+    expect(calculatedAssessment.variables.awardEligibilityBCAG).toBe(true);
+    expect(calculatedAssessment.variables.limitAwardBCAGRemaining).toBe(99);
+    expect(calculatedAssessment.variables.provincialAwardNetBCAGAmount).toBe(0);
+  });
 });

--- a/sources/packages/backend/workflow/test/2021-2022/parttime-assessment/awards-amounts/parttime-assessment-2021-2022-awards-amount-BCAG.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2021-2022/parttime-assessment/awards-amounts/parttime-assessment-2021-2022-awards-amount-BCAG.e2e-spec.ts
@@ -127,4 +127,31 @@ describe(`E2E Test Workflow parttime-assessment-${PROGRAM_YEAR}-awards-amount-BC
     expect(calculatedAssessment.variables.awardEligibilityBCAG).toBe(false);
     expect(calculatedAssessment.variables.provincialAwardNetBCAGAmount).toBe(0);
   });
+
+  it("Should determine provincialAwardNetBCAGAmount when awardEligibilityBCAG is true and provincialAwardPartTimeBCAGAmount is null", async () => {
+    // Arrange
+    const assessmentConsolidatedData =
+      createFakeConsolidatedPartTimeData(PROGRAM_YEAR);
+    assessmentConsolidatedData.studentDataCRAReportedIncome = 20001;
+    assessmentConsolidatedData.studentDataRelationshipStatus = "married";
+    assessmentConsolidatedData.studentDataIsYourSpouseACanadianCitizen =
+      YesNoOptions.Yes;
+    assessmentConsolidatedData.partner1CRAReportedIncome = 22999;
+    // Public institution
+    assessmentConsolidatedData.institutionType = InstitutionTypes.BCPublic;
+    assessmentConsolidatedData.programYearTotalPartTimeBCAG = null;
+
+    // Act
+    const calculatedAssessment = await executePartTimeAssessmentForProgramYear(
+      PROGRAM_YEAR,
+      assessmentConsolidatedData,
+    );
+    // Assert
+    // awardEligibilityBCAG is true.
+    // provincialAwardNetBCAGAmount is 1000.
+    expect(calculatedAssessment.variables.awardEligibilityBCAG).toBe(true);
+    expect(calculatedAssessment.variables.provincialAwardNetBCAGAmount).toBe(
+      1000,
+    );
+  });
 });

--- a/sources/packages/backend/workflow/test/2021-2022/parttime-assessment/awards-amounts/parttime-assessment-2021-2022-awards-amount-BCAG.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2021-2022/parttime-assessment/awards-amounts/parttime-assessment-2021-2022-awards-amount-BCAG.e2e-spec.ts
@@ -128,7 +128,7 @@ describe(`E2E Test Workflow parttime-assessment-${PROGRAM_YEAR}-awards-amount-BC
     expect(calculatedAssessment.variables.provincialAwardNetBCAGAmount).toBe(0);
   });
 
-  it("Should determine provincialAwardNetBCAGAmount when awardEligibilityBCAG is true and provincialAwardPartTimeBCAGAmount is null", async () => {
+  it("Should determine provincialAwardNetBCAGAmount when awardEligibilityBCAG is true and no BCAG awarded in the program year previously", async () => {
     // Arrange
     const assessmentConsolidatedData =
       createFakeConsolidatedPartTimeData(PROGRAM_YEAR);

--- a/sources/packages/backend/workflow/test/2021-2022/parttime-assessment/awards-amounts/parttime-assessment-2021-2022-awards-amount-BCAG.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2021-2022/parttime-assessment/awards-amounts/parttime-assessment-2021-2022-awards-amount-BCAG.e2e-spec.ts
@@ -139,7 +139,7 @@ describe(`E2E Test Workflow parttime-assessment-${PROGRAM_YEAR}-awards-amount-BC
     assessmentConsolidatedData.partner1CRAReportedIncome = 22999;
     // Public institution
     assessmentConsolidatedData.institutionType = InstitutionTypes.BCPublic;
-    assessmentConsolidatedData.programYearTotalPartTimeBCAG = null;
+    assessmentConsolidatedData.programYearTotalPartTimeBCAG = undefined;
 
     // Act
     const calculatedAssessment = await executePartTimeAssessmentForProgramYear(

--- a/sources/packages/backend/workflow/test/2021-2022/parttime-assessment/awards-amounts/parttime-assessment-2021-2022-awards-amount-CSGD.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2021-2022/parttime-assessment/awards-amounts/parttime-assessment-2021-2022-awards-amount-CSGD.e2e-spec.ts
@@ -221,4 +221,37 @@ describe(`E2E Test Workflow parttime-assessment-${PROGRAM_YEAR}-awards-amount-CS
       659.0567998,
     );
   });
+
+  it("Should determine federalAwardCSGDAmount when awardEligibilityCSGD is true and programYearTotalPartTimeCSGD is null", async () => {
+    // Arrange
+    const assessmentConsolidatedData =
+      createFakeConsolidatedPartTimeData(PROGRAM_YEAR);
+    assessmentConsolidatedData.studentDataCRAReportedIncome = 35000;
+    assessmentConsolidatedData.studentDataRelationshipStatus = "married";
+    assessmentConsolidatedData.studentDataIsYourSpouseACanadianCitizen =
+      YesNoOptions.Yes;
+    assessmentConsolidatedData.partner1CRAReportedIncome = 35000;
+    assessmentConsolidatedData.studentDataDependants = [
+      createFakeStudentDependentEligible(
+        DependentEligibility.Eligible0To18YearsOld,
+      ),
+    ];
+    assessmentConsolidatedData.programYearTotalPartTimeCSGD = null;
+
+    // Act
+    const calculatedAssessment = await executePartTimeAssessmentForProgramYear(
+      PROGRAM_YEAR,
+      assessmentConsolidatedData,
+    );
+    // Assert
+    // calculatedDataTotalFamilyIncome <= limitAwardCSGDIncomeCap
+    // federalAwardCSGDAmount
+    expect(calculatedAssessment.variables.awardEligibilityCSGD).toBe(true);
+    expect(calculatedAssessment.variables.federalAwardCSGDAmount).toBe(
+      859.0567998,
+    );
+    expect(calculatedAssessment.variables.federalAwardNetCSGDAmount).toBe(
+      859.0567998,
+    );
+  });
 });

--- a/sources/packages/backend/workflow/test/2021-2022/parttime-assessment/awards-amounts/parttime-assessment-2021-2022-awards-amount-CSGD.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2021-2022/parttime-assessment/awards-amounts/parttime-assessment-2021-2022-awards-amount-CSGD.e2e-spec.ts
@@ -236,7 +236,7 @@ describe(`E2E Test Workflow parttime-assessment-${PROGRAM_YEAR}-awards-amount-CS
         DependentEligibility.Eligible0To18YearsOld,
       ),
     ];
-    assessmentConsolidatedData.programYearTotalPartTimeCSGD = null;
+    assessmentConsolidatedData.programYearTotalPartTimeCSGD = undefined;
 
     // Act
     const calculatedAssessment = await executePartTimeAssessmentForProgramYear(

--- a/sources/packages/backend/workflow/test/2021-2022/parttime-assessment/awards-amounts/parttime-assessment-2021-2022-awards-amount-CSGD.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2021-2022/parttime-assessment/awards-amounts/parttime-assessment-2021-2022-awards-amount-CSGD.e2e-spec.ts
@@ -222,7 +222,7 @@ describe(`E2E Test Workflow parttime-assessment-${PROGRAM_YEAR}-awards-amount-CS
     );
   });
 
-  it("Should determine federalAwardCSGDAmount when awardEligibilityCSGD is true and programYearTotalPartTimeCSGD is null", async () => {
+  it("Should determine federalAwardCSGDAmount when awardEligibilityCSGD is true and no CSGD awarded in the program year previously", async () => {
     // Arrange
     const assessmentConsolidatedData =
       createFakeConsolidatedPartTimeData(PROGRAM_YEAR);

--- a/sources/packages/backend/workflow/test/2021-2022/parttime-assessment/awards-amounts/parttime-assessment-2021-2022-awards-amount-CSPT.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2021-2022/parttime-assessment/awards-amounts/parttime-assessment-2021-2022-awards-amount-CSPT.e2e-spec.ts
@@ -124,16 +124,6 @@ describe(`E2E Test Workflow parttime-assessment-${PROGRAM_YEAR}-awards-amount-CS
     expect(
       calculatedAssessment.variables.federalAwardCSPTAmount,
     ).toBeGreaterThan(100);
-    expect(calculatedAssessment.variables.federalAwardNetCSPTAmount).toBe(
-      Math.min(
-        calculatedAssessment.variables.calculatedDataTotalRemainingNeed1,
-        Math.min(
-          calculatedAssessment.variables.dmnPartTimeAwardAllowableLimits
-            .limitAwardCSPTAmount,
-          calculatedAssessment.variables.federalAwardCSPTAmount,
-        ),
-      ),
-    );
     expect(calculatedAssessment.variables.federalAwardNetCSPTAmount).toBe(3600);
   });
 });

--- a/sources/packages/backend/workflow/test/2021-2022/parttime-assessment/awards-amounts/parttime-assessment-2021-2022-awards-amount-CSPT.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2021-2022/parttime-assessment/awards-amounts/parttime-assessment-2021-2022-awards-amount-CSPT.e2e-spec.ts
@@ -126,4 +126,28 @@ describe(`E2E Test Workflow parttime-assessment-${PROGRAM_YEAR}-awards-amount-CS
     ).toBeGreaterThan(100);
     expect(calculatedAssessment.variables.federalAwardNetCSPTAmount).toBe(3600);
   });
+
+  it("Should determine federalAwardNetCSPTAmount as zero when awardEligibilityCSPT is true and difference between the programYearLimits and CSPT awarded in the program year previously is less than 100", async () => {
+    // Arrange
+    const assessmentConsolidatedData =
+      createFakeConsolidatedPartTimeData(PROGRAM_YEAR);
+    assessmentConsolidatedData.studentDataCRAReportedIncome = 60001;
+    assessmentConsolidatedData.studentDataRelationshipStatus = "married";
+    assessmentConsolidatedData.studentDataIsYourSpouseACanadianCitizen =
+      YesNoOptions.Yes;
+    assessmentConsolidatedData.partner1CRAReportedIncome = 22999;
+    assessmentConsolidatedData.programYearTotalPartTimeCSPT = 3501;
+    // Act
+    const calculatedAssessment = await executePartTimeAssessmentForProgramYear(
+      PROGRAM_YEAR,
+      assessmentConsolidatedData,
+    );
+    // Assert
+    expect(calculatedAssessment.variables.awardEligibilityCSPT).toBe(true);
+    expect(calculatedAssessment.variables.limitAwardCSPTRemaining).toBe(99);
+    expect(
+      calculatedAssessment.variables.federalAwardCSPTAmount,
+    ).toBeGreaterThan(100);
+    expect(calculatedAssessment.variables.federalAwardNetCSPTAmount).toBe(0);
+  });
 });

--- a/sources/packages/backend/workflow/test/2021-2022/parttime-assessment/awards-amounts/parttime-assessment-2021-2022-awards-amount-CSPT.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2021-2022/parttime-assessment/awards-amounts/parttime-assessment-2021-2022-awards-amount-CSPT.e2e-spec.ts
@@ -113,7 +113,7 @@ describe(`E2E Test Workflow parttime-assessment-${PROGRAM_YEAR}-awards-amount-CS
     assessmentConsolidatedData.studentDataIsYourSpouseACanadianCitizen =
       YesNoOptions.Yes;
     assessmentConsolidatedData.partner1CRAReportedIncome = 22999;
-    assessmentConsolidatedData.programYearTotalPartTimeCSPT = null;
+    assessmentConsolidatedData.programYearTotalPartTimeCSPT = undefined;
     // Act
     const calculatedAssessment = await executePartTimeAssessmentForProgramYear(
       PROGRAM_YEAR,

--- a/sources/packages/backend/workflow/test/2021-2022/parttime-assessment/awards-amounts/parttime-assessment-2021-2022-awards-amount-CSPT.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2021-2022/parttime-assessment/awards-amounts/parttime-assessment-2021-2022-awards-amount-CSPT.e2e-spec.ts
@@ -104,7 +104,7 @@ describe(`E2E Test Workflow parttime-assessment-${PROGRAM_YEAR}-awards-amount-CS
     expect(calculatedAssessment.variables.federalAwardNetCSPTAmount).toBe(0);
   });
 
-  it("Should determine federalAwardNetCSPTAmount when awardEligibilityCSPT is true and programYearTotalPartTimeCSPT is null", async () => {
+  it("Should determine federalAwardNetCSPTAmount when awardEligibilityCSPT is true and no CSPT awarded in the program year previously", async () => {
     // Arrange
     const assessmentConsolidatedData =
       createFakeConsolidatedPartTimeData(PROGRAM_YEAR);

--- a/sources/packages/backend/workflow/test/2021-2022/parttime-assessment/awards-amounts/parttime-assessment-2021-2022-awards-amount-CSPT.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2021-2022/parttime-assessment/awards-amounts/parttime-assessment-2021-2022-awards-amount-CSPT.e2e-spec.ts
@@ -61,18 +61,6 @@ describe(`E2E Test Workflow parttime-assessment-${PROGRAM_YEAR}-awards-amount-CS
     expect(calculatedAssessment.variables.calculatedDataTotalFamilyIncome).toBe(
       53000,
     );
-    expect(calculatedAssessment.variables.federalAwardCSPTAmount).toBe(
-      Math.max(
-        calculatedAssessment.variables.dmnPartTimeAwardAllowableLimits
-          .limitAwardCSPTAmount -
-          (calculatedAssessment.variables.calculatedDataTotalFamilyIncome -
-            calculatedAssessment.variables.dmnPartTimeAwardFamilySizeVariables
-              .limitAwardCSPTIncomeCap) *
-            calculatedAssessment.variables.dmnPartTimeAwardFamilySizeVariables
-              .limitAwardCSPTSlope,
-        100,
-      ),
-    );
     expect(calculatedAssessment.variables.federalAwardCSPTAmount).toBeLessThan(
       3000,
     );
@@ -97,17 +85,7 @@ describe(`E2E Test Workflow parttime-assessment-${PROGRAM_YEAR}-awards-amount-CS
     expect(
       calculatedAssessment.variables.federalAwardCSPTAmount,
     ).toBeGreaterThan(100);
-    expect(calculatedAssessment.variables.federalAwardNetCSPTAmount).toBe(
-      Math.min(
-        calculatedAssessment.variables.calculatedDataTotalRemainingNeed1,
-        Math.min(
-          calculatedAssessment.variables.dmnPartTimeAwardAllowableLimits
-            .limitAwardCSPTAmount,
-          calculatedAssessment.variables.federalAwardCSPTAmount,
-        ),
-      ),
-    );
-    expect(calculatedAssessment.variables.federalAwardNetCSPTAmount).toBe(3600);
+    expect(calculatedAssessment.variables.federalAwardNetCSPTAmount).toBe(3520);
   });
 
   it("Should determine federalAwardNetCSPTAmount as zero when awardEligibilityCSPT is false", async () => {
@@ -124,5 +102,38 @@ describe(`E2E Test Workflow parttime-assessment-${PROGRAM_YEAR}-awards-amount-CS
     // Assert
     expect(calculatedAssessment.variables.awardEligibilityCSPT).toBe(false);
     expect(calculatedAssessment.variables.federalAwardNetCSPTAmount).toBe(0);
+  });
+
+  it("Should determine federalAwardNetCSPTAmount when awardEligibilityCSPT is true and programYearTotalPartTimeCSPT is null", async () => {
+    // Arrange
+    const assessmentConsolidatedData =
+      createFakeConsolidatedPartTimeData(PROGRAM_YEAR);
+    assessmentConsolidatedData.studentDataCRAReportedIncome = 20001;
+    assessmentConsolidatedData.studentDataRelationshipStatus = "married";
+    assessmentConsolidatedData.studentDataIsYourSpouseACanadianCitizen =
+      YesNoOptions.Yes;
+    assessmentConsolidatedData.partner1CRAReportedIncome = 22999;
+    assessmentConsolidatedData.programYearTotalPartTimeCSPT = null;
+    // Act
+    const calculatedAssessment = await executePartTimeAssessmentForProgramYear(
+      PROGRAM_YEAR,
+      assessmentConsolidatedData,
+    );
+    // Assert
+    expect(calculatedAssessment.variables.awardEligibilityCSPT).toBe(true);
+    expect(
+      calculatedAssessment.variables.federalAwardCSPTAmount,
+    ).toBeGreaterThan(100);
+    expect(calculatedAssessment.variables.federalAwardNetCSPTAmount).toBe(
+      Math.min(
+        calculatedAssessment.variables.calculatedDataTotalRemainingNeed1,
+        Math.min(
+          calculatedAssessment.variables.dmnPartTimeAwardAllowableLimits
+            .limitAwardCSPTAmount,
+          calculatedAssessment.variables.federalAwardCSPTAmount,
+        ),
+      ),
+    );
+    expect(calculatedAssessment.variables.federalAwardNetCSPTAmount).toBe(3600);
   });
 });

--- a/sources/packages/backend/workflow/test/2021-2022/parttime-assessment/awards-amounts/parttime-assessment-awards-amount-CSGP.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2021-2022/parttime-assessment/awards-amounts/parttime-assessment-awards-amount-CSGP.e2e-spec.ts
@@ -47,4 +47,26 @@ describe(`E2E Test Workflow parttime-assessment-${PROGRAM_YEAR}-awards-amount-CS
       0,
     );
   });
+
+  it("Should determine federalAwardCSGPAmount when awardEligibilityCSGP is true, programYearTotalPartTimeCSGP, programYearTotalFullTimeCSGP are null and studentDataApplicationPDPPDStatus is true", async () => {
+    // Arrange
+    const assessmentConsolidatedData =
+      createFakeConsolidatedPartTimeData(PROGRAM_YEAR);
+    assessmentConsolidatedData.studentDataApplicationPDPPDStatus = "yes";
+    assessmentConsolidatedData.programYearTotalFullTimeCSGP = null;
+    assessmentConsolidatedData.programYearTotalPartTimeCSGP = null;
+
+    // Act
+    const calculatedAssessment = await executePartTimeAssessmentForProgramYear(
+      PROGRAM_YEAR,
+      assessmentConsolidatedData,
+    );
+
+    // Assert
+    expect(calculatedAssessment.variables.programYearTotalCSGP).toBe(null);
+    expect(calculatedAssessment.variables.federalAwardNetCSGPAmount).toBe(4000);
+    expect(calculatedAssessment.variables.finalFederalAwardNetCSGPAmount).toBe(
+      4000,
+    );
+  });
 });

--- a/sources/packages/backend/workflow/test/2021-2022/parttime-assessment/awards-amounts/parttime-assessment-awards-amount-CSGP.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2021-2022/parttime-assessment/awards-amounts/parttime-assessment-awards-amount-CSGP.e2e-spec.ts
@@ -63,7 +63,7 @@ describe(`E2E Test Workflow parttime-assessment-${PROGRAM_YEAR}-awards-amount-CS
     );
 
     // Assert
-    expect(calculatedAssessment.variables.programYearTotalCSGP).toBe(null);
+    expect(calculatedAssessment.variables.programYearTotalCSGP).toBe(0);
     expect(calculatedAssessment.variables.federalAwardNetCSGPAmount).toBe(4000);
     expect(calculatedAssessment.variables.finalFederalAwardNetCSGPAmount).toBe(
       4000,

--- a/sources/packages/backend/workflow/test/2021-2022/parttime-assessment/awards-amounts/parttime-assessment-awards-amount-CSGP.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2021-2022/parttime-assessment/awards-amounts/parttime-assessment-awards-amount-CSGP.e2e-spec.ts
@@ -48,7 +48,7 @@ describe(`E2E Test Workflow parttime-assessment-${PROGRAM_YEAR}-awards-amount-CS
     );
   });
 
-  it("Should determine federalAwardCSGPAmount when awardEligibilityCSGP is true, programYearTotalPartTimeCSGP, programYearTotalFullTimeCSGP are null and studentDataApplicationPDPPDStatus is true", async () => {
+  it("Should determine federalAwardCSGPAmount when awardEligibilityCSGP is true, no CSGP awarded in the program year previously and studentDataApplicationPDPPDStatus is true", async () => {
     // Arrange
     const assessmentConsolidatedData =
       createFakeConsolidatedPartTimeData(PROGRAM_YEAR);

--- a/sources/packages/backend/workflow/test/2021-2022/parttime-assessment/awards-amounts/parttime-assessment-awards-amount-CSGP.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2021-2022/parttime-assessment/awards-amounts/parttime-assessment-awards-amount-CSGP.e2e-spec.ts
@@ -53,8 +53,8 @@ describe(`E2E Test Workflow parttime-assessment-${PROGRAM_YEAR}-awards-amount-CS
     const assessmentConsolidatedData =
       createFakeConsolidatedPartTimeData(PROGRAM_YEAR);
     assessmentConsolidatedData.studentDataApplicationPDPPDStatus = "yes";
-    assessmentConsolidatedData.programYearTotalFullTimeCSGP = null;
-    assessmentConsolidatedData.programYearTotalPartTimeCSGP = null;
+    assessmentConsolidatedData.programYearTotalFullTimeCSGP = undefined;
+    assessmentConsolidatedData.programYearTotalPartTimeCSGP = undefined;
 
     // Act
     const calculatedAssessment = await executePartTimeAssessmentForProgramYear(

--- a/sources/packages/backend/workflow/test/2021-2022/parttime-assessment/awards-amounts/parttime-assessment-awards-amount-CSGP.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2021-2022/parttime-assessment/awards-amounts/parttime-assessment-awards-amount-CSGP.e2e-spec.ts
@@ -5,7 +5,7 @@ import {
 } from "../../../test-utils";
 
 describe(`E2E Test Workflow parttime-assessment-${PROGRAM_YEAR}-awards-amount-CSGP.`, () => {
-  it("Should determine federalAwardCSGPAmount when awardEligibilityCSGP is true and studentDataApplicationPDPPDStatus is true", async () => {
+  it("Should determine federalAwardCSGPAmount when awardEligibilityCSGP is true and studentDataApplicationPDPPDStatus is yes", async () => {
     // Arrange
     const assessmentConsolidatedData =
       createFakeConsolidatedPartTimeData(PROGRAM_YEAR);
@@ -48,7 +48,7 @@ describe(`E2E Test Workflow parttime-assessment-${PROGRAM_YEAR}-awards-amount-CS
     );
   });
 
-  it("Should determine federalAwardCSGPAmount when awardEligibilityCSGP is true, no CSGP awarded in the program year previously and studentDataApplicationPDPPDStatus is true", async () => {
+  it("Should determine federalAwardCSGPAmount when awardEligibilityCSGP is true, no CSGP awarded in the program year previously and studentDataApplicationPDPPDStatus is yes", async () => {
     // Arrange
     const assessmentConsolidatedData =
       createFakeConsolidatedPartTimeData(PROGRAM_YEAR);

--- a/sources/packages/backend/workflow/test/2021-2022/parttime-assessment/awards-amounts/parttime-assessment-awards-amount-SBSD.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2021-2022/parttime-assessment/awards-amounts/parttime-assessment-awards-amount-SBSD.e2e-spec.ts
@@ -90,4 +90,28 @@ describe(`E2E Test Workflow parttime-assessment-${PROGRAM_YEAR}-awards-amount-SB
       calculatedAssessment.variables.finalProvincialAwardNetSBSDAmount,
     ).toBe(0);
   });
+
+  it("Should determine provincialAwardSBSDAmount when awardEligibilitySBSD is true, programYearTotalPartTimeSBSD, programYearTotalFullTimeSBSD are null and offeringCourseLoad is 40 and up", async () => {
+    // Arrange
+    const assessmentConsolidatedData =
+      createFakeConsolidatedPartTimeData(PROGRAM_YEAR);
+    assessmentConsolidatedData.studentDataApplicationPDPPDStatus = "yes";
+    assessmentConsolidatedData.programYearTotalPartTimeSBSD = null;
+    assessmentConsolidatedData.programYearTotalFullTimeSBSD = null;
+
+    // Act
+    const calculatedAssessment = await executePartTimeAssessmentForProgramYear(
+      PROGRAM_YEAR,
+      assessmentConsolidatedData,
+    );
+
+    // Assert
+    expect(calculatedAssessment.variables.programYearTotalSBSD).toBe(null);
+    expect(calculatedAssessment.variables.provincialAwardNetSBSDAmount).toBe(
+      800,
+    );
+    expect(
+      calculatedAssessment.variables.finalProvincialAwardNetSBSDAmount,
+    ).toBe(800);
+  });
 });

--- a/sources/packages/backend/workflow/test/2021-2022/parttime-assessment/awards-amounts/parttime-assessment-awards-amount-SBSD.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2021-2022/parttime-assessment/awards-amounts/parttime-assessment-awards-amount-SBSD.e2e-spec.ts
@@ -106,7 +106,7 @@ describe(`E2E Test Workflow parttime-assessment-${PROGRAM_YEAR}-awards-amount-SB
     );
 
     // Assert
-    expect(calculatedAssessment.variables.programYearTotalSBSD).toBe(null);
+    expect(calculatedAssessment.variables.programYearTotalSBSD).toBe(0);
     expect(calculatedAssessment.variables.provincialAwardNetSBSDAmount).toBe(
       800,
     );

--- a/sources/packages/backend/workflow/test/2021-2022/parttime-assessment/awards-amounts/parttime-assessment-awards-amount-SBSD.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2021-2022/parttime-assessment/awards-amounts/parttime-assessment-awards-amount-SBSD.e2e-spec.ts
@@ -91,7 +91,7 @@ describe(`E2E Test Workflow parttime-assessment-${PROGRAM_YEAR}-awards-amount-SB
     ).toBe(0);
   });
 
-  it("Should determine provincialAwardSBSDAmount when awardEligibilitySBSD is true, programYearTotalPartTimeSBSD, programYearTotalFullTimeSBSD are null and offeringCourseLoad is 40 and up", async () => {
+  it("Should determine provincialAwardSBSDAmount when awardEligibilitySBSD is true, no SBSD awarded in the program year previously and offeringCourseLoad is 40 and up", async () => {
     // Arrange
     const assessmentConsolidatedData =
       createFakeConsolidatedPartTimeData(PROGRAM_YEAR);

--- a/sources/packages/backend/workflow/test/2021-2022/parttime-assessment/awards-amounts/parttime-assessment-awards-amount-SBSD.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2021-2022/parttime-assessment/awards-amounts/parttime-assessment-awards-amount-SBSD.e2e-spec.ts
@@ -96,8 +96,8 @@ describe(`E2E Test Workflow parttime-assessment-${PROGRAM_YEAR}-awards-amount-SB
     const assessmentConsolidatedData =
       createFakeConsolidatedPartTimeData(PROGRAM_YEAR);
     assessmentConsolidatedData.studentDataApplicationPDPPDStatus = "yes";
-    assessmentConsolidatedData.programYearTotalPartTimeSBSD = null;
-    assessmentConsolidatedData.programYearTotalFullTimeSBSD = null;
+    assessmentConsolidatedData.programYearTotalPartTimeSBSD = undefined;
+    assessmentConsolidatedData.programYearTotalFullTimeSBSD = undefined;
 
     // Act
     const calculatedAssessment = await executePartTimeAssessmentForProgramYear(

--- a/sources/packages/backend/workflow/test/2022-2023/parttime-assessment/awards-amounts/parttime-assessment-2022-2023-awards-amount-BCAG.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2022-2023/parttime-assessment/awards-amounts/parttime-assessment-2022-2023-awards-amount-BCAG.e2e-spec.ts
@@ -142,7 +142,7 @@ describe(`E2E Test Workflow parttime-assessment-${PROGRAM_YEAR}-awards-amount-BC
     assessmentConsolidatedData.partner1CRAReportedIncome = 22999;
     // Public institution
     assessmentConsolidatedData.institutionType = InstitutionTypes.BCPublic;
-    assessmentConsolidatedData.programYearTotalPartTimeBCAG = null;
+    assessmentConsolidatedData.programYearTotalPartTimeBCAG = undefined;
 
     // Act
     const calculatedAssessment = await executePartTimeAssessmentForProgramYear(

--- a/sources/packages/backend/workflow/test/2022-2023/parttime-assessment/awards-amounts/parttime-assessment-2022-2023-awards-amount-BCAG.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2022-2023/parttime-assessment/awards-amounts/parttime-assessment-2022-2023-awards-amount-BCAG.e2e-spec.ts
@@ -131,7 +131,7 @@ describe(`E2E Test Workflow parttime-assessment-${PROGRAM_YEAR}-awards-amount-BC
     expect(calculatedAssessment.variables.provincialAwardNetBCAGAmount).toBe(0);
   });
 
-  it("Should determine provincialAwardNetBCAGAmount when awardEligibilityBCAG is true and provincialAwardPartTimeBCAGAmount is null", async () => {
+  it("Should determine provincialAwardNetBCAGAmount when awardEligibilityBCAG is true and no BCAG awarded in the program year previously", async () => {
     // Arrange
     const assessmentConsolidatedData =
       createFakeConsolidatedPartTimeData(PROGRAM_YEAR);

--- a/sources/packages/backend/workflow/test/2022-2023/parttime-assessment/awards-amounts/parttime-assessment-2022-2023-awards-amount-BCAG.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2022-2023/parttime-assessment/awards-amounts/parttime-assessment-2022-2023-awards-amount-BCAG.e2e-spec.ts
@@ -157,4 +157,30 @@ describe(`E2E Test Workflow parttime-assessment-${PROGRAM_YEAR}-awards-amount-BC
       1000,
     );
   });
+
+  it("Should determine provincialAwardNetBCAGAmount as zero when awardEligibilityBCAG is true and difference between the programYearLimits and BCAG awarded in the program year previously is less than 100", async () => {
+    // Arrange
+    const assessmentConsolidatedData =
+      createFakeConsolidatedPartTimeData(PROGRAM_YEAR);
+    assessmentConsolidatedData.studentDataCRAReportedIncome = 20001;
+    assessmentConsolidatedData.studentDataRelationshipStatus = "married";
+    assessmentConsolidatedData.studentDataIsYourSpouseACanadianCitizen =
+      YesNoOptions.Yes;
+    assessmentConsolidatedData.partner1CRAReportedIncome = 22999;
+    // Public institution
+    assessmentConsolidatedData.institutionType = InstitutionTypes.BCPublic;
+    assessmentConsolidatedData.programYearTotalPartTimeBCAG = 901;
+
+    // Act
+    const calculatedAssessment = await executePartTimeAssessmentForProgramYear(
+      PROGRAM_YEAR,
+      assessmentConsolidatedData,
+    );
+    // Assert
+    // awardEligibilityBCAG is true.
+    // provincialAwardNetBCAGAmount is 0.
+    expect(calculatedAssessment.variables.awardEligibilityBCAG).toBe(true);
+    expect(calculatedAssessment.variables.limitAwardBCAGRemaining).toBe(99);
+    expect(calculatedAssessment.variables.provincialAwardNetBCAGAmount).toBe(0);
+  });
 });

--- a/sources/packages/backend/workflow/test/2022-2023/parttime-assessment/awards-amounts/parttime-assessment-2022-2023-awards-amount-BCAG.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2022-2023/parttime-assessment/awards-amounts/parttime-assessment-2022-2023-awards-amount-BCAG.e2e-spec.ts
@@ -130,4 +130,31 @@ describe(`E2E Test Workflow parttime-assessment-${PROGRAM_YEAR}-awards-amount-BC
     expect(calculatedAssessment.variables.awardEligibilityBCAG).toBe(false);
     expect(calculatedAssessment.variables.provincialAwardNetBCAGAmount).toBe(0);
   });
+
+  it("Should determine provincialAwardNetBCAGAmount when awardEligibilityBCAG is true and provincialAwardPartTimeBCAGAmount is null", async () => {
+    // Arrange
+    const assessmentConsolidatedData =
+      createFakeConsolidatedPartTimeData(PROGRAM_YEAR);
+    assessmentConsolidatedData.studentDataCRAReportedIncome = 20001;
+    assessmentConsolidatedData.studentDataRelationshipStatus = "married";
+    assessmentConsolidatedData.studentDataIsYourSpouseACanadianCitizen =
+      YesNoOptions.Yes;
+    assessmentConsolidatedData.partner1CRAReportedIncome = 22999;
+    // Public institution
+    assessmentConsolidatedData.institutionType = InstitutionTypes.BCPublic;
+    assessmentConsolidatedData.programYearTotalPartTimeBCAG = null;
+
+    // Act
+    const calculatedAssessment = await executePartTimeAssessmentForProgramYear(
+      PROGRAM_YEAR,
+      assessmentConsolidatedData,
+    );
+    // Assert
+    // awardEligibilityBCAG is true.
+    // provincialAwardNetBCAGAmount is 1000.
+    expect(calculatedAssessment.variables.awardEligibilityBCAG).toBe(true);
+    expect(calculatedAssessment.variables.provincialAwardNetBCAGAmount).toBe(
+      1000,
+    );
+  });
 });

--- a/sources/packages/backend/workflow/test/2022-2023/parttime-assessment/awards-amounts/parttime-assessment-2022-2023-awards-amount-CSGD.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2022-2023/parttime-assessment/awards-amounts/parttime-assessment-2022-2023-awards-amount-CSGD.e2e-spec.ts
@@ -221,4 +221,37 @@ describe(`E2E Test Workflow parttime-assessment-${PROGRAM_YEAR}-awards-amount-CS
       659.0567998,
     );
   });
+
+  it("Should determine federalAwardCSGDAmount when awardEligibilityCSGD is true and programYearTotalPartTimeCSGD is null", async () => {
+    // Arrange
+    const assessmentConsolidatedData =
+      createFakeConsolidatedPartTimeData(PROGRAM_YEAR);
+    assessmentConsolidatedData.studentDataCRAReportedIncome = 35000;
+    assessmentConsolidatedData.studentDataRelationshipStatus = "married";
+    assessmentConsolidatedData.studentDataIsYourSpouseACanadianCitizen =
+      YesNoOptions.Yes;
+    assessmentConsolidatedData.partner1CRAReportedIncome = 35000;
+    assessmentConsolidatedData.studentDataDependants = [
+      createFakeStudentDependentEligible(
+        DependentEligibility.Eligible0To18YearsOld,
+      ),
+    ];
+    assessmentConsolidatedData.programYearTotalPartTimeCSGD = null;
+
+    // Act
+    const calculatedAssessment = await executePartTimeAssessmentForProgramYear(
+      PROGRAM_YEAR,
+      assessmentConsolidatedData,
+    );
+    // Assert
+    // calculatedDataTotalFamilyIncome <= limitAwardCSGDIncomeCap
+    // federalAwardCSGDAmount
+    expect(calculatedAssessment.variables.awardEligibilityCSGD).toBe(true);
+    expect(calculatedAssessment.variables.federalAwardCSGDAmount).toBe(
+      859.0567998,
+    );
+    expect(calculatedAssessment.variables.federalAwardNetCSGDAmount).toBe(
+      859.0567998,
+    );
+  });
 });

--- a/sources/packages/backend/workflow/test/2022-2023/parttime-assessment/awards-amounts/parttime-assessment-2022-2023-awards-amount-CSGD.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2022-2023/parttime-assessment/awards-amounts/parttime-assessment-2022-2023-awards-amount-CSGD.e2e-spec.ts
@@ -236,7 +236,7 @@ describe(`E2E Test Workflow parttime-assessment-${PROGRAM_YEAR}-awards-amount-CS
         DependentEligibility.Eligible0To18YearsOld,
       ),
     ];
-    assessmentConsolidatedData.programYearTotalPartTimeCSGD = null;
+    assessmentConsolidatedData.programYearTotalPartTimeCSGD = undefined;
 
     // Act
     const calculatedAssessment = await executePartTimeAssessmentForProgramYear(

--- a/sources/packages/backend/workflow/test/2022-2023/parttime-assessment/awards-amounts/parttime-assessment-2022-2023-awards-amount-CSGD.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2022-2023/parttime-assessment/awards-amounts/parttime-assessment-2022-2023-awards-amount-CSGD.e2e-spec.ts
@@ -222,7 +222,7 @@ describe(`E2E Test Workflow parttime-assessment-${PROGRAM_YEAR}-awards-amount-CS
     );
   });
 
-  it("Should determine federalAwardCSGDAmount when awardEligibilityCSGD is true and programYearTotalPartTimeCSGD is null", async () => {
+  it("Should determine federalAwardCSGDAmount when awardEligibilityCSGD is true and no CSGD awarded in the program year previously", async () => {
     // Arrange
     const assessmentConsolidatedData =
       createFakeConsolidatedPartTimeData(PROGRAM_YEAR);

--- a/sources/packages/backend/workflow/test/2022-2023/parttime-assessment/awards-amounts/parttime-assessment-2022-2023-awards-amount-CSPT.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2022-2023/parttime-assessment/awards-amounts/parttime-assessment-2022-2023-awards-amount-CSPT.e2e-spec.ts
@@ -124,16 +124,6 @@ describe(`E2E Test Workflow parttime-assessment-${PROGRAM_YEAR}-awards-amount-CS
     expect(
       calculatedAssessment.variables.federalAwardCSPTAmount,
     ).toBeGreaterThan(100);
-    expect(calculatedAssessment.variables.federalAwardNetCSPTAmount).toBe(
-      Math.min(
-        calculatedAssessment.variables.calculatedDataTotalRemainingNeed1,
-        Math.min(
-          calculatedAssessment.variables.dmnPartTimeAwardAllowableLimits
-            .limitAwardCSPTAmount,
-          calculatedAssessment.variables.federalAwardCSPTAmount,
-        ),
-      ),
-    );
     expect(calculatedAssessment.variables.federalAwardNetCSPTAmount).toBe(3600);
   });
 });

--- a/sources/packages/backend/workflow/test/2022-2023/parttime-assessment/awards-amounts/parttime-assessment-2022-2023-awards-amount-CSPT.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2022-2023/parttime-assessment/awards-amounts/parttime-assessment-2022-2023-awards-amount-CSPT.e2e-spec.ts
@@ -126,4 +126,28 @@ describe(`E2E Test Workflow parttime-assessment-${PROGRAM_YEAR}-awards-amount-CS
     ).toBeGreaterThan(100);
     expect(calculatedAssessment.variables.federalAwardNetCSPTAmount).toBe(3600);
   });
+
+  it("Should determine federalAwardNetCSPTAmount as zero when awardEligibilityCSPT is true and difference between the programYearLimits and CSPT awarded in the program year previously is less than 100", async () => {
+    // Arrange
+    const assessmentConsolidatedData =
+      createFakeConsolidatedPartTimeData(PROGRAM_YEAR);
+    assessmentConsolidatedData.studentDataCRAReportedIncome = 60001;
+    assessmentConsolidatedData.studentDataRelationshipStatus = "married";
+    assessmentConsolidatedData.studentDataIsYourSpouseACanadianCitizen =
+      YesNoOptions.Yes;
+    assessmentConsolidatedData.partner1CRAReportedIncome = 22999;
+    assessmentConsolidatedData.programYearTotalPartTimeCSPT = 3501;
+    // Act
+    const calculatedAssessment = await executePartTimeAssessmentForProgramYear(
+      PROGRAM_YEAR,
+      assessmentConsolidatedData,
+    );
+    // Assert
+    expect(calculatedAssessment.variables.awardEligibilityCSPT).toBe(true);
+    expect(calculatedAssessment.variables.limitAwardCSPTRemaining).toBe(99);
+    expect(
+      calculatedAssessment.variables.federalAwardCSPTAmount,
+    ).toBeGreaterThan(100);
+    expect(calculatedAssessment.variables.federalAwardNetCSPTAmount).toBe(0);
+  });
 });

--- a/sources/packages/backend/workflow/test/2022-2023/parttime-assessment/awards-amounts/parttime-assessment-2022-2023-awards-amount-CSPT.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2022-2023/parttime-assessment/awards-amounts/parttime-assessment-2022-2023-awards-amount-CSPT.e2e-spec.ts
@@ -113,7 +113,7 @@ describe(`E2E Test Workflow parttime-assessment-${PROGRAM_YEAR}-awards-amount-CS
     assessmentConsolidatedData.studentDataIsYourSpouseACanadianCitizen =
       YesNoOptions.Yes;
     assessmentConsolidatedData.partner1CRAReportedIncome = 22999;
-    assessmentConsolidatedData.programYearTotalPartTimeCSPT = null;
+    assessmentConsolidatedData.programYearTotalPartTimeCSPT = undefined;
     // Act
     const calculatedAssessment = await executePartTimeAssessmentForProgramYear(
       PROGRAM_YEAR,

--- a/sources/packages/backend/workflow/test/2022-2023/parttime-assessment/awards-amounts/parttime-assessment-2022-2023-awards-amount-CSPT.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2022-2023/parttime-assessment/awards-amounts/parttime-assessment-2022-2023-awards-amount-CSPT.e2e-spec.ts
@@ -104,7 +104,7 @@ describe(`E2E Test Workflow parttime-assessment-${PROGRAM_YEAR}-awards-amount-CS
     expect(calculatedAssessment.variables.federalAwardNetCSPTAmount).toBe(0);
   });
 
-  it("Should determine federalAwardNetCSPTAmount when awardEligibilityCSPT is true and programYearTotalPartTimeCSPT is null", async () => {
+  it("Should determine federalAwardNetCSPTAmount when awardEligibilityCSPT is true and no CSPT awarded in the program year previously", async () => {
     // Arrange
     const assessmentConsolidatedData =
       createFakeConsolidatedPartTimeData(PROGRAM_YEAR);

--- a/sources/packages/backend/workflow/test/2022-2023/parttime-assessment/awards-amounts/parttime-assessment-2022-2023-awards-amount-CSPT.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2022-2023/parttime-assessment/awards-amounts/parttime-assessment-2022-2023-awards-amount-CSPT.e2e-spec.ts
@@ -61,18 +61,6 @@ describe(`E2E Test Workflow parttime-assessment-${PROGRAM_YEAR}-awards-amount-CS
     expect(calculatedAssessment.variables.calculatedDataTotalFamilyIncome).toBe(
       53000,
     );
-    expect(calculatedAssessment.variables.federalAwardCSPTAmount).toBe(
-      Math.max(
-        calculatedAssessment.variables.dmnPartTimeAwardAllowableLimits
-          .limitAwardCSPTAmount -
-          (calculatedAssessment.variables.calculatedDataTotalFamilyIncome -
-            calculatedAssessment.variables.dmnPartTimeAwardFamilySizeVariables
-              .limitAwardCSPTIncomeCap) *
-            calculatedAssessment.variables.dmnPartTimeAwardFamilySizeVariables
-              .limitAwardCSPTSlope,
-        100,
-      ),
-    );
     expect(calculatedAssessment.variables.federalAwardCSPTAmount).toBeLessThan(
       3000,
     );
@@ -97,17 +85,7 @@ describe(`E2E Test Workflow parttime-assessment-${PROGRAM_YEAR}-awards-amount-CS
     expect(
       calculatedAssessment.variables.federalAwardCSPTAmount,
     ).toBeGreaterThan(100);
-    expect(calculatedAssessment.variables.federalAwardNetCSPTAmount).toBe(
-      Math.min(
-        calculatedAssessment.variables.calculatedDataTotalRemainingNeed1,
-        Math.min(
-          calculatedAssessment.variables.dmnPartTimeAwardAllowableLimits
-            .limitAwardCSPTAmount,
-          calculatedAssessment.variables.federalAwardCSPTAmount,
-        ),
-      ),
-    );
-    expect(calculatedAssessment.variables.federalAwardNetCSPTAmount).toBe(3600);
+    expect(calculatedAssessment.variables.federalAwardNetCSPTAmount).toBe(3520);
   });
 
   it("Should determine federalAwardNetCSPTAmount as zero when awardEligibilityCSPT is false", async () => {
@@ -124,5 +102,38 @@ describe(`E2E Test Workflow parttime-assessment-${PROGRAM_YEAR}-awards-amount-CS
     // Assert
     expect(calculatedAssessment.variables.awardEligibilityCSPT).toBe(false);
     expect(calculatedAssessment.variables.federalAwardNetCSPTAmount).toBe(0);
+  });
+
+  it("Should determine federalAwardNetCSPTAmount when awardEligibilityCSPT is true and programYearTotalPartTimeCSPT is null", async () => {
+    // Arrange
+    const assessmentConsolidatedData =
+      createFakeConsolidatedPartTimeData(PROGRAM_YEAR);
+    assessmentConsolidatedData.studentDataCRAReportedIncome = 20001;
+    assessmentConsolidatedData.studentDataRelationshipStatus = "married";
+    assessmentConsolidatedData.studentDataIsYourSpouseACanadianCitizen =
+      YesNoOptions.Yes;
+    assessmentConsolidatedData.partner1CRAReportedIncome = 22999;
+    assessmentConsolidatedData.programYearTotalPartTimeCSPT = null;
+    // Act
+    const calculatedAssessment = await executePartTimeAssessmentForProgramYear(
+      PROGRAM_YEAR,
+      assessmentConsolidatedData,
+    );
+    // Assert
+    expect(calculatedAssessment.variables.awardEligibilityCSPT).toBe(true);
+    expect(
+      calculatedAssessment.variables.federalAwardCSPTAmount,
+    ).toBeGreaterThan(100);
+    expect(calculatedAssessment.variables.federalAwardNetCSPTAmount).toBe(
+      Math.min(
+        calculatedAssessment.variables.calculatedDataTotalRemainingNeed1,
+        Math.min(
+          calculatedAssessment.variables.dmnPartTimeAwardAllowableLimits
+            .limitAwardCSPTAmount,
+          calculatedAssessment.variables.federalAwardCSPTAmount,
+        ),
+      ),
+    );
+    expect(calculatedAssessment.variables.federalAwardNetCSPTAmount).toBe(3600);
   });
 });

--- a/sources/packages/backend/workflow/test/2022-2023/parttime-assessment/awards-amounts/parttime-assessment-awards-amount-CSGP.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2022-2023/parttime-assessment/awards-amounts/parttime-assessment-awards-amount-CSGP.e2e-spec.ts
@@ -47,4 +47,26 @@ describe(`E2E Test Workflow parttime-assessment-${PROGRAM_YEAR}-awards-amount-CS
       0,
     );
   });
+
+  it("Should determine federalAwardCSGPAmount when awardEligibilityCSGP is true, programYearTotalPartTimeCSGP, programYearTotalFullTimeCSGP are null and studentDataApplicationPDPPDStatus is true", async () => {
+    // Arrange
+    const assessmentConsolidatedData =
+      createFakeConsolidatedPartTimeData(PROGRAM_YEAR);
+    assessmentConsolidatedData.studentDataApplicationPDPPDStatus = "yes";
+    assessmentConsolidatedData.programYearTotalFullTimeCSGP = null;
+    assessmentConsolidatedData.programYearTotalPartTimeCSGP = null;
+
+    // Act
+    const calculatedAssessment = await executePartTimeAssessmentForProgramYear(
+      PROGRAM_YEAR,
+      assessmentConsolidatedData,
+    );
+
+    // Assert
+    expect(calculatedAssessment.variables.programYearTotalCSGP).toBe(null);
+    expect(calculatedAssessment.variables.federalAwardNetCSGPAmount).toBe(4000);
+    expect(calculatedAssessment.variables.finalFederalAwardNetCSGPAmount).toBe(
+      4000,
+    );
+  });
 });

--- a/sources/packages/backend/workflow/test/2022-2023/parttime-assessment/awards-amounts/parttime-assessment-awards-amount-CSGP.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2022-2023/parttime-assessment/awards-amounts/parttime-assessment-awards-amount-CSGP.e2e-spec.ts
@@ -63,7 +63,7 @@ describe(`E2E Test Workflow parttime-assessment-${PROGRAM_YEAR}-awards-amount-CS
     );
 
     // Assert
-    expect(calculatedAssessment.variables.programYearTotalCSGP).toBe(null);
+    expect(calculatedAssessment.variables.programYearTotalCSGP).toBe(0);
     expect(calculatedAssessment.variables.federalAwardNetCSGPAmount).toBe(4000);
     expect(calculatedAssessment.variables.finalFederalAwardNetCSGPAmount).toBe(
       4000,

--- a/sources/packages/backend/workflow/test/2022-2023/parttime-assessment/awards-amounts/parttime-assessment-awards-amount-CSGP.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2022-2023/parttime-assessment/awards-amounts/parttime-assessment-awards-amount-CSGP.e2e-spec.ts
@@ -48,7 +48,7 @@ describe(`E2E Test Workflow parttime-assessment-${PROGRAM_YEAR}-awards-amount-CS
     );
   });
 
-  it("Should determine federalAwardCSGPAmount when awardEligibilityCSGP is true, programYearTotalPartTimeCSGP, programYearTotalFullTimeCSGP are null and studentDataApplicationPDPPDStatus is true", async () => {
+  it("Should determine federalAwardCSGPAmount when awardEligibilityCSGP is true, no CSGP awarded in the program year previously and studentDataApplicationPDPPDStatus is true", async () => {
     // Arrange
     const assessmentConsolidatedData =
       createFakeConsolidatedPartTimeData(PROGRAM_YEAR);

--- a/sources/packages/backend/workflow/test/2022-2023/parttime-assessment/awards-amounts/parttime-assessment-awards-amount-CSGP.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2022-2023/parttime-assessment/awards-amounts/parttime-assessment-awards-amount-CSGP.e2e-spec.ts
@@ -53,8 +53,8 @@ describe(`E2E Test Workflow parttime-assessment-${PROGRAM_YEAR}-awards-amount-CS
     const assessmentConsolidatedData =
       createFakeConsolidatedPartTimeData(PROGRAM_YEAR);
     assessmentConsolidatedData.studentDataApplicationPDPPDStatus = "yes";
-    assessmentConsolidatedData.programYearTotalFullTimeCSGP = null;
-    assessmentConsolidatedData.programYearTotalPartTimeCSGP = null;
+    assessmentConsolidatedData.programYearTotalFullTimeCSGP = undefined;
+    assessmentConsolidatedData.programYearTotalPartTimeCSGP = undefined;
 
     // Act
     const calculatedAssessment = await executePartTimeAssessmentForProgramYear(

--- a/sources/packages/backend/workflow/test/2022-2023/parttime-assessment/awards-amounts/parttime-assessment-awards-amount-CSGP.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2022-2023/parttime-assessment/awards-amounts/parttime-assessment-awards-amount-CSGP.e2e-spec.ts
@@ -5,7 +5,7 @@ import {
 } from "../../../test-utils";
 
 describe(`E2E Test Workflow parttime-assessment-${PROGRAM_YEAR}-awards-amount-CSGP.`, () => {
-  it("Should determine federalAwardCSGPAmount when awardEligibilityCSGP is true and studentDataApplicationPDPPDStatus is true", async () => {
+  it("Should determine federalAwardCSGPAmount when awardEligibilityCSGP is true and studentDataApplicationPDPPDStatus is yes", async () => {
     // Arrange
     const assessmentConsolidatedData =
       createFakeConsolidatedPartTimeData(PROGRAM_YEAR);
@@ -48,7 +48,7 @@ describe(`E2E Test Workflow parttime-assessment-${PROGRAM_YEAR}-awards-amount-CS
     );
   });
 
-  it("Should determine federalAwardCSGPAmount when awardEligibilityCSGP is true, no CSGP awarded in the program year previously and studentDataApplicationPDPPDStatus is true", async () => {
+  it("Should determine federalAwardCSGPAmount when awardEligibilityCSGP is true, no CSGP awarded in the program year previously and studentDataApplicationPDPPDStatus is yes", async () => {
     // Arrange
     const assessmentConsolidatedData =
       createFakeConsolidatedPartTimeData(PROGRAM_YEAR);

--- a/sources/packages/backend/workflow/test/2022-2023/parttime-assessment/awards-amounts/parttime-assessment-awards-amount-SBSD.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2022-2023/parttime-assessment/awards-amounts/parttime-assessment-awards-amount-SBSD.e2e-spec.ts
@@ -90,4 +90,28 @@ describe(`E2E Test Workflow parttime-assessment-${PROGRAM_YEAR}-awards-amount-SB
       calculatedAssessment.variables.finalProvincialAwardNetSBSDAmount,
     ).toBe(0);
   });
+
+  it("Should determine provincialAwardSBSDAmount when awardEligibilitySBSD is true, programYearTotalPartTimeSBSD, programYearTotalFullTimeSBSD are null and offeringCourseLoad is 40 and up", async () => {
+    // Arrange
+    const assessmentConsolidatedData =
+      createFakeConsolidatedPartTimeData(PROGRAM_YEAR);
+    assessmentConsolidatedData.studentDataApplicationPDPPDStatus = "yes";
+    assessmentConsolidatedData.programYearTotalPartTimeSBSD = null;
+    assessmentConsolidatedData.programYearTotalFullTimeSBSD = null;
+
+    // Act
+    const calculatedAssessment = await executePartTimeAssessmentForProgramYear(
+      PROGRAM_YEAR,
+      assessmentConsolidatedData,
+    );
+
+    // Assert
+    expect(calculatedAssessment.variables.programYearTotalSBSD).toBe(null);
+    expect(calculatedAssessment.variables.provincialAwardNetSBSDAmount).toBe(
+      800,
+    );
+    expect(
+      calculatedAssessment.variables.finalProvincialAwardNetSBSDAmount,
+    ).toBe(800);
+  });
 });

--- a/sources/packages/backend/workflow/test/2022-2023/parttime-assessment/awards-amounts/parttime-assessment-awards-amount-SBSD.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2022-2023/parttime-assessment/awards-amounts/parttime-assessment-awards-amount-SBSD.e2e-spec.ts
@@ -106,7 +106,7 @@ describe(`E2E Test Workflow parttime-assessment-${PROGRAM_YEAR}-awards-amount-SB
     );
 
     // Assert
-    expect(calculatedAssessment.variables.programYearTotalSBSD).toBe(null);
+    expect(calculatedAssessment.variables.programYearTotalSBSD).toBe(0);
     expect(calculatedAssessment.variables.provincialAwardNetSBSDAmount).toBe(
       800,
     );

--- a/sources/packages/backend/workflow/test/2022-2023/parttime-assessment/awards-amounts/parttime-assessment-awards-amount-SBSD.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2022-2023/parttime-assessment/awards-amounts/parttime-assessment-awards-amount-SBSD.e2e-spec.ts
@@ -91,7 +91,7 @@ describe(`E2E Test Workflow parttime-assessment-${PROGRAM_YEAR}-awards-amount-SB
     ).toBe(0);
   });
 
-  it("Should determine provincialAwardSBSDAmount when awardEligibilitySBSD is true, programYearTotalPartTimeSBSD, programYearTotalFullTimeSBSD are null and offeringCourseLoad is 40 and up", async () => {
+  it("Should determine provincialAwardSBSDAmount when awardEligibilitySBSD is true, no SBSD awarded in the program year previously and offeringCourseLoad is 40 and up", async () => {
     // Arrange
     const assessmentConsolidatedData =
       createFakeConsolidatedPartTimeData(PROGRAM_YEAR);

--- a/sources/packages/backend/workflow/test/2022-2023/parttime-assessment/awards-amounts/parttime-assessment-awards-amount-SBSD.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2022-2023/parttime-assessment/awards-amounts/parttime-assessment-awards-amount-SBSD.e2e-spec.ts
@@ -96,8 +96,8 @@ describe(`E2E Test Workflow parttime-assessment-${PROGRAM_YEAR}-awards-amount-SB
     const assessmentConsolidatedData =
       createFakeConsolidatedPartTimeData(PROGRAM_YEAR);
     assessmentConsolidatedData.studentDataApplicationPDPPDStatus = "yes";
-    assessmentConsolidatedData.programYearTotalPartTimeSBSD = null;
-    assessmentConsolidatedData.programYearTotalFullTimeSBSD = null;
+    assessmentConsolidatedData.programYearTotalPartTimeSBSD = undefined;
+    assessmentConsolidatedData.programYearTotalFullTimeSBSD = undefined;
 
     // Act
     const calculatedAssessment = await executePartTimeAssessmentForProgramYear(

--- a/sources/packages/backend/workflow/test/2023-2024/parttime-assessment/awards-amounts/parttime-assessment-2023-2024-awards-amount-BCAG.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2023-2024/parttime-assessment/awards-amounts/parttime-assessment-2023-2024-awards-amount-BCAG.e2e-spec.ts
@@ -142,7 +142,7 @@ describe(`E2E Test Workflow parttime-assessment-${PROGRAM_YEAR}-awards-amount-BC
     assessmentConsolidatedData.partner1CRAReportedIncome = 22999;
     // Public institution
     assessmentConsolidatedData.institutionType = InstitutionTypes.BCPublic;
-    assessmentConsolidatedData.programYearTotalPartTimeBCAG = null;
+    assessmentConsolidatedData.programYearTotalPartTimeBCAG = undefined;
 
     // Act
     const calculatedAssessment = await executePartTimeAssessmentForProgramYear(

--- a/sources/packages/backend/workflow/test/2023-2024/parttime-assessment/awards-amounts/parttime-assessment-2023-2024-awards-amount-BCAG.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2023-2024/parttime-assessment/awards-amounts/parttime-assessment-2023-2024-awards-amount-BCAG.e2e-spec.ts
@@ -131,7 +131,7 @@ describe(`E2E Test Workflow parttime-assessment-${PROGRAM_YEAR}-awards-amount-BC
     expect(calculatedAssessment.variables.provincialAwardNetBCAGAmount).toBe(0);
   });
 
-  it("Should determine provincialAwardNetBCAGAmount when awardEligibilityBCAG is true and provincialAwardPartTimeBCAGAmount is null", async () => {
+  it("Should determine provincialAwardNetBCAGAmount when awardEligibilityBCAG is true and no BCAG awarded in the program year previously", async () => {
     // Arrange
     const assessmentConsolidatedData =
       createFakeConsolidatedPartTimeData(PROGRAM_YEAR);

--- a/sources/packages/backend/workflow/test/2023-2024/parttime-assessment/awards-amounts/parttime-assessment-2023-2024-awards-amount-BCAG.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2023-2024/parttime-assessment/awards-amounts/parttime-assessment-2023-2024-awards-amount-BCAG.e2e-spec.ts
@@ -157,4 +157,30 @@ describe(`E2E Test Workflow parttime-assessment-${PROGRAM_YEAR}-awards-amount-BC
       1000,
     );
   });
+
+  it("Should determine provincialAwardNetBCAGAmount as zero when awardEligibilityBCAG is true and difference between the programYearLimits and BCAG awarded in the program year previously is less than 100", async () => {
+    // Arrange
+    const assessmentConsolidatedData =
+      createFakeConsolidatedPartTimeData(PROGRAM_YEAR);
+    assessmentConsolidatedData.studentDataCRAReportedIncome = 20001;
+    assessmentConsolidatedData.studentDataRelationshipStatus = "married";
+    assessmentConsolidatedData.studentDataIsYourSpouseACanadianCitizen =
+      YesNoOptions.Yes;
+    assessmentConsolidatedData.partner1CRAReportedIncome = 22999;
+    // Public institution
+    assessmentConsolidatedData.institutionType = InstitutionTypes.BCPublic;
+    assessmentConsolidatedData.programYearTotalPartTimeBCAG = 901;
+
+    // Act
+    const calculatedAssessment = await executePartTimeAssessmentForProgramYear(
+      PROGRAM_YEAR,
+      assessmentConsolidatedData,
+    );
+    // Assert
+    // awardEligibilityBCAG is true.
+    // provincialAwardNetBCAGAmount is 0.
+    expect(calculatedAssessment.variables.awardEligibilityBCAG).toBe(true);
+    expect(calculatedAssessment.variables.limitAwardBCAGRemaining).toBe(99);
+    expect(calculatedAssessment.variables.provincialAwardNetBCAGAmount).toBe(0);
+  });
 });

--- a/sources/packages/backend/workflow/test/2023-2024/parttime-assessment/awards-amounts/parttime-assessment-2023-2024-awards-amount-BCAG.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2023-2024/parttime-assessment/awards-amounts/parttime-assessment-2023-2024-awards-amount-BCAG.e2e-spec.ts
@@ -130,4 +130,31 @@ describe(`E2E Test Workflow parttime-assessment-${PROGRAM_YEAR}-awards-amount-BC
     expect(calculatedAssessment.variables.awardEligibilityBCAG).toBe(false);
     expect(calculatedAssessment.variables.provincialAwardNetBCAGAmount).toBe(0);
   });
+
+  it("Should determine provincialAwardNetBCAGAmount when awardEligibilityBCAG is true and provincialAwardPartTimeBCAGAmount is null", async () => {
+    // Arrange
+    const assessmentConsolidatedData =
+      createFakeConsolidatedPartTimeData(PROGRAM_YEAR);
+    assessmentConsolidatedData.studentDataCRAReportedIncome = 20001;
+    assessmentConsolidatedData.studentDataRelationshipStatus = "married";
+    assessmentConsolidatedData.studentDataIsYourSpouseACanadianCitizen =
+      YesNoOptions.Yes;
+    assessmentConsolidatedData.partner1CRAReportedIncome = 22999;
+    // Public institution
+    assessmentConsolidatedData.institutionType = InstitutionTypes.BCPublic;
+    assessmentConsolidatedData.programYearTotalPartTimeBCAG = null;
+
+    // Act
+    const calculatedAssessment = await executePartTimeAssessmentForProgramYear(
+      PROGRAM_YEAR,
+      assessmentConsolidatedData,
+    );
+    // Assert
+    // awardEligibilityBCAG is true.
+    // provincialAwardNetBCAGAmount is 1000.
+    expect(calculatedAssessment.variables.awardEligibilityBCAG).toBe(true);
+    expect(calculatedAssessment.variables.provincialAwardNetBCAGAmount).toBe(
+      1000,
+    );
+  });
 });

--- a/sources/packages/backend/workflow/test/2023-2024/parttime-assessment/awards-amounts/parttime-assessment-2023-2024-awards-amount-CSGD.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2023-2024/parttime-assessment/awards-amounts/parttime-assessment-2023-2024-awards-amount-CSGD.e2e-spec.ts
@@ -236,7 +236,7 @@ describe(`E2E Test Workflow parttime-assessment-${PROGRAM_YEAR}-awards-amount-CS
         DependentEligibility.Eligible0To18YearsOld,
       ),
     ];
-    assessmentConsolidatedData.programYearTotalPartTimeCSGD = null;
+    assessmentConsolidatedData.programYearTotalPartTimeCSGD = undefined;
 
     // Act
     const calculatedAssessment = await executePartTimeAssessmentForProgramYear(

--- a/sources/packages/backend/workflow/test/2023-2024/parttime-assessment/awards-amounts/parttime-assessment-2023-2024-awards-amount-CSGD.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2023-2024/parttime-assessment/awards-amounts/parttime-assessment-2023-2024-awards-amount-CSGD.e2e-spec.ts
@@ -222,7 +222,7 @@ describe(`E2E Test Workflow parttime-assessment-${PROGRAM_YEAR}-awards-amount-CS
     );
   });
 
-  it("Should determine federalAwardCSGDAmount when awardEligibilityCSGD is true and programYearTotalPartTimeCSGD is null", async () => {
+  it("Should determine federalAwardCSGDAmount when awardEligibilityCSGD is true and no CSGD awarded in the program year previously", async () => {
     // Arrange
     const assessmentConsolidatedData =
       createFakeConsolidatedPartTimeData(PROGRAM_YEAR);

--- a/sources/packages/backend/workflow/test/2023-2024/parttime-assessment/awards-amounts/parttime-assessment-2023-2024-awards-amount-CSGD.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2023-2024/parttime-assessment/awards-amounts/parttime-assessment-2023-2024-awards-amount-CSGD.e2e-spec.ts
@@ -221,4 +221,37 @@ describe(`E2E Test Workflow parttime-assessment-${PROGRAM_YEAR}-awards-amount-CS
       496.86684445,
     );
   });
+
+  it("Should determine federalAwardCSGDAmount when awardEligibilityCSGD is true and programYearTotalPartTimeCSGD is null", async () => {
+    // Arrange
+    const assessmentConsolidatedData =
+      createFakeConsolidatedPartTimeData(PROGRAM_YEAR);
+    assessmentConsolidatedData.studentDataCRAReportedIncome = 35000;
+    assessmentConsolidatedData.studentDataRelationshipStatus = "married";
+    assessmentConsolidatedData.studentDataIsYourSpouseACanadianCitizen =
+      YesNoOptions.Yes;
+    assessmentConsolidatedData.partner1CRAReportedIncome = 35000;
+    assessmentConsolidatedData.studentDataDependants = [
+      createFakeStudentDependentEligible(
+        DependentEligibility.Eligible0To18YearsOld,
+      ),
+    ];
+    assessmentConsolidatedData.programYearTotalPartTimeCSGD = null;
+
+    // Act
+    const calculatedAssessment = await executePartTimeAssessmentForProgramYear(
+      PROGRAM_YEAR,
+      assessmentConsolidatedData,
+    );
+    // Assert
+    // calculatedDataTotalFamilyIncome <= limitAwardCSGDIncomeCap
+    // federalAwardCSGDAmount
+    expect(calculatedAssessment.variables.awardEligibilityCSGD).toBe(true);
+    expect(calculatedAssessment.variables.federalAwardCSGDAmount).toBe(
+      696.86684445,
+    );
+    expect(calculatedAssessment.variables.federalAwardNetCSGDAmount).toBe(
+      696.86684445,
+    );
+  });
 });

--- a/sources/packages/backend/workflow/test/2023-2024/parttime-assessment/awards-amounts/parttime-assessment-2023-2024-awards-amount-CSPT.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2023-2024/parttime-assessment/awards-amounts/parttime-assessment-2023-2024-awards-amount-CSPT.e2e-spec.ts
@@ -104,7 +104,7 @@ describe(`E2E Test Workflow parttime-assessment-${PROGRAM_YEAR}-awards-amount-CS
     expect(calculatedAssessment.variables.federalAwardNetCSPTAmount).toBe(0);
   });
 
-  it("Should determine federalAwardNetCSPTAmount when awardEligibilityCSPT is true and programYearTotalPartTimeCSPT is null", async () => {
+  it.only("Should determine federalAwardNetCSPTAmount when awardEligibilityCSPT is true and no CSPT awarded in the program year previously", async () => {
     // Arrange
     const assessmentConsolidatedData =
       createFakeConsolidatedPartTimeData(PROGRAM_YEAR);

--- a/sources/packages/backend/workflow/test/2023-2024/parttime-assessment/awards-amounts/parttime-assessment-2023-2024-awards-amount-CSPT.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2023-2024/parttime-assessment/awards-amounts/parttime-assessment-2023-2024-awards-amount-CSPT.e2e-spec.ts
@@ -104,7 +104,7 @@ describe(`E2E Test Workflow parttime-assessment-${PROGRAM_YEAR}-awards-amount-CS
     expect(calculatedAssessment.variables.federalAwardNetCSPTAmount).toBe(0);
   });
 
-  it.only("Should determine federalAwardNetCSPTAmount when awardEligibilityCSPT is true and no CSPT awarded in the program year previously", async () => {
+  it("Should determine federalAwardNetCSPTAmount when awardEligibilityCSPT is true and no CSPT awarded in the program year previously", async () => {
     // Arrange
     const assessmentConsolidatedData =
       createFakeConsolidatedPartTimeData(PROGRAM_YEAR);
@@ -113,7 +113,7 @@ describe(`E2E Test Workflow parttime-assessment-${PROGRAM_YEAR}-awards-amount-CS
     assessmentConsolidatedData.studentDataIsYourSpouseACanadianCitizen =
       YesNoOptions.Yes;
     assessmentConsolidatedData.partner1CRAReportedIncome = 22999;
-    assessmentConsolidatedData.programYearTotalPartTimeCSPT = null;
+    assessmentConsolidatedData.programYearTotalPartTimeCSPT = undefined;
     // Act
     const calculatedAssessment = await executePartTimeAssessmentForProgramYear(
       PROGRAM_YEAR,

--- a/sources/packages/backend/workflow/test/2023-2024/parttime-assessment/awards-amounts/parttime-assessment-2023-2024-awards-amount-CSPT.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2023-2024/parttime-assessment/awards-amounts/parttime-assessment-2023-2024-awards-amount-CSPT.e2e-spec.ts
@@ -124,16 +124,6 @@ describe(`E2E Test Workflow parttime-assessment-${PROGRAM_YEAR}-awards-amount-CS
     expect(
       calculatedAssessment.variables.federalAwardCSPTAmount,
     ).toBeGreaterThan(100);
-    expect(calculatedAssessment.variables.federalAwardNetCSPTAmount).toBe(
-      Math.min(
-        calculatedAssessment.variables.calculatedDataTotalRemainingNeed1,
-        Math.min(
-          calculatedAssessment.variables.dmnPartTimeAwardAllowableLimits
-            .limitAwardCSPTAmount,
-          calculatedAssessment.variables.federalAwardCSPTAmount,
-        ),
-      ),
-    );
     expect(calculatedAssessment.variables.federalAwardNetCSPTAmount).toBe(2520);
   });
 });

--- a/sources/packages/backend/workflow/test/2023-2024/parttime-assessment/awards-amounts/parttime-assessment-2023-2024-awards-amount-CSPT.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2023-2024/parttime-assessment/awards-amounts/parttime-assessment-2023-2024-awards-amount-CSPT.e2e-spec.ts
@@ -126,4 +126,28 @@ describe(`E2E Test Workflow parttime-assessment-${PROGRAM_YEAR}-awards-amount-CS
     ).toBeGreaterThan(100);
     expect(calculatedAssessment.variables.federalAwardNetCSPTAmount).toBe(2520);
   });
+
+  it("Should determine federalAwardNetCSPTAmount as zero when awardEligibilityCSPT is true and difference between the programYearLimits and CSPT awarded in the program year previously is less than 100", async () => {
+    // Arrange
+    const assessmentConsolidatedData =
+      createFakeConsolidatedPartTimeData(PROGRAM_YEAR);
+    assessmentConsolidatedData.studentDataCRAReportedIncome = 60001;
+    assessmentConsolidatedData.studentDataRelationshipStatus = "married";
+    assessmentConsolidatedData.studentDataIsYourSpouseACanadianCitizen =
+      YesNoOptions.Yes;
+    assessmentConsolidatedData.partner1CRAReportedIncome = 22999;
+    assessmentConsolidatedData.programYearTotalPartTimeCSPT = 2421;
+    // Act
+    const calculatedAssessment = await executePartTimeAssessmentForProgramYear(
+      PROGRAM_YEAR,
+      assessmentConsolidatedData,
+    );
+    // Assert
+    expect(calculatedAssessment.variables.awardEligibilityCSPT).toBe(true);
+    expect(calculatedAssessment.variables.limitAwardCSPTRemaining).toBe(99);
+    expect(
+      calculatedAssessment.variables.federalAwardCSPTAmount,
+    ).toBeGreaterThan(100);
+    expect(calculatedAssessment.variables.federalAwardNetCSPTAmount).toBe(0);
+  });
 });

--- a/sources/packages/backend/workflow/test/2023-2024/parttime-assessment/awards-amounts/parttime-assessment-awards-amount-CSGP.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2023-2024/parttime-assessment/awards-amounts/parttime-assessment-awards-amount-CSGP.e2e-spec.ts
@@ -48,7 +48,7 @@ describe(`E2E Test Workflow parttime-assessment-${PROGRAM_YEAR}-awards-amount-CS
     );
   });
 
-  it("Should determine federalAwardCSGPAmount when awardEligibilityCSGP is true, programYearTotalPartTimeCSGP, programYearTotalFullTimeCSGP are null and studentDataApplicationPDPPDStatus is true", async () => {
+  it("Should determine federalAwardCSGPAmount when awardEligibilityCSGP is true, no CSGP awarded in the program year previously and studentDataApplicationPDPPDStatus is true", async () => {
     // Arrange
     const assessmentConsolidatedData =
       createFakeConsolidatedPartTimeData(PROGRAM_YEAR);

--- a/sources/packages/backend/workflow/test/2023-2024/parttime-assessment/awards-amounts/parttime-assessment-awards-amount-CSGP.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2023-2024/parttime-assessment/awards-amounts/parttime-assessment-awards-amount-CSGP.e2e-spec.ts
@@ -47,4 +47,26 @@ describe(`E2E Test Workflow parttime-assessment-${PROGRAM_YEAR}-awards-amount-CS
       0,
     );
   });
+
+  it("Should determine federalAwardCSGPAmount when awardEligibilityCSGP is true, programYearTotalPartTimeCSGP, programYearTotalFullTimeCSGP are null and studentDataApplicationPDPPDStatus is true", async () => {
+    // Arrange
+    const assessmentConsolidatedData =
+      createFakeConsolidatedPartTimeData(PROGRAM_YEAR);
+    assessmentConsolidatedData.studentDataApplicationPDPPDStatus = "yes";
+    assessmentConsolidatedData.programYearTotalFullTimeCSGP = null;
+    assessmentConsolidatedData.programYearTotalPartTimeCSGP = null;
+
+    // Act
+    const calculatedAssessment = await executePartTimeAssessmentForProgramYear(
+      PROGRAM_YEAR,
+      assessmentConsolidatedData,
+    );
+
+    // Assert
+    expect(calculatedAssessment.variables.programYearTotalCSGP).toBe(null);
+    expect(calculatedAssessment.variables.federalAwardNetCSGPAmount).toBe(2800);
+    expect(calculatedAssessment.variables.finalFederalAwardNetCSGPAmount).toBe(
+      2800,
+    );
+  });
 });

--- a/sources/packages/backend/workflow/test/2023-2024/parttime-assessment/awards-amounts/parttime-assessment-awards-amount-CSGP.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2023-2024/parttime-assessment/awards-amounts/parttime-assessment-awards-amount-CSGP.e2e-spec.ts
@@ -63,7 +63,7 @@ describe(`E2E Test Workflow parttime-assessment-${PROGRAM_YEAR}-awards-amount-CS
     );
 
     // Assert
-    expect(calculatedAssessment.variables.programYearTotalCSGP).toBe(null);
+    expect(calculatedAssessment.variables.programYearTotalCSGP).toBe(0);
     expect(calculatedAssessment.variables.federalAwardNetCSGPAmount).toBe(2800);
     expect(calculatedAssessment.variables.finalFederalAwardNetCSGPAmount).toBe(
       2800,

--- a/sources/packages/backend/workflow/test/2023-2024/parttime-assessment/awards-amounts/parttime-assessment-awards-amount-CSGP.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2023-2024/parttime-assessment/awards-amounts/parttime-assessment-awards-amount-CSGP.e2e-spec.ts
@@ -53,8 +53,8 @@ describe(`E2E Test Workflow parttime-assessment-${PROGRAM_YEAR}-awards-amount-CS
     const assessmentConsolidatedData =
       createFakeConsolidatedPartTimeData(PROGRAM_YEAR);
     assessmentConsolidatedData.studentDataApplicationPDPPDStatus = "yes";
-    assessmentConsolidatedData.programYearTotalFullTimeCSGP = null;
-    assessmentConsolidatedData.programYearTotalPartTimeCSGP = null;
+    assessmentConsolidatedData.programYearTotalFullTimeCSGP = undefined;
+    assessmentConsolidatedData.programYearTotalPartTimeCSGP = undefined;
 
     // Act
     const calculatedAssessment = await executePartTimeAssessmentForProgramYear(

--- a/sources/packages/backend/workflow/test/2023-2024/parttime-assessment/awards-amounts/parttime-assessment-awards-amount-CSGP.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2023-2024/parttime-assessment/awards-amounts/parttime-assessment-awards-amount-CSGP.e2e-spec.ts
@@ -5,7 +5,7 @@ import {
 } from "../../../test-utils";
 
 describe(`E2E Test Workflow parttime-assessment-${PROGRAM_YEAR}-awards-amount-CSGP.`, () => {
-  it("Should determine federalAwardCSGPAmount when awardEligibilityCSGP is true and studentDataApplicationPDPPDStatus is true", async () => {
+  it("Should determine federalAwardCSGPAmount when awardEligibilityCSGP is true and studentDataApplicationPDPPDStatus is yes", async () => {
     // Arrange
     const assessmentConsolidatedData =
       createFakeConsolidatedPartTimeData(PROGRAM_YEAR);
@@ -48,7 +48,7 @@ describe(`E2E Test Workflow parttime-assessment-${PROGRAM_YEAR}-awards-amount-CS
     );
   });
 
-  it("Should determine federalAwardCSGPAmount when awardEligibilityCSGP is true, no CSGP awarded in the program year previously and studentDataApplicationPDPPDStatus is true", async () => {
+  it("Should determine federalAwardCSGPAmount when awardEligibilityCSGP is true, no CSGP awarded in the program year previously and studentDataApplicationPDPPDStatus is yes", async () => {
     // Arrange
     const assessmentConsolidatedData =
       createFakeConsolidatedPartTimeData(PROGRAM_YEAR);

--- a/sources/packages/backend/workflow/test/2023-2024/parttime-assessment/awards-amounts/parttime-assessment-awards-amount-SBSD.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2023-2024/parttime-assessment/awards-amounts/parttime-assessment-awards-amount-SBSD.e2e-spec.ts
@@ -90,4 +90,28 @@ describe(`E2E Test Workflow parttime-assessment-${PROGRAM_YEAR}-awards-amount-SB
       calculatedAssessment.variables.finalProvincialAwardNetSBSDAmount,
     ).toBe(0);
   });
+
+  it("Should determine provincialAwardSBSDAmount when awardEligibilitySBSD is true, programYearTotalPartTimeSBSD, programYearTotalFullTimeSBSD are null and offeringCourseLoad is 40 and up", async () => {
+    // Arrange
+    const assessmentConsolidatedData =
+      createFakeConsolidatedPartTimeData(PROGRAM_YEAR);
+    assessmentConsolidatedData.studentDataApplicationPDPPDStatus = "yes";
+    assessmentConsolidatedData.programYearTotalPartTimeSBSD = null;
+    assessmentConsolidatedData.programYearTotalFullTimeSBSD = null;
+
+    // Act
+    const calculatedAssessment = await executePartTimeAssessmentForProgramYear(
+      PROGRAM_YEAR,
+      assessmentConsolidatedData,
+    );
+
+    // Assert
+    expect(calculatedAssessment.variables.programYearTotalSBSD).toBe(null);
+    expect(calculatedAssessment.variables.provincialAwardNetSBSDAmount).toBe(
+      800,
+    );
+    expect(
+      calculatedAssessment.variables.finalProvincialAwardNetSBSDAmount,
+    ).toBe(800);
+  });
 });

--- a/sources/packages/backend/workflow/test/2023-2024/parttime-assessment/awards-amounts/parttime-assessment-awards-amount-SBSD.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2023-2024/parttime-assessment/awards-amounts/parttime-assessment-awards-amount-SBSD.e2e-spec.ts
@@ -106,7 +106,7 @@ describe(`E2E Test Workflow parttime-assessment-${PROGRAM_YEAR}-awards-amount-SB
     );
 
     // Assert
-    expect(calculatedAssessment.variables.programYearTotalSBSD).toBe(null);
+    expect(calculatedAssessment.variables.programYearTotalSBSD).toBe(0);
     expect(calculatedAssessment.variables.provincialAwardNetSBSDAmount).toBe(
       800,
     );

--- a/sources/packages/backend/workflow/test/2023-2024/parttime-assessment/awards-amounts/parttime-assessment-awards-amount-SBSD.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2023-2024/parttime-assessment/awards-amounts/parttime-assessment-awards-amount-SBSD.e2e-spec.ts
@@ -91,7 +91,7 @@ describe(`E2E Test Workflow parttime-assessment-${PROGRAM_YEAR}-awards-amount-SB
     ).toBe(0);
   });
 
-  it("Should determine provincialAwardSBSDAmount when awardEligibilitySBSD is true, programYearTotalPartTimeSBSD, programYearTotalFullTimeSBSD are null and offeringCourseLoad is 40 and up", async () => {
+  it("Should determine provincialAwardSBSDAmount when awardEligibilitySBSD is true, no SBSD awarded in the program year previously and offeringCourseLoad is 40 and up", async () => {
     // Arrange
     const assessmentConsolidatedData =
       createFakeConsolidatedPartTimeData(PROGRAM_YEAR);

--- a/sources/packages/backend/workflow/test/2023-2024/parttime-assessment/awards-amounts/parttime-assessment-awards-amount-SBSD.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2023-2024/parttime-assessment/awards-amounts/parttime-assessment-awards-amount-SBSD.e2e-spec.ts
@@ -96,8 +96,8 @@ describe(`E2E Test Workflow parttime-assessment-${PROGRAM_YEAR}-awards-amount-SB
     const assessmentConsolidatedData =
       createFakeConsolidatedPartTimeData(PROGRAM_YEAR);
     assessmentConsolidatedData.studentDataApplicationPDPPDStatus = "yes";
-    assessmentConsolidatedData.programYearTotalPartTimeSBSD = null;
-    assessmentConsolidatedData.programYearTotalFullTimeSBSD = null;
+    assessmentConsolidatedData.programYearTotalPartTimeSBSD = undefined;
+    assessmentConsolidatedData.programYearTotalFullTimeSBSD = undefined;
 
     // Act
     const calculatedAssessment = await executePartTimeAssessmentForProgramYear(

--- a/sources/packages/backend/workflow/test/models/assessment.model.ts
+++ b/sources/packages/backend/workflow/test/models/assessment.model.ts
@@ -261,6 +261,7 @@ export interface CalculatedAssessmentModel {
   awardEligibilityCSPT: boolean;
   federalAwardCSPTAmount: number;
   federalAwardNetCSPTAmount: number;
+  limitAwardCSPTRemaining: number;
   finalFederalAwardNetCSPTAmount: number;
   // CSGP
   finalFederalAwardNetCSGPAmount: number;
@@ -268,6 +269,7 @@ export interface CalculatedAssessmentModel {
   finalFederalAwardNetCSGDAmount: number;
   // BCAG
   federalAwardBCAGAmount: number;
+  limitAwardBCAGRemaining: number;
   finalProvincialAwardNetBCAGAmount: number;
   // SBSD
   finalProvincialAwardNetSBSDAmount: number;

--- a/sources/packages/backend/workflow/test/test-utils/factories/assessment-consolidated-data.ts
+++ b/sources/packages/backend/workflow/test/test-utils/factories/assessment-consolidated-data.ts
@@ -94,6 +94,7 @@ export function createFakePartTimeAssessmentConsolidatedData(
     programYearTotalFullTimeSBSD: 50,
     programYearTotalPartTimeCSGP: 60,
     programYearTotalFullTimeCSGP: 70,
+    programYearTotalPartTimeCSPT: 80,
   };
 }
 /**


### PR DESCRIPTION
PT award configuration CSPT updated to consider the program year totals of CSPT already given to the student.

![image](https://github.com/bcgov/SIMS/assets/62901416/4d478842-487b-469b-8c44-5e36aea94b05)

Bug resolved in this PR:

PT award configuration variables 
- federalAwardNetCSGPAmount
- federalAwardNetCSGDAmount
- provincialAwardNetBCAGAmount
- provincialAwardNetSBSDAmount

all became null when they do not find the below values for the student in the particular year (or if its the first application for a student in a PY) so it will return as null
- programYearTotalFullTimeSBSD
- programYearTotalPartTimeSBSD
- programYearTotalFullTimeCSGP
- programYearTotalPartTimeCSGP
- programYearTotalPartTimeCSGD
- programYearTotalPartTimeSBSD

So fixed it by checking a null for the above values and return 0 if they are null.

![image](https://github.com/bcgov/SIMS/assets/62901416/6fa10019-3116-4d48-943c-f78f982b5f0e)

E2E Test cases  updated
