### PR TITLE
#2875 - Newborn dependant born after study end date E2E

### DIFF
--- a/sources/packages/backend/workflow/test/2022-2023/parttime-assessment/awards-amounts/parttime-assessment-awards-amount-CSGD.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2022-2023/parttime-assessment/awards-amounts/parttime-assessment-awards-amount-CSGD.e2e-spec.ts
@@ -5,6 +5,7 @@ import {
 } from "../../../test-utils";
 import {
   DependentEligibility,
+  createFakeStudentDependentBornAfterStudyEndDate,
   createFakeStudentDependentEligible,
 } from "../../../test-utils/factories";
 import { YesNoOptions } from "@sims/test-utils";
@@ -143,6 +144,13 @@ describe(`E2E Test Workflow parttime-assessment-${PROGRAM_YEAR}-awards-amount-CS
         DependentEligibility.Eligible0To18YearsOld,
         { referenceDate: assessmentConsolidatedData.offeringStudyStartDate },
       ),
+      createFakeStudentDependentEligible(
+        DependentEligibility.Eligible18To22YearsOldAttendingHighSchool,
+        { referenceDate: assessmentConsolidatedData.offeringStudyStartDate },
+      ),
+      createFakeStudentDependentBornAfterStudyEndDate(
+        assessmentConsolidatedData.offeringStudyEndDate,
+      ),
     ];
     // Act
     const calculatedAssessment = await executePartTimeAssessmentForProgramYear(
@@ -152,6 +160,9 @@ describe(`E2E Test Workflow parttime-assessment-${PROGRAM_YEAR}-awards-amount-CS
     // Assert
     // calculatedDataTotalFamilyIncome <= limitAwardCSGDIncomeCap
     // federalAwardCSGDAmount
+    expect(
+      calculatedAssessment.variables.calculatedDataTotalEligibleDependants,
+    ).toBe(2);
     expect(
       calculatedAssessment.variables.calculatedDataTotalFamilyIncome,
     ).toBeLessThan(

--- a/sources/packages/backend/workflow/test/2022-2023/parttime-assessment/awards-amounts/parttime-assessment-awards-amount-CSGD.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2022-2023/parttime-assessment/awards-amounts/parttime-assessment-awards-amount-CSGD.e2e-spec.ts
@@ -148,6 +148,8 @@ describe(`E2E Test Workflow parttime-assessment-${PROGRAM_YEAR}-awards-amount-CS
         DependentEligibility.Eligible18To22YearsOldAttendingHighSchool,
         { referenceDate: assessmentConsolidatedData.offeringStudyStartDate },
       ),
+      // Dependent(s) born after study end date are not considered
+      // as eligible for any calculation.
       createFakeStudentDependentBornAfterStudyEndDate(
         assessmentConsolidatedData.offeringStudyEndDate,
       ),

--- a/sources/packages/backend/workflow/test/2022-2023/parttime-assessment/eligibility/parttime-assessment-eligibility-CSGD.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2022-2023/parttime-assessment/eligibility/parttime-assessment-eligibility-CSGD.e2e-spec.ts
@@ -5,6 +5,7 @@ import {
 } from "../../../test-utils";
 import {
   DependentEligibility,
+  createFakeStudentDependentBornAfterStudyEndDate,
   createFakeStudentDependentEligible,
 } from "../../../test-utils/factories";
 
@@ -76,6 +77,33 @@ describe(`E2E Test Workflow parttime-assessment-${PROGRAM_YEAR}-eligibility-CSGD
     );
 
     // Assert
+    expect(calculatedAssessment.variables.awardEligibilityCSGD).toBe(false);
+    expect(calculatedAssessment.variables.finalFederalAwardNetCSGDAmount).toBe(
+      0,
+    );
+  });
+
+  it("Should determine CSGD as not eligible when there is no dependant born on or before study end date.", async () => {
+    // Arrange
+    const assessmentConsolidatedData =
+      createFakeConsolidatedPartTimeData(PROGRAM_YEAR);
+    // Dependent(s) born after study end date are not considered
+    // as eligible for any calculation.
+    assessmentConsolidatedData.studentDataDependants = [
+      createFakeStudentDependentBornAfterStudyEndDate(
+        assessmentConsolidatedData.offeringStudyEndDate,
+      ),
+    ];
+    // Act
+    const calculatedAssessment = await executePartTimeAssessmentForProgramYear(
+      PROGRAM_YEAR,
+      assessmentConsolidatedData,
+    );
+
+    // Assert
+    expect(
+      calculatedAssessment.variables.calculatedDataTotalEligibleDependants,
+    ).toBe(0);
     expect(calculatedAssessment.variables.awardEligibilityCSGD).toBe(false);
     expect(calculatedAssessment.variables.finalFederalAwardNetCSGDAmount).toBe(
       0,

--- a/sources/packages/backend/workflow/test/2023-2024/parttime-assessment/awards-amounts/parttime-assessment-awards-amount-CSGD.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2023-2024/parttime-assessment/awards-amounts/parttime-assessment-awards-amount-CSGD.e2e-spec.ts
@@ -5,6 +5,7 @@ import {
 } from "../../../test-utils";
 import {
   DependentEligibility,
+  createFakeStudentDependentBornAfterStudyEndDate,
   createFakeStudentDependentEligible,
 } from "../../../test-utils/factories";
 import { YesNoOptions } from "@sims/test-utils";
@@ -143,6 +144,15 @@ describe(`E2E Test Workflow parttime-assessment-${PROGRAM_YEAR}-awards-amount-CS
         DependentEligibility.Eligible0To18YearsOld,
         { referenceDate: assessmentConsolidatedData.offeringStudyStartDate },
       ),
+      createFakeStudentDependentEligible(
+        DependentEligibility.Eligible18To22YearsOldAttendingHighSchool,
+        { referenceDate: assessmentConsolidatedData.offeringStudyStartDate },
+      ),
+      // Dependent(s) born after study end date are not considered
+      // as eligible for any calculation.
+      createFakeStudentDependentBornAfterStudyEndDate(
+        assessmentConsolidatedData.offeringStudyEndDate,
+      ),
     ];
     // Act
     const calculatedAssessment = await executePartTimeAssessmentForProgramYear(
@@ -152,6 +162,9 @@ describe(`E2E Test Workflow parttime-assessment-${PROGRAM_YEAR}-awards-amount-CS
     // Assert
     // calculatedDataTotalFamilyIncome <= limitAwardCSGDIncomeCap
     // federalAwardCSGDAmount
+    expect(
+      calculatedAssessment.variables.calculatedDataTotalEligibleDependants,
+    ).toBe(2);
     expect(
       calculatedAssessment.variables.calculatedDataTotalFamilyIncome,
     ).toBeLessThan(

--- a/sources/packages/backend/workflow/test/2023-2024/parttime-assessment/eligibility/parttime-assessment-eligibility-CSGD.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2023-2024/parttime-assessment/eligibility/parttime-assessment-eligibility-CSGD.e2e-spec.ts
@@ -5,6 +5,7 @@ import {
 } from "../../../test-utils";
 import {
   DependentEligibility,
+  createFakeStudentDependentBornAfterStudyEndDate,
   createFakeStudentDependentEligible,
 } from "../../../test-utils/factories";
 
@@ -63,7 +64,7 @@ describe(`E2E Test Workflow parttime-assessment-${PROGRAM_YEAR}-eligibility-CSGD
     );
   });
 
-  it("Should determine CSGD as not eligible when there is no total eligible dependant.", async () => {
+  it("Should determine CSGD as not eligible when there is no dependant.", async () => {
     // Arrange
     const assessmentConsolidatedData =
       createFakeConsolidatedPartTimeData(PROGRAM_YEAR);
@@ -76,6 +77,33 @@ describe(`E2E Test Workflow parttime-assessment-${PROGRAM_YEAR}-eligibility-CSGD
     );
 
     // Assert
+    expect(calculatedAssessment.variables.awardEligibilityCSGD).toBe(false);
+    expect(calculatedAssessment.variables.finalFederalAwardNetCSGDAmount).toBe(
+      0,
+    );
+  });
+
+  it("Should determine CSGD as not eligible when there is no dependant born on or before study end date.", async () => {
+    // Arrange
+    const assessmentConsolidatedData =
+      createFakeConsolidatedPartTimeData(PROGRAM_YEAR);
+    // Dependent(s) born after study end date are not considered
+    // as eligible for any calculation.
+    assessmentConsolidatedData.studentDataDependants = [
+      createFakeStudentDependentBornAfterStudyEndDate(
+        assessmentConsolidatedData.offeringStudyEndDate,
+      ),
+    ];
+    // Act
+    const calculatedAssessment = await executePartTimeAssessmentForProgramYear(
+      PROGRAM_YEAR,
+      assessmentConsolidatedData,
+    );
+
+    // Assert
+    expect(
+      calculatedAssessment.variables.calculatedDataTotalEligibleDependants,
+    ).toBe(0);
     expect(calculatedAssessment.variables.awardEligibilityCSGD).toBe(false);
     expect(calculatedAssessment.variables.finalFederalAwardNetCSGDAmount).toBe(
       0,

--- a/sources/packages/backend/workflow/test/2024-2025/parttime-assessment/awards-amounts/parttime-assessment-awards-amount-CSGD.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2024-2025/parttime-assessment/awards-amounts/parttime-assessment-awards-amount-CSGD.e2e-spec.ts
@@ -5,6 +5,7 @@ import {
 } from "../../../test-utils";
 import {
   DependentEligibility,
+  createFakeStudentDependentBornAfterStudyEndDate,
   createFakeStudentDependentEligible,
 } from "../../../test-utils/factories";
 import { YesNoOptions } from "@sims/test-utils";
@@ -143,6 +144,15 @@ describe(`E2E Test Workflow parttime-assessment-${PROGRAM_YEAR}-awards-amount-CS
         DependentEligibility.Eligible0To18YearsOld,
         { referenceDate: assessmentConsolidatedData.offeringStudyStartDate },
       ),
+      createFakeStudentDependentEligible(
+        DependentEligibility.Eligible18To22YearsOldAttendingHighSchool,
+        { referenceDate: assessmentConsolidatedData.offeringStudyStartDate },
+      ),
+      // Dependent(s) born after study end date are not considered
+      // as eligible for any calculation.
+      createFakeStudentDependentBornAfterStudyEndDate(
+        assessmentConsolidatedData.offeringStudyEndDate,
+      ),
     ];
     // Act
     const calculatedAssessment = await executePartTimeAssessmentForProgramYear(
@@ -152,6 +162,9 @@ describe(`E2E Test Workflow parttime-assessment-${PROGRAM_YEAR}-awards-amount-CS
     // Assert
     // calculatedDataTotalFamilyIncome <= limitAwardCSGDIncomeCap
     // federalAwardCSGDAmount
+    expect(
+      calculatedAssessment.variables.calculatedDataTotalEligibleDependants,
+    ).toBe(2);
     expect(
       calculatedAssessment.variables.calculatedDataTotalFamilyIncome,
     ).toBeLessThan(

--- a/sources/packages/backend/workflow/test/2024-2025/parttime-assessment/eligibility/parttime-assessment-eligibility-CSGD.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2024-2025/parttime-assessment/eligibility/parttime-assessment-eligibility-CSGD.e2e-spec.ts
@@ -5,6 +5,7 @@ import {
 } from "../../../test-utils";
 import {
   DependentEligibility,
+  createFakeStudentDependentBornAfterStudyEndDate,
   createFakeStudentDependentEligible,
 } from "../../../test-utils/factories";
 
@@ -76,6 +77,33 @@ describe(`E2E Test Workflow parttime-assessment-${PROGRAM_YEAR}-eligibility-CSGD
     );
 
     // Assert
+    expect(calculatedAssessment.variables.awardEligibilityCSGD).toBe(false);
+    expect(calculatedAssessment.variables.finalFederalAwardNetCSGDAmount).toBe(
+      0,
+    );
+  });
+
+  it("Should determine CSGD as not eligible when there is no dependant born on or before study end date.", async () => {
+    // Arrange
+    const assessmentConsolidatedData =
+      createFakeConsolidatedPartTimeData(PROGRAM_YEAR);
+    // Dependent(s) born after study end date are not considered
+    // as eligible for any calculation.
+    assessmentConsolidatedData.studentDataDependants = [
+      createFakeStudentDependentBornAfterStudyEndDate(
+        assessmentConsolidatedData.offeringStudyEndDate,
+      ),
+    ];
+    // Act
+    const calculatedAssessment = await executePartTimeAssessmentForProgramYear(
+      PROGRAM_YEAR,
+      assessmentConsolidatedData,
+    );
+
+    // Assert
+    expect(
+      calculatedAssessment.variables.calculatedDataTotalEligibleDependants,
+    ).toBe(0);
     expect(calculatedAssessment.variables.awardEligibilityCSGD).toBe(false);
     expect(calculatedAssessment.variables.finalFederalAwardNetCSGDAmount).toBe(
       0,

--- a/sources/packages/backend/workflow/test/test-utils/factories/student-dependent.ts
+++ b/sources/packages/backend/workflow/test/test-utils/factories/student-dependent.ts
@@ -155,3 +155,18 @@ export function createFakeStudentDependentNotEligibleForChildcareCost(
     declaredOnTaxes: YesNoOptions.No,
   };
 }
+
+/**
+ * Create a student dependent who is born after study end date.
+ * @param studyEndDate study end date of the offering.
+ * @returns dependent born after study end date.
+ */
+export function createFakeStudentDependentBornAfterStudyEndDate(
+  studyEndDate: Date | string,
+): StudentDependent {
+  return {
+    dateOfBirth: addToDateOnlyString(studyEndDate, 1, "day"),
+    attendingPostSecondarySchool: YesNoOptions.No,
+    declaredOnTaxes: YesNoOptions.No,
+  };
+}


### PR DESCRIPTION
# Exclude dependents born after study end date from eligible dependents from all calculations

**Motive of tests:** To workflow E2E tests that validate outputs based on student dependents (e.g CSGD award eligibility, child care cost calculation), add tests with dependant born after study end date and ensure that dependant is not included as eligible dependant for any calculations.

- [x] Created a factory to return student dependant born after study end date.

## E2E Tests for Eligible Dependents calculation

- [x] Added Tests to CSGD award eligibility 
![image](https://github.com/bcgov/SIMS/assets/54600590/79f70d0c-61ad-4ce5-8674-ef5afb077f54)

- [x] Added Tests to CSGD award amounts

![image](https://github.com/bcgov/SIMS/assets/54600590/c0d120be-3bf6-422a-9438-a9f2f789c6a1)

![image](https://github.com/bcgov/SIMS/assets/54600590/147760bc-972f-4f2f-b83b-6e1902f5ffde)

## E2E Tests for Eligible Dependents for child care cost calculation

- [x] Added tests to child care cost
![image](https://github.com/bcgov/SIMS/assets/54600590/ab7de765-ad25-44c6-b9ad-0c41324892ec)
