### PR TITLE
#2536 - Notify Student About Blocked Disbursements (e2e tests)

### DIFF
--- a/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/esdc-integration/ecert-integration/_tests_/ecert-part-time-process-integration.scheduler.e2e-spec.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/esdc-integration/ecert-integration/_tests_/ecert-part-time-process-integration.scheduler.e2e-spec.ts
@@ -278,7 +278,6 @@ describe(
           },
         },
       );
-      const todaysDate = new Date();
       // Create 1 pre-existing notification for the above created disbursement.
       await saveFakeNotification(
         db.dataSource,
@@ -304,7 +303,7 @@ describe(
               disbursementId:
                 application.currentAssessment.disbursementSchedules[0].id,
             },
-            createdAt: new Date(todaysDate.setDate(todaysDate.getDate() - 6)),
+            createdAt: addDays(-6),
           },
         },
       );
@@ -368,7 +367,6 @@ describe(
           },
         },
       );
-      const todaysDate = new Date();
       // Create 1 pre-existing notification for the above created disbursement.
       await saveFakeNotification(
         db.dataSource,
@@ -394,7 +392,7 @@ describe(
               disbursementId:
                 application.currentAssessment.disbursementSchedules[0].id,
             },
-            createdAt: new Date(todaysDate.setDate(todaysDate.getDate() - 7)),
+            createdAt: addDays(-7),
           },
         },
       );

--- a/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/esdc-integration/ecert-integration/_tests_/ecert-part-time-process-integration.scheduler.e2e-spec.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/esdc-integration/ecert-integration/_tests_/ecert-part-time-process-integration.scheduler.e2e-spec.ts
@@ -53,7 +53,7 @@ describe(
       sftpClientMock = sshClientMock;
       // Processor under test.
       processor = app.get(PartTimeECertProcessIntegrationScheduler);
-      systemUsersService = nestApplication.get(SystemUsersService);
+      systemUsersService = app.get(SystemUsersService);
     });
 
     beforeEach(async () => {
@@ -100,10 +100,6 @@ describe(
         {
           offeringIntensity: OfferingIntensity.partTime,
           applicationStatus: ApplicationStatus.Completed,
-          currentAssessmentInitialValues: {
-            assessmentData: { weeks: 5 } as Assessment,
-            assessmentDate: new Date(),
-          },
           firstDisbursementInitialValues: {
             coeStatus: COEStatus.completed,
           },
@@ -121,10 +117,12 @@ describe(
         "Generated file: none",
         "Uploaded records: 0",
       ]);
+      const disbursementScheduleId =
+        application.currentAssessment.disbursementSchedules[0].id;
       expect(
         mockedJob.containLogMessages([
-          `Creating notifications for disbursement id: ${application.currentAssessment.disbursementSchedules[0].id} for student and ministry.`,
-          `Completed creating notifications for disbursement id: ${application.currentAssessment.disbursementSchedules[0].id} for student and ministry.`,
+          `Creating notifications for disbursement id: ${disbursementScheduleId} for student and ministry.`,
+          `Completed creating notifications for disbursement id: ${disbursementScheduleId} for student and ministry.`,
         ]),
       ).toBe(true);
       const studentNotificationCount = await db.notification.count({
@@ -184,10 +182,6 @@ describe(
         {
           offeringIntensity: OfferingIntensity.partTime,
           applicationStatus: ApplicationStatus.Completed,
-          currentAssessmentInitialValues: {
-            assessmentData: { weeks: 5 } as Assessment,
-            assessmentDate: new Date(),
-          },
           firstDisbursementInitialValues: {
             coeStatus: COEStatus.completed,
           },
@@ -279,10 +273,6 @@ describe(
         {
           offeringIntensity: OfferingIntensity.partTime,
           applicationStatus: ApplicationStatus.Completed,
-          currentAssessmentInitialValues: {
-            assessmentData: { weeks: 5 } as Assessment,
-            assessmentDate: new Date(),
-          },
           firstDisbursementInitialValues: {
             coeStatus: COEStatus.completed,
           },
@@ -373,10 +363,6 @@ describe(
         {
           offeringIntensity: OfferingIntensity.partTime,
           applicationStatus: ApplicationStatus.Completed,
-          currentAssessmentInitialValues: {
-            assessmentData: { weeks: 5 } as Assessment,
-            assessmentDate: new Date(),
-          },
           firstDisbursementInitialValues: {
             coeStatus: COEStatus.completed,
           },

--- a/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/esdc-integration/ecert-integration/_tests_/ecert-part-time-process-integration.scheduler.e2e-spec.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/esdc-integration/ecert-integration/_tests_/ecert-part-time-process-integration.scheduler.e2e-spec.ts
@@ -3,6 +3,7 @@ import {
   Assessment,
   COEStatus,
   DisbursementScheduleStatus,
+  Notification,
   NotificationMessage,
   NotificationMessageType,
   OfferingIntensity,
@@ -467,7 +468,7 @@ describe(
       daysAhead?: number,
     ): Promise<void> {
       let notificationsCount = notificationsCounter;
-      const notificationPromises = [];
+      const notifications: Notification[] = [];
       while (notificationsCount > 0) {
         const studentNotification = createFakeNotification(
           {
@@ -492,6 +493,7 @@ describe(
                 disbursementId,
               },
               createdAt: daysAhead ? addDays(daysAhead) : new Date(),
+              dateSent: new Date(),
             },
           },
         );
@@ -518,17 +520,15 @@ describe(
                 disbursementId,
               },
               createdAt: daysAhead ? addDays(daysAhead) : new Date(),
+              dateSent: new Date(),
             },
           },
         );
-        studentNotification.dateSent = new Date();
-        ministryNotification.dateSent = new Date();
-        notificationPromises.push(
-          db.notification.save([studentNotification, ministryNotification]),
-        );
+        notifications.push(studentNotification);
+        notifications.push(ministryNotification);
         notificationsCount--;
       }
-      await Promise.all(notificationPromises);
+      await db.notification.save(notifications);
     }
 
     /**

--- a/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/esdc-integration/ecert-integration/_tests_/ecert-part-time-process-integration.scheduler.e2e-spec.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/esdc-integration/ecert-integration/_tests_/ecert-part-time-process-integration.scheduler.e2e-spec.ts
@@ -14,7 +14,7 @@ import {
   createFakeMSFAANumber,
   saveFakeApplicationDisbursements,
   saveFakeStudent,
-  saveFakeNotification,
+  createFakeNotification,
 } from "@sims/test-utils";
 import { getUploadedFile } from "@sims/test-utils/mocks";
 import { IsNull, Like, Not } from "typeorm";
@@ -190,11 +190,10 @@ describe(
       // Create pre-existing 3 notifications for the above created disbursement.
       let notificationCounter = 3;
       while (notificationCounter > 0 && notificationCounter--) {
-        await saveFakeNotification(
-          db.dataSource,
+        const notification = createFakeNotification(
           {
             user: student.user,
-            creator: systemUsersService.systemUser,
+            auditUser: systemUsersService.systemUser,
             notificationMessage: {
               id: NotificationMessageType.StudentNotificationDisbursementBlocked,
             } as NotificationMessage,
@@ -217,6 +216,7 @@ describe(
             },
           },
         );
+        await db.notification.save(notification);
       }
       // Queued job.
       const mockedJob = mockBullJob<void>();
@@ -279,11 +279,10 @@ describe(
         },
       );
       // Create 1 pre-existing notification for the above created disbursement.
-      await saveFakeNotification(
-        db.dataSource,
+      const notification = createFakeNotification(
         {
           user: student.user,
-          creator: systemUsersService.systemUser,
+          auditUser: systemUsersService.systemUser,
           notificationMessage: {
             id: NotificationMessageType.StudentNotificationDisbursementBlocked,
           } as NotificationMessage,
@@ -307,6 +306,7 @@ describe(
           },
         },
       );
+      await db.notification.save(notification);
       // Queued job.
       const mockedJob = mockBullJob<void>();
 
@@ -368,11 +368,10 @@ describe(
         },
       );
       // Create 1 pre-existing notification for the above created disbursement.
-      await saveFakeNotification(
-        db.dataSource,
+      const notification = createFakeNotification(
         {
           user: student.user,
-          creator: systemUsersService.systemUser,
+          auditUser: systemUsersService.systemUser,
           notificationMessage: {
             id: NotificationMessageType.StudentNotificationDisbursementBlocked,
           } as NotificationMessage,
@@ -396,6 +395,7 @@ describe(
           },
         },
       );
+      await db.notification.save(notification);
       // Queued job.
       const mockedJob = mockBullJob<void>();
 

--- a/sources/packages/backend/libs/integrations/src/services/disbursement-schedule/e-cert-calculation/e-cert-calculation-process.ts
+++ b/sources/packages/backend/libs/integrations/src/services/disbursement-schedule/e-cert-calculation/e-cert-calculation-process.ts
@@ -126,6 +126,7 @@ export abstract class ECertCalculationProcess {
               await this.eCertNotificationService.createDisbursementBlockedNotification(
                 eCertDisbursement.disbursement.id,
                 entityManager,
+                parentLog,
               );
               disbursementLog.info(
                 "The step determined that the calculation should be interrupted. This disbursement will not be part of the next e-Cert generation.",

--- a/sources/packages/backend/libs/integrations/src/services/disbursement-schedule/e-cert-notification/e-cert-notification.service.ts
+++ b/sources/packages/backend/libs/integrations/src/services/disbursement-schedule/e-cert-notification/e-cert-notification.service.ts
@@ -14,6 +14,7 @@ import {
   NotificationMessageType,
 } from "@sims/sims-db";
 import { dateDifference } from "@sims/utilities";
+import { ProcessSummary } from "@sims/utilities/logger";
 import { EntityManager } from "typeorm";
 
 interface NotificationData {
@@ -31,10 +32,12 @@ export class ECertNotificationService {
    * Checks and creates disbursement blocked notification.
    * @param disbursementId disbursement id.
    * @param entityManager entity manager to execute in transaction.
+   * @param parentLog cumulative process log.
    */
   async createDisbursementBlockedNotification(
     disbursementId: number,
     entityManager: EntityManager,
+    parentLog: ProcessSummary,
   ): Promise<void> {
     const shouldCreateNotification =
       await this.shouldCreateDisbursementBlockedNotification(
@@ -42,9 +45,17 @@ export class ECertNotificationService {
         entityManager,
       );
     if (shouldCreateNotification) {
+      const notificationLog = new ProcessSummary();
+      parentLog.children(notificationLog);
+      notificationLog.info(
+        `Creating notifications for disbursement id: ${disbursementId} for student and ministry.`,
+      );
       await this.createDisbursementBlockedNotifications(
         disbursementId,
         entityManager,
+      );
+      notificationLog.info(
+        `Completed creating notifications for disbursement id: ${disbursementId} for student and ministry.`,
       );
     }
   }

--- a/sources/packages/backend/libs/sims-db/src/database.module.ts
+++ b/sources/packages/backend/libs/sims-db/src/database.module.ts
@@ -7,7 +7,7 @@ import { DBEntities, ormConfig } from "./data-source";
   imports: [
     TypeOrmModule.forRoot({
       ...ormConfig,
-      logging: ["error", "warn", "query"],
+      logging: ["error", "warn"],
       entities: DBEntities,
     }),
     TypeOrmModule.forFeature(DBEntities),

--- a/sources/packages/backend/libs/sims-db/src/database.module.ts
+++ b/sources/packages/backend/libs/sims-db/src/database.module.ts
@@ -7,7 +7,7 @@ import { DBEntities, ormConfig } from "./data-source";
   imports: [
     TypeOrmModule.forRoot({
       ...ormConfig,
-      logging: ["error", "warn"],
+      logging: ["error", "warn", "query"],
       entities: DBEntities,
     }),
     TypeOrmModule.forFeature(DBEntities),

--- a/sources/packages/backend/libs/test-utils/src/factories/notification.ts
+++ b/sources/packages/backend/libs/test-utils/src/factories/notification.ts
@@ -14,7 +14,7 @@ import * as faker from "faker";
 function createDummyMessagePayload(): NotificationEmailMessage {
   return {
     email_address: faker.internet.email(),
-    template_id: NotificationMessageType.StudentFileUpload.toString(),
+    template_id: faker.datatype.string(),
     personalisation: {
       givenNames: faker.name.firstName(),
       lastName: faker.name.lastName(),

--- a/sources/packages/backend/libs/test-utils/src/factories/notification.ts
+++ b/sources/packages/backend/libs/test-utils/src/factories/notification.ts
@@ -5,7 +5,6 @@ import {
   User,
 } from "@sims/sims-db";
 import { DataSource } from "typeorm";
-import { createFakeUser } from "./user";
 import * as faker from "faker";
 
 /**
@@ -62,7 +61,7 @@ function createFakeNotification(
   },
 ): Notification {
   const notification = new Notification();
-  notification.user = relations?.user ?? createFakeUser();
+  notification.user = relations?.user;
   notification.notificationMessage =
     relations?.notificationMessage ??
     ({

--- a/sources/packages/backend/libs/test-utils/src/factories/notification.ts
+++ b/sources/packages/backend/libs/test-utils/src/factories/notification.ts
@@ -62,7 +62,7 @@ function createFakeNotification(
   },
 ): Notification {
   const notification = new Notification();
-  notification.user = relations.user ?? createFakeUser();
+  notification.user = relations?.user ?? createFakeUser();
   notification.notificationMessage =
     relations?.notificationMessage ??
     ({

--- a/sources/packages/backend/libs/test-utils/src/factories/notification.ts
+++ b/sources/packages/backend/libs/test-utils/src/factories/notification.ts
@@ -54,6 +54,5 @@ export function createFakeNotification(
     options?.initialValue?.messagePayload ?? createDummyMessagePayload();
   notification.creator = relations?.auditUser ?? null;
   notification.createdAt = options?.initialValue?.createdAt;
-  notification.dateSent = new Date();
   return notification;
 }

--- a/sources/packages/backend/libs/test-utils/src/factories/notification.ts
+++ b/sources/packages/backend/libs/test-utils/src/factories/notification.ts
@@ -54,5 +54,6 @@ export function createFakeNotification(
     options?.initialValue?.messagePayload ?? createDummyMessagePayload();
   notification.creator = relations?.auditUser ?? null;
   notification.createdAt = options?.initialValue?.createdAt;
+  notification.dateSent = options?.initialValue?.dateSent;
   return notification;
 }

--- a/sources/packages/backend/libs/test-utils/src/factories/notification.ts
+++ b/sources/packages/backend/libs/test-utils/src/factories/notification.ts
@@ -1,0 +1,115 @@
+import {
+  Notification,
+  NotificationMessage,
+  NotificationMessageType,
+  User,
+} from "@sims/sims-db";
+import { DataSource } from "typeorm";
+import { createFakeUser } from "./user";
+import * as faker from "faker";
+
+/**
+ * Email message format.
+ */
+interface NotificationEmailMessage {
+  template_id: string;
+  email_address: string;
+  personalisation?: {
+    [key: string]:
+      | string
+      | number
+      | {
+          file: string;
+          filename: string;
+          sending_method: "attach" | "link";
+        };
+  };
+}
+
+/**
+ * Creates a fake message payload.
+ * @returns created message payload.
+ */
+function createDummyMessagePayload(): NotificationEmailMessage {
+  return {
+    email_address: faker.internet.email(),
+    template_id: NotificationMessageType.StudentFileUpload.toString(),
+    personalisation: {
+      givenNames: faker.name.firstName(),
+      lastName: faker.name.lastName(),
+    },
+  };
+}
+
+/**
+ *
+ * @param relations notification entity relations.
+ * - `user` related user.
+ * - `creator` related creator.
+ * - `notificationMessage` related notification message.
+ * @param options notification options.
+ * - `initialValue` notification initial values.
+ * @returns created notification.
+ */
+function createFakeNotification(
+  relations?: {
+    user?: User;
+    creator?: User;
+    notificationMessage?: NotificationMessage;
+  },
+  options?: {
+    initialValue?: Partial<Notification>;
+  },
+): Notification {
+  const notification = new Notification();
+  notification.user = relations.user ?? createFakeUser();
+  notification.notificationMessage =
+    relations?.notificationMessage ??
+    ({
+      id: NotificationMessageType.StudentFileUpload,
+    } as NotificationMessage);
+  notification.metadata = options?.initialValue?.metadata ?? null;
+  notification.messagePayload =
+    options?.initialValue?.messagePayload ?? createDummyMessagePayload();
+  notification.creator = relations?.creator ?? null;
+  notification.createdAt = options?.initialValue?.createdAt;
+  return notification;
+}
+
+/**
+ * Create and save fake student.
+ * @param dataSource data source to persist the notification.
+ * @param relations notification entity relations.
+ * - `notification` notification to be created and associated with other relations.
+ * - `notificationMessage` related notification message.
+ * - `user` related user.
+ * - `creator` related creator.
+ * @param options notification options.
+ * - `initialValue` notification initial values.
+ * @returns persisted notification.
+ */
+export async function saveFakeNotification(
+  dataSource: DataSource,
+  relations?: {
+    notification?: Notification;
+    notificationMessage?: NotificationMessage;
+    user?: User;
+    creator?: User;
+  },
+  options?: {
+    initialValue?: Partial<Notification>;
+  },
+): Promise<Notification> {
+  const notificationRepo = dataSource.getRepository(Notification);
+  return notificationRepo.save(
+    relations?.notification ??
+      createFakeNotification(
+        {
+          user: relations?.user,
+          creator: relations?.creator,
+          notificationMessage: relations?.notificationMessage,
+        },
+        { initialValue: options?.initialValue },
+      ),
+  );
+}

--- a/sources/packages/backend/libs/test-utils/src/factories/notification.ts
+++ b/sources/packages/backend/libs/test-utils/src/factories/notification.ts
@@ -1,29 +1,11 @@
+import { NotificationEmailMessage } from "@sims/services";
 import {
   Notification,
   NotificationMessage,
   NotificationMessageType,
   User,
 } from "@sims/sims-db";
-import { DataSource } from "typeorm";
 import * as faker from "faker";
-
-/**
- * Email message format.
- */
-interface NotificationEmailMessage {
-  template_id: string;
-  email_address: string;
-  personalisation?: {
-    [key: string]:
-      | string
-      | number
-      | {
-          file: string;
-          filename: string;
-          sending_method: "attach" | "link";
-        };
-  };
-}
 
 /**
  * Creates a fake message payload.
@@ -44,16 +26,16 @@ function createDummyMessagePayload(): NotificationEmailMessage {
  *
  * @param relations notification entity relations.
  * - `user` related user.
- * - `creator` related creator.
+ * - `auditUser` related audit user.
  * - `notificationMessage` related notification message.
  * @param options notification options.
  * - `initialValue` notification initial values.
  * @returns created notification.
  */
-function createFakeNotification(
+export function createFakeNotification(
   relations?: {
     user?: User;
-    creator?: User;
+    auditUser?: User;
     notificationMessage?: NotificationMessage;
   },
   options?: {
@@ -70,45 +52,8 @@ function createFakeNotification(
   notification.metadata = options?.initialValue?.metadata ?? null;
   notification.messagePayload =
     options?.initialValue?.messagePayload ?? createDummyMessagePayload();
-  notification.creator = relations?.creator ?? null;
+  notification.creator = relations?.auditUser ?? null;
   notification.createdAt = options?.initialValue?.createdAt;
+  notification.dateSent = new Date();
   return notification;
-}
-
-/**
- * Create and save fake student.
- * @param dataSource data source to persist the notification.
- * @param relations notification entity relations.
- * - `notification` notification to be created and associated with other relations.
- * - `notificationMessage` related notification message.
- * - `user` related user.
- * - `creator` related creator.
- * @param options notification options.
- * - `initialValue` notification initial values.
- * @returns persisted notification.
- */
-export async function saveFakeNotification(
-  dataSource: DataSource,
-  relations?: {
-    notification?: Notification;
-    notificationMessage?: NotificationMessage;
-    user?: User;
-    creator?: User;
-  },
-  options?: {
-    initialValue?: Partial<Notification>;
-  },
-): Promise<Notification> {
-  const notificationRepo = dataSource.getRepository(Notification);
-  return notificationRepo.save(
-    relations?.notification ??
-      createFakeNotification(
-        {
-          user: relations?.user,
-          creator: relations?.creator,
-          notificationMessage: relations?.notificationMessage,
-        },
-        { initialValue: options?.initialValue },
-      ),
-  );
 }

--- a/sources/packages/backend/libs/test-utils/src/factories/sin-validation.ts
+++ b/sources/packages/backend/libs/test-utils/src/factories/sin-validation.ts
@@ -1,9 +1,12 @@
 import { SINValidation, Student } from "@sims/sims-db";
 import * as faker from "faker";
 
-export function createFakeSINValidation(relations?: {
-  student?: Student;
-}): SINValidation {
+export function createFakeSINValidation(
+  relations?: {
+    student?: Student;
+  },
+  options?: { initialValue?: Partial<SINValidation> },
+): SINValidation {
   const now = new Date();
   const sinValidation = new SINValidation();
   // Generated an invalid SIN and avoiding a number starting with 9
@@ -19,7 +22,7 @@ export function createFakeSINValidation(relations?: {
   sinValidation.surnameSent = null;
   sinValidation.dobSent = null;
   sinValidation.genderSent = null;
-  sinValidation.isValidSIN = true;
+  sinValidation.isValidSIN = options?.initialValue?.isValidSIN ?? true;
   sinValidation.sinStatus = "1";
   sinValidation.validSINCheck = "Y";
   sinValidation.validBirthdateCheck = "Y";

--- a/sources/packages/backend/libs/test-utils/src/factories/sin-validation.ts
+++ b/sources/packages/backend/libs/test-utils/src/factories/sin-validation.ts
@@ -1,6 +1,14 @@
 import { SINValidation, Student } from "@sims/sims-db";
 import * as faker from "faker";
 
+/**
+ * Creates a fake SINValidation.
+ * @param relations SINValidation relations.
+ * `student` related student.
+ * @param options SINValidation options.
+ * `initialValue` SINValidation initial value.
+ * @returns persisted SINValidation with relations provided.
+ */
 export function createFakeSINValidation(
   relations?: {
     student?: Student;

--- a/sources/packages/backend/libs/test-utils/src/factories/student.ts
+++ b/sources/packages/backend/libs/test-utils/src/factories/student.ts
@@ -40,12 +40,16 @@ export function createFakeStudent(
  * - `sinValidation` related SIN validation.
  * @param options student options.
  * - `initialValue` student initial values.
+ * - `sinValidationInitialValue` sinValidation initial value.
  * @returns persisted student with relations provided.
  */
 export async function saveFakeStudent(
   dataSource: DataSource,
   relations?: { student?: Student; user?: User; sinValidation?: SINValidation },
-  options?: { initialValue?: Partial<Student> },
+  options?: {
+    initialValue?: Partial<Student>;
+    sinValidationInitialValue?: Partial<SINValidation>;
+  },
 ): Promise<Student> {
   const studentRepo = dataSource.getRepository(Student);
   const student = await studentRepo.save(
@@ -56,6 +60,10 @@ export async function saveFakeStudent(
   );
   // Saving SIN validation after student is saved due to cyclic dependency error.
   student.sinValidation =
-    relations?.sinValidation ?? createFakeSINValidation({ student });
+    relations?.sinValidation ??
+    createFakeSINValidation(
+      { student },
+      { initialValue: options?.sinValidationInitialValue },
+    );
   return studentRepo.save(student);
 }

--- a/sources/packages/backend/libs/test-utils/src/index.ts
+++ b/sources/packages/backend/libs/test-utils/src/index.ts
@@ -29,3 +29,4 @@ export * from "./factories/disbursement-receipt-value";
 export * from "./factories/application-offering-change-request";
 export * from "./factories/designation-agreement-locations";
 export * from "./factories/disbursement-feedback-error";
+export * from "./factories/notification";


### PR DESCRIPTION
### As a part of this PR, wrote the following e2e tests:

- Scheduler queue processor for part-time-e-cert-integration.
    √ Should create a notification for the ministry and student for a blocked disbursement when there are no previously existing notifications for the disbursement.
    √ Should not create a notification for the student for a disbursement when there are already 3 notifications created.
    √ Should not create a notification for the student for a disbursement when an attempt is made to create the 2nd notification before 7 days from the first notification.
    √ Should create a notification for the student for a disbursement when an attempt is made to create the 2nd notification on or after 7 days from the first notification.

### Screenshot:

<img width="1208" alt="image" src="https://github.com/bcgov/SIMS/assets/7859295/4be5c720-2a2c-4662-a514-b8fdd27cfbf4">