### PR TITLE
#2645 - Program deactivation UI - Part 2

### DIFF
--- a/sims.code-workspace
+++ b/sims.code-workspace
@@ -91,6 +91,7 @@
     "typescript.preferences.importModuleSpecifier": "non-relative",
     "cSpell.words": [
       "AEST",
+      "composables",
       "ESDC",
       "MSFAA",
       "NSLSC",

--- a/sources/packages/backend/apps/api/src/route-controllers/education-program/_tests_/e2e/education-program.institutions.controller.createEducationProgram.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/education-program/_tests_/e2e/education-program.institutions.controller.createEducationProgram.e2e-spec.ts
@@ -165,6 +165,7 @@ describe("EducationProgramInstitutionsController(e2e)-createEducationProgram", (
         programNoteId: null,
         assessedById: null,
         submittedById: collegeFUser.id,
+        isActive: true,
       }),
     );
   });

--- a/sources/packages/backend/apps/api/src/route-controllers/education-program/education-program.controller.service.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/education-program/education-program.controller.service.ts
@@ -71,6 +71,7 @@ export class EducationProgramControllerService {
         locationId: program.locationId,
         locationName: program.locationName,
         programStatus: program.programStatus,
+        isActive: program.isActive,
         credentialTypeToDisplay: credentialTypeToDisplay(
           program.credentialType,
         ),
@@ -87,11 +88,6 @@ export class EducationProgramControllerService {
    * @param auditUserId user that should be considered the one that is causing the changes.
    * @returns inserted/updated program.
    */
-  @ApiUnprocessableEntityResponse({
-    description:
-      "Not able to a save the program due to an invalid request or " +
-      "SABC code is duplicated.",
-  })
   async saveProgram(
     payload: EducationProgramAPIInDTO,
     institutionId: number,
@@ -128,13 +124,15 @@ export class EducationProgramControllerService {
       );
     } catch (error: unknown) {
       if (error instanceof CustomNamedError) {
-        if (error.name === EDUCATION_PROGRAM_NOT_FOUND) {
-          throw new NotFoundException(error.message);
-        }
-        if (error.name === DUPLICATE_SABC_CODE) {
-          throw new UnprocessableEntityException(
-            new ApiProcessError(error.message, error.name),
-          );
+        switch (error.name) {
+          case EDUCATION_PROGRAM_NOT_FOUND:
+            throw new NotFoundException(error.message);
+          case EDUCATION_PROGRAM_INVALID_OPERATION:
+            throw new UnprocessableEntityException(error.message);
+          case DUPLICATE_SABC_CODE:
+            throw new UnprocessableEntityException(
+              new ApiProcessError(error.message, error.name),
+            );
         }
       }
       throw error;
@@ -224,6 +222,7 @@ export class EducationProgramControllerService {
       isBCPublic: program.institution.institutionType.isBCPublic,
       isBCPrivate: program.institution.institutionType.isBCPrivate,
       hasOfferings,
+      isActive: program.isActive,
     };
   }
 

--- a/sources/packages/backend/apps/api/src/route-controllers/education-program/education-program.controller.service.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/education-program/education-program.controller.service.ts
@@ -27,7 +27,6 @@ import {
   EDUCATION_PROGRAM_INVALID_OPERATION,
 } from "../../constants";
 import { ApiProcessError } from "../../types";
-import { ApiUnprocessableEntityResponse } from "@nestjs/swagger";
 import { SaveEducationProgram } from "../../services/education-program/education-program.service.models";
 import { InstitutionService } from "../../services/institution/institution.service";
 
@@ -108,7 +107,8 @@ export class EducationProgramControllerService {
 
     if (!submissionResult.valid) {
       throw new UnprocessableEntityException(
-        "Not able to a save the program due to an invalid request.",
+        "Not able to a save the program due to an invalid request or " +
+          "duplicate SABC code.",
       );
     }
 

--- a/sources/packages/backend/apps/api/src/route-controllers/education-program/education-program.controller.service.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/education-program/education-program.controller.service.ts
@@ -107,8 +107,7 @@ export class EducationProgramControllerService {
 
     if (!submissionResult.valid) {
       throw new UnprocessableEntityException(
-        "Not able to a save the program due to an invalid request or " +
-          "duplicate SABC code.",
+        "Not able to a save the program due to an invalid request.",
       );
     }
 

--- a/sources/packages/backend/apps/api/src/route-controllers/education-program/education-program.institutions.controller.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/education-program/education-program.institutions.controller.ts
@@ -73,7 +73,9 @@ export class EducationProgramInstitutionsController extends BaseController {
    * @returns id of the created program.
    */
   @ApiUnprocessableEntityResponse({
-    description: "Not able to a save the program due to an invalid request.",
+    description:
+      "Not able to a save the program due to an invalid request or " +
+      "duplicate SABC code.",
   })
   @Post()
   async createEducationProgram(

--- a/sources/packages/backend/apps/api/src/route-controllers/education-program/education-program.institutions.controller.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/education-program/education-program.institutions.controller.ts
@@ -94,7 +94,10 @@ export class EducationProgramInstitutionsController extends BaseController {
    * @param payload information to be updated.
    */
   @ApiUnprocessableEntityResponse({
-    description: "Not able to a save the program due to an invalid request.",
+    description:
+      "Not able to a save the program due to an invalid request or " +
+      "SABC code is duplicated or " +
+      "program is inactive.",
   })
   @ApiNotFoundResponse({
     description: "Not able to find the education program.",

--- a/sources/packages/backend/apps/api/src/route-controllers/education-program/models/education-program.dto.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/education-program/models/education-program.dto.ts
@@ -58,6 +58,7 @@ export class EducationProgramAPIOutDTO {
   assessedDate?: Date;
   assessedBy?: string;
   effectiveEndDate?: string;
+  isActive: boolean;
 }
 
 export class StudentEducationProgramAPIOutDTO {
@@ -80,6 +81,7 @@ export class EducationProgramsSummaryAPIOutDTO {
   locationName: string;
   locationId: number;
   programStatus: ProgramStatus;
+  isActive: boolean;
 }
 
 /**

--- a/sources/packages/backend/apps/api/src/services/education-program/education-program.service.models.ts
+++ b/sources/packages/backend/apps/api/src/services/education-program/education-program.service.models.ts
@@ -56,6 +56,7 @@ export interface EducationProgramsSummary {
   credentialType: string;
   submittedDate: Date;
   programStatus: ProgramStatus;
+  isActive: boolean;
   totalOfferings: number;
   locationId: number;
   locationName: string;

--- a/sources/packages/backend/apps/api/src/services/education-program/education-program.service.ts
+++ b/sources/packages/backend/apps/api/src/services/education-program/education-program.service.ts
@@ -686,6 +686,7 @@ export class EducationProgramService extends RecordDataModelService<EducationPro
         institution: {
           id: institutionId,
         },
+        isActive: true,
       },
     });
   }

--- a/sources/packages/backend/apps/api/src/services/education-program/education-program.service.ts
+++ b/sources/packages/backend/apps/api/src/services/education-program/education-program.service.ts
@@ -691,7 +691,7 @@ export class EducationProgramService extends RecordDataModelService<EducationPro
   }
 
   /**
-   * Check if the given institution has already a program with the given SABC code.
+   * Check if the given institution has already a program with the given SABC code for an active program.
    * @param institutionId id of the institution to have the programs retrieved.
    * @param sabcCode SABC code.
    * @param programId programId in case it is an update. It will be ignored in case of `undefined`.
@@ -702,20 +702,16 @@ export class EducationProgramService extends RecordDataModelService<EducationPro
     sabcCode: string,
     programId?: number,
   ): Promise<boolean> {
-    const result = await this.repo.findOne({
-      select: {
-        id: true,
-      },
+    return this.repo.exists({
       where: {
         id: programId ? Not(Equal(programId)) : undefined,
         sabcCode: sabcCode,
         institution: {
           id: institutionId,
         },
+        isActive: true,
       },
     });
-
-    return !!result?.id;
   }
 
   /**

--- a/sources/packages/backend/apps/api/src/services/education-program/education-program.service.ts
+++ b/sources/packages/backend/apps/api/src/services/education-program/education-program.service.ts
@@ -350,48 +350,6 @@ export class EducationProgramService extends RecordDataModelService<EducationPro
   }
 
   /**
-   * Gets the program with respect to the programId
-   * @param programId Id of the Program.
-   * @returns summary for location
-   */
-  async getLocationPrograms(
-    programId: number,
-    institutionId: number,
-  ): Promise<EducationProgram> {
-    return this.repo
-      .createQueryBuilder("programs")
-      .select([
-        "programs.id",
-        "programs.name",
-        "programs.description",
-        "programs.credentialType",
-        "programs.cipCode",
-        "programs.nocCode",
-        "programs.sabcCode",
-        "programs.programStatus",
-        "programs.programIntensity",
-        "programs.institutionProgramCode",
-        "programs.institution",
-        "institution.id",
-        "institution.legalOperatingName",
-        "institution.operatingName",
-        "programs.submittedDate",
-        "submittedBy.firstName",
-        "submittedBy.lastName",
-        "assessedBy.firstName",
-        "assessedBy.lastName",
-        "programs.assessedDate",
-        "programs.effectiveEndDate",
-      ])
-      .where("programs.id = :id", { id: programId })
-      .andWhere("programs.institution.id = :institutionId", { institutionId })
-      .innerJoin("programs.institution", "institution")
-      .leftJoin("programs.submittedBy", "submittedBy")
-      .leftJoin("programs.assessedBy", "assessedBy")
-      .getOne();
-  }
-
-  /**
    * Get programs that have at least one offering
    * for a particular location.
    * @param locationId id of the location that should have the

--- a/sources/packages/backend/apps/api/src/services/education-program/education-program.service.ts
+++ b/sources/packages/backend/apps/api/src/services/education-program/education-program.service.ts
@@ -129,6 +129,12 @@ export class EducationProgramService extends RecordDataModelService<EducationPro
           EDUCATION_PROGRAM_NOT_FOUND,
         );
       }
+      if (!program.isActive) {
+        throw new CustomNamedError(
+          "Education program cannot be edited when inactive.",
+          EDUCATION_PROGRAM_INVALID_OPERATION,
+        );
+      }
       // Check if education program has offering(s). This check is required to
       // prevent a user from updating fields that are not supposed
       // to be updated if the education program has 1 or more offerings.
@@ -248,6 +254,7 @@ export class EducationProgramService extends RecordDataModelService<EducationPro
       .addSelect("location.id", "locationId")
       .addSelect("location.name", "locationName")
       .addSelect("programs.programStatus", "programStatus")
+      .addSelect("programs.isActive", "isActive")
       .addSelect(
         (qb) =>
           qb
@@ -330,6 +337,7 @@ export class EducationProgramService extends RecordDataModelService<EducationPro
       credentialType: program.credentialType,
       submittedDate: program.programSubmittedAt,
       programStatus: program.programStatus,
+      isActive: program.isActive,
       totalOfferings: program.totalOfferings,
       locationId: program.locationId,
       locationName: program.locationName,
@@ -513,6 +521,7 @@ export class EducationProgramService extends RecordDataModelService<EducationPro
         "assessedBy.lastName",
         "programs.assessedDate",
         "programs.effectiveEndDate",
+        "programs.isActive",
       ])
       .leftJoin("programs.submittedBy", "submittedBy")
       .leftJoin("programs.assessedBy", "assessedBy")

--- a/sources/packages/backend/apps/db-migrations/src/migrations/1711405137371-AlterSABCCodeUniqueConstraintToActivePrograms.ts
+++ b/sources/packages/backend/apps/db-migrations/src/migrations/1711405137371-AlterSABCCodeUniqueConstraintToActivePrograms.ts
@@ -1,0 +1,24 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+import { getSQLFileData } from "../utilities/sqlLoader";
+
+export class AlterSABCCodeUniqueConstraintToActivePrograms1711405137371
+  implements MigrationInterface
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      getSQLFileData(
+        "Alter-sabc-code-unique-constraint-to-active-programs.sql",
+        "EducationPrograms",
+      ),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      getSQLFileData(
+        "Rollback-alter-sabc-code-unique-constraint-to-active-programs.sql",
+        "EducationPrograms",
+      ),
+    );
+  }
+}

--- a/sources/packages/backend/apps/db-migrations/src/sql/EducationPrograms/Alter-sabc-code-unique-constraint-to-active-programs.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/EducationPrograms/Alter-sabc-code-unique-constraint-to-active-programs.sql
@@ -1,0 +1,9 @@
+-- Remove existing constraint to allow the creation of the new index.
+ALTER TABLE
+  sims.education_programs DROP CONSTRAINT institution_id_sabc_code_unique;
+
+CREATE UNIQUE INDEX institution_id_sabc_code_unique ON sims.education_programs(institution_id, sabc_code)
+WHERE
+  is_active = TRUE;
+
+COMMENT ON INDEX sims.institution_id_sabc_code_unique IS 'Ensures SABC code will be unique for active programs under a particular institution. The uniqueness is critical to allow the offering bulk upload which uses the SABC code as a unique identifier for a program under a specific institution.';

--- a/sources/packages/backend/apps/db-migrations/src/sql/EducationPrograms/Rollback-alter-sabc-code-unique-constraint-to-active-programs.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/EducationPrograms/Rollback-alter-sabc-code-unique-constraint-to-active-programs.sql
@@ -1,0 +1,10 @@
+-- Remove existing index to allow the creation of the previous constraint.
+DROP INDEX sims.institution_id_sabc_code_unique;
+
+-- Create the unique constraint for institution_id and sabc_code.
+ALTER TABLE
+  sims.education_programs
+ADD
+  CONSTRAINT institution_id_sabc_code_unique UNIQUE (institution_id, sabc_code);
+
+COMMENT ON CONSTRAINT institution_id_sabc_code_unique ON sims.education_programs IS 'Ensures SABC code will be unique for a particular institution. The uniqueness is critical to allow the offering bulk upload which uses the SABC code as a unique identifier for a program under a specific institution.';

--- a/sources/packages/forms/src/form-definitions/educationprogram.json
+++ b/sources/packages/forms/src/form-definitions/educationprogram.json
@@ -9,1407 +9,25 @@
     ],
     "components": [
         {
-            "label": "HTML",
-            "labelWidth": "",
-            "labelMargin": "",
-            "tag": "h2",
-            "className": "category-header-large primary-color",
-            "attrs": [
-                {
-                    "attr": "",
-                    "value": ""
-                }
-            ],
-            "content": "Program information",
-            "refreshOnChange": false,
-            "customClass": "",
-            "hidden": false,
-            "modalEdit": false,
-            "key": "html3",
-            "tags": [],
-            "properties": {},
-            "conditional": {
-                "show": null,
-                "when": null,
-                "eq": "",
-                "json": ""
-            },
-            "customConditional": "",
-            "logic": [],
-            "attributes": {},
-            "overlay": {
-                "style": "",
-                "page": "",
-                "left": "",
-                "top": "",
-                "width": "",
-                "height": ""
-            },
-            "type": "htmlelement",
-            "input": false,
-            "tableView": false,
-            "placeholder": "",
-            "prefix": "",
-            "suffix": "",
-            "multiple": false,
-            "defaultValue": null,
-            "protected": false,
-            "unique": false,
-            "persistent": false,
-            "clearOnHide": true,
-            "refreshOn": "",
-            "redrawOn": "",
-            "dataGridLabel": false,
-            "labelPosition": "top",
-            "description": "",
-            "errorLabel": "",
-            "tooltip": "",
-            "hideLabel": false,
-            "tabindex": "",
-            "disabled": false,
-            "autofocus": false,
-            "dbIndex": false,
-            "customDefaultValue": "",
-            "calculateValue": "",
-            "calculateServer": false,
-            "widget": null,
-            "validateOn": "change",
-            "validate": {
-                "required": false,
-                "custom": "",
-                "customPrivate": false,
-                "strictDateValidation": false,
-                "multiple": false,
-                "unique": false
-            },
-            "allowCalculateOverride": false,
-            "encrypted": false,
-            "showCharCount": false,
-            "showWordCount": false,
-            "allowMultipleMasks": false,
-            "addons": [],
-            "id": "emwa9fr"
-        },
-        {
-            "title": "Panel",
-            "theme": "default",
-            "tooltip": "",
-            "customClass": "",
+            "title": "Education Program Main Container",
+            "customClass": "formio-panel-unset",
             "collapsible": false,
-            "hidden": false,
             "hideLabel": true,
-            "disabled": false,
-            "modalEdit": false,
-            "key": "panel",
-            "tags": [],
-            "properties": {},
-            "customConditional": "",
-            "conditional": {
-                "json": "",
-                "show": null,
-                "when": null,
-                "eq": ""
-            },
-            "logic": [],
-            "attributes": {},
-            "overlay": {
-                "style": "",
-                "page": "",
-                "left": "",
-                "top": "",
-                "width": "",
-                "height": ""
-            },
-            "type": "panel",
-            "label": "Panel",
-            "breadcrumb": "default",
-            "tabindex": "",
-            "input": false,
-            "tableView": false,
-            "components": [
-                {
-                    "label": "Level Of Study Codes",
-                    "labelWidth": "",
-                    "labelMargin": "",
-                    "customClass": "",
-                    "modalEdit": false,
-                    "defaultValue": null,
-                    "persistent": true,
-                    "protected": false,
-                    "dbIndex": false,
-                    "encrypted": false,
-                    "redrawOn": "",
-                    "customDefaultValue": "",
-                    "calculateValue": "value = {\r\n    undergraduateCertificate: \"8\",\r\n    undergraduateCitation: \"8\",\r\n    undergraduateDiploma: \"7\",\r\n    undergraduateDegree: \"3\",\r\n    graduateCertificate: \"5\",\r\n    graduateDiploma: \"5\",\r\n    graduateDegreeOrMasters: \"5\",\r\n    postGraduateOrDoctorate: \"6\",\r\n    qualifyingStudies: \"1\",\r\n};",
-                    "calculateServer": true,
-                    "key": "levelOfStudyCodes",
-                    "tags": [],
-                    "properties": {},
-                    "logic": [],
-                    "attributes": {},
-                    "overlay": {
-                        "style": "",
-                        "page": "",
-                        "left": "",
-                        "top": "",
-                        "width": "",
-                        "height": ""
-                    },
-                    "type": "hidden",
-                    "input": true,
-                    "tableView": false,
-                    "placeholder": "",
-                    "prefix": "",
-                    "suffix": "",
-                    "multiple": false,
-                    "unique": false,
-                    "hidden": false,
-                    "clearOnHide": true,
-                    "refreshOn": "",
-                    "dataGridLabel": false,
-                    "labelPosition": "top",
-                    "description": "",
-                    "errorLabel": "",
-                    "tooltip": "",
-                    "hideLabel": false,
-                    "tabindex": "",
-                    "disabled": false,
-                    "autofocus": false,
-                    "widget": {
-                        "type": "input"
-                    },
-                    "validateOn": "change",
-                    "validate": {
-                        "required": false,
-                        "custom": "",
-                        "customPrivate": false,
-                        "strictDateValidation": false,
-                        "multiple": false,
-                        "unique": false
-                    },
-                    "conditional": {
-                        "show": null,
-                        "when": null,
-                        "eq": ""
-                    },
-                    "allowCalculateOverride": false,
-                    "showCharCount": false,
-                    "showWordCount": false,
-                    "allowMultipleMasks": false,
-                    "addons": [],
-                    "inputType": "hidden",
-                    "id": "eq2rzu6"
-                },
-                {
-                    "label": "Field Of Study Codes",
-                    "labelWidth": "",
-                    "labelMargin": "",
-                    "customClass": "",
-                    "modalEdit": false,
-                    "defaultValue": null,
-                    "persistent": true,
-                    "protected": false,
-                    "dbIndex": false,
-                    "encrypted": false,
-                    "redrawOn": "",
-                    "customDefaultValue": "",
-                    "calculateValue": "value = {\r\n  P7: \"25\",\r\n  P5: \"55\",\r\n  P8: \"25\",\r\n  P3: \"40\",\r\n  P6: \"70\",\r\n  P4: \"40\",\r\n  P2: \"25\",\r\n  P1: \"25\",\r\n  Q4: \"39\",\r\n  Q7: \"24\",\r\n  Q5: \"54\",\r\n  Q1: \"24\",\r\n  Q6: \"69\",\r\n  Q2: \"24\",\r\n  Q8: \"24\",\r\n  Q3: \"39\",\r\n  R7: \"23\",\r\n  R6: \"68\",\r\n  R4: \"38\",\r\n  R5: \"53\",\r\n  R2: \"23\",\r\n  R3: \"38\",\r\n  R8: \"23\",\r\n  R1: \"23\",\r\n  S8: \"22\",\r\n  S1: \"22\",\r\n  S4: \"37\",\r\n  S3: \"37\",\r\n  S2: \"22\",\r\n  S5: \"52\",\r\n  S7: \"22\",\r\n  S6: \"67\",\r\n  T1: \"21\",\r\n  T7: \"21\",\r\n  T4: \"36\",\r\n  T5: \"51\",\r\n  T3: \"36\",\r\n  T8: \"21\",\r\n  T6: \"66\",\r\n  T2: \"21\",\r\n  U8: \"20\",\r\n  U3: \"35\",\r\n  U2: \"20\",\r\n  U4: \"35\",\r\n  U7: \"20\",\r\n  U5: \"50\",\r\n  U1: \"20\",\r\n  U6: \"65\",\r\n  V1: \"19\",\r\n  V3: \"34\",\r\n  V6: \"64\",\r\n  V5: \"49\",\r\n  V2: \"19\",\r\n  V7: \"19\",\r\n  V4: \"34\",\r\n  V8: \"19\",\r\n  W8: \"18\",\r\n  W4: \"33\",\r\n  W2: \"18\",\r\n  W7: \"18\",\r\n  W5: \"48\",\r\n  W1: \"18\",\r\n  W3: \"33\",\r\n  W6: \"63\",\r\n  X5: \"47\",\r\n  X2: \"17\",\r\n  X1: \"17\",\r\n  X4: \"32\",\r\n  X8: \"17\",\r\n  X3: \"32\",\r\n  X6: \"62\",\r\n  X7: \"17\",\r\n  Y4: \"31\",\r\n  Y8: \"16\",\r\n  Y5: \"46\",\r\n  Y6: \"61\",\r\n  Y2: \"16\",\r\n  Y3: \"31\",\r\n  Y1: \"16\",\r\n  Y7: \"16\",\r\n  Z7: \"15\",\r\n  Z8: \"15\",\r\n  Z5: \"45\",\r\n  Z4: \"30\",\r\n  Z2: \"15\",\r\n  Z3: \"30\",\r\n  Z1: \"15\",\r\n  Z6: \"60\",\r\n};",
-                    "calculateServer": true,
-                    "key": "fieldOfStudyCodes",
-                    "tags": [],
-                    "properties": {},
-                    "logic": [],
-                    "attributes": {},
-                    "overlay": {
-                        "style": "",
-                        "page": "",
-                        "left": "",
-                        "top": "",
-                        "width": "",
-                        "height": ""
-                    },
-                    "type": "hidden",
-                    "input": true,
-                    "tableView": false,
-                    "placeholder": "",
-                    "prefix": "",
-                    "suffix": "",
-                    "multiple": false,
-                    "unique": false,
-                    "hidden": false,
-                    "clearOnHide": true,
-                    "refreshOn": "",
-                    "dataGridLabel": false,
-                    "labelPosition": "top",
-                    "description": "",
-                    "errorLabel": "",
-                    "tooltip": "",
-                    "hideLabel": false,
-                    "tabindex": "",
-                    "disabled": false,
-                    "autofocus": false,
-                    "widget": {
-                        "type": "input"
-                    },
-                    "validateOn": "change",
-                    "validate": {
-                        "required": false,
-                        "custom": "",
-                        "customPrivate": false,
-                        "strictDateValidation": false,
-                        "multiple": false,
-                        "unique": false
-                    },
-                    "conditional": {
-                        "show": "",
-                        "when": null,
-                        "eq": ""
-                    },
-                    "allowCalculateOverride": false,
-                    "showCharCount": false,
-                    "showWordCount": false,
-                    "allowMultipleMasks": false,
-                    "addons": [],
-                    "inputType": "hidden",
-                    "id": "e3k12bd"
-                },
-                {
-                    "label": "SABC Codes",
-                    "labelWidth": "",
-                    "labelMargin": "",
-                    "customClass": "",
-                    "modalEdit": false,
-                    "defaultValue": null,
-                    "persistent": true,
-                    "protected": false,
-                    "dbIndex": false,
-                    "encrypted": false,
-                    "redrawOn": "",
-                    "customDefaultValue": "",
-                    "calculateValue": "value =\r\n{\r\n    11: \"Z\",\r\n    \"09\": \"Z\",\r\n    52: \"Z\",\r\n    \"01\": \"Z\",\r\n    \"03\": \"Z\",\r\n    \"05\": \"X\",\r\n    16: \"X\",\r\n    23: \"X\",\r\n    24: \"X\",\r\n    25: \"X\",\r\n    42: \"X\",\r\n    27: \"X\",\r\n    30: \"X\",\r\n    38: \"X\",\r\n    40: \"X\",\r\n    45: \"X\",\r\n    50: \"X\",\r\n    53: \"X\",\r\n    54: \"X\",\r\n    55: \"X\",\r\n    13: \"W\",\r\n    19: \"W\",\r\n    28: \"W\",\r\n    31: \"W\",\r\n    44: \"W\",\r\n    60: \"V\",\r\n    \"04\": \"U\",\r\n    10: \"U\",\r\n    14: \"U\",\r\n    15: \"U\",\r\n    29: \"U\",\r\n    41: \"U\",\r\n    26: \"U\",\r\n    22: \"S\",\r\n    43: \"S\",\r\n    51: \"R\",\r\n    61: \"R\",\r\n    39: \"Q\",\r\n    12: \"P\",\r\n    21: \"P\",\r\n    32: \"P\",\r\n    33: \"P\",\r\n    34: \"P\",\r\n    35: \"P\",\r\n    36: \"P\",\r\n    37: \"P\",\r\n    46: \"P\",\r\n    47: \"P\",\r\n    48: \"P\",\r\n    49: \"P\"\r\n};",
-                    "calculateServer": true,
-                    "key": "sabcCodes",
-                    "tags": [],
-                    "properties": {},
-                    "logic": [],
-                    "attributes": {},
-                    "overlay": {
-                        "style": "",
-                        "page": "",
-                        "left": "",
-                        "top": "",
-                        "width": "",
-                        "height": ""
-                    },
-                    "type": "hidden",
-                    "input": true,
-                    "tableView": false,
-                    "placeholder": "",
-                    "prefix": "",
-                    "suffix": "",
-                    "multiple": false,
-                    "unique": false,
-                    "hidden": false,
-                    "clearOnHide": true,
-                    "refreshOn": "",
-                    "dataGridLabel": false,
-                    "labelPosition": "top",
-                    "description": "",
-                    "errorLabel": "",
-                    "tooltip": "",
-                    "hideLabel": false,
-                    "tabindex": "",
-                    "disabled": false,
-                    "autofocus": false,
-                    "widget": {
-                        "type": "input"
-                    },
-                    "validateOn": "change",
-                    "validate": {
-                        "required": false,
-                        "custom": "",
-                        "customPrivate": false,
-                        "strictDateValidation": false,
-                        "multiple": false,
-                        "unique": false
-                    },
-                    "conditional": {
-                        "show": "",
-                        "when": null,
-                        "eq": ""
-                    },
-                    "allowCalculateOverride": false,
-                    "showCharCount": false,
-                    "showWordCount": false,
-                    "allowMultipleMasks": false,
-                    "addons": [],
-                    "inputType": "hidden",
-                    "id": "ej7k78of"
-                },
-                {
-                    "label": "Program name",
-                    "labelPosition": "top",
-                    "labelWidth": "",
-                    "labelMargin": "",
-                    "placeholder": "",
-                    "description": "",
-                    "tooltip": "",
-                    "prefix": "",
-                    "suffix": "",
-                    "widget": {
-                        "type": "input"
-                    },
-                    "inputMask": "",
-                    "displayMask": "",
-                    "allowMultipleMasks": false,
-                    "customClass": "",
-                    "tabindex": "",
-                    "autocomplete": "",
-                    "hidden": false,
-                    "hideLabel": false,
-                    "showWordCount": false,
-                    "showCharCount": true,
-                    "mask": false,
-                    "autofocus": false,
-                    "spellcheck": true,
-                    "disabled": false,
-                    "tableView": true,
-                    "modalEdit": false,
-                    "multiple": false,
-                    "persistent": true,
-                    "inputFormat": "plain",
-                    "protected": false,
-                    "dbIndex": false,
-                    "case": "",
-                    "truncateMultipleSpaces": false,
-                    "encrypted": false,
-                    "redrawOn": "",
-                    "clearOnHide": true,
-                    "customDefaultValue": "",
-                    "calculateValue": "",
-                    "calculateServer": false,
-                    "allowCalculateOverride": false,
-                    "validateOn": "change",
-                    "validate": {
-                        "required": true,
-                        "minLength": "",
-                        "maxLength": 100,
-                        "minWords": "",
-                        "maxWords": "",
-                        "pattern": "",
-                        "customMessage": "",
-                        "custom": "",
-                        "customPrivate": false,
-                        "json": "",
-                        "strictDateValidation": false,
-                        "multiple": false,
-                        "unique": false
-                    },
-                    "unique": false,
-                    "errorLabel": "",
-                    "errors": "",
-                    "key": "name",
-                    "tags": [],
-                    "properties": {},
-                    "conditional": {
-                        "show": null,
-                        "when": null,
-                        "eq": "",
-                        "json": ""
-                    },
-                    "customConditional": "",
-                    "logic": [],
-                    "attributes": {
-                        "data-cy": "programName"
-                    },
-                    "overlay": {
-                        "style": "",
-                        "page": "",
-                        "left": "",
-                        "top": "",
-                        "width": "",
-                        "height": ""
-                    },
-                    "type": "textfield",
-                    "input": true,
-                    "refreshOn": "",
-                    "dataGridLabel": false,
-                    "addons": [],
-                    "inputType": "text",
-                    "id": "e9u2ut8",
-                    "defaultValue": ""
-                },
-                {
-                    "label": "Program description",
-                    "labelPosition": "top",
-                    "labelWidth": "",
-                    "labelMargin": "",
-                    "placeholder": "",
-                    "description": "",
-                    "rows": 3,
-                    "tooltip": "",
-                    "prefix": "",
-                    "suffix": "",
-                    "widget": {
-                        "type": "input"
-                    },
-                    "displayMask": "",
-                    "editor": "",
-                    "autoExpand": false,
-                    "customClass": "",
-                    "tabindex": "",
-                    "autocomplete": "",
-                    "hidden": false,
-                    "hideLabel": false,
-                    "showWordCount": false,
-                    "showCharCount": true,
-                    "autofocus": false,
-                    "spellcheck": true,
-                    "disabled": false,
-                    "tableView": true,
-                    "modalEdit": false,
-                    "multiple": false,
-                    "persistent": true,
-                    "inputFormat": "html",
-                    "protected": false,
-                    "dbIndex": false,
-                    "case": "",
-                    "truncateMultipleSpaces": false,
-                    "encrypted": false,
-                    "redrawOn": "",
-                    "clearOnHide": true,
-                    "customDefaultValue": "",
-                    "calculateValue": "",
-                    "calculateServer": false,
-                    "allowCalculateOverride": false,
-                    "validateOn": "change",
-                    "validate": {
-                        "required": false,
-                        "minLength": "",
-                        "maxLength": 500,
-                        "minWords": "",
-                        "maxWords": "",
-                        "pattern": "",
-                        "customMessage": "Too Long",
-                        "custom": "",
-                        "customPrivate": false,
-                        "json": "",
-                        "strictDateValidation": false,
-                        "multiple": false,
-                        "unique": false
-                    },
-                    "unique": false,
-                    "errorLabel": "",
-                    "errors": "",
-                    "key": "description",
-                    "tags": [],
-                    "properties": {},
-                    "conditional": {
-                        "show": null,
-                        "when": null,
-                        "eq": "",
-                        "json": ""
-                    },
-                    "customConditional": "",
-                    "logic": [],
-                    "attributes": {
-                        "data-cy": "programDescription"
-                    },
-                    "overlay": {
-                        "style": "",
-                        "page": "",
-                        "left": "",
-                        "top": "",
-                        "width": "",
-                        "height": ""
-                    },
-                    "type": "textarea",
-                    "wysiwyg": false,
-                    "input": true,
-                    "refreshOn": "",
-                    "dataGridLabel": false,
-                    "allowMultipleMasks": false,
-                    "addons": [],
-                    "mask": false,
-                    "inputType": "text",
-                    "inputMask": "",
-                    "fixedSize": true,
-                    "id": "e56enu9",
-                    "defaultValue": ""
-                },
-                {
-                    "label": "Credential type",
-                    "labelPosition": "top",
-                    "widget": "html5",
-                    "labelWidth": "",
-                    "labelMargin": "",
-                    "placeholder": "",
-                    "description": "",
-                    "tooltip": "",
-                    "customClass": "",
-                    "tabindex": "",
-                    "hidden": false,
-                    "hideLabel": false,
-                    "uniqueOptions": false,
-                    "autofocus": false,
-                    "disabled": false,
-                    "tableView": true,
-                    "modalEdit": false,
-                    "multiple": false,
-                    "dataSrc": "values",
-                    "data": {
-                        "values": [
-                            {
-                                "label": "Undergraduate Certificate",
-                                "value": "undergraduateCertificate"
-                            },
-                            {
-                                "label": "Undergraduate Citation",
-                                "value": "undergraduateCitation"
-                            },
-                            {
-                                "label": "Undergraduate Diploma",
-                                "value": "undergraduateDiploma"
-                            },
-                            {
-                                "label": "Undergraduate Degree",
-                                "value": "undergraduateDegree"
-                            },
-                            {
-                                "label": "Graduate Certificate",
-                                "value": "graduateCertificate"
-                            },
-                            {
-                                "label": "Graduate Diploma",
-                                "value": "graduateDiploma"
-                            },
-                            {
-                                "label": "Graduate Degree / Master’s",
-                                "value": "graduateDegreeOrMasters"
-                            },
-                            {
-                                "label": "Post-Graduate / Doctorate",
-                                "value": "postGraduateOrDoctorate"
-                            },
-                            {
-                                "label": "Qualifying Studies",
-                                "value": "qualifyingStudies"
-                            }
-                        ],
-                        "resource": "",
-                        "json": "",
-                        "url": "",
-                        "custom": ""
-                    },
-                    "dataType": "",
-                    "idPath": "id",
-                    "valueProperty": "",
-                    "limit": 100,
-                    "template": "<span>{{ item.label }}</span>",
-                    "refreshOn": "",
-                    "refreshOnBlur": "",
-                    "clearOnRefresh": false,
-                    "searchEnabled": true,
-                    "selectThreshold": 0.3,
-                    "readOnlyValue": false,
-                    "customOptions": {},
-                    "useExactSearch": false,
-                    "persistent": true,
-                    "protected": false,
-                    "dbIndex": false,
-                    "encrypted": false,
-                    "clearOnHide": true,
-                    "customDefaultValue": "",
-                    "calculateValue": "",
-                    "calculateServer": false,
-                    "allowCalculateOverride": false,
-                    "validateOn": "change",
-                    "validate": {
-                        "required": true,
-                        "onlyAvailableItems": true,
-                        "customMessage": "",
-                        "custom": "",
-                        "customPrivate": false,
-                        "json": "",
-                        "strictDateValidation": false,
-                        "multiple": false,
-                        "unique": false
-                    },
-                    "unique": false,
-                    "errorLabel": "",
-                    "errors": "",
-                    "key": "credentialType",
-                    "tags": [],
-                    "properties": {},
-                    "conditional": {
-                        "show": null,
-                        "when": null,
-                        "eq": "",
-                        "json": ""
-                    },
-                    "customConditional": "",
-                    "logic": [
-                        {
-                            "name": "Disable Credential Input",
-                            "trigger": {
-                                "type": "javascript",
-                                "javascript": "result = data.hasOfferings;"
-                            },
-                            "actions": [
-                                {
-                                    "name": "Disable edit",
-                                    "type": "property",
-                                    "property": {
-                                        "label": "Disabled",
-                                        "value": "disabled",
-                                        "type": "boolean"
-                                    },
-                                    "state": true
-                                }
-                            ]
-                        }
-                    ],
-                    "attributes": {
-                        "data-cy": "credentialType"
-                    },
-                    "overlay": {
-                        "style": "",
-                        "page": "",
-                        "left": "",
-                        "top": "",
-                        "width": "",
-                        "height": ""
-                    },
-                    "type": "select",
-                    "indexeddb": {
-                        "filter": {}
-                    },
-                    "selectFields": "",
-                    "searchField": "",
-                    "searchDebounce": 0.3,
-                    "minSearch": 0,
-                    "filter": "",
-                    "redrawOn": "",
-                    "input": true,
-                    "searchThreshold": 0.3,
-                    "prefix": "",
-                    "suffix": "",
-                    "dataGridLabel": false,
-                    "showCharCount": false,
-                    "showWordCount": false,
-                    "allowMultipleMasks": false,
-                    "addons": [],
-                    "lazyLoad": true,
-                    "authenticate": false,
-                    "ignoreCache": false,
-                    "fuseOptions": {
-                        "include": "score",
-                        "threshold": 0.3
-                    },
-                    "id": "ed45dyk",
-                    "defaultValue": ""
-                },
-                {
-                    "label": "Classification of Instructional Programs (CIP)",
-                    "labelPosition": "top",
-                    "labelWidth": "",
-                    "labelMargin": "",
-                    "placeholder": "",
-                    "description": "Format (##.####)",
-                    "tooltip": "",
-                    "prefix": "",
-                    "suffix": "",
-                    "widget": {
-                        "type": "input"
-                    },
-                    "inputMask": "",
-                    "displayMask": "",
-                    "allowMultipleMasks": false,
-                    "customClass": "",
-                    "tabindex": "",
-                    "autocomplete": "",
-                    "hidden": false,
-                    "hideLabel": false,
-                    "showWordCount": false,
-                    "showCharCount": false,
-                    "mask": false,
-                    "autofocus": false,
-                    "spellcheck": true,
-                    "disabled": false,
-                    "tableView": true,
-                    "modalEdit": false,
-                    "multiple": false,
-                    "persistent": true,
-                    "inputFormat": "plain",
-                    "protected": false,
-                    "dbIndex": false,
-                    "case": "",
-                    "truncateMultipleSpaces": false,
-                    "encrypted": false,
-                    "redrawOn": "",
-                    "clearOnHide": true,
-                    "customDefaultValue": "",
-                    "calculateValue": "",
-                    "calculateServer": true,
-                    "allowCalculateOverride": false,
-                    "validateOn": "change",
-                    "validate": {
-                        "required": true,
-                        "minLength": "",
-                        "maxLength": "",
-                        "minWords": "",
-                        "maxWords": "",
-                        "pattern": "^[0-9]{2}\\.[0-9]{4}$",
-                        "customMessage": "Invalid format",
-                        "custom": "",
-                        "customPrivate": false,
-                        "json": "",
-                        "strictDateValidation": false,
-                        "multiple": false,
-                        "unique": false
-                    },
-                    "unique": false,
-                    "errorLabel": "",
-                    "errors": "",
-                    "key": "cipCode",
-                    "tags": [],
-                    "properties": {},
-                    "conditional": {
-                        "show": "",
-                        "when": null,
-                        "eq": "",
-                        "json": ""
-                    },
-                    "customConditional": "",
-                    "logic": [
-                        {
-                            "name": "Disable CIP Code Input",
-                            "trigger": {
-                                "type": "javascript",
-                                "javascript": "result = data.hasOfferings;"
-                            },
-                            "actions": [
-                                {
-                                    "name": "Disable Input",
-                                    "type": "property",
-                                    "property": {
-                                        "label": "Disabled",
-                                        "value": "disabled",
-                                        "type": "boolean"
-                                    },
-                                    "state": true
-                                }
-                            ]
-                        }
-                    ],
-                    "attributes": {
-                        "data-cy": "cipCode"
-                    },
-                    "overlay": {
-                        "style": "",
-                        "page": "",
-                        "left": "",
-                        "top": "",
-                        "width": "",
-                        "height": ""
-                    },
-                    "type": "textfield",
-                    "input": true,
-                    "refreshOn": "",
-                    "dataGridLabel": false,
-                    "addons": [],
-                    "inputType": "text",
-                    "id": "e7oydq",
-                    "defaultValue": ""
-                },
-                {
-                    "label": "Field of study code",
-                    "labelPosition": "top",
-                    "labelWidth": "",
-                    "labelMargin": "",
-                    "placeholder": "",
-                    "description": "",
-                    "tooltip": "",
-                    "prefix": "",
-                    "suffix": "",
-                    "widget": {
-                        "type": "input"
-                    },
-                    "inputMask": "",
-                    "displayMask": "",
-                    "allowMultipleMasks": false,
-                    "customClass": "",
-                    "tabindex": "",
-                    "autocomplete": "",
-                    "hidden": false,
-                    "hideLabel": false,
-                    "showWordCount": false,
-                    "showCharCount": false,
-                    "mask": false,
-                    "autofocus": false,
-                    "spellcheck": true,
-                    "disabled": true,
-                    "tableView": true,
-                    "modalEdit": false,
-                    "multiple": false,
-                    "persistent": true,
-                    "inputFormat": "plain",
-                    "protected": false,
-                    "dbIndex": false,
-                    "case": "",
-                    "truncateMultipleSpaces": false,
-                    "encrypted": false,
-                    "redrawOn": "",
-                    "clearOnHide": true,
-                    "customDefaultValue": "",
-                    "calculateValue": "const sabcCode = data.sabcCodes[data.cipCode.substring(0, 2)];\r\nconst levelOfStudyCode =  data.levelOfStudyCodes[data.credentialType];\r\nvalue = (sabcCode && levelOfStudyCode) ? data.fieldOfStudyCodes[sabcCode + levelOfStudyCode] : 20;",
-                    "calculateServer": true,
-                    "allowCalculateOverride": false,
-                    "validateOn": "change",
-                    "validate": {
-                        "required": true,
-                        "minLength": "",
-                        "maxLength": "",
-                        "minWords": "",
-                        "maxWords": "",
-                        "pattern": "",
-                        "customMessage": "The combination of the Credential Type and CIP did not result in a known Field of Study code.",
-                        "custom": "",
-                        "customPrivate": false,
-                        "json": "",
-                        "strictDateValidation": false,
-                        "multiple": false,
-                        "unique": false
-                    },
-                    "unique": false,
-                    "errorLabel": "",
-                    "errors": "",
-                    "key": "fieldOfStudyCode",
-                    "tags": [],
-                    "properties": {},
-                    "conditional": {
-                        "show": "",
-                        "when": null,
-                        "eq": "",
-                        "json": ""
-                    },
-                    "customConditional": "",
-                    "logic": [],
-                    "attributes": {
-                        "data-cy": "fieldOfStudyCode"
-                    },
-                    "overlay": {
-                        "style": "",
-                        "page": "",
-                        "left": "",
-                        "top": "",
-                        "width": "",
-                        "height": ""
-                    },
-                    "type": "textfield",
-                    "input": true,
-                    "refreshOn": "",
-                    "dataGridLabel": false,
-                    "addons": [],
-                    "inputType": "text",
-                    "id": "em8z7aa",
-                    "defaultValue": ""
-                },
-                {
-                    "label": "National Occupational Classifcation (NOC)",
-                    "labelPosition": "top",
-                    "labelWidth": "",
-                    "labelMargin": "",
-                    "placeholder": "",
-                    "description": "Format (#####) Optional**",
-                    "tooltip": "",
-                    "prefix": "",
-                    "suffix": "",
-                    "widget": {
-                        "type": "input"
-                    },
-                    "inputMask": "",
-                    "displayMask": "",
-                    "allowMultipleMasks": false,
-                    "customClass": "",
-                    "tabindex": "",
-                    "autocomplete": "",
-                    "hidden": false,
-                    "hideLabel": false,
-                    "showWordCount": false,
-                    "showCharCount": false,
-                    "mask": false,
-                    "autofocus": false,
-                    "spellcheck": true,
-                    "disabled": false,
-                    "tableView": true,
-                    "modalEdit": false,
-                    "multiple": false,
-                    "persistent": true,
-                    "inputFormat": "plain",
-                    "protected": false,
-                    "dbIndex": false,
-                    "case": "",
-                    "truncateMultipleSpaces": false,
-                    "encrypted": false,
-                    "redrawOn": "",
-                    "clearOnHide": true,
-                    "customDefaultValue": "",
-                    "calculateValue": "",
-                    "calculateServer": false,
-                    "allowCalculateOverride": false,
-                    "validateOn": "change",
-                    "validate": {
-                        "required": false,
-                        "minLength": "",
-                        "maxLength": "",
-                        "minWords": "",
-                        "maxWords": "",
-                        "pattern": "[0-9]{5}",
-                        "customMessage": "Incorrect Format",
-                        "custom": "",
-                        "customPrivate": false,
-                        "json": "",
-                        "strictDateValidation": false,
-                        "multiple": false,
-                        "unique": false
-                    },
-                    "unique": false,
-                    "errorLabel": "",
-                    "errors": "",
-                    "key": "nocCode",
-                    "tags": [],
-                    "properties": {},
-                    "conditional": {
-                        "show": "",
-                        "when": null,
-                        "eq": "",
-                        "json": ""
-                    },
-                    "customConditional": "",
-                    "logic": [
-                        {
-                            "name": "Disable NOC Code",
-                            "trigger": {
-                                "type": "javascript",
-                                "javascript": "result = data.hasOfferings;"
-                            },
-                            "actions": [
-                                {
-                                    "name": "Disable Input",
-                                    "type": "property",
-                                    "property": {
-                                        "label": "Disabled",
-                                        "value": "disabled",
-                                        "type": "boolean"
-                                    },
-                                    "state": true
-                                }
-                            ]
-                        }
-                    ],
-                    "attributes": {
-                        "data-cy": "nocCode"
-                    },
-                    "overlay": {
-                        "style": "",
-                        "page": "",
-                        "left": "",
-                        "top": "",
-                        "width": "",
-                        "height": ""
-                    },
-                    "type": "textfield",
-                    "input": true,
-                    "refreshOn": "",
-                    "dataGridLabel": false,
-                    "addons": [],
-                    "inputType": "text",
-                    "id": "esqh37ui",
-                    "defaultValue": "",
-                    "lockKey": true
-                },
-                {
-                    "label": "SABC program code, if this program has been approved for SABC funding before",
-                    "labelPosition": "top",
-                    "labelWidth": "",
-                    "labelMargin": "",
-                    "placeholder": "",
-                    "description": "Format (XXX#) Optional**",
-                    "tooltip": "",
-                    "prefix": "",
-                    "suffix": "",
-                    "widget": {
-                        "type": "input"
-                    },
-                    "inputMask": "",
-                    "displayMask": "",
-                    "allowMultipleMasks": false,
-                    "customClass": "",
-                    "tabindex": "",
-                    "autocomplete": "",
-                    "hidden": false,
-                    "hideLabel": false,
-                    "showWordCount": false,
-                    "showCharCount": false,
-                    "mask": false,
-                    "autofocus": false,
-                    "spellcheck": true,
-                    "disabled": false,
-                    "tableView": true,
-                    "modalEdit": false,
-                    "multiple": false,
-                    "persistent": true,
-                    "inputFormat": "plain",
-                    "protected": false,
-                    "dbIndex": false,
-                    "case": "",
-                    "truncateMultipleSpaces": false,
-                    "encrypted": false,
-                    "redrawOn": "",
-                    "clearOnHide": true,
-                    "customDefaultValue": "",
-                    "calculateValue": "",
-                    "calculateServer": false,
-                    "allowCalculateOverride": false,
-                    "validateOn": "change",
-                    "validate": {
-                        "required": false,
-                        "minLength": "",
-                        "maxLength": "",
-                        "minWords": "",
-                        "maxWords": "",
-                        "pattern": "[[A-Z]{3}[0-9]{1}",
-                        "customMessage": "Incorrect Format",
-                        "custom": "",
-                        "customPrivate": false,
-                        "json": "",
-                        "strictDateValidation": false,
-                        "multiple": false,
-                        "unique": false
-                    },
-                    "unique": false,
-                    "errorLabel": "",
-                    "errors": "",
-                    "key": "sabcCode",
-                    "tags": [],
-                    "properties": {},
-                    "conditional": {
-                        "show": "",
-                        "when": null,
-                        "eq": "",
-                        "json": ""
-                    },
-                    "customConditional": "",
-                    "logic": [
-                        {
-                            "name": "Disable SABC Input",
-                            "trigger": {
-                                "type": "javascript",
-                                "javascript": "result = data.hasOfferings;"
-                            },
-                            "actions": [
-                                {
-                                    "name": "Disable Input",
-                                    "type": "property",
-                                    "property": {
-                                        "label": "Disabled",
-                                        "value": "disabled",
-                                        "type": "boolean"
-                                    },
-                                    "state": true
-                                }
-                            ]
-                        }
-                    ],
-                    "attributes": {
-                        "data-cy": "sabcCode"
-                    },
-                    "overlay": {
-                        "style": "",
-                        "page": "",
-                        "left": "",
-                        "top": "",
-                        "width": "",
-                        "height": ""
-                    },
-                    "type": "textfield",
-                    "input": true,
-                    "refreshOn": "",
-                    "dataGridLabel": false,
-                    "addons": [],
-                    "inputType": "text",
-                    "id": "ec64vb7",
-                    "defaultValue": ""
-                },
-                {
-                    "label": "Institution Program Code",
-                    "labelPosition": "top",
-                    "labelWidth": "",
-                    "labelMargin": "",
-                    "placeholder": "",
-                    "description": "",
-                    "tooltip": "",
-                    "prefix": "",
-                    "suffix": "",
-                    "widget": {
-                        "type": "input"
-                    },
-                    "inputMask": "",
-                    "displayMask": "",
-                    "allowMultipleMasks": false,
-                    "customClass": "",
-                    "tabindex": "",
-                    "autocomplete": "",
-                    "hidden": false,
-                    "hideLabel": false,
-                    "showWordCount": false,
-                    "showCharCount": false,
-                    "mask": false,
-                    "autofocus": false,
-                    "spellcheck": true,
-                    "disabled": false,
-                    "tableView": true,
-                    "modalEdit": false,
-                    "multiple": false,
-                    "persistent": true,
-                    "inputFormat": "plain",
-                    "protected": false,
-                    "dbIndex": false,
-                    "case": "",
-                    "truncateMultipleSpaces": false,
-                    "encrypted": false,
-                    "redrawOn": "",
-                    "clearOnHide": true,
-                    "customDefaultValue": "",
-                    "calculateValue": "",
-                    "calculateServer": false,
-                    "allowCalculateOverride": false,
-                    "validateOn": "change",
-                    "validate": {
-                        "required": false,
-                        "minLength": "",
-                        "maxLength": "",
-                        "minWords": "",
-                        "maxWords": "",
-                        "pattern": "",
-                        "customMessage": "",
-                        "custom": "",
-                        "customPrivate": false,
-                        "json": "",
-                        "strictDateValidation": false,
-                        "multiple": false,
-                        "unique": false
-                    },
-                    "unique": false,
-                    "errorLabel": "",
-                    "errors": "",
-                    "key": "institutionProgramCode",
-                    "tags": [],
-                    "properties": {},
-                    "conditional": {
-                        "show": null,
-                        "when": null,
-                        "eq": "",
-                        "json": ""
-                    },
-                    "customConditional": "",
-                    "logic": [
-                        {
-                            "name": "Disable Program Code Input",
-                            "trigger": {
-                                "type": "javascript",
-                                "javascript": "result = data.hasOfferings;"
-                            },
-                            "actions": [
-                                {
-                                    "name": "Disable Input",
-                                    "type": "property",
-                                    "property": {
-                                        "label": "Disabled",
-                                        "value": "disabled",
-                                        "type": "boolean"
-                                    },
-                                    "state": true
-                                }
-                            ]
-                        }
-                    ],
-                    "attributes": {
-                        "data-cy": "institutionProgramCode"
-                    },
-                    "overlay": {
-                        "style": "",
-                        "page": "",
-                        "left": "",
-                        "top": "",
-                        "width": "",
-                        "height": ""
-                    },
-                    "type": "textfield",
-                    "input": true,
-                    "refreshOn": "",
-                    "dataGridLabel": false,
-                    "addons": [],
-                    "inputType": "text",
-                    "id": "e82wb1b",
-                    "defaultValue": ""
-                }
-            ],
-            "placeholder": "",
-            "prefix": "",
-            "suffix": "",
-            "multiple": false,
-            "defaultValue": null,
-            "protected": false,
-            "unique": false,
-            "persistent": false,
-            "clearOnHide": false,
-            "refreshOn": "",
-            "redrawOn": "",
-            "dataGridLabel": false,
-            "labelPosition": "top",
-            "description": "",
-            "errorLabel": "",
-            "autofocus": false,
-            "dbIndex": false,
-            "customDefaultValue": "",
-            "calculateValue": "",
-            "calculateServer": false,
-            "widget": null,
-            "validateOn": "change",
-            "validate": {
-                "required": false,
-                "custom": "",
-                "customPrivate": false,
-                "strictDateValidation": false,
-                "multiple": false,
-                "unique": false
-            },
-            "allowCalculateOverride": false,
-            "encrypted": false,
-            "showCharCount": false,
-            "showWordCount": false,
-            "allowMultipleMasks": false,
-            "tree": false,
-            "id": "egrd3p",
-            "addons": [],
-            "lazyLoad": false
-        },
-        {
-            "label": "Program eligibility",
-            "labelWidth": "",
-            "labelMargin": "",
-            "tag": "h2",
-            "className": "category-header-large primary-color",
-            "attrs": [
-                {
-                    "attr": "",
-                    "value": ""
-                }
-            ],
-            "content": "Program eligibility",
-            "refreshOnChange": false,
-            "customClass": "category-header-medium primary-color",
-            "hidden": false,
-            "modalEdit": false,
-            "key": "programEligibility",
-            "tags": [],
-            "properties": {},
-            "conditional": {
-                "show": null,
-                "when": null,
-                "eq": "",
-                "json": ""
-            },
-            "customConditional": "",
-            "logic": [],
-            "attributes": {},
-            "overlay": {
-                "style": "",
-                "page": "",
-                "left": "",
-                "top": "",
-                "width": "",
-                "height": ""
-            },
-            "type": "htmlelement",
-            "input": false,
-            "tableView": false,
-            "placeholder": "",
-            "prefix": "",
-            "suffix": "",
-            "multiple": false,
-            "defaultValue": null,
-            "protected": false,
-            "unique": false,
-            "persistent": false,
-            "clearOnHide": true,
-            "refreshOn": "",
-            "redrawOn": "",
-            "dataGridLabel": false,
-            "labelPosition": "top",
-            "description": "",
-            "errorLabel": "",
-            "tooltip": "",
-            "hideLabel": false,
-            "tabindex": "",
-            "disabled": false,
-            "autofocus": false,
-            "dbIndex": false,
-            "customDefaultValue": "",
-            "calculateValue": "",
-            "calculateServer": false,
-            "widget": null,
-            "validateOn": "change",
-            "validate": {
-                "required": false,
-                "custom": "",
-                "customPrivate": false,
-                "strictDateValidation": false,
-                "multiple": false,
-                "unique": false
-            },
-            "allowCalculateOverride": false,
-            "encrypted": false,
-            "showCharCount": false,
-            "showWordCount": false,
-            "allowMultipleMasks": false,
-            "addons": [],
-            "id": "egvsdkj"
-        },
-        {
-            "title": "Panel",
-            "labelWidth": "",
-            "labelMargin": "",
-            "theme": "default",
-            "tooltip": "",
-            "customClass": "",
-            "collapsible": false,
-            "hidden": false,
-            "hideLabel": true,
-            "disabled": false,
-            "modalEdit": false,
-            "key": "panel1",
-            "tags": [],
-            "properties": {},
-            "customConditional": "",
-            "conditional": {
-                "json": "",
-                "show": null,
-                "when": null,
-                "eq": ""
-            },
+            "key": "educationProgramMainContainer",
             "logic": [
                 {
-                    "name": "Disable Eligibility Inputs",
+                    "name": "Read-only Form",
                     "trigger": {
-                        "type": "javascript",
-                        "javascript": "result = data.hasOfferings;"
+                        "type": "simple",
+                        "simple": {
+                            "show": true,
+                            "when": "isReadonly",
+                            "eq": "true"
+                        }
                     },
                     "actions": [
                         {
-                            "name": "Disable Inputs",
+                            "name": "Disable form",
                             "type": "property",
                             "property": {
                                 "label": "Disabled",
@@ -1421,4561 +39,1090 @@
                     ]
                 }
             ],
-            "attributes": {},
-            "overlay": {
-                "style": "",
-                "page": "",
-                "left": "",
-                "top": "",
-                "width": "",
-                "height": ""
-            },
             "type": "panel",
             "label": "Panel",
-            "breadcrumb": "default",
-            "tabindex": "",
             "input": false,
             "tableView": false,
             "components": [
                 {
-                    "label": "Are students able to take this on a part time basis?",
-                    "labelPosition": "top",
-                    "labelWidth": "",
-                    "labelMargin": "",
-                    "optionsLabelPosition": "right",
-                    "description": "",
-                    "tooltip": "A part-time program has a course load between 20 and 59%. A full-time program must have a course load of: 60% or greater or Between 40 and 60% for students with a permanent disability.",
-                    "customClass": "",
-                    "tabindex": "",
-                    "inline": false,
-                    "hidden": false,
-                    "hideLabel": false,
-                    "autofocus": false,
-                    "disabled": false,
-                    "tableView": false,
-                    "modalEdit": false,
-                    "values": [
-                        {
-                            "label": "Yes",
-                            "value": "Full Time and Part Time",
-                            "shortcut": ""
-                        },
-                        {
-                            "label": "No",
-                            "value": "Full Time",
-                            "shortcut": ""
-                        }
-                    ],
-                    "dataType": "",
-                    "persistent": true,
-                    "protected": false,
-                    "dbIndex": false,
-                    "encrypted": false,
-                    "redrawOn": "",
-                    "clearOnHide": true,
-                    "customDefaultValue": "",
-                    "calculateValue": "",
-                    "calculateServer": false,
-                    "allowCalculateOverride": false,
-                    "validate": {
-                        "required": true,
-                        "onlyAvailableItems": true,
-                        "customMessage": "",
-                        "custom": "",
-                        "customPrivate": false,
-                        "json": "",
-                        "strictDateValidation": false,
-                        "multiple": false,
-                        "unique": false
-                    },
-                    "errorLabel": "",
-                    "errors": "",
-                    "key": "programIntensity",
-                    "tags": [],
-                    "properties": {},
-                    "conditional": {
-                        "show": null,
-                        "when": null,
-                        "eq": "",
-                        "json": ""
-                    },
-                    "customConditional": "",
-                    "logic": [],
-                    "attributes": {
-                        "data-cy": "programIntensity"
-                    },
-                    "overlay": {
-                        "style": "",
-                        "page": "",
-                        "left": "",
-                        "top": "",
-                        "width": "",
-                        "height": ""
-                    },
-                    "type": "radio",
-                    "input": true,
-                    "placeholder": "",
-                    "prefix": "",
-                    "suffix": "",
-                    "multiple": false,
-                    "unique": false,
-                    "refreshOn": "",
-                    "dataGridLabel": false,
-                    "widget": null,
-                    "validateOn": "change",
-                    "showCharCount": false,
-                    "showWordCount": false,
-                    "allowMultipleMasks": false,
-                    "addons": [],
-                    "inputType": "radio",
-                    "fieldSet": false,
-                    "id": "ebhrwe5",
-                    "defaultValue": ""
-                },
-                {
-                    "label": "How will this program be delivered? (Select all that apply)",
-                    "labelPosition": "top",
-                    "labelWidth": "",
-                    "labelMargin": "",
-                    "optionsLabelPosition": "right",
-                    "description": "",
-                    "tooltip": "",
-                    "customClass": "",
-                    "tabindex": "",
-                    "inline": false,
-                    "hidden": false,
-                    "hideLabel": false,
-                    "autofocus": false,
-                    "disabled": false,
-                    "tableView": false,
-                    "modalEdit": false,
-                    "defaultValue": {
-                        "deliveredOnSite": false,
-                        "deliveredOnline": false,
-                        "onSite": false,
-                        "online": false,
-                        "onsite": false
-                    },
-                    "values": [
-                        {
-                            "label": "On site",
-                            "value": "deliveredOnSite",
-                            "shortcut": ""
-                        },
-                        {
-                            "label": "Online",
-                            "value": "deliveredOnline",
-                            "shortcut": ""
-                        }
-                    ],
-                    "persistent": true,
-                    "protected": false,
-                    "dbIndex": false,
-                    "encrypted": false,
-                    "redrawOn": "",
-                    "clearOnHide": true,
-                    "customDefaultValue": "",
-                    "calculateValue": "",
-                    "calculateServer": false,
-                    "allowCalculateOverride": false,
-                    "validate": {
-                        "required": true,
-                        "onlyAvailableItems": false,
-                        "customMessage": "",
-                        "minSelectedCount": "",
-                        "maxSelectedCount": "",
-                        "custom": "",
-                        "customPrivate": false,
-                        "json": "",
-                        "strictDateValidation": false,
-                        "multiple": false,
-                        "unique": false
-                    },
-                    "errorLabel": "",
-                    "minSelectedCountMessage": "",
-                    "maxSelectedCountMessage": "",
-                    "errors": "",
-                    "key": "programDeliveryTypes",
-                    "tags": [],
-                    "properties": {},
-                    "conditional": {
-                        "show": null,
-                        "when": null,
-                        "eq": "",
-                        "json": ""
-                    },
-                    "customConditional": "",
-                    "logic": [],
-                    "attributes": {
-                        "data-cy": "programDeliveryTypes"
-                    },
-                    "overlay": {
-                        "style": "",
-                        "page": "",
-                        "left": "",
-                        "top": "",
-                        "width": "",
-                        "height": ""
-                    },
-                    "type": "selectboxes",
-                    "input": true,
-                    "inputType": "checkbox",
-                    "placeholder": "",
-                    "prefix": "",
-                    "suffix": "",
-                    "multiple": false,
-                    "unique": false,
-                    "refreshOn": "",
-                    "dataGridLabel": false,
-                    "widget": null,
-                    "validateOn": "change",
-                    "showCharCount": false,
-                    "showWordCount": false,
-                    "allowMultipleMasks": false,
-                    "addons": [],
-                    "fieldSet": false,
-                    "id": "e3tglfe",
-                    "lockKey": true
-                },
-                {
-                    "label": "Will the program also be offered and delivered at 100% course load on site?",
-                    "labelPosition": "top",
-                    "labelWidth": "",
-                    "labelMargin": "",
-                    "optionsLabelPosition": "right",
-                    "description": "",
-                    "tooltip": "",
-                    "customClass": "",
-                    "tabindex": "",
-                    "inline": false,
-                    "hidden": false,
-                    "hideLabel": false,
-                    "autofocus": false,
-                    "disabled": false,
-                    "tableView": false,
-                    "modalEdit": false,
-                    "values": [
-                        {
-                            "label": "Yes",
-                            "value": "yes",
-                            "shortcut": ""
-                        },
-                        {
-                            "label": "No",
-                            "value": "no",
-                            "shortcut": ""
-                        }
-                    ],
-                    "dataType": "",
-                    "persistent": true,
-                    "protected": false,
-                    "dbIndex": false,
-                    "encrypted": false,
-                    "redrawOn": "",
-                    "clearOnHide": true,
-                    "customDefaultValue": "",
-                    "calculateValue": "",
-                    "calculateServer": false,
-                    "allowCalculateOverride": false,
-                    "validate": {
-                        "required": true,
-                        "onlyAvailableItems": false,
-                        "customMessage": "",
-                        "custom": "",
-                        "customPrivate": false,
-                        "json": "",
-                        "strictDateValidation": false,
-                        "multiple": false,
-                        "unique": false
-                    },
-                    "errorLabel": "",
-                    "errors": "",
-                    "key": "deliveredOnlineAlsoOnsite",
-                    "tags": [],
-                    "properties": {},
-                    "conditional": {
-                        "show": "",
-                        "when": null,
-                        "eq": "",
-                        "json": ""
-                    },
-                    "customConditional": "const isBCInstitution = data.isBCPublic || data.isBCPrivate;\nshow = (!isBCInstitution && data.programDeliveryTypes.deliveredOnline);",
-                    "logic": [],
-                    "attributes": {
-                        "data-cy": "deliveredOnlineAlsoOnsite"
-                    },
-                    "overlay": {
-                        "style": "",
-                        "page": "",
-                        "left": "",
-                        "top": "",
-                        "width": "",
-                        "height": ""
-                    },
-                    "type": "radio",
-                    "input": true,
-                    "placeholder": "",
-                    "prefix": "",
-                    "suffix": "",
-                    "multiple": false,
-                    "unique": false,
-                    "refreshOn": "",
-                    "dataGridLabel": false,
-                    "widget": null,
-                    "validateOn": "change",
-                    "showCharCount": false,
-                    "showWordCount": false,
-                    "allowMultipleMasks": false,
-                    "addons": [],
-                    "inputType": "radio",
-                    "fieldSet": false,
-                    "id": "el1u4p",
-                    "defaultValue": ""
-                },
-                {
-                    "label": "Will the students earn the same number of credits in the same time period as students in other StudentAid BC eligible programs delivered on site?",
-                    "labelPosition": "top",
-                    "labelWidth": "",
-                    "labelMargin": "",
-                    "optionsLabelPosition": "right",
-                    "description": "",
-                    "tooltip": "",
-                    "customClass": "",
-                    "tabindex": "",
-                    "inline": false,
-                    "hidden": false,
-                    "hideLabel": false,
-                    "autofocus": false,
-                    "disabled": false,
-                    "tableView": false,
-                    "modalEdit": false,
-                    "values": [
-                        {
-                            "label": "Yes",
-                            "value": "yes",
-                            "shortcut": ""
-                        },
-                        {
-                            "label": "No",
-                            "value": "no",
-                            "shortcut": ""
-                        }
-                    ],
-                    "dataType": "",
-                    "persistent": true,
-                    "protected": false,
-                    "dbIndex": false,
-                    "encrypted": false,
-                    "redrawOn": "",
-                    "clearOnHide": true,
-                    "customDefaultValue": "",
-                    "calculateValue": "",
-                    "calculateServer": false,
-                    "allowCalculateOverride": false,
-                    "validate": {
-                        "required": true,
-                        "onlyAvailableItems": true,
-                        "customMessage": "",
-                        "custom": "",
-                        "customPrivate": false,
-                        "json": "",
-                        "strictDateValidation": false,
-                        "multiple": false,
-                        "unique": false
-                    },
-                    "errorLabel": "",
-                    "errors": "",
-                    "key": "sameOnlineCreditsEarned",
-                    "tags": [],
-                    "properties": {},
-                    "conditional": {
-                        "show": "",
-                        "when": null,
-                        "eq": "",
-                        "json": ""
-                    },
-                    "customConditional": "const isBCInstitution = data.isBCPublic || data.isBCPrivate;\nshow = (!isBCInstitution && data.deliveredOnlineAlsoOnsite === \"no\");",
-                    "logic": [],
-                    "attributes": {
-                        "data-cy": "sameOnlineCreditsEarned"
-                    },
-                    "overlay": {
-                        "style": "",
-                        "page": "",
-                        "left": "",
-                        "top": "",
-                        "width": "",
-                        "height": ""
-                    },
-                    "type": "radio",
-                    "input": true,
-                    "placeholder": "",
-                    "prefix": "",
-                    "suffix": "",
-                    "multiple": false,
-                    "unique": false,
-                    "refreshOn": "",
-                    "dataGridLabel": false,
-                    "widget": null,
-                    "validateOn": "change",
-                    "showCharCount": false,
-                    "showWordCount": false,
-                    "allowMultipleMasks": false,
-                    "addons": [],
-                    "inputType": "radio",
-                    "fieldSet": false,
-                    "id": "e6vyjtc",
-                    "defaultValue": ""
-                },
-                {
-                    "label": "Will they earn academic credits that are recognized at another designated institution listed in the BC Transfer Guide or other acceptable articulation agreements from other jurisdictions?",
-                    "labelPosition": "top",
-                    "labelWidth": "",
-                    "labelMargin": "",
-                    "optionsLabelPosition": "right",
-                    "description": "",
-                    "tooltip": "",
-                    "customClass": "",
-                    "tabindex": "",
-                    "inline": false,
-                    "hidden": false,
-                    "hideLabel": false,
-                    "autofocus": false,
-                    "disabled": false,
-                    "tableView": false,
-                    "modalEdit": false,
-                    "values": [
-                        {
-                            "label": "Yes",
-                            "value": "yes",
-                            "shortcut": ""
-                        },
-                        {
-                            "label": "No",
-                            "value": "no",
-                            "shortcut": ""
-                        }
-                    ],
-                    "dataType": "",
-                    "persistent": true,
-                    "protected": false,
-                    "dbIndex": false,
-                    "encrypted": false,
-                    "redrawOn": "",
-                    "clearOnHide": true,
-                    "customDefaultValue": "",
-                    "calculateValue": "",
-                    "calculateServer": false,
-                    "allowCalculateOverride": false,
-                    "validate": {
-                        "required": true,
-                        "onlyAvailableItems": false,
-                        "customMessage": "",
-                        "custom": "",
-                        "customPrivate": false,
-                        "json": "",
-                        "strictDateValidation": false,
-                        "multiple": false,
-                        "unique": false
-                    },
-                    "errorLabel": "",
-                    "errors": "",
-                    "key": "earnAcademicCreditsOtherInstitution",
-                    "tags": [],
-                    "properties": {},
-                    "conditional": {
-                        "show": "",
-                        "when": null,
-                        "eq": "",
-                        "json": ""
-                    },
-                    "customConditional": "const isBCInstitution = data.isBCPublic || data.isBCPrivate;\nshow = (!isBCInstitution && data.deliveredOnlineAlsoOnsite === \"no\" && data.sameOnlineCreditsEarned ===\"no\");",
-                    "logic": [],
-                    "attributes": {
-                        "data-cy": "earnAcademicCreditsOtherInstitution"
-                    },
-                    "overlay": {
-                        "style": "",
-                        "page": "",
-                        "left": "",
-                        "top": "",
-                        "width": "",
-                        "height": ""
-                    },
-                    "type": "radio",
-                    "input": true,
-                    "placeholder": "",
-                    "prefix": "",
-                    "suffix": "",
-                    "multiple": false,
-                    "unique": false,
-                    "refreshOn": "",
-                    "dataGridLabel": false,
-                    "widget": null,
-                    "validateOn": "change",
-                    "showCharCount": false,
-                    "showWordCount": false,
-                    "allowMultipleMasks": false,
-                    "addons": [],
-                    "inputType": "radio",
-                    "fieldSet": false,
-                    "id": "e3s18a",
-                    "defaultValue": ""
-                },
-                {
                     "label": "HTML",
-                    "className": "alert alert-warning fa fa-exclamation-circle",
+                    "tag": "h2",
+                    "className": "category-header-large primary-color",
                     "attrs": [
                         {
                             "attr": "",
                             "value": ""
                         }
                     ],
-                    "content": "<strong> This program is ineligible for StudentAid BC funding</strong>",
+                    "content": "Program information",
                     "refreshOnChange": false,
-                    "customClass": "banner-warning",
-                    "key": "html4",
-                    "customConditional": "const isBCInstitution = data.isBCPublic || data.isBCPrivate;\nshow = (!isBCInstitution && data.deliveredOnlineAlsoOnsite === \"no\" && data.sameOnlineCreditsEarned === \"no\" && data.earnAcademicCreditsOtherInstitution === \"no\");",
+                    "key": "html3",
                     "type": "htmlelement",
                     "input": false,
-                    "tableView": false,
-                    "placeholder": "",
-                    "prefix": "",
-                    "suffix": "",
-                    "multiple": false,
-                    "defaultValue": null,
-                    "protected": false,
-                    "unique": false,
-                    "persistent": false,
-                    "hidden": false,
-                    "clearOnHide": true,
-                    "refreshOn": "",
-                    "redrawOn": "",
-                    "modalEdit": false,
-                    "dataGridLabel": false,
-                    "labelPosition": "top",
-                    "description": "",
-                    "errorLabel": "",
-                    "tooltip": "",
-                    "hideLabel": false,
-                    "tabindex": "",
-                    "disabled": false,
-                    "autofocus": false,
-                    "dbIndex": false,
-                    "customDefaultValue": "",
-                    "calculateValue": "",
-                    "calculateServer": false,
-                    "widget": null,
-                    "attributes": {},
-                    "validateOn": "change",
-                    "validate": {
-                        "required": false,
-                        "custom": "",
-                        "customPrivate": false,
-                        "strictDateValidation": false,
-                        "multiple": false,
-                        "unique": false
-                    },
-                    "conditional": {
-                        "show": "",
-                        "when": null,
-                        "eq": ""
-                    },
-                    "overlay": {
-                        "style": "",
-                        "left": "",
-                        "top": "",
-                        "width": "",
-                        "height": ""
-                    },
-                    "allowCalculateOverride": false,
-                    "encrypted": false,
-                    "showCharCount": false,
-                    "showWordCount": false,
-                    "properties": {},
-                    "allowMultipleMasks": false,
-                    "addons": [],
-                    "tag": "p",
-                    "id": "elz5y9j",
-                    "tags": []
+                    "tableView": false
                 },
                 {
-                    "label": "HTML",
-                    "attrs": [
-                        {
-                            "attr": "",
-                            "value": ""
-                        }
-                    ],
-                    "content": "<strong>Program length</strong><br>This qualifies students for specific funds or grants.",
-                    "refreshOnChange": false,
-                    "key": "html11",
-                    "type": "htmlelement",
-                    "input": false,
-                    "tableView": false,
-                    "placeholder": "",
-                    "prefix": "",
-                    "customClass": "",
-                    "suffix": "",
-                    "multiple": false,
-                    "defaultValue": null,
-                    "protected": false,
-                    "unique": false,
-                    "persistent": false,
-                    "hidden": false,
-                    "clearOnHide": true,
-                    "refreshOn": "",
-                    "redrawOn": "",
-                    "modalEdit": false,
-                    "dataGridLabel": false,
-                    "labelPosition": "top",
-                    "description": "",
-                    "errorLabel": "",
-                    "tooltip": "",
-                    "hideLabel": false,
-                    "tabindex": "",
-                    "disabled": false,
-                    "autofocus": false,
-                    "dbIndex": false,
-                    "customDefaultValue": "",
-                    "calculateValue": "",
-                    "calculateServer": false,
-                    "widget": null,
-                    "attributes": {},
-                    "validateOn": "change",
-                    "validate": {
-                        "required": false,
-                        "custom": "",
-                        "customPrivate": false,
-                        "strictDateValidation": false,
-                        "multiple": false,
-                        "unique": false
-                    },
-                    "conditional": {
-                        "show": null,
-                        "when": null,
-                        "eq": ""
-                    },
-                    "overlay": {
-                        "style": "",
-                        "left": "",
-                        "top": "",
-                        "width": "",
-                        "height": ""
-                    },
-                    "allowCalculateOverride": false,
-                    "encrypted": false,
-                    "showCharCount": false,
-                    "showWordCount": false,
-                    "properties": {},
-                    "allowMultipleMasks": false,
-                    "addons": [],
-                    "tag": "p",
-                    "id": "eaximc",
-                    "className": ""
-                },
-                {
-                    "label": "Program length",
-                    "labelPosition": "top",
-                    "widget": "html5",
-                    "labelWidth": "",
-                    "labelMargin": "",
-                    "placeholder": "",
-                    "description": "",
-                    "tooltip": "",
-                    "customClass": "",
-                    "tabindex": "",
-                    "hidden": false,
+                    "collapsible": false,
                     "hideLabel": true,
-                    "uniqueOptions": false,
-                    "autofocus": false,
-                    "disabled": false,
-                    "tableView": true,
-                    "modalEdit": false,
-                    "multiple": false,
-                    "dataSrc": "values",
-                    "data": {
-                        "values": [
-                            {
-                                "label": "12 weeks to 52 weeks",
-                                "value": "12WeeksTo52Weeks"
-                            },
-                            {
-                                "label": "53 weeks to 59 weeks",
-                                "value": "53WeeksTo59Weeks"
-                            },
-                            {
-                                "label": "60 weeks to less than 2 years",
-                                "value": "60WeeksToLessThan2Years"
-                            },
-                            {
-                                "label": "2 Years to less than 3Years",
-                                "value": "2YearsToLessThan3Years"
-                            },
-                            {
-                                "label": "3 Years to less than 4 Years",
-                                "value": "3YearsToLessThan4Years"
-                            },
-                            {
-                                "label": "4 Years to less than 5Years",
-                                "value": "4YearsToLessThan5Years"
-                            },
-                            {
-                                "value": "5YearsOrMore",
-                                "label": "5 Years or More"
-                            }
-                        ],
-                        "resource": "",
-                        "json": "",
-                        "url": "",
-                        "custom": ""
-                    },
-                    "dataType": "",
-                    "idPath": "id",
-                    "valueProperty": "",
-                    "limit": 100,
-                    "template": "<span>{{ item.label }}</span>",
-                    "refreshOn": "",
-                    "refreshOnBlur": "",
-                    "clearOnRefresh": false,
-                    "searchEnabled": true,
-                    "selectThreshold": 0.3,
-                    "readOnlyValue": false,
-                    "customOptions": {},
-                    "useExactSearch": false,
-                    "persistent": true,
-                    "protected": false,
-                    "dbIndex": false,
-                    "encrypted": false,
-                    "clearOnHide": true,
-                    "customDefaultValue": "",
-                    "calculateValue": "",
-                    "calculateServer": false,
-                    "allowCalculateOverride": false,
-                    "validateOn": "change",
-                    "validate": {
-                        "required": true,
-                        "onlyAvailableItems": true,
-                        "customMessage": "",
-                        "custom": "",
-                        "customPrivate": false,
-                        "json": "",
-                        "strictDateValidation": false,
-                        "multiple": false,
-                        "unique": false
-                    },
-                    "unique": false,
-                    "errorLabel": "",
-                    "errors": "",
-                    "key": "completionYears",
-                    "tags": [],
-                    "properties": {},
-                    "conditional": {
-                        "show": "",
-                        "when": null,
-                        "eq": "",
-                        "json": ""
-                    },
-                    "customConditional": "",
-                    "logic": [],
-                    "attributes": {
-                        "data-cy": "completionYears"
-                    },
-                    "overlay": {
-                        "style": "",
-                        "page": "",
-                        "left": "",
-                        "top": "",
-                        "width": "",
-                        "height": ""
-                    },
-                    "type": "select",
-                    "indexeddb": {
-                        "filter": {}
-                    },
-                    "selectFields": "",
-                    "searchField": "",
-                    "searchDebounce": 0.3,
-                    "minSearch": 0,
-                    "filter": "",
-                    "redrawOn": "",
-                    "input": true,
-                    "searchThreshold": 0.3,
-                    "prefix": "",
-                    "suffix": "",
-                    "dataGridLabel": false,
-                    "showCharCount": false,
-                    "showWordCount": false,
-                    "allowMultipleMasks": false,
-                    "addons": [],
-                    "lazyLoad": true,
-                    "authenticate": false,
-                    "ignoreCache": false,
-                    "fuseOptions": {
-                        "include": "score",
-                        "threshold": 0.3
-                    },
-                    "id": "eauuw5l",
-                    "defaultValue": ""
-                },
-                {
-                    "label": "Program course load calculation is:",
-                    "labelPosition": "top",
-                    "labelWidth": "",
-                    "labelMargin": "",
-                    "optionsLabelPosition": "right",
-                    "description": "",
-                    "tooltip": "",
-                    "customClass": "",
-                    "tabindex": "",
-                    "inline": false,
-                    "hidden": false,
-                    "hideLabel": false,
-                    "autofocus": false,
-                    "disabled": false,
-                    "tableView": false,
-                    "modalEdit": false,
-                    "values": [
-                        {
-                            "label": "Credit based",
-                            "value": "credit",
-                            "shortcut": ""
-                        },
-                        {
-                            "label": "Hours based",
-                            "value": "hours",
-                            "shortcut": ""
-                        }
-                    ],
-                    "dataType": "",
-                    "persistent": true,
-                    "protected": false,
-                    "dbIndex": false,
-                    "encrypted": false,
-                    "redrawOn": "",
-                    "clearOnHide": true,
-                    "customDefaultValue": "",
-                    "calculateValue": "",
-                    "calculateServer": false,
-                    "allowCalculateOverride": false,
-                    "validate": {
-                        "required": true,
-                        "onlyAvailableItems": false,
-                        "customMessage": "",
-                        "custom": "",
-                        "customPrivate": false,
-                        "json": "",
-                        "strictDateValidation": false,
-                        "multiple": false,
-                        "unique": false
-                    },
-                    "errorLabel": "",
-                    "errors": "",
-                    "key": "courseLoadCalculation",
-                    "tags": [],
-                    "properties": {},
-                    "conditional": {
-                        "show": null,
-                        "when": null,
-                        "eq": "",
-                        "json": ""
-                    },
-                    "customConditional": "",
-                    "logic": [],
-                    "attributes": {
-                        "data-cy": "courseLoadCalculation"
-                    },
-                    "overlay": {
-                        "style": "",
-                        "page": "",
-                        "left": "",
-                        "top": "",
-                        "width": "",
-                        "height": ""
-                    },
-                    "type": "radio",
-                    "input": true,
-                    "placeholder": "",
-                    "prefix": "",
-                    "suffix": "",
-                    "multiple": false,
-                    "unique": false,
-                    "refreshOn": "",
-                    "dataGridLabel": false,
-                    "widget": null,
-                    "validateOn": "change",
-                    "showCharCount": false,
-                    "showWordCount": false,
-                    "allowMultipleMasks": false,
-                    "addons": [],
-                    "inputType": "radio",
-                    "fieldSet": false,
-                    "id": "eecl29k",
-                    "defaultValue": ""
-                },
-                {
-                    "label": "Does this program include a minimum of 20 instructional hours per week?",
-                    "labelPosition": "top",
-                    "labelWidth": "",
-                    "labelMargin": "",
-                    "optionsLabelPosition": "right",
-                    "description": "",
-                    "tooltip": "",
-                    "customClass": "",
-                    "tabindex": "",
-                    "inline": false,
-                    "hidden": false,
-                    "hideLabel": false,
-                    "autofocus": false,
-                    "disabled": false,
-                    "tableView": false,
-                    "modalEdit": false,
-                    "values": [
-                        {
-                            "label": "Yes",
-                            "value": "yes",
-                            "shortcut": ""
-                        },
-                        {
-                            "label": "No",
-                            "value": "no",
-                            "shortcut": ""
-                        }
-                    ],
-                    "dataType": "",
-                    "persistent": true,
-                    "protected": false,
-                    "dbIndex": false,
-                    "encrypted": false,
-                    "redrawOn": "",
-                    "clearOnHide": true,
-                    "customDefaultValue": "",
-                    "calculateValue": "",
-                    "calculateServer": false,
-                    "allowCalculateOverride": false,
-                    "validate": {
-                        "required": true,
-                        "onlyAvailableItems": false,
-                        "customMessage": "",
-                        "custom": "",
-                        "customPrivate": false,
-                        "json": "",
-                        "strictDateValidation": false,
-                        "multiple": false,
-                        "unique": false
-                    },
-                    "errorLabel": "",
-                    "errors": "",
-                    "key": "minHoursWeek",
-                    "tags": [],
-                    "properties": {},
-                    "conditional": {
-                        "show": true,
-                        "when": "courseLoadCalculation",
-                        "eq": "hours",
-                        "json": ""
-                    },
-                    "customConditional": "",
-                    "logic": [],
-                    "attributes": {
-                        "data-cy": "minHoursWeek"
-                    },
-                    "overlay": {
-                        "style": "",
-                        "page": "",
-                        "left": "",
-                        "top": "",
-                        "width": "",
-                        "height": ""
-                    },
-                    "type": "radio",
-                    "input": true,
-                    "placeholder": "",
-                    "prefix": "",
-                    "suffix": "",
-                    "multiple": false,
-                    "unique": false,
-                    "refreshOn": "",
-                    "dataGridLabel": false,
-                    "widget": null,
-                    "validateOn": "change",
-                    "showCharCount": false,
-                    "showWordCount": false,
-                    "allowMultipleMasks": false,
-                    "addons": [],
-                    "inputType": "radio",
-                    "fieldSet": false,
-                    "id": "ezm087",
-                    "defaultValue": ""
-                },
-                {
-                    "label": "Is this an aviation program?",
-                    "labelPosition": "top",
-                    "labelWidth": "",
-                    "labelMargin": "",
-                    "optionsLabelPosition": "right",
-                    "description": "",
-                    "tooltip": "",
-                    "customClass": "",
-                    "tabindex": "",
-                    "inline": false,
-                    "hidden": false,
-                    "hideLabel": false,
-                    "autofocus": false,
-                    "disabled": false,
-                    "tableView": false,
-                    "modalEdit": false,
-                    "values": [
-                        {
-                            "label": "Yes",
-                            "value": "yes",
-                            "shortcut": ""
-                        },
-                        {
-                            "label": "No",
-                            "value": "no",
-                            "shortcut": ""
-                        }
-                    ],
-                    "dataType": "",
-                    "persistent": true,
-                    "protected": false,
-                    "dbIndex": false,
-                    "encrypted": false,
-                    "redrawOn": "",
-                    "clearOnHide": true,
-                    "customDefaultValue": "",
-                    "calculateValue": "",
-                    "calculateServer": false,
-                    "allowCalculateOverride": false,
-                    "validate": {
-                        "required": true,
-                        "onlyAvailableItems": false,
-                        "customMessage": "",
-                        "custom": "",
-                        "customPrivate": false,
-                        "json": "",
-                        "strictDateValidation": false,
-                        "multiple": false,
-                        "unique": false
-                    },
-                    "errorLabel": "",
-                    "errors": "",
-                    "key": "isAviationProgram",
-                    "tags": [],
-                    "properties": {},
-                    "conditional": {
-                        "show": null,
-                        "when": null,
-                        "eq": "",
-                        "json": ""
-                    },
-                    "customConditional": "show = (data.courseLoadCalculation === \"hours\" && data.minHoursWeek === \"no\");",
-                    "logic": [],
-                    "attributes": {
-                        "data-cy": "isAviationProgram"
-                    },
-                    "overlay": {
-                        "style": "",
-                        "page": "",
-                        "left": "",
-                        "top": "",
-                        "width": "",
-                        "height": ""
-                    },
-                    "type": "radio",
-                    "input": true,
-                    "placeholder": "",
-                    "prefix": "",
-                    "suffix": "",
-                    "multiple": false,
-                    "unique": false,
-                    "refreshOn": "",
-                    "dataGridLabel": false,
-                    "widget": null,
-                    "validateOn": "change",
-                    "showCharCount": false,
-                    "showWordCount": false,
-                    "allowMultipleMasks": false,
-                    "addons": [],
-                    "inputType": "radio",
-                    "fieldSet": false,
-                    "id": "erbwah8",
-                    "defaultValue": ""
-                },
-                {
-                    "label": "HTML",
-                    "className": "alert alert-warning fa fa-exclamation-circle",
-                    "attrs": [
-                        {
-                            "attr": "",
-                            "value": ""
-                        }
-                    ],
-                    "content": "<strong> This program is inegligible for StudentAid BC funding</strong><br>The program needs to be a minimum of 20 instructional hours.",
-                    "refreshOnChange": true,
-                    "customClass": "banner-warning",
-                    "key": "html6",
-                    "customConditional": "show = (data.courseLoadCalculation === \"hours\" && data.minHoursWeek === \"no\" && data.isAviationProgram === \"no\");",
-                    "type": "htmlelement",
+                    "key": "panel",
+                    "type": "panel",
+                    "label": "Panel",
                     "input": false,
                     "tableView": false,
-                    "placeholder": "",
-                    "prefix": "",
-                    "suffix": "",
-                    "multiple": false,
-                    "defaultValue": null,
-                    "protected": false,
-                    "unique": false,
-                    "persistent": false,
-                    "hidden": false,
-                    "clearOnHide": true,
-                    "refreshOn": "",
-                    "redrawOn": "",
-                    "modalEdit": false,
-                    "dataGridLabel": false,
-                    "labelPosition": "top",
-                    "description": "",
-                    "errorLabel": "",
-                    "tooltip": "",
-                    "hideLabel": false,
-                    "tabindex": "",
-                    "disabled": false,
-                    "autofocus": false,
-                    "dbIndex": false,
-                    "customDefaultValue": "",
-                    "calculateValue": "",
-                    "calculateServer": false,
-                    "widget": null,
-                    "attributes": {},
-                    "validateOn": "change",
-                    "validate": {
-                        "required": false,
-                        "custom": "",
-                        "customPrivate": false,
-                        "strictDateValidation": false,
-                        "multiple": false,
-                        "unique": false
-                    },
-                    "conditional": {
-                        "show": null,
-                        "when": null,
-                        "eq": ""
-                    },
-                    "overlay": {
-                        "style": "",
-                        "left": "",
-                        "top": "",
-                        "width": "",
-                        "height": ""
-                    },
-                    "allowCalculateOverride": false,
-                    "encrypted": false,
-                    "showCharCount": false,
-                    "showWordCount": false,
-                    "properties": {},
-                    "allowMultipleMasks": false,
-                    "addons": [],
-                    "tag": "p",
-                    "id": "e28swbq"
-                },
-                {
-                    "label": "Does this program include a minimum of 15 instructional hours per week",
-                    "labelPosition": "top",
-                    "labelWidth": "",
-                    "labelMargin": "",
-                    "optionsLabelPosition": "right",
-                    "description": "",
-                    "tooltip": "",
-                    "customClass": "",
-                    "tabindex": "",
-                    "inline": false,
-                    "hidden": false,
-                    "hideLabel": false,
-                    "autofocus": false,
-                    "disabled": false,
-                    "tableView": false,
-                    "modalEdit": false,
-                    "values": [
+                    "components": [
                         {
-                            "label": "Yes",
-                            "value": "yes",
-                            "shortcut": ""
+                            "label": "Level Of Study Codes",
+                            "calculateValue": "value = {\r\n    undergraduateCertificate: \"8\",\r\n    undergraduateCitation: \"8\",\r\n    undergraduateDiploma: \"7\",\r\n    undergraduateDegree: \"3\",\r\n    graduateCertificate: \"5\",\r\n    graduateDiploma: \"5\",\r\n    graduateDegreeOrMasters: \"5\",\r\n    postGraduateOrDoctorate: \"6\",\r\n    qualifyingStudies: \"1\",\r\n};",
+                            "calculateServer": true,
+                            "key": "levelOfStudyCodes",
+                            "type": "hidden",
+                            "input": true,
+                            "tableView": false
                         },
                         {
-                            "label": "No",
-                            "value": "no",
-                            "shortcut": ""
+                            "label": "Field Of Study Codes",
+                            "calculateValue": "value = {\r\n  P7: \"25\",\r\n  P5: \"55\",\r\n  P8: \"25\",\r\n  P3: \"40\",\r\n  P6: \"70\",\r\n  P4: \"40\",\r\n  P2: \"25\",\r\n  P1: \"25\",\r\n  Q4: \"39\",\r\n  Q7: \"24\",\r\n  Q5: \"54\",\r\n  Q1: \"24\",\r\n  Q6: \"69\",\r\n  Q2: \"24\",\r\n  Q8: \"24\",\r\n  Q3: \"39\",\r\n  R7: \"23\",\r\n  R6: \"68\",\r\n  R4: \"38\",\r\n  R5: \"53\",\r\n  R2: \"23\",\r\n  R3: \"38\",\r\n  R8: \"23\",\r\n  R1: \"23\",\r\n  S8: \"22\",\r\n  S1: \"22\",\r\n  S4: \"37\",\r\n  S3: \"37\",\r\n  S2: \"22\",\r\n  S5: \"52\",\r\n  S7: \"22\",\r\n  S6: \"67\",\r\n  T1: \"21\",\r\n  T7: \"21\",\r\n  T4: \"36\",\r\n  T5: \"51\",\r\n  T3: \"36\",\r\n  T8: \"21\",\r\n  T6: \"66\",\r\n  T2: \"21\",\r\n  U8: \"20\",\r\n  U3: \"35\",\r\n  U2: \"20\",\r\n  U4: \"35\",\r\n  U7: \"20\",\r\n  U5: \"50\",\r\n  U1: \"20\",\r\n  U6: \"65\",\r\n  V1: \"19\",\r\n  V3: \"34\",\r\n  V6: \"64\",\r\n  V5: \"49\",\r\n  V2: \"19\",\r\n  V7: \"19\",\r\n  V4: \"34\",\r\n  V8: \"19\",\r\n  W8: \"18\",\r\n  W4: \"33\",\r\n  W2: \"18\",\r\n  W7: \"18\",\r\n  W5: \"48\",\r\n  W1: \"18\",\r\n  W3: \"33\",\r\n  W6: \"63\",\r\n  X5: \"47\",\r\n  X2: \"17\",\r\n  X1: \"17\",\r\n  X4: \"32\",\r\n  X8: \"17\",\r\n  X3: \"32\",\r\n  X6: \"62\",\r\n  X7: \"17\",\r\n  Y4: \"31\",\r\n  Y8: \"16\",\r\n  Y5: \"46\",\r\n  Y6: \"61\",\r\n  Y2: \"16\",\r\n  Y3: \"31\",\r\n  Y1: \"16\",\r\n  Y7: \"16\",\r\n  Z7: \"15\",\r\n  Z8: \"15\",\r\n  Z5: \"45\",\r\n  Z4: \"30\",\r\n  Z2: \"15\",\r\n  Z3: \"30\",\r\n  Z1: \"15\",\r\n  Z6: \"60\",\r\n};",
+                            "calculateServer": true,
+                            "key": "fieldOfStudyCodes",
+                            "type": "hidden",
+                            "input": true,
+                            "tableView": false
+                        },
+                        {
+                            "label": "SABC Codes",
+                            "calculateValue": "value =\r\n{\r\n    11: \"Z\",\r\n    \"09\": \"Z\",\r\n    52: \"Z\",\r\n    \"01\": \"Z\",\r\n    \"03\": \"Z\",\r\n    \"05\": \"X\",\r\n    16: \"X\",\r\n    23: \"X\",\r\n    24: \"X\",\r\n    25: \"X\",\r\n    42: \"X\",\r\n    27: \"X\",\r\n    30: \"X\",\r\n    38: \"X\",\r\n    40: \"X\",\r\n    45: \"X\",\r\n    50: \"X\",\r\n    53: \"X\",\r\n    54: \"X\",\r\n    55: \"X\",\r\n    13: \"W\",\r\n    19: \"W\",\r\n    28: \"W\",\r\n    31: \"W\",\r\n    44: \"W\",\r\n    60: \"V\",\r\n    \"04\": \"U\",\r\n    10: \"U\",\r\n    14: \"U\",\r\n    15: \"U\",\r\n    29: \"U\",\r\n    41: \"U\",\r\n    26: \"U\",\r\n    22: \"S\",\r\n    43: \"S\",\r\n    51: \"R\",\r\n    61: \"R\",\r\n    39: \"Q\",\r\n    12: \"P\",\r\n    21: \"P\",\r\n    32: \"P\",\r\n    33: \"P\",\r\n    34: \"P\",\r\n    35: \"P\",\r\n    36: \"P\",\r\n    37: \"P\",\r\n    46: \"P\",\r\n    47: \"P\",\r\n    48: \"P\",\r\n    49: \"P\"\r\n};",
+                            "calculateServer": true,
+                            "key": "sabcCodes",
+                            "type": "hidden",
+                            "input": true,
+                            "tableView": false
+                        },
+                        {
+                            "label": "Program name",
+                            "showCharCount": true,
+                            "tableView": true,
+                            "validate": {
+                                "required": true,
+                                "maxLength": 100
+                            },
+                            "key": "name",
+                            "attributes": {
+                                "data-cy": "programName"
+                            },
+                            "type": "textfield",
+                            "input": true
+                        },
+                        {
+                            "label": "Program description",
+                            "autoExpand": false,
+                            "showCharCount": true,
+                            "tableView": true,
+                            "validate": {
+                                "maxLength": 500,
+                                "customMessage": "Too Long"
+                            },
+                            "key": "description",
+                            "attributes": {
+                                "data-cy": "programDescription"
+                            },
+                            "type": "textarea",
+                            "input": true
+                        },
+                        {
+                            "label": "Credential type",
+                            "widget": "html5",
+                            "tableView": true,
+                            "data": {
+                                "values": [
+                                    {
+                                        "label": "Undergraduate Certificate",
+                                        "value": "undergraduateCertificate"
+                                    },
+                                    {
+                                        "label": "Undergraduate Citation",
+                                        "value": "undergraduateCitation"
+                                    },
+                                    {
+                                        "label": "Undergraduate Diploma",
+                                        "value": "undergraduateDiploma"
+                                    },
+                                    {
+                                        "label": "Undergraduate Degree",
+                                        "value": "undergraduateDegree"
+                                    },
+                                    {
+                                        "label": "Graduate Certificate",
+                                        "value": "graduateCertificate"
+                                    },
+                                    {
+                                        "label": "Graduate Diploma",
+                                        "value": "graduateDiploma"
+                                    },
+                                    {
+                                        "label": "Graduate Degree / Master’s",
+                                        "value": "graduateDegreeOrMasters"
+                                    },
+                                    {
+                                        "label": "Post-Graduate / Doctorate",
+                                        "value": "postGraduateOrDoctorate"
+                                    },
+                                    {
+                                        "label": "Qualifying Studies",
+                                        "value": "qualifyingStudies"
+                                    }
+                                ]
+                            },
+                            "validate": {
+                                "required": true,
+                                "onlyAvailableItems": true
+                            },
+                            "key": "credentialType",
+                            "logic": [
+                                {
+                                    "name": "Disable Credential Input",
+                                    "trigger": {
+                                        "type": "javascript",
+                                        "javascript": "result = data.hasOfferings;"
+                                    },
+                                    "actions": [
+                                        {
+                                            "name": "Disable edit",
+                                            "type": "property",
+                                            "property": {
+                                                "label": "Disabled",
+                                                "value": "disabled",
+                                                "type": "boolean"
+                                            },
+                                            "state": true
+                                        }
+                                    ]
+                                }
+                            ],
+                            "attributes": {
+                                "data-cy": "credentialType"
+                            },
+                            "type": "select",
+                            "input": true,
+                            "searchThreshold": 0.3
+                        },
+                        {
+                            "label": "Classification of Instructional Programs (CIP)",
+                            "description": "Format (##.####)",
+                            "tableView": true,
+                            "calculateServer": true,
+                            "validate": {
+                                "required": true,
+                                "pattern": "^[0-9]{2}\\.[0-9]{4}$",
+                                "customMessage": "Invalid format"
+                            },
+                            "key": "cipCode",
+                            "logic": [
+                                {
+                                    "name": "Disable CIP Code Input",
+                                    "trigger": {
+                                        "type": "javascript",
+                                        "javascript": "result = data.hasOfferings;"
+                                    },
+                                    "actions": [
+                                        {
+                                            "name": "Disable Input",
+                                            "type": "property",
+                                            "property": {
+                                                "label": "Disabled",
+                                                "value": "disabled",
+                                                "type": "boolean"
+                                            },
+                                            "state": true
+                                        }
+                                    ]
+                                }
+                            ],
+                            "attributes": {
+                                "data-cy": "cipCode"
+                            },
+                            "type": "textfield",
+                            "input": true
+                        },
+                        {
+                            "label": "Field of study code",
+                            "disabled": true,
+                            "tableView": true,
+                            "calculateValue": "const sabcCode = data.sabcCodes[data.cipCode.substring(0, 2)];\r\nconst levelOfStudyCode =  data.levelOfStudyCodes[data.credentialType];\r\nvalue = (sabcCode && levelOfStudyCode) ? data.fieldOfStudyCodes[sabcCode + levelOfStudyCode] : 20;",
+                            "calculateServer": true,
+                            "validate": {
+                                "required": true,
+                                "customMessage": "The combination of the Credential Type and CIP did not result in a known Field of Study code."
+                            },
+                            "key": "fieldOfStudyCode",
+                            "attributes": {
+                                "data-cy": "fieldOfStudyCode"
+                            },
+                            "type": "textfield",
+                            "input": true
+                        },
+                        {
+                            "label": "National Occupational Classifcation (NOC)",
+                            "description": "Format (#####) Optional**",
+                            "tableView": true,
+                            "validate": {
+                                "pattern": "[0-9]{5}",
+                                "customMessage": "Incorrect Format"
+                            },
+                            "key": "nocCode",
+                            "logic": [
+                                {
+                                    "name": "Disable NOC Code",
+                                    "trigger": {
+                                        "type": "javascript",
+                                        "javascript": "result = data.hasOfferings;"
+                                    },
+                                    "actions": [
+                                        {
+                                            "name": "Disable Input",
+                                            "type": "property",
+                                            "property": {
+                                                "label": "Disabled",
+                                                "value": "disabled",
+                                                "type": "boolean"
+                                            },
+                                            "state": true
+                                        }
+                                    ]
+                                }
+                            ],
+                            "attributes": {
+                                "data-cy": "nocCode"
+                            },
+                            "type": "textfield",
+                            "input": true,
+                            "lockKey": true
+                        },
+                        {
+                            "label": "SABC program code, if this program has been approved for SABC funding before",
+                            "description": "Format (XXX#) Optional**",
+                            "tableView": true,
+                            "validate": {
+                                "pattern": "[[A-Z]{3}[0-9]{1}",
+                                "customMessage": "Incorrect Format"
+                            },
+                            "key": "sabcCode",
+                            "logic": [
+                                {
+                                    "name": "Disable SABC Input",
+                                    "trigger": {
+                                        "type": "javascript",
+                                        "javascript": "result = data.hasOfferings;"
+                                    },
+                                    "actions": [
+                                        {
+                                            "name": "Disable Input",
+                                            "type": "property",
+                                            "property": {
+                                                "label": "Disabled",
+                                                "value": "disabled",
+                                                "type": "boolean"
+                                            },
+                                            "state": true
+                                        }
+                                    ]
+                                }
+                            ],
+                            "attributes": {
+                                "data-cy": "sabcCode"
+                            },
+                            "type": "textfield",
+                            "input": true
+                        },
+                        {
+                            "label": "Institution Program Code",
+                            "tableView": true,
+                            "key": "institutionProgramCode",
+                            "logic": [
+                                {
+                                    "name": "Disable Program Code Input",
+                                    "trigger": {
+                                        "type": "javascript",
+                                        "javascript": "result = data.hasOfferings;"
+                                    },
+                                    "actions": [
+                                        {
+                                            "name": "Disable Input",
+                                            "type": "property",
+                                            "property": {
+                                                "label": "Disabled",
+                                                "value": "disabled",
+                                                "type": "boolean"
+                                            },
+                                            "state": true
+                                        }
+                                    ]
+                                }
+                            ],
+                            "attributes": {
+                                "data-cy": "institutionProgramCode"
+                            },
+                            "type": "textfield",
+                            "input": true
                         }
-                    ],
-                    "dataType": "",
-                    "persistent": true,
-                    "protected": false,
-                    "dbIndex": false,
-                    "encrypted": false,
-                    "redrawOn": "",
-                    "clearOnHide": true,
-                    "customDefaultValue": "",
-                    "calculateValue": "",
-                    "calculateServer": false,
-                    "allowCalculateOverride": false,
-                    "validate": {
-                        "required": true,
-                        "onlyAvailableItems": false,
-                        "customMessage": "",
-                        "custom": "",
-                        "customPrivate": false,
-                        "json": "",
-                        "strictDateValidation": false,
-                        "multiple": false,
-                        "unique": false
-                    },
-                    "errorLabel": "",
-                    "errors": "",
-                    "key": "minHoursWeekAvi",
-                    "tags": [],
-                    "properties": {},
-                    "conditional": {
-                        "show": null,
-                        "when": null,
-                        "eq": "",
-                        "json": ""
-                    },
-                    "customConditional": "show = (data.courseLoadCalculation === \"hours\" && data.minHoursWeek === \"no\" && data.isAviationProgram === \"yes\");",
-                    "logic": [],
-                    "attributes": {
-                        "data-cy": "minHoursWeekAvi"
-                    },
-                    "overlay": {
-                        "style": "",
-                        "page": "",
-                        "left": "",
-                        "top": "",
-                        "width": "",
-                        "height": ""
-                    },
-                    "type": "radio",
-                    "input": true,
-                    "placeholder": "",
-                    "prefix": "",
-                    "suffix": "",
-                    "multiple": false,
-                    "unique": false,
-                    "refreshOn": "",
-                    "dataGridLabel": false,
-                    "widget": null,
-                    "validateOn": "change",
-                    "showCharCount": false,
-                    "showWordCount": false,
-                    "allowMultipleMasks": false,
-                    "addons": [],
-                    "inputType": "radio",
-                    "fieldSet": false,
-                    "id": "eupk3a",
-                    "defaultValue": ""
+                    ]
                 },
                 {
-                    "label": "HTML",
-                    "className": "alert alert-warning fa fa-exclamation-circle",
+                    "label": "Program eligibility",
+                    "tag": "h2",
+                    "className": "category-header-large primary-color",
                     "attrs": [
                         {
                             "attr": "",
                             "value": ""
                         }
                     ],
-                    "content": "<strong> This program is ineligible for StudentAid BC funding</strong><br>The aviation program needs to be a minimum of 15 instructional hours.",
+                    "content": "Program eligibility",
                     "refreshOnChange": false,
-                    "customClass": "banner-warning",
-                    "key": "html5",
-                    "customConditional": "show = (data.courseLoadCalculation === \"hours\" && data.minHoursWeek === \"no\" && data.isAviationProgram === \"yes\" && data.minHoursWeekAvi === \"no\");",
+                    "customClass": "category-header-medium primary-color",
+                    "key": "programEligibility",
                     "type": "htmlelement",
                     "input": false,
+                    "tableView": false
+                },
+                {
+                    "collapsible": false,
+                    "hideLabel": true,
+                    "key": "panel1",
+                    "logic": [
+                        {
+                            "name": "Disable Eligibility Inputs",
+                            "trigger": {
+                                "type": "javascript",
+                                "javascript": "result = data.hasOfferings;"
+                            },
+                            "actions": [
+                                {
+                                    "name": "Disable Inputs",
+                                    "type": "property",
+                                    "property": {
+                                        "label": "Disabled",
+                                        "value": "disabled",
+                                        "type": "boolean"
+                                    },
+                                    "state": true
+                                }
+                            ]
+                        }
+                    ],
+                    "type": "panel",
+                    "label": "Panel",
+                    "input": false,
                     "tableView": false,
-                    "placeholder": "",
-                    "prefix": "",
-                    "suffix": "",
-                    "multiple": false,
-                    "defaultValue": null,
-                    "protected": false,
-                    "unique": false,
-                    "persistent": false,
-                    "hidden": false,
-                    "clearOnHide": true,
-                    "refreshOn": "",
-                    "redrawOn": "",
-                    "modalEdit": false,
-                    "dataGridLabel": false,
-                    "labelPosition": "top",
-                    "description": "",
-                    "errorLabel": "",
-                    "tooltip": "",
-                    "hideLabel": false,
-                    "tabindex": "",
-                    "disabled": false,
-                    "autofocus": false,
-                    "dbIndex": false,
-                    "customDefaultValue": "",
-                    "calculateValue": "",
-                    "calculateServer": false,
-                    "widget": null,
-                    "attributes": {},
-                    "validateOn": "change",
-                    "validate": {
-                        "required": false,
-                        "custom": "",
-                        "customPrivate": false,
-                        "strictDateValidation": false,
-                        "multiple": false,
-                        "unique": false
-                    },
-                    "conditional": {
-                        "show": null,
-                        "when": null,
-                        "eq": ""
-                    },
-                    "overlay": {
-                        "style": "",
-                        "left": "",
-                        "top": "",
-                        "width": "",
-                        "height": ""
-                    },
-                    "allowCalculateOverride": false,
-                    "encrypted": false,
-                    "showCharCount": false,
-                    "showWordCount": false,
-                    "properties": {},
-                    "allowMultipleMasks": false,
-                    "addons": [],
-                    "tag": "p",
-                    "id": "emof1eo"
+                    "components": [
+                        {
+                            "label": "Are students able to take this on a part time basis?",
+                            "optionsLabelPosition": "right",
+                            "tooltip": "A part-time program has a course load between 20 and 59%. A full-time program must have a course load of: 60% or greater or Between 40 and 60% for students with a permanent disability.",
+                            "inline": false,
+                            "tableView": false,
+                            "values": [
+                                {
+                                    "label": "Yes",
+                                    "value": "Full Time and Part Time",
+                                    "shortcut": ""
+                                },
+                                {
+                                    "label": "No",
+                                    "value": "Full Time",
+                                    "shortcut": ""
+                                }
+                            ],
+                            "validate": {
+                                "required": true,
+                                "onlyAvailableItems": true
+                            },
+                            "key": "programIntensity",
+                            "attributes": {
+                                "data-cy": "programIntensity"
+                            },
+                            "type": "radio",
+                            "input": true
+                        },
+                        {
+                            "label": "How will this program be delivered? (Select all that apply)",
+                            "optionsLabelPosition": "right",
+                            "tableView": false,
+                            "defaultValue": {
+                                "deliveredOnSite": false,
+                                "deliveredOnline": false,
+                                "onSite": false,
+                                "online": false,
+                                "onsite": false
+                            },
+                            "values": [
+                                {
+                                    "label": "On site",
+                                    "value": "deliveredOnSite",
+                                    "shortcut": ""
+                                },
+                                {
+                                    "label": "Online",
+                                    "value": "deliveredOnline",
+                                    "shortcut": ""
+                                }
+                            ],
+                            "validate": {
+                                "required": true
+                            },
+                            "key": "programDeliveryTypes",
+                            "attributes": {
+                                "data-cy": "programDeliveryTypes"
+                            },
+                            "type": "selectboxes",
+                            "input": true,
+                            "inputType": "checkbox",
+                            "lockKey": true
+                        },
+                        {
+                            "label": "Will the program also be offered and delivered at 100% course load on site?",
+                            "optionsLabelPosition": "right",
+                            "inline": false,
+                            "tableView": false,
+                            "values": [
+                                {
+                                    "label": "Yes",
+                                    "value": "yes",
+                                    "shortcut": ""
+                                },
+                                {
+                                    "label": "No",
+                                    "value": "no",
+                                    "shortcut": ""
+                                }
+                            ],
+                            "validate": {
+                                "required": true
+                            },
+                            "key": "deliveredOnlineAlsoOnsite",
+                            "customConditional": "const isBCInstitution = data.isBCPublic || data.isBCPrivate;\nshow = (!isBCInstitution && data.programDeliveryTypes.deliveredOnline);",
+                            "attributes": {
+                                "data-cy": "deliveredOnlineAlsoOnsite"
+                            },
+                            "type": "radio",
+                            "input": true
+                        },
+                        {
+                            "label": "Will the students earn the same number of credits in the same time period as students in other StudentAid BC eligible programs delivered on site?",
+                            "optionsLabelPosition": "right",
+                            "inline": false,
+                            "tableView": false,
+                            "values": [
+                                {
+                                    "label": "Yes",
+                                    "value": "yes",
+                                    "shortcut": ""
+                                },
+                                {
+                                    "label": "No",
+                                    "value": "no",
+                                    "shortcut": ""
+                                }
+                            ],
+                            "validate": {
+                                "required": true,
+                                "onlyAvailableItems": true
+                            },
+                            "key": "sameOnlineCreditsEarned",
+                            "customConditional": "const isBCInstitution = data.isBCPublic || data.isBCPrivate;\nshow = (!isBCInstitution && data.deliveredOnlineAlsoOnsite === \"no\");",
+                            "attributes": {
+                                "data-cy": "sameOnlineCreditsEarned"
+                            },
+                            "type": "radio",
+                            "input": true
+                        },
+                        {
+                            "label": "Will they earn academic credits that are recognized at another designated institution listed in the BC Transfer Guide or other acceptable articulation agreements from other jurisdictions?",
+                            "optionsLabelPosition": "right",
+                            "inline": false,
+                            "tableView": false,
+                            "values": [
+                                {
+                                    "label": "Yes",
+                                    "value": "yes",
+                                    "shortcut": ""
+                                },
+                                {
+                                    "label": "No",
+                                    "value": "no",
+                                    "shortcut": ""
+                                }
+                            ],
+                            "validate": {
+                                "required": true
+                            },
+                            "key": "earnAcademicCreditsOtherInstitution",
+                            "customConditional": "const isBCInstitution = data.isBCPublic || data.isBCPrivate;\nshow = (!isBCInstitution && data.deliveredOnlineAlsoOnsite === \"no\" && data.sameOnlineCreditsEarned ===\"no\");",
+                            "attributes": {
+                                "data-cy": "earnAcademicCreditsOtherInstitution"
+                            },
+                            "type": "radio",
+                            "input": true
+                        },
+                        {
+                            "label": "HTML",
+                            "className": "alert alert-warning fa fa-exclamation-circle",
+                            "attrs": [
+                                {
+                                    "attr": "",
+                                    "value": ""
+                                }
+                            ],
+                            "content": "<strong> This program is ineligible for StudentAid BC funding</strong>",
+                            "refreshOnChange": false,
+                            "customClass": "banner-warning",
+                            "key": "html4",
+                            "customConditional": "const isBCInstitution = data.isBCPublic || data.isBCPrivate;\nshow = (!isBCInstitution && data.deliveredOnlineAlsoOnsite === \"no\" && data.sameOnlineCreditsEarned === \"no\" && data.earnAcademicCreditsOtherInstitution === \"no\");",
+                            "type": "htmlelement",
+                            "input": false,
+                            "tableView": false
+                        },
+                        {
+                            "label": "HTML",
+                            "attrs": [
+                                {
+                                    "attr": "",
+                                    "value": ""
+                                }
+                            ],
+                            "content": "<strong>Program length</strong><br>This qualifies students for specific funds or grants.",
+                            "refreshOnChange": false,
+                            "key": "html11",
+                            "type": "htmlelement",
+                            "input": false,
+                            "tableView": false
+                        },
+                        {
+                            "label": "Program length",
+                            "widget": "html5",
+                            "hideLabel": true,
+                            "tableView": true,
+                            "data": {
+                                "values": [
+                                    {
+                                        "label": "12 weeks to 52 weeks",
+                                        "value": "12WeeksTo52Weeks"
+                                    },
+                                    {
+                                        "label": "53 weeks to 59 weeks",
+                                        "value": "53WeeksTo59Weeks"
+                                    },
+                                    {
+                                        "label": "60 weeks to less than 2 years",
+                                        "value": "60WeeksToLessThan2Years"
+                                    },
+                                    {
+                                        "label": "2 Years to less than 3Years",
+                                        "value": "2YearsToLessThan3Years"
+                                    },
+                                    {
+                                        "label": "3 Years to less than 4 Years",
+                                        "value": "3YearsToLessThan4Years"
+                                    },
+                                    {
+                                        "label": "4 Years to less than 5Years",
+                                        "value": "4YearsToLessThan5Years"
+                                    },
+                                    {
+                                        "value": "5YearsOrMore",
+                                        "label": "5 Years or More"
+                                    }
+                                ]
+                            },
+                            "validate": {
+                                "required": true,
+                                "onlyAvailableItems": true
+                            },
+                            "key": "completionYears",
+                            "attributes": {
+                                "data-cy": "completionYears"
+                            },
+                            "type": "select",
+                            "input": true,
+                            "searchThreshold": 0.3
+                        },
+                        {
+                            "label": "Program course load calculation is:",
+                            "optionsLabelPosition": "right",
+                            "inline": false,
+                            "tableView": false,
+                            "values": [
+                                {
+                                    "label": "Credit based",
+                                    "value": "credit",
+                                    "shortcut": ""
+                                },
+                                {
+                                    "label": "Hours based",
+                                    "value": "hours",
+                                    "shortcut": ""
+                                }
+                            ],
+                            "validate": {
+                                "required": true
+                            },
+                            "key": "courseLoadCalculation",
+                            "attributes": {
+                                "data-cy": "courseLoadCalculation"
+                            },
+                            "type": "radio",
+                            "input": true
+                        },
+                        {
+                            "label": "Does this program include a minimum of 20 instructional hours per week?",
+                            "optionsLabelPosition": "right",
+                            "inline": false,
+                            "tableView": false,
+                            "values": [
+                                {
+                                    "label": "Yes",
+                                    "value": "yes",
+                                    "shortcut": ""
+                                },
+                                {
+                                    "label": "No",
+                                    "value": "no",
+                                    "shortcut": ""
+                                }
+                            ],
+                            "validate": {
+                                "required": true
+                            },
+                            "key": "minHoursWeek",
+                            "conditional": {
+                                "show": true,
+                                "when": "courseLoadCalculation",
+                                "eq": "hours"
+                            },
+                            "attributes": {
+                                "data-cy": "minHoursWeek"
+                            },
+                            "type": "radio",
+                            "input": true
+                        },
+                        {
+                            "label": "Is this an aviation program?",
+                            "optionsLabelPosition": "right",
+                            "inline": false,
+                            "tableView": false,
+                            "values": [
+                                {
+                                    "label": "Yes",
+                                    "value": "yes",
+                                    "shortcut": ""
+                                },
+                                {
+                                    "label": "No",
+                                    "value": "no",
+                                    "shortcut": ""
+                                }
+                            ],
+                            "validate": {
+                                "required": true
+                            },
+                            "key": "isAviationProgram",
+                            "customConditional": "show = (data.courseLoadCalculation === \"hours\" && data.minHoursWeek === \"no\");",
+                            "attributes": {
+                                "data-cy": "isAviationProgram"
+                            },
+                            "type": "radio",
+                            "input": true
+                        },
+                        {
+                            "label": "HTML",
+                            "className": "alert alert-warning fa fa-exclamation-circle",
+                            "attrs": [
+                                {
+                                    "attr": "",
+                                    "value": ""
+                                }
+                            ],
+                            "content": "<strong> This program is inegligible for StudentAid BC funding</strong><br>The program needs to be a minimum of 20 instructional hours.",
+                            "refreshOnChange": true,
+                            "customClass": "banner-warning",
+                            "key": "html6",
+                            "customConditional": "show = (data.courseLoadCalculation === \"hours\" && data.minHoursWeek === \"no\" && data.isAviationProgram === \"no\");",
+                            "type": "htmlelement",
+                            "input": false,
+                            "tableView": false
+                        },
+                        {
+                            "label": "Does this program include a minimum of 15 instructional hours per week",
+                            "optionsLabelPosition": "right",
+                            "inline": false,
+                            "tableView": false,
+                            "values": [
+                                {
+                                    "label": "Yes",
+                                    "value": "yes",
+                                    "shortcut": ""
+                                },
+                                {
+                                    "label": "No",
+                                    "value": "no",
+                                    "shortcut": ""
+                                }
+                            ],
+                            "validate": {
+                                "required": true
+                            },
+                            "key": "minHoursWeekAvi",
+                            "customConditional": "show = (data.courseLoadCalculation === \"hours\" && data.minHoursWeek === \"no\" && data.isAviationProgram === \"yes\");",
+                            "attributes": {
+                                "data-cy": "minHoursWeekAvi"
+                            },
+                            "type": "radio",
+                            "input": true
+                        },
+                        {
+                            "label": "HTML",
+                            "className": "alert alert-warning fa fa-exclamation-circle",
+                            "attrs": [
+                                {
+                                    "attr": "",
+                                    "value": ""
+                                }
+                            ],
+                            "content": "<strong> This program is ineligible for StudentAid BC funding</strong><br>The aviation program needs to be a minimum of 15 instructional hours.",
+                            "refreshOnChange": false,
+                            "customClass": "banner-warning",
+                            "key": "html5",
+                            "customConditional": "show = (data.courseLoadCalculation === \"hours\" && data.minHoursWeek === \"no\" && data.isAviationProgram === \"yes\" && data.minHoursWeekAvi === \"no\");",
+                            "type": "htmlelement",
+                            "input": false,
+                            "tableView": false
+                        },
+                        {
+                            "label": "HTML",
+                            "attrs": [
+                                {
+                                    "attr": "",
+                                    "value": ""
+                                }
+                            ],
+                            "content": "<strong>Which regulatory body does this program belong to?</strong><br>\nAll programs must be approved by your regulatory body to meet the criteria. If your program has not been approved yet, please contact your regulatory body first.",
+                            "refreshOnChange": false,
+                            "key": "html7",
+                            "type": "htmlelement",
+                            "input": false,
+                            "tableView": false
+                        },
+                        {
+                            "label": "Which regulatory body does this program belong to?",
+                            "widget": "html5",
+                            "tableView": true,
+                            "data": {
+                                "values": [
+                                    {
+                                        "label": "PTIB",
+                                        "value": "ptib"
+                                    },
+                                    {
+                                        "label": "DQAB",
+                                        "value": "dqab"
+                                    },
+                                    {
+                                        "label": "Private Act of B.C. Legislature",
+                                        "value": "privateActLegislature"
+                                    },
+                                    {
+                                        "label": "Skilled Trades BC",
+                                        "value": "skilledTradesBC"
+                                    },
+                                    {
+                                        "label": "ICBC",
+                                        "value": "icbc"
+                                    },
+                                    {
+                                        "value": "senateOrEducationCouncil",
+                                        "label": "Senate, Academic Council, Education Council, and/or Program Council and Board of Governors"
+                                    },
+                                    {
+                                        "value": "other",
+                                        "label": "Other"
+                                    }
+                                ]
+                            },
+                            "validate": {
+                                "required": true
+                            },
+                            "key": "regulatoryBody",
+                            "attributes": {
+                                "data-cy": "regulatoryBody"
+                            },
+                            "type": "select",
+                            "input": true,
+                            "searchThreshold": 0.3,
+                            "hideLabel": true
+                        },
+                        {
+                            "input": true,
+                            "tableView": true,
+                            "label": "Other institution regulatory body",
+                            "key": "otherRegulatoryBody",
+                            "validate": {
+                                "required": true,
+                                "minLength": 1,
+                                "maxLength": 100
+                            },
+                            "conditional": {
+                                "show": "true",
+                                "when": "regulatoryBody",
+                                "eq": "other"
+                            },
+                            "type": "textfield",
+                            "lockKey": true
+                        }
+                    ]
                 },
                 {
                     "label": "HTML",
-                    "labelWidth": "",
-                    "labelMargin": "",
-                    "tag": "p",
-                    "className": "",
+                    "tag": "h2",
+                    "className": "category-header-large primary-color",
                     "attrs": [
                         {
                             "attr": "",
                             "value": ""
                         }
                     ],
-                    "content": "<strong>Which regulatory body does this program belong to?</strong><br>\nAll programs must be approved by your regulatory body to meet the criteria. If your program has not been approved yet, please contact your regulatory body first.",
+                    "content": "Entrance requirements",
                     "refreshOnChange": false,
-                    "customClass": "",
-                    "hidden": false,
-                    "modalEdit": false,
-                    "key": "html7",
-                    "tags": [],
-                    "properties": {},
-                    "conditional": {
-                        "show": null,
-                        "when": null,
-                        "eq": "",
-                        "json": ""
-                    },
-                    "customConditional": "",
-                    "logic": [],
-                    "attributes": {},
-                    "overlay": {
-                        "style": "",
-                        "page": "",
-                        "left": "",
-                        "top": "",
-                        "width": "",
-                        "height": ""
-                    },
+                    "key": "html8",
                     "type": "htmlelement",
                     "input": false,
                     "tableView": false,
-                    "placeholder": "",
-                    "prefix": "",
-                    "suffix": "",
-                    "multiple": false,
-                    "defaultValue": null,
-                    "protected": false,
-                    "unique": false,
-                    "persistent": false,
-                    "clearOnHide": true,
-                    "refreshOn": "",
-                    "redrawOn": "",
-                    "dataGridLabel": false,
-                    "labelPosition": "top",
-                    "description": "",
-                    "errorLabel": "",
-                    "tooltip": "",
-                    "hideLabel": false,
-                    "tabindex": "",
-                    "disabled": false,
-                    "autofocus": false,
-                    "dbIndex": false,
-                    "customDefaultValue": "",
-                    "calculateValue": "",
-                    "calculateServer": false,
-                    "widget": null,
-                    "validateOn": "change",
-                    "validate": {
-                        "required": false,
-                        "custom": "",
-                        "customPrivate": false,
-                        "strictDateValidation": false,
-                        "multiple": false,
-                        "unique": false
-                    },
-                    "allowCalculateOverride": false,
-                    "encrypted": false,
-                    "showCharCount": false,
-                    "showWordCount": false,
-                    "allowMultipleMasks": false,
-                    "addons": [],
-                    "id": "eug8su"
-                },
-                {
-                    "label": "Which regulatory body does this program belong to?",
-                    "labelPosition": "top",
-                    "widget": "html5",
-                    "labelWidth": "",
-                    "labelMargin": "",
-                    "placeholder": "",
-                    "description": "",
-                    "tooltip": "",
-                    "customClass": "",
-                    "tabindex": "",
-                    "hidden": false,
-                    "uniqueOptions": false,
-                    "autofocus": false,
-                    "disabled": false,
-                    "tableView": true,
-                    "modalEdit": false,
-                    "multiple": false,
-                    "dataSrc": "values",
-                    "data": {
-                        "values": [
-                            {
-                                "label": "PTIB",
-                                "value": "ptib"
-                            },
-                            {
-                                "label": "DQAB",
-                                "value": "dqab"
-                            },
-                            {
-                                "label": "Private Act of B.C. Legislature",
-                                "value": "privateActLegislature"
-                            },
-                            {
-                                "label": "Skilled Trades BC",
-                                "value": "skilledTradesBC"
-                            },
-                            {
-                                "label": "ICBC",
-                                "value": "icbc"
-                            },
-                            {
-                                "value": "senateOrEducationCouncil",
-                                "label": "Senate, Academic Council, Education Council, and/or Program Council and Board of Governors"
-                            },
-                            {
-                                "value": "other",
-                                "label": "Other"
-                            }
-                        ],
-                        "resource": "",
-                        "json": "",
-                        "url": "",
-                        "custom": ""
-                    },
-                    "dataType": "",
-                    "idPath": "id",
-                    "valueProperty": "",
-                    "limit": 100,
-                    "template": "<span>{{ item.label }}</span>",
-                    "refreshOn": "",
-                    "refreshOnBlur": "",
-                    "clearOnRefresh": false,
-                    "searchEnabled": true,
-                    "selectThreshold": 0.3,
-                    "readOnlyValue": false,
-                    "customOptions": {},
-                    "useExactSearch": false,
-                    "persistent": true,
-                    "protected": false,
-                    "dbIndex": false,
-                    "encrypted": false,
-                    "clearOnHide": true,
-                    "customDefaultValue": "",
-                    "calculateValue": "",
-                    "calculateServer": false,
-                    "allowCalculateOverride": false,
-                    "validateOn": "change",
-                    "validate": {
-                        "required": true,
-                        "onlyAvailableItems": false,
-                        "customMessage": "",
-                        "custom": "",
-                        "customPrivate": false,
-                        "json": "",
-                        "strictDateValidation": false,
-                        "multiple": false,
-                        "unique": false
-                    },
-                    "unique": false,
-                    "errorLabel": "",
-                    "errors": "",
-                    "key": "regulatoryBody",
-                    "tags": [],
-                    "properties": {},
-                    "conditional": {
-                        "show": "",
-                        "when": null,
-                        "eq": "",
-                        "json": ""
-                    },
-                    "customConditional": "",
-                    "logic": [],
-                    "attributes": {
-                        "data-cy": "regulatoryBody"
-                    },
-                    "overlay": {
-                        "style": "",
-                        "page": "",
-                        "left": "",
-                        "top": "",
-                        "width": "",
-                        "height": ""
-                    },
-                    "type": "select",
-                    "indexeddb": {
-                        "filter": {}
-                    },
-                    "selectFields": "",
-                    "searchField": "",
-                    "searchDebounce": 0.3,
-                    "minSearch": 0,
-                    "filter": "",
-                    "redrawOn": "",
-                    "input": true,
-                    "searchThreshold": 0.3,
-                    "prefix": "",
-                    "suffix": "",
-                    "dataGridLabel": false,
-                    "showCharCount": false,
-                    "showWordCount": false,
-                    "allowMultipleMasks": false,
-                    "addons": [],
-                    "lazyLoad": true,
-                    "authenticate": false,
-                    "ignoreCache": false,
-                    "fuseOptions": {
-                        "include": "score",
-                        "threshold": 0.3
-                    },
-                    "id": "e7o9328",
-                    "defaultValue": "",
                     "hideLabel": true
                 },
                 {
-                    "autofocus": false,
-                    "input": true,
-                    "tableView": true,
-                    "inputType": "text",
-                    "inputMask": "",
-                    "label": "Other institution regulatory body",
-                    "key": "otherRegulatoryBody",
-                    "placeholder": "",
-                    "prefix": "",
-                    "suffix": "",
-                    "multiple": false,
-                    "defaultValue": "",
-                    "protected": false,
-                    "unique": false,
-                    "persistent": true,
-                    "hidden": false,
-                    "clearOnHide": true,
-                    "spellcheck": true,
-                    "validate": {
-                        "required": true,
-                        "minLength": 1,
-                        "maxLength": 100,
-                        "pattern": "",
-                        "custom": "",
-                        "customPrivate": false
-                    },
-                    "conditional": {
-                        "show": "true",
-                        "when": "regulatoryBody",
-                        "eq": "other"
-                    },
-                    "type": "textfield",
-                    "labelPosition": "top",
-                    "inputFormat": "plain",
-                    "tags": [],
-                    "properties": {},
-                    "lockKey": true
-                }
-            ],
-            "placeholder": "",
-            "prefix": "",
-            "suffix": "",
-            "multiple": false,
-            "defaultValue": null,
-            "protected": false,
-            "unique": false,
-            "persistent": false,
-            "clearOnHide": false,
-            "refreshOn": "",
-            "redrawOn": "",
-            "dataGridLabel": false,
-            "labelPosition": "top",
-            "description": "",
-            "errorLabel": "",
-            "autofocus": false,
-            "dbIndex": false,
-            "customDefaultValue": "",
-            "calculateValue": "",
-            "calculateServer": false,
-            "widget": null,
-            "validateOn": "change",
-            "validate": {
-                "required": false,
-                "custom": "",
-                "customPrivate": false,
-                "strictDateValidation": false,
-                "multiple": false,
-                "unique": false
-            },
-            "allowCalculateOverride": false,
-            "encrypted": false,
-            "showCharCount": false,
-            "showWordCount": false,
-            "allowMultipleMasks": false,
-            "addons": [],
-            "tree": false,
-            "lazyLoad": false,
-            "id": "e1fg1xb"
-        },
-        {
-            "label": "HTML",
-            "labelWidth": "",
-            "labelMargin": "",
-            "tag": "h2",
-            "className": "category-header-large primary-color",
-            "attrs": [
-                {
-                    "attr": "",
-                    "value": ""
-                }
-            ],
-            "content": "Entrance requirements",
-            "refreshOnChange": false,
-            "customClass": "",
-            "hidden": false,
-            "modalEdit": false,
-            "key": "html8",
-            "tags": [],
-            "properties": {},
-            "conditional": {
-                "show": null,
-                "when": null,
-                "eq": "",
-                "json": ""
-            },
-            "customConditional": "",
-            "logic": [],
-            "attributes": {},
-            "overlay": {
-                "style": "",
-                "page": "",
-                "left": "",
-                "top": "",
-                "width": "",
-                "height": ""
-            },
-            "type": "htmlelement",
-            "input": false,
-            "tableView": false,
-            "placeholder": "",
-            "prefix": "",
-            "suffix": "",
-            "multiple": false,
-            "defaultValue": null,
-            "protected": false,
-            "unique": false,
-            "persistent": false,
-            "clearOnHide": true,
-            "refreshOn": "",
-            "redrawOn": "",
-            "dataGridLabel": false,
-            "labelPosition": "top",
-            "description": "",
-            "errorLabel": "",
-            "tooltip": "",
-            "tabindex": "",
-            "disabled": false,
-            "autofocus": false,
-            "dbIndex": false,
-            "customDefaultValue": "",
-            "calculateValue": "",
-            "calculateServer": false,
-            "widget": null,
-            "validateOn": "change",
-            "validate": {
-                "required": false,
-                "custom": "",
-                "customPrivate": false,
-                "strictDateValidation": false,
-                "multiple": false,
-                "unique": false
-            },
-            "allowCalculateOverride": false,
-            "encrypted": false,
-            "showCharCount": false,
-            "showWordCount": false,
-            "allowMultipleMasks": false,
-            "addons": [],
-            "id": "eezpkk",
-            "hideLabel": true
-        },
-        {
-            "title": "Panel",
-            "labelWidth": "",
-            "labelMargin": "",
-            "theme": "default",
-            "tooltip": "",
-            "customClass": "",
-            "collapsible": false,
-            "hidden": false,
-            "hideLabel": true,
-            "disabled": false,
-            "modalEdit": false,
-            "key": "panel8",
-            "tags": [],
-            "properties": {},
-            "customConditional": "",
-            "conditional": {
-                "json": "",
-                "show": null,
-                "when": null,
-                "eq": ""
-            },
-            "logic": [
-                {
-                    "name": "Disable Entrance Inputs",
-                    "trigger": {
-                        "type": "javascript",
-                        "javascript": "result = data.hasOfferings;"
-                    },
-                    "actions": [
-                        {
-                            "name": "Disable Inputs",
-                            "type": "property",
-                            "property": {
-                                "label": "Disabled",
-                                "value": "disabled",
-                                "type": "boolean"
-                            },
-                            "state": true
-                        }
-                    ]
-                }
-            ],
-            "attributes": {},
-            "overlay": {
-                "style": "",
-                "page": "",
-                "left": "",
-                "top": "",
-                "width": "",
-                "height": ""
-            },
-            "type": "panel",
-            "label": "Panel",
-            "breadcrumb": "default",
-            "tabindex": "",
-            "input": false,
-            "tableView": false,
-            "components": [
-                {
-                    "label": "What are the entrance requirements for this program? (Select all that apply)",
-                    "labelPosition": "top",
-                    "labelWidth": "",
-                    "labelMargin": "",
-                    "optionsLabelPosition": "right",
-                    "description": "",
-                    "tooltip": "",
-                    "customClass": "",
-                    "tabindex": "",
-                    "inline": false,
-                    "hidden": false,
-                    "autofocus": false,
-                    "disabled": false,
-                    "tableView": false,
-                    "modalEdit": false,
-                    "defaultValue": {
-                        "studentsToHaveGraduatedFromGrade12OrEquivalent": false,
-                        "studentsAre19YearsOldOrOlderBeforeTheStartOfClasses": false,
-                        "thisProgramHasEntranceRequirementsEstablishedByTheInstitutionThatEnableCompletionOfTheProgramStudy": false,
-                        "thisProgramIsApprovedByTheBCInudstryTrainingAuthorityAndStudentsMustMeetTheEntranceRequirementsSetByTheBCIta": false,
-                        "hasMinimunAge": false,
-                        "highSchool": false,
-                        "minHighSchool": false,
-                        "requirementsByInstitution": false,
-                        "requirementsByBcita": false,
-                        "hasMinimumAge": false,
-                        "requirementsByBCITA": false
-                    },
-                    "values": [
-                        {
-                            "label": "Students to have graduated from grade 12 or equivalent.",
-                            "value": "minHighSchool",
-                            "shortcut": ""
-                        },
-                        {
-                            "label": "Students are 19 years old or older before the start of classes.",
-                            "value": "hasMinimumAge",
-                            "shortcut": ""
-                        },
-                        {
-                            "label": "For post-secondary level academic credit-based programs: This program has entrance requirements established by the institution that enable completion of the program of study.",
-                            "value": "requirementsByInstitution",
-                            "shortcut": ""
-                        },
-                        {
-                            "label": "This program is approved by the SkilledTradesBC and students must meet the entrance requirements set by the B.C. ITA.",
-                            "value": "requirementsByBCITA",
-                            "shortcut": ""
-                        },
-                        {
-                            "value": "noneOfTheAboveEntranceRequirements",
-                            "label": "None of the above",
-                            "shortcut": ""
-                        }
-                    ],
-                    "persistent": true,
-                    "protected": false,
-                    "dbIndex": false,
-                    "encrypted": false,
-                    "redrawOn": "",
-                    "clearOnHide": true,
-                    "customDefaultValue": "",
-                    "calculateValue": "",
-                    "calculateServer": false,
-                    "allowCalculateOverride": false,
-                    "validate": {
-                        "required": true,
-                        "onlyAvailableItems": false,
-                        "customMessage": "",
-                        "minSelectedCount": "",
-                        "maxSelectedCount": "",
-                        "custom": "const shouldSelectOneOfTheAboveOrAnotherOption =\r\n  (data.entranceRequirements.minHighSchool ||\r\n    data.entranceRequirements.hasMinimumAge ||\r\n    data.entranceRequirements.requirementsByInstitution ||\r\n    data.entranceRequirements.requirementsByBCITA) &&\r\n  data.entranceRequirements.noneOfTheAboveEntranceRequirements;\r\n\r\nvalid = shouldSelectOneOfTheAboveOrAnotherOption\r\n  ? \"Please select at least one of the entrance requirements or 'None of the above'.\"\r\n  : true;",
-                        "customPrivate": false,
-                        "json": "",
-                        "strictDateValidation": false,
-                        "multiple": false,
-                        "unique": false
-                    },
-                    "errorLabel": "",
-                    "minSelectedCountMessage": "",
-                    "maxSelectedCountMessage": "",
-                    "errors": "",
-                    "key": "entranceRequirements",
-                    "tags": [],
-                    "properties": {},
-                    "conditional": {
-                        "show": "",
-                        "when": null,
-                        "eq": "",
-                        "json": ""
-                    },
-                    "customConditional": "",
-                    "logic": [],
-                    "attributes": {
-                        "data-cy": "entranceRequirements"
-                    },
-                    "overlay": {
-                        "style": "",
-                        "page": "",
-                        "left": "",
-                        "top": "",
-                        "width": "",
-                        "height": ""
-                    },
-                    "type": "selectboxes",
-                    "input": true,
-                    "inputType": "checkbox",
-                    "placeholder": "",
-                    "prefix": "",
-                    "suffix": "",
-                    "multiple": false,
-                    "unique": false,
-                    "refreshOn": "",
-                    "dataGridLabel": false,
-                    "widget": null,
-                    "validateOn": "change",
-                    "showCharCount": false,
-                    "showWordCount": false,
-                    "allowMultipleMasks": false,
-                    "addons": [],
-                    "fieldSet": false,
-                    "id": "egl3cl",
-                    "lockKey": true
-                },
-                {
-                    "label": "Entrance requirements warning banner",
-                    "className": "alert alert-warning fa fa-exclamation-circle",
-                    "attrs": [
-                        {
-                            "attr": "",
-                            "value": ""
-                        }
-                    ],
-                    "content": "<strong> This program is ineligible for StudentAid BC funding.</strong><br/>\nAn entrance requirement is required.",
-                    "refreshOnChange": false,
-                    "customClass": "banner-warning",
-                    "key": "entrance-requirement-banner",
-                    "conditional": {
-                        "show": null,
-                        "when": null,
-                        "eq": ""
-                    },
-                    "type": "htmlelement",
-                    "input": false,
-                    "tableView": false,
-                    "placeholder": "",
-                    "prefix": "",
-                    "suffix": "",
-                    "multiple": false,
-                    "defaultValue": null,
-                    "protected": false,
-                    "unique": false,
-                    "persistent": false,
-                    "hidden": false,
-                    "clearOnHide": true,
-                    "refreshOn": "",
-                    "redrawOn": "",
-                    "modalEdit": false,
-                    "dataGridLabel": false,
-                    "labelPosition": "top",
-                    "description": "",
-                    "errorLabel": "",
-                    "tooltip": "",
-                    "tabindex": "",
-                    "disabled": false,
-                    "autofocus": false,
-                    "dbIndex": false,
-                    "customDefaultValue": "",
-                    "calculateValue": "",
-                    "calculateServer": false,
-                    "widget": null,
-                    "attributes": {},
-                    "validateOn": "change",
-                    "validate": {
-                        "required": false,
-                        "custom": "",
-                        "customPrivate": false,
-                        "strictDateValidation": false,
-                        "multiple": false,
-                        "unique": false
-                    },
-                    "overlay": {
-                        "style": "",
-                        "left": "",
-                        "top": "",
-                        "width": "",
-                        "height": ""
-                    },
-                    "allowCalculateOverride": false,
-                    "encrypted": false,
-                    "showCharCount": false,
-                    "showWordCount": false,
-                    "properties": {},
-                    "allowMultipleMasks": false,
-                    "addons": [],
-                    "tag": "p",
-                    "id": "evsiyhh",
+                    "collapsible": false,
                     "hideLabel": true,
-                    "tags": [],
-                    "lockKey": true,
-                    "customConditional": "show = !!data.entranceRequirements.noneOfTheAboveEntranceRequirements;"
-                }
-            ],
-            "placeholder": "",
-            "prefix": "",
-            "suffix": "",
-            "multiple": false,
-            "defaultValue": null,
-            "protected": false,
-            "unique": false,
-            "persistent": false,
-            "clearOnHide": false,
-            "refreshOn": "",
-            "redrawOn": "",
-            "dataGridLabel": false,
-            "labelPosition": "top",
-            "description": "",
-            "errorLabel": "",
-            "autofocus": false,
-            "dbIndex": false,
-            "customDefaultValue": "",
-            "calculateValue": "",
-            "calculateServer": false,
-            "widget": null,
-            "validateOn": "change",
-            "validate": {
-                "required": false,
-                "custom": "",
-                "customPrivate": false,
-                "strictDateValidation": false,
-                "multiple": false,
-                "unique": false
-            },
-            "allowCalculateOverride": false,
-            "encrypted": false,
-            "showCharCount": false,
-            "showWordCount": false,
-            "allowMultipleMasks": false,
-            "addons": [],
-            "tree": false,
-            "lazyLoad": false,
-            "id": "eotcors"
-        },
-        {
-            "label": "HTML",
-            "labelWidth": "",
-            "labelMargin": "",
-            "tag": "h2",
-            "className": "category-header-large primary-color",
-            "attrs": [
-                {
-                    "attr": "",
-                    "value": ""
-                }
-            ],
-            "content": "English as a Second Language (ESL) content",
-            "refreshOnChange": false,
-            "customClass": "",
-            "hidden": false,
-            "modalEdit": false,
-            "key": "html9",
-            "tags": [],
-            "properties": {},
-            "conditional": {
-                "show": null,
-                "when": null,
-                "eq": "",
-                "json": ""
-            },
-            "customConditional": "",
-            "logic": [],
-            "attributes": {},
-            "overlay": {
-                "style": "",
-                "page": "",
-                "left": "",
-                "top": "",
-                "width": "",
-                "height": ""
-            },
-            "type": "htmlelement",
-            "input": false,
-            "tableView": false,
-            "placeholder": "",
-            "prefix": "",
-            "suffix": "",
-            "multiple": false,
-            "defaultValue": null,
-            "protected": false,
-            "unique": false,
-            "persistent": false,
-            "clearOnHide": true,
-            "refreshOn": "",
-            "redrawOn": "",
-            "dataGridLabel": false,
-            "labelPosition": "top",
-            "description": "",
-            "errorLabel": "",
-            "tooltip": "",
-            "hideLabel": false,
-            "tabindex": "",
-            "disabled": false,
-            "autofocus": false,
-            "dbIndex": false,
-            "customDefaultValue": "",
-            "calculateValue": "",
-            "calculateServer": false,
-            "widget": null,
-            "validateOn": "change",
-            "validate": {
-                "required": false,
-                "custom": "",
-                "customPrivate": false,
-                "strictDateValidation": false,
-                "multiple": false,
-                "unique": false
-            },
-            "allowCalculateOverride": false,
-            "encrypted": false,
-            "showCharCount": false,
-            "showWordCount": false,
-            "allowMultipleMasks": false,
-            "addons": [],
-            "id": "ecegrsq"
-        },
-        {
-            "title": "Panel",
-            "labelWidth": "",
-            "labelMargin": "",
-            "theme": "default",
-            "tooltip": "",
-            "customClass": "",
-            "collapsible": false,
-            "hidden": false,
-            "hideLabel": true,
-            "disabled": false,
-            "modalEdit": false,
-            "key": "panel9",
-            "tags": [],
-            "properties": {},
-            "customConditional": "",
-            "conditional": {
-                "json": "",
-                "show": null,
-                "when": null,
-                "eq": ""
-            },
-            "logic": [
-                {
-                    "name": "Disable ESL Inputs",
-                    "trigger": {
-                        "type": "javascript",
-                        "javascript": "result = data.hasOfferings;"
-                    },
-                    "actions": [
+                    "key": "panel8",
+                    "logic": [
                         {
-                            "name": "Disable Inputs",
-                            "type": "property",
-                            "property": {
-                                "label": "Disabled",
-                                "value": "disabled",
-                                "type": "boolean"
+                            "name": "Disable Entrance Inputs",
+                            "trigger": {
+                                "type": "javascript",
+                                "javascript": "result = data.hasOfferings;"
                             },
-                            "state": true
-                        }
-                    ]
-                }
-            ],
-            "attributes": {},
-            "overlay": {
-                "style": "",
-                "page": "",
-                "left": "",
-                "top": "",
-                "width": "",
-                "height": ""
-            },
-            "type": "panel",
-            "label": "Panel",
-            "breadcrumb": "default",
-            "tabindex": "",
-            "input": false,
-            "tableView": false,
-            "components": [
-                {
-                    "label": "What percentage of the program has ESL Content?",
-                    "labelPosition": "top",
-                    "labelWidth": "",
-                    "labelMargin": "",
-                    "optionsLabelPosition": "right",
-                    "description": "",
-                    "tooltip": "",
-                    "customClass": "",
-                    "tabindex": "",
-                    "inline": false,
-                    "hidden": false,
-                    "hideLabel": false,
-                    "autofocus": false,
-                    "disabled": false,
-                    "tableView": false,
-                    "modalEdit": false,
-                    "values": [
-                        {
-                            "label": "Less than 20%",
-                            "value": "lessThan20",
-                            "shortcut": ""
-                        },
-                        {
-                            "label": "20% or more",
-                            "value": "20OrMore",
-                            "shortcut": ""
+                            "actions": [
+                                {
+                                    "name": "Disable Inputs",
+                                    "type": "property",
+                                    "property": {
+                                        "label": "Disabled",
+                                        "value": "disabled",
+                                        "type": "boolean"
+                                    },
+                                    "state": true
+                                }
+                            ]
                         }
                     ],
-                    "dataType": "",
-                    "persistent": true,
-                    "protected": false,
-                    "dbIndex": false,
-                    "encrypted": false,
-                    "redrawOn": "data",
-                    "clearOnHide": true,
-                    "customDefaultValue": "",
-                    "calculateValue": "",
-                    "calculateServer": false,
-                    "allowCalculateOverride": false,
-                    "validate": {
-                        "required": true,
-                        "onlyAvailableItems": false,
-                        "customMessage": "",
-                        "custom": "",
-                        "customPrivate": false,
-                        "json": "",
-                        "strictDateValidation": false,
-                        "multiple": false,
-                        "unique": false
-                    },
-                    "errorLabel": "",
-                    "errors": "",
-                    "key": "eslEligibility",
-                    "tags": [],
-                    "properties": {},
-                    "conditional": {
-                        "show": null,
-                        "when": null,
-                        "eq": "",
-                        "json": ""
-                    },
-                    "customConditional": "",
-                    "logic": [],
-                    "attributes": {
-                        "data-cy": "eslEligibility"
-                    },
-                    "overlay": {
-                        "style": "",
-                        "page": "",
-                        "left": "",
-                        "top": "",
-                        "width": "",
-                        "height": ""
-                    },
-                    "type": "radio",
-                    "input": true,
-                    "placeholder": "",
-                    "prefix": "",
-                    "suffix": "",
-                    "multiple": false,
-                    "unique": false,
-                    "refreshOn": "",
-                    "dataGridLabel": false,
-                    "widget": null,
-                    "validateOn": "change",
-                    "showCharCount": false,
-                    "showWordCount": false,
-                    "allowMultipleMasks": false,
-                    "addons": [],
-                    "inputType": "radio",
-                    "fieldSet": false,
-                    "id": "ekau4o",
-                    "defaultValue": ""
-                },
-                {
-                    "label": "ESL Error",
-                    "className": "alert alert-warning fa fa-exclamation-circle",
-                    "attrs": [
-                        {
-                            "attr": "",
-                            "value": ""
-                        }
-                    ],
-                    "content": "<strong> This program is ineligible for StudentAid BC funding.</strong><br/>\nESL can’t exceed 20% of course content.",
-                    "refreshOnChange": false,
-                    "customClass": "banner-warning",
-                    "key": "html",
-                    "conditional": {
-                        "show": true,
-                        "when": "eslEligibility",
-                        "eq": "20OrMore"
-                    },
-                    "type": "htmlelement",
+                    "type": "panel",
+                    "label": "Panel",
                     "input": false,
                     "tableView": false,
-                    "placeholder": "",
-                    "prefix": "",
-                    "suffix": "",
-                    "multiple": false,
-                    "defaultValue": null,
-                    "protected": false,
-                    "unique": false,
-                    "persistent": false,
-                    "hidden": false,
-                    "clearOnHide": true,
-                    "refreshOn": "",
-                    "redrawOn": "",
-                    "modalEdit": false,
-                    "dataGridLabel": false,
-                    "labelPosition": "top",
-                    "description": "",
-                    "errorLabel": "",
-                    "tooltip": "",
-                    "hideLabel": false,
-                    "tabindex": "",
-                    "disabled": false,
-                    "autofocus": false,
-                    "dbIndex": false,
-                    "customDefaultValue": "",
-                    "calculateValue": "",
-                    "calculateServer": false,
-                    "widget": null,
-                    "attributes": {},
-                    "validateOn": "change",
-                    "validate": {
-                        "required": false,
-                        "custom": "",
-                        "customPrivate": false,
-                        "strictDateValidation": false,
-                        "multiple": false,
-                        "unique": false
-                    },
-                    "overlay": {
-                        "style": "",
-                        "left": "",
-                        "top": "",
-                        "width": "",
-                        "height": ""
-                    },
-                    "allowCalculateOverride": false,
-                    "encrypted": false,
-                    "showCharCount": false,
-                    "showWordCount": false,
-                    "properties": {},
-                    "allowMultipleMasks": false,
-                    "addons": [],
-                    "tag": "p",
-                    "id": "evsiyhh"
-                }
-            ],
-            "placeholder": "",
-            "prefix": "",
-            "suffix": "",
-            "multiple": false,
-            "defaultValue": null,
-            "protected": false,
-            "unique": false,
-            "persistent": false,
-            "clearOnHide": false,
-            "refreshOn": "",
-            "redrawOn": "",
-            "dataGridLabel": false,
-            "labelPosition": "top",
-            "description": "",
-            "errorLabel": "",
-            "autofocus": false,
-            "dbIndex": false,
-            "customDefaultValue": "",
-            "calculateValue": "",
-            "calculateServer": false,
-            "widget": null,
-            "validateOn": "change",
-            "validate": {
-                "required": false,
-                "custom": "",
-                "customPrivate": false,
-                "strictDateValidation": false,
-                "multiple": false,
-                "unique": false
-            },
-            "allowCalculateOverride": false,
-            "encrypted": false,
-            "showCharCount": false,
-            "showWordCount": false,
-            "allowMultipleMasks": false,
-            "addons": [],
-            "tree": false,
-            "lazyLoad": false,
-            "id": "ez6zpg6"
-        },
-        {
-            "label": "Program partnerships",
-            "labelWidth": "",
-            "labelMargin": "",
-            "tag": "h2",
-            "className": "category-header-large primary-color",
-            "attrs": [
-                {
-                    "attr": "",
-                    "value": ""
-                }
-            ],
-            "content": "Program partnerships",
-            "refreshOnChange": false,
-            "customClass": "",
-            "hidden": false,
-            "modalEdit": false,
-            "key": "programPartnerships",
-            "tags": [],
-            "properties": {},
-            "conditional": {
-                "show": null,
-                "when": null,
-                "eq": "",
-                "json": ""
-            },
-            "customConditional": "",
-            "logic": [],
-            "attributes": {},
-            "overlay": {
-                "style": "",
-                "page": "",
-                "left": "",
-                "top": "",
-                "width": "",
-                "height": ""
-            },
-            "type": "htmlelement",
-            "input": false,
-            "tableView": false,
-            "placeholder": "",
-            "prefix": "",
-            "suffix": "",
-            "multiple": false,
-            "defaultValue": null,
-            "protected": false,
-            "unique": false,
-            "persistent": false,
-            "clearOnHide": true,
-            "refreshOn": "",
-            "redrawOn": "",
-            "dataGridLabel": false,
-            "labelPosition": "top",
-            "description": "",
-            "errorLabel": "",
-            "tooltip": "",
-            "hideLabel": false,
-            "tabindex": "",
-            "disabled": false,
-            "autofocus": false,
-            "dbIndex": false,
-            "customDefaultValue": "",
-            "calculateValue": "",
-            "calculateServer": false,
-            "widget": null,
-            "validateOn": "change",
-            "validate": {
-                "required": false,
-                "custom": "",
-                "customPrivate": false,
-                "strictDateValidation": false,
-                "multiple": false,
-                "unique": false
-            },
-            "allowCalculateOverride": false,
-            "encrypted": false,
-            "showCharCount": false,
-            "showWordCount": false,
-            "allowMultipleMasks": false,
-            "addons": [],
-            "id": "epxr6f"
-        },
-        {
-            "label": "HTML",
-            "tag": "p",
-            "className": "",
-            "attrs": [
-                {
-                    "attr": "",
-                    "value": ""
-                }
-            ],
-            "content": "If this program is offered at a partner institution, that institution must also be designated by SABC. Find out which institutions are designated on <a href=\"https://studentaidbc.ca/\">StudentAidBC.ca.</a>",
-            "refreshOnChange": false,
-            "customClass": "mt-n2",
-            "hidden": false,
-            "modalEdit": false,
-            "key": "html10",
-            "tags": [],
-            "properties": {},
-            "conditional": {
-                "show": null,
-                "when": null,
-                "eq": "",
-                "json": ""
-            },
-            "customConditional": "",
-            "logic": [],
-            "attributes": {},
-            "overlay": {
-                "style": "",
-                "page": "",
-                "left": "",
-                "top": "",
-                "width": "",
-                "height": ""
-            },
-            "type": "htmlelement",
-            "input": false,
-            "tableView": false,
-            "placeholder": "",
-            "prefix": "",
-            "suffix": "",
-            "multiple": false,
-            "defaultValue": null,
-            "protected": false,
-            "unique": false,
-            "persistent": false,
-            "clearOnHide": true,
-            "refreshOn": "",
-            "redrawOn": "",
-            "dataGridLabel": false,
-            "labelPosition": "top",
-            "description": "",
-            "errorLabel": "",
-            "tooltip": "",
-            "hideLabel": false,
-            "tabindex": "",
-            "disabled": false,
-            "autofocus": false,
-            "dbIndex": false,
-            "customDefaultValue": "",
-            "calculateValue": "",
-            "calculateServer": false,
-            "widget": null,
-            "validateOn": "change",
-            "validate": {
-                "required": false,
-                "custom": "",
-                "customPrivate": false,
-                "strictDateValidation": false,
-                "multiple": false,
-                "unique": false
-            },
-            "allowCalculateOverride": false,
-            "encrypted": false,
-            "showCharCount": false,
-            "showWordCount": false,
-            "allowMultipleMasks": false,
-            "id": "ea288xg",
-            "addons": []
-        },
-        {
-            "title": "Panel",
-            "labelWidth": "",
-            "labelMargin": "",
-            "theme": "default",
-            "tooltip": "",
-            "customClass": "",
-            "collapsible": false,
-            "hidden": false,
-            "hideLabel": true,
-            "disabled": false,
-            "modalEdit": false,
-            "key": "panel10",
-            "tags": [],
-            "properties": {},
-            "customConditional": "",
-            "conditional": {
-                "json": "",
-                "show": null,
-                "when": null,
-                "eq": ""
-            },
-            "logic": [
-                {
-                    "name": "Disable Partnership Input",
-                    "trigger": {
-                        "type": "javascript",
-                        "javascript": "result = data.hasOfferings;"
-                    },
-                    "actions": [
+                    "components": [
                         {
-                            "name": "Disable Input",
-                            "type": "property",
-                            "property": {
-                                "label": "Disabled",
-                                "value": "disabled",
-                                "type": "boolean"
+                            "label": "What are the entrance requirements for this program? (Select all that apply)",
+                            "optionsLabelPosition": "right",
+                            "tableView": false,
+                            "defaultValue": {
+                                "studentsToHaveGraduatedFromGrade12OrEquivalent": false,
+                                "studentsAre19YearsOldOrOlderBeforeTheStartOfClasses": false,
+                                "thisProgramHasEntranceRequirementsEstablishedByTheInstitutionThatEnableCompletionOfTheProgramStudy": false,
+                                "thisProgramIsApprovedByTheBCInudstryTrainingAuthorityAndStudentsMustMeetTheEntranceRequirementsSetByTheBCIta": false,
+                                "hasMinimunAge": false,
+                                "highSchool": false,
+                                "minHighSchool": false,
+                                "requirementsByInstitution": false,
+                                "requirementsByBcita": false,
+                                "hasMinimumAge": false,
+                                "requirementsByBCITA": false,
+                                "noneOfTheAboveEntranceRequirements": false
                             },
-                            "state": true
+                            "values": [
+                                {
+                                    "label": "Students to have graduated from grade 12 or equivalent.",
+                                    "value": "minHighSchool",
+                                    "shortcut": ""
+                                },
+                                {
+                                    "label": "Students are 19 years old or older before the start of classes.",
+                                    "value": "hasMinimumAge",
+                                    "shortcut": ""
+                                },
+                                {
+                                    "label": "For post-secondary level academic credit-based programs: This program has entrance requirements established by the institution that enable completion of the program of study.",
+                                    "value": "requirementsByInstitution",
+                                    "shortcut": ""
+                                },
+                                {
+                                    "label": "This program is approved by the SkilledTradesBC and students must meet the entrance requirements set by the B.C. ITA.",
+                                    "value": "requirementsByBCITA",
+                                    "shortcut": ""
+                                },
+                                {
+                                    "value": "noneOfTheAboveEntranceRequirements",
+                                    "label": "None of the above",
+                                    "shortcut": ""
+                                }
+                            ],
+                            "validate": {
+                                "required": true,
+                                "custom": "const shouldSelectOneOfTheAboveOrAnotherOption =\r\n  (data.entranceRequirements.minHighSchool ||\r\n    data.entranceRequirements.hasMinimumAge ||\r\n    data.entranceRequirements.requirementsByInstitution ||\r\n    data.entranceRequirements.requirementsByBCITA) &&\r\n  data.entranceRequirements.noneOfTheAboveEntranceRequirements;\r\n\r\nvalid = shouldSelectOneOfTheAboveOrAnotherOption\r\n  ? \"Please select at least one of the entrance requirements or 'None of the above'.\"\r\n  : true;"
+                            },
+                            "key": "entranceRequirements",
+                            "attributes": {
+                                "data-cy": "entranceRequirements"
+                            },
+                            "type": "selectboxes",
+                            "input": true,
+                            "inputType": "checkbox",
+                            "lockKey": true
+                        },
+                        {
+                            "label": "Entrance requirements warning banner",
+                            "className": "alert alert-warning fa fa-exclamation-circle",
+                            "attrs": [
+                                {
+                                    "attr": "",
+                                    "value": ""
+                                }
+                            ],
+                            "content": "<strong> This program is ineligible for StudentAid BC funding.</strong><br/>\nAn entrance requirement is required.",
+                            "refreshOnChange": false,
+                            "customClass": "banner-warning",
+                            "key": "entrance-requirement-banner",
+                            "type": "htmlelement",
+                            "input": false,
+                            "tableView": false,
+                            "hideLabel": true,
+                            "lockKey": true,
+                            "customConditional": "show = !!data.entranceRequirements.noneOfTheAboveEntranceRequirements;"
                         }
                     ]
-                }
-            ],
-            "attributes": {},
-            "overlay": {
-                "style": "",
-                "page": "",
-                "left": "",
-                "top": "",
-                "width": "",
-                "height": ""
-            },
-            "type": "panel",
-            "label": "Panel",
-            "breadcrumb": "default",
-            "tabindex": "",
-            "input": false,
-            "tableView": false,
-            "components": [
-                {
-                    "label": "Is the program offered jointly or in partnership with other institutions?",
-                    "labelPosition": "top",
-                    "labelWidth": "",
-                    "labelMargin": "",
-                    "optionsLabelPosition": "right",
-                    "description": "",
-                    "tooltip": "",
-                    "customClass": "",
-                    "tabindex": "",
-                    "inline": false,
-                    "hidden": false,
-                    "hideLabel": false,
-                    "autofocus": false,
-                    "disabled": false,
-                    "tableView": false,
-                    "modalEdit": false,
-                    "values": [
-                        {
-                            "label": "Yes",
-                            "value": "yes",
-                            "shortcut": ""
-                        },
-                        {
-                            "label": "No",
-                            "value": "no",
-                            "shortcut": ""
-                        }
-                    ],
-                    "dataType": "",
-                    "persistent": true,
-                    "protected": false,
-                    "dbIndex": false,
-                    "encrypted": false,
-                    "redrawOn": "",
-                    "clearOnHide": true,
-                    "customDefaultValue": "",
-                    "calculateValue": "",
-                    "calculateServer": false,
-                    "allowCalculateOverride": false,
-                    "validate": {
-                        "required": true,
-                        "onlyAvailableItems": false,
-                        "customMessage": "",
-                        "custom": "",
-                        "customPrivate": false,
-                        "json": "",
-                        "strictDateValidation": false,
-                        "multiple": false,
-                        "unique": false
-                    },
-                    "errorLabel": "",
-                    "errors": "",
-                    "key": "hasJointInstitution",
-                    "tags": [],
-                    "properties": {},
-                    "conditional": {
-                        "show": null,
-                        "when": null,
-                        "eq": "",
-                        "json": ""
-                    },
-                    "customConditional": "",
-                    "logic": [],
-                    "attributes": {
-                        "data-cy": "hasJointInstitution"
-                    },
-                    "overlay": {
-                        "style": "",
-                        "page": "",
-                        "left": "",
-                        "top": "",
-                        "width": "",
-                        "height": ""
-                    },
-                    "type": "radio",
-                    "input": true,
-                    "placeholder": "",
-                    "prefix": "",
-                    "suffix": "",
-                    "multiple": false,
-                    "unique": false,
-                    "refreshOn": "",
-                    "dataGridLabel": false,
-                    "widget": null,
-                    "validateOn": "change",
-                    "showCharCount": false,
-                    "showWordCount": false,
-                    "allowMultipleMasks": false,
-                    "addons": [],
-                    "inputType": "radio",
-                    "fieldSet": false,
-                    "id": "ect6j35",
-                    "defaultValue": ""
-                },
-                {
-                    "label": "Are all institutions you partner with for this program designated by Student Aid BC?",
-                    "labelPosition": "top",
-                    "labelWidth": "",
-                    "labelMargin": "",
-                    "optionsLabelPosition": "right",
-                    "description": "",
-                    "tooltip": "",
-                    "customClass": "",
-                    "tabindex": "",
-                    "inline": false,
-                    "hidden": false,
-                    "hideLabel": false,
-                    "autofocus": false,
-                    "disabled": false,
-                    "tableView": false,
-                    "modalEdit": false,
-                    "values": [
-                        {
-                            "label": "Yes",
-                            "value": "yes",
-                            "shortcut": ""
-                        },
-                        {
-                            "label": "No",
-                            "value": "no",
-                            "shortcut": ""
-                        }
-                    ],
-                    "dataType": "",
-                    "persistent": true,
-                    "protected": false,
-                    "dbIndex": false,
-                    "encrypted": false,
-                    "redrawOn": "",
-                    "clearOnHide": true,
-                    "customDefaultValue": "",
-                    "calculateValue": "",
-                    "calculateServer": false,
-                    "allowCalculateOverride": false,
-                    "validate": {
-                        "required": true,
-                        "onlyAvailableItems": false,
-                        "customMessage": "",
-                        "custom": "",
-                        "customPrivate": false,
-                        "json": "",
-                        "strictDateValidation": false,
-                        "multiple": false,
-                        "unique": false
-                    },
-                    "errorLabel": "",
-                    "errors": "",
-                    "key": "hasJointDesignatedInstitution",
-                    "tags": [],
-                    "properties": {},
-                    "conditional": {
-                        "show": true,
-                        "when": "hasJointInstitution",
-                        "eq": "yes",
-                        "json": ""
-                    },
-                    "customConditional": "",
-                    "logic": [],
-                    "attributes": {
-                        "data-cy": "hasJointDesignatedInstitution"
-                    },
-                    "overlay": {
-                        "style": "",
-                        "page": "",
-                        "left": "",
-                        "top": "",
-                        "width": "",
-                        "height": ""
-                    },
-                    "type": "radio",
-                    "input": true,
-                    "placeholder": "",
-                    "prefix": "",
-                    "suffix": "",
-                    "multiple": false,
-                    "unique": false,
-                    "refreshOn": "",
-                    "dataGridLabel": false,
-                    "widget": null,
-                    "validateOn": "change",
-                    "showCharCount": false,
-                    "showWordCount": false,
-                    "allowMultipleMasks": false,
-                    "addons": [],
-                    "inputType": "radio",
-                    "fieldSet": false,
-                    "id": "el7ezzb",
-                    "defaultValue": ""
-                },
-                {
-                    "label": "Join Program Error",
-                    "className": "alert alert-warning fa fa-exclamation-circle",
-                    "attrs": [
-                        {
-                            "attr": "",
-                            "value": ""
-                        }
-                    ],
-                    "content": "<strong> This program is ineligible for StudentAid BC funding.</strong><br/>\nAll partner institutions must be designated by StudentAid BC..",
-                    "refreshOnChange": false,
-                    "customClass": "banner-warning",
-                    "key": "joinProgramError",
-                    "conditional": {
-                        "show": true,
-                        "when": "hasJointDesignatedInstitution",
-                        "eq": "no"
-                    },
-                    "type": "htmlelement",
-                    "input": false,
-                    "tableView": false,
-                    "placeholder": "",
-                    "prefix": "",
-                    "suffix": "",
-                    "multiple": false,
-                    "defaultValue": null,
-                    "protected": false,
-                    "unique": false,
-                    "persistent": false,
-                    "hidden": false,
-                    "clearOnHide": true,
-                    "refreshOn": "",
-                    "redrawOn": "",
-                    "modalEdit": false,
-                    "dataGridLabel": false,
-                    "labelPosition": "top",
-                    "description": "",
-                    "errorLabel": "",
-                    "tooltip": "",
-                    "hideLabel": false,
-                    "tabindex": "",
-                    "disabled": false,
-                    "autofocus": false,
-                    "dbIndex": false,
-                    "customDefaultValue": "",
-                    "calculateValue": "",
-                    "calculateServer": false,
-                    "widget": null,
-                    "attributes": {},
-                    "validateOn": "change",
-                    "validate": {
-                        "required": false,
-                        "custom": "",
-                        "customPrivate": false,
-                        "strictDateValidation": false,
-                        "multiple": false,
-                        "unique": false
-                    },
-                    "overlay": {
-                        "style": "",
-                        "left": "",
-                        "top": "",
-                        "width": "",
-                        "height": ""
-                    },
-                    "allowCalculateOverride": false,
-                    "encrypted": false,
-                    "showCharCount": false,
-                    "showWordCount": false,
-                    "properties": {},
-                    "allowMultipleMasks": false,
-                    "addons": [],
-                    "tag": "p",
-                    "id": "ekm8tmk"
-                }
-            ],
-            "placeholder": "",
-            "prefix": "",
-            "suffix": "",
-            "multiple": false,
-            "defaultValue": null,
-            "protected": false,
-            "unique": false,
-            "persistent": false,
-            "clearOnHide": false,
-            "refreshOn": "",
-            "redrawOn": "",
-            "dataGridLabel": false,
-            "labelPosition": "top",
-            "description": "",
-            "errorLabel": "",
-            "autofocus": false,
-            "dbIndex": false,
-            "customDefaultValue": "",
-            "calculateValue": "",
-            "calculateServer": false,
-            "widget": null,
-            "validateOn": "change",
-            "validate": {
-                "required": false,
-                "custom": "",
-                "customPrivate": false,
-                "strictDateValidation": false,
-                "multiple": false,
-                "unique": false
-            },
-            "allowCalculateOverride": false,
-            "encrypted": false,
-            "showCharCount": false,
-            "showWordCount": false,
-            "allowMultipleMasks": false,
-            "addons": [],
-            "tree": false,
-            "lazyLoad": false,
-            "id": "elve7jc"
-        },
-        {
-            "label": "HTML",
-            "labelWidth": "",
-            "labelMargin": "",
-            "tag": "h2",
-            "className": "category-header-large primary-color",
-            "attrs": [
-                {
-                    "attr": "",
-                    "value": ""
-                }
-            ],
-            "content": "Work-integrated learning (WIL)",
-            "refreshOnChange": false,
-            "customClass": "",
-            "hidden": false,
-            "modalEdit": false,
-            "key": "html13",
-            "tags": [],
-            "properties": {},
-            "conditional": {
-                "show": null,
-                "when": null,
-                "eq": "",
-                "json": ""
-            },
-            "customConditional": "",
-            "logic": [],
-            "attributes": {},
-            "overlay": {
-                "style": "",
-                "page": "",
-                "left": "",
-                "top": "",
-                "width": "",
-                "height": ""
-            },
-            "type": "htmlelement",
-            "input": false,
-            "tableView": false,
-            "placeholder": "",
-            "prefix": "",
-            "suffix": "",
-            "multiple": false,
-            "defaultValue": null,
-            "protected": false,
-            "unique": false,
-            "persistent": false,
-            "clearOnHide": true,
-            "refreshOn": "",
-            "redrawOn": "",
-            "dataGridLabel": false,
-            "labelPosition": "top",
-            "description": "",
-            "errorLabel": "",
-            "tooltip": "",
-            "hideLabel": false,
-            "tabindex": "",
-            "disabled": false,
-            "autofocus": false,
-            "dbIndex": false,
-            "customDefaultValue": "",
-            "calculateValue": "",
-            "calculateServer": false,
-            "widget": null,
-            "validateOn": "change",
-            "validate": {
-                "required": false,
-                "custom": "",
-                "customPrivate": false,
-                "strictDateValidation": false,
-                "multiple": false,
-                "unique": false
-            },
-            "allowCalculateOverride": false,
-            "encrypted": false,
-            "showCharCount": false,
-            "showWordCount": false,
-            "allowMultipleMasks": false,
-            "addons": [],
-            "id": "eluszxy"
-        },
-        {
-            "title": "Panel",
-            "labelWidth": "",
-            "labelMargin": "",
-            "theme": "default",
-            "tooltip": "",
-            "customClass": "",
-            "collapsible": false,
-            "hidden": false,
-            "hideLabel": true,
-            "disabled": false,
-            "modalEdit": false,
-            "key": "panel13",
-            "tags": [],
-            "properties": {},
-            "customConditional": "",
-            "conditional": {
-                "json": "",
-                "show": null,
-                "when": null,
-                "eq": ""
-            },
-            "logic": [
-                {
-                    "name": "Disable WIL Input",
-                    "trigger": {
-                        "type": "javascript",
-                        "javascript": "result = data.hasOfferings;"
-                    },
-                    "actions": [
-                        {
-                            "name": "Disable Input",
-                            "type": "property",
-                            "property": {
-                                "label": "Disabled",
-                                "value": "disabled",
-                                "type": "boolean"
-                            },
-                            "state": true
-                        }
-                    ]
-                }
-            ],
-            "attributes": {},
-            "overlay": {
-                "style": "",
-                "page": "",
-                "left": "",
-                "top": "",
-                "width": "",
-                "height": ""
-            },
-            "type": "panel",
-            "label": "Panel",
-            "breadcrumb": "default",
-            "tabindex": "",
-            "input": false,
-            "tableView": false,
-            "components": [
-                {
-                    "label": "Does this program have a WIL component?",
-                    "labelPosition": "top",
-                    "labelWidth": "",
-                    "labelMargin": "",
-                    "optionsLabelPosition": "right",
-                    "description": "",
-                    "tooltip": "",
-                    "customClass": "",
-                    "tabindex": "",
-                    "inline": false,
-                    "hidden": false,
-                    "hideLabel": false,
-                    "autofocus": false,
-                    "disabled": false,
-                    "tableView": false,
-                    "modalEdit": false,
-                    "values": [
-                        {
-                            "label": "Yes",
-                            "value": "yes",
-                            "shortcut": ""
-                        },
-                        {
-                            "label": "No",
-                            "value": "no",
-                            "shortcut": ""
-                        }
-                    ],
-                    "dataType": "",
-                    "persistent": true,
-                    "protected": false,
-                    "dbIndex": false,
-                    "encrypted": false,
-                    "redrawOn": "",
-                    "clearOnHide": true,
-                    "customDefaultValue": "",
-                    "calculateValue": "",
-                    "calculateServer": false,
-                    "allowCalculateOverride": false,
-                    "validate": {
-                        "required": true,
-                        "onlyAvailableItems": false,
-                        "customMessage": "",
-                        "custom": "",
-                        "customPrivate": false,
-                        "json": "",
-                        "strictDateValidation": false,
-                        "multiple": false,
-                        "unique": false
-                    },
-                    "errorLabel": "",
-                    "errors": "",
-                    "key": "hasWILComponent",
-                    "tags": [],
-                    "properties": {},
-                    "conditional": {
-                        "show": null,
-                        "when": null,
-                        "eq": "",
-                        "json": ""
-                    },
-                    "customConditional": "",
-                    "logic": [],
-                    "attributes": {
-                        "data-cy": "hasWILComponent"
-                    },
-                    "overlay": {
-                        "style": "",
-                        "page": "",
-                        "left": "",
-                        "top": "",
-                        "width": "",
-                        "height": ""
-                    },
-                    "type": "radio",
-                    "input": true,
-                    "placeholder": "",
-                    "prefix": "",
-                    "suffix": "",
-                    "multiple": false,
-                    "unique": false,
-                    "refreshOn": "",
-                    "dataGridLabel": false,
-                    "widget": null,
-                    "validateOn": "change",
-                    "showCharCount": false,
-                    "showWordCount": false,
-                    "allowMultipleMasks": false,
-                    "addons": [],
-                    "inputType": "radio",
-                    "fieldSet": false,
-                    "id": "euaf0n5",
-                    "defaultValue": ""
-                },
-                {
-                    "label": "Is the WIL approved by your regulator or oversight body?",
-                    "labelPosition": "top",
-                    "labelWidth": "",
-                    "labelMargin": "",
-                    "optionsLabelPosition": "right",
-                    "description": "",
-                    "tooltip": "",
-                    "customClass": "",
-                    "tabindex": "",
-                    "inline": false,
-                    "hidden": false,
-                    "hideLabel": false,
-                    "autofocus": false,
-                    "disabled": false,
-                    "tableView": false,
-                    "modalEdit": false,
-                    "values": [
-                        {
-                            "label": "Yes",
-                            "value": "yes",
-                            "shortcut": ""
-                        },
-                        {
-                            "label": "No",
-                            "value": "no",
-                            "shortcut": ""
-                        }
-                    ],
-                    "dataType": "",
-                    "persistent": true,
-                    "protected": false,
-                    "dbIndex": false,
-                    "encrypted": false,
-                    "redrawOn": "",
-                    "clearOnHide": true,
-                    "customDefaultValue": "",
-                    "calculateValue": "",
-                    "calculateServer": false,
-                    "allowCalculateOverride": false,
-                    "validate": {
-                        "required": true,
-                        "onlyAvailableItems": false,
-                        "customMessage": "",
-                        "custom": "",
-                        "customPrivate": false,
-                        "json": "",
-                        "strictDateValidation": false,
-                        "multiple": false,
-                        "unique": false
-                    },
-                    "errorLabel": "",
-                    "errors": "",
-                    "key": "isWILApproved",
-                    "tags": [],
-                    "properties": {},
-                    "conditional": {
-                        "show": true,
-                        "when": "hasWILComponent",
-                        "eq": "yes",
-                        "json": ""
-                    },
-                    "customConditional": "",
-                    "logic": [],
-                    "attributes": {
-                        "data-cy": "isWILApproved"
-                    },
-                    "overlay": {
-                        "style": "",
-                        "page": "",
-                        "left": "",
-                        "top": "",
-                        "width": "",
-                        "height": ""
-                    },
-                    "type": "radio",
-                    "input": true,
-                    "placeholder": "",
-                    "prefix": "",
-                    "suffix": "",
-                    "multiple": false,
-                    "unique": false,
-                    "refreshOn": "",
-                    "dataGridLabel": false,
-                    "widget": null,
-                    "validateOn": "change",
-                    "showCharCount": false,
-                    "showWordCount": false,
-                    "allowMultipleMasks": false,
-                    "addons": [],
-                    "inputType": "radio",
-                    "fieldSet": false,
-                    "id": "eas5r7",
-                    "defaultValue": ""
                 },
                 {
                     "label": "HTML",
-                    "className": "alert alert-warning fa fa-exclamation-circle",
+                    "tag": "h2",
+                    "className": "category-header-large primary-color",
                     "attrs": [
                         {
                             "attr": "",
                             "value": ""
                         }
                     ],
-                    "content": "<strong> This program is ineligible for StudentAid BC funding</strong><br>The work-integrated learning component must be approved by your regulator or oversight body first.",
+                    "content": "English as a Second Language (ESL) content",
                     "refreshOnChange": false,
-                    "customClass": "banner-warning",
-                    "key": "html14",
-                    "customConditional": "show = (data.hasWILComponent === \"yes\" && data.isWILApproved === \"no\");",
+                    "key": "html9",
                     "type": "htmlelement",
                     "input": false,
-                    "tableView": false,
-                    "placeholder": "",
-                    "prefix": "",
-                    "suffix": "",
-                    "multiple": false,
-                    "defaultValue": null,
-                    "protected": false,
-                    "unique": false,
-                    "persistent": false,
-                    "hidden": false,
-                    "clearOnHide": true,
-                    "refreshOn": "",
-                    "redrawOn": "",
-                    "modalEdit": false,
-                    "dataGridLabel": false,
-                    "labelPosition": "top",
-                    "description": "",
-                    "errorLabel": "",
-                    "tooltip": "",
-                    "hideLabel": false,
-                    "tabindex": "",
-                    "disabled": false,
-                    "autofocus": false,
-                    "dbIndex": false,
-                    "customDefaultValue": "",
-                    "calculateValue": "",
-                    "calculateServer": false,
-                    "widget": null,
-                    "attributes": {},
-                    "validateOn": "change",
-                    "validate": {
-                        "required": false,
-                        "custom": "",
-                        "customPrivate": false,
-                        "strictDateValidation": false,
-                        "multiple": false,
-                        "unique": false
-                    },
-                    "conditional": {
-                        "show": null,
-                        "when": null,
-                        "eq": ""
-                    },
-                    "overlay": {
-                        "style": "",
-                        "left": "",
-                        "top": "",
-                        "width": "",
-                        "height": ""
-                    },
-                    "allowCalculateOverride": false,
-                    "encrypted": false,
-                    "showCharCount": false,
-                    "showWordCount": false,
-                    "properties": {},
-                    "allowMultipleMasks": false,
-                    "addons": [],
-                    "tag": "p",
-                    "id": "e97jmf"
+                    "tableView": false
                 },
                 {
-                    "label": "Does the WIL meet the program eligibility requirements according to StudentAid BC policy?",
-                    "labelPosition": "top",
-                    "labelWidth": "",
-                    "labelMargin": "",
-                    "optionsLabelPosition": "right",
-                    "description": "",
-                    "tooltip": "",
-                    "customClass": "",
-                    "tabindex": "",
-                    "inline": false,
-                    "hidden": false,
-                    "hideLabel": false,
-                    "autofocus": false,
-                    "disabled": false,
-                    "tableView": false,
-                    "modalEdit": false,
-                    "values": [
+                    "collapsible": false,
+                    "hideLabel": true,
+                    "key": "panel9",
+                    "logic": [
                         {
-                            "label": "Yes",
-                            "value": "yes",
-                            "shortcut": ""
+                            "name": "Disable ESL Inputs",
+                            "trigger": {
+                                "type": "javascript",
+                                "javascript": "result = data.hasOfferings;"
+                            },
+                            "actions": [
+                                {
+                                    "name": "Disable Inputs",
+                                    "type": "property",
+                                    "property": {
+                                        "label": "Disabled",
+                                        "value": "disabled",
+                                        "type": "boolean"
+                                    },
+                                    "state": true
+                                }
+                            ]
+                        }
+                    ],
+                    "type": "panel",
+                    "label": "Panel",
+                    "input": false,
+                    "tableView": false,
+                    "components": [
+                        {
+                            "label": "What percentage of the program has ESL Content?",
+                            "optionsLabelPosition": "right",
+                            "inline": false,
+                            "tableView": false,
+                            "values": [
+                                {
+                                    "label": "Less than 20%",
+                                    "value": "lessThan20",
+                                    "shortcut": ""
+                                },
+                                {
+                                    "label": "20% or more",
+                                    "value": "20OrMore",
+                                    "shortcut": ""
+                                }
+                            ],
+                            "redrawOn": "data",
+                            "validate": {
+                                "required": true
+                            },
+                            "key": "eslEligibility",
+                            "attributes": {
+                                "data-cy": "eslEligibility"
+                            },
+                            "type": "radio",
+                            "input": true
                         },
                         {
-                            "label": "No",
-                            "value": "no",
-                            "shortcut": ""
-                        }
-                    ],
-                    "dataType": "",
-                    "persistent": true,
-                    "protected": false,
-                    "dbIndex": false,
-                    "encrypted": false,
-                    "redrawOn": "data",
-                    "clearOnHide": true,
-                    "customDefaultValue": "",
-                    "calculateValue": "",
-                    "calculateServer": false,
-                    "allowCalculateOverride": false,
-                    "validate": {
-                        "required": true,
-                        "onlyAvailableItems": false,
-                        "customMessage": "",
-                        "custom": "",
-                        "customPrivate": false,
-                        "json": "",
-                        "strictDateValidation": false,
-                        "multiple": false,
-                        "unique": false
-                    },
-                    "errorLabel": "",
-                    "errors": "",
-                    "key": "wilProgramEligibility",
-                    "tags": [],
-                    "properties": {},
-                    "conditional": {
-                        "show": null,
-                        "when": null,
-                        "eq": "",
-                        "json": ""
-                    },
-                    "customConditional": "show = (data.hasWILComponent === \"yes\" && data.isWILApproved === \"yes\");",
-                    "logic": [],
-                    "attributes": {
-                        "data-cy": "wilProgramEligibility"
-                    },
-                    "overlay": {
-                        "style": "",
-                        "page": "",
-                        "left": "",
-                        "top": "",
-                        "width": "",
-                        "height": ""
-                    },
-                    "type": "radio",
-                    "input": true,
-                    "placeholder": "",
-                    "prefix": "",
-                    "suffix": "",
-                    "multiple": false,
-                    "unique": false,
-                    "refreshOn": "",
-                    "dataGridLabel": false,
-                    "widget": null,
-                    "validateOn": "change",
-                    "showCharCount": false,
-                    "showWordCount": false,
-                    "allowMultipleMasks": false,
-                    "addons": [],
-                    "inputType": "radio",
-                    "fieldSet": false,
-                    "id": "es0u0up",
-                    "defaultValue": ""
-                },
-                {
-                    "label": "HTML",
-                    "className": "alert alert-warning fa fa-exclamation-circle",
-                    "attrs": [
-                        {
-                            "attr": "",
-                            "value": ""
-                        }
-                    ],
-                    "content": "<strong> This program is ineligible for StudentAid BC funding</strong><br>This must meet the StudentAid BC policy.",
-                    "refreshOnChange": false,
-                    "customClass": "banner-warning",
-                    "key": "html15",
-                    "customConditional": "show = (data.hasWILComponent === \"yes\" && data.isWILApproved === \"yes\" && data.wilProgramEligibility === \"no\");",
-                    "type": "htmlelement",
-                    "input": false,
-                    "tableView": false,
-                    "placeholder": "",
-                    "prefix": "",
-                    "suffix": "",
-                    "multiple": false,
-                    "defaultValue": null,
-                    "protected": false,
-                    "unique": false,
-                    "persistent": false,
-                    "hidden": false,
-                    "clearOnHide": true,
-                    "refreshOn": "",
-                    "redrawOn": "",
-                    "modalEdit": false,
-                    "dataGridLabel": false,
-                    "labelPosition": "top",
-                    "description": "",
-                    "errorLabel": "",
-                    "tooltip": "",
-                    "hideLabel": false,
-                    "tabindex": "",
-                    "disabled": false,
-                    "autofocus": false,
-                    "dbIndex": false,
-                    "customDefaultValue": "",
-                    "calculateValue": "",
-                    "calculateServer": false,
-                    "widget": null,
-                    "attributes": {},
-                    "validateOn": "change",
-                    "validate": {
-                        "required": false,
-                        "custom": "",
-                        "customPrivate": false,
-                        "strictDateValidation": false,
-                        "multiple": false,
-                        "unique": false
-                    },
-                    "conditional": {
-                        "show": null,
-                        "when": null,
-                        "eq": ""
-                    },
-                    "overlay": {
-                        "style": "",
-                        "left": "",
-                        "top": "",
-                        "width": "",
-                        "height": ""
-                    },
-                    "allowCalculateOverride": false,
-                    "encrypted": false,
-                    "showCharCount": false,
-                    "showWordCount": false,
-                    "properties": {},
-                    "allowMultipleMasks": false,
-                    "addons": [],
-                    "tag": "p",
-                    "id": "es5wzcb"
-                }
-            ],
-            "placeholder": "",
-            "prefix": "",
-            "suffix": "",
-            "multiple": false,
-            "defaultValue": null,
-            "protected": false,
-            "unique": false,
-            "persistent": false,
-            "clearOnHide": false,
-            "refreshOn": "",
-            "redrawOn": "",
-            "dataGridLabel": false,
-            "labelPosition": "top",
-            "description": "",
-            "errorLabel": "",
-            "autofocus": false,
-            "dbIndex": false,
-            "customDefaultValue": "",
-            "calculateValue": "",
-            "calculateServer": false,
-            "widget": null,
-            "validateOn": "change",
-            "validate": {
-                "required": false,
-                "custom": "",
-                "customPrivate": false,
-                "strictDateValidation": false,
-                "multiple": false,
-                "unique": false
-            },
-            "allowCalculateOverride": false,
-            "encrypted": false,
-            "showCharCount": false,
-            "showWordCount": false,
-            "allowMultipleMasks": false,
-            "addons": [],
-            "tree": false,
-            "lazyLoad": false,
-            "id": "enuzo2q"
-        },
-        {
-            "label": "HTML",
-            "labelWidth": "",
-            "labelMargin": "",
-            "tag": "h2",
-            "className": "category-header-large primary-color",
-            "attrs": [
-                {
-                    "attr": "",
-                    "value": ""
-                }
-            ],
-            "content": "Field trip, field placement, or travel",
-            "refreshOnChange": false,
-            "customClass": "",
-            "hidden": false,
-            "modalEdit": false,
-            "key": "html16",
-            "tags": [],
-            "properties": {},
-            "conditional": {
-                "show": null,
-                "when": null,
-                "eq": "",
-                "json": ""
-            },
-            "customConditional": "",
-            "logic": [],
-            "attributes": {},
-            "overlay": {
-                "style": "",
-                "page": "",
-                "left": "",
-                "top": "",
-                "width": "",
-                "height": ""
-            },
-            "type": "htmlelement",
-            "input": false,
-            "tableView": false,
-            "placeholder": "",
-            "prefix": "",
-            "suffix": "",
-            "multiple": false,
-            "defaultValue": null,
-            "protected": false,
-            "unique": false,
-            "persistent": false,
-            "clearOnHide": true,
-            "refreshOn": "",
-            "redrawOn": "",
-            "dataGridLabel": false,
-            "labelPosition": "top",
-            "description": "",
-            "errorLabel": "",
-            "tooltip": "",
-            "hideLabel": false,
-            "tabindex": "",
-            "disabled": false,
-            "autofocus": false,
-            "dbIndex": false,
-            "customDefaultValue": "",
-            "calculateValue": "",
-            "calculateServer": false,
-            "widget": null,
-            "validateOn": "change",
-            "validate": {
-                "required": false,
-                "custom": "",
-                "customPrivate": false,
-                "strictDateValidation": false,
-                "multiple": false,
-                "unique": false
-            },
-            "allowCalculateOverride": false,
-            "encrypted": false,
-            "showCharCount": false,
-            "showWordCount": false,
-            "allowMultipleMasks": false,
-            "addons": [],
-            "id": "ev5sta"
-        },
-        {
-            "title": "Panel",
-            "labelWidth": "",
-            "labelMargin": "",
-            "theme": "default",
-            "tooltip": "",
-            "customClass": "",
-            "collapsible": false,
-            "hidden": false,
-            "hideLabel": true,
-            "disabled": false,
-            "modalEdit": false,
-            "key": "panel16",
-            "tags": [],
-            "properties": {},
-            "customConditional": "",
-            "conditional": {
-                "json": "",
-                "show": null,
-                "when": null,
-                "eq": ""
-            },
-            "logic": [
-                {
-                    "name": "Disable Field Trip Input",
-                    "trigger": {
-                        "type": "javascript",
-                        "javascript": "result = data.hasOfferings;"
-                    },
-                    "actions": [
-                        {
-                            "name": "Disable Input",
-                            "type": "property",
-                            "property": {
-                                "label": "Disabled",
-                                "value": "disabled",
-                                "type": "boolean"
+                            "label": "ESL Error",
+                            "className": "alert alert-warning fa fa-exclamation-circle",
+                            "attrs": [
+                                {
+                                    "attr": "",
+                                    "value": ""
+                                }
+                            ],
+                            "content": "<strong> This program is ineligible for StudentAid BC funding.</strong><br/>\nESL can’t exceed 20% of course content.",
+                            "refreshOnChange": false,
+                            "customClass": "banner-warning",
+                            "key": "html",
+                            "conditional": {
+                                "show": true,
+                                "when": "eslEligibility",
+                                "eq": "20OrMore"
                             },
-                            "state": true
+                            "type": "htmlelement",
+                            "input": false,
+                            "tableView": false
                         }
                     ]
-                }
-            ],
-            "attributes": {},
-            "overlay": {
-                "style": "",
-                "page": "",
-                "left": "",
-                "top": "",
-                "width": "",
-                "height": ""
-            },
-            "type": "panel",
-            "label": "Panel",
-            "breadcrumb": "default",
-            "tabindex": "",
-            "input": false,
-            "tableView": false,
-            "components": [
-                {
-                    "label": "Is a field trip, field placement or travel part of this program?",
-                    "labelPosition": "top",
-                    "labelWidth": "",
-                    "labelMargin": "",
-                    "optionsLabelPosition": "right",
-                    "description": "",
-                    "tooltip": "",
-                    "customClass": "",
-                    "tabindex": "",
-                    "inline": false,
-                    "hidden": false,
-                    "hideLabel": false,
-                    "autofocus": false,
-                    "disabled": false,
-                    "tableView": false,
-                    "modalEdit": false,
-                    "values": [
-                        {
-                            "label": "Yes",
-                            "value": "yes",
-                            "shortcut": ""
-                        },
-                        {
-                            "label": "No",
-                            "value": "no",
-                            "shortcut": ""
-                        }
-                    ],
-                    "dataType": "",
-                    "persistent": true,
-                    "protected": false,
-                    "dbIndex": false,
-                    "encrypted": false,
-                    "redrawOn": "",
-                    "clearOnHide": true,
-                    "customDefaultValue": "",
-                    "calculateValue": "",
-                    "calculateServer": false,
-                    "allowCalculateOverride": false,
-                    "validate": {
-                        "required": true,
-                        "onlyAvailableItems": false,
-                        "customMessage": "",
-                        "custom": "",
-                        "customPrivate": false,
-                        "json": "",
-                        "strictDateValidation": false,
-                        "multiple": false,
-                        "unique": false
-                    },
-                    "errorLabel": "",
-                    "errors": "",
-                    "key": "hasTravel",
-                    "tags": [],
-                    "properties": {},
-                    "conditional": {
-                        "show": null,
-                        "when": null,
-                        "eq": "",
-                        "json": ""
-                    },
-                    "customConditional": "",
-                    "logic": [],
-                    "attributes": {
-                        "data-cy": "hasTravel"
-                    },
-                    "overlay": {
-                        "style": "",
-                        "page": "",
-                        "left": "",
-                        "top": "",
-                        "width": "",
-                        "height": ""
-                    },
-                    "type": "radio",
-                    "input": true,
-                    "placeholder": "",
-                    "prefix": "",
-                    "suffix": "",
-                    "multiple": false,
-                    "unique": false,
-                    "refreshOn": "",
-                    "dataGridLabel": false,
-                    "widget": null,
-                    "validateOn": "change",
-                    "showCharCount": false,
-                    "showWordCount": false,
-                    "allowMultipleMasks": false,
-                    "addons": [],
-                    "inputType": "radio",
-                    "fieldSet": false,
-                    "id": "ey4ggp",
-                    "defaultValue": ""
                 },
                 {
-                    "label": "Does the field trip, field placement, or travel meet the program eligibility requirements according to StudentAid BC policy?",
-                    "labelPosition": "top",
-                    "labelWidth": "",
-                    "labelMargin": "",
-                    "optionsLabelPosition": "right",
-                    "description": "",
-                    "tooltip": "",
-                    "customClass": "",
-                    "tabindex": "",
-                    "inline": false,
-                    "hidden": false,
-                    "hideLabel": false,
-                    "autofocus": false,
-                    "disabled": false,
-                    "tableView": false,
-                    "modalEdit": false,
-                    "values": [
-                        {
-                            "label": "Yes",
-                            "value": "yes",
-                            "shortcut": ""
-                        },
-                        {
-                            "label": "No",
-                            "value": "no",
-                            "shortcut": ""
-                        }
-                    ],
-                    "dataType": "",
-                    "persistent": true,
-                    "protected": false,
-                    "dbIndex": false,
-                    "encrypted": false,
-                    "redrawOn": "",
-                    "clearOnHide": true,
-                    "customDefaultValue": "",
-                    "calculateValue": "",
-                    "calculateServer": false,
-                    "allowCalculateOverride": false,
-                    "validate": {
-                        "required": true,
-                        "onlyAvailableItems": false,
-                        "customMessage": "",
-                        "custom": "",
-                        "customPrivate": false,
-                        "json": "",
-                        "strictDateValidation": false,
-                        "multiple": false,
-                        "unique": false
-                    },
-                    "errorLabel": "",
-                    "errors": "",
-                    "key": "travelProgramEligibility",
-                    "tags": [],
-                    "properties": {},
-                    "conditional": {
-                        "show": true,
-                        "when": "hasTravel",
-                        "eq": "yes",
-                        "json": ""
-                    },
-                    "customConditional": "",
-                    "logic": [],
-                    "attributes": {
-                        "data-cy": "travelProgramEligibility"
-                    },
-                    "overlay": {
-                        "style": "",
-                        "page": "",
-                        "left": "",
-                        "top": "",
-                        "width": "",
-                        "height": ""
-                    },
-                    "type": "radio",
-                    "input": true,
-                    "placeholder": "",
-                    "prefix": "",
-                    "suffix": "",
-                    "multiple": false,
-                    "unique": false,
-                    "refreshOn": "",
-                    "dataGridLabel": false,
-                    "widget": null,
-                    "validateOn": "change",
-                    "showCharCount": false,
-                    "showWordCount": false,
-                    "allowMultipleMasks": false,
-                    "addons": [],
-                    "inputType": "radio",
-                    "fieldSet": false,
-                    "id": "eutg67n",
-                    "defaultValue": ""
-                },
-                {
-                    "label": "HTML",
-                    "className": "alert alert-warning fa fa-exclamation-circle",
+                    "label": "Program partnerships",
+                    "tag": "h2",
+                    "className": "category-header-large primary-color",
                     "attrs": [
                         {
                             "attr": "",
                             "value": ""
                         }
                     ],
-                    "content": "<strong> This program is ineligible for StudentAid BC funding</strong><br>This must meet the StudentAid BC policy.",
+                    "content": "Program partnerships",
                     "refreshOnChange": false,
-                    "customClass": "banner-warning",
-                    "key": "html17",
-                    "customConditional": "show = (data.hasTravel === \"yes\" && data.travelProgramEligibility === \"no\");",
+                    "key": "programPartnerships",
                     "type": "htmlelement",
                     "input": false,
-                    "tableView": false,
-                    "placeholder": "",
-                    "prefix": "",
-                    "suffix": "",
-                    "multiple": false,
-                    "defaultValue": null,
-                    "protected": false,
-                    "unique": false,
-                    "persistent": false,
-                    "hidden": false,
-                    "clearOnHide": true,
-                    "refreshOn": "",
-                    "redrawOn": "",
-                    "modalEdit": false,
-                    "dataGridLabel": false,
-                    "labelPosition": "top",
-                    "description": "",
-                    "errorLabel": "",
-                    "tooltip": "",
-                    "hideLabel": false,
-                    "tabindex": "",
-                    "disabled": false,
-                    "autofocus": false,
-                    "dbIndex": false,
-                    "customDefaultValue": "",
-                    "calculateValue": "",
-                    "calculateServer": false,
-                    "widget": null,
-                    "attributes": {},
-                    "validateOn": "change",
-                    "validate": {
-                        "required": false,
-                        "custom": "",
-                        "customPrivate": false,
-                        "strictDateValidation": false,
-                        "multiple": false,
-                        "unique": false
-                    },
-                    "conditional": {
-                        "show": null,
-                        "when": null,
-                        "eq": ""
-                    },
-                    "overlay": {
-                        "style": "",
-                        "left": "",
-                        "top": "",
-                        "width": "",
-                        "height": ""
-                    },
-                    "allowCalculateOverride": false,
-                    "encrypted": false,
-                    "showCharCount": false,
-                    "showWordCount": false,
-                    "properties": {},
-                    "allowMultipleMasks": false,
-                    "addons": [],
-                    "tag": "p",
-                    "id": "ew9ecfm"
-                }
-            ],
-            "placeholder": "",
-            "prefix": "",
-            "suffix": "",
-            "multiple": false,
-            "defaultValue": null,
-            "protected": false,
-            "unique": false,
-            "persistent": false,
-            "clearOnHide": false,
-            "refreshOn": "",
-            "redrawOn": "",
-            "dataGridLabel": false,
-            "labelPosition": "top",
-            "description": "",
-            "errorLabel": "",
-            "autofocus": false,
-            "dbIndex": false,
-            "customDefaultValue": "",
-            "calculateValue": "",
-            "calculateServer": false,
-            "widget": null,
-            "validateOn": "change",
-            "validate": {
-                "required": false,
-                "custom": "",
-                "customPrivate": false,
-                "strictDateValidation": false,
-                "multiple": false,
-                "unique": false
-            },
-            "allowCalculateOverride": false,
-            "encrypted": false,
-            "showCharCount": false,
-            "showWordCount": false,
-            "allowMultipleMasks": false,
-            "addons": [],
-            "tree": false,
-            "lazyLoad": false,
-            "id": "e3kva1s"
-        },
-        {
-            "label": "HTML",
-            "labelWidth": "",
-            "labelMargin": "",
-            "tag": "h2",
-            "className": "category-header-large primary-color",
-            "attrs": [
-                {
-                    "attr": "",
-                    "value": ""
-                }
-            ],
-            "content": "International exchange",
-            "refreshOnChange": false,
-            "customClass": "",
-            "hidden": false,
-            "modalEdit": false,
-            "key": "html18",
-            "tags": [],
-            "properties": {},
-            "conditional": {
-                "show": null,
-                "when": null,
-                "eq": "",
-                "json": ""
-            },
-            "customConditional": "",
-            "logic": [],
-            "attributes": {},
-            "overlay": {
-                "style": "",
-                "page": "",
-                "left": "",
-                "top": "",
-                "width": "",
-                "height": ""
-            },
-            "type": "htmlelement",
-            "input": false,
-            "tableView": false,
-            "placeholder": "",
-            "prefix": "",
-            "suffix": "",
-            "multiple": false,
-            "defaultValue": null,
-            "protected": false,
-            "unique": false,
-            "persistent": false,
-            "clearOnHide": true,
-            "refreshOn": "",
-            "redrawOn": "",
-            "dataGridLabel": false,
-            "labelPosition": "top",
-            "description": "",
-            "errorLabel": "",
-            "tooltip": "",
-            "hideLabel": false,
-            "tabindex": "",
-            "disabled": false,
-            "autofocus": false,
-            "dbIndex": false,
-            "customDefaultValue": "",
-            "calculateValue": "",
-            "calculateServer": false,
-            "widget": null,
-            "validateOn": "change",
-            "validate": {
-                "required": false,
-                "custom": "",
-                "customPrivate": false,
-                "strictDateValidation": false,
-                "multiple": false,
-                "unique": false
-            },
-            "allowCalculateOverride": false,
-            "encrypted": false,
-            "showCharCount": false,
-            "showWordCount": false,
-            "allowMultipleMasks": false,
-            "addons": [],
-            "id": "efsbaoc"
-        },
-        {
-            "title": "Panel",
-            "labelWidth": "",
-            "labelMargin": "",
-            "theme": "default",
-            "tooltip": "",
-            "customClass": "",
-            "collapsible": false,
-            "hidden": false,
-            "hideLabel": true,
-            "disabled": false,
-            "modalEdit": false,
-            "key": "panel18",
-            "tags": [],
-            "properties": {},
-            "customConditional": "",
-            "conditional": {
-                "json": "",
-                "show": null,
-                "when": null,
-                "eq": ""
-            },
-            "logic": [
-                {
-                    "name": "Disable Exchange Input",
-                    "trigger": {
-                        "type": "javascript",
-                        "javascript": "result = data.hasOfferings;"
-                    },
-                    "actions": [
-                        {
-                            "name": "Disable Input",
-                            "type": "property",
-                            "property": {
-                                "label": "Disabled",
-                                "value": "disabled",
-                                "type": "boolean"
-                            },
-                            "state": true
-                        }
-                    ]
-                }
-            ],
-            "attributes": {},
-            "overlay": {
-                "style": "",
-                "page": "",
-                "left": "",
-                "top": "",
-                "width": "",
-                "height": ""
-            },
-            "type": "panel",
-            "label": "Panel",
-            "breadcrumb": "default",
-            "tabindex": "",
-            "input": false,
-            "tableView": false,
-            "components": [
-                {
-                    "label": "Does the program have an international exchange?",
-                    "labelPosition": "top",
-                    "labelWidth": "",
-                    "labelMargin": "",
-                    "optionsLabelPosition": "right",
-                    "description": "",
-                    "tooltip": "",
-                    "customClass": "",
-                    "tabindex": "",
-                    "inline": false,
-                    "hidden": false,
-                    "hideLabel": false,
-                    "autofocus": false,
-                    "disabled": false,
-                    "tableView": false,
-                    "modalEdit": false,
-                    "values": [
-                        {
-                            "label": "Yes",
-                            "value": "yes",
-                            "shortcut": ""
-                        },
-                        {
-                            "label": "No",
-                            "value": "no",
-                            "shortcut": ""
-                        }
-                    ],
-                    "dataType": "",
-                    "persistent": true,
-                    "protected": false,
-                    "dbIndex": false,
-                    "encrypted": false,
-                    "redrawOn": "",
-                    "clearOnHide": true,
-                    "customDefaultValue": "",
-                    "calculateValue": "",
-                    "calculateServer": false,
-                    "allowCalculateOverride": false,
-                    "validate": {
-                        "required": true,
-                        "onlyAvailableItems": false,
-                        "customMessage": "",
-                        "custom": "",
-                        "customPrivate": false,
-                        "json": "",
-                        "strictDateValidation": false,
-                        "multiple": false,
-                        "unique": false
-                    },
-                    "errorLabel": "",
-                    "errors": "",
-                    "key": "hasIntlExchange",
-                    "tags": [],
-                    "properties": {},
-                    "conditional": {
-                        "show": null,
-                        "when": null,
-                        "eq": "",
-                        "json": ""
-                    },
-                    "customConditional": "",
-                    "logic": [],
-                    "attributes": {
-                        "data-cy": "hasIntlExchange"
-                    },
-                    "overlay": {
-                        "style": "",
-                        "page": "",
-                        "left": "",
-                        "top": "",
-                        "width": "",
-                        "height": ""
-                    },
-                    "type": "radio",
-                    "input": true,
-                    "placeholder": "",
-                    "prefix": "",
-                    "suffix": "",
-                    "multiple": false,
-                    "unique": false,
-                    "refreshOn": "",
-                    "dataGridLabel": false,
-                    "widget": null,
-                    "validateOn": "change",
-                    "showCharCount": false,
-                    "showWordCount": false,
-                    "allowMultipleMasks": false,
-                    "addons": [],
-                    "inputType": "radio",
-                    "fieldSet": false,
-                    "id": "eav2vh",
-                    "defaultValue": ""
+                    "tableView": false
                 },
-                {
-                    "label": "Does the international exchange meet the program eligibility requirements according to StudentAid BC policy?",
-                    "labelPosition": "top",
-                    "labelWidth": "",
-                    "labelMargin": "",
-                    "optionsLabelPosition": "right",
-                    "description": "",
-                    "tooltip": "",
-                    "customClass": "",
-                    "tabindex": "",
-                    "inline": false,
-                    "hidden": false,
-                    "hideLabel": false,
-                    "autofocus": false,
-                    "disabled": false,
-                    "tableView": false,
-                    "modalEdit": false,
-                    "values": [
-                        {
-                            "label": "Yes",
-                            "value": "yes",
-                            "shortcut": ""
-                        },
-                        {
-                            "label": "No",
-                            "value": "no",
-                            "shortcut": ""
-                        }
-                    ],
-                    "dataType": "",
-                    "persistent": true,
-                    "protected": false,
-                    "dbIndex": false,
-                    "encrypted": false,
-                    "redrawOn": "",
-                    "clearOnHide": true,
-                    "customDefaultValue": "",
-                    "calculateValue": "",
-                    "calculateServer": false,
-                    "allowCalculateOverride": false,
-                    "validate": {
-                        "required": true,
-                        "onlyAvailableItems": false,
-                        "customMessage": "",
-                        "custom": "",
-                        "customPrivate": false,
-                        "json": "",
-                        "strictDateValidation": false,
-                        "multiple": false,
-                        "unique": false
-                    },
-                    "errorLabel": "",
-                    "errors": "",
-                    "key": "intlExchangeProgramEligibility",
-                    "tags": [],
-                    "properties": {},
-                    "conditional": {
-                        "show": true,
-                        "when": "hasIntlExchange",
-                        "eq": "yes",
-                        "json": ""
-                    },
-                    "customConditional": "",
-                    "logic": [],
-                    "attributes": {
-                        "data-cy": "intlExchangeProgramEligibility"
-                    },
-                    "overlay": {
-                        "style": "",
-                        "page": "",
-                        "left": "",
-                        "top": "",
-                        "width": "",
-                        "height": ""
-                    },
-                    "type": "radio",
-                    "input": true,
-                    "placeholder": "",
-                    "prefix": "",
-                    "suffix": "",
-                    "multiple": false,
-                    "unique": false,
-                    "refreshOn": "",
-                    "dataGridLabel": false,
-                    "widget": null,
-                    "validateOn": "change",
-                    "showCharCount": false,
-                    "showWordCount": false,
-                    "allowMultipleMasks": false,
-                    "addons": [],
-                    "inputType": "radio",
-                    "fieldSet": false,
-                    "id": "emcp5rn",
-                    "defaultValue": ""
-                },
-                {
-                    "label": "HTML",
-                    "className": "alert alert-warning fa fa-exclamation-circle",
-                    "attrs": [
-                        {
-                            "attr": "",
-                            "value": ""
-                        }
-                    ],
-                    "content": "<strong> This program is ineligible for StudentAid BC funding</strong><br>This must meet the StudentAid BC policy.",
-                    "refreshOnChange": false,
-                    "customClass": "banner-warning",
-                    "key": "html19",
-                    "customConditional": "show = (data.hasIntlExchange === \"yes\" && data.intlExchangeProgramEligibility === \"no\");",
-                    "type": "htmlelement",
-                    "input": false,
-                    "tableView": false,
-                    "placeholder": "",
-                    "prefix": "",
-                    "suffix": "",
-                    "multiple": false,
-                    "defaultValue": null,
-                    "protected": false,
-                    "unique": false,
-                    "persistent": false,
-                    "hidden": false,
-                    "clearOnHide": true,
-                    "refreshOn": "",
-                    "redrawOn": "",
-                    "modalEdit": false,
-                    "dataGridLabel": false,
-                    "labelPosition": "top",
-                    "description": "",
-                    "errorLabel": "",
-                    "tooltip": "",
-                    "hideLabel": false,
-                    "tabindex": "",
-                    "disabled": false,
-                    "autofocus": false,
-                    "dbIndex": false,
-                    "customDefaultValue": "",
-                    "calculateValue": "",
-                    "calculateServer": false,
-                    "widget": null,
-                    "attributes": {},
-                    "validateOn": "change",
-                    "validate": {
-                        "required": false,
-                        "custom": "",
-                        "customPrivate": false,
-                        "strictDateValidation": false,
-                        "multiple": false,
-                        "unique": false
-                    },
-                    "conditional": {
-                        "show": null,
-                        "when": null,
-                        "eq": ""
-                    },
-                    "overlay": {
-                        "style": "",
-                        "left": "",
-                        "top": "",
-                        "width": "",
-                        "height": ""
-                    },
-                    "allowCalculateOverride": false,
-                    "encrypted": false,
-                    "showCharCount": false,
-                    "showWordCount": false,
-                    "properties": {},
-                    "allowMultipleMasks": false,
-                    "addons": [],
-                    "tag": "p",
-                    "id": "e76mex"
-                }
-            ],
-            "placeholder": "",
-            "prefix": "",
-            "suffix": "",
-            "multiple": false,
-            "defaultValue": null,
-            "protected": false,
-            "unique": false,
-            "persistent": false,
-            "clearOnHide": false,
-            "refreshOn": "",
-            "redrawOn": "",
-            "dataGridLabel": false,
-            "labelPosition": "top",
-            "description": "",
-            "errorLabel": "",
-            "autofocus": false,
-            "dbIndex": false,
-            "customDefaultValue": "",
-            "calculateValue": "",
-            "calculateServer": false,
-            "widget": null,
-            "validateOn": "change",
-            "validate": {
-                "required": false,
-                "custom": "",
-                "customPrivate": false,
-                "strictDateValidation": false,
-                "multiple": false,
-                "unique": false
-            },
-            "allowCalculateOverride": false,
-            "encrypted": false,
-            "showCharCount": false,
-            "showWordCount": false,
-            "allowMultipleMasks": false,
-            "addons": [],
-            "tree": false,
-            "lazyLoad": false,
-            "id": "et7eh68"
-        },
-        {
-            "label": "Declaration",
-            "labelWidth": "",
-            "labelMargin": "",
-            "tag": "h2",
-            "className": "category-header-large primary-color",
-            "attrs": [
-                {
-                    "attr": "",
-                    "value": ""
-                }
-            ],
-            "content": "Declaration",
-            "refreshOnChange": false,
-            "customClass": "",
-            "hidden": false,
-            "modalEdit": false,
-            "key": "declaration",
-            "tags": [],
-            "properties": {},
-            "conditional": {
-                "show": null,
-                "when": null,
-                "eq": "",
-                "json": ""
-            },
-            "customConditional": "",
-            "logic": [],
-            "attributes": {},
-            "overlay": {
-                "style": "",
-                "page": "",
-                "left": "",
-                "top": "",
-                "width": "",
-                "height": ""
-            },
-            "type": "htmlelement",
-            "input": false,
-            "tableView": false,
-            "placeholder": "",
-            "prefix": "",
-            "suffix": "",
-            "multiple": false,
-            "defaultValue": null,
-            "protected": false,
-            "unique": false,
-            "persistent": false,
-            "clearOnHide": true,
-            "refreshOn": "",
-            "redrawOn": "",
-            "dataGridLabel": false,
-            "labelPosition": "top",
-            "description": "",
-            "errorLabel": "",
-            "tooltip": "",
-            "hideLabel": false,
-            "tabindex": "",
-            "disabled": false,
-            "autofocus": false,
-            "dbIndex": false,
-            "customDefaultValue": "",
-            "calculateValue": "",
-            "calculateServer": false,
-            "widget": null,
-            "validateOn": "change",
-            "validate": {
-                "required": false,
-                "custom": "",
-                "customPrivate": false,
-                "strictDateValidation": false,
-                "multiple": false,
-                "unique": false
-            },
-            "allowCalculateOverride": false,
-            "encrypted": false,
-            "showCharCount": false,
-            "showWordCount": false,
-            "allowMultipleMasks": false,
-            "addons": [],
-            "id": "e92jch"
-        },
-        {
-            "title": "Panel",
-            "labelWidth": "",
-            "labelMargin": "",
-            "theme": "default",
-            "tooltip": "",
-            "customClass": "",
-            "collapsible": false,
-            "hidden": false,
-            "hideLabel": true,
-            "disabled": false,
-            "modalEdit": false,
-            "key": "panel12",
-            "tags": [],
-            "properties": {},
-            "customConditional": "",
-            "conditional": {
-                "json": "",
-                "show": null,
-                "when": null,
-                "eq": ""
-            },
-            "logic": [
-                {
-                    "name": "Disable Declaration Input",
-                    "trigger": {
-                        "type": "javascript",
-                        "javascript": "result = data.hasOfferings;"
-                    },
-                    "actions": [
-                        {
-                            "name": "Disable Input",
-                            "type": "property",
-                            "property": {
-                                "label": "Disabled",
-                                "value": "disabled",
-                                "type": "boolean"
-                            },
-                            "state": true
-                        }
-                    ]
-                }
-            ],
-            "attributes": {},
-            "overlay": {
-                "style": "",
-                "page": "",
-                "left": "",
-                "top": "",
-                "width": "",
-                "height": ""
-            },
-            "type": "panel",
-            "label": "Panel",
-            "breadcrumb": "default",
-            "tabindex": "",
-            "input": false,
-            "tableView": false,
-            "components": [
                 {
                     "label": "HTML",
                     "attrs": [
@@ -5984,431 +1131,671 @@
                             "value": ""
                         }
                     ],
-                    "content": "All information is subject to verification and auditing.",
+                    "content": "If this program is offered at a partner institution, that institution must also be designated by SABC. Find out which institutions are designated on <a href=\"https://studentaidbc.ca/\">StudentAidBC.ca.</a>",
                     "refreshOnChange": false,
-                    "customClass": "category-header-medium-small primary-color",
-                    "key": "html12",
+                    "customClass": "mt-n2",
+                    "key": "html10",
                     "type": "htmlelement",
                     "input": false,
-                    "tableView": false,
-                    "placeholder": "",
-                    "prefix": "",
-                    "suffix": "",
-                    "multiple": false,
-                    "defaultValue": null,
-                    "protected": false,
-                    "unique": false,
-                    "persistent": false,
-                    "hidden": false,
-                    "clearOnHide": true,
-                    "refreshOn": "",
-                    "redrawOn": "",
-                    "modalEdit": false,
-                    "dataGridLabel": false,
-                    "labelPosition": "top",
-                    "description": "",
-                    "errorLabel": "",
-                    "tooltip": "",
-                    "hideLabel": false,
-                    "tabindex": "",
-                    "disabled": false,
-                    "autofocus": false,
-                    "dbIndex": false,
-                    "customDefaultValue": "",
-                    "calculateValue": "",
-                    "calculateServer": false,
-                    "widget": null,
-                    "attributes": {},
-                    "validateOn": "change",
-                    "validate": {
-                        "required": false,
-                        "custom": "",
-                        "customPrivate": false,
-                        "strictDateValidation": false,
-                        "multiple": false,
-                        "unique": false
-                    },
-                    "conditional": {
-                        "show": null,
-                        "when": null,
-                        "eq": ""
-                    },
-                    "overlay": {
-                        "style": "",
-                        "left": "",
-                        "top": "",
-                        "width": "",
-                        "height": ""
-                    },
-                    "allowCalculateOverride": false,
-                    "encrypted": false,
-                    "showCharCount": false,
-                    "showWordCount": false,
-                    "properties": {},
-                    "allowMultipleMasks": false,
-                    "addons": [],
-                    "tag": "p",
-                    "id": "exxean",
-                    "className": ""
+                    "tableView": false
                 },
                 {
-                    "label": "I confirm this program meets the policies outlined in the StudentAid BC policy manual.",
-                    "labelWidth": "",
-                    "labelMargin": "",
-                    "description": "",
-                    "tooltip": "",
-                    "shortcut": "",
-                    "inputType": "checkbox",
-                    "customClass": "",
-                    "tabindex": "",
-                    "hidden": false,
-                    "hideLabel": false,
-                    "autofocus": false,
-                    "disabled": false,
+                    "collapsible": false,
+                    "hideLabel": true,
+                    "key": "panel10",
+                    "logic": [
+                        {
+                            "name": "Disable Partnership Input",
+                            "trigger": {
+                                "type": "javascript",
+                                "javascript": "result = data.hasOfferings;"
+                            },
+                            "actions": [
+                                {
+                                    "name": "Disable Input",
+                                    "type": "property",
+                                    "property": {
+                                        "label": "Disabled",
+                                        "value": "disabled",
+                                        "type": "boolean"
+                                    },
+                                    "state": true
+                                }
+                            ]
+                        }
+                    ],
+                    "type": "panel",
+                    "label": "Panel",
+                    "input": false,
                     "tableView": false,
-                    "modalEdit": false,
-                    "defaultValue": false,
-                    "persistent": true,
-                    "protected": false,
-                    "dbIndex": false,
-                    "encrypted": false,
-                    "redrawOn": "",
-                    "clearOnHide": true,
-                    "customDefaultValue": "",
-                    "calculateValue": "",
-                    "calculateServer": false,
-                    "allowCalculateOverride": false,
-                    "validate": {
-                        "required": true,
-                        "customMessage": "",
-                        "custom": "",
-                        "customPrivate": false,
-                        "json": "",
-                        "strictDateValidation": false,
-                        "multiple": false,
-                        "unique": false
-                    },
-                    "errorLabel": "",
-                    "errors": "",
-                    "key": "programDeclaration",
-                    "tags": [],
-                    "properties": {},
-                    "conditional": {
-                        "show": null,
-                        "when": null,
-                        "eq": "",
-                        "json": ""
-                    },
-                    "customConditional": "",
-                    "logic": [],
-                    "attributes": {
-                        "data-cy": "programDeclaration"
-                    },
-                    "overlay": {
-                        "style": "",
-                        "page": "",
-                        "left": "",
-                        "top": "",
-                        "width": "",
-                        "height": ""
-                    },
-                    "type": "checkbox",
-                    "name": "",
-                    "value": "",
-                    "input": true,
-                    "placeholder": "",
-                    "prefix": "",
-                    "suffix": "",
-                    "multiple": false,
-                    "unique": false,
-                    "refreshOn": "",
-                    "dataGridLabel": true,
-                    "labelPosition": "right",
-                    "widget": null,
-                    "validateOn": "change",
-                    "showCharCount": false,
-                    "showWordCount": false,
-                    "allowMultipleMasks": false,
-                    "addons": [],
-                    "id": "ea9w893"
+                    "components": [
+                        {
+                            "label": "Is the program offered jointly or in partnership with other institutions?",
+                            "optionsLabelPosition": "right",
+                            "inline": false,
+                            "tableView": false,
+                            "values": [
+                                {
+                                    "label": "Yes",
+                                    "value": "yes",
+                                    "shortcut": ""
+                                },
+                                {
+                                    "label": "No",
+                                    "value": "no",
+                                    "shortcut": ""
+                                }
+                            ],
+                            "validate": {
+                                "required": true
+                            },
+                            "key": "hasJointInstitution",
+                            "attributes": {
+                                "data-cy": "hasJointInstitution"
+                            },
+                            "type": "radio",
+                            "input": true
+                        },
+                        {
+                            "label": "Are all institutions you partner with for this program designated by Student Aid BC?",
+                            "optionsLabelPosition": "right",
+                            "inline": false,
+                            "tableView": false,
+                            "values": [
+                                {
+                                    "label": "Yes",
+                                    "value": "yes",
+                                    "shortcut": ""
+                                },
+                                {
+                                    "label": "No",
+                                    "value": "no",
+                                    "shortcut": ""
+                                }
+                            ],
+                            "validate": {
+                                "required": true
+                            },
+                            "key": "hasJointDesignatedInstitution",
+                            "conditional": {
+                                "show": true,
+                                "when": "hasJointInstitution",
+                                "eq": "yes"
+                            },
+                            "attributes": {
+                                "data-cy": "hasJointDesignatedInstitution"
+                            },
+                            "type": "radio",
+                            "input": true
+                        },
+                        {
+                            "label": "Join Program Error",
+                            "className": "alert alert-warning fa fa-exclamation-circle",
+                            "attrs": [
+                                {
+                                    "attr": "",
+                                    "value": ""
+                                }
+                            ],
+                            "content": "<strong> This program is ineligible for StudentAid BC funding.</strong><br/>\nAll partner institutions must be designated by StudentAid BC..",
+                            "refreshOnChange": false,
+                            "customClass": "banner-warning",
+                            "key": "joinProgramError",
+                            "conditional": {
+                                "show": true,
+                                "when": "hasJointDesignatedInstitution",
+                                "eq": "no"
+                            },
+                            "type": "htmlelement",
+                            "input": false,
+                            "tableView": false
+                        }
+                    ]
+                },
+                {
+                    "label": "HTML",
+                    "tag": "h2",
+                    "className": "category-header-large primary-color",
+                    "attrs": [
+                        {
+                            "attr": "",
+                            "value": ""
+                        }
+                    ],
+                    "content": "Work-integrated learning (WIL)",
+                    "refreshOnChange": false,
+                    "key": "html13",
+                    "type": "htmlelement",
+                    "input": false,
+                    "tableView": false
+                },
+                {
+                    "collapsible": false,
+                    "hideLabel": true,
+                    "key": "panel13",
+                    "logic": [
+                        {
+                            "name": "Disable WIL Input",
+                            "trigger": {
+                                "type": "javascript",
+                                "javascript": "result = data.hasOfferings;"
+                            },
+                            "actions": [
+                                {
+                                    "name": "Disable Input",
+                                    "type": "property",
+                                    "property": {
+                                        "label": "Disabled",
+                                        "value": "disabled",
+                                        "type": "boolean"
+                                    },
+                                    "state": true
+                                }
+                            ]
+                        }
+                    ],
+                    "type": "panel",
+                    "label": "Panel",
+                    "input": false,
+                    "tableView": false,
+                    "components": [
+                        {
+                            "label": "Does this program have a WIL component?",
+                            "optionsLabelPosition": "right",
+                            "inline": false,
+                            "tableView": false,
+                            "values": [
+                                {
+                                    "label": "Yes",
+                                    "value": "yes",
+                                    "shortcut": ""
+                                },
+                                {
+                                    "label": "No",
+                                    "value": "no",
+                                    "shortcut": ""
+                                }
+                            ],
+                            "validate": {
+                                "required": true
+                            },
+                            "key": "hasWILComponent",
+                            "attributes": {
+                                "data-cy": "hasWILComponent"
+                            },
+                            "type": "radio",
+                            "input": true
+                        },
+                        {
+                            "label": "Is the WIL approved by your regulator or oversight body?",
+                            "optionsLabelPosition": "right",
+                            "inline": false,
+                            "tableView": false,
+                            "values": [
+                                {
+                                    "label": "Yes",
+                                    "value": "yes",
+                                    "shortcut": ""
+                                },
+                                {
+                                    "label": "No",
+                                    "value": "no",
+                                    "shortcut": ""
+                                }
+                            ],
+                            "validate": {
+                                "required": true
+                            },
+                            "key": "isWILApproved",
+                            "conditional": {
+                                "show": true,
+                                "when": "hasWILComponent",
+                                "eq": "yes"
+                            },
+                            "attributes": {
+                                "data-cy": "isWILApproved"
+                            },
+                            "type": "radio",
+                            "input": true
+                        },
+                        {
+                            "label": "HTML",
+                            "className": "alert alert-warning fa fa-exclamation-circle",
+                            "attrs": [
+                                {
+                                    "attr": "",
+                                    "value": ""
+                                }
+                            ],
+                            "content": "<strong> This program is ineligible for StudentAid BC funding</strong><br>The work-integrated learning component must be approved by your regulator or oversight body first.",
+                            "refreshOnChange": false,
+                            "customClass": "banner-warning",
+                            "key": "html14",
+                            "customConditional": "show = (data.hasWILComponent === \"yes\" && data.isWILApproved === \"no\");",
+                            "type": "htmlelement",
+                            "input": false,
+                            "tableView": false
+                        },
+                        {
+                            "label": "Does the WIL meet the program eligibility requirements according to StudentAid BC policy?",
+                            "optionsLabelPosition": "right",
+                            "inline": false,
+                            "tableView": false,
+                            "values": [
+                                {
+                                    "label": "Yes",
+                                    "value": "yes",
+                                    "shortcut": ""
+                                },
+                                {
+                                    "label": "No",
+                                    "value": "no",
+                                    "shortcut": ""
+                                }
+                            ],
+                            "redrawOn": "data",
+                            "validate": {
+                                "required": true
+                            },
+                            "key": "wilProgramEligibility",
+                            "customConditional": "show = (data.hasWILComponent === \"yes\" && data.isWILApproved === \"yes\");",
+                            "attributes": {
+                                "data-cy": "wilProgramEligibility"
+                            },
+                            "type": "radio",
+                            "input": true
+                        },
+                        {
+                            "label": "HTML",
+                            "className": "alert alert-warning fa fa-exclamation-circle",
+                            "attrs": [
+                                {
+                                    "attr": "",
+                                    "value": ""
+                                }
+                            ],
+                            "content": "<strong> This program is ineligible for StudentAid BC funding</strong><br>This must meet the StudentAid BC policy.",
+                            "refreshOnChange": false,
+                            "customClass": "banner-warning",
+                            "key": "html15",
+                            "customConditional": "show = (data.hasWILComponent === \"yes\" && data.isWILApproved === \"yes\" && data.wilProgramEligibility === \"no\");",
+                            "type": "htmlelement",
+                            "input": false,
+                            "tableView": false
+                        }
+                    ]
+                },
+                {
+                    "label": "HTML",
+                    "tag": "h2",
+                    "className": "category-header-large primary-color",
+                    "attrs": [
+                        {
+                            "attr": "",
+                            "value": ""
+                        }
+                    ],
+                    "content": "Field trip, field placement, or travel",
+                    "refreshOnChange": false,
+                    "key": "html16",
+                    "type": "htmlelement",
+                    "input": false,
+                    "tableView": false
+                },
+                {
+                    "collapsible": false,
+                    "hideLabel": true,
+                    "key": "panel16",
+                    "logic": [
+                        {
+                            "name": "Disable Field Trip Input",
+                            "trigger": {
+                                "type": "javascript",
+                                "javascript": "result = data.hasOfferings;"
+                            },
+                            "actions": [
+                                {
+                                    "name": "Disable Input",
+                                    "type": "property",
+                                    "property": {
+                                        "label": "Disabled",
+                                        "value": "disabled",
+                                        "type": "boolean"
+                                    },
+                                    "state": true
+                                }
+                            ]
+                        }
+                    ],
+                    "type": "panel",
+                    "label": "Panel",
+                    "input": false,
+                    "tableView": false,
+                    "components": [
+                        {
+                            "label": "Is a field trip, field placement or travel part of this program?",
+                            "optionsLabelPosition": "right",
+                            "inline": false,
+                            "tableView": false,
+                            "values": [
+                                {
+                                    "label": "Yes",
+                                    "value": "yes",
+                                    "shortcut": ""
+                                },
+                                {
+                                    "label": "No",
+                                    "value": "no",
+                                    "shortcut": ""
+                                }
+                            ],
+                            "validate": {
+                                "required": true
+                            },
+                            "key": "hasTravel",
+                            "attributes": {
+                                "data-cy": "hasTravel"
+                            },
+                            "type": "radio",
+                            "input": true
+                        },
+                        {
+                            "label": "Does the field trip, field placement, or travel meet the program eligibility requirements according to StudentAid BC policy?",
+                            "optionsLabelPosition": "right",
+                            "inline": false,
+                            "tableView": false,
+                            "values": [
+                                {
+                                    "label": "Yes",
+                                    "value": "yes",
+                                    "shortcut": ""
+                                },
+                                {
+                                    "label": "No",
+                                    "value": "no",
+                                    "shortcut": ""
+                                }
+                            ],
+                            "validate": {
+                                "required": true
+                            },
+                            "key": "travelProgramEligibility",
+                            "conditional": {
+                                "show": true,
+                                "when": "hasTravel",
+                                "eq": "yes"
+                            },
+                            "attributes": {
+                                "data-cy": "travelProgramEligibility"
+                            },
+                            "type": "radio",
+                            "input": true
+                        },
+                        {
+                            "label": "HTML",
+                            "className": "alert alert-warning fa fa-exclamation-circle",
+                            "attrs": [
+                                {
+                                    "attr": "",
+                                    "value": ""
+                                }
+                            ],
+                            "content": "<strong> This program is ineligible for StudentAid BC funding</strong><br>This must meet the StudentAid BC policy.",
+                            "refreshOnChange": false,
+                            "customClass": "banner-warning",
+                            "key": "html17",
+                            "customConditional": "show = (data.hasTravel === \"yes\" && data.travelProgramEligibility === \"no\");",
+                            "type": "htmlelement",
+                            "input": false,
+                            "tableView": false
+                        }
+                    ]
+                },
+                {
+                    "label": "HTML",
+                    "tag": "h2",
+                    "className": "category-header-large primary-color",
+                    "attrs": [
+                        {
+                            "attr": "",
+                            "value": ""
+                        }
+                    ],
+                    "content": "International exchange",
+                    "refreshOnChange": false,
+                    "key": "html18",
+                    "type": "htmlelement",
+                    "input": false,
+                    "tableView": false
+                },
+                {
+                    "collapsible": false,
+                    "hideLabel": true,
+                    "key": "panel18",
+                    "logic": [
+                        {
+                            "name": "Disable Exchange Input",
+                            "trigger": {
+                                "type": "javascript",
+                                "javascript": "result = data.hasOfferings;"
+                            },
+                            "actions": [
+                                {
+                                    "name": "Disable Input",
+                                    "type": "property",
+                                    "property": {
+                                        "label": "Disabled",
+                                        "value": "disabled",
+                                        "type": "boolean"
+                                    },
+                                    "state": true
+                                }
+                            ]
+                        }
+                    ],
+                    "type": "panel",
+                    "label": "Panel",
+                    "input": false,
+                    "tableView": false,
+                    "components": [
+                        {
+                            "label": "Does the program have an international exchange?",
+                            "optionsLabelPosition": "right",
+                            "inline": false,
+                            "tableView": false,
+                            "values": [
+                                {
+                                    "label": "Yes",
+                                    "value": "yes",
+                                    "shortcut": ""
+                                },
+                                {
+                                    "label": "No",
+                                    "value": "no",
+                                    "shortcut": ""
+                                }
+                            ],
+                            "validate": {
+                                "required": true
+                            },
+                            "key": "hasIntlExchange",
+                            "attributes": {
+                                "data-cy": "hasIntlExchange"
+                            },
+                            "type": "radio",
+                            "input": true
+                        },
+                        {
+                            "label": "Does the international exchange meet the program eligibility requirements according to StudentAid BC policy?",
+                            "optionsLabelPosition": "right",
+                            "inline": false,
+                            "tableView": false,
+                            "values": [
+                                {
+                                    "label": "Yes",
+                                    "value": "yes",
+                                    "shortcut": ""
+                                },
+                                {
+                                    "label": "No",
+                                    "value": "no",
+                                    "shortcut": ""
+                                }
+                            ],
+                            "validate": {
+                                "required": true
+                            },
+                            "key": "intlExchangeProgramEligibility",
+                            "conditional": {
+                                "show": true,
+                                "when": "hasIntlExchange",
+                                "eq": "yes"
+                            },
+                            "attributes": {
+                                "data-cy": "intlExchangeProgramEligibility"
+                            },
+                            "type": "radio",
+                            "input": true
+                        },
+                        {
+                            "label": "HTML",
+                            "className": "alert alert-warning fa fa-exclamation-circle",
+                            "attrs": [
+                                {
+                                    "attr": "",
+                                    "value": ""
+                                }
+                            ],
+                            "content": "<strong> This program is ineligible for StudentAid BC funding</strong><br>This must meet the StudentAid BC policy.",
+                            "refreshOnChange": false,
+                            "customClass": "banner-warning",
+                            "key": "html19",
+                            "customConditional": "show = (data.hasIntlExchange === \"yes\" && data.intlExchangeProgramEligibility === \"no\");",
+                            "type": "htmlelement",
+                            "input": false,
+                            "tableView": false
+                        }
+                    ]
+                },
+                {
+                    "label": "Declaration",
+                    "tag": "h2",
+                    "className": "category-header-large primary-color",
+                    "attrs": [
+                        {
+                            "attr": "",
+                            "value": ""
+                        }
+                    ],
+                    "content": "Declaration",
+                    "refreshOnChange": false,
+                    "key": "declaration",
+                    "type": "htmlelement",
+                    "input": false,
+                    "tableView": false
+                },
+                {
+                    "collapsible": false,
+                    "hideLabel": true,
+                    "key": "panel12",
+                    "logic": [
+                        {
+                            "name": "Disable Declaration Input",
+                            "trigger": {
+                                "type": "javascript",
+                                "javascript": "result = data.hasOfferings;"
+                            },
+                            "actions": [
+                                {
+                                    "name": "Disable Input",
+                                    "type": "property",
+                                    "property": {
+                                        "label": "Disabled",
+                                        "value": "disabled",
+                                        "type": "boolean"
+                                    },
+                                    "state": true
+                                }
+                            ]
+                        }
+                    ],
+                    "type": "panel",
+                    "label": "Panel",
+                    "input": false,
+                    "tableView": false,
+                    "components": [
+                        {
+                            "label": "HTML",
+                            "attrs": [
+                                {
+                                    "attr": "",
+                                    "value": ""
+                                }
+                            ],
+                            "content": "All information is subject to verification and auditing.",
+                            "refreshOnChange": false,
+                            "customClass": "category-header-medium-small primary-color",
+                            "key": "html12",
+                            "type": "htmlelement",
+                            "input": false,
+                            "tableView": false
+                        },
+                        {
+                            "label": "I confirm this program meets the policies outlined in the StudentAid BC policy manual.",
+                            "tableView": false,
+                            "defaultValue": false,
+                            "validate": {
+                                "required": true
+                            },
+                            "key": "programDeclaration",
+                            "attributes": {
+                                "data-cy": "programDeclaration"
+                            },
+                            "type": "checkbox",
+                            "input": true
+                        }
+                    ]
                 }
-            ],
-            "placeholder": "",
-            "prefix": "",
-            "suffix": "",
-            "multiple": false,
-            "defaultValue": null,
-            "protected": false,
-            "unique": false,
-            "persistent": false,
-            "clearOnHide": false,
-            "refreshOn": "",
-            "redrawOn": "",
-            "dataGridLabel": false,
-            "labelPosition": "top",
-            "description": "",
-            "errorLabel": "",
-            "autofocus": false,
-            "dbIndex": false,
-            "customDefaultValue": "",
-            "calculateValue": "",
-            "calculateServer": false,
-            "widget": null,
-            "validateOn": "change",
-            "validate": {
-                "required": false,
-                "custom": "",
-                "customPrivate": false,
-                "strictDateValidation": false,
-                "multiple": false,
-                "unique": false
-            },
-            "allowCalculateOverride": false,
-            "encrypted": false,
-            "showCharCount": false,
-            "showWordCount": false,
-            "allowMultipleMasks": false,
-            "addons": [],
-            "tree": false,
-            "lazyLoad": false,
-            "id": "ec2eh6"
+            ]
         },
         {
             "label": "hasOfferings",
-            "labelWidth": "",
-            "labelMargin": "",
-            "customClass": "",
-            "modalEdit": false,
-            "defaultValue": null,
-            "persistent": true,
-            "protected": false,
-            "dbIndex": false,
-            "encrypted": false,
-            "redrawOn": "",
-            "customDefaultValue": "",
-            "calculateValue": "",
-            "calculateServer": false,
             "key": "totalOfferings",
-            "tags": [],
-            "properties": {},
-            "logic": [],
-            "attributes": {},
-            "overlay": {
-                "style": "",
-                "page": "",
-                "left": "",
-                "top": "",
-                "width": "",
-                "height": ""
-            },
             "type": "hidden",
             "input": true,
-            "tableView": false,
-            "placeholder": "",
-            "prefix": "",
-            "suffix": "",
-            "multiple": false,
-            "unique": false,
-            "hidden": false,
-            "clearOnHide": true,
-            "refreshOn": "",
-            "dataGridLabel": false,
-            "labelPosition": "top",
-            "description": "",
-            "errorLabel": "",
-            "tooltip": "",
-            "hideLabel": false,
-            "tabindex": "",
-            "disabled": false,
-            "autofocus": false,
-            "widget": {
-                "type": "input"
-            },
-            "validateOn": "change",
-            "validate": {
-                "required": false,
-                "custom": "",
-                "customPrivate": false,
-                "strictDateValidation": false,
-                "multiple": false,
-                "unique": false
-            },
-            "conditional": {
-                "show": null,
-                "when": null,
-                "eq": ""
-            },
-            "allowCalculateOverride": false,
-            "showCharCount": false,
-            "showWordCount": false,
-            "allowMultipleMasks": false,
-            "addons": [],
-            "inputType": "hidden",
-            "id": "evt09sp"
+            "tableView": false
+        },
+        {
+            "label": "Is Read-only",
+            "persistent": "client-only",
+            "key": "isReadonly",
+            "type": "hidden",
+            "input": true,
+            "tableView": false
         },
         {
             "label": "isBCPrivate",
-            "customClass": "",
-            "modalEdit": false,
-            "defaultValue": null,
-            "persistent": true,
-            "protected": false,
-            "dbIndex": false,
-            "encrypted": false,
-            "redrawOn": "",
-            "customDefaultValue": "",
-            "calculateValue": "",
-            "calculateServer": false,
             "key": "isBCPrivate",
-            "tags": [],
-            "properties": {},
-            "logic": [],
-            "attributes": {},
-            "overlay": {
-                "style": "",
-                "page": "",
-                "left": "",
-                "top": "",
-                "width": "",
-                "height": ""
-            },
             "type": "hidden",
             "input": true,
-            "tableView": false,
-            "placeholder": "",
-            "prefix": "",
-            "suffix": "",
-            "multiple": false,
-            "unique": false,
-            "hidden": false,
-            "clearOnHide": true,
-            "refreshOn": "",
-            "dataGridLabel": false,
-            "labelPosition": "top",
-            "description": "",
-            "errorLabel": "",
-            "tooltip": "",
-            "hideLabel": false,
-            "tabindex": "",
-            "disabled": false,
-            "autofocus": false,
-            "widget": {
-                "type": "input"
-            },
-            "validateOn": "change",
-            "validate": {
-                "required": false,
-                "custom": "",
-                "customPrivate": false,
-                "strictDateValidation": false,
-                "multiple": false,
-                "unique": false
-            },
-            "conditional": {
-                "show": null,
-                "when": null,
-                "eq": ""
-            },
-            "allowCalculateOverride": false,
-            "showCharCount": false,
-            "showWordCount": false,
-            "allowMultipleMasks": false,
-            "inputType": "hidden",
-            "id": "egqexmm",
-            "addons": []
+            "tableView": false
         },
         {
             "input": true,
             "tableView": false,
             "key": "isBCPublic",
             "label": "isBCPublic",
-            "protected": false,
-            "unique": false,
-            "persistent": true,
             "type": "hidden",
-            "tags": [],
-            "conditional": {
-                "show": "",
-                "when": null,
-                "eq": ""
-            },
-            "properties": {},
-            "lockKey": true,
-            "customDefaultValue": "",
-            "customConditional": ""
+            "lockKey": true
         },
         {
             "label": "Program Status",
-            "labelWidth": "",
-            "labelMargin": "",
-            "customClass": "",
-            "modalEdit": false,
-            "defaultValue": null,
-            "persistent": true,
-            "protected": false,
-            "dbIndex": false,
-            "encrypted": false,
-            "redrawOn": "",
-            "customDefaultValue": "",
             "calculateValue": "if (\r\n  data.hasJointDesignatedInstitution === \"no\" ||\r\n  data.eslEligibility === \"20OrMore\" ||\r\n  data.entranceRequirements.noneOfTheAboveEntranceRequirements === true ||\r\n  (data.deliveredOnlineAlsoOnsite === \"no\" &&\r\n    data.sameOnlineCreditsEarned === \"no\" &&\r\n    data.earnAcademicCreditsOtherInstitution === \"no\") ||\r\n  (data.courseLoadCalculation === \"hours\" &&\r\n    data.minHoursWeek === \"no\" &&\r\n    data.isAviationProgram === \"no\") ||\r\n  (data.courseLoadCalculation === \"hours\" &&\r\n    data.minHoursWeek === \"no\" &&\r\n    data.isAviationProgram === \"yes\" &&\r\n    data.minHoursWeekAvi === \"no\") ||\r\n  (data.hasWILComponent === \"yes\" && data.isWILApproved === \"no\") ||\r\n  (data.hasWILComponent === \"yes\" &&\r\n    data.isWILApproved === \"yes\" &&\r\n    data.wilProgramEligibility === \"no\") ||\r\n  (data.hasTravel === \"yes\" && data.travelProgramEligibility === \"no\") ||\r\n  (data.hasIntlExchange === \"yes\" &&\r\n    data.intlExchangeProgramEligibility === \"no\")\r\n) {\r\n  value = \"Pending\";\r\n} else {\r\n  value = \"Approved\";\r\n}",
             "calculateServer": true,
             "key": "programStatus",
-            "tags": [],
-            "properties": {},
-            "logic": [],
-            "attributes": {},
-            "overlay": {
-                "style": "",
-                "page": "",
-                "left": "",
-                "top": "",
-                "width": "",
-                "height": ""
-            },
             "type": "hidden",
             "input": true,
-            "tableView": false,
-            "placeholder": "",
-            "prefix": "",
-            "suffix": "",
-            "multiple": false,
-            "unique": false,
-            "hidden": false,
-            "clearOnHide": true,
-            "refreshOn": "",
-            "dataGridLabel": false,
-            "labelPosition": "top",
-            "description": "",
-            "errorLabel": "",
-            "tooltip": "",
-            "hideLabel": false,
-            "tabindex": "",
-            "disabled": false,
-            "autofocus": false,
-            "widget": {
-                "type": "input"
-            },
-            "validateOn": "change",
-            "validate": {
-                "required": false,
-                "custom": "",
-                "customPrivate": false,
-                "strictDateValidation": false,
-                "multiple": false,
-                "unique": false
-            },
-            "conditional": {
-                "show": null,
-                "when": null,
-                "eq": ""
-            },
-            "allowCalculateOverride": false,
-            "showCharCount": false,
-            "showWordCount": false,
-            "allowMultipleMasks": false,
-            "addons": [],
-            "inputType": "hidden",
-            "id": "edkeirb"
+            "tableView": false
         }
     ]
 }

--- a/sources/packages/web/src/assets/css/vuetify.scss
+++ b/sources/packages/web/src/assets/css/vuetify.scss
@@ -180,3 +180,7 @@
 .overflow-visible .v-card {
   overflow: visible;
 }
+
+.label-bold-menu .v-list-item .v-list-item-title {
+  @extend .label-bold;
+}

--- a/sources/packages/web/src/components/common/ManageProgramAndOfferingSummary.vue
+++ b/sources/packages/web/src/components/common/ManageProgramAndOfferingSummary.vue
@@ -5,6 +5,7 @@
         :programId="programId"
         :locationId="locationId"
         :educationProgram="educationProgram"
+        @program-data-updated="$emit('programDataUpdated')"
       />
       <hr class="horizontal-divider" />
       <offering-summary
@@ -23,6 +24,9 @@ import OfferingSummary from "@/components/common/OfferingSummary.vue";
 import { EducationProgramAPIOutDTO } from "@/services/http/dto";
 
 export default defineComponent({
+  emits: {
+    programDataUpdated: null,
+  },
   components: { ProgramDetails, OfferingSummary },
   props: {
     programId: {

--- a/sources/packages/web/src/components/common/ProgramDetails.vue
+++ b/sources/packages/web/src/components/common/ProgramDetails.vue
@@ -9,7 +9,7 @@
       ></status-chip-program>
     </template>
     <template #actions>
-      <v-menu class="label-bold-menu" v-if="educationProgram.isActive">
+      <v-menu class="label-bold-menu">
         <template v-slot:activator="{ props }">
           <v-btn
             color="primary"
@@ -29,7 +29,8 @@
           <v-list-item @click="goToProgram" :title="programActionLabel" />
           <v-divider-inset-opaque />
           <v-list-item
-            base-color="red"
+            :disabled="!educationProgram.isActive"
+            base-color="danger"
             @click="deactivate"
             title="Deactivate"
           />
@@ -149,9 +150,13 @@ export default defineComponent({
     );
 
     const programActionLabel = computed(() => {
-      return AuthService.shared.authClientType === ClientIdType.Institution
-        ? "Edit"
-        : "View Program";
+      if (
+        !props.educationProgram.isActive ||
+        AuthService.shared.authClientType === ClientIdType.AEST
+      ) {
+        return "View Program";
+      }
+      return "Edit";
     });
 
     const goToProgram = () => {

--- a/sources/packages/web/src/components/common/ProgramDetails.vue
+++ b/sources/packages/web/src/components/common/ProgramDetails.vue
@@ -8,15 +8,32 @@
       ></status-chip-program>
     </template>
     <template #actions>
-      <v-btn
-        class="float-right label-bold"
-        variant="outlined"
-        @click="programButtonAction"
-        color="primary"
-        data-cy="programButtonAction"
-      >
-        {{ programActionLabel }}
-      </v-btn>
+      <v-menu class="label-bold-menu">
+        <template v-slot:activator="{ props }">
+          <v-btn
+            color="primary"
+            v-bind="props"
+            prepend-icon="fa:fa fa-chevron-circle-down"
+            class="float-right"
+          >
+            Program actions
+          </v-btn>
+        </template>
+        <v-list
+          active-class="active-list-item"
+          density="compact"
+          bg-color="default"
+          color="primary"
+        >
+          <v-list-item @click="goToProgram" :title="programActionLabel" />
+          <v-divider-inset-opaque />
+          <v-list-item
+            base-color="red"
+            @click="deactivate"
+            title="Deactivate"
+          />
+        </v-list>
+      </v-menu>
     </template>
   </body-header>
   <v-row>
@@ -79,11 +96,12 @@
       />
     </v-col>
   </v-row>
+  <decline-education-program-modal ref="declineEducationProgramModal" />
 </template>
 
 <script lang="ts">
 import { useRouter } from "vue-router";
-import { computed, defineComponent } from "vue";
+import { computed, defineComponent, ref } from "vue";
 import {
   InstitutionRoutesConst,
   AESTRoutesConst,
@@ -91,10 +109,16 @@ import {
 import { ProgramIntensity, ClientIdType } from "@/types";
 import StatusChipProgram from "@/components/generic/StatusChipProgram.vue";
 import { AuthService } from "@/services/AuthService";
-import { EducationProgramAPIOutDTO } from "@/services/http/dto";
+import {
+  DeactivateProgramAPIInDTO,
+  EducationProgramAPIOutDTO,
+} from "@/services/http/dto";
+import DeclineEducationProgramModal from "@/components/common/modals/DeclineEducationProgramModal.vue";
+import { ModalDialog, useSnackBar } from "@/composables";
+import ApiClient from "@/services/http/ApiClient";
 
 export default defineComponent({
-  components: { StatusChipProgram },
+  components: { DeclineEducationProgramModal, StatusChipProgram },
   props: {
     programId: {
       type: Number,
@@ -111,24 +135,20 @@ export default defineComponent({
     },
   },
   setup(props) {
+    const snackBar = useSnackBar();
     const router = useRouter();
-    const clientType = computed(() => AuthService.shared.authClientType);
-
-    const isInstitutionUser = computed(() => {
-      return clientType.value === ClientIdType.Institution;
-    });
-
-    const isAESTUser = computed(() => {
-      return clientType.value === ClientIdType.AEST;
-    });
-
+    const declineEducationProgramModal = ref(
+      {} as ModalDialog<DeactivateProgramAPIInDTO | boolean>,
+    );
     const programActionLabel = computed(() => {
-      return isInstitutionUser.value ? "Edit" : "View Program";
+      return AuthService.shared.authClientType === ClientIdType.Institution
+        ? "Edit"
+        : "View Program";
     });
 
-    const programButtonAction = () => {
-      if (isInstitutionUser.value) {
-        router.push({
+    const goToProgram = () => {
+      if (AuthService.shared.authClientType === ClientIdType.Institution) {
+        return router.push({
           name: InstitutionRoutesConst.EDIT_LOCATION_PROGRAMS,
           params: {
             programId: props.programId,
@@ -136,24 +156,44 @@ export default defineComponent({
           },
         });
       }
+      return router.push({
+        name: AESTRoutesConst.VIEW_PROGRAM,
+        params: {
+          programId: props.programId,
+          locationId: props.locationId,
+        },
+      });
+    };
 
-      if (isAESTUser.value) {
-        router.push({
-          name: AESTRoutesConst.VIEW_PROGRAM,
-          params: {
-            programId: props.programId,
-            locationId: props.locationId,
-          },
-        });
+    const canResolvePromise = async (
+      modalResult: DeactivateProgramAPIInDTO | boolean,
+    ): Promise<boolean> => {
+      if (modalResult === false) {
+        return true;
+      }
+      try {
+        await ApiClient.EducationProgram.deactivateProgram(props.programId);
+        snackBar.success("Program deactivate with success.");
+        return true;
+      } catch (error) {
+        snackBar.error("An error happened while deactivating the program.");
+        return false;
       }
     };
 
+    const deactivate = async () => {
+      await declineEducationProgramModal.value.showModal(
+        undefined,
+        canResolvePromise,
+      );
+    };
+
     return {
-      programButtonAction,
+      goToProgram,
       ProgramIntensity,
-      isInstitutionUser,
-      isAESTUser,
       programActionLabel,
+      declineEducationProgramModal,
+      deactivate,
     };
   },
 });

--- a/sources/packages/web/src/components/common/ProgramDetails.vue
+++ b/sources/packages/web/src/components/common/ProgramDetails.vue
@@ -154,7 +154,7 @@ export default defineComponent({
       default: {} as EducationProgramAPIOutDTO,
     },
   },
-  setup(props, context) {
+  setup(props, { emit }) {
     const snackBar = useSnackBar();
     const router = useRouter();
     const declineEducationProgramModal = ref(
@@ -212,8 +212,8 @@ export default defineComponent({
           props.programId,
           modalResult as DeactivateProgramAPIInDTO,
         );
-        snackBar.success("Program deactivate with success.");
-        context.emit("programDataUpdated");
+        snackBar.success("Program deactivated with success.");
+        emit("programDataUpdated");
         return true;
       } catch (error) {
         snackBar.error("An error happened while deactivating the program.");

--- a/sources/packages/web/src/components/common/ProgramDetails.vue
+++ b/sources/packages/web/src/components/common/ProgramDetails.vue
@@ -105,7 +105,7 @@
     </v-col>
   </v-row>
   <education-program-deactivation-modal
-    ref="declineEducationProgramModal"
+    ref="deactivateEducationProgramModal"
     :notes-required="notesRequired"
   />
 </template>
@@ -157,7 +157,7 @@ export default defineComponent({
   setup(props, { emit }) {
     const snackBar = useSnackBar();
     const router = useRouter();
-    const declineEducationProgramModal = ref(
+    const deactivateEducationProgramModal = ref(
       {} as ModalDialog<DeactivateProgramAPIInDTO | boolean>,
     );
 
@@ -195,7 +195,7 @@ export default defineComponent({
     );
 
     const deactivate = async () => {
-      await declineEducationProgramModal.value.showModal(
+      await deactivateEducationProgramModal.value.showModal(
         undefined,
         canResolvePromise,
       );
@@ -225,7 +225,7 @@ export default defineComponent({
       goToProgram,
       ProgramIntensity,
       programActionLabel,
-      declineEducationProgramModal,
+      deactivateEducationProgramModal,
       deactivate,
       notesRequired,
       Role,

--- a/sources/packages/web/src/components/common/ProgramDetails.vue
+++ b/sources/packages/web/src/components/common/ProgramDetails.vue
@@ -28,12 +28,18 @@
         >
           <v-list-item @click="goToProgram" :title="programActionLabel" />
           <v-divider-inset-opaque />
-          <v-list-item
-            :disabled="!educationProgram.isActive"
-            base-color="danger"
-            @click="deactivate"
-            title="Deactivate"
-          />
+          <check-permission-role
+            :role="Role.InstitutionDeactivateEducationProgram"
+          >
+            <template #="{ notAllowed }">
+              <v-list-item
+                :disabled="!educationProgram.isActive || notAllowed"
+                base-color="danger"
+                @click="deactivate"
+                title="Deactivate"
+              />
+            </template>
+          </check-permission-role>
         </v-list>
       </v-menu>
     </template>
@@ -121,12 +127,18 @@ import {
 import EducationProgramDeactivationModal from "@/components/common/modals/EducationProgramDeactivationModal.vue";
 import { ModalDialog, useSnackBar } from "@/composables";
 import ApiClient from "@/services/http/ApiClient";
+import CheckPermissionRole from "@/components/generic/CheckPermissionRole.vue";
+import { Role } from "@/types";
 
 export default defineComponent({
   emits: {
     programDataUpdated: null,
   },
-  components: { EducationProgramDeactivationModal, StatusChipProgram },
+  components: {
+    EducationProgramDeactivationModal,
+    StatusChipProgram,
+    CheckPermissionRole,
+  },
   props: {
     programId: {
       type: Number,
@@ -216,6 +228,7 @@ export default defineComponent({
       declineEducationProgramModal,
       deactivate,
       notesRequired,
+      Role,
     };
   },
 });

--- a/sources/packages/web/src/components/common/ProgramDetails.vue
+++ b/sources/packages/web/src/components/common/ProgramDetails.vue
@@ -4,11 +4,12 @@
       <status-chip-program
         class="ml-2 mb-2"
         :status="educationProgram.programStatus"
+        :is-active="educationProgram.isActive"
         data-cy="programStatus"
       ></status-chip-program>
     </template>
     <template #actions>
-      <v-menu class="label-bold-menu">
+      <v-menu class="label-bold-menu" v-if="educationProgram.isActive">
         <template v-slot:activator="{ props }">
           <v-btn
             color="primary"
@@ -118,6 +119,9 @@ import { ModalDialog, useSnackBar } from "@/composables";
 import ApiClient from "@/services/http/ApiClient";
 
 export default defineComponent({
+  emits: {
+    programDataUpdated: null,
+  },
   components: { DeclineEducationProgramModal, StatusChipProgram },
   props: {
     programId: {
@@ -134,7 +138,7 @@ export default defineComponent({
       default: {} as EducationProgramAPIOutDTO,
     },
   },
-  setup(props) {
+  setup(props, context) {
     const snackBar = useSnackBar();
     const router = useRouter();
     const declineEducationProgramModal = ref(
@@ -174,6 +178,7 @@ export default defineComponent({
       try {
         await ApiClient.EducationProgram.deactivateProgram(props.programId);
         snackBar.success("Program deactivate with success.");
+        context.emit("programDataUpdated");
         return true;
       } catch (error) {
         snackBar.error("An error happened while deactivating the program.");

--- a/sources/packages/web/src/components/common/modals/DeclineEducationProgramModal.vue
+++ b/sources/packages/web/src/components/common/modals/DeclineEducationProgramModal.vue
@@ -1,0 +1,88 @@
+<template>
+  <v-form ref="deactivateProgramForm">
+    <modal-dialog-base
+      :showDialog="showDialog"
+      title="Confirm deactivation"
+      ref="confirmDeactivationModal"
+      okLabel="Confirm deactivation"
+      primary-button-color="red"
+      keepModalOpen="true"
+      ><template #content
+        ><span class="font-bold"
+          >Please confirm you no longer require this program?</span
+        >
+        <p class="mt-5">
+          Confirming deactivation means that this will no longer be visible to
+          students when starting an application. It wil not impact any students
+          with active applications for offerings under this program. This action
+          cannot be undone.
+        </p>
+        <v-textarea
+          v-model="noteDescription"
+          variant="outlined"
+          label="Note"
+          :rules="[checkNotesLengthRule]"
+          required
+          class="mt-4"
+          hide-details="auto"
+        ></v-textarea>
+      </template>
+      <template #footer>
+        <footer-buttons
+          primaryLabel="Confirm deactivation"
+          primaryButtonColor="red"
+          @primaryClick="submit"
+          @secondaryClick="cancel"
+          :processing="loading"
+        />
+      </template>
+    </modal-dialog-base>
+  </v-form>
+</template>
+<script lang="ts">
+import { ref, defineComponent } from "vue";
+import { useModalDialog, useRules } from "@/composables";
+import { VForm } from "@/types";
+import { DeactivateProgramAPIInDTO } from "@/services/http/dto";
+
+export default defineComponent({
+  setup() {
+    const { showDialog, resolvePromise, showModal, loading, hideModal } =
+      useModalDialog<DeactivateProgramAPIInDTO | boolean>();
+    const { checkNotesLengthRule } = useRules();
+    const noteDescription = ref("");
+    const deactivateProgramForm = ref({} as VForm);
+
+    const submit = async () => {
+      const validationResult = await deactivateProgramForm.value.validate();
+      if (!validationResult.valid) {
+        return;
+      }
+      const payload = {
+        note: noteDescription.value,
+      };
+      await resolvePromise(payload);
+      deactivateProgramForm.value.reset();
+    };
+
+    const cancel = () => {
+      deactivateProgramForm.value.reset();
+      deactivateProgramForm.value.resetValidation();
+      resolvePromise(false);
+      hideModal();
+    };
+
+    return {
+      noteDescription,
+      deactivateProgramForm,
+      showDialog,
+      showModal,
+      resolvePromise,
+      loading,
+      checkNotesLengthRule,
+      submit,
+      cancel,
+    };
+  },
+});
+</script>

--- a/sources/packages/web/src/components/common/modals/EducationProgramDeactivationModal.vue
+++ b/sources/packages/web/src/components/common/modals/EducationProgramDeactivationModal.vue
@@ -5,7 +5,6 @@
       title="Confirm deactivation"
       ref="confirmDeactivationModal"
       okLabel="Confirm deactivation"
-      primary-button-color="red"
       keepModalOpen="true"
       ><template #content
         ><span class="font-bold"
@@ -31,7 +30,7 @@
       <template #footer>
         <footer-buttons
           primaryLabel="Confirm deactivation"
-          primaryButtonColor="red"
+          primaryButtonColor="danger"
           @primaryClick="submit"
           @secondaryClick="cancel"
           :processing="loading"
@@ -83,7 +82,6 @@ export default defineComponent({
       deactivateProgramForm,
       showDialog,
       showModal,
-      resolvePromise,
       loading,
       checkNotesLengthRule,
       submit,

--- a/sources/packages/web/src/components/common/modals/EducationProgramDeactivationModal.vue
+++ b/sources/packages/web/src/components/common/modals/EducationProgramDeactivationModal.vue
@@ -18,6 +18,7 @@
           cannot be undone.
         </p>
         <v-textarea
+          v-if="notesRequired"
           v-model="noteDescription"
           variant="outlined"
           label="Note"
@@ -46,6 +47,12 @@ import { VForm } from "@/types";
 import { DeactivateProgramAPIInDTO } from "@/services/http/dto";
 
 export default defineComponent({
+  props: {
+    notesRequired: {
+      type: Boolean,
+      required: true,
+    },
+  },
   setup() {
     const { showDialog, resolvePromise, showModal, loading, hideModal } =
       useModalDialog<DeactivateProgramAPIInDTO | boolean>();
@@ -67,7 +74,6 @@ export default defineComponent({
 
     const cancel = () => {
       deactivateProgramForm.value.reset();
-      deactivateProgramForm.value.resetValidation();
       resolvePromise(false);
       hideModal();
     };

--- a/sources/packages/web/src/components/common/modals/EducationProgramDeactivationModal.vue
+++ b/sources/packages/web/src/components/common/modals/EducationProgramDeactivationModal.vue
@@ -4,8 +4,6 @@
       :showDialog="showDialog"
       title="Confirm deactivation"
       ref="confirmDeactivationModal"
-      okLabel="Confirm deactivation"
-      keepModalOpen="true"
       ><template #content
         ><span class="font-bold"
           >Please confirm you no longer require this program?</span

--- a/sources/packages/web/src/components/generic/FooterButtons.vue
+++ b/sources/packages/web/src/components/generic/FooterButtons.vue
@@ -17,7 +17,7 @@
         class="ml-2"
         variant="elevated"
         data-cy="primaryFooterButton"
-        color="primary"
+        :color="primaryButtonColor"
         @click="$emit('primaryClick')"
         :loading="processing"
       >
@@ -55,6 +55,11 @@ export default defineComponent({
       type: Boolean,
       required: false,
       default: true,
+    },
+    primaryButtonColor: {
+      type: String,
+      required: false,
+      default: "primary",
     },
     justify: {
       type: String,

--- a/sources/packages/web/src/components/generic/StatusChipProgram.vue
+++ b/sources/packages/web/src/components/generic/StatusChipProgram.vue
@@ -1,5 +1,5 @@
 <template>
-  <chip-status :status="chipStatus" :label="status" />
+  <chip-status :status="chipStatus" :label="overallStatusLabel" />
 </template>
 <script lang="ts">
 import { computed, defineComponent, PropType } from "vue";
@@ -14,11 +14,23 @@ export default defineComponent({
       type: String as PropType<ProgramStatus>,
       required: true,
     },
+    isActive: {
+      type: Boolean,
+      required: true,
+    },
   },
   setup(props) {
     const { mapProgramChipStatus } = useProgram();
-    const chipStatus = computed(() => mapProgramChipStatus(props.status));
-    return { chipStatus };
+    const overallStatusLabel = computed(() => {
+      if (!props.isActive) {
+        return "Inactive";
+      }
+      return props.status.toString();
+    });
+    const chipStatus = computed(() =>
+      mapProgramChipStatus(props.status, props.isActive),
+    );
+    return { chipStatus, overallStatusLabel };
   },
 });
 </script>

--- a/sources/packages/web/src/composables/useProgram.ts
+++ b/sources/packages/web/src/composables/useProgram.ts
@@ -1,7 +1,13 @@
 import { ProgramStatus, StatusChipTypes } from "@/types";
 
 export function useProgram() {
-  const mapProgramChipStatus = (status: ProgramStatus): StatusChipTypes => {
+  const mapProgramChipStatus = (
+    status: ProgramStatus,
+    isActive: boolean,
+  ): StatusChipTypes => {
+    if (!isActive) {
+      return StatusChipTypes.Inactive;
+    }
     switch (status) {
       case ProgramStatus.Approved:
         return StatusChipTypes.Success;

--- a/sources/packages/web/src/plugins/vuetify.ts
+++ b/sources/packages/web/src/plugins/vuetify.ts
@@ -51,6 +51,7 @@ export default createVuetify({
           warning: "#ff7a00",
           success: "#16c92e",
           error: "#e4222e",
+          danger: "#e4222e",
           "info-bg": "#F0EEF9",
           "warning-bg": "#FFF9ED",
           "success-bg": "#EEFFEF",

--- a/sources/packages/web/src/services/EducationProgramService.ts
+++ b/sources/packages/web/src/services/EducationProgramService.ts
@@ -6,6 +6,7 @@ import {
 import ApiClient from "@/services/http/ApiClient";
 import {
   ApproveProgramAPIInDTO,
+  DeactivateProgramAPIInDTO,
   DeclineProgramAPIInDTO,
   EducationProgramAPIInDTO,
   EducationProgramAPIOutDTO,
@@ -182,5 +183,17 @@ export class EducationProgramService {
       institutionId,
       payload,
     );
+  }
+
+  /**
+   * Allows a program to be deactivated.
+   * @param programId program to be deactivated.
+   * @param payload information to support the deactivation.
+   */
+  async deactivateProgram(
+    programId: number,
+    payload?: DeactivateProgramAPIInDTO,
+  ): Promise<void> {
+    await ApiClient.EducationProgram.deactivateProgram(programId, payload);
   }
 }

--- a/sources/packages/web/src/services/http/EducationProgramApi.ts
+++ b/sources/packages/web/src/services/http/EducationProgramApi.ts
@@ -3,6 +3,7 @@ import HttpBaseClient from "./common/HttpBaseClient";
 import { getPaginationQueryString } from "@/helpers";
 import {
   ApproveProgramAPIInDTO,
+  DeactivateProgramAPIInDTO,
   DeclineProgramAPIInDTO,
   EducationProgramAPIInDTO,
   EducationProgramAPIOutDTO,
@@ -162,6 +163,21 @@ export class EducationProgramApi extends HttpBaseClient {
       this.addClientRoot(
         `education-program/${programId}/institution/${institutionId}/decline`,
       ),
+      payload,
+    );
+  }
+
+  /**
+   * Allows a program to be deactivated.
+   * @param programId program to be deactivated.
+   * @param payload information to support the deactivation.
+   */
+  async deactivateProgram(
+    programId: number,
+    payload?: DeactivateProgramAPIInDTO,
+  ): Promise<void> {
+    await this.patchCall(
+      this.addClientRoot(`education-program/${programId}/deactivate`),
       payload,
     );
   }

--- a/sources/packages/web/src/services/http/dto/EducationProgram.dto.ts
+++ b/sources/packages/web/src/services/http/dto/EducationProgram.dto.ts
@@ -165,3 +165,7 @@ export interface ApproveProgramAPIInDTO {
 export interface DeclineProgramAPIInDTO {
   declinedNote: string;
 }
+
+export interface DeactivateProgramAPIInDTO {
+  note: string;
+}

--- a/sources/packages/web/src/services/http/dto/EducationProgram.dto.ts
+++ b/sources/packages/web/src/services/http/dto/EducationProgram.dto.ts
@@ -56,6 +56,7 @@ export interface EducationProgramAPIOutDTO {
   assessedBy?: string;
   effectiveEndDate?: string;
   fieldOfStudyCode: number;
+  isActive: boolean;
 }
 
 /**
@@ -72,6 +73,7 @@ export interface EducationProgramsSummaryAPIOutDTO {
   locationName: string;
   locationId: number;
   programStatus: ProgramStatus;
+  isActive: boolean;
 }
 
 /**

--- a/sources/packages/web/src/types/contracts/aest/roles.ts
+++ b/sources/packages/web/src/types/contracts/aest/roles.ts
@@ -31,6 +31,7 @@ export enum Role {
   InstitutionApproveDeclineDesignation = "institution-approve-decline-designation",
   InstitutionApproveDeclineOfferingChanges = "institution-approve-decline-offering-changes",
   InstitutionApproveDeclineApplicationOfferingChangeRequest = "institution-approve-decline-application-offering-change-request",
+  InstitutionDeactivateEducationProgram = "institution-deactivate-education-program",
   StudentReissueMSFAA = "student-reissue-msfaa",
   StudentUpdateDisabilityStatus = "student-update-disability-status",
 }

--- a/sources/packages/web/src/views/aest/institution/ProgramDetails.vue
+++ b/sources/packages/web/src/views/aest/institution/ProgramDetails.vue
@@ -38,11 +38,12 @@
         status: educationProgram.programStatus,
       }"
     />
-    <ManageProgramAndOfferingSummary
+    <manage-program-and-offering-summary
       :programId="programId"
       :locationId="locationId"
       :educationProgram="educationProgram"
       :institutionId="institutionId"
+      @program-data-updated="programDataUpdated"
     />
     <!-- approve program modal -->
     <ApproveProgramModal ref="approveProgramModal" />
@@ -153,6 +154,8 @@ export default defineComponent({
       if (declineProgramData) await submitDeclineProgram(declineProgramData);
     };
 
+    const programDataUpdated = () => getEducationProgramAndOffering();
+
     onMounted(getEducationProgramAndOffering);
 
     return {
@@ -164,6 +167,7 @@ export default defineComponent({
       declineProgramModal,
       declineProgram,
       Role,
+      programDataUpdated,
     };
   },
 });

--- a/sources/packages/web/src/views/aest/institution/Programs.vue
+++ b/sources/packages/web/src/views/aest/institution/Programs.vue
@@ -72,6 +72,7 @@
             ><template #body="slotProps">
               <status-chip-program
                 :status="slotProps.data.programStatus"
+                :is-active="slotProps.data.isActive"
               ></status-chip-program> </template
           ></Column>
           <Column header="Action">

--- a/sources/packages/web/src/views/institution/locations/confirmation-of-enrollment/ApplicationDetailsForCOE.vue
+++ b/sources/packages/web/src/views/institution/locations/confirmation-of-enrollment/ApplicationDetailsForCOE.vue
@@ -31,7 +31,7 @@
             >
               <template v-for="(item, index) in items" :key="index">
                 <v-list-item :value="index" @click="item.command">
-                  <v-list-item-title :class="item.textColor">
+                  <v-list-item-title>
                     <span class="label-bold">{{ item.label }}</span>
                   </v-list-item-title>
                 </v-list-item>

--- a/sources/packages/web/src/views/institution/locations/programs/LocationProgramAddEdit.vue
+++ b/sources/packages/web/src/views/institution/locations/programs/LocationProgramAddEdit.vue
@@ -28,9 +28,8 @@
     <formio-container
       formName="educationProgram"
       :formData="programData"
-      :readOnly="isReadonly"
       @submitted="submitted"
-      ><template #actions="{ submit }" v-if="!isReadonly">
+      ><template #actions="{ submit }" v-if="!programData.isReadonly">
         <footer-buttons
           :processing="processing"
           primaryLabel="Submit"
@@ -48,7 +47,7 @@ import {
   InstitutionRoutesConst,
   AESTRoutesConst,
 } from "@/constants/routes/RouteConstants";
-import { onMounted, ref, computed, defineComponent } from "vue";
+import { ref, computed, defineComponent, isReadonly, onMounted } from "vue";
 import { ApiProcessError, ClientIdType, FormIOForm } from "@/types";
 import { useFormioUtils, useSnackBar } from "@/composables";
 import { AuthService } from "@/services/AuthService";
@@ -58,6 +57,10 @@ import {
   EducationProgramAPIOutDTO,
 } from "@/services/http/dto";
 import { InstitutionService } from "@/services/InstitutionService";
+
+type EducationProgramFormData = EducationProgramAPIOutDTO & {
+  isReadonly: boolean;
+};
 
 export default defineComponent({
   props: {
@@ -76,23 +79,24 @@ export default defineComponent({
     const { excludeExtraneousValues } = useFormioUtils();
     const router = useRouter();
     const clientType = computed(() => AuthService.shared.authClientType);
-    const programData = ref({} as EducationProgramAPIOutDTO);
+    const programData = ref({} as EducationProgramFormData);
     const isInstitutionUser = computed(() => {
       return clientType.value === ClientIdType.Institution;
     });
     const isAESTUser = computed(() => {
       return clientType.value === ClientIdType.AEST;
     });
-    const isReadonly = computed(() => {
-      return isAESTUser.value || !programData.value.isActive;
-    });
 
     const loadFormData = async () => {
       if (props.programId) {
-        programData.value =
+        const educationProgram =
           await EducationProgramService.shared.getEducationProgram(
             props.programId,
           );
+        programData.value = {
+          ...educationProgram,
+          isReadonly: isAESTUser.value || !educationProgram.isActive,
+        };
       } else {
         // Initialize programData with institution profile data.
         const institutionProfile = await InstitutionService.shared.getDetail();
@@ -100,7 +104,8 @@ export default defineComponent({
           isBCPrivate: institutionProfile.isBCPrivate,
           isBCPublic: institutionProfile.isBCPublic,
           hasOfferings: false,
-        } as EducationProgramAPIOutDTO;
+          isReadonly: false,
+        } as EducationProgramFormData;
       }
     };
 
@@ -172,9 +177,9 @@ export default defineComponent({
     });
 
     const subTitle = computed(() => {
-      if (isReadonly.value) {
+      if (programData.value.isReadonly) {
         return "View Program";
-      } else if (props.programId && !isReadonly.value) {
+      } else if (props.programId && !programData.value.isReadonly) {
         return "Edit Program";
       } else if (!props?.programId) {
         return "Create Program";

--- a/sources/packages/web/src/views/institution/locations/programs/LocationProgramAddEdit.vue
+++ b/sources/packages/web/src/views/institution/locations/programs/LocationProgramAddEdit.vue
@@ -84,7 +84,7 @@ export default defineComponent({
       return clientType.value === ClientIdType.AEST;
     });
     const isReadonly = computed(() => {
-      return isAESTUser.value;
+      return isAESTUser.value || !programData.value.isActive;
     });
 
     const loadFormData = async () => {

--- a/sources/packages/web/src/views/institution/locations/programs/LocationProgramView.vue
+++ b/sources/packages/web/src/views/institution/locations/programs/LocationProgramView.vue
@@ -23,6 +23,7 @@
       :programId="programId"
       :locationId="locationId"
       :educationProgram="educationProgram"
+      @program-data-updated="programDataUpdated"
     />
   </full-page-container>
 </template>
@@ -58,9 +59,12 @@ export default defineComponent({
 
     onMounted(getEducationProgramAndOffering);
 
+    const programDataUpdated = () => getEducationProgramAndOffering();
+
     return {
       educationProgram,
       InstitutionRoutesConst,
+      programDataUpdated,
     };
   },
 });

--- a/sources/packages/web/src/views/institution/locations/programs/LocationPrograms.vue
+++ b/sources/packages/web/src/views/institution/locations/programs/LocationPrograms.vue
@@ -59,6 +59,7 @@
               <td data-cy="programStatus">
                 <status-chip-program
                   :status="item.programStatus"
+                  :is-active="item.isActive"
                 ></status-chip-program>
               </td>
               <td>


### PR DESCRIPTION
#### Added a new actions menu for the programs available for Institutions and the ministry.

Institutions will see a label for "Edit program" or "View program" based in the fact that the program is editable or not.
Ministry will always see the label as "View program".

![image](https://github.com/bcgov/SIMS/assets/61259237/6d75e812-d380-4abe-b800-67b1835b67d1)

When a program is `Inactive` the badges are adjusted and the menu options are changed to "View program" and the `Deactivate` option is disabled.

![image](https://github.com/bcgov/SIMS/assets/61259237/655b2e97-9621-44be-8961-30cee860488d)

Badges were also adjusted for the summary view, as shown below.

![image](https://github.com/bcgov/SIMS/assets/61259237/f2421177-d651-4939-be06-d45bc7fa319c)

Program visualization adjusted to display the form is read-only when Inactive.
_An existing and known error was affecting the form.io to display the program in read-only.  The right visualization is read-only works depending in the order that the form.io definition and program data are loaded from the API. To fix it a main container was added to the form.io definition._

![image](https://github.com/bcgov/SIMS/assets/61259237/97cc0963-f0a6-4c99-8ee3-4702e6a1d899)

- API validation was added to prevent saving an inactive program.
- Created DB migration to allow the SABC code validation only for active programs. Following similar features, a unique index was used instead of a DB constraint to allow the `where` condition in DB validation.
- Minor CSS styles were created to allow the bold style to be applied to the menu action items.
- Created a `danger` global style for Vue following the same color as `Error`. The goal is to have a better context while setting the color.
- The same modal is shared for Ministry and Institution. The existing component was already executing client-type checks (they were kept, just refactored).

**Ministry Modal**
![image](https://github.com/bcgov/SIMS/assets/61259237/20514563-aedd-4389-95c1-02f9ef97deba)

**Institution Modal**
![image](https://github.com/bcgov/SIMS/assets/61259237/b014b96f-70fa-42f0-95f8-aa0c0acdd387)

### Modal Existing Issue
The latest developed modals introduced using the `keepModalOpen` option have an issue when the API call fails and the API call will not be executed again if the user retries the operation. This happens because the promise is not held once the API fails.
To resolve this issue and achieve the same behavior it was introduced the `beforeResolvePromise` callback that allow the modal to stay open and the retry operation to work. Please take a look and share some thoughts.

#### Bulk uploaded constraint adjustment
The bulk uploaded query to search programs was adjusted to include the `isActive` in the clause allowing the build upload to work also considering the deactivated programs.






