### PR TITLE
Queue-consumers Fail to Start 

### DIFF
--- a/sources/packages/backend/package.json
+++ b/sources/packages/backend/package.json
@@ -11,7 +11,7 @@
     "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
     "start": "nest start",
     "start:dev": "npm run migration:run && nest start --watch --preserveWatchOutput",
-    "start:debug": "nest start --debug --watch --preserveWatchOutput",
+    "start:debug": "cross-env DEBUG=true nest start --debug --watch --preserveWatchOutput",
     "start:prod:db-migrations": "npm run migration:run",
     "start:prod:api": "node --enable-source-maps dist/apps/api/main.js",
     "docker:start:api": "node --enable-source-maps dist/apps/api/main.js",

--- a/sources/packages/backend/webpack.config.js
+++ b/sources/packages/backend/webpack.config.js
@@ -1,5 +1,9 @@
 const CopyPlugin = require("copy-webpack-plugin");
-const exports = {
+module.exports = {
+  // Enable the source maps needed to support proper stack trace errors in production
+  // pointing to typescript files (.ts) instead of javascript (.js) references.
+  // DEBUG is set as 'true' only when using start:debug' script.
+  devtool: process.env.DEBUG === "true" ? undefined : "source-map",
   plugins: [
     new CopyPlugin({
       patterns: [
@@ -11,9 +15,3 @@ const exports = {
     }),
   ],
 };
-if (process.env.NODE_ENV === "production") {
-  // Enable the source maps needed to support proper stack trace errors in production
-  // pointing to typescript files (.ts) instead of javascript (.js) references.
-  exports.devtool = "source-map";
-}
-module.exports = exports;


### PR DESCRIPTION
The PR #3188 introduced an issue where the SQL files expected to be copied by the `copy-webpack-plugin` during the `webpack` build are no longer copied.
The current check was failing because the ENV variable was not present at "build time" and new syntax was also affecting the `plugins` configuration.

A new env variable (`DEBUG`) was introduced only to allow the `webpack` to be aware of the `devtools` expected value.