### PR TITLE
#3282 - Detect Assessment Offering Dates Change (Part 2)

### DIFF
--- a/sources/packages/backend/apps/workers/src/controllers/assessment/assessment.controller.ts
+++ b/sources/packages/backend/apps/workers/src/controllers/assessment/assessment.controller.ts
@@ -273,7 +273,11 @@ export class AssessmentController {
           return job.complete();
         }
         const application = assessment.application;
-        // Only check for previousDateChangedReportedAssessment only if there doesn't exist one and the application is in Completed state.
+        // Previous date change reported assessments can only exist for completed applications
+        // with at least one disbursement sent to ESDC.
+        // Hence applications that are not completed cannot have previous date change reported assessments.
+        // To ensure the implementation to be idempotent, update previous date change reported assessment
+        // only if it is not updated already.
         if (
           application.applicationStatus === ApplicationStatus.Completed &&
           !assessment.previousDateChangedReportedAssessment

--- a/sources/packages/backend/apps/workers/src/controllers/assessment/assessment.controller.ts
+++ b/sources/packages/backend/apps/workers/src/controllers/assessment/assessment.controller.ts
@@ -281,7 +281,9 @@ export class AssessmentController {
             lastReportedAssessmentId,
           );
         } else {
-          jobLogger.log("No last reported assessment id found.");
+          jobLogger.log(
+            "Application not yet completed or no last reported assessment id found.",
+          );
         }
         const impactedApplication =
           await this.assessmentSequentialProcessingService.assessImpactedApplicationReassessmentNeeded(

--- a/sources/packages/backend/apps/workers/src/controllers/assessment/assessment.controller.ts
+++ b/sources/packages/backend/apps/workers/src/controllers/assessment/assessment.controller.ts
@@ -273,20 +273,23 @@ export class AssessmentController {
           return job.complete();
         }
         const application = assessment.application;
-        if (application.applicationStatus === ApplicationStatus.Completed) {
+        if (
+          application.applicationStatus === ApplicationStatus.Completed &&
+          !assessment.previousDateChangedReportedAssessment
+        ) {
           const updatedLastReportedAssessment =
             await this.studentAssessmentService.updateLastReportedAssessment(
               job.variables.assessmentId,
-              application.id,
-              assessment.offering.studyStartDate,
-              assessment.offering.studyEndDate,
+              entityManager,
             );
-          if (updatedLastReportedAssessment === undefined) {
-            jobLogger.log("No previous reported assessment found.");
-          } else if (!updatedLastReportedAssessment) {
+          if (updatedLastReportedAssessment.affected) {
+            jobLogger.log("Last reported date changed assessment was updated.");
+          } else if (updatedLastReportedAssessment === undefined) {
             jobLogger.log(
-              "Last reported assessment id was previously updated or need not be updated.",
+              "No previous reported assessment found or no last reported assessment update needed.",
             );
+          } else if (!updatedLastReportedAssessment) {
+            jobLogger.log("Last reported assessment was previously updated.");
           }
         } else {
           jobLogger.log("Application is not yet completed.");

--- a/sources/packages/backend/apps/workers/src/controllers/assessment/assessment.controller.ts
+++ b/sources/packages/backend/apps/workers/src/controllers/assessment/assessment.controller.ts
@@ -282,7 +282,7 @@ export class AssessmentController {
               job.variables.assessmentId,
               entityManager,
             );
-          if (updatedLastReportedAssessment.affected) {
+          if (updatedLastReportedAssessment?.affected) {
             jobLogger.log("Last reported date changed assessment was updated.");
           } else if (updatedLastReportedAssessment === undefined) {
             jobLogger.log(

--- a/sources/packages/backend/apps/workers/src/controllers/assessment/assessment.controller.ts
+++ b/sources/packages/backend/apps/workers/src/controllers/assessment/assessment.controller.ts
@@ -273,26 +273,25 @@ export class AssessmentController {
           return job.complete();
         }
         const application = assessment.application;
+        // Only check for previousDateChangedReportedAssessment only if there doesn't exist one and the application is in Completed state.
         if (
           application.applicationStatus === ApplicationStatus.Completed &&
           !assessment.previousDateChangedReportedAssessment
         ) {
-          const updatedLastReportedAssessment =
+          const lastReportedAssessmentUpdateResult =
             await this.studentAssessmentService.updateLastReportedAssessment(
               job.variables.assessmentId,
               entityManager,
             );
-          if (updatedLastReportedAssessment?.affected) {
+          if (lastReportedAssessmentUpdateResult?.affected) {
             jobLogger.log("Last reported date changed assessment was updated.");
-          } else if (updatedLastReportedAssessment === undefined) {
+          } else if (lastReportedAssessmentUpdateResult === undefined) {
             jobLogger.log(
               "No previous reported assessment found or no last reported assessment update needed.",
             );
-          } else if (!updatedLastReportedAssessment) {
+          } else if (!lastReportedAssessmentUpdateResult?.affected) {
             jobLogger.log("Last reported assessment was previously updated.");
           }
-        } else {
-          jobLogger.log("Application is not yet completed.");
         }
         const impactedApplication =
           await this.assessmentSequentialProcessingService.assessImpactedApplicationReassessmentNeeded(

--- a/sources/packages/backend/apps/workers/src/controllers/assessment/assessment.controller.ts
+++ b/sources/packages/backend/apps/workers/src/controllers/assessment/assessment.controller.ts
@@ -271,6 +271,18 @@ export class AssessmentController {
           );
           return job.complete();
         }
+        const lastReportedAssessmentId =
+          await this.studentAssessmentService.getLastReportedAssessment(
+            job.variables.assessmentId,
+          );
+        if (lastReportedAssessmentId) {
+          await this.studentAssessmentService.updateLastReportedAssessment(
+            job.variables.assessmentId,
+            lastReportedAssessmentId,
+          );
+        } else {
+          jobLogger.log("No last reported assessment id found.");
+        }
         const impactedApplication =
           await this.assessmentSequentialProcessingService.assessImpactedApplicationReassessmentNeeded(
             job.variables.assessmentId,

--- a/sources/packages/backend/apps/workers/src/controllers/assessment/assessment.controller.ts
+++ b/sources/packages/backend/apps/workers/src/controllers/assessment/assessment.controller.ts
@@ -626,7 +626,9 @@ export class AssessmentController {
         entityManager,
       );
     if (!lastReportedAssessmentUpdateResult) {
-      jobLogger.log("No last reported date changed assessment was found.");
+      jobLogger.log(
+        "No last reported date change assessment was found or the last reported date change assessment update is not required.",
+      );
       return;
     }
     if (lastReportedAssessmentUpdateResult.affected) {

--- a/sources/packages/backend/apps/workers/src/services/student-assessment/student-assessment.service.ts
+++ b/sources/packages/backend/apps/workers/src/services/student-assessment/student-assessment.service.ts
@@ -405,7 +405,7 @@ export class StudentAssessmentService extends RecordDataModelService<StudentAsse
         select: {
           id: true,
           assessmentDate: true,
-          offering: { studyStartDate: true, studyEndDate: true },
+          offering: { id: true, studyStartDate: true, studyEndDate: true },
         },
         relations: { offering: true },
         where: {
@@ -422,7 +422,7 @@ export class StudentAssessmentService extends RecordDataModelService<StudentAsse
       select: {
         id: true,
         assessmentDate: true,
-        offering: { studyStartDate: true, studyEndDate: true },
+        offering: { id: true, studyStartDate: true, studyEndDate: true },
       },
       relations: { offering: true },
       where: {

--- a/sources/packages/backend/apps/workers/src/services/student-assessment/student-assessment.service.ts
+++ b/sources/packages/backend/apps/workers/src/services/student-assessment/student-assessment.service.ts
@@ -344,7 +344,9 @@ export class StudentAssessmentService extends RecordDataModelService<StudentAsse
     assessmentId: number,
     entityManager: EntityManager,
   ): Promise<UpdateResult | undefined> {
-    const assessment = await this.repo.findOne({
+    const studentAssessmentRepo =
+      entityManager.getRepository(StudentAssessment);
+    const assessment = await studentAssessmentRepo.findOne({
       select: {
         id: true,
         offering: {
@@ -361,8 +363,6 @@ export class StudentAssessmentService extends RecordDataModelService<StudentAsse
       },
       where: { id: assessmentId },
     });
-    const studentAssessmentRepo =
-      entityManager.getRepository(StudentAssessment);
     const auditUser = this.systemUsersService.systemUser;
     const lastReportedAssessment = await this.getLastReportedAssessment(
       assessment.application.id,

--- a/sources/packages/backend/apps/workers/src/services/student-assessment/student-assessment.service.ts
+++ b/sources/packages/backend/apps/workers/src/services/student-assessment/student-assessment.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from "@nestjs/common";
 import {
+  ApplicationStatus,
   AssessmentStatus,
   DisbursementScheduleStatus,
   RecordDataModelService,
@@ -368,8 +369,14 @@ export class StudentAssessmentService extends RecordDataModelService<StudentAsse
   async getLastReportedAssessment(assessmentId: number): Promise<number> {
     const application = await this.repo.findOne({
       select: { application: { id: true } },
-      where: { id: assessmentId },
+      where: {
+        id: assessmentId,
+        application: { applicationStatus: ApplicationStatus.Completed },
+      },
     });
+    if (!application) {
+      return;
+    }
     const lastBTypeReportedAssessment = await this.repo.findOne({
       select: { id: true },
       where: {

--- a/sources/packages/backend/apps/workers/src/services/student-assessment/student-assessment.service.ts
+++ b/sources/packages/backend/apps/workers/src/services/student-assessment/student-assessment.service.ts
@@ -389,6 +389,7 @@ export class StudentAssessmentService extends RecordDataModelService<StudentAsse
     const lastBTypeReportedAssessment = await this.repo.findOne({
       select: {
         id: true,
+        assessmentDate: true,
         offering: { studyStartDate: true, studyEndDate: true },
       },
       relations: { offering: true },
@@ -403,6 +404,7 @@ export class StudentAssessmentService extends RecordDataModelService<StudentAsse
       const lastReportedDisbursement = await this.repo.findOne({
         select: {
           id: true,
+          assessmentDate: true,
           offering: { studyStartDate: true, studyEndDate: true },
         },
         where: {

--- a/sources/packages/backend/apps/workers/src/services/student-assessment/student-assessment.service.ts
+++ b/sources/packages/backend/apps/workers/src/services/student-assessment/student-assessment.service.ts
@@ -504,6 +504,7 @@ export class StudentAssessmentService extends RecordDataModelService<StudentAsse
       },
       relations: {
         application: { student: true, programYear: true },
+        previousDateChangedReportedAssessment: true,
         offering: true,
       },
       where: { id: assessmentId },

--- a/sources/packages/backend/apps/workers/src/services/student-assessment/student-assessment.service.ts
+++ b/sources/packages/backend/apps/workers/src/services/student-assessment/student-assessment.service.ts
@@ -1,8 +1,6 @@
 import { Injectable } from "@nestjs/common";
 import {
-  ApplicationStatus,
   AssessmentStatus,
-  AssessmentTriggerType,
   DisbursementScheduleStatus,
   RecordDataModelService,
   StudentAppealStatus,

--- a/sources/packages/backend/apps/workers/src/services/student-assessment/student-assessment.service.ts
+++ b/sources/packages/backend/apps/workers/src/services/student-assessment/student-assessment.service.ts
@@ -408,7 +408,7 @@ export class StudentAssessmentService extends RecordDataModelService<StudentAsse
   ): Promise<LastApplicationChangeReportedAssessment> {
     const studentAssessmentRepo =
       entityManager.getRepository(StudentAssessment);
-    let lastApplicationChangeReportedAssessment = await studentAssessmentRepo
+    const lastApplicationChangeReportedAssessment = await studentAssessmentRepo
       .createQueryBuilder("studentAssessment")
       .select("studentAssessment.id", "studentAssessmentId")
       .addSelect("offering.studyStartDate", "offeringStudyStartDate")
@@ -426,18 +426,9 @@ export class StudentAssessmentService extends RecordDataModelService<StudentAsse
       .limit(1)
       .getRawOne<LastApplicationChangeReportedAssessment>();
     if (lastApplicationChangeReportedAssessment) {
-      return {
-        studentAssessmentId:
-          lastApplicationChangeReportedAssessment.studentAssessmentId,
-        offeringStudyStartDate: getISODateOnlyString(
-          lastApplicationChangeReportedAssessment.offeringStudyStartDate,
-        ),
-        offeringStudyEndDate: getISODateOnlyString(
-          lastApplicationChangeReportedAssessment.offeringStudyEndDate,
-        ),
-      };
+      return lastApplicationChangeReportedAssessment;
     }
-    lastApplicationChangeReportedAssessment = await studentAssessmentRepo
+    return studentAssessmentRepo
       .createQueryBuilder("studentAssessment")
       .select("studentAssessment.id", "studentAssessmentId")
       .addSelect("offering.studyStartDate", "offeringStudyStartDate")
@@ -458,16 +449,6 @@ export class StudentAssessmentService extends RecordDataModelService<StudentAsse
       .orderBy("studentAssessment.assessmentDate", "DESC")
       .limit(1)
       .getRawOne<LastApplicationChangeReportedAssessment>();
-    return {
-      studentAssessmentId:
-        lastApplicationChangeReportedAssessment.studentAssessmentId,
-      offeringStudyStartDate: getISODateOnlyString(
-        lastApplicationChangeReportedAssessment.offeringStudyStartDate,
-      ),
-      offeringStudyEndDate: getISODateOnlyString(
-        lastApplicationChangeReportedAssessment.offeringStudyEndDate,
-      ),
-    };
   }
 
   /**


### PR DESCRIPTION
### As a part of this PR, the following was completed:

- `workflow-wrap-up` worker was updated to populate the new column `previous_date_changed_reported_assessment_id` for an application in `Completed` state. The following were considered when updating the worker:

    **Scenario 1**
      Checked if there is a previously reported assessment for the application (ordered by assessment_date desc, limit 1), immediately before the assessment being processed right now.

    **Scenario 2**
      If no assessment was ever reported, checked if an e-Cert was generated for this application.
    
    **If Scenario 1 or Scenario 2 produced an assessment:**
      Checked if the offering dates changed,
        If yes, saved the assessment in the `previous_date_changed_reported_assessment_id`.
        If no, then left the column as is.

**Generated Queries for reference:**
```sql
	
-- SELECT 1st

SELECT
	"studentAssessment"."id" AS "studentAssessmentId",
	"offering"."study_start_date" AS "offeringStudyStartDate",
	"offering"."study_end_date" AS "offeringStudyEndDate"
FROM
	"sims"."student_assessments" "studentAssessment"
INNER JOIN "sims"."education_programs_offerings" "offering" ON
	"offering"."id" = "studentAssessment"."offering_id"
INNER JOIN "sims"."applications" "application" ON
	"application"."id" = "studentAssessment"."application_id"
WHERE
	"application"."id" = $1
	AND "studentAssessment"."previous_date_changed_reported_assessment_id" IS NOT NULL
	AND "studentAssessment"."reported_date" IS NOT NULL
ORDER BY
	"studentAssessment"."assessment_date" DESC
LIMIT 1;

-- SELECT 2nd

SELECT
	"studentAssessment"."id" AS "studentAssessmentId",
	"offering"."study_start_date" AS "offeringStudyStartDate",
	"offering"."study_end_date" AS "offeringStudyEndDate"
FROM
	"sims"."student_assessments" "studentAssessment"
INNER JOIN "sims"."education_programs_offerings" "offering" ON
	"offering"."id" = "studentAssessment"."offering_id"
INNER JOIN "sims"."applications" "application" ON
	"application"."id" = "studentAssessment"."application_id"
INNER JOIN "sims"."disbursement_schedules" "disbursementSchedules" ON
	"disbursementSchedules"."student_assessment_id" = "studentAssessment"."id"
WHERE
	"application"."id" = $1
	AND "disbursementSchedules"."disbursement_schedule_status" = $2
ORDER BY
	"studentAssessment"."assessment_date" DESC
LIMIT 1;

-- UPDATE

UPDATE
	"sims"."student_assessments"
SET
	"previous_date_changed_reported_assessment_id" = $1,
	"modifier" = $2,
	"updated_at" = CURRENT_TIMESTAMP
WHERE
	"id" = $3;
```

**Next PR:** e2e tests