### PR TITLE
#2958 - Part-time Final Award From e-Certs - UI

### DIFF
--- a/sources/packages/backend/apps/api/src/route-controllers/assessment/_tests_/e2e/assessment.aest.controller.getAssessmentAwardDetails.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/assessment/_tests_/e2e/assessment.aest.controller.getAssessmentAwardDetails.e2e-spec.ts
@@ -324,6 +324,7 @@ describe("AssessmentAESTController(e2e)-getAssessmentAwardDetails", () => {
           dateSent: dateSent1,
         },
         secondDisbursementInitialValues: {
+          disbursementScheduleStatus: DisbursementScheduleStatus.Sent,
           coeStatus: COEStatus.completed,
           tuitionRemittanceRequestedAmount: 9876,
           dateSent: dateSent2,

--- a/sources/packages/backend/apps/api/src/route-controllers/assessment/_tests_/e2e/assessment.aest.controller.getAssessmentAwardDetails.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/assessment/_tests_/e2e/assessment.aest.controller.getAssessmentAwardDetails.e2e-spec.ts
@@ -124,6 +124,7 @@ describe("AssessmentAESTController(e2e)-getAssessmentAwardDetails", () => {
           tuitionRemittanceRequestedAmount: 1099,
         },
         secondDisbursementInitialValues: {
+          disbursementScheduleStatus: DisbursementScheduleStatus.Sent,
           coeStatus: COEStatus.completed,
           dateSent: dateSent2,
         },

--- a/sources/packages/backend/apps/api/src/route-controllers/assessment/_tests_/e2e/assessment.students.controller.getAssessmentAwardDetails.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/assessment/_tests_/e2e/assessment.students.controller.getAssessmentAwardDetails.e2e-spec.ts
@@ -109,6 +109,11 @@ describe("AssessmentStudentsController(e2e)-getAssessmentAwardDetails", () => {
           // Adding date sent to ensure that will not be returned by the API (students should not receive it).
           dateSent: new Date(),
         },
+        secondDisbursementInitialValues: {
+          disbursementScheduleStatus: DisbursementScheduleStatus.Sent,
+          // Adding date sent to ensure that will not be returned by the API (students should not receive it).
+          dateSent: new Date(),
+        },
       },
     );
 
@@ -257,6 +262,7 @@ describe("AssessmentStudentsController(e2e)-getAssessmentAwardDetails", () => {
           disbursementScheduleStatus: DisbursementScheduleStatus.Sent,
         },
         secondDisbursementInitialValues: {
+          disbursementScheduleStatus: DisbursementScheduleStatus.Sent,
           coeStatus: COEStatus.completed,
           tuitionRemittanceRequestedAmount: 9876,
         },

--- a/sources/packages/backend/apps/api/src/route-controllers/assessment/_tests_/e2e/assessment.students.controller.getAssessmentAwardDetails.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/assessment/_tests_/e2e/assessment.students.controller.getAssessmentAwardDetails.e2e-spec.ts
@@ -502,6 +502,7 @@ describe("AssessmentStudentsController(e2e)-getAssessmentAwardDetails", () => {
           dateSent: new Date(),
         },
         secondDisbursementInitialValues: {
+          disbursementScheduleStatus: DisbursementScheduleStatus.Sent,
           coeStatus: COEStatus.completed,
         },
       },

--- a/sources/packages/backend/apps/api/src/route-controllers/assessment/assessment.controller.service.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/assessment/assessment.controller.service.ts
@@ -293,6 +293,12 @@ export class AssessmentControllerService {
       }
       let index = 1;
       for (const schedule of assessment.disbursementSchedules) {
+        if (
+          schedule.disbursementScheduleStatus !==
+          DisbursementScheduleStatus.Sent
+        ) {
+          break;
+        }
         const awards = this.populateDisbursementReceiptAwardValues(
           disbursementReceipts,
           schedule,

--- a/sources/packages/backend/apps/api/src/route-controllers/assessment/assessment.controller.service.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/assessment/assessment.controller.service.ts
@@ -306,6 +306,11 @@ export class AssessmentControllerService {
     // values are used instead to provide the best information as possible.
     let index = 1;
     for (const schedule of assessment.disbursementSchedules) {
+      if (
+        schedule.disbursementScheduleStatus !== DisbursementScheduleStatus.Sent
+      ) {
+        break;
+      }
       const awards = this.populateDisbursementECertAwardValues(
         schedule.disbursementValues,
         `${DISBURSEMENT_RECEIPT_PREFIX}${index++}`,

--- a/sources/packages/backend/apps/api/src/services/student-assessment/student-assessment.service.ts
+++ b/sources/packages/backend/apps/api/src/services/student-assessment/student-assessment.service.ts
@@ -57,6 +57,7 @@ export class StudentAssessmentService extends RecordDataModelService<StudentAsse
     const query = this.repo
       .createQueryBuilder("assessment")
       .select([
+        "assessment.id",
         "assessment.assessmentData",
         "assessment.noaApprovalStatus",
         "application.id",

--- a/sources/packages/web/src/components/common/AssessmentAwardDetails.vue
+++ b/sources/packages/web/src/components/common/AssessmentAwardDetails.vue
@@ -355,18 +355,11 @@ export default defineComponent({
         props.assessmentAwardData.estimatedAward?.disbursement2COEStatus ===
         COEStatus.completed,
     );
-    const showFirstFinalAward = computed<boolean>(() => {
-      return !!(
-        isFirstDisbursementCompleted.value &&
-        hasDisbursementReceipt("first", props.assessmentAwardData.finalAward)
-      );
-    });
-    const showSecondFinalAward = computed<boolean>(
-      () =>
-        !!(
-          isSecondDisbursementCompleted.value &&
-          hasDisbursementReceipt("second", props.assessmentAwardData.finalAward)
-        ),
+    const showFirstFinalAward = computed<boolean>(() =>
+      hasDisbursementReceipt("first", props.assessmentAwardData.finalAward),
+    );
+    const showSecondFinalAward = computed<boolean>(() =>
+      hasDisbursementReceipt("second", props.assessmentAwardData.finalAward),
     );
     const getFinalAwardNotAvailableMessage = (
       coeStatus: COEStatus,

--- a/sources/packages/web/src/components/common/AssessmentAwardDetails.vue
+++ b/sources/packages/web/src/components/common/AssessmentAwardDetails.vue
@@ -365,6 +365,9 @@ export default defineComponent({
       coeStatus: COEStatus,
       disbursementStatus: DisbursementScheduleStatus,
     ): string | undefined => {
+      if (coeStatus === COEStatus.declined) {
+        return "The final award is no longer applicable due to a change. Any scheduled disbursements will be cancelled.";
+      }
       if (disbursementStatus === DisbursementScheduleStatus.Pending) {
         return "The final award can't be calculated at this time.";
       }
@@ -372,9 +375,6 @@ export default defineComponent({
         // This message will be displayed only for full-time since the part-time sent e-Cert
         // will have the final awards populates, which should overrides this message entirely.
         return "The final award will be shown once confirmed by NSLSC.";
-      }
-      if (coeStatus === COEStatus.declined) {
-        return "The final award is no longer applicable due to a change. Any scheduled disbursements will be cancelled.";
       }
       return undefined;
     };

--- a/sources/packages/web/src/components/common/AssessmentAwardDetails.vue
+++ b/sources/packages/web/src/components/common/AssessmentAwardDetails.vue
@@ -67,7 +67,7 @@
               <span class="label-bold"
                 >-${{
                   assessmentAwardData.estimatedAward
-                    .disbursement2TuitionRemittance
+                    .disbursement1TuitionRemittance
                 }}</span
               >
               <tooltip-icon
@@ -342,7 +342,6 @@ export default defineComponent({
         propName.startsWith(identifier),
       );
     };
-
     const isFirstDisbursementCompleted = computed<boolean>(
       () =>
         props.assessmentAwardData.estimatedAward?.disbursement1COEStatus ===
@@ -369,7 +368,6 @@ export default defineComponent({
           hasDisbursementReceipt("second", props.assessmentAwardData.finalAward)
         ),
     );
-
     const getFinalAwardNotAvailableMessage = (
       coeStatus: COEStatus,
       disbursementStatus: DisbursementScheduleStatus,

--- a/sources/packages/web/src/components/common/AssessmentAwardDetails.vue
+++ b/sources/packages/web/src/components/common/AssessmentAwardDetails.vue
@@ -82,12 +82,31 @@
         <content-group>
           <h3 class="category-header-medium primary-color my-3">Final award</h3>
           <!-- Final award table. -->
-          <award-table
-            :awardDetails="assessmentAwardData.finalAward"
-            :offeringIntensity="assessmentAwardData.offeringIntensity"
-            identifier="disbursementReceipt1"
-            v-if="showFirstFinalAward"
-          />
+          <div v-if="isFirstDisbursementCompleted">
+            <award-table
+              v-if="showFirstFinalAward"
+              :awardDetails="assessmentAwardData.finalAward"
+              :offeringIntensity="assessmentAwardData.offeringIntensity"
+              identifier="disbursementReceipt1"
+            />
+            <content-group-info v-if="allowFinalAwardExtendedInformation">
+              <div>
+                <span class="label-bold">Date eCert sent: </span>
+                <span>{{
+                  dateOnlyLongString(
+                    assessmentAwardData.estimatedAward
+                      .disbursement1DateSent as Date,
+                  )
+                }}</span>
+              </div>
+              <div>
+                <span class="label-bold">Certificate number: </span>
+                <span>{{
+                  assessmentAwardData.estimatedAward.disbursement1DocumentNumber
+                }}</span>
+              </div>
+            </content-group-info>
+          </div>
           <div v-else>
             {{
               getFinalAwardNotAvailableMessage(
@@ -180,12 +199,30 @@
             Final award
           </div>
           <!-- Final award table. -->
-          <award-table
-            :awardDetails="assessmentAwardData.finalAward"
-            :offeringIntensity="assessmentAwardData.offeringIntensity"
-            identifier="disbursementReceipt2"
-            v-if="showSecondFinalAward"
-          />
+          <div v-if="showSecondFinalAward">
+            <award-table
+              :awardDetails="assessmentAwardData.finalAward"
+              :offeringIntensity="assessmentAwardData.offeringIntensity"
+              identifier="disbursementReceipt2"
+            />
+            <content-group-info v-if="allowFinalAwardExtendedInformation">
+              <div>
+                <span class="label-bold">Date eCert sent: </span>
+                <span>{{
+                  dateOnlyLongString(
+                    assessmentAwardData.estimatedAward
+                      .disbursement2DateSent as Date,
+                  )
+                }}</span>
+              </div>
+              <div>
+                <span class="label-bold">Certificate number: </span>
+                <span>{{
+                  assessmentAwardData.estimatedAward.disbursement2DocumentNumber
+                }}</span>
+              </div>
+            </content-group-info>
+          </div>
           <div v-else>
             {{
               getFinalAwardNotAvailableMessage(
@@ -202,11 +239,12 @@
 <script lang="ts">
 import { AESTRoutesConst } from "@/constants/routes/RouteConstants";
 import { AwardDetailsAPIOutDTO } from "@/services/http/dto";
-import { COEStatus, StatusInfo } from "@/types";
+import { COEStatus, DisbursementScheduleStatus, StatusInfo } from "@/types";
 import { PropType, computed, defineComponent } from "vue";
 import AwardTable from "@/components/common/AwardTable.vue";
 import StatusInfoEnrolment from "@/components/common/StatusInfoEnrolment.vue";
 import ConfirmEnrolment from "@/components/common/ConfirmEnrolment.vue";
+import { useFormatters } from "@/composables";
 
 export default defineComponent({
   emits: {
@@ -229,20 +267,26 @@ export default defineComponent({
       type: Boolean,
       required: false,
     },
+    allowFinalAwardExtendedInformation: {
+      type: Boolean,
+      required: false,
+      default: false,
+    },
   },
   setup(props) {
+    const { dateOnlyLongString } = useFormatters();
     const isFirstDisbursementCompleted = computed<boolean>(
       () =>
-        props.assessmentAwardData.estimatedAward?.disbursement1COEStatus ===
-        COEStatus.completed,
+        props.assessmentAwardData.estimatedAward?.disbursement1Status ===
+        DisbursementScheduleStatus.Sent,
     );
     const isSecondDisbursementAvailable = computed(
       () => props.assessmentAwardData.estimatedAward?.disbursement2Date,
     );
     const isSecondDisbursementCompleted = computed<boolean>(
       () =>
-        props.assessmentAwardData.estimatedAward?.disbursement2COEStatus ===
-        COEStatus.completed,
+        props.assessmentAwardData.estimatedAward?.disbursement2Status ===
+        DisbursementScheduleStatus.Sent,
     );
     const showFirstFinalAward = computed<boolean>(
       () =>
@@ -256,7 +300,7 @@ export default defineComponent({
       () =>
         !!(
           isSecondDisbursementCompleted.value &&
-          props.assessmentAwardData.finalAward
+          !!props.assessmentAwardData.finalAward
         ),
     );
 
@@ -271,6 +315,7 @@ export default defineComponent({
     };
 
     return {
+      dateOnlyLongString,
       AESTRoutesConst,
       isSecondDisbursementAvailable,
       isSecondDisbursementCompleted,

--- a/sources/packages/web/src/components/common/AwardTable.vue
+++ b/sources/packages/web/src/components/common/AwardTable.vue
@@ -23,13 +23,14 @@
 import { PropType, defineComponent, computed } from "vue";
 import { OfferingIntensity } from "@/types";
 import { AWARDS, AwardDetail } from "@/constants/award-constants";
+import { DynamicAwardValue } from "@/services/http/dto";
 
 export default defineComponent({
   props: {
     awardDetails: {
-      type: Object as PropType<Record<string, string | number | Date>>,
+      type: Object as PropType<DynamicAwardValue>,
       required: true,
-      default: {} as Record<string, string | number | Date>,
+      default: {} as DynamicAwardValue,
     },
     identifier: {
       type: String,

--- a/sources/packages/web/src/components/common/AwardTable.vue
+++ b/sources/packages/web/src/components/common/AwardTable.vue
@@ -27,9 +27,9 @@ import { AWARDS, AwardDetail } from "@/constants/award-constants";
 export default defineComponent({
   props: {
     awardDetails: {
-      type: Object as PropType<Record<string, string | number>>,
+      type: Object as PropType<Record<string, string | number | Date>>,
       required: true,
-      default: {} as Record<string, string | number>,
+      default: {} as Record<string, string | number | Date>,
     },
     identifier: {
       type: String,
@@ -47,7 +47,7 @@ export default defineComponent({
       ),
     );
 
-    const getAwardValue = (awardType: string): string | number => {
+    const getAwardValue = (awardType: string): string | number | Date => {
       const awardValue =
         props.awardDetails[`${props.identifier}${awardType.toLowerCase()}`];
       // If the award is defined but no values are present it means that a receipt value is missing.

--- a/sources/packages/web/src/components/common/students/applicationDetails/AssessmentAward.vue
+++ b/sources/packages/web/src/components/common/students/applicationDetails/AssessmentAward.vue
@@ -16,6 +16,7 @@
   <assessment-award-details
     :assessmentAwardData="assessmentAwardData"
     :allowConfirmEnrolment="allowConfirmEnrolment"
+    :allow-final-award-extended-information="allowFinalAwardExtendedInformation"
     @confirmEnrolment="$emit('confirmEnrolment', $event)"
   />
 </template>
@@ -44,6 +45,11 @@ export default defineComponent({
       required: true,
     },
     allowConfirmEnrolment: {
+      type: Boolean,
+      required: false,
+      default: false,
+    },
+    allowFinalAwardExtendedInformation: {
       type: Boolean,
       required: false,
       default: false,

--- a/sources/packages/web/src/services/http/dto/Assessment.dto.ts
+++ b/sources/packages/web/src/services/http/dto/Assessment.dto.ts
@@ -75,7 +75,7 @@ export interface AwardDetailsAPIOutDTO {
    * Dynamic output of the workflow calculation.
    * Contains data that could represent a part-time or a full-time award details.
    */
-  estimatedAward: Record<string, string | number>;
+  estimatedAward: Record<string, string | number | Date>;
   /**
    * Dynamic output from disbursement receipt for the given disbursement.
    * Contains data that could represent a part-time or a full-time award details.

--- a/sources/packages/web/src/services/http/dto/Assessment.dto.ts
+++ b/sources/packages/web/src/services/http/dto/Assessment.dto.ts
@@ -63,6 +63,26 @@ export interface AssessmentNOAAPIOutDTO {
   applicationStatus: ApplicationStatus;
 }
 
+/**
+ * Dynamic object with awards values.
+ * @example
+ * {
+ *    disbursementReceipt1cslf: 1000,
+ *    disbursementReceipt1csgp: 10001,
+ *    disbursementReceipt1bcsl: 1005,
+ *    disbursementReceipt1bcag: 1006,
+ *    disbursementReceipt1bgpd: 1007,
+ *    disbursementReceipt1sbsd: 1008,
+ *    disbursementReceipt2cslf: 1000,
+ *    disbursementReceipt2csgp: 10001,
+ *    disbursementReceipt2bcsl: 1005,
+ *    disbursementReceipt2bcag: 1006,
+ *    disbursementReceipt2bgpd: 1007,
+ *    disbursementReceipt2sbsd: 1008,
+ *   }
+ */
+export type DynamicAwardValue = Record<string, string | number | Date>;
+
 export interface AwardDetailsAPIOutDTO {
   applicationNumber: string;
   applicationStatus: ApplicationStatus;
@@ -75,13 +95,13 @@ export interface AwardDetailsAPIOutDTO {
    * Dynamic output of the workflow calculation.
    * Contains data that could represent a part-time or a full-time award details.
    */
-  estimatedAward: Record<string, string | number | Date>;
+  estimatedAward: DynamicAwardValue;
   /**
    * Dynamic output from disbursement receipt for the given disbursement.
    * Contains data that could represent a part-time or a full-time award details.
    * If the conditions to have a receipt are not match this information will not be available.
    */
-  finalAward?: Record<string, string | number>;
+  finalAward?: DynamicAwardValue;
 }
 
 export interface ManualReassessmentAPIInDTO {

--- a/sources/packages/web/src/views/aest/student/applicationDetails/AssessmentAward.vue
+++ b/sources/packages/web/src/views/aest/student/applicationDetails/AssessmentAward.vue
@@ -15,6 +15,7 @@
       :assessment-award-data="assessmentAwardData"
       :notice-of-assessment-route="noticeOfAssessmentRoute"
       :allow-confirm-enrolment="true"
+      :allow-final-award-extended-information="true"
       @confirm-enrolment="confirmEnrolment"
     />
   </full-page-container>


### PR DESCRIPTION
## General notes
- The UI page has some components and some duplicated logic already when the application has two disbursements. This behavior has not changed. Some refactors in the future can improve this page.
- Two minor bugs were found from the previous PR, a missing assessment ID in a SQL query and `null` values returned for a second disbursement (the expectation was to not return null awards.)

## Ministry

### Part-time application with two disbursements, the second one waiting for disbursement to be sent.

![image](https://github.com/bcgov/SIMS/assets/61259237/28525df8-3e6e-4b23-a2bc-56a37cbbd743)

## Students

### Part-time application with two disbursements, one sent and one pending.

![image](https://github.com/bcgov/SIMS/assets/61259237/fa5c0b19-a4a2-473a-9391-79d083a07d5d)

## Institution

### Part-time application with two disbursements, both sent.

![image](https://github.com/bcgov/SIMS/assets/61259237/7853c2c5-13c3-4834-84cd-14df3f3dafc8)

## Common existing messages logic changes

### Part-time
- Disbursement pending: "The final award can't be calculated at this time." (previously COE Required)
- Disbursement sent: no message expected since we will display the values.
- COE Declined: "The final award is no longer applicable due to a change. Any scheduled disbursements will be canceled." (Same as before)
 
### Full-time
- Disbursement pending: "The final award can't be calculated at this time." (previously COE Required and same from Part-time)
- Disbursement sent: "The final award will be shown once confirmed by NSLSC."
- COE Declined: "The final award is no longer applicable due to a change. Any scheduled disbursements will be canceled." (Same as before)

