### PR TITLE
#2650 - Cancel Future Disbursements if COE is declined (Bug)

### DIFF
--- a/sources/packages/backend/apps/api/src/route-controllers/confirmation-of-enrollment/_tests_/e2e/confirmation-of-enrollment.institutions.denyConfirmationOfEnrollment.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/confirmation-of-enrollment/_tests_/e2e/confirmation-of-enrollment.institutions.denyConfirmationOfEnrollment.e2e-spec.ts
@@ -197,7 +197,6 @@ describe("ConfirmationOfEnrollmentInstitutionsController(e2e)-denyConfirmationOf
 
   it("Should decline first and the second COEs and cancel first and the second disbursements when the institution declines the first COE.", async () => {
     // Arrange
-    // Application in the past that must be ignored.
     const application = await saveFakeApplicationDisbursements(
       db.dataSource,
       {
@@ -296,7 +295,6 @@ describe("ConfirmationOfEnrollmentInstitutionsController(e2e)-denyConfirmationOf
 
   it("Should decline the second COE and cancel the second disbursement when the institution declines the second COE.", async () => {
     // Arrange
-    // Application in the past that must be ignored.
     const application = await saveFakeApplicationDisbursements(
       db.dataSource,
       {

--- a/sources/packages/backend/apps/api/src/route-controllers/confirmation-of-enrollment/_tests_/e2e/confirmation-of-enrollment.institutions.denyConfirmationOfEnrollment.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/confirmation-of-enrollment/_tests_/e2e/confirmation-of-enrollment.institutions.denyConfirmationOfEnrollment.e2e-spec.ts
@@ -20,12 +20,13 @@ import {
   ApplicationStatus,
   AssessmentTriggerType,
   COEStatus,
+  DisbursementScheduleStatus,
   Institution,
   InstitutionLocation,
   OfferingIntensity,
   StudentAssessmentStatus,
 } from "@sims/sims-db";
-import { addDays } from "@sims/utilities";
+import { addDays, getISODateOnlyString } from "@sims/utilities";
 
 describe("ConfirmationOfEnrollmentInstitutionsController(e2e)-denyConfirmationOfEnrollment", () => {
   let app: INestApplication;
@@ -193,6 +194,104 @@ describe("ConfirmationOfEnrollmentInstitutionsController(e2e)-denyConfirmationOf
       ).not.toBe(AssessmentTriggerType.RelatedApplicationChanged);
     },
   );
+
+  it("Should decline the second COE and cancel disbursements when the institution declines the first COE.", async () => {
+    // Arrange
+    // Application in the past that must be ignored.
+    const application = await saveFakeApplicationDisbursements(
+      db.dataSource,
+      {
+        institution: collegeC,
+        institutionLocation: collegeCLocation,
+      },
+      {
+        createSecondDisbursement: true,
+        offeringIntensity: OfferingIntensity.partTime,
+        applicationStatus: ApplicationStatus.Enrolment,
+        firstDisbursementInitialValues: {
+          coeStatus: COEStatus.required,
+          disbursementDate: getISODateOnlyString(new Date()),
+        },
+        secondDisbursementInitialValues: {
+          coeStatus: COEStatus.required,
+          disbursementDate: getISODateOnlyString(addDays(30)),
+        },
+      },
+    );
+
+    const [firstDisbursement] =
+      application.currentAssessment.disbursementSchedules;
+    const endpoint = `/institutions/location/${collegeCLocation.id}/confirmation-of-enrollment/disbursement-schedule/${firstDisbursement.id}/deny`;
+    const token = await getInstitutionToken(InstitutionTokenTypes.CollegeCUser);
+    const coeDenyReasonId = 2;
+    // Act/Assert
+    await request(app.getHttpServer())
+      .patch(endpoint)
+      .send({ coeDenyReasonId })
+      .auth(token, BEARER_AUTH_TYPE)
+      .expect(HttpStatus.OK);
+
+    // Check if the COEs were declined and the expected fields were updated.
+    const [firstDisbursementSaved, secondDisbursementSaved] =
+      await db.disbursementSchedule.find({
+        select: {
+          coeStatus: true,
+          coeDeniedReason: { id: true },
+          disbursementScheduleStatus: true,
+          coeUpdatedBy: {
+            id: true,
+          },
+          modifier: {
+            id: true,
+          },
+          coeUpdatedAt: true,
+          updatedAt: true,
+        },
+        relations: {
+          coeDeniedReason: true,
+          coeUpdatedBy: true,
+          modifier: true,
+        },
+        where: { studentAssessment: { id: application.currentAssessment.id } },
+        order: { disbursementDate: "ASC" },
+      });
+    // Values expected to be the same among the saved disbursements.
+    const sharedExpectedSavedValues = {
+      coeStatus: COEStatus.declined,
+      coeDeniedReason: {
+        id: coeDenyReasonId,
+      },
+      disbursementScheduleStatus: DisbursementScheduleStatus.Cancelled,
+      coeUpdatedBy: {
+        id: expect.any(Number),
+      },
+      modifier: {
+        id: expect.any(Number),
+      },
+      coeUpdatedAt: expect.any(Date),
+      updatedAt: expect.any(Date),
+    };
+    expect(firstDisbursementSaved).toEqual({
+      id: firstDisbursementSaved.id,
+      ...sharedExpectedSavedValues,
+    });
+    expect(secondDisbursementSaved).toEqual({
+      id: secondDisbursementSaved.id,
+      ...sharedExpectedSavedValues,
+    });
+    expect(firstDisbursementSaved.modifier.id).toBe(
+      secondDisbursementSaved.modifier.id,
+    );
+    expect(firstDisbursementSaved.coeUpdatedBy.id).toBe(
+      secondDisbursementSaved.coeUpdatedBy.id,
+    );
+    expect(firstDisbursementSaved.coeUpdatedAt).toEqual(
+      secondDisbursementSaved.coeUpdatedAt,
+    );
+    expect(firstDisbursementSaved.updatedAt).toEqual(
+      secondDisbursementSaved.updatedAt,
+    );
+  });
 
   /**
    * Get application current assessment details to

--- a/sources/packages/backend/libs/services/src/confirmation-of-enrollment/confirmation-of-enrollment.service.ts
+++ b/sources/packages/backend/libs/services/src/confirmation-of-enrollment/confirmation-of-enrollment.service.ts
@@ -431,7 +431,7 @@ export class ConfirmationOfEnrollmentService {
         .update(
           {
             coeStatus: COEStatus.required,
-            // Use th assessment id to ensure the second disbursement will
+            // Use assessment id to ensure the second disbursement will
             // be cancelled if the first one is cancelled.
             studentAssessment: { id: studentAssessmentId },
           },
@@ -449,7 +449,11 @@ export class ConfirmationOfEnrollmentService {
 
       if (!updateResult.affected || updateResult.affected > 2) {
         throw new Error(
-          `While updating COE status to '${COEStatus.declined}' the number of affected records was not expected. Expected 1 or 2, received ${updateResult.affected}.`,
+          `While updating COE status to '${
+            COEStatus.declined
+          }' the number of affected records was not expected. Expected 1 or 2, received ${
+            updateResult.affected ?? 0
+          }.`,
         );
       }
       this.logger.log(

--- a/sources/packages/web/src/components/students/applicationTracker/DisbursementBanner.vue
+++ b/sources/packages/web/src/components/students/applicationTracker/DisbursementBanner.vue
@@ -29,9 +29,11 @@
     background-color="error-bg"
   >
     <template #content
-      ><span class="font-bold">Reason from your institution:</span>
-      {{ coeDenialReason }}. Please note any scheduled payment(s) will be
-      cancelled.</template
+      ><strong>Your institution declined your enrolment status.</strong> Reason
+      from your institution: {{ coeDenialReason }}. The disbursement associated
+      with this application have now been cancelled. To receive funding for this
+      application, you must 'edit' your application and re-submit in order to
+      allow your institution to Confirm your Enrolment again.</template
     >
   </application-status-tracker-banner>
 

--- a/sources/packages/web/src/components/students/applicationTracker/MultipleDisbursementBanner.vue
+++ b/sources/packages/web/src/components/students/applicationTracker/MultipleDisbursementBanner.vue
@@ -29,9 +29,14 @@
     background-color="error-bg"
   >
     <template #content
-      ><span class="font-bold">Reason from your institution:</span>
-      {{ coeDenialReason }}. Please note any scheduled payment(s) will be
-      cancelled.</template
+      ><span class="font-bold"
+        >Your institution declined your enrolment status.</span
+      >
+      Reason from your institution: {{ coeDenialReason }}. All disbursements
+      associated with this application have now been cancelled. To receive
+      funding for this application, you must 'edit' your application and
+      re-submit in order to allow your institution to Confirm your Enrolment
+      again.</template
     >
   </application-status-tracker-banner>
 

--- a/sources/packages/web/src/components/students/applicationTracker/MultipleDisbursementBanner.vue
+++ b/sources/packages/web/src/components/students/applicationTracker/MultipleDisbursementBanner.vue
@@ -29,14 +29,11 @@
     background-color="error-bg"
   >
     <template #content
-      ><span class="font-bold"
-        >Your institution declined your enrolment status.</span
-      >
-      Reason from your institution: {{ coeDenialReason }}. All disbursements
-      associated with this application have now been cancelled. To receive
-      funding for this application, you must 'edit' your application and
-      re-submit in order to allow your institution to Confirm your Enrolment
-      again.</template
+      ><strong>Your institution declined your enrolment status.</strong> Reason
+      from your institution: {{ coeDenialReason }}. All disbursements associated
+      with this application have now been cancelled. To receive funding for this
+      application, you must 'edit' your application and re-submit in order to
+      allow your institution to Confirm your Enrolment again.</template
     >
   </application-status-tracker-banner>
 


### PR DESCRIPTION
### Student Application in Enrollment status waiting for the COE approval.

![image](https://github.com/bcgov/SIMS/assets/61259237/ab0b5c3e-9772-451d-962d-431b23b1db77)

### Student Application when the first COE is declined, the message for the first COE was adjusted.

![image](https://github.com/bcgov/SIMS/assets/61259237/7b239aad-9f88-4565-89a2-5516e88e6c61)

### Completed Student Application when the second COE is declined.

![image](https://github.com/bcgov/SIMS/assets/61259237/d39f1b55-8247-4218-9c69-f26eee9adb25)

### Student application with only one disbursement declined.

![image](https://github.com/bcgov/SIMS/assets/61259237/94e16476-1c3c-4d5c-9047-90c5e18fc92c)





