### PR TITLE
#2685 - Import Provincial Restrictions from SFAS to SIMS (Bug Fix)

### DIFF
--- a/sources/packages/backend/libs/integrations/src/sfas-integration/sfas-integration.models.ts
+++ b/sources/packages/backend/libs/integrations/src/sfas-integration/sfas-integration.models.ts
@@ -17,4 +17,5 @@ export class DownloadResult {
 export class ProcessSftpResponseResult {
   summary: string[] = [];
   success: boolean;
+  error: string[] = [];
 }

--- a/sources/packages/backend/libs/integrations/src/sfas-integration/sfas-integration.models.ts
+++ b/sources/packages/backend/libs/integrations/src/sfas-integration/sfas-integration.models.ts
@@ -17,5 +17,4 @@ export class DownloadResult {
 export class ProcessSftpResponseResult {
   summary: string[] = [];
   success: boolean;
-  error: string[] = [];
 }

--- a/sources/packages/backend/libs/integrations/src/sfas-integration/sfas-integration.processing.service.ts
+++ b/sources/packages/backend/libs/integrations/src/sfas-integration/sfas-integration.processing.service.ts
@@ -54,7 +54,28 @@ export class SFASIntegrationProcessingService {
         break;
       }
     }
-
+    // The following sequence of actions take place after the files have been imported and processed.
+    // The below steps need to run even if there were 0 files imported. For instance, in case of a new
+    // student account creation, when this scheduler is run again, even though there are no files to process,
+    // the insertStudentRestrictions method below will be responsible for inserting the restrictions for this
+    // student previously imported from SFAS.
+    this.logger.log("Updating student ids for SFAS individuals.");
+    await this.sfasIndividualService.updateStudentId();
+    this.logger.log("Student ids updated.");
+    this.logger.log(
+      "Updating and inserting new disbursement overaward balances from sfas to disbursement overawards table.",
+    );
+    await this.sfasIndividualService.updateDisbursementOverawards();
+    this.logger.log(
+      "New disbursement overaward balances inserted to disbursement overawards table.",
+    );
+    this.logger.log(
+      "Inserting student restrictions from SFAS restrictions data.",
+    );
+    await this.sfasRestrictionService.insertStudentRestrictions();
+    this.logger.log(
+      "Inserted student restrictions from SFAS restrictions data.",
+    );
     return results;
   }
 
@@ -138,23 +159,6 @@ export class SFASIntegrationProcessingService {
       }
       await Promise.all(promises);
       this.logger.log("Records imported.");
-      this.logger.log("Updating student ids for SFAS individuals.");
-      await this.sfasIndividualService.updateStudentId();
-      this.logger.log("Student ids updated.");
-      this.logger.log(
-        "Updating and inserting new disbursement overaward balances from sfas to disbursement overawards table.",
-      );
-      await this.sfasIndividualService.updateDisbursementOverawards();
-      this.logger.log(
-        "New disbursement overaward balances inserted to disbursement overawards table.",
-      );
-      this.logger.log(
-        "Inserting student restrictions from SFAS restrictions data.",
-      );
-      await this.sfasRestrictionService.insertStudentRestrictions();
-      this.logger.log(
-        "Inserted student restrictions from SFAS restrictions data.",
-      );
       if (result.success) {
         /**
          * Delete the file only if it was processed with success.

--- a/sources/packages/backend/libs/services/src/sfas/sfas-individual.service.ts
+++ b/sources/packages/backend/libs/services/src/sfas/sfas-individual.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from "@nestjs/common";
 import { Raw, Repository } from "typeorm";
-import { DataModelService, SFASIndividual, Student } from "@sims/sims-db";
+import { SFASIndividual, Student } from "@sims/sims-db";
 import { SFASIndividualDataSummary } from "./sfas-individual.model";
 import { InjectRepository } from "@nestjs/typeorm";
 
@@ -8,15 +8,13 @@ import { InjectRepository } from "@nestjs/typeorm";
  * Manages the data related to an individual/student in SFAS.
  */
 @Injectable()
-export class SFASIndividualService extends DataModelService<SFASIndividual> {
+export class SFASIndividualService {
   constructor(
     @InjectRepository(SFASIndividual)
-    sfasIndividualRepo: Repository<SFASIndividual>,
+    private readonly sfasIndividualRepo: Repository<SFASIndividual>,
     @InjectRepository(Student)
     private readonly studentRepo: Repository<Student>,
-  ) {
-    super(sfasIndividualRepo);
-  }
+  ) {}
 
   /**
    * Get SFAS student, if available.
@@ -30,9 +28,9 @@ export class SFASIndividualService extends DataModelService<SFASIndividual> {
     birthDate: string,
     sin: string,
   ): Promise<SFASIndividual> {
-    const individual = await this.repo
+    const individual = await this.sfasIndividualRepo
       .createQueryBuilder("individual")
-      .select("individual.pdStatus")
+      .select(["individual.id", "individual.pdStatus"])
       .where("lower(individual.lastName) = :lastName", {
         lastName: lastName.toLowerCase(),
       })
@@ -55,7 +53,7 @@ export class SFASIndividualService extends DataModelService<SFASIndividual> {
     birthDate: string,
     sin: string,
   ): Promise<SFASIndividual> {
-    return await this.repo.findOne({
+    return await this.sfasIndividualRepo.findOne({
       select: {
         id: true,
         cslOveraward: true,
@@ -97,7 +95,7 @@ export class SFASIndividualService extends DataModelService<SFASIndividual> {
     const sin = studentData.sinValidation.sin;
     const birthDate = studentData.birthDate;
     const lastName = studentData.user.lastName;
-    const sfasIndividualData = await this.repo
+    const sfasIndividualData = await this.sfasIndividualRepo
       .createQueryBuilder("sfasIndividual")
       .select(
         "SUM(sfasIndividual.unsuccessfulCompletion)::int",


### PR DESCRIPTION
### As a part of this PR, the following bug was fixed:

**Bug:** After student account creation, when the `sfas-integration` scheduler runs, it calls the `insertStudentRestrictions` method which ensures that the restrictions imported for the newly created student, if any, from SFAS are inserted into the SIMS student restrictions. However, as per the current code, the `insertStudentRestrictions` method is only called when there is atleast one SFAS file to process.

**Fix:** Code has been refactored to ensure that this block of code runs even when there are no SFAS file imports to be processed.

**Note:** There is some additional code cleanup in the file `sfas-individual.service.ts`.

### **Screenshot:**

<img width="1920" alt="image" src="https://github.com/bcgov/SIMS/assets/7859295/905c08d0-3182-4497-aae1-e3053c7ff84d">
