### PR TITLE
#2852 - SFAS SAIL Student Data Match Import Note

### DIFF
--- a/sources/packages/backend/apps/api/src/services/student/student.service.ts
+++ b/sources/packages/backend/apps/api/src/services/student/student.service.ts
@@ -232,11 +232,12 @@ export class StudentService extends RecordDataModelService<Student> {
           .update({ individualId: sfasIndividual.id }, { processed: false });
 
         // If there is a match in SFAS, record that information is available from legacy system with a note attached to the student.
-        this.addStudentNote(
+        await this.noteSharedService.createStudentNote(
           student.id,
           NoteType.General,
           "Successful match with legacy systems - data has been transferred.",
           this.systemUsersService.systemUser.id,
+          entityManager,
         );
       }
 

--- a/sources/packages/backend/apps/api/src/services/student/student.service.ts
+++ b/sources/packages/backend/apps/api/src/services/student/student.service.ts
@@ -234,7 +234,7 @@ export class StudentService extends RecordDataModelService<Student> {
         // If there is a match in SFAS, record that information is available from legacy system with a note attached to the student.
         this.addStudentNote(
           student.id,
-          NoteType.System,
+          NoteType.General,
           "Successful match with legacy systems - data has been transferred.",
           this.systemUsersService.systemUser.id,
         );

--- a/sources/packages/backend/apps/api/src/services/student/student.service.ts
+++ b/sources/packages/backend/apps/api/src/services/student/student.service.ts
@@ -38,6 +38,7 @@ import {
 import {
   DisbursementOverawardService,
   NoteSharedService,
+  SystemUsersService,
 } from "@sims/services";
 import {
   BC_STUDENT_LOAN_AWARD_CODE,
@@ -51,6 +52,7 @@ export class StudentService extends RecordDataModelService<Student> {
     private readonly sfasIndividualService: SFASIndividualService,
     private readonly disbursementOverawardService: DisbursementOverawardService,
     private readonly noteSharedService: NoteSharedService,
+    private readonly systemUsersService: SystemUsersService,
   ) {
     super(dataSource.getRepository(Student));
     this.logger.log("[Created]");
@@ -228,6 +230,14 @@ export class StudentService extends RecordDataModelService<Student> {
         await entityManager
           .getRepository(SFASRestriction)
           .update({ individualId: sfasIndividual.id }, { processed: false });
+
+        // If there is a match in SFAS, record that information is available from legacy system with a note attached to the student.
+        this.addStudentNote(
+          student.id,
+          NoteType.System,
+          "Successful match with legacy systems - data has been transferred.",
+          this.systemUsersService.systemUser.id,
+        );
       }
 
       // Create the new entry in the student/user history/audit.


### PR DESCRIPTION
Add a system note upon student creation when there is a legacy system match. 

The note is further down in the code than suggested in the ticket so that the student has been created and has an id to use for the note.