### PR TITLE
Fix Webpack Config and Enable Multiple Debug

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,6 +2,57 @@
   "version": "0.2.0",
   "configurations": [
     {
+      "type": "node",
+      "request": "launch",
+      "name": "Debug - API",
+      "cwd": "${workspaceFolder}/sources/packages/backend",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["run", "start:debug", "api"],
+      "autoAttachChildProcesses": true,
+      "restart": true,
+      "sourceMaps": true,
+      "stopOnEntry": false,
+      "console": "integratedTerminal",
+      "sourceMapPathOverrides": {
+        "webpack:///./~/*": "${workspaceFolder}/sources/packages/backend/node_modules/*",
+        "webpack://?:*/*": "${workspaceFolder}/sources/packages/backend/*"
+      }
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Debug - Workers",
+      "cwd": "${workspaceFolder}/sources/packages/backend",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["run", "start:debug", "workers"],
+      "autoAttachChildProcesses": true,
+      "restart": true,
+      "sourceMaps": true,
+      "stopOnEntry": false,
+      "console": "integratedTerminal",
+      "sourceMapPathOverrides": {
+        "webpack:///./~/*": "${workspaceFolder}/sources/packages/backend/node_modules/*",
+        "webpack://?:*/*": "${workspaceFolder}/sources/packages/backend/*"
+      }
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Debug - Queue-consumers",
+      "cwd": "${workspaceFolder}/sources/packages/backend",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["run", "start:debug", "queue-consumers"],
+      "autoAttachChildProcesses": true,
+      "restart": true,
+      "sourceMaps": true,
+      "stopOnEntry": false,
+      "console": "integratedTerminal",
+      "sourceMapPathOverrides": {
+        "webpack:///./~/*": "${workspaceFolder}/sources/packages/backend/node_modules/*",
+        "webpack://?:*/*": "${workspaceFolder}/sources/packages/backend/*"
+      }
+    },
+    {
       "name": "Attach Nest JS",
       "request": "attach",
       "sourceMapPathOverrides": {

--- a/sources/packages/backend/webpack.config.js
+++ b/sources/packages/backend/webpack.config.js
@@ -12,6 +12,8 @@ const exports = {
   ],
 };
 if (process.env.NODE_ENV === "production") {
+  // Enable the source maps needed to support proper stack trace errors in production
+  // pointing to typescript files (.ts) instead of javascript (.js) references.
   exports.devtool = "source-map";
 }
 module.exports = exports;

--- a/sources/packages/backend/webpack.config.js
+++ b/sources/packages/backend/webpack.config.js
@@ -1,6 +1,5 @@
 const CopyPlugin = require("copy-webpack-plugin");
-module.exports = {
-  devtool: "source-map",
+const exports = {
   plugins: [
     new CopyPlugin({
       patterns: [
@@ -12,3 +11,7 @@ module.exports = {
     }),
   ],
 };
+if (process.env.NODE_ENV === "production") {
+  exports.devtool = "source-map";
+}
+module.exports = exports;


### PR DESCRIPTION
Over the past weeks, the debug was not working properly due to the `devtool` configuration (that is the assumption). The configuration we have right now is the [right one for production](https://webpack.js.org/configuration/devtool/#devtool) and to produce the correct stack trace for errors but it was preventing the debugging from properly working. 
A further investigation was not done and the current change is not supposed to affect production, hence it is intended only to quickly bring back the debug functionality.

Besides that, new configurations were added to allow the debugging of the backend applications. Below are the benefits.
- Start the application with the debugger attached.
- Allow application modification keeping the debugger attached.
- Allow the debugging of multiple applications at the same time.

The below image display `api`, `workers`, and `queue-consumers` executed at the same time with the debugger attached to all of them.

![image](https://github.com/bcgov/SIMS/assets/61259237/1fc8f27c-3b30-413e-becd-d255105ca056)
