### PR TITLE
#3062 - Enable Reports for BC Public Institutions (Part 3)

### DIFF
--- a/sources/packages/backend/apps/api/src/app.institutions.module.ts
+++ b/sources/packages/backend/apps/api/src/app.institutions.module.ts
@@ -72,6 +72,7 @@ import {
   ProgramYearInstitutionsController,
   ReportInstitutionsController,
   ProgramYearControllerService,
+  ReportControllerService,
 } from "./route-controllers";
 import { AuthModule } from "./auth/auth.module";
 import {
@@ -178,6 +179,7 @@ import {
     AssessmentSequentialProcessingService,
     ProgramYearControllerService,
     ProgramYearService,
+    ReportControllerService,
     ReportService,
   ],
 })

--- a/sources/packages/backend/apps/api/src/route-controllers/report/models/report.dto.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/report/models/report.dto.ts
@@ -24,10 +24,11 @@ enum MinistryReportNames {
  * API dto to define the criteria to extract the financial report.
  * Basic class validators used as dry-run submission will validate payload.
  */
-export class ReportsFilterAPIInDTO {
+export abstract class ReportsFilterAPIInDTO {
   @Allow()
   @JsonMaxSize(JSON_10KB)
   params: ReportFilterParamAPIInDTO;
+  abstract reportName: string;
 }
 
 export class InstitutionReportsFilterAPIInDTO extends ReportsFilterAPIInDTO {

--- a/sources/packages/backend/apps/api/src/route-controllers/report/report.aest.controller.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/report/report.aest.controller.ts
@@ -1,33 +1,18 @@
-import {
-  BadRequestException,
-  Body,
-  Controller,
-  Post,
-  Res,
-  UnprocessableEntityException,
-} from "@nestjs/common";
+import { Body, Controller, Post, Res } from "@nestjs/common";
 import {
   ApiBadRequestResponse,
   ApiTags,
   ApiUnprocessableEntityResponse,
 } from "@nestjs/swagger";
-import { Response } from "express";
 import { AuthorizedParties } from "../../auth/authorized-parties.enum";
 import { AllowAuthorizedParty, Groups, Roles } from "../../auth/decorators";
 import { UserGroups } from "../../auth/user-groups.enum";
-import { FormService } from "../../services";
 import { ClientTypeBaseRoute } from "../../types";
-import { CustomNamedError } from "@sims/utilities";
 import BaseController from "../BaseController";
-import { MinistryReportsFilterAPIInDTO } from "./models/report.dto";
-import { FormNames } from "../../services/form/constants";
-import { Role } from "../../auth/roles.enum";
-import {
-  FILTER_PARAMS_MISMATCH,
-  ReportService,
-  REPORT_CONFIG_NOT_FOUND,
-} from "@sims/services";
 import { ReportControllerService } from "./report.controller.service";
+import { Role } from "../../auth";
+import { MinistryReportsFilterAPIInDTO } from "./models/report.dto";
+import { Response } from "express";
 
 /**
  * Controller for Reports for AEST Client.
@@ -40,8 +25,6 @@ import { ReportControllerService } from "./report.controller.service";
 export class ReportAESTController extends BaseController {
   constructor(
     private readonly reportControllerService: ReportControllerService,
-    private readonly reportService: ReportService,
-    private readonly formService: FormService,
   ) {
     super();
   }
@@ -64,37 +47,6 @@ export class ReportAESTController extends BaseController {
     @Body() payload: MinistryReportsFilterAPIInDTO,
     @Res() response: Response,
   ): Promise<void> {
-    const submissionResult = await this.formService.dryRunSubmission(
-      FormNames.ExportFinancialReports,
-      payload,
-    );
-
-    if (!submissionResult.valid) {
-      throw new BadRequestException(
-        "Not able to export report due to an invalid request.",
-      );
-    }
-
-    try {
-      const reportData = await this.reportService.getReportDataAsCSV(
-        submissionResult.data.data,
-      );
-      this.reportControllerService.streamFile(
-        response,
-        payload.reportName,
-        reportData,
-      );
-    } catch (error: unknown) {
-      if (error instanceof CustomNamedError) {
-        switch (error.name) {
-          case REPORT_CONFIG_NOT_FOUND:
-          case FILTER_PARAMS_MISMATCH:
-            throw new UnprocessableEntityException(error.message);
-          default:
-            throw error;
-        }
-      }
-      throw error;
-    }
+    await this.reportControllerService.generateReport(payload, response);
   }
 }

--- a/sources/packages/backend/apps/api/src/route-controllers/report/report.controller.service.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/report/report.controller.service.ts
@@ -15,7 +15,7 @@ import {
 import { Response } from "express";
 import { Readable } from "stream";
 import { FormService } from "../../services";
-import { MinistryReportsFilterAPIInDTO } from "./models/report.dto";
+import { ReportsFilterAPIInDTO } from "./models/report.dto";
 import { FormNames } from "../../services/form/constants";
 
 /**
@@ -36,7 +36,7 @@ export class ReportControllerService {
    * - `institutionId` related institution id.
    */
   async generateReport(
-    payload: MinistryReportsFilterAPIInDTO,
+    payload: ReportsFilterAPIInDTO,
     response: Response,
     options?: { institutionId?: number },
   ): Promise<void> {
@@ -61,8 +61,6 @@ export class ReportControllerService {
           case REPORT_CONFIG_NOT_FOUND:
           case FILTER_PARAMS_MISMATCH:
             throw new UnprocessableEntityException(error.message);
-          default:
-            throw error;
         }
       }
       throw error;

--- a/sources/packages/backend/apps/api/src/route-controllers/report/report.controller.service.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/report/report.controller.service.ts
@@ -49,11 +49,16 @@ export class ReportControllerService {
         "Not able to export report due to an invalid request.",
       );
     }
+    options?.institutionId
+      ? (submissionResult.data.data.params = {
+          ...submissionResult.data.data.params,
+          institutionId: options?.institutionId,
+        })
+      : null;
     try {
-      const reportData = await this.reportService.getReportDataAsCSV({
-        ...submissionResult.data.data,
-        institutionId: options?.institutionId,
-      });
+      const reportData = await this.reportService.getReportDataAsCSV(
+        submissionResult.data.data,
+      );
       this.streamFile(response, payload.reportName, reportData);
     } catch (error: unknown) {
       if (error instanceof CustomNamedError) {

--- a/sources/packages/backend/apps/api/src/route-controllers/report/report.controller.service.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/report/report.controller.service.ts
@@ -32,10 +32,13 @@ export class ReportControllerService {
    * Generates report in csv format.
    * @param payload report filter payload.
    * @param response http response as file.
+   * @param options related options.
+   * - `institutionId` related institution id.
    */
   async generateReport(
     payload: MinistryReportsFilterAPIInDTO,
     response: Response,
+    options?: { institutionId?: number },
   ): Promise<void> {
     const submissionResult = await this.formService.dryRunSubmission(
       FormNames.ExportFinancialReports,
@@ -47,9 +50,10 @@ export class ReportControllerService {
       );
     }
     try {
-      const reportData = await this.reportService.getReportDataAsCSV(
-        submissionResult.data.data,
-      );
+      const reportData = await this.reportService.getReportDataAsCSV({
+        ...submissionResult.data.data,
+        institutionId: options?.institutionId,
+      });
       this.streamFile(response, payload.reportName, reportData);
     } catch (error: unknown) {
       if (error instanceof CustomNamedError) {

--- a/sources/packages/backend/apps/api/src/route-controllers/report/report.controller.service.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/report/report.controller.service.ts
@@ -49,12 +49,9 @@ export class ReportControllerService {
         "Not able to export report due to an invalid request.",
       );
     }
-    options?.institutionId
-      ? (submissionResult.data.data.params = {
-          ...submissionResult.data.data.params,
-          institutionId: options?.institutionId,
-        })
-      : null;
+    if (options?.institutionId) {
+      submissionResult.data.data.params.institutionId = options.institutionId;
+    }
     try {
       const reportData = await this.reportService.getReportDataAsCSV(
         submissionResult.data.data,

--- a/sources/packages/backend/apps/api/src/route-controllers/report/report.controller.service.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/report/report.controller.service.ts
@@ -3,18 +3,20 @@ import {
   Injectable,
   UnprocessableEntityException,
 } from "@nestjs/common";
-import { ReportService } from "@sims/services";
-import { getFileNameAsCurrentTimestamp } from "@sims/utilities";
-import { Response } from "express";
-import { Readable } from "stream";
-import { FormService } from "../../services";
-import { CustomNamedError } from "@sims/utilities";
-import { MinistryReportsFilterAPIInDTO } from "./models/report.dto";
-import { FormNames } from "../../services/form/constants";
 import {
+  ReportService,
   FILTER_PARAMS_MISMATCH,
   REPORT_CONFIG_NOT_FOUND,
 } from "@sims/services";
+import {
+  getFileNameAsCurrentTimestamp,
+  CustomNamedError,
+} from "@sims/utilities";
+import { Response } from "express";
+import { Readable } from "stream";
+import { FormService } from "../../services";
+import { MinistryReportsFilterAPIInDTO } from "./models/report.dto";
+import { FormNames } from "../../services/form/constants";
 
 /**
  * Controller Service layer for reports.

--- a/sources/packages/backend/apps/api/src/route-controllers/report/report.controller.service.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/report/report.controller.service.ts
@@ -1,20 +1,79 @@
-import { Injectable } from "@nestjs/common";
+import {
+  BadRequestException,
+  Injectable,
+  UnprocessableEntityException,
+} from "@nestjs/common";
+import { ReportService } from "@sims/services";
 import { getFileNameAsCurrentTimestamp } from "@sims/utilities";
 import { Response } from "express";
 import { Readable } from "stream";
+import { FormService } from "../../services";
+import { CustomNamedError } from "@sims/utilities";
+import { MinistryReportsFilterAPIInDTO } from "./models/report.dto";
+import { FormNames } from "../../services/form/constants";
+import {
+  FILTER_PARAMS_MISMATCH,
+  REPORT_CONFIG_NOT_FOUND,
+} from "@sims/services";
 
 /**
- * Service layer for reports.
+ * Controller Service layer for reports.
  */
 @Injectable()
 export class ReportControllerService {
+  constructor(
+    private readonly reportService: ReportService,
+    private readonly formService: FormService,
+  ) {}
+
+  /**
+   * Generates report in csv format.
+   * @param payload report filter payload.
+   * @param response http response as file.
+   */
+  async generateReport(
+    payload: MinistryReportsFilterAPIInDTO,
+    response: Response,
+  ): Promise<void> {
+    const submissionResult = await this.formService.dryRunSubmission(
+      FormNames.ExportFinancialReports,
+      payload,
+    );
+    if (!submissionResult.valid) {
+      throw new BadRequestException(
+        "Not able to export report due to an invalid request.",
+      );
+    }
+    try {
+      const reportData = await this.reportService.getReportDataAsCSV(
+        submissionResult.data.data,
+      );
+      this.streamFile(response, payload.reportName, reportData);
+    } catch (error: unknown) {
+      if (error instanceof CustomNamedError) {
+        switch (error.name) {
+          case REPORT_CONFIG_NOT_FOUND:
+          case FILTER_PARAMS_MISMATCH:
+            throw new UnprocessableEntityException(error.message);
+          default:
+            throw error;
+        }
+      }
+      throw error;
+    }
+  }
+
   /**
    * Stream file as downloadable response.
    * @param response http response as file.
    * @param reportName report name.
    * @param fileContent content of the file.
    */
-  streamFile(response: Response, reportName: string, fileContent: string) {
+  private streamFile(
+    response: Response,
+    reportName: string,
+    fileContent: string,
+  ) {
     const timestamp = getFileNameAsCurrentTimestamp();
     const filename = `${reportName}_${timestamp}.csv`;
     response.setHeader(

--- a/sources/packages/backend/apps/api/src/route-controllers/report/report.institutions.controller.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/report/report.institutions.controller.ts
@@ -9,12 +9,14 @@ import {
   AllowAuthorizedParty,
   IsBCPublicInstitution,
   IsInstitutionAdmin,
+  UserToken,
 } from "../../auth/decorators";
 import { ClientTypeBaseRoute } from "../../types";
 import BaseController from "../BaseController";
 import { InstitutionReportsFilterAPIInDTO } from "./models/report.dto";
 import { Response } from "express";
 import { ReportControllerService } from "./report.controller.service";
+import { IInstitutionUserToken } from "../../auth";
 
 /**
  * Controller for Reports for Institution Client.
@@ -35,6 +37,7 @@ export class ReportInstitutionsController extends BaseController {
   /**
    * Rest API to export reports in csv format.
    * @param payload report filter payload.
+   * @param userToken institution user token.
    * @param response http response as file.
    */
   @ApiBadRequestResponse({
@@ -47,8 +50,11 @@ export class ReportInstitutionsController extends BaseController {
   @Post()
   async exportReport(
     @Body() payload: InstitutionReportsFilterAPIInDTO,
+    @UserToken() userToken: IInstitutionUserToken,
     @Res() response: Response,
   ): Promise<void> {
-    await this.reportControllerService.generateReport(payload, response);
+    await this.reportControllerService.generateReport(payload, response, {
+      institutionId: userToken.authorizations.institutionId,
+    });
   }
 }

--- a/sources/packages/backend/apps/db-migrations/src/migrations/1715153766792-OfferingDetailsReport.ts
+++ b/sources/packages/backend/apps/db-migrations/src/migrations/1715153766792-OfferingDetailsReport.ts
@@ -1,0 +1,16 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+import { getSQLFileData } from "../utilities/sqlLoader";
+
+export class OfferingDetailsReport1715153766792 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      getSQLFileData("Create-offering-details-report.sql", "Reports"),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      getSQLFileData("Rollback-create-offering-details-report.sql", "Reports"),
+    );
+  }
+}

--- a/sources/packages/backend/apps/db-migrations/src/sql/Reports/Create-offering-details-report.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/Reports/Create-offering-details-report.sql
@@ -4,66 +4,74 @@ VALUES
   (
     'Offering_Details_Report',
     'SELECT
-      institution_locations.institution_code AS "Institution Location Code",
-      education_programs.program_name AS "Program",
-      education_programs.sabc_code AS "SABC Program Code",
-      offering."Offering Name",
-      offering."Year of Study",
-      offering."Offering Intensity",
-      offering."Course Load",
-      offering."Delivery Type",
-      offering."WIL Component",
-      offering."WIL Component Type",
-      offering."Start Date",
-      offering."End Date",
-      offering."Has Study Breaks",
-      offering."Actual Tuition",
-      offering."Program Related Costs",
-      offering."Mandatory Fees",
-      offering."Exceptional Expenses",
-      offering."Public Offering",
-      offering."Status",
-      offering."Funded Weeks",
-      offering."Total Applications"
-    FROM
-      (
-      SELECT
-        education_programs_offerings.id AS "ID",
-        education_programs_offerings.offering_name AS "Offering Name",
-        education_programs_offerings.year_of_study AS "Year of Study",
-        education_programs_offerings."offering_intensity" AS "Offering Intensity",
-        education_programs_offerings.course_load AS "Course Load",
-        education_programs_offerings.offering_delivered AS "Delivery Type",
-        education_programs_offerings.has_offering_wil_component AS "WIL Component",
-        education_programs_offerings.offering_wil_type AS "WIL Component Type",
-        education_programs_offerings.study_start_date AS "Start Date",
-        education_programs_offerings.study_end_date AS "End Date",
-        NOT education_programs_offerings.lacks_study_breaks AS "Has Study Breaks",
-        education_programs_offerings.actual_tuition_costs AS "Actual Tuition",
-        education_programs_offerings.program_related_costs AS "Program Related Costs",
-        education_programs_offerings.mandatory_fees AS "Mandatory Fees",
-        education_programs_offerings.exceptional_expenses AS "Exceptional Expenses",
-        education_programs_offerings.offering_type AS "Public Offering",
-        education_programs_offerings."offering_status" AS "Status",
-        education_programs_offerings.study_breaks ->> ''totalFundedWeeks'' AS "Funded Weeks",
-        COUNT(applications.id) AS "Total Applications",
-        education_programs_offerings.location_id AS "Location ID",
-        education_programs_offerings.program_id AS "Program ID"
-      FROM
-        sims.education_programs_offerings education_programs_offerings
-      LEFT JOIN sims.student_assessments student_assessments ON
-        education_programs_offerings.id = student_assessments.offering_id
-      LEFT JOIN sims.applications applications ON
-        applications.id = student_assessments.application_id
-      LEFT JOIN sims.program_years program_years ON
-        applications.program_year_id = program_years.id
-      WHERE
-        program_years.id = :programYear
-        AND education_programs_offerings.offering_intensity = ANY(:offeringIntensity)
-      GROUP BY
-        education_programs_offerings.id) offering
-    INNER JOIN sims.institution_locations institution_locations ON
-      offering."Location ID" = institution_locations.id
-    INNER JOIN sims.education_programs education_programs ON
-      offering."Program ID" = education_programs.id;'
+	institution_locations.institution_code AS "Institution Location Code",
+	education_programs.program_name AS "Program",
+	education_programs.sabc_code AS "SABC Program Code",
+	offering."Offering Name",
+	offering."Year of Study",
+	offering."Offering Intensity",
+	offering."Course Load",
+	offering."Delivery Type",
+	offering."WIL Component",
+	offering."WIL Component Type",
+	offering."Start Date",
+	offering."End Date",
+	offering."Has Study Breaks",
+	offering."Actual Tuition",
+	offering."Program Related Costs",
+	offering."Mandatory Fees",
+	offering."Exceptional Expenses",
+	offering."Public Offering",
+	offering."Status",
+	offering."Funded Weeks",
+	offering."Total Applications"
+FROM
+	(
+	SELECT
+		education_programs_offerings.id AS "ID",
+		education_programs_offerings.offering_name AS "Offering Name",
+		education_programs_offerings.year_of_study AS "Year of Study",
+		education_programs_offerings."offering_intensity" AS "Offering Intensity",
+		education_programs_offerings.course_load AS "Course Load",
+		education_programs_offerings.offering_delivered AS "Delivery Type",
+		education_programs_offerings.has_offering_wil_component AS "WIL Component",
+		education_programs_offerings.offering_wil_type AS "WIL Component Type",
+		education_programs_offerings.study_start_date AS "Start Date",
+		education_programs_offerings.study_end_date AS "End Date",
+		NOT education_programs_offerings.lacks_study_breaks AS "Has Study Breaks",
+		education_programs_offerings.actual_tuition_costs AS "Actual Tuition",
+		education_programs_offerings.program_related_costs AS "Program Related Costs",
+		education_programs_offerings.mandatory_fees AS "Mandatory Fees",
+		education_programs_offerings.exceptional_expenses AS "Exceptional Expenses",
+		education_programs_offerings.offering_type AS "Public Offering",
+		education_programs_offerings."offering_status" AS "Status",
+		education_programs_offerings.study_breaks ->> ''totalFundedWeeks'' AS "Funded Weeks",
+		COUNT(applications.id) AS "Total Applications",
+		education_programs_offerings.location_id AS "Location ID",
+		education_programs_offerings.program_id AS "Program ID"
+	FROM
+		sims.education_programs_offerings education_programs_offerings
+	LEFT JOIN sims.student_assessments student_assessments ON
+		education_programs_offerings.id = student_assessments.offering_id
+	LEFT JOIN sims.applications applications ON
+		applications.id = student_assessments.application_id
+	LEFT JOIN sims.program_years program_years ON
+		applications.program_year_id = program_years.id
+	WHERE
+		program_years.id = :programYear
+		AND education_programs_offerings.offering_intensity = ANY(:offeringIntensity)
+	GROUP BY
+		education_programs_offerings.id) offering
+INNER JOIN sims.institution_locations institution_locations ON
+	offering."Location ID" = institution_locations.id
+INNER JOIN sims.education_programs education_programs ON
+	offering."Program ID" = education_programs.id
+WHERE
+	institution_locations.institution_code IN (
+	SELECT
+		institution_locations.institution_code
+	FROM
+		sims.institution_locations
+	WHERE
+		institution_locations.institution_id = :institutionId);'
   );

--- a/sources/packages/backend/apps/db-migrations/src/sql/Reports/Create-offering-details-report.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/Reports/Create-offering-details-report.sql
@@ -7,71 +7,61 @@ VALUES
       institution_locations.institution_code AS "Institution Location Code",
       education_programs.program_name AS "Program",
       education_programs.sabc_code AS "SABC Program Code",
-      offering."Offering Name",
-      offering."Year of Study",
-      offering."Offering Intensity",
-      offering."Course Load",
-      offering."Delivery Type",
-      offering."WIL Component",
-      offering."WIL Component Type",
-      offering."Start Date",
-      offering."End Date",
-      offering."Has Study Breaks",
-      offering."Actual Tuition",
-      offering."Program Related Costs",
-      offering."Mandatory Fees",
-      offering."Exceptional Expenses",
-      offering."Public Offering",
-      offering."Status",
-      offering."Funded Weeks",
-      offering."Total Applications"
+      education_programs_offerings.offering_name AS "Offering Name",
+      education_programs_offerings.year_of_study AS "Year of Study",
+      education_programs_offerings."offering_intensity" AS "Offering Intensity",
+      education_programs_offerings.course_load AS "Course Load",
+      education_programs_offerings.offering_delivered AS "Delivery Type",
+      education_programs_offerings.has_offering_wil_component AS "WIL Component",
+      education_programs_offerings.offering_wil_type AS "WIL Component Type",
+      education_programs_offerings.study_start_date AS "Start Date",
+      education_programs_offerings.study_end_date AS "End Date",
+      NOT education_programs_offerings.lacks_study_breaks AS "Has Study Breaks",
+      COALESCE(education_programs_offerings.actual_tuition_costs,
+      0) AS "Actual Tuition",
+      COALESCE(education_programs_offerings.program_related_costs,
+      0) AS "Program Related Costs",
+      COALESCE(education_programs_offerings.mandatory_fees,
+      0) AS "Mandatory Fees",
+      COALESCE(education_programs_offerings.exceptional_expenses,
+      0) AS "Exceptional Expenses",
+      education_programs_offerings.offering_type AS "Public Offering",
+      education_programs_offerings."offering_status" AS "Status",
+      COALESCE((education_programs_offerings.study_breaks ->> ' totalFundedWeeks ')::INTEGER,
+      0) AS "Funded Weeks",
+      COALESCE(offerings_with_applications."Total Applications",
+      0)
     FROM
-      (
+      sims.education_programs_offerings education_programs_offerings
+    INNER JOIN sims.institution_locations institution_locations ON
+      education_programs_offerings.location_id = institution_locations.id
+    INNER JOIN sims.education_programs education_programs ON
+      education_programs_offerings.program_id = education_programs.id
+    INNER JOIN sims.program_years ON
+      program_years.id = :programYear
+    LEFT JOIN (
       SELECT
         education_programs_offerings.id AS "ID",
-        education_programs_offerings.offering_name AS "Offering Name",
-        education_programs_offerings.year_of_study AS "Year of Study",
-        education_programs_offerings."offering_intensity" AS "Offering Intensity",
-        education_programs_offerings.course_load AS "Course Load",
-        education_programs_offerings.offering_delivered AS "Delivery Type",
-        education_programs_offerings.has_offering_wil_component AS "WIL Component",
-        education_programs_offerings.offering_wil_type AS "WIL Component Type",
-        education_programs_offerings.study_start_date AS "Start Date",
-        education_programs_offerings.study_end_date AS "End Date",
-        NOT education_programs_offerings.lacks_study_breaks AS "Has Study Breaks",
-        education_programs_offerings.actual_tuition_costs AS "Actual Tuition",
-        education_programs_offerings.program_related_costs AS "Program Related Costs",
-        education_programs_offerings.mandatory_fees AS "Mandatory Fees",
-        education_programs_offerings.exceptional_expenses AS "Exceptional Expenses",
-        education_programs_offerings.offering_type AS "Public Offering",
-        education_programs_offerings."offering_status" AS "Status",
-        education_programs_offerings.study_breaks ->> ''totalFundedWeeks'' AS "Funded Weeks",
-        COUNT(applications.id) AS "Total Applications",
-        education_programs_offerings.location_id AS "Location ID",
-        education_programs_offerings.program_id AS "Program ID"
+        COUNT(applications.id) AS "Total Applications"
       FROM
         sims.education_programs_offerings education_programs_offerings
-      LEFT JOIN sims.student_assessments student_assessments ON
+      INNER JOIN sims.institution_locations institution_locations ON
+        education_programs_offerings.location_id = institution_locations.id
+      INNER JOIN sims.student_assessments student_assessments ON
         education_programs_offerings.id = student_assessments.offering_id
-      LEFT JOIN sims.applications applications ON
-        applications.id = student_assessments.application_id
-      LEFT JOIN sims.program_years program_years ON
+      INNER JOIN sims.applications applications ON
+        applications.current_assessment_id = student_assessments.id
+      INNER JOIN sims.program_years program_years ON
         applications.program_year_id = program_years.id
       WHERE
         program_years.id = :programYear
         AND education_programs_offerings.offering_intensity = ANY(:offeringIntensity)
-      GROUP BY
-        education_programs_offerings.id) offering
-    INNER JOIN sims.institution_locations institution_locations ON
-      offering."Location ID" = institution_locations.id
-    INNER JOIN sims.education_programs education_programs ON
-      offering."Program ID" = education_programs.id
+          AND institution_locations.institution_id = :institutionId
+        GROUP BY
+          education_programs_offerings.id) offerings_with_applications ON
+      education_programs_offerings.id = offerings_with_applications."ID"
     WHERE
-      institution_locations.institution_code IN (
-      SELECT
-        institution_locations.institution_code
-      FROM
-        sims.institution_locations
-      WHERE
-        institution_locations.institution_id = :institutionId);'
+      education_programs_offerings.offering_intensity = ANY(:offeringIntensity)
+      AND institution_locations.institution_id = :institutionId
+      AND education_programs_offerings.study_start_date BETWEEN program_years.start_date AND program_years.end_date;'
   );

--- a/sources/packages/backend/apps/db-migrations/src/sql/Reports/Create-offering-details-report.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/Reports/Create-offering-details-report.sql
@@ -37,8 +37,8 @@ VALUES
       -- the provided program year in the WHERE clause.  
       program_years.id = :programYear
     LEFT JOIN (
-      -- Get all the offerings having atleast one application in the given 
-      -- program year with their applications count satisfying the conditions
+      -- Get all the offerings having at least one application in the given 
+      -- Program year with their applications count satisfying the conditions
       -- from the WHERE clause.
       SELECT
         education_programs_offerings.id AS "id",

--- a/sources/packages/backend/apps/db-migrations/src/sql/Reports/Create-offering-details-report.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/Reports/Create-offering-details-report.sql
@@ -27,7 +27,7 @@ VALUES
       0) AS "Exceptional Expenses",
       education_programs_offerings.offering_type AS "Public Offering",
       education_programs_offerings."offering_status" AS "Status",
-      COALESCE((education_programs_offerings.study_breaks ->> ' totalFundedWeeks ')::INTEGER,
+      COALESCE((education_programs_offerings.study_breaks ->> ''totalFundedWeeks'')::INTEGER,
       0) AS "Funded Weeks",
       COALESCE(offerings_with_applications."Total Applications",
       0)
@@ -63,5 +63,10 @@ VALUES
     WHERE
       education_programs_offerings.offering_intensity = ANY(:offeringIntensity)
       AND institution_locations.institution_id = :institutionId
-      AND education_programs_offerings.study_start_date BETWEEN program_years.start_date AND program_years.end_date;'
+      AND education_programs_offerings.study_start_date BETWEEN program_years.start_date AND program_years.end_date
+    ORDER BY
+      institution_locations.institution_code,
+      education_programs.program_name,
+      education_programs_offerings.offering_name,
+      education_programs_offerings."offering_intensity";'
   );

--- a/sources/packages/backend/apps/db-migrations/src/sql/Reports/Create-offering-details-report.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/Reports/Create-offering-details-report.sql
@@ -1,0 +1,69 @@
+INSERT INTO
+  sims.report_configs (report_name, report_sql)
+VALUES
+  (
+    'Offering_Details_Report',
+    'SELECT
+      institution_locations.institution_code AS "Institution Location Code",
+      education_programs.program_name AS "Program",
+      education_programs.sabc_code AS "SABC Program Code",
+      offering."Offering Name",
+      offering."Year of Study",
+      offering."Offering Intensity",
+      offering."Course Load",
+      offering."Delivery Type",
+      offering."WIL Component",
+      offering."WIL Component Type",
+      offering."Start Date",
+      offering."End Date",
+      offering."Has Study Breaks",
+      offering."Actual Tuition",
+      offering."Program Related Costs",
+      offering."Mandatory Fees",
+      offering."Exceptional Expenses",
+      offering."Public Offering",
+      offering."Status",
+      offering."Funded Weeks",
+      offering."Total Applications"
+    FROM
+      (
+      SELECT
+        education_programs_offerings.id AS "ID",
+        education_programs_offerings.offering_name AS "Offering Name",
+        education_programs_offerings.year_of_study AS "Year of Study",
+        education_programs_offerings."offering_intensity" AS "Offering Intensity",
+        education_programs_offerings.course_load AS "Course Load",
+        education_programs_offerings.offering_delivered AS "Delivery Type",
+        education_programs_offerings.has_offering_wil_component AS "WIL Component",
+        education_programs_offerings.offering_wil_type AS "WIL Component Type",
+        education_programs_offerings.study_start_date AS "Start Date",
+        education_programs_offerings.study_end_date AS "End Date",
+        NOT education_programs_offerings.lacks_study_breaks AS "Has Study Breaks",
+        education_programs_offerings.actual_tuition_costs AS "Actual Tuition",
+        education_programs_offerings.program_related_costs AS "Program Related Costs",
+        education_programs_offerings.mandatory_fees AS "Mandatory Fees",
+        education_programs_offerings.exceptional_expenses AS "Exceptional Expenses",
+        education_programs_offerings.offering_type AS "Public Offering",
+        education_programs_offerings."offering_status" AS "Status",
+        education_programs_offerings.study_breaks ->> ''totalFundedWeeks'' AS "Funded Weeks",
+        COUNT(applications.id) AS "Total Applications",
+        education_programs_offerings.location_id AS "Location ID",
+        education_programs_offerings.program_id AS "Program ID"
+      FROM
+        sims.education_programs_offerings education_programs_offerings
+      LEFT JOIN sims.student_assessments student_assessments ON
+        education_programs_offerings.id = student_assessments.offering_id
+      LEFT JOIN sims.applications applications ON
+        applications.id = student_assessments.application_id
+      LEFT JOIN sims.program_years program_years ON
+        applications.program_year_id = program_years.id
+      WHERE
+        program_years.id = :programYear
+        AND education_programs_offerings.offering_intensity = ANY(:offeringIntensity)
+      GROUP BY
+        education_programs_offerings.id) offering
+    INNER JOIN sims.institution_locations institution_locations ON
+      offering."Location ID" = institution_locations.id
+    INNER JOIN sims.education_programs education_programs ON
+      offering."Program ID" = education_programs.id;'
+  );

--- a/sources/packages/backend/apps/db-migrations/src/sql/Reports/Create-offering-details-report.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/Reports/Create-offering-details-report.sql
@@ -4,74 +4,74 @@ VALUES
   (
     'Offering_Details_Report',
     'SELECT
-	institution_locations.institution_code AS "Institution Location Code",
-	education_programs.program_name AS "Program",
-	education_programs.sabc_code AS "SABC Program Code",
-	offering."Offering Name",
-	offering."Year of Study",
-	offering."Offering Intensity",
-	offering."Course Load",
-	offering."Delivery Type",
-	offering."WIL Component",
-	offering."WIL Component Type",
-	offering."Start Date",
-	offering."End Date",
-	offering."Has Study Breaks",
-	offering."Actual Tuition",
-	offering."Program Related Costs",
-	offering."Mandatory Fees",
-	offering."Exceptional Expenses",
-	offering."Public Offering",
-	offering."Status",
-	offering."Funded Weeks",
-	offering."Total Applications"
-FROM
-	(
-	SELECT
-		education_programs_offerings.id AS "ID",
-		education_programs_offerings.offering_name AS "Offering Name",
-		education_programs_offerings.year_of_study AS "Year of Study",
-		education_programs_offerings."offering_intensity" AS "Offering Intensity",
-		education_programs_offerings.course_load AS "Course Load",
-		education_programs_offerings.offering_delivered AS "Delivery Type",
-		education_programs_offerings.has_offering_wil_component AS "WIL Component",
-		education_programs_offerings.offering_wil_type AS "WIL Component Type",
-		education_programs_offerings.study_start_date AS "Start Date",
-		education_programs_offerings.study_end_date AS "End Date",
-		NOT education_programs_offerings.lacks_study_breaks AS "Has Study Breaks",
-		education_programs_offerings.actual_tuition_costs AS "Actual Tuition",
-		education_programs_offerings.program_related_costs AS "Program Related Costs",
-		education_programs_offerings.mandatory_fees AS "Mandatory Fees",
-		education_programs_offerings.exceptional_expenses AS "Exceptional Expenses",
-		education_programs_offerings.offering_type AS "Public Offering",
-		education_programs_offerings."offering_status" AS "Status",
-		education_programs_offerings.study_breaks ->> ''totalFundedWeeks'' AS "Funded Weeks",
-		COUNT(applications.id) AS "Total Applications",
-		education_programs_offerings.location_id AS "Location ID",
-		education_programs_offerings.program_id AS "Program ID"
-	FROM
-		sims.education_programs_offerings education_programs_offerings
-	LEFT JOIN sims.student_assessments student_assessments ON
-		education_programs_offerings.id = student_assessments.offering_id
-	LEFT JOIN sims.applications applications ON
-		applications.id = student_assessments.application_id
-	LEFT JOIN sims.program_years program_years ON
-		applications.program_year_id = program_years.id
-	WHERE
-		program_years.id = :programYear
-		AND education_programs_offerings.offering_intensity = ANY(:offeringIntensity)
-	GROUP BY
-		education_programs_offerings.id) offering
-INNER JOIN sims.institution_locations institution_locations ON
-	offering."Location ID" = institution_locations.id
-INNER JOIN sims.education_programs education_programs ON
-	offering."Program ID" = education_programs.id
-WHERE
-	institution_locations.institution_code IN (
-	SELECT
-		institution_locations.institution_code
-	FROM
-		sims.institution_locations
-	WHERE
-		institution_locations.institution_id = :institutionId);'
+      institution_locations.institution_code AS "Institution Location Code",
+      education_programs.program_name AS "Program",
+      education_programs.sabc_code AS "SABC Program Code",
+      offering."Offering Name",
+      offering."Year of Study",
+      offering."Offering Intensity",
+      offering."Course Load",
+      offering."Delivery Type",
+      offering."WIL Component",
+      offering."WIL Component Type",
+      offering."Start Date",
+      offering."End Date",
+      offering."Has Study Breaks",
+      offering."Actual Tuition",
+      offering."Program Related Costs",
+      offering."Mandatory Fees",
+      offering."Exceptional Expenses",
+      offering."Public Offering",
+      offering."Status",
+      offering."Funded Weeks",
+      offering."Total Applications"
+    FROM
+      (
+      SELECT
+        education_programs_offerings.id AS "ID",
+        education_programs_offerings.offering_name AS "Offering Name",
+        education_programs_offerings.year_of_study AS "Year of Study",
+        education_programs_offerings."offering_intensity" AS "Offering Intensity",
+        education_programs_offerings.course_load AS "Course Load",
+        education_programs_offerings.offering_delivered AS "Delivery Type",
+        education_programs_offerings.has_offering_wil_component AS "WIL Component",
+        education_programs_offerings.offering_wil_type AS "WIL Component Type",
+        education_programs_offerings.study_start_date AS "Start Date",
+        education_programs_offerings.study_end_date AS "End Date",
+        NOT education_programs_offerings.lacks_study_breaks AS "Has Study Breaks",
+        education_programs_offerings.actual_tuition_costs AS "Actual Tuition",
+        education_programs_offerings.program_related_costs AS "Program Related Costs",
+        education_programs_offerings.mandatory_fees AS "Mandatory Fees",
+        education_programs_offerings.exceptional_expenses AS "Exceptional Expenses",
+        education_programs_offerings.offering_type AS "Public Offering",
+        education_programs_offerings."offering_status" AS "Status",
+        education_programs_offerings.study_breaks ->> ''totalFundedWeeks'' AS "Funded Weeks",
+        COUNT(applications.id) AS "Total Applications",
+        education_programs_offerings.location_id AS "Location ID",
+        education_programs_offerings.program_id AS "Program ID"
+      FROM
+        sims.education_programs_offerings education_programs_offerings
+      LEFT JOIN sims.student_assessments student_assessments ON
+        education_programs_offerings.id = student_assessments.offering_id
+      LEFT JOIN sims.applications applications ON
+        applications.id = student_assessments.application_id
+      LEFT JOIN sims.program_years program_years ON
+        applications.program_year_id = program_years.id
+      WHERE
+        program_years.id = :programYear
+        AND education_programs_offerings.offering_intensity = ANY(:offeringIntensity)
+      GROUP BY
+        education_programs_offerings.id) offering
+    INNER JOIN sims.institution_locations institution_locations ON
+      offering."Location ID" = institution_locations.id
+    INNER JOIN sims.education_programs education_programs ON
+      offering."Program ID" = education_programs.id
+    WHERE
+      institution_locations.institution_code IN (
+      SELECT
+        institution_locations.institution_code
+      FROM
+        sims.institution_locations
+      WHERE
+        institution_locations.institution_id = :institutionId);'
   );

--- a/sources/packages/backend/apps/db-migrations/src/sql/Reports/Rollback-create-offering-details-report.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/Reports/Rollback-create-offering-details-report.sql
@@ -1,0 +1,4 @@
+DELETE from
+  sims.report_configs
+WHERE
+  report_name = 'Offering_Details_Report';


### PR DESCRIPTION
### As a part of this PR, the following have been completed:

- SQL query for **Offering Details Report**.

**Query:**

```sql
SELECT
	institution_locations.institution_code AS "Institution Location Code",
	education_programs.program_name AS "Program",
	education_programs.sabc_code AS "SABC Program Code",
	education_programs_offerings.offering_name AS "Offering Name",
	education_programs_offerings.year_of_study AS "Year of Study",
	education_programs_offerings.offering_intensity AS "Offering Intensity",
	education_programs_offerings.course_load AS "Course Load",
	education_programs_offerings.offering_delivered AS "Delivery Type",
	education_programs_offerings.has_offering_wil_component AS "WIL Component",
	education_programs_offerings.offering_wil_type AS "WIL Component Type",
	education_programs_offerings.study_start_date AS "Start Date",
	education_programs_offerings.study_end_date AS "End Date",
	NOT education_programs_offerings.lacks_study_breaks AS "Has Study Breaks",
	education_programs_offerings.actual_tuition_costs AS "Actual Tuition",
	education_programs_offerings.program_related_costs AS "Program Related Costs",
	education_programs_offerings.mandatory_fees AS "Mandatory Fees",
	education_programs_offerings.exceptional_expenses AS "Exceptional Expenses",
	education_programs_offerings.offering_type AS "Offering Type",
	education_programs_offerings.offering_status AS "Status",
	education_programs_offerings.study_breaks ->> 'totalFundedWeeks' AS "Funded Weeks",
	offerings_with_applications.total_applications AS "Total Applications"
FROM
	sims.education_programs_offerings education_programs_offerings
INNER JOIN sims.institution_locations institution_locations ON
	education_programs_offerings.location_id = institution_locations.id
INNER JOIN sims.education_programs education_programs ON
	education_programs_offerings.program_id = education_programs.id
INNER JOIN sims.program_years ON
	-- program year is used to merge the offerings and the program year table on the
	-- provided program year which is then used to filter the offerings belonging to
	-- the provided program year in the WHERE clause.  
	program_years.id = :programYear
LEFT JOIN (
	-- Get all the offerings having atleast one application in the given 
	-- program year with their applications count satisfying the conditions
	-- from the WHERE clause.
	SELECT
		education_programs_offerings.id AS "id",
		COUNT(applications.id) AS "total_applications"
	FROM
		sims.education_programs_offerings education_programs_offerings
	INNER JOIN sims.institution_locations institution_locations ON
		education_programs_offerings.location_id = institution_locations.id
	INNER JOIN sims.student_assessments student_assessments ON
		education_programs_offerings.id = student_assessments.offering_id
	INNER JOIN sims.applications applications ON
		applications.current_assessment_id = student_assessments.id
	WHERE
		applications.program_year_id = :programYear
		AND education_programs_offerings.offering_intensity = ANY(:offeringIntensity)
			AND institution_locations.institution_id = :institutionId
			AND applications.application_status = 'Completed'
		GROUP BY
			education_programs_offerings.id) offerings_with_applications ON
	education_programs_offerings.id = offerings_with_applications."id"
WHERE
	education_programs_offerings.offering_intensity = ANY(:offeringIntensity)
	AND education_programs_offerings.offering_type != 'Scholastic standing'
	AND institution_locations.institution_id = :institutionId
	AND education_programs_offerings.study_start_date BETWEEN program_years.start_date AND program_years.end_date
ORDER BY
	institution_locations.institution_code,
	education_programs.program_name,
	education_programs_offerings.offering_name,
	education_programs_offerings.offering_intensity;
```

- Refactored (moved) code from `report.aest.controller.ts` to common `report.controller.service.ts` since both the institution reports controller and ministry reports controller share the same report generation methods.

### **Screenshot for the generated report:**

<img width="1919" alt="image" src="https://github.com/bcgov/SIMS/assets/7859295/b27d6507-9cc6-48cd-a8c7-294f91e9f669">