### PR TITLE
#2369 - Added missing institution id to prevent institution creation from Typeorm

### DIFF
--- a/sources/packages/backend/apps/api/src/services/institution-location/institution-location.service.ts
+++ b/sources/packages/backend/apps/api/src/services/institution-location/institution-location.service.ts
@@ -177,6 +177,7 @@ export class InstitutionLocationService extends RecordDataModelService<Instituti
         "institutionLocation.id",
         "institutionLocation.institutionCode",
         "institutionLocation.primaryContact",
+        "institution.id",
         "institution.operatingName",
         "institution.legalOperatingName",
         "institution.primaryEmail",


### PR DESCRIPTION
Due to a missing institution ID Typeorm was trying to create an institution because the modal is also defined with `cascade: true`.
This is blocking the demo of the other sprint ticket and **the fix is intended to allow the Student Application to be submitted**.

API Error:
```console
[Nest] 17 - 04/23/2024, 9:35:27 PM LOG [SequenceControlService] Persisting new sequence number to database...
query failed: INSERT INTO "sims"."institutions"("created_at", "updated_at", "business_guid", "legal_operating_name", "operating_name", "primary_phone", "primary_email", "website", "regulating_body", "other_regulating_body", "established_date", "primary_contact", "institution_address", "creator", "modifier", "institution_type_id") VALUES (DEFAULT, DEFAULT, DEFAULT, $1, $2, DEFAULT, $3, DEFAULT, DEFAULT, DEFAULT, DEFAULT, DEFAULT, DEFAULT, DEFAULT, DEFAULT, DEFAULT) RETURNING "created_at", "updated_at", "id" -- PARAMETERS: ["College E","College E - Operating name","zoe_1@admin.com"]
error: error: null value in column "primary_phone" violates not-null constraint
[Nest] 17 - 04/23/2024, 9:35:29 PM ERROR [AppAllExceptionsFilter] Unhandled exception
[Nest] 17 - 04/23/2024, 9:35:29 PM ERROR [AppAllExceptionsFilter] Request path [/api/students/application/118105/submit]
[Nest] 17 - 04/23/2024, 9:35:29 PM ERROR [AppAllExceptionsFilter] {"response":{"message":"Unexpected error while submitting the application.","error":"Internal Server Error","statusCode":500},"status":500,"options":{},"message":"Unexpected error while submitting the application.","name":"InternalServerErrorException"}
```