### PR TITLE
#2589 - Use a CSV parser library for the report service

### DIFF
--- a/sims.code-workspace
+++ b/sims.code-workspace
@@ -113,7 +113,8 @@
       "sbsd",
       "SFAS",
       "timestamptz",
-      "typeorm"
+      "typeorm",
+      "unparse"
     ],
     "[json]": {
       "editor.defaultFormatter": "vscode.json-language-features"

--- a/sources/packages/backend/libs/services/src/report/report.service.ts
+++ b/sources/packages/backend/libs/services/src/report/report.service.ts
@@ -4,6 +4,8 @@ import { RecordDataModelService, ReportConfig } from "@sims/sims-db";
 import { CustomNamedError, StringBuilder } from "@sims/utilities";
 import { ReportsFilterModel } from "./report.models";
 import { REPORT_CONFIG_NOT_FOUND, FILTER_PARAMS_MISMATCH } from "./constants";
+import { unparse } from "papaparse";
+
 /**
  * Service layer for reports.
  */
@@ -49,7 +51,7 @@ export class ReportService extends RecordDataModelService<ReportConfig> {
       }
     });
     const reportData = await this.connection.query(reportQuery, parameters);
-    return this.buildCSVString(reportData);
+    return unparse(reportData);
   }
 
   /**
@@ -86,31 +88,5 @@ export class ReportService extends RecordDataModelService<ReportConfig> {
    */
   private async getConfig(reportName: string): Promise<ReportConfig> {
     return this.repo.findOne({ where: { reportName: reportName } });
-  }
-
-  /**
-   * Build CSV string from a dynamic object array.
-   * @param reportData
-   * @returns CSV string.
-   */
-  private buildCSVString(reportData: any[]): string {
-    if (!reportData || reportData.length === 0) {
-      return "No data found.";
-    }
-    //The report data as array of dynamic object is transformed into CSV string content to
-    //to be streamed as CSV file. Keys of first array item used to form the header line of CSV string.
-    const reportCSVContent = new StringBuilder();
-    const reportHeaders = Object.keys(reportData[0]);
-    reportCSVContent.appendLine(reportHeaders.join(","));
-    reportData.forEach((reportDataItem) => {
-      let dataItem = "";
-      reportHeaders.forEach((header, index) => {
-        dataItem += index
-          ? `,${reportDataItem[header]}`
-          : reportDataItem[header];
-      });
-      reportCSVContent.appendLine(dataItem);
-    });
-    return reportCSVContent.toString();
   }
 }

--- a/sources/packages/backend/libs/services/src/report/report.service.ts
+++ b/sources/packages/backend/libs/services/src/report/report.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from "@nestjs/common";
 import { Connection } from "typeorm";
 import { RecordDataModelService, ReportConfig } from "@sims/sims-db";
-import { CustomNamedError, StringBuilder } from "@sims/utilities";
+import { CustomNamedError } from "@sims/utilities";
 import { ReportsFilterModel } from "./report.models";
 import { REPORT_CONFIG_NOT_FOUND, FILTER_PARAMS_MISMATCH } from "./constants";
 import { unparse } from "papaparse";

--- a/sources/packages/backend/package-lock.json
+++ b/sources/packages/backend/package-lock.json
@@ -37,7 +37,7 @@
         "ioredis": "^5.2.4",
         "jsonpath": "^1.1.1",
         "jwt-decode": "^3.1.2",
-        "papaparse": "^5.3.2",
+        "papaparse": "^5.4.1",
         "passport": "^0.6.0",
         "passport-jwt": "^4.0.1",
         "pg": "^8.5.1",

--- a/sources/packages/backend/package.json
+++ b/sources/packages/backend/package.json
@@ -70,7 +70,7 @@
     "ioredis": "^5.2.4",
     "jsonpath": "^1.1.1",
     "jwt-decode": "^3.1.2",
-    "papaparse": "^5.3.2",
+    "papaparse": "^5.4.1",
     "passport": "^0.6.0",
     "passport-jwt": "^4.0.1",
     "pg": "^8.5.1",


### PR DESCRIPTION
The backend is currently using the [papaparse ](https://www.npmjs.com/package/papaparse) lib to read CSVs from the bulk file uploads and the same library has a method to convert objects to CSV ([unparse](https://www.papaparse.com/docs)).

Used the `Data Inventory Report` as a POC, changing a user first name to a string with characters that would break the CSV generation.

- Input string: `Testing "quotes" and comma, and more; characters, and values $45.123,21!`
- Escaped string: `"Testing ""quotes"" and comma, and more; characters, and values $45.123,21!"`

#### Generated Report
![image](https://github.com/bcgov/SIMS/assets/61259237/4fa78873-de01-448c-b298-5111165e3fa8)

#### CSV escaped string
![image](https://github.com/bcgov/SIMS/assets/61259237/16869fe0-cd7e-40eb-abc6-a6d420b1458a)

#### Same report without using the lib
![image](https://github.com/bcgov/SIMS/assets/61259237/83fe93eb-6c42-4236-9a92-71bd81bc7955)

#### Header is also able to support quotes and other characters

![image](https://github.com/bcgov/SIMS/assets/61259237/968d5460-b0fd-400e-b697-800bc46ffd0a)

Typeorm will produce an object as below. The property names are enclosed in single or double quotes depending on their content. Please see the difference between `'Application Number'`, `'First Name with quotes " in the name and ,coma'`, and  `Gender` (this explanation is not part of the PR and it was added here just for curiosity).
```ts
 {
    'Application ID': 73,
    'Application Number': '5007443876',
    'Application Status': 'Completed',
    'Assessment Date': null,
    'Re-assessment Indicator': 'Original assessment',
    "Marital Status (or 'category')": 'SI',
    'Student Dependency Status': 'dependant',
    'First Name with quotes " in the name and ,coma': 'Maud',
    'Last Name': 'Robel',
    'Date of Birth': 2018-08-01T00:00:00.000Z,
    Gender: 'X',
    SIN: '428314025',
}
```

##### Notes
1. lib was updated to the latest version to take advantage of the opportunity to use the latest package version.
2. The downloaded file is encoded in UTF-8 as the result of writing it to the stream, no changes in this behavior since the lib is currently converting the object to a CSV string that is later written to the desired output.



