### PR TITLE
#3040 - Allow the first disbursement to be not present

### DIFF
--- a/sources/packages/backend/apps/api/src/route-controllers/application/application.controller.service.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/application/application.controller.service.ts
@@ -188,21 +188,22 @@ export class ApplicationControllerService {
     disbursementSchedules: DisbursementSchedule[],
   ): EnrolmentApplicationDetailsAPIOutDTO {
     const [firstDisbursement, secondDisbursement] = disbursementSchedules;
-    const details: EnrolmentApplicationDetailsAPIOutDTO = {
-      firstDisbursement: {
+    const details = {} as EnrolmentApplicationDetailsAPIOutDTO;
+    if (firstDisbursement) {
+      details.firstDisbursement = {
         coeStatus: firstDisbursement.coeStatus,
         disbursementScheduleStatus:
           firstDisbursement.disbursementScheduleStatus,
         coeDenialReason: getCOEDeniedReason(firstDisbursement),
-      },
-    };
-    if (secondDisbursement) {
-      details.secondDisbursement = {
-        coeStatus: secondDisbursement.coeStatus,
-        disbursementScheduleStatus:
-          secondDisbursement.disbursementScheduleStatus,
-        coeDenialReason: getCOEDeniedReason(secondDisbursement),
       };
+      if (secondDisbursement) {
+        details.secondDisbursement = {
+          coeStatus: secondDisbursement.coeStatus,
+          disbursementScheduleStatus:
+            secondDisbursement.disbursementScheduleStatus,
+          coeDenialReason: getCOEDeniedReason(secondDisbursement),
+        };
+      }
     }
     return details;
   }

--- a/sources/packages/backend/apps/api/src/route-controllers/application/models/application.dto.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/application/models/application.dto.ts
@@ -175,7 +175,7 @@ export class DisbursementDetailsAPIOutDTO {
 }
 
 export class EnrolmentApplicationDetailsAPIOutDTO {
-  firstDisbursement: DisbursementDetailsAPIOutDTO;
+  firstDisbursement?: DisbursementDetailsAPIOutDTO;
   secondDisbursement?: DisbursementDetailsAPIOutDTO;
   assessmentTriggerType?: AssessmentTriggerType;
 }

--- a/sources/packages/web/src/components/students/applicationTracker/Completed.vue
+++ b/sources/packages/web/src/components/students/applicationTracker/Completed.vue
@@ -226,7 +226,7 @@ export default defineComponent({
 
     const hasDisbursementEvent = computed(() => {
       return (
-        assessmentDetails.value.firstDisbursement.coeStatus !==
+        assessmentDetails.value.firstDisbursement?.coeStatus !==
         COEStatus.required
       );
     });

--- a/sources/packages/web/src/components/students/applicationTracker/DisbursementBanner.vue
+++ b/sources/packages/web/src/components/students/applicationTracker/DisbursementBanner.vue
@@ -81,11 +81,11 @@ export default defineComponent({
   props: {
     coeStatus: {
       type: String as PropType<COEStatus>,
-      required: true,
+      required: false,
     },
     coeDenialReason: {
       type: String,
-      required: true,
+      required: false,
     },
     disbursementStatus: {
       type: String as PropType<DisbursementScheduleStatus>,

--- a/sources/packages/web/src/components/students/applicationTracker/MultipleDisbursementBanner.vue
+++ b/sources/packages/web/src/components/students/applicationTracker/MultipleDisbursementBanner.vue
@@ -150,11 +150,11 @@ export default defineComponent({
   props: {
     firstCOEStatus: {
       type: String as PropType<COEStatus>,
-      required: true,
+      required: false,
     },
     secondCOEStatus: {
       type: String as PropType<COEStatus>,
-      required: true,
+      required: false,
     },
     coeDenialReason: {
       type: String,

--- a/sources/packages/web/src/services/http/dto/Application.dto.ts
+++ b/sources/packages/web/src/services/http/dto/Application.dto.ts
@@ -119,7 +119,7 @@ export interface DisbursementDetailsAPIOutDTO {
 }
 
 export interface EnrolmentApplicationDetailsAPIOutDTO {
-  firstDisbursement: DisbursementDetailsAPIOutDTO;
+  firstDisbursement?: DisbursementDetailsAPIOutDTO;
   secondDisbursement?: DisbursementDetailsAPIOutDTO;
   assessmentTriggerType: AssessmentTriggerType;
 }


### PR DESCRIPTION
Reassessments were not displaying a card while the assessment was `In progress` because there was an expectation that at least the first disbursement would always be present, which is true only when the assessment workflow is completed.

The UI was already completely ready expecting the `first disbursement` not to be present, but the API was throwing an error every time.

### Current UI without the fix

![image](https://github.com/bcgov/SIMS/assets/61259237/3227a998-3cba-45bc-b810-0655a5f07c56)

### UI after the fix

![image](https://github.com/bcgov/SIMS/assets/61259237/08f95cea-8331-4897-9670-a43551b878a3)

