### PR TITLE
#2645 - Program Deactivation - DB migrations

### DIFF
--- a/sims.code-workspace
+++ b/sims.code-workspace
@@ -89,6 +89,14 @@
       }
     },
     "typescript.preferences.importModuleSpecifier": "non-relative",
-    "cSpell.words": ["ESDC", "MSFAA", "NSLSC", "Overaward", "SFAS", "typeorm"]
+    "cSpell.words": [
+      "ESDC",
+      "MSFAA",
+      "NSLSC",
+      "Overaward",
+      "SFAS",
+      "timestamptz",
+      "typeorm"
+    ]
   }
 }

--- a/sources/packages/backend/apps/db-migrations/src/migrations/1710462853532-CreateProgramDeactivationColumns.ts
+++ b/sources/packages/backend/apps/db-migrations/src/migrations/1710462853532-CreateProgramDeactivationColumns.ts
@@ -1,0 +1,21 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+import { getSQLFileData } from "../utilities/sqlLoader";
+
+export class CreateProgramDeactivationColumns1710462853532
+  implements MigrationInterface
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      getSQLFileData("Add-deactivation-columns.sql", "EducationPrograms"),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      getSQLFileData(
+        "Rollback-add-deactivation-columns.sql",
+        "EducationPrograms",
+      ),
+    );
+  }
+}

--- a/sources/packages/backend/apps/db-migrations/src/sql/EducationPrograms/Add-deactivation-columns.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/EducationPrograms/Add-deactivation-columns.sql
@@ -1,14 +1,14 @@
 ALTER TABLE
   sims.education_programs
 ADD
-  COLUMN is_active BOOLEAN DEFAULT TRUE,
+  COLUMN is_active BOOLEAN NOT NULL DEFAULT TRUE,
 ADD
-  COLUMN is_active_updated_by INT NULL REFERENCES sims.users(id),
+  COLUMN is_active_updated_by INT REFERENCES sims.users(id),
 ADD
   COLUMN is_active_updated_on TIMESTAMP WITH TIME ZONE;
 
-COMMENT ON COLUMN sims.education_programs.is_active IS 'Indicates if an education program is active and should be available for student and for institutions, for instance, while completing PIRs.';
+COMMENT ON COLUMN sims.education_programs.is_active IS 'Indicates if an education program is active and should be available, for instance, for students creating new applications or institutions completing PIRs.';
 
-COMMENT ON COLUMN sims.education_programs.is_active_updated_by IS 'Last user id that updated the is_active column value. If null, the is_active was never changed since its creation.';
+COMMENT ON COLUMN sims.education_programs.is_active_updated_by IS 'Last user ID that updated the is_active column value. If null, the is_active has never changed since its creation.';
 
-COMMENT ON COLUMN sims.education_programs.is_active_updated_on IS 'Last date and time the is_active column value was updated. If null, the is_active was never changed since its creation.';
+COMMENT ON COLUMN sims.education_programs.is_active_updated_on IS 'Last date and time the is_active column value was updated. If null, the is_active has never changed since its creation.';

--- a/sources/packages/backend/apps/db-migrations/src/sql/EducationPrograms/Add-deactivation-columns.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/EducationPrograms/Add-deactivation-columns.sql
@@ -1,0 +1,14 @@
+ALTER TABLE
+  sims.education_programs
+ADD
+  COLUMN is_active BOOLEAN DEFAULT TRUE,
+ADD
+  COLUMN is_active_updated_by INT NULL REFERENCES sims.users(id),
+ADD
+  COLUMN is_active_updated_on TIMESTAMP WITH TIME ZONE;
+
+COMMENT ON COLUMN sims.education_programs.is_active IS 'Indicates if an education program is active and should be available for student and for institutions, for instance, while completing PIRs.';
+
+COMMENT ON COLUMN sims.education_programs.is_active_updated_by IS 'Last user id that updated the is_active column value. If null, the is_active was never changed since its creation.';
+
+COMMENT ON COLUMN sims.education_programs.is_active_updated_on IS 'Last date and time the is_active column value was updated. If null, the is_active was never changed since its creation.';

--- a/sources/packages/backend/apps/db-migrations/src/sql/EducationPrograms/Rollback-add-deactivation-columns.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/EducationPrograms/Rollback-add-deactivation-columns.sql
@@ -1,0 +1,4 @@
+ALTER TABLE
+  sims.education_programs DROP COLUMN is_active,
+  DROP COLUMN is_active_updated_by,
+  DROP COLUMN is_active_updated_on;

--- a/sources/packages/backend/libs/sims-db/src/entities/education-program.model.ts
+++ b/sources/packages/backend/libs/sims-db/src/entities/education-program.model.ts
@@ -403,4 +403,36 @@ export class EducationProgram extends RecordDataModel {
     name: "field_of_study_code",
   })
   fieldOfStudyCode: number;
+
+  /**
+   * Indicates if an education program is active and should be available for
+   * student and for institutions, for instance, while completing PIRs.
+   */
+  @Column({
+    name: "is_active",
+    nullable: false,
+  })
+  isActive: boolean;
+
+  /**
+   * Last user id that updated the {@link isActive} column value on DB.
+   * If null, the is_active was never changed since its creation.
+   */
+  @ManyToOne(() => User, { eager: false, nullable: true })
+  @JoinColumn({
+    name: "is_active_updated_by",
+    referencedColumnName: ColumnNames.ID,
+  })
+  isActiveUpdatedBy?: User;
+
+  /**
+   * Last date and time the {@link isActive} column value was updated on DB.
+   * If null, the is_active was never changed since its creation.
+   */
+  @Column({
+    name: "is_active_updated_on",
+    type: "timestamptz",
+    nullable: true,
+  })
+  isActiveUpdatedOn?: Date;
 }

--- a/sources/packages/backend/libs/sims-db/src/entities/education-program.model.ts
+++ b/sources/packages/backend/libs/sims-db/src/entities/education-program.model.ts
@@ -405,8 +405,8 @@ export class EducationProgram extends RecordDataModel {
   fieldOfStudyCode: number;
 
   /**
-   * Indicates if an education program is active and should be available for
-   * student and for institutions, for instance, while completing PIRs.
+   * Indicates if an education program is active and should be available, for instance,
+   * for students creating new applications or institutions completing PIRs.
    */
   @Column({
     name: "is_active",
@@ -416,7 +416,7 @@ export class EducationProgram extends RecordDataModel {
 
   /**
    * Last user id that updated the {@link isActive} column value on DB.
-   * If null, the is_active was never changed since its creation.
+   *  If null, the {@link isActive} value has never changed since its creation.
    */
   @ManyToOne(() => User, { eager: false, nullable: true })
   @JoinColumn({
@@ -427,7 +427,7 @@ export class EducationProgram extends RecordDataModel {
 
   /**
    * Last date and time the {@link isActive} column value was updated on DB.
-   * If null, the is_active was never changed since its creation.
+   * If null, the {@link isActive} value has never changed since its creation.
    */
   @Column({
     name: "is_active_updated_on",

--- a/sources/packages/backend/libs/sims-db/src/entities/education-program.model.ts
+++ b/sources/packages/backend/libs/sims-db/src/entities/education-program.model.ts
@@ -416,7 +416,7 @@ export class EducationProgram extends RecordDataModel {
 
   /**
    * Last user id that updated the {@link isActive} column value on DB.
-   *  If null, the {@link isActive} value has never changed since its creation.
+   * If null, the {@link isActive} value has never changed since its creation.
    */
   @ManyToOne(() => User, { eager: false, nullable: true })
   @JoinColumn({


### PR DESCRIPTION
Created the new columns related to the education program deactivation. Used one of the suggested name combinations in the ticket technical discussion.
- isActive
- isActiveUpdatedBy
- isActiveUpdatedOn

_Minor comment, we did not plan to add a specific note id associated with the is_active column. The note requested will be created without it and it was my understanding that it would not be required. Please let me know if it need to be discussed._

_Minor update in the shared workspace `cSpell.words`._
