### PR TITLE
#2694 - PT life time maximum part 2

### DIFF
--- a/sources/packages/backend/apps/api/src/app.aest.module.ts
+++ b/sources/packages/backend/apps/api/src/app.aest.module.ts
@@ -29,6 +29,7 @@ import {
   DisbursementReceiptService,
   DisbursementScheduleService,
   ApplicationOfferingChangeRequestService,
+  StudentLoanBalanceService,
 } from "./services";
 import {
   SupportingUserAESTController,
@@ -176,6 +177,7 @@ import {
     ApplicationOfferingChangeRequestService,
     ApplicationOfferingChangeRequestControllerService,
     AssessmentSequentialProcessingService,
+    StudentLoanBalanceService,
   ],
 })
 export class AppAESTModule {}

--- a/sources/packages/backend/apps/api/src/route-controllers/student-loan-balance/_tests_/e2e/student-loan-balance.aest.controller.getStudentLoanBalance.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/student-loan-balance/_tests_/e2e/student-loan-balance.aest.controller.getStudentLoanBalance.e2e-spec.ts
@@ -107,6 +107,12 @@ describe("StudentLoanBalanceAESTController(e2e)-getStudentLoanBalance", () => {
     await app?.close();
   });
 
+  /**
+   * Created student loan balance records.
+   * @param numberOfRecords number of records to create.
+   * @param cslBalance loan balance amount.
+   * @returns student loan balance records.
+   */
   function createStudentBalanceRecords(
     numberOfRecords: number,
     cslBalance: number,

--- a/sources/packages/backend/apps/api/src/route-controllers/student-loan-balance/_tests_/e2e/student-loan-balance.aest.controller.getStudentLoanBalance.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/student-loan-balance/_tests_/e2e/student-loan-balance.aest.controller.getStudentLoanBalance.e2e-spec.ts
@@ -11,7 +11,7 @@ import {
   E2EDataSources,
   createE2EDataSources,
   saveFakeStudent,
-  createStudentBalanceRecords,
+  createFakeStudentBalances,
 } from "@sims/test-utils";
 
 describe("StudentLoanBalanceAESTController(e2e)-getStudentLoanBalance", () => {
@@ -31,7 +31,7 @@ describe("StudentLoanBalanceAESTController(e2e)-getStudentLoanBalance", () => {
       // Arrange
       const student = await saveFakeStudent(db.dataSource);
       // Create loan balance records less than maximum essential records in recent for the student.
-      const studentBalanceRecords = createStudentBalanceRecords(
+      const studentBalanceRecords = createFakeStudentBalances(
         student.id,
         MAXIMUM_ESSENTIAL_LOAN_BALANCE_RECORDS - 1,
         { cslBalance: 100 },
@@ -67,14 +67,14 @@ describe("StudentLoanBalanceAESTController(e2e)-getStudentLoanBalance", () => {
       // Arrange
       const student = await saveFakeStudent(db.dataSource);
       // Create loan balance records more than maximum essential records in recent for the student.
-      const studentBalanceRecords = createStudentBalanceRecords(
+      const studentBalanceRecords = createFakeStudentBalances(
         student.id,
         MAXIMUM_ESSENTIAL_LOAN_BALANCE_RECORDS + 1,
         { cslBalance: 100 },
       );
       await db.studentLoanBalance.save(studentBalanceRecords);
       // Maximum essential recent loan balance records.
-      const essentialStudentLoanBalanceRecords = createStudentBalanceRecords(
+      const essentialStudentLoanBalanceRecords = createFakeStudentBalances(
         student.id,
         MAXIMUM_ESSENTIAL_LOAN_BALANCE_RECORDS,
         { cslBalance: 100 },

--- a/sources/packages/backend/apps/api/src/route-controllers/student-loan-balance/_tests_/e2e/student-loan-balance.aest.controller.getStudentLoanBalance.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/student-loan-balance/_tests_/e2e/student-loan-balance.aest.controller.getStudentLoanBalance.e2e-spec.ts
@@ -28,10 +28,11 @@ describe("StudentLoanBalanceAESTController(e2e)-getStudentLoanBalance", () => {
 
   it(
     "Should get all the student loan balance records," +
-      ` when a student has loan balance records less than ${MAXIMUM_ESSENTIAL_LOAN_BALANCE_RECORDS}.`,
+      ` when a student has less than ${MAXIMUM_ESSENTIAL_LOAN_BALANCE_RECORDS} loan balance records.`,
     async () => {
       // Arrange
       const student = await saveFakeStudent(db.dataSource);
+      // Create 4 loan balance records for the student.
       const studentBalanceRecords = createStudentBalanceRecords(4, 100);
       const studentLoanBalance = studentBalanceRecords.map((record) => {
         return createFakeStudentLoanBalance(
@@ -63,10 +64,11 @@ describe("StudentLoanBalanceAESTController(e2e)-getStudentLoanBalance", () => {
 
   it(
     `Should get the student loan balance up to recent ${MAXIMUM_ESSENTIAL_LOAN_BALANCE_RECORDS}` +
-      ` records, when a student has loan balance records more than ${MAXIMUM_ESSENTIAL_LOAN_BALANCE_RECORDS}.`,
+      ` records, when a student has more than ${MAXIMUM_ESSENTIAL_LOAN_BALANCE_RECORDS} loan balance records.`,
     async () => {
       // Arrange
       const student = await saveFakeStudent(db.dataSource);
+      // Create loan balance records more than maximum essential records in recent  for the student.
       const studentBalanceRecords = createStudentBalanceRecords(
         MAXIMUM_ESSENTIAL_LOAN_BALANCE_RECORDS + 2,
         100,
@@ -88,7 +90,7 @@ describe("StudentLoanBalanceAESTController(e2e)-getStudentLoanBalance", () => {
         100,
       );
       const endpoint = `/aest/student-loan-balance/student/${student.id}`;
-      const token = await getAESTToken(AESTGroups.BusinessAdministrators);
+      const token = await getAESTToken(AESTGroups.Operations);
 
       // Act/Assert
       await request(app.getHttpServer())
@@ -102,6 +104,23 @@ describe("StudentLoanBalanceAESTController(e2e)-getStudentLoanBalance", () => {
         });
     },
   );
+
+  it("Should throw not found error when the student id is not valid. ", async () => {
+    // Arrange
+    const endpoint = "/aest/student-loan-balance/student/99999";
+    const token = await getAESTToken(AESTGroups.BusinessAdministrators);
+
+    // Act/Assert
+    await request(app.getHttpServer())
+      .get(endpoint)
+      .auth(token, BEARER_AUTH_TYPE)
+      .expect(HttpStatus.NOT_FOUND)
+      .expect({
+        statusCode: 404,
+        message: "Student not found.",
+        error: "Not Found",
+      });
+  });
 
   afterAll(async () => {
     await app?.close();

--- a/sources/packages/backend/apps/api/src/route-controllers/student-loan-balance/_tests_/e2e/student-loan-balance.aest.controller.getStudentLoanBalance.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/student-loan-balance/_tests_/e2e/student-loan-balance.aest.controller.getStudentLoanBalance.e2e-spec.ts
@@ -1,0 +1,124 @@
+import { HttpStatus, INestApplication } from "@nestjs/common";
+import * as request from "supertest";
+import {
+  AESTGroups,
+  BEARER_AUTH_TYPE,
+  createTestingAppModule,
+  getAESTToken,
+} from "../../../../testHelpers";
+import { MAXIMUM_ESSENTIAL_LOAN_BALANCE_RECORDS } from "../../../../utilities";
+
+import {
+  E2EDataSources,
+  createE2EDataSources,
+  saveFakeStudent,
+} from "@sims/test-utils";
+import { createFakeStudentLoanBalance } from "@sims/test-utils/factories/student-loan-balance";
+import { addToDateOnlyString } from "@sims/utilities";
+
+describe("StudentLoanBalanceAESTController(e2e)-getStudentLoanBalance", () => {
+  let app: INestApplication;
+  let db: E2EDataSources;
+
+  beforeAll(async () => {
+    const { nestApplication, dataSource } = await createTestingAppModule();
+    app = nestApplication;
+    db = createE2EDataSources(dataSource);
+  });
+
+  it(
+    "Should get all the student loan balance records," +
+      ` when a student has loan balance records less than ${MAXIMUM_ESSENTIAL_LOAN_BALANCE_RECORDS}.`,
+    async () => {
+      // Arrange
+      const student = await saveFakeStudent(db.dataSource);
+      const studentBalanceRecords = createStudentBalanceRecords(4, 100);
+      const studentLoanBalance = studentBalanceRecords.map((record) => {
+        return createFakeStudentLoanBalance(
+          { student },
+          {
+            initialValues: {
+              cslBalance: record.cslBalance,
+              balanceDate: record.balanceDate,
+            },
+          },
+        );
+      });
+      await db.studentLoanBalance.save(studentLoanBalance);
+      const endpoint = `/aest/student-loan-balance/student/${student.id}`;
+      const token = await getAESTToken(AESTGroups.BusinessAdministrators);
+
+      // Act/Assert
+      await request(app.getHttpServer())
+        .get(endpoint)
+        .auth(token, BEARER_AUTH_TYPE)
+        .expect(HttpStatus.OK)
+        .expect((response) => {
+          expect(response.body.loanBalanceDetails).toStrictEqual(
+            studentBalanceRecords,
+          );
+        });
+    },
+  );
+
+  it(
+    `Should get the student loan balance up to recent ${MAXIMUM_ESSENTIAL_LOAN_BALANCE_RECORDS}` +
+      ` records, when a student has loan balance records more than ${MAXIMUM_ESSENTIAL_LOAN_BALANCE_RECORDS}.`,
+    async () => {
+      // Arrange
+      const student = await saveFakeStudent(db.dataSource);
+      const studentBalanceRecords = createStudentBalanceRecords(
+        MAXIMUM_ESSENTIAL_LOAN_BALANCE_RECORDS + 2,
+        100,
+      );
+      const studentLoanBalance = studentBalanceRecords.map((record) => {
+        return createFakeStudentLoanBalance(
+          { student },
+          {
+            initialValues: {
+              cslBalance: record.cslBalance,
+              balanceDate: record.balanceDate,
+            },
+          },
+        );
+      });
+      await db.studentLoanBalance.save(studentLoanBalance);
+      const expectedStudentBalanceRecords = createStudentBalanceRecords(
+        MAXIMUM_ESSENTIAL_LOAN_BALANCE_RECORDS,
+        100,
+      );
+      const endpoint = `/aest/student-loan-balance/student/${student.id}`;
+      const token = await getAESTToken(AESTGroups.BusinessAdministrators);
+
+      // Act/Assert
+      await request(app.getHttpServer())
+        .get(endpoint)
+        .auth(token, BEARER_AUTH_TYPE)
+        .expect(HttpStatus.OK)
+        .expect((response) => {
+          expect(response.body.loanBalanceDetails).toStrictEqual(
+            expectedStudentBalanceRecords,
+          );
+        });
+    },
+  );
+
+  afterAll(async () => {
+    await app?.close();
+  });
+
+  function createStudentBalanceRecords(
+    numberOfRecords: number,
+    cslBalance: number,
+  ): { cslBalance: number; balanceDate: string }[] {
+    const loanBalanceRecords: { cslBalance: number; balanceDate: string }[] =
+      [];
+    for (let i = 1; i <= numberOfRecords; i++) {
+      loanBalanceRecords.push({
+        cslBalance,
+        balanceDate: addToDateOnlyString(new Date(), -i, "month"),
+      });
+    }
+    return loanBalanceRecords;
+  }
+});

--- a/sources/packages/backend/apps/api/src/route-controllers/student-loan-balance/_tests_/e2e/student-loan-balance.aest.controller.getStudentLoanBalance.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/student-loan-balance/_tests_/e2e/student-loan-balance.aest.controller.getStudentLoanBalance.e2e-spec.ts
@@ -7,13 +7,12 @@ import {
   getAESTToken,
 } from "../../../../testHelpers";
 import { MAXIMUM_ESSENTIAL_LOAN_BALANCE_RECORDS } from "../../../../utilities";
-
 import {
   E2EDataSources,
   createE2EDataSources,
   saveFakeStudent,
+  createFakeStudentLoanBalance,
 } from "@sims/test-utils";
-import { createFakeStudentLoanBalance } from "@sims/test-utils/factories/student-loan-balance";
 import { addToDateOnlyString } from "@sims/utilities";
 
 describe("StudentLoanBalanceAESTController(e2e)-getStudentLoanBalance", () => {
@@ -27,13 +26,16 @@ describe("StudentLoanBalanceAESTController(e2e)-getStudentLoanBalance", () => {
   });
 
   it(
-    "Should get all the student loan balance records," +
+    "Should get all the student loan balance records" +
       ` when a student has less than ${MAXIMUM_ESSENTIAL_LOAN_BALANCE_RECORDS} loan balance records.`,
     async () => {
       // Arrange
       const student = await saveFakeStudent(db.dataSource);
-      // Create 4 loan balance records for the student.
-      const studentBalanceRecords = createStudentBalanceRecords(4, 100);
+      // Create loan balance records less than maximum essential records in recent for the student.
+      const studentBalanceRecords = createStudentBalanceRecords(
+        MAXIMUM_ESSENTIAL_LOAN_BALANCE_RECORDS - 1,
+        100,
+      );
       const studentLoanBalance = studentBalanceRecords.map((record) => {
         return createFakeStudentLoanBalance(
           { student },
@@ -64,13 +66,13 @@ describe("StudentLoanBalanceAESTController(e2e)-getStudentLoanBalance", () => {
 
   it(
     `Should get the student loan balance up to recent ${MAXIMUM_ESSENTIAL_LOAN_BALANCE_RECORDS}` +
-      ` records, when a student has more than ${MAXIMUM_ESSENTIAL_LOAN_BALANCE_RECORDS} loan balance records.`,
+      ` records when a student has more than ${MAXIMUM_ESSENTIAL_LOAN_BALANCE_RECORDS} loan balance records.`,
     async () => {
       // Arrange
       const student = await saveFakeStudent(db.dataSource);
-      // Create loan balance records more than maximum essential records in recent  for the student.
+      // Create loan balance records more than maximum essential records in recent for the student.
       const studentBalanceRecords = createStudentBalanceRecords(
-        MAXIMUM_ESSENTIAL_LOAN_BALANCE_RECORDS + 2,
+        MAXIMUM_ESSENTIAL_LOAN_BALANCE_RECORDS + 1,
         100,
       );
       const studentLoanBalance = studentBalanceRecords.map((record) => {
@@ -116,7 +118,7 @@ describe("StudentLoanBalanceAESTController(e2e)-getStudentLoanBalance", () => {
       .auth(token, BEARER_AUTH_TYPE)
       .expect(HttpStatus.NOT_FOUND)
       .expect({
-        statusCode: 404,
+        statusCode: HttpStatus.NOT_FOUND,
         message: "Student not found.",
         error: "Not Found",
       });

--- a/sources/packages/backend/apps/api/src/route-controllers/student-loan-balance/_tests_/e2e/student-loan-balance.aest.controller.getStudentLoanBalance.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/student-loan-balance/_tests_/e2e/student-loan-balance.aest.controller.getStudentLoanBalance.e2e-spec.ts
@@ -37,13 +37,6 @@ describe("StudentLoanBalanceAESTController(e2e)-getStudentLoanBalance", () => {
         { cslBalance: 100 },
       );
       await db.studentLoanBalance.save(studentBalanceRecords);
-      // Expected loan balance records.
-      const expectedStudentBalanceRecords = studentBalanceRecords.map(
-        (record) => ({
-          cslBalance: record.cslBalance,
-          balanceDate: record.balanceDate,
-        }),
-      );
       const endpoint = `/aest/student-loan-balance/student/${student.id}`;
       const token = await getAESTToken(AESTGroups.BusinessAdministrators);
 
@@ -53,6 +46,13 @@ describe("StudentLoanBalanceAESTController(e2e)-getStudentLoanBalance", () => {
         .auth(token, BEARER_AUTH_TYPE)
         .expect(HttpStatus.OK)
         .expect((response) => {
+          // Expected loan balance records.
+          const expectedStudentBalanceRecords = studentBalanceRecords.map(
+            (record) => ({
+              cslBalance: record.cslBalance,
+              balanceDate: record.balanceDate,
+            }),
+          );
           expect(response.body.loanBalanceDetails).toStrictEqual(
             expectedStudentBalanceRecords,
           );
@@ -79,12 +79,6 @@ describe("StudentLoanBalanceAESTController(e2e)-getStudentLoanBalance", () => {
         MAXIMUM_ESSENTIAL_LOAN_BALANCE_RECORDS,
         { cslBalance: 100 },
       );
-      // Expected loan balance records based on maximum essential count of records.
-      const expectedStudentBalanceRecords =
-        essentialStudentLoanBalanceRecords.map((record) => ({
-          cslBalance: record.cslBalance,
-          balanceDate: record.balanceDate,
-        }));
       const endpoint = `/aest/student-loan-balance/student/${student.id}`;
       const token = await getAESTToken(AESTGroups.Operations);
 
@@ -94,6 +88,12 @@ describe("StudentLoanBalanceAESTController(e2e)-getStudentLoanBalance", () => {
         .auth(token, BEARER_AUTH_TYPE)
         .expect(HttpStatus.OK)
         .expect((response) => {
+          // Expected loan balance records based on maximum essential count of records.
+          const expectedStudentBalanceRecords =
+            essentialStudentLoanBalanceRecords.map((record) => ({
+              cslBalance: record.cslBalance,
+              balanceDate: record.balanceDate,
+            }));
           expect(response.body.loanBalanceDetails).toStrictEqual(
             expectedStudentBalanceRecords,
           );

--- a/sources/packages/backend/apps/api/src/route-controllers/student-loan-balance/models/student-loan-balance.dto.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/student-loan-balance/models/student-loan-balance.dto.ts
@@ -1,7 +1,7 @@
 /**
  * Student loan balance details.
  */
-class StudentLoanBalanceDetailAPIOutDTO {
+export class StudentLoanBalanceDetailAPIOutDTO {
   balanceDate: string;
   cslBalance: number;
 }

--- a/sources/packages/backend/apps/api/src/route-controllers/student-loan-balance/student-loan-balance.aest.controller.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/student-loan-balance/student-loan-balance.aest.controller.ts
@@ -31,7 +31,7 @@ export class StudentLoanBalanceAESTController extends BaseController {
 
   /**
    * Get loan balance details of
-   * the given student upto 12 recent records received.
+   * the given student upto essential recent records received.
    * @param studentId student.
    * @returns student loan balance.
    */

--- a/sources/packages/backend/apps/api/src/route-controllers/student-loan-balance/student-loan-balance.aest.controller.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/student-loan-balance/student-loan-balance.aest.controller.ts
@@ -9,17 +9,23 @@ import { ApiNotFoundResponse, ApiTags } from "@nestjs/swagger";
 import { AuthorizedParties } from "../../auth/authorized-parties.enum";
 import { AllowAuthorizedParty, Groups } from "../../auth/decorators";
 import { UserGroups } from "../../auth/user-groups.enum";
-import { StudentService } from "../../services";
+import { StudentLoanBalanceService, StudentService } from "../../services";
 import { ClientTypeBaseRoute } from "../../types";
 import BaseController from "../BaseController";
-import { StudentLoanBalanceAPIOutDTO } from "./models/student-loan-balance.dto";
+import {
+  StudentLoanBalanceAPIOutDTO,
+  StudentLoanBalanceDetailAPIOutDTO,
+} from "./models/student-loan-balance.dto";
 
 @AllowAuthorizedParty(AuthorizedParties.aest)
 @Groups(UserGroups.AESTUser)
 @Controller("student-loan-balance")
 @ApiTags(`${ClientTypeBaseRoute.AEST}-student-loan-balance`)
 export class StudentLoanBalanceAESTController extends BaseController {
-  constructor(private readonly studentService: StudentService) {
+  constructor(
+    private readonly studentService: StudentService,
+    private readonly studentLoanBalanceService: StudentLoanBalanceService,
+  ) {
     super();
   }
 
@@ -40,14 +46,17 @@ export class StudentLoanBalanceAESTController extends BaseController {
     if (!studentExist) {
       throw new NotFoundException("Student not found.");
     }
-    //TODO: Remove the static values when actual implementation is done.
-    const staticData: StudentLoanBalanceAPIOutDTO = {
-      loanBalanceDetails: [
-        { balanceDate: "2024-03-10", cslBalance: 100 },
-        { balanceDate: "2024-02-10", cslBalance: 200 },
-        { balanceDate: "2024-01-10", cslBalance: 300 },
-      ],
+    const studentLoanBalances =
+      await this.studentLoanBalanceService.getStudentLoanBalance(studentId);
+    const loanBalanceDetails =
+      studentLoanBalances.map<StudentLoanBalanceDetailAPIOutDTO>(
+        (studentLoanBalance) => ({
+          balanceDate: studentLoanBalance.balanceDate,
+          cslBalance: studentLoanBalance.cslBalance,
+        }),
+      );
+    return {
+      loanBalanceDetails,
     };
-    return staticData;
   }
 }

--- a/sources/packages/backend/apps/api/src/services/index.ts
+++ b/sources/packages/backend/apps/api/src/services/index.ts
@@ -43,3 +43,4 @@ export * from "./application-bulk-withdrawal/application-bulk-withdrawal-import-
 export * from "./application-bulk-withdrawal/application-bulk-withdrawal-import-validation.service";
 export * from "./application-bulk-withdrawal/application-bulk-withdrawal-validation.models";
 export * from "./application-bulk-withdrawal/application-bulk-withdrawal-import-text.models";
+export * from "./student-loan-balance/student-loan-balance.service";

--- a/sources/packages/backend/apps/api/src/services/student-loan-balance/student-loan-balance.service.ts
+++ b/sources/packages/backend/apps/api/src/services/student-loan-balance/student-loan-balance.service.ts
@@ -13,7 +13,7 @@ export class StudentLoanBalanceService {
 
   /**
    * Get loan balance details of
-   * the given student upto essential recent records.
+   * the given student up to essential recent records.
    * @param studentId student.
    * @returns student loan balance.
    */

--- a/sources/packages/backend/apps/api/src/services/student-loan-balance/student-loan-balance.service.ts
+++ b/sources/packages/backend/apps/api/src/services/student-loan-balance/student-loan-balance.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from "@nestjs/common";
 import { InjectRepository } from "@nestjs/typeorm";
 import { StudentLoanBalances } from "@sims/sims-db";
 import { Repository } from "typeorm";
+import { MAXIMUM_ESSENTIAL_LOAN_BALANCE_RECORDS } from "../../utilities";
 
 @Injectable()
 export class StudentLoanBalanceService {
@@ -12,7 +13,7 @@ export class StudentLoanBalanceService {
 
   /**
    * Get loan balance details of
-   * the given student upto 12 recent records.
+   * the given student upto essential recent records.
    * @param studentId student.
    * @returns student loan balance.
    */
@@ -23,7 +24,7 @@ export class StudentLoanBalanceService {
       select: { id: true, balanceDate: true, cslBalance: true },
       where: { student: { id: studentId } },
       order: { balanceDate: "DESC" },
-      take: 12,
+      take: MAXIMUM_ESSENTIAL_LOAN_BALANCE_RECORDS,
     });
   }
 }

--- a/sources/packages/backend/apps/api/src/services/student-loan-balance/student-loan-balance.service.ts
+++ b/sources/packages/backend/apps/api/src/services/student-loan-balance/student-loan-balance.service.ts
@@ -1,16 +1,29 @@
 import { Injectable } from "@nestjs/common";
 import { InjectRepository } from "@nestjs/typeorm";
-import { Application, StudentLoanBalances } from "@sims/sims-db";
+import { StudentLoanBalances } from "@sims/sims-db";
 import { Repository } from "typeorm";
 
 @Injectable()
-export class ApplicationOfferingChangeRequestService {
+export class StudentLoanBalanceService {
   constructor(
-    @InjectRepository(Application)
+    @InjectRepository(StudentLoanBalances)
     private readonly studentLoanBalanceRepo: Repository<StudentLoanBalances>,
   ) {}
 
-  async getSummaryByStatus(): Promise<StudentLoanBalances[]> {
-    return [];
+  /**
+   * Get loan balance details of
+   * the given student upto 12 recent records.
+   * @param studentId student.
+   * @returns student loan balance.
+   */
+  async getStudentLoanBalance(
+    studentId: number,
+  ): Promise<StudentLoanBalances[]> {
+    return this.studentLoanBalanceRepo.find({
+      select: { id: true, balanceDate: true, cslBalance: true },
+      where: { student: { id: studentId } },
+      order: { balanceDate: "DESC" },
+      take: 12,
+    });
   }
 }

--- a/sources/packages/backend/apps/api/src/services/student-loan-balance/student-loan-balance.service.ts
+++ b/sources/packages/backend/apps/api/src/services/student-loan-balance/student-loan-balance.service.ts
@@ -1,14 +1,14 @@
 import { Injectable } from "@nestjs/common";
 import { InjectRepository } from "@nestjs/typeorm";
-import { StudentLoanBalances } from "@sims/sims-db";
+import { StudentLoanBalance } from "@sims/sims-db";
 import { Repository } from "typeorm";
 import { MAXIMUM_ESSENTIAL_LOAN_BALANCE_RECORDS } from "../../utilities";
 
 @Injectable()
 export class StudentLoanBalanceService {
   constructor(
-    @InjectRepository(StudentLoanBalances)
-    private readonly studentLoanBalanceRepo: Repository<StudentLoanBalances>,
+    @InjectRepository(StudentLoanBalance)
+    private readonly studentLoanBalanceRepo: Repository<StudentLoanBalance>,
   ) {}
 
   /**
@@ -19,7 +19,7 @@ export class StudentLoanBalanceService {
    */
   async getStudentLoanBalance(
     studentId: number,
-  ): Promise<StudentLoanBalances[]> {
+  ): Promise<StudentLoanBalance[]> {
     return this.studentLoanBalanceRepo.find({
       select: { id: true, balanceDate: true, cslBalance: true },
       where: { student: { id: studentId } },

--- a/sources/packages/backend/apps/api/src/services/student-loan-balance/student-loan-balance.service.ts
+++ b/sources/packages/backend/apps/api/src/services/student-loan-balance/student-loan-balance.service.ts
@@ -1,0 +1,16 @@
+import { Injectable } from "@nestjs/common";
+import { InjectRepository } from "@nestjs/typeorm";
+import { Application, StudentLoanBalances } from "@sims/sims-db";
+import { Repository } from "typeorm";
+
+@Injectable()
+export class ApplicationOfferingChangeRequestService {
+  constructor(
+    @InjectRepository(Application)
+    private readonly studentLoanBalanceRepo: Repository<StudentLoanBalances>,
+  ) {}
+
+  async getSummaryByStatus(): Promise<StudentLoanBalances[]> {
+    return [];
+  }
+}

--- a/sources/packages/backend/apps/api/src/utilities/system-configurations-constants.ts
+++ b/sources/packages/backend/apps/api/src/utilities/system-configurations-constants.ts
@@ -103,3 +103,8 @@ export const AWARD_VALUE_CODE_LENGTH = 4;
  * weeks reaches the value in the const, a restriction will be generated.
  */
 export const SCHOLASTIC_STANDING_MINIMUM_UNSUCCESSFUL_WEEKS = 68;
+/**
+ * Maximum recent loan balance records considered essential for
+ * the loan balance statement.
+ */
+export const MAXIMUM_ESSENTIAL_LOAN_BALANCE_RECORDS = 12;

--- a/sources/packages/backend/apps/db-migrations/src/migrations/1711342815738-CreateStudentLoanBalances.ts
+++ b/sources/packages/backend/apps/db-migrations/src/migrations/1711342815738-CreateStudentLoanBalances.ts
@@ -1,0 +1,21 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+import { getSQLFileData } from "../utilities/sqlLoader";
+
+export class CreateStudentLoanBalances1711342815738
+  implements MigrationInterface
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      getSQLFileData("Create-student-loan-balances.sql", "StudentLoanBalances"),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      getSQLFileData(
+        "Rollback-create-student-loan-balances.sql",
+        "StudentLoanBalances",
+      ),
+    );
+  }
+}

--- a/sources/packages/backend/apps/db-migrations/src/sql/StudentLoanBalances/Create-student-loan-balances.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/StudentLoanBalances/Create-student-loan-balances.sql
@@ -1,0 +1,32 @@
+CREATE TABLE sims.student_loan_balances(
+  id SERIAL PRIMARY KEY,
+  student_id INT NOT NULL REFERENCES sims.students(id),
+  csl_balance NUMERIC(8, 2) NOT NULL,
+  balance_date DATE NOT NULL,
+  -- Audit columns
+  created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+  creator INT NULL DEFAULT NULL REFERENCES sims.users(id),
+  modifier INT NULL DEFAULT NULL REFERENCES sims.users(id),
+  -- Constraint
+  CONSTRAINT student_balance_date UNIQUE (student_id, balance_date)
+);
+
+-- ## Comments
+COMMENT ON TABLE sims.student_loan_balances IS 'Student Loan Balances for a student shared by NSLSC monthly.';
+
+COMMENT ON COLUMN sims.student_loan_balances.id IS 'Auto-generated sequential primary key column';
+
+COMMENT ON COLUMN sims.student_loan_balances.student_id IS 'Student Id whose balance is shared by NSLSC.';
+
+COMMENT ON COLUMN sims.student_loan_balances.csl_balance IS 'Student loan balance amount for a student.';
+
+COMMENT ON COLUMN sims.student_loan_balances.balance_date IS 'Student loan balance generated and shared date by NSLSC.';
+
+COMMENT ON COLUMN sims.student_loan_balances.created_at IS 'Record creation timestamp.';
+
+COMMENT ON COLUMN sims.student_loan_balances.updated_at IS 'Record update timestamp.';
+
+COMMENT ON COLUMN sims.student_loan_balances.creator IS 'Creator of the record.';
+
+COMMENT ON COLUMN sims.student_loan_balances.modifier IS 'Modifier of the record.';

--- a/sources/packages/backend/apps/db-migrations/src/sql/StudentLoanBalances/Create-student-loan-balances.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/StudentLoanBalances/Create-student-loan-balances.sql
@@ -30,3 +30,5 @@ COMMENT ON COLUMN sims.student_loan_balances.updated_at IS 'Record update timest
 COMMENT ON COLUMN sims.student_loan_balances.creator IS 'Creator of the record.';
 
 COMMENT ON COLUMN sims.student_loan_balances.modifier IS 'Modifier of the record.';
+
+COMMENT ON CONSTRAINT student_balance_date ON sims.student_loan_balances IS 'Ensures student loan balance for a particular student and the balance date is unique.';

--- a/sources/packages/backend/apps/db-migrations/src/sql/StudentLoanBalances/Rollback-create-student-loan-balances.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/StudentLoanBalances/Rollback-create-student-loan-balances.sql
@@ -1,0 +1,1 @@
+DROP TABLE sims.student_loan_balances;

--- a/sources/packages/backend/libs/sims-db/src/constant.ts
+++ b/sources/packages/backend/libs/sims-db/src/constant.ts
@@ -57,6 +57,7 @@ export const TableNames = {
   Notifications: "notifications",
   QueueConfigurations: "queue_configurations",
   ApplicationOfferingChangeRequests: "application_offering_change_requests",
+  StudentLoanBalances: "student_loan_balances",
 };
 
 export const INSTITUTION_TYPE_BC_PUBLIC = 1;

--- a/sources/packages/backend/libs/sims-db/src/data-source.ts
+++ b/sources/packages/backend/libs/sims-db/src/data-source.ts
@@ -52,7 +52,7 @@ import {
   DisbursementOveraward,
   QueueConfiguration,
   ApplicationOfferingChangeRequest,
-  StudentLoanBalances,
+  StudentLoanBalance,
 } from "./entities";
 import { ClusterNode, ClusterOptions, RedisOptions } from "ioredis";
 import {
@@ -203,5 +203,5 @@ export const DBEntities = [
   DisbursementOveraward,
   QueueConfiguration,
   ApplicationOfferingChangeRequest,
-  StudentLoanBalances,
+  StudentLoanBalance,
 ];

--- a/sources/packages/backend/libs/sims-db/src/data-source.ts
+++ b/sources/packages/backend/libs/sims-db/src/data-source.ts
@@ -52,6 +52,7 @@ import {
   DisbursementOveraward,
   QueueConfiguration,
   ApplicationOfferingChangeRequest,
+  StudentLoanBalances,
 } from "./entities";
 import { ClusterNode, ClusterOptions, RedisOptions } from "ioredis";
 import {
@@ -202,4 +203,5 @@ export const DBEntities = [
   DisbursementOveraward,
   QueueConfiguration,
   ApplicationOfferingChangeRequest,
+  StudentLoanBalances,
 ];

--- a/sources/packages/backend/libs/sims-db/src/entities/index.ts
+++ b/sources/packages/backend/libs/sims-db/src/entities/index.ts
@@ -87,3 +87,4 @@ export * from "./application-offering-change-request-status.type";
 export * from "./application-offering-change-request.model";
 export * from "./student-disability-status.type";
 export * from "./application-disability-status.type";
+export * from "./student-loan-balances.model";

--- a/sources/packages/backend/libs/sims-db/src/entities/student-loan-balances.model.ts
+++ b/sources/packages/backend/libs/sims-db/src/entities/student-loan-balances.model.ts
@@ -1,0 +1,52 @@
+import {
+  Column,
+  Entity,
+  JoinColumn,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+} from "typeorm";
+import { ColumnNames, TableNames } from "../constant";
+import { RecordDataModel } from "./record.model";
+import { Student } from "./student.model";
+import { numericTransformer } from "../transformers/numeric.transformer";
+
+/**
+ * Stores files information and content from NSLSC
+ * Loan Balance file.
+ */
+@Entity({ name: TableNames.StudentLoanBalances })
+export class StudentLoanBalances extends RecordDataModel {
+  @PrimaryGeneratedColumn()
+  id: number;
+  /**
+   * Student id associated with this Loan Balance.
+   */
+  studentId: number;
+  /**
+   * Student associated with this Loan Balance.
+   */
+  @ManyToOne(() => Student, { eager: false, cascade: false })
+  @JoinColumn({
+    name: "student_id",
+    referencedColumnName: ColumnNames.ID,
+  })
+  student: Student;
+  /**
+   * Loan balance value (a positive value indicates the amount the student owes as NSLSC Loan).
+   */
+  @Column({
+    name: "csl_balance",
+    type: "numeric",
+    nullable: false,
+    transformer: numericTransformer,
+  })
+  cslBalance: number;
+  /**
+   * Date when the balance date generated and shared by NSLSC.
+   */
+  @Column({
+    name: "balance_date",
+    type: "date",
+  })
+  balanceDate: Date;
+}

--- a/sources/packages/backend/libs/sims-db/src/entities/student-loan-balances.model.ts
+++ b/sources/packages/backend/libs/sims-db/src/entities/student-loan-balances.model.ts
@@ -15,7 +15,7 @@ import { Student } from "./student.model";
  * Loan Balance file.
  */
 @Entity({ name: TableNames.StudentLoanBalances })
-export class StudentLoanBalances extends RecordDataModel {
+export class StudentLoanBalance extends RecordDataModel {
   @PrimaryGeneratedColumn()
   id: number;
   /**

--- a/sources/packages/backend/libs/sims-db/src/entities/student-loan-balances.model.ts
+++ b/sources/packages/backend/libs/sims-db/src/entities/student-loan-balances.model.ts
@@ -7,8 +7,8 @@ import {
 } from "typeorm";
 import { ColumnNames, TableNames } from "../constant";
 import { RecordDataModel } from "./record.model";
-import { Student } from "./student.model";
 import { numericTransformer } from "../transformers/numeric.transformer";
+import { Student } from "./student.model";
 
 /**
  * Stores files information and content from NSLSC
@@ -19,13 +19,9 @@ export class StudentLoanBalances extends RecordDataModel {
   @PrimaryGeneratedColumn()
   id: number;
   /**
-   * Student id associated with this Loan Balance.
-   */
-  studentId: number;
-  /**
    * Student associated with this Loan Balance.
    */
-  @ManyToOne(() => Student, { eager: false, cascade: false })
+  @ManyToOne(() => Student, { eager: false, cascade: false, nullable: false })
   @JoinColumn({
     name: "student_id",
     referencedColumnName: ColumnNames.ID,
@@ -47,6 +43,7 @@ export class StudentLoanBalances extends RecordDataModel {
   @Column({
     name: "balance_date",
     type: "date",
+    nullable: false,
   })
-  balanceDate: Date;
+  balanceDate: string;
 }

--- a/sources/packages/backend/libs/test-utils/src/data-source/e2e-data-source.ts
+++ b/sources/packages/backend/libs/test-utils/src/data-source/e2e-data-source.ts
@@ -49,6 +49,7 @@ import {
   StudentUser,
   SupportingUser,
   User,
+  StudentLoanBalances,
 } from "@sims/sims-db";
 import { DataSource, Repository } from "typeorm";
 
@@ -133,6 +134,7 @@ export function createE2EDataSources(dataSource: DataSource): E2EDataSources {
     applicationOfferingChangeRequest: dataSource.getRepository(
       ApplicationOfferingChangeRequest,
     ),
+    studentLoanBalance: dataSource.getRepository(StudentLoanBalances),
   };
 }
 
@@ -191,4 +193,5 @@ export interface E2EDataSources {
   user: Repository<User>;
   notification: Repository<Notification>;
   applicationOfferingChangeRequest: Repository<ApplicationOfferingChangeRequest>;
+  studentLoanBalance: Repository<StudentLoanBalances>;
 }

--- a/sources/packages/backend/libs/test-utils/src/data-source/e2e-data-source.ts
+++ b/sources/packages/backend/libs/test-utils/src/data-source/e2e-data-source.ts
@@ -49,7 +49,7 @@ import {
   StudentUser,
   SupportingUser,
   User,
-  StudentLoanBalances,
+  StudentLoanBalance,
 } from "@sims/sims-db";
 import { DataSource, Repository } from "typeorm";
 
@@ -134,7 +134,7 @@ export function createE2EDataSources(dataSource: DataSource): E2EDataSources {
     applicationOfferingChangeRequest: dataSource.getRepository(
       ApplicationOfferingChangeRequest,
     ),
-    studentLoanBalance: dataSource.getRepository(StudentLoanBalances),
+    studentLoanBalance: dataSource.getRepository(StudentLoanBalance),
   };
 }
 
@@ -193,5 +193,5 @@ export interface E2EDataSources {
   user: Repository<User>;
   notification: Repository<Notification>;
   applicationOfferingChangeRequest: Repository<ApplicationOfferingChangeRequest>;
-  studentLoanBalance: Repository<StudentLoanBalances>;
+  studentLoanBalance: Repository<StudentLoanBalance>;
 }

--- a/sources/packages/backend/libs/test-utils/src/factories/student-loan-balance.ts
+++ b/sources/packages/backend/libs/test-utils/src/factories/student-loan-balance.ts
@@ -35,10 +35,11 @@ export function createFakeStudentLoanBalance(
 
 /**
  * Created student loan balance records.
+ * @param studentId student who has the loan balance.
  * @param numberOfRecords number of records to create.
  * @param options options.
  * - `cslBalance` loan balance amount.
- * @returns student loan balance to be persisted.
+ * @returns list of student loan balances to be persisted.
  */
 export function createFakeStudentBalances(
   studentId: number,

--- a/sources/packages/backend/libs/test-utils/src/factories/student-loan-balance.ts
+++ b/sources/packages/backend/libs/test-utils/src/factories/student-loan-balance.ts
@@ -1,0 +1,34 @@
+import { Student, StudentLoanBalances, User } from "@sims/sims-db";
+import { getISODateOnlyString } from "@sims/utilities";
+import * as faker from "faker";
+
+/**
+ * Create fake student loan balance.
+ * @param relations student loan balance dependencies.
+ * - `student` student who has the loan balance.
+ * - `auditUser` audit user for student loan balance.
+ * @param options student loan balance options.
+ * - `initialValues` initial values to be used to create the
+ * student loan balance.
+ * @returns student loan balance to be persisted.
+ */
+export function createFakeStudentLoanBalance(
+  relations: {
+    student: Student;
+    auditUser?: User;
+  },
+  options?: { initialValues: Partial<StudentLoanBalances> },
+): StudentLoanBalances {
+  const studentLoanBalance = new StudentLoanBalances();
+  studentLoanBalance.student = relations?.student;
+  studentLoanBalance.cslBalance =
+    options?.initialValues?.cslBalance ??
+    faker.datatype.number({
+      min: 500,
+      max: 50000,
+    });
+  studentLoanBalance.balanceDate =
+    options?.initialValues?.balanceDate ?? getISODateOnlyString(new Date());
+  studentLoanBalance.creator = relations.auditUser;
+  return studentLoanBalance;
+}

--- a/sources/packages/backend/libs/test-utils/src/factories/student-loan-balance.ts
+++ b/sources/packages/backend/libs/test-utils/src/factories/student-loan-balance.ts
@@ -45,7 +45,6 @@ export function createFakeStudentBalances(
   numberOfRecords: number,
   options?: { cslBalance?: number },
 ): StudentLoanBalance[] {
-  [];
   return Array.from(Array(numberOfRecords).keys()).map((recordIndex) =>
     createFakeStudentLoanBalance(
       {

--- a/sources/packages/backend/libs/test-utils/src/factories/student-loan-balance.ts
+++ b/sources/packages/backend/libs/test-utils/src/factories/student-loan-balance.ts
@@ -38,7 +38,7 @@ export function createFakeStudentLoanBalance(
  * @param numberOfRecords number of records to create.
  * @param options options.
  * - `cslBalance` loan balance amount.
- * @returns student loan balance records.
+ * @returns student loan balance to be persisted.
  */
 export function createFakeStudentBalances(
   studentId: number,

--- a/sources/packages/backend/libs/test-utils/src/factories/student-loan-balance.ts
+++ b/sources/packages/backend/libs/test-utils/src/factories/student-loan-balance.ts
@@ -1,4 +1,4 @@
-import { Student, StudentLoanBalances, User } from "@sims/sims-db";
+import { Student, StudentLoanBalance, User } from "@sims/sims-db";
 import { addToDateOnlyString, getISODateOnlyString } from "@sims/utilities";
 import * as faker from "faker";
 
@@ -17,9 +17,9 @@ export function createFakeStudentLoanBalance(
     student: Student;
     auditUser?: User;
   },
-  options?: { initialValues: Partial<StudentLoanBalances> },
-): StudentLoanBalances {
-  const studentLoanBalance = new StudentLoanBalances();
+  options?: { initialValues: Partial<StudentLoanBalance> },
+): StudentLoanBalance {
+  const studentLoanBalance = new StudentLoanBalance();
   studentLoanBalance.student = relations.student;
   studentLoanBalance.cslBalance =
     options?.initialValues?.cslBalance ??
@@ -40,26 +40,20 @@ export function createFakeStudentLoanBalance(
  * - `cslBalance` loan balance amount.
  * @returns student loan balance records.
  */
-export function createStudentBalanceRecords(
+export function createFakeStudentBalances(
   studentId: number,
   numberOfRecords: number,
   options?: { cslBalance?: number },
-): StudentLoanBalances[] {
+): StudentLoanBalance[] {
   [];
-  const cslBalance =
-    options?.cslBalance ??
-    faker.datatype.number({
-      min: 100,
-      max: 900,
-    });
-  return Array.from(Array(numberOfRecords).keys()).map((recordIndex) => {
-    return createFakeStudentLoanBalance(
+  return Array.from(Array(numberOfRecords).keys()).map((recordIndex) =>
+    createFakeStudentLoanBalance(
       {
         student: { id: studentId } as Student,
       },
       {
         initialValues: {
-          cslBalance,
+          cslBalance: options?.cslBalance,
           balanceDate: addToDateOnlyString(
             new Date(),
             (recordIndex + 1) * -1,
@@ -67,6 +61,6 @@ export function createStudentBalanceRecords(
           ),
         },
       },
-    );
-  });
+    ),
+  );
 }

--- a/sources/packages/backend/libs/test-utils/src/factories/student-loan-balance.ts
+++ b/sources/packages/backend/libs/test-utils/src/factories/student-loan-balance.ts
@@ -1,5 +1,5 @@
 import { Student, StudentLoanBalances, User } from "@sims/sims-db";
-import { getISODateOnlyString } from "@sims/utilities";
+import { addToDateOnlyString, getISODateOnlyString } from "@sims/utilities";
 import * as faker from "faker";
 
 /**
@@ -20,7 +20,7 @@ export function createFakeStudentLoanBalance(
   options?: { initialValues: Partial<StudentLoanBalances> },
 ): StudentLoanBalances {
   const studentLoanBalance = new StudentLoanBalances();
-  studentLoanBalance.student = relations?.student;
+  studentLoanBalance.student = relations.student;
   studentLoanBalance.cslBalance =
     options?.initialValues?.cslBalance ??
     faker.datatype.number({
@@ -31,4 +31,42 @@ export function createFakeStudentLoanBalance(
     options?.initialValues?.balanceDate ?? getISODateOnlyString(new Date());
   studentLoanBalance.creator = relations.auditUser;
   return studentLoanBalance;
+}
+
+/**
+ * Created student loan balance records.
+ * @param numberOfRecords number of records to create.
+ * @param options options.
+ * - `cslBalance` loan balance amount.
+ * @returns student loan balance records.
+ */
+export function createStudentBalanceRecords(
+  studentId: number,
+  numberOfRecords: number,
+  options?: { cslBalance?: number },
+): StudentLoanBalances[] {
+  [];
+  const cslBalance =
+    options?.cslBalance ??
+    faker.datatype.number({
+      min: 100,
+      max: 900,
+    });
+  return Array.from(Array(numberOfRecords).keys()).map((recordIndex) => {
+    return createFakeStudentLoanBalance(
+      {
+        student: { id: studentId } as Student,
+      },
+      {
+        initialValues: {
+          cslBalance,
+          balanceDate: addToDateOnlyString(
+            new Date(),
+            (recordIndex + 1) * -1,
+            "month",
+          ),
+        },
+      },
+    );
+  });
 }

--- a/sources/packages/backend/libs/test-utils/src/index.ts
+++ b/sources/packages/backend/libs/test-utils/src/index.ts
@@ -30,3 +30,4 @@ export * from "./factories/application-offering-change-request";
 export * from "./factories/designation-agreement-locations";
 export * from "./factories/disbursement-feedback-error";
 export * from "./factories/notification";
+export * from "./factories/student-loan-balance";

--- a/sources/packages/web/src/services/StudentLoanBalanceService.ts
+++ b/sources/packages/web/src/services/StudentLoanBalanceService.ts
@@ -14,7 +14,7 @@ export class StudentLoanBalanceService {
 
   /**
    * Get loan balance details of
-   * the given student up to 12 recent records received.
+   * the given student up to essential recent records received.
    * @param studentId student.
    * @returns student loan balance.
    */

--- a/sources/packages/web/src/services/http/StudentLoanBalanceApi.ts
+++ b/sources/packages/web/src/services/http/StudentLoanBalanceApi.ts
@@ -7,7 +7,7 @@ import { StudentLoanBalanceAPIOutDTO } from "@/services/http/dto";
 export class StudentLoanBalanceApi extends HttpBaseClient {
   /**
    * Get loan balance details of
-   * the given student upto 12 recent records received.
+   * the given student upto essential recent records received.
    * @param studentId student.
    * @returns student loan balance.
    */


### PR DESCRIPTION
## PT Student loan balance

- [x] Read student loan balances from `sims.student_loan_balances` table.
- [x] Return up to 12 recent records of the student loan balance. Typeorm query property `take` is used to limit records.
- [x] E2E Tests

![image](https://github.com/bcgov/SIMS/assets/54600590/37bfadfd-c902-4fb5-954c-d8332a1955ec)

## Files copied from the PR #3036 

Following files are copied from the PR #3036  as this story has dependency on #3018 

```
sources/packages/backend/apps/db-migrations/src/migrations/1711342815738-CreateStudentLoanBalances.ts
sources/packages/backend/apps/db-migrations/src/sql/StudentLoanBalances/Create-student-loan-balances.sql
sources/packages/backend/apps/db-migrations/src/sql/StudentLoanBalances/Rollback-create-student-loan-balances.sql
sources/packages/backend/libs/sims-db/src/constant.ts
sources/packages/backend/libs/sims-db/src/entities/student-loan-balances.model.ts

```
