### PR TITLE
#3076 - Application exception bug fix

### DIFF
--- a/sources/packages/backend/apps/api/src/route-controllers/application-exception/_tests_/e2e/application-exception.aest.approveException.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/application-exception/_tests_/e2e/application-exception.aest.approveException.e2e-spec.ts
@@ -56,7 +56,7 @@ describe("ApplicationExceptionAESTController(e2e)-approveException", () => {
 
     expect(zbClient.publishMessage).toHaveBeenCalledWith(
       expect.objectContaining({
-        correlationKey: application.applicationException.id.toString(),
+        correlationKey: application.id.toString(),
         name: "application-exception-verified",
         variables: {
           applicationExceptionStatus: "Approved",
@@ -95,7 +95,7 @@ describe("ApplicationExceptionAESTController(e2e)-approveException", () => {
 
     expect(zbClient.publishMessage).toHaveBeenCalledWith(
       expect.objectContaining({
-        correlationKey: application.applicationException.id.toString(),
+        correlationKey: application.id.toString(),
         name: "application-exception-verified",
         variables: {
           applicationExceptionStatus: "Declined",

--- a/sources/packages/backend/apps/api/src/route-controllers/application-exception/application-exception.aest.controller.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/application-exception/application-exception.aest.controller.ts
@@ -105,7 +105,7 @@ export class ApplicationExceptionAESTController extends BaseController {
           userToken.userId,
         );
       await this.workflowClientService.sendApplicationExceptionApproval(
-        updatedException.id,
+        updatedException.application.id,
         updatedException.exceptionStatus,
       );
     } catch (error: unknown) {

--- a/sources/packages/backend/libs/services/src/workflow/workflow-client.service.ts
+++ b/sources/packages/backend/libs/services/src/workflow/workflow-client.service.ts
@@ -150,17 +150,17 @@ export class WorkflowClientService {
    * When an exception is detected in the student application dynamic data, for instance,
    * when some document was uploaded and need to be reviewed, the workflow will stop till
    * this message is received with the approval or denial from the Ministry user.
-   * @param applicationExceptionId exception id to send the message.
+   * @param applicationId application id to send the message when exception is verified.
    * @param status approval or denial status.
    */
   async sendApplicationExceptionApproval(
-    applicationExceptionId: number,
+    applicationId: number,
     status: ApplicationExceptionStatus,
   ): Promise<void> {
     try {
       await this.zeebeClient.publishMessage({
         name: "application-exception-verified",
-        correlationKey: applicationExceptionId.toString(),
+        correlationKey: applicationId.toString(),
         timeToLive: ZEEBE_PUBLISH_MESSAGE_DEFAULT_TIME_TO_LEAVE,
         variables: {
           [APPLICATION_EXCEPTION_STATUS]: status,
@@ -168,7 +168,7 @@ export class WorkflowClientService {
       });
     } catch (error: unknown) {
       this.logger.error(
-        `Error while sending application exception approval message applicationExceptionId: ${applicationExceptionId}.`,
+        `Error while sending application exception verified message for applicationId: ${applicationId}.`,
       );
       this.logger.error(error);
       // The error is not thrown here, as we are failing silently.


### PR DESCRIPTION
# Fix the correlation id sent on application exception verified message

## Bug
When application exception is verified by ministry (Approved or Declined), message is sent to workflow with correlation id, so that the workflow can proceed for further processing.

The workflow expects a message with name `application-exception-verified` and correlation id `${applicationId}` but it was receiving a message with correlation id `${applicationExceptionId}` and hence the message was not accepted and processed by workflow.

## Fix

Updated the code to send `applicationId` as correlation id for the message.

![image](https://github.com/bcgov/SIMS/assets/54600590/7ff4439e-c12c-465e-b35f-0dac2a9316df)

