### PR TITLE
#2645 - Program Deactivation - API Changes

### DIFF
--- a/sims.code-workspace
+++ b/sims.code-workspace
@@ -90,6 +90,7 @@
     },
     "typescript.preferences.importModuleSpecifier": "non-relative",
     "cSpell.words": [
+      "AEST",
       "ESDC",
       "MSFAA",
       "NSLSC",

--- a/sims.code-workspace
+++ b/sims.code-workspace
@@ -95,6 +95,7 @@
       "MSFAA",
       "NSLSC",
       "Overaward",
+      "SABC",
       "SFAS",
       "timestamptz",
       "typeorm"

--- a/sources/packages/backend/.vscode/settings.json
+++ b/sources/packages/backend/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "cSpell.words": ["SABC"]
+}

--- a/sources/packages/backend/.vscode/settings.json
+++ b/sources/packages/backend/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-  "cSpell.words": ["SABC"]
-}

--- a/sources/packages/backend/apps/api/src/app.students.module.ts
+++ b/sources/packages/backend/apps/api/src/app.students.module.ts
@@ -23,6 +23,10 @@ import {
   SupportingUserService,
   StudentAccountApplicationsService,
   ApplicationOfferingChangeRequestService,
+  InstitutionService,
+  BCeIDService,
+  InstitutionUserAuthService,
+  UserService,
 } from "./services";
 import {
   ApplicationStudentsController,
@@ -126,6 +130,10 @@ import { ATBCIntegrationModule } from "@sims/integrations/atbc-integration";
     ApplicationOfferingChangeRequestService,
     ScholasticStandingControllerService,
     AssessmentSequentialProcessingService,
+    InstitutionService,
+    BCeIDService,
+    InstitutionUserAuthService,
+    UserService,
   ],
 })
 export class AppStudentsModule {}

--- a/sources/packages/backend/apps/api/src/auth/roles.enum.ts
+++ b/sources/packages/backend/apps/api/src/auth/roles.enum.ts
@@ -31,6 +31,7 @@ export enum Role {
   InstitutionApproveDeclineDesignation = "institution-approve-decline-designation",
   InstitutionApproveDeclineOfferingChanges = "institution-approve-decline-offering-changes",
   InstitutionApproveDeclineApplicationOfferingChangeRequest = "institution-approve-decline-application-offering-change-request",
+  InstitutionDeclineEducationProgram = "institution-decline-education-program",
   StudentReissueMSFAA = "student-reissue-msfaa",
   StudentUpdateDisabilityStatus = "student-update-disability-status",
 }

--- a/sources/packages/backend/apps/api/src/auth/roles.enum.ts
+++ b/sources/packages/backend/apps/api/src/auth/roles.enum.ts
@@ -31,7 +31,7 @@ export enum Role {
   InstitutionApproveDeclineDesignation = "institution-approve-decline-designation",
   InstitutionApproveDeclineOfferingChanges = "institution-approve-decline-offering-changes",
   InstitutionApproveDeclineApplicationOfferingChangeRequest = "institution-approve-decline-application-offering-change-request",
-  InstitutionDeclineEducationProgram = "institution-decline-education-program",
+  InstitutionDeactivateEducationProgram = "institution-deactivate-education-program",
   StudentReissueMSFAA = "student-reissue-msfaa",
   StudentUpdateDisabilityStatus = "student-update-disability-status",
 }

--- a/sources/packages/backend/apps/api/src/constants/error-code.constants.ts
+++ b/sources/packages/backend/apps/api/src/constants/error-code.constants.ts
@@ -45,8 +45,15 @@ export const BCEID_ACCOUNT_NOT_FOUND = "BCEID_ACCOUNT_NOT_FOUND";
 export const PIR_REQUEST_NOT_FOUND_ERROR = "PIR_REQUEST_NOT_FOUND_ERROR";
 export const PIR_DENIED_REASON_NOT_FOUND_ERROR =
   "PIR_DENIED_REASON_NOT_FOUND_ERROR";
-
+/**
+ * Education program not found. Also used when the institution does not have access to it.
+ */
 export const EDUCATION_PROGRAM_NOT_FOUND = "EDUCATION_PROGRAM_NOT_FOUND";
+/**
+ * Some operation is being executed in a program in a moment that it is not expected.
+ */
+export const EDUCATION_PROGRAM_INVALID_OPERATION =
+  "EDUCATION_PROGRAM_INVALID_OPERATION";
 
 export const STUDENT_ACCOUNT_APPLICATION_NOT_FOUND =
   "STUDENT_ACCOUNT_APPLICATION_NOT_FOUND";

--- a/sources/packages/backend/apps/api/src/route-controllers/education-program/_tests_/e2e/education-program.aest.controller.deactivateProgram.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/education-program/_tests_/e2e/education-program.aest.controller.deactivateProgram.e2e-spec.ts
@@ -96,7 +96,7 @@ describe("EducationProgramAESTController(e2e)-deactivateProgram", () => {
     await db.educationProgram.save(program);
 
     const endpoint = `/aest/education-program/${program.id}/deactivate`;
-    const userToken = await getAESTToken(AESTGroups.OperationsAdministrators);
+    const userToken = await getAESTToken(AESTGroups.BusinessAdministrators);
 
     // Act/Assert
     await request(app.getHttpServer())
@@ -115,7 +115,7 @@ describe("EducationProgramAESTController(e2e)-deactivateProgram", () => {
   it("Should return a not found HTTP status when the program id does not exists.", async () => {
     // Arrange
     const endpoint = `/aest/education-program/99999/deactivate`;
-    const userToken = await getAESTToken(AESTGroups.OperationsAdministrators);
+    const userToken = await getAESTToken(AESTGroups.BusinessAdministrators);
 
     // Act/Assert
     await request(app.getHttpServer())
@@ -129,6 +129,29 @@ describe("EducationProgramAESTController(e2e)-deactivateProgram", () => {
         statusCode: HttpStatus.NOT_FOUND,
         message: "Not able to find the education program.",
         error: "Not Found",
+      });
+  });
+
+  it("Should return a bad request HTTP status when payload is invalid.", async () => {
+    // Arrange
+    const endpoint = `/aest/education-program/99999/deactivate`;
+    const userToken = await getAESTToken(AESTGroups.BusinessAdministrators);
+
+    // Act/Assert
+    await request(app.getHttpServer())
+      .patch(endpoint)
+      .send({
+        note: undefined,
+      })
+      .auth(userToken, BEARER_AUTH_TYPE)
+      .expect(HttpStatus.BAD_REQUEST)
+      .expect({
+        statusCode: HttpStatus.BAD_REQUEST,
+        message: [
+          "note must be shorter than or equal to 1000 characters",
+          "note should not be empty",
+        ],
+        error: "Bad Request",
       });
   });
 

--- a/sources/packages/backend/apps/api/src/route-controllers/education-program/_tests_/e2e/education-program.aest.controller.deactivateProgram.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/education-program/_tests_/e2e/education-program.aest.controller.deactivateProgram.e2e-spec.ts
@@ -107,8 +107,9 @@ describe("EducationProgramAESTController(e2e)-deactivateProgram", () => {
       .auth(userToken, BEARER_AUTH_TYPE)
       .expect(HttpStatus.UNPROCESSABLE_ENTITY)
       .expect({
+        statusCode: HttpStatus.UNPROCESSABLE_ENTITY,
         message: "The education program is already set as requested.",
-        errorType: "EDUCATION_PROGRAM_INVALID_OPERATION",
+        error: "Unprocessable Entity",
       });
   });
 

--- a/sources/packages/backend/apps/api/src/route-controllers/education-program/_tests_/e2e/education-program.aest.controller.deactivateProgram.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/education-program/_tests_/e2e/education-program.aest.controller.deactivateProgram.e2e-spec.ts
@@ -1,0 +1,138 @@
+import { HttpStatus, INestApplication } from "@nestjs/common";
+import {
+  E2EDataSources,
+  createE2EDataSources,
+  createFakeInstitution,
+  createFakeUser,
+} from "@sims/test-utils";
+import {
+  createTestingAppModule,
+  BEARER_AUTH_TYPE,
+  createFakeEducationProgram,
+  getAESTToken,
+  getAESTUser,
+  AESTGroups,
+} from "../../../../testHelpers";
+import * as request from "supertest";
+import { Institution, User } from "@sims/sims-db";
+
+describe("EducationProgramAESTController(e2e)-deactivateProgram", () => {
+  let app: INestApplication;
+  let db: E2EDataSources;
+  let sharedInstitution: Institution;
+  let sharedUser: User;
+
+  beforeAll(async () => {
+    const { nestApplication, dataSource } = await createTestingAppModule();
+    app = nestApplication;
+    db = createE2EDataSources(dataSource);
+    sharedInstitution = createFakeInstitution();
+    await db.institution.save(sharedInstitution);
+    sharedUser = createFakeUser();
+    await db.user.save(sharedUser);
+  });
+
+  it("Should allow an education program to be deactivated when the program is active.", async () => {
+    // Arrange
+    const program = createFakeEducationProgram({
+      institution: sharedInstitution,
+      user: sharedUser,
+    });
+    await db.educationProgram.save(program);
+
+    const endpoint = `/aest/education-program/${program.id}/deactivate`;
+    const userToken = await getAESTToken(AESTGroups.BusinessAdministrators);
+    const aestUser = await getAESTUser(
+      db.dataSource,
+      AESTGroups.BusinessAdministrators,
+    );
+
+    // Act/Assert
+    await request(app.getHttpServer())
+      .patch(endpoint)
+      .send({
+        note: "Some notes.",
+      })
+      .auth(userToken, BEARER_AUTH_TYPE)
+      .expect(HttpStatus.OK);
+
+    const educationProgram = await db.educationProgram.findOne({
+      select: {
+        id: true,
+        isActive: true,
+        isActiveUpdatedOn: true,
+        isActiveUpdatedBy: {
+          id: true,
+        },
+        modifier: { id: true },
+      },
+      relations: {
+        isActiveUpdatedBy: true,
+        modifier: true,
+      },
+      where: { id: program.id },
+    });
+    const expectedUser = { id: aestUser.id };
+    expect(educationProgram).toEqual({
+      id: program.id,
+      isActive: false,
+      isActiveUpdatedOn: expect.any(Date),
+      isActiveUpdatedBy: expectedUser,
+      modifier: expectedUser,
+    });
+  });
+
+  it("Should return an unprocessable entity HTTP status when the program is already deactivated.", async () => {
+    // Arrange
+    const program = createFakeEducationProgram(
+      {
+        institution: sharedInstitution,
+        user: sharedUser,
+      },
+      {
+        initialValue: { isActive: false },
+      },
+    );
+    await db.educationProgram.save(program);
+
+    const endpoint = `/aest/education-program/${program.id}/deactivate`;
+    const userToken = await getAESTToken(AESTGroups.OperationsAdministrators);
+
+    // Act/Assert
+    await request(app.getHttpServer())
+      .patch(endpoint)
+      .send({
+        note: "Some notes.",
+      })
+      .auth(userToken, BEARER_AUTH_TYPE)
+      .expect(HttpStatus.UNPROCESSABLE_ENTITY)
+      .expect({
+        message: "The education program is already set as requested.",
+        errorType: "EDUCATION_PROGRAM_INVALID_OPERATION",
+      });
+  });
+
+  it("Should return a not found HTTP status when the program id does not exists.", async () => {
+    // Arrange
+    const endpoint = `/aest/education-program/99999/deactivate`;
+    const userToken = await getAESTToken(AESTGroups.OperationsAdministrators);
+
+    // Act/Assert
+    await request(app.getHttpServer())
+      .patch(endpoint)
+      .send({
+        note: "Some notes.",
+      })
+      .auth(userToken, BEARER_AUTH_TYPE)
+      .expect(HttpStatus.NOT_FOUND)
+      .expect({
+        statusCode: HttpStatus.NOT_FOUND,
+        message: "Not able to find the education program.",
+        error: "Not Found",
+      });
+  });
+
+  afterAll(async () => {
+    await app?.close();
+  });
+});

--- a/sources/packages/backend/apps/api/src/route-controllers/education-program/_tests_/e2e/education-program.institutions.controller.deactivateProgram.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/education-program/_tests_/e2e/education-program.institutions.controller.deactivateProgram.e2e-spec.ts
@@ -1,0 +1,127 @@
+import { HttpStatus, INestApplication } from "@nestjs/common";
+import { Institution, User } from "@sims/sims-db";
+import { E2EDataSources, createE2EDataSources } from "@sims/test-utils";
+import {
+  createTestingAppModule,
+  BEARER_AUTH_TYPE,
+  InstitutionTokenTypes,
+  getInstitutionToken,
+  getAuthRelatedEntities,
+  createFakeEducationProgram,
+} from "../../../../testHelpers";
+import * as request from "supertest";
+
+describe("EducationProgramInstitutionsController(e2e)-deactivateProgram", () => {
+  let app: INestApplication;
+  let db: E2EDataSources;
+  let collegeC: Institution;
+  let collegeCUser: User;
+
+  beforeAll(async () => {
+    const { nestApplication, dataSource } = await createTestingAppModule();
+    app = nestApplication;
+    db = createE2EDataSources(dataSource);
+    const { institution, user } = await getAuthRelatedEntities(
+      db.dataSource,
+      InstitutionTokenTypes.CollegeCUser,
+    );
+    collegeC = institution;
+    collegeCUser = user;
+  });
+
+  it("Should allow an education program to be deactivated when the program belongs to the institution and the program is active.", async () => {
+    // Arrange
+    const program = createFakeEducationProgram({
+      institution: collegeC,
+      user: collegeCUser,
+    });
+    await db.educationProgram.save(program);
+
+    const endpoint = `/institutions/education-program/${program.id}/deactivate`;
+    const institutionUserToken = await getInstitutionToken(
+      InstitutionTokenTypes.CollegeCUser,
+    );
+
+    // Act/Assert
+    await request(app.getHttpServer())
+      .patch(endpoint)
+      .auth(institutionUserToken, BEARER_AUTH_TYPE)
+      .expect(HttpStatus.OK);
+
+    const educationProgram = await db.educationProgram.findOne({
+      select: {
+        id: true,
+        isActive: true,
+        isActiveUpdatedOn: true,
+        isActiveUpdatedBy: {
+          id: true,
+        },
+        modifier: { id: true },
+      },
+      relations: {
+        isActiveUpdatedBy: true,
+        modifier: true,
+      },
+      where: { id: program.id },
+    });
+    expect(educationProgram).toEqual({
+      id: program.id,
+      isActive: false,
+      isActiveUpdatedOn: expect.any(Date),
+      isActiveUpdatedBy: { id: collegeCUser.id },
+      modifier: { id: collegeCUser.id },
+    });
+  });
+
+  it("Should return a not found HTTP status when a different institution accesses the program.", async () => {
+    // Arrange
+    const program = createFakeEducationProgram({
+      institution: collegeC,
+      user: collegeCUser,
+    });
+    await db.educationProgram.save(program);
+
+    const endpoint = `/institutions/education-program/${program.id}/deactivate`;
+    // Program created by College C user and tried to be accessed by the College C.
+    const institutionUserToken = await getInstitutionToken(
+      InstitutionTokenTypes.CollegeFUser,
+    );
+
+    // Act/Assert
+    await request(app.getHttpServer())
+      .patch(endpoint)
+      .auth(institutionUserToken, BEARER_AUTH_TYPE)
+      .expect(HttpStatus.NOT_FOUND);
+  });
+
+  it("Should return an unprocessable entity HTTP status when the program is already deactivated.", async () => {
+    // Arrange
+    const program = createFakeEducationProgram(
+      {
+        institution: collegeC,
+        user: collegeCUser,
+      },
+      { initialValue: { isActive: false } },
+    );
+    await db.educationProgram.save(program);
+
+    const endpoint = `/institutions/education-program/${program.id}/deactivate`;
+    const institutionUserToken = await getInstitutionToken(
+      InstitutionTokenTypes.CollegeCUser,
+    );
+
+    // Act/Assert
+    await request(app.getHttpServer())
+      .patch(endpoint)
+      .auth(institutionUserToken, BEARER_AUTH_TYPE)
+      .expect(HttpStatus.UNPROCESSABLE_ENTITY)
+      .expect({
+        message: "The education program is already set as requested.",
+        errorType: "EDUCATION_PROGRAM_INVALID_OPERATION",
+      });
+  });
+
+  afterAll(async () => {
+    await app?.close();
+  });
+});

--- a/sources/packages/backend/apps/api/src/route-controllers/education-program/_tests_/e2e/education-program.institutions.controller.deactivateProgram.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/education-program/_tests_/e2e/education-program.institutions.controller.deactivateProgram.e2e-spec.ts
@@ -64,12 +64,13 @@ describe("EducationProgramInstitutionsController(e2e)-deactivateProgram", () => 
       },
       where: { id: program.id },
     });
+    const expectedUser = { id: collegeCUser.id };
     expect(educationProgram).toEqual({
       id: program.id,
       isActive: false,
       isActiveUpdatedOn: expect.any(Date),
-      isActiveUpdatedBy: { id: collegeCUser.id },
-      modifier: { id: collegeCUser.id },
+      isActiveUpdatedBy: expectedUser,
+      modifier: expectedUser,
     });
   });
 
@@ -82,7 +83,7 @@ describe("EducationProgramInstitutionsController(e2e)-deactivateProgram", () => 
     await db.educationProgram.save(program);
 
     const endpoint = `/institutions/education-program/${program.id}/deactivate`;
-    // Program created by College C user and tried to be accessed by the College C.
+    // Program created by College C and the user will be authenticated using College F.
     const institutionUserToken = await getInstitutionToken(
       InstitutionTokenTypes.CollegeFUser,
     );

--- a/sources/packages/backend/apps/api/src/route-controllers/education-program/_tests_/e2e/education-program.institutions.controller.deactivateProgram.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/education-program/_tests_/e2e/education-program.institutions.controller.deactivateProgram.e2e-spec.ts
@@ -117,8 +117,9 @@ describe("EducationProgramInstitutionsController(e2e)-deactivateProgram", () => 
       .auth(institutionUserToken, BEARER_AUTH_TYPE)
       .expect(HttpStatus.UNPROCESSABLE_ENTITY)
       .expect({
+        statusCode: HttpStatus.UNPROCESSABLE_ENTITY,
         message: "The education program is already set as requested.",
-        errorType: "EDUCATION_PROGRAM_INVALID_OPERATION",
+        error: "Unprocessable Entity",
       });
   });
 

--- a/sources/packages/backend/apps/api/src/route-controllers/education-program/education-program.aest.controller.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/education-program/education-program.aest.controller.ts
@@ -140,8 +140,7 @@ export class EducationProgramAESTController extends BaseController {
   @ApiUnprocessableEntityResponse({
     description: "The education program is already set as requested.",
   })
-  // TODO: To be added
-  //@Roles(Role.InstitutionApproveDeclineProgram)
+  @Roles(Role.InstitutionDeactivateEducationProgram)
   @Patch(":programId/deactivate")
   async deactivateProgram(
     @UserToken() userToken: IUserToken,

--- a/sources/packages/backend/apps/api/src/route-controllers/education-program/education-program.aest.controller.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/education-program/education-program.aest.controller.ts
@@ -20,11 +20,16 @@ import {
   ApproveProgramAPIInDTO,
   EducationProgramAPIOutDTO,
   EducationProgramsSummaryAPIOutDTO,
+  DeactivateProgramAPIInDTO,
 } from "./models/education-program.dto";
 import { EducationProgramService } from "../../services";
 import { ClientTypeBaseRoute } from "../../types";
 import { UserGroups } from "../../auth/user-groups.enum";
-import { ApiNotFoundResponse, ApiTags } from "@nestjs/swagger";
+import {
+  ApiNotFoundResponse,
+  ApiTags,
+  ApiUnprocessableEntityResponse,
+} from "@nestjs/swagger";
 import BaseController from "../BaseController";
 import {
   PaginatedResultsAPIOutDTO,
@@ -121,6 +126,30 @@ export class EducationProgramAESTController extends BaseController {
       institutionId,
       programId,
       userToken.userId,
+    );
+  }
+
+  /**
+   * Allows a program to be deactivated.
+   * @param programId program to be deactivated.
+   * @param payload information to support the deactivation.
+   */
+  @ApiNotFoundResponse({
+    description: "Not able to find the education program.",
+  })
+  @ApiUnprocessableEntityResponse({
+    description: "The education program is already set as requested.",
+  })
+  @Patch(":programId/deactivate")
+  async deactivateProgram(
+    @UserToken() userToken: IUserToken,
+    @Param("programId", ParseIntPipe) programId: number,
+    @Body() payload: DeactivateProgramAPIInDTO,
+  ): Promise<void> {
+    await this.educationProgramControllerService.deactivateProgram(
+      programId,
+      userToken.userId,
+      { notes: payload.note },
     );
   }
 }

--- a/sources/packages/backend/apps/api/src/route-controllers/education-program/education-program.aest.controller.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/education-program/education-program.aest.controller.ts
@@ -140,6 +140,8 @@ export class EducationProgramAESTController extends BaseController {
   @ApiUnprocessableEntityResponse({
     description: "The education program is already set as requested.",
   })
+  // TODO: To be added
+  //@Roles(Role.InstitutionApproveDeclineProgram)
   @Patch(":programId/deactivate")
   async deactivateProgram(
     @UserToken() userToken: IUserToken,

--- a/sources/packages/backend/apps/api/src/route-controllers/education-program/education-program.controller.service.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/education-program/education-program.controller.service.ts
@@ -234,7 +234,7 @@ export class EducationProgramControllerService {
    * @param isActive value to update the isActive state for the program.
    * @param options method options.
    * - `institutionId` institution used for authorization.
-   * - `notes` notes associated with the change. Notes are optional and expected.
+   * - `notes` notes associated with the change.
    */
   async deactivateProgram(
     programId: number,

--- a/sources/packages/backend/apps/api/src/route-controllers/education-program/education-program.controller.service.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/education-program/education-program.controller.service.ts
@@ -231,7 +231,6 @@ export class EducationProgramControllerService {
    * Allows a program to be deactivated.
    * @param programId program to be updated.
    * @param auditUserId user that should be considered the one that is causing the changes.
-   * @param isActive value to update the isActive state for the program.
    * @param options method options.
    * - `institutionId` institution used for authorization.
    * - `notes` notes associated with the change.
@@ -257,9 +256,7 @@ export class EducationProgramControllerService {
           throw new NotFoundException(error.message);
         }
         if (error.name === EDUCATION_PROGRAM_INVALID_OPERATION) {
-          throw new UnprocessableEntityException(
-            new ApiProcessError(error.message, error.name),
-          );
+          throw new UnprocessableEntityException(error.message);
         }
       }
       throw error;

--- a/sources/packages/backend/apps/api/src/route-controllers/education-program/education-program.controller.service.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/education-program/education-program.controller.service.ts
@@ -228,6 +228,34 @@ export class EducationProgramControllerService {
   }
 
   /**
+   * Allows a program to be deactivated by an Institution.
+   * @param programId program to be updated.
+   * @param auditUserId user that should be considered the one that is causing the changes.
+   * @param options method options.
+   * - `institutionId` institution used for authorization.
+   */
+  async deactivateProgram(
+    programId: number,
+    auditUserId: number,
+    options: {
+      institutionId: number;
+    },
+  ): Promise<void>;
+  /**
+   * Allows a program to be deactivated by the Ministry providing additional notes.
+   * @param programId program to be updated.
+   * @param auditUserId user that should be considered the one that is causing the changes.
+   * @param options method options.
+   * - `notes` notes associated with the change.
+   */
+  async deactivateProgram(
+    programId: number,
+    auditUserId: number,
+    options: {
+      notes: string;
+    },
+  ): Promise<void>;
+  /**
    * Allows a program to be deactivated.
    * @param programId program to be updated.
    * @param auditUserId user that should be considered the one that is causing the changes.

--- a/sources/packages/backend/apps/api/src/route-controllers/education-program/education-program.institutions.controller.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/education-program/education-program.institutions.controller.ts
@@ -116,7 +116,6 @@ export class EducationProgramInstitutionsController extends BaseController {
   /**
    * Allows a program to be deactivated.
    * @param programId program to be deactivated.
-   * @param payload information to support the deactivation.
    */
   @ApiNotFoundResponse({
     description: "Not able to find the education program.",

--- a/sources/packages/backend/apps/api/src/route-controllers/education-program/education-program.institutions.controller.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/education-program/education-program.institutions.controller.ts
@@ -114,6 +114,29 @@ export class EducationProgramInstitutionsController extends BaseController {
   }
 
   /**
+   * Allows a program to be deactivated.
+   * @param programId program to be deactivated.
+   * @param payload information to support the deactivation.
+   */
+  @ApiNotFoundResponse({
+    description: "Not able to find the education program.",
+  })
+  @ApiUnprocessableEntityResponse({
+    description: "The education program is already set as requested.",
+  })
+  @Patch(":programId/deactivate")
+  async deactivateProgram(
+    @Param("programId", ParseIntPipe) programId: number,
+    @UserToken() userToken: IInstitutionUserToken,
+  ): Promise<void> {
+    await this.educationProgramControllerService.deactivateProgram(
+      programId,
+      userToken.userId,
+      { institutionId: userToken.authorizations.institutionId },
+    );
+  }
+
+  /**
    * Get a key/value pair list of all approved programs.
    * @returns key/value pair list of all approved programs.
    */

--- a/sources/packages/backend/apps/api/src/route-controllers/education-program/models/education-program.dto.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/education-program/models/education-program.dto.ts
@@ -179,3 +179,9 @@ export class DeclineProgramAPIInDTO {
   @MaxLength(NOTE_DESCRIPTION_MAX_LENGTH)
   declinedNote: string;
 }
+
+export class DeactivateProgramAPIInDTO {
+  @IsNotEmpty()
+  @MaxLength(NOTE_DESCRIPTION_MAX_LENGTH)
+  note: string;
+}

--- a/sources/packages/backend/apps/api/src/services/education-program/education-program.service.ts
+++ b/sources/packages/backend/apps/api/src/services/education-program/education-program.service.ts
@@ -716,7 +716,7 @@ export class EducationProgramService extends RecordDataModelService<EducationPro
    * @param isActive value to update the isActive state for the program.
    * @param options method options.
    * - `institutionId` institution used for authorization.
-   * - `notes` notes associated with the change. Notes are optional and expected.
+   * - `notes` notes associated with the change.
    * @returns update result.
    */
   async updateEducationProgramIsActive(
@@ -758,7 +758,7 @@ export class EducationProgramService extends RecordDataModelService<EducationPro
       }
       const now = new Date();
       const auditUser = { id: auditUserId } as User;
-      return this.repo.update(program.id, {
+      return entityManager.getRepository(EducationProgram).update(program.id, {
         isActive,
         isActiveUpdatedBy: auditUser,
         isActiveUpdatedOn: now,

--- a/sources/packages/backend/apps/api/src/services/institution/institution.service.ts
+++ b/sources/packages/backend/apps/api/src/services/institution/institution.service.ts
@@ -778,6 +778,7 @@ export class InstitutionService extends RecordDataModelService<Institution> {
    * @param institutionId
    * @param note
    * @returns saved Note.
+   * @deprecated use {@link createInstitutionNote} instead.
    */
   async saveInstitutionNote(institutionId: number, note: Note): Promise<Note> {
     await this.repo
@@ -795,6 +796,7 @@ export class InstitutionService extends RecordDataModelService<Institution> {
    * @param noteDescription note description.
    * @param auditUserId user that should be considered the one that is causing the changes.
    * @returns saved Note.
+   * @deprecated use {@link createInstitutionNote} instead.
    */
   async addInstitutionNote(
     institutionId: number,

--- a/sources/packages/backend/apps/api/src/testHelpers/fake-entities/education-program-fake.ts
+++ b/sources/packages/backend/apps/api/src/testHelpers/fake-entities/education-program-fake.ts
@@ -32,7 +32,7 @@ export function createFakeEducationProgram(
   program.credentialType = "credentialType";
   program.cipCode = "cipCode";
   program.nocCode = "nocCode";
-  program.sabcCode = options?.initialValue?.sabcCode ?? "sabcCode";
+  program.sabcCode = undefined; // Must be set by the consumer since it has unique constraints validation.
   program.regulatoryBody = "regulatoryBody";
   program.deliveredOnSite = options?.initialValue?.deliveredOnSite ?? false;
   program.deliveredOnline = options?.initialValue?.deliveredOnline ?? false;
@@ -50,5 +50,6 @@ export function createFakeEducationProgram(
   program.programIntensity = ProgramIntensity.fullTime;
   program.submittedBy = relations?.user;
   program.fieldOfStudyCode = 1;
+  program.isActive = options?.initialValue?.isActive ?? true;
   return program;
 }

--- a/sources/packages/backend/apps/api/src/testHelpers/fake-entities/education-program-fake.ts
+++ b/sources/packages/backend/apps/api/src/testHelpers/fake-entities/education-program-fake.ts
@@ -32,7 +32,7 @@ export function createFakeEducationProgram(
   program.credentialType = "credentialType";
   program.cipCode = "cipCode";
   program.nocCode = "nocCode";
-  program.sabcCode = undefined; // Must be set by the consumer since it has unique constraints validation.
+  program.sabcCode = options?.initialValue?.sabcCode;
   program.regulatoryBody = "regulatoryBody";
   program.deliveredOnSite = options?.initialValue?.deliveredOnSite ?? false;
   program.deliveredOnline = options?.initialValue?.deliveredOnline ?? false;


### PR DESCRIPTION
- Created new API endpoints to deactivate the program available for Institutions and the Ministry. The controller was created to specifically deactivate the program and the service was created to be generic to also allow the reactivation in case we need to work in the requirement in the future.
- Created a new role `institution-deactivate-education-program`.
- Created E2E tests for the new endpoints.
  - Ministry
    - Should allow an education program to be deactivated when the program is active.
    - Should return an unprocessable entity HTTP status when the program is already deactivated.
    - Should return a not found HTTP status when the program id does not exists.
    - Should return a bad request HTTP status when payload is invalid.
  - Institutions
    - Should allow an education program to be deactivated when the program belongs to the institution and the program is active.
    - Should return a not found HTTP status when a different institution accesses the program.
    - Should return an unprocessable entity HTTP status when the program is already deactivated.