### PR TITLE
#3141 - 2.4.3 Menu- Student- Accessibility Fixes - Level A - Focus Order

### DIFF
--- a/sources/packages/web/src/views/student/StudentApplicationDetails.vue
+++ b/sources/packages/web/src/views/student/StudentApplicationDetails.vue
@@ -25,7 +25,7 @@
               color="primary"
             >
               <template v-for="(item, index) in items" :key="index">
-                <v-list-item :value="index" @click="item.command">
+                <v-list-item :value="index" @click="item.command" tabindex="0">
                   <template v-slot:prepend>
                     <v-icon :icon="item.icon" :color="item.iconColor"></v-icon>
                   </template>


### PR DESCRIPTION
- Checked how to change the current dropdown menu to allow tab navigation across all its subitems.
- Implemented the solution in the application tracker landing page present in the image above.

Screenshot of the button for the Completed tracker card
![image](https://github.com/bcgov/SIMS/assets/148148914/5fbedd43-5f07-453c-b954-8d69e9e47940)

Screenshot of the button for the Assessment tracker card
![image](https://github.com/bcgov/SIMS/assets/148148914/428c09c6-f2f6-432f-a7ce-bc2e61927feb)
