### PR TITLE
#3282 - Detect Assessment Offering Dates Change - Part 3 (e2e tests)

### DIFF
--- a/sources/packages/backend/apps/workers/src/controllers/assessment/_tests_/e2e/assessment.controller-workflowWrapUp.e2e-spec.ts
+++ b/sources/packages/backend/apps/workers/src/controllers/assessment/_tests_/e2e/assessment.controller-workflowWrapUp.e2e-spec.ts
@@ -274,7 +274,7 @@ describe("AssessmentController(e2e)-workflowWrapUp", () => {
       addDays(1, savedApplication.currentAssessment.offering.studyStartDate),
     );
     await saveOfferingAndAssessment(savedApplication, now, auditUser, null, {
-      studyStartDate: getISODateOnlyString(differentStudyStartDate),
+      studyStartDate: differentStudyStartDate,
     });
     savedApplication.currentAssessment.studentAssessmentStatus =
       StudentAssessmentStatus.InProgress;
@@ -382,7 +382,7 @@ describe("AssessmentController(e2e)-workflowWrapUp", () => {
       addDays(1, savedApplication.currentAssessment.offering.studyStartDate),
     );
     await saveOfferingAndAssessment(savedApplication, now, auditUser, null, {
-      studyStartDate: getISODateOnlyString(differentStudyStartDate),
+      studyStartDate: differentStudyStartDate,
     });
     savedApplication.currentAssessment.studentAssessmentStatus =
       StudentAssessmentStatus.InProgress;
@@ -530,13 +530,10 @@ describe("AssessmentController(e2e)-workflowWrapUp", () => {
     );
     const originalAssessment = savedApplication.currentAssessment;
     const tomorrow = addDays(1, new Date());
-    let differentStudyStartDate = addDays(
-      1,
-      originalAssessment.offering.studyStartDate,
+    let differentStudyStartDate = getISODateOnlyString(
+      addDays(1, originalAssessment.offering.studyStartDate),
     );
-    const reportedReassessmentStudyStartDate = getISODateOnlyString(
-      differentStudyStartDate,
-    );
+    const reportedReassessmentStudyStartDate = differentStudyStartDate;
     const reportedReassessmentStudyEndDate = getISODateOnlyString(
       originalAssessment.offering.studyEndDate,
     );
@@ -554,9 +551,8 @@ describe("AssessmentController(e2e)-workflowWrapUp", () => {
       },
     );
     const dayAfterTomorrow = addDays(2, new Date());
-    differentStudyStartDate = addDays(
-      2,
-      originalAssessment.offering.studyStartDate,
+    differentStudyStartDate = getISODateOnlyString(
+      addDays(2, originalAssessment.offering.studyStartDate),
     );
     await saveOfferingAndAssessment(
       savedApplication,
@@ -566,7 +562,7 @@ describe("AssessmentController(e2e)-workflowWrapUp", () => {
         previousDateChangedReportedAssessment: firstReportedReassessment,
       },
       {
-        studyStartDate: getISODateOnlyString(differentStudyStartDate),
+        studyStartDate: differentStudyStartDate,
       },
     );
     const afterDayAfterTomorrow = addDays(3, new Date());
@@ -636,9 +632,8 @@ describe("AssessmentController(e2e)-workflowWrapUp", () => {
       originalAssessment.offering.studyEndDate,
     );
     const tomorrow = addDays(1, new Date());
-    const differentStudyStartDate = addDays(
-      1,
-      originalAssessment.offering.studyStartDate,
+    const differentStudyStartDate = getISODateOnlyString(
+      addDays(1, originalAssessment.offering.studyStartDate),
     );
     await saveOfferingAndAssessment(
       savedApplication,
@@ -648,7 +643,7 @@ describe("AssessmentController(e2e)-workflowWrapUp", () => {
         previousDateChangedReportedAssessment: originalAssessment,
       },
       {
-        studyStartDate: getISODateOnlyString(differentStudyStartDate),
+        studyStartDate: differentStudyStartDate,
       },
     );
     const dayAfterTomorrow = addDays(2, new Date());

--- a/sources/packages/backend/apps/workers/src/controllers/assessment/_tests_/e2e/assessment.controller-workflowWrapUp.e2e-spec.ts
+++ b/sources/packages/backend/apps/workers/src/controllers/assessment/_tests_/e2e/assessment.controller-workflowWrapUp.e2e-spec.ts
@@ -251,7 +251,7 @@ describe("AssessmentController(e2e)-workflowWrapUp", () => {
     ).not.toHaveBeenCalled();
   });
 
-  it("Should populate the previousDateChangedReportedAssessment when the e-Cert was generated for the 'Original Assessment' and offering dates changed as a result of the reassessment.", async () => {
+  it("Should populate the previous date changed reported assessment when the e-Cert was generated for the 'Original Assessment' and offering dates changed as a result of the reassessment.", async () => {
     // Arrange
     const savedApplication = await saveFakeApplicationDisbursements(
       db.dataSource,
@@ -270,27 +270,21 @@ describe("AssessmentController(e2e)-workflowWrapUp", () => {
       },
     );
     const originalAssessmentId = savedApplication.currentAssessment.id;
-    const differentStudyStartDate = new Date(
-      savedApplication.currentAssessment.offering.studyStartDate,
+    const differentStudyStartDate = getISODateOnlyString(
+      addDays(1, savedApplication.currentAssessment.offering.studyStartDate),
     );
-    differentStudyStartDate.setDate(differentStudyStartDate.getDate() + 1);
     await saveOfferingAndAssessment(savedApplication, now, auditUser, {
       studyStartDate: getISODateOnlyString(differentStudyStartDate),
     });
     savedApplication.currentAssessment.studentAssessmentStatus =
       StudentAssessmentStatus.InProgress;
     await db.studentAssessment.save(savedApplication.currentAssessment);
-    const workflowData = {
-      studentData: {
-        dependantStatus: "independant",
-      },
-    } as WorkflowData;
 
     // Act
     const result = await assessmentController.workflowWrapUp(
       createFakeWorkflowWrapUpPayload(
         savedApplication.currentAssessment.id,
-        workflowData,
+        {} as WorkflowData,
       ),
     );
 
@@ -298,7 +292,6 @@ describe("AssessmentController(e2e)-workflowWrapUp", () => {
     expect(FakeWorkerJobResult.getResultType(result)).toBe(
       MockedZeebeJobResult.Complete,
     );
-    // Asserts that the student assessment status has changed to completed.
     const expectedAssessment = await db.studentAssessment.findOne({
       select: {
         id: true,
@@ -315,7 +308,7 @@ describe("AssessmentController(e2e)-workflowWrapUp", () => {
     );
   });
 
-  it("Should not populate the previousDateChangedReportedAssessment when the e-Cert was generated for the 'Original Assessment' and offering dates didn't change as a result of the reassessment.", async () => {
+  it("Should not populate the previous date changed reported assessment when the e-Cert was generated for the 'Original Assessment' and offering dates didn't change as a result of the reassessment.", async () => {
     // Arrange
     const savedApplication = await saveFakeApplicationDisbursements(
       db.dataSource,
@@ -340,18 +333,13 @@ describe("AssessmentController(e2e)-workflowWrapUp", () => {
     });
     savedApplication.currentAssessment.studentAssessmentStatus =
       StudentAssessmentStatus.InProgress;
-    const workflowData = {
-      studentData: {
-        dependantStatus: "independant",
-      },
-    } as WorkflowData;
     await db.studentAssessment.save(savedApplication.currentAssessment);
 
     // Act
     const result = await assessmentController.workflowWrapUp(
       createFakeWorkflowWrapUpPayload(
         savedApplication.currentAssessment.id,
-        workflowData,
+        {} as WorkflowData,
       ),
     );
 
@@ -359,7 +347,6 @@ describe("AssessmentController(e2e)-workflowWrapUp", () => {
     expect(FakeWorkerJobResult.getResultType(result)).toBe(
       MockedZeebeJobResult.Complete,
     );
-    // Asserts that the student assessment status has changed to completed.
     const expectedAssessment = await db.studentAssessment.findOne({
       select: {
         id: true,
@@ -374,7 +361,7 @@ describe("AssessmentController(e2e)-workflowWrapUp", () => {
     expect(expectedAssessment.previousDateChangedReportedAssessment).toBeNull();
   });
 
-  it("Should not populate the previousDateChangedReportedAssessment when the e-Cert is not generated for the 'Original Assessment' and offering dates changed as a result of the reassessment.", async () => {
+  it("Should not populate the previous date changed reported assessment when the e-Cert is not generated for the 'Original Assessment' and offering dates changed as a result of the reassessment.", async () => {
     // Arrange
     const savedApplication = await saveFakeApplicationDisbursements(
       db.dataSource,
@@ -391,27 +378,21 @@ describe("AssessmentController(e2e)-workflowWrapUp", () => {
         },
       },
     );
-    const differentStudyStartDate = new Date(
-      savedApplication.currentAssessment.offering.studyStartDate,
+    const differentStudyStartDate = getISODateOnlyString(
+      addDays(1, savedApplication.currentAssessment.offering.studyStartDate),
     );
-    differentStudyStartDate.setDate(differentStudyStartDate.getDate() + 1);
     await saveOfferingAndAssessment(savedApplication, now, auditUser, {
       studyStartDate: getISODateOnlyString(differentStudyStartDate),
     });
     savedApplication.currentAssessment.studentAssessmentStatus =
       StudentAssessmentStatus.InProgress;
-    const workflowData = {
-      studentData: {
-        dependantStatus: "independant",
-      },
-    } as WorkflowData;
     await db.studentAssessment.save(savedApplication.currentAssessment);
 
     // Act
     const result = await assessmentController.workflowWrapUp(
       createFakeWorkflowWrapUpPayload(
         savedApplication.currentAssessment.id,
-        workflowData,
+        {} as WorkflowData,
       ),
     );
 
@@ -419,7 +400,6 @@ describe("AssessmentController(e2e)-workflowWrapUp", () => {
     expect(FakeWorkerJobResult.getResultType(result)).toBe(
       MockedZeebeJobResult.Complete,
     );
-    // Asserts that the student assessment status has changed to completed.
     const expectedAssessment = await db.studentAssessment.findOne({
       select: {
         id: true,
@@ -434,7 +414,7 @@ describe("AssessmentController(e2e)-workflowWrapUp", () => {
     expect(expectedAssessment.previousDateChangedReportedAssessment).toBeNull();
   });
 
-  it("Should populate the previousDateChangedReportedAssessment with the most recent reported reassessment when there are previously reported reassessments.", async () => {
+  it("Should populate the previous date changed reported assessment with the most recent reported reassessment when there are previously reported reassessments.", async () => {
     // Arrange
     const savedApplication = await saveFakeApplicationDisbursements(
       db.dataSource,
@@ -453,60 +433,55 @@ describe("AssessmentController(e2e)-workflowWrapUp", () => {
       },
     );
     const originalAssessment = savedApplication.currentAssessment;
-    const tomorrow = new Date();
-    tomorrow.setDate(tomorrow.getDate() + 1);
-    const differentStudyStartDate = new Date(
-      savedApplication.currentAssessment.offering.studyStartDate,
+    const tomorrow = addDays(1, new Date());
+    let differentStudyStartDate = getISODateOnlyString(
+      addDays(1, originalAssessment.offering.studyStartDate),
     );
-    differentStudyStartDate.setDate(differentStudyStartDate.getDate() + 1);
     const firstReassessment = await saveOfferingAndAssessment(
       savedApplication,
       tomorrow,
       auditUser,
       {
-        studyStartDate: getISODateOnlyString(differentStudyStartDate),
+        studyStartDate: differentStudyStartDate,
         reportedDate: now,
         previousDateChangedReportedAssessment: originalAssessment,
       },
     );
-    const dayAfterTomorrow = new Date();
-    dayAfterTomorrow.setDate(dayAfterTomorrow.getDate() + 2);
-    differentStudyStartDate.setDate(differentStudyStartDate.getDate() + 1);
+    const dayAfterTomorrow = addDays(2, new Date());
+    differentStudyStartDate = getISODateOnlyString(
+      addDays(2, originalAssessment.offering.studyStartDate),
+    );
     const latestReportedAssessment = await saveOfferingAndAssessment(
       savedApplication,
       dayAfterTomorrow,
       auditUser,
       {
-        studyStartDate: getISODateOnlyString(differentStudyStartDate),
+        studyStartDate: differentStudyStartDate,
         reportedDate: now,
         previousDateChangedReportedAssessment: firstReassessment,
       },
     );
-    const afterDayAfterTomorrow = new Date();
-    afterDayAfterTomorrow.setDate(afterDayAfterTomorrow.getDate() + 3);
-    differentStudyStartDate.setDate(differentStudyStartDate.getDate() + 1);
+    const afterDayAfterTomorrow = addDays(3, new Date());
+    differentStudyStartDate = getISODateOnlyString(
+      addDays(3, originalAssessment.offering.studyStartDate),
+    );
     await saveOfferingAndAssessment(
       savedApplication,
       afterDayAfterTomorrow,
       auditUser,
       {
-        studyStartDate: getISODateOnlyString(differentStudyStartDate),
+        studyStartDate: differentStudyStartDate,
       },
     );
     savedApplication.currentAssessment.studentAssessmentStatus =
       StudentAssessmentStatus.InProgress;
     await db.studentAssessment.save(savedApplication.currentAssessment);
-    const workflowData = {
-      studentData: {
-        dependantStatus: "independant",
-      },
-    } as WorkflowData;
 
     // Act
     const result = await assessmentController.workflowWrapUp(
       createFakeWorkflowWrapUpPayload(
         savedApplication.currentAssessment.id,
-        workflowData,
+        {} as WorkflowData,
       ),
     );
 
@@ -514,7 +489,6 @@ describe("AssessmentController(e2e)-workflowWrapUp", () => {
     expect(FakeWorkerJobResult.getResultType(result)).toBe(
       MockedZeebeJobResult.Complete,
     );
-    // Asserts that the student assessment status has changed to completed.
     const expectedAssessment = await db.studentAssessment.findOne({
       select: {
         id: true,
@@ -531,7 +505,7 @@ describe("AssessmentController(e2e)-workflowWrapUp", () => {
     );
   });
 
-  it("Should not populate the previousDateChangedReportedAssessment if there are multiple reassessments where an intermediate reassessment has a different offering date but the current one changed the offering date back to the value of the latest reported assessment.", async () => {
+  it("Should not populate the previous date changed reported assessment if there are multiple reassessments where an intermediate reassessment has a different offering date but the current one changed the offering date back to the value of the latest reported assessment.", async () => {
     // Arrange
     const savedApplication = await saveFakeApplicationDisbursements(
       db.dataSource,
@@ -550,17 +524,16 @@ describe("AssessmentController(e2e)-workflowWrapUp", () => {
       },
     );
     const originalAssessment = savedApplication.currentAssessment;
-    const tomorrow = new Date();
-    tomorrow.setDate(tomorrow.getDate() + 1);
-    const differentStudyStartDate = new Date(
-      savedApplication.currentAssessment.offering.studyStartDate,
+    const tomorrow = addDays(1, new Date());
+    let differentStudyStartDate = addDays(
+      1,
+      originalAssessment.offering.studyStartDate,
     );
-    differentStudyStartDate.setDate(differentStudyStartDate.getDate() + 1);
     const reportedReassessmentStudyStartDate = getISODateOnlyString(
       differentStudyStartDate,
     );
     const reportedReassessmentStudyEndDate = getISODateOnlyString(
-      savedApplication.currentAssessment.offering.studyEndDate,
+      originalAssessment.offering.studyEndDate,
     );
     const firstReportedReassessment = await saveOfferingAndAssessment(
       savedApplication,
@@ -573,9 +546,11 @@ describe("AssessmentController(e2e)-workflowWrapUp", () => {
         previousDateChangedReportedAssessment: originalAssessment,
       },
     );
-    const dayAfterTomorrow = new Date();
-    dayAfterTomorrow.setDate(dayAfterTomorrow.getDate() + 2);
-    differentStudyStartDate.setDate(differentStudyStartDate.getDate() + 1);
+    const dayAfterTomorrow = addDays(2, new Date());
+    differentStudyStartDate = addDays(
+      2,
+      originalAssessment.offering.studyStartDate,
+    );
     await saveOfferingAndAssessment(
       savedApplication,
       dayAfterTomorrow,
@@ -585,9 +560,7 @@ describe("AssessmentController(e2e)-workflowWrapUp", () => {
         previousDateChangedReportedAssessment: firstReportedReassessment,
       },
     );
-    const afterDayAfterTomorrow = new Date();
-    afterDayAfterTomorrow.setDate(afterDayAfterTomorrow.getDate() + 3);
-    differentStudyStartDate.setDate(differentStudyStartDate.getDate() + 1);
+    const afterDayAfterTomorrow = addDays(3, new Date());
     await saveOfferingAndAssessment(
       savedApplication,
       afterDayAfterTomorrow,
@@ -600,17 +573,12 @@ describe("AssessmentController(e2e)-workflowWrapUp", () => {
     savedApplication.currentAssessment.studentAssessmentStatus =
       StudentAssessmentStatus.InProgress;
     await db.studentAssessment.save(savedApplication.currentAssessment);
-    const workflowData = {
-      studentData: {
-        dependantStatus: "independant",
-      },
-    } as WorkflowData;
 
     // Act
     const result = await assessmentController.workflowWrapUp(
       createFakeWorkflowWrapUpPayload(
         savedApplication.currentAssessment.id,
-        workflowData,
+        {} as WorkflowData,
       ),
     );
 
@@ -618,7 +586,6 @@ describe("AssessmentController(e2e)-workflowWrapUp", () => {
     expect(FakeWorkerJobResult.getResultType(result)).toBe(
       MockedZeebeJobResult.Complete,
     );
-    // Asserts that the student assessment status has changed to completed.
     const expectedAssessment = await db.studentAssessment.findOne({
       select: {
         id: true,
@@ -633,7 +600,7 @@ describe("AssessmentController(e2e)-workflowWrapUp", () => {
     expect(expectedAssessment.previousDateChangedReportedAssessment).toBeNull();
   });
 
-  it("Should not populate the previousDateChangedReportedAssessment if there are multiple reassessments where an intermediate reassessment has a different offering date but the current one changed the offering dates back to the value of the last generated ecert when there are no report based reported assessments.", async () => {
+  it("Should not populate the previous date changed reported assessment if there are multiple reassessments where an intermediate reassessment has a different offering date but the current one changed the offering dates back to the value of the last generated ecert when there are no report based reported assessments.", async () => {
     // Arrange
     const savedApplication = await saveFakeApplicationDisbursements(
       db.dataSource,
@@ -653,24 +620,21 @@ describe("AssessmentController(e2e)-workflowWrapUp", () => {
     );
     const originalAssessment = savedApplication.currentAssessment;
     const originalAssessmentStudyStartDate = getISODateOnlyString(
-      savedApplication.currentAssessment.offering.studyStartDate,
+      originalAssessment.offering.studyStartDate,
     );
     const originalAssessmentStudyEndDate = getISODateOnlyString(
-      savedApplication.currentAssessment.offering.studyEndDate,
+      originalAssessment.offering.studyEndDate,
     );
-    const tomorrow = new Date();
-    tomorrow.setDate(tomorrow.getDate() + 1);
-    const differentStudyStartDate = new Date(
-      savedApplication.currentAssessment.offering.studyStartDate,
+    const tomorrow = addDays(1, new Date());
+    const differentStudyStartDate = addDays(
+      1,
+      originalAssessment.offering.studyStartDate,
     );
-    differentStudyStartDate.setDate(differentStudyStartDate.getDate() + 1);
     await saveOfferingAndAssessment(savedApplication, tomorrow, auditUser, {
       studyStartDate: getISODateOnlyString(differentStudyStartDate),
       previousDateChangedReportedAssessment: originalAssessment,
     });
-    const dayAfterTomorrow = new Date();
-    dayAfterTomorrow.setDate(dayAfterTomorrow.getDate() + 2);
-    differentStudyStartDate.setDate(differentStudyStartDate.getDate() + 1);
+    const dayAfterTomorrow = addDays(2, new Date());
     await saveOfferingAndAssessment(
       savedApplication,
       dayAfterTomorrow,
@@ -683,17 +647,12 @@ describe("AssessmentController(e2e)-workflowWrapUp", () => {
     savedApplication.currentAssessment.studentAssessmentStatus =
       StudentAssessmentStatus.InProgress;
     await db.studentAssessment.save(savedApplication.currentAssessment);
-    const workflowData = {
-      studentData: {
-        dependantStatus: "independant",
-      },
-    } as WorkflowData;
 
     // Act
     const result = await assessmentController.workflowWrapUp(
       createFakeWorkflowWrapUpPayload(
         savedApplication.currentAssessment.id,
-        workflowData,
+        {} as WorkflowData,
       ),
     );
 
@@ -701,7 +660,6 @@ describe("AssessmentController(e2e)-workflowWrapUp", () => {
     expect(FakeWorkerJobResult.getResultType(result)).toBe(
       MockedZeebeJobResult.Complete,
     );
-    // Asserts that the student assessment status has changed to completed.
     const expectedAssessment = await db.studentAssessment.findOne({
       select: {
         id: true,

--- a/sources/packages/backend/libs/test-utils/src/factories/education-program-offering.ts
+++ b/sources/packages/backend/libs/test-utils/src/factories/education-program-offering.ts
@@ -15,8 +15,8 @@ import {
 import { getISODateOnlyString } from "@sims/utilities";
 
 export function createFakeEducationProgramOffering(
-  relations?: {
-    auditUser?: User;
+  relations: {
+    auditUser: User;
     program?: EducationProgram;
     institution?: Institution;
     institutionLocation?: InstitutionLocation;

--- a/sources/packages/backend/libs/test-utils/src/factories/education-program.ts
+++ b/sources/packages/backend/libs/test-utils/src/factories/education-program.ts
@@ -9,7 +9,7 @@ import {
 import { createFakeInstitution } from "@sims/test-utils";
 
 export function createFakeEducationProgram(
-  relations?: {
+  relations: {
     auditUser: User;
     institution?: Institution;
   },
@@ -37,7 +37,7 @@ export function createFakeEducationProgram(
   program.programDeclaration = true;
   program.institution = relations?.institution ?? createFakeInstitution();
   program.programIntensity = ProgramIntensity.fullTime;
-  program.submittedBy = relations?.auditUser;
+  program.submittedBy = relations.auditUser;
   program.isActive = options?.initialValues?.isActive ?? true;
   return program;
 }

--- a/sources/packages/backend/libs/test-utils/src/factories/student-assessment.ts
+++ b/sources/packages/backend/libs/test-utils/src/factories/student-assessment.ts
@@ -35,7 +35,10 @@ export function createFakeStudentAssessment(
     AssessmentTriggerType.OriginalAssessment;
   assessment.offering =
     relations?.offering ??
-    createFakeEducationProgramOffering({ auditUser: relations?.auditUser });
+    createFakeEducationProgramOffering(
+      { auditUser: relations?.auditUser },
+      { initialValues: options?.initialValue },
+    );
   assessment.studentAppeal = relations?.studentAppeal ?? null;
   assessment.studentScholasticStanding = null;
   assessment.noaApprovalStatus = null;
@@ -45,5 +48,8 @@ export function createFakeStudentAssessment(
     StudentAssessmentStatus.Submitted;
   assessment.calculationStartDate =
     options?.initialValue?.calculationStartDate ?? null;
+  assessment.previousDateChangedReportedAssessment =
+    options?.initialValue?.previousDateChangedReportedAssessment ?? null;
+  assessment.reportedDate = options?.initialValue?.reportedDate ?? null;
   return assessment;
 }

--- a/sources/packages/backend/libs/test-utils/src/factories/student-assessment.ts
+++ b/sources/packages/backend/libs/test-utils/src/factories/student-assessment.ts
@@ -17,6 +17,7 @@ export function createFakeStudentAssessment(
     application?: Application;
     offering?: EducationProgramOffering;
     studentAppeal?: StudentAppeal;
+    previousDateChangedReportedAssessment?: StudentAssessment;
   },
   options?: { initialValue?: Partial<StudentAssessment> },
 ): StudentAssessment {
@@ -49,7 +50,7 @@ export function createFakeStudentAssessment(
   assessment.calculationStartDate =
     options?.initialValue?.calculationStartDate ?? null;
   assessment.previousDateChangedReportedAssessment =
-    options?.initialValue?.previousDateChangedReportedAssessment ?? null;
+    relations?.previousDateChangedReportedAssessment ?? null;
   assessment.reportedDate = options?.initialValue?.reportedDate ?? null;
   return assessment;
 }


### PR DESCRIPTION
### As a part of this PR, the following e2e tests for the workers were completed:

AssessmentController(e2e)-workflowWrapUp
    √ Should populate the previousDateChangedReportedAssessment when the e-Cert was generated for the 'Original Assessment' and offering dates changed as a result of the reassessment. 
    √ Should not populate the previousDateChangedReportedAssessment when the e-Cert was generated for the 'Original Assessment' and offering dates didn't change as a result of the reassessment.
    √ Should not populate the previousDateChangedReportedAssessment when the e-Cert is not generated for the 'Original Assessment' and offering dates changed as a result of the reassessment.   
    √ Should populate the previousDateChangedReportedAssessment with the most recent reported reassessment when there are previously reported reassessments.
    √ Should not populate the previousDateChangedReportedAssessment if there are multiple reassessments where an intermediate reassessment has a different offering date but the current one changed the offering date back to the value of the latest reported assessment. 
    √ Should not populate the previousDateChangedReportedAssessment if there are multiple reassessments where an intermediate reassessment has a different offering date but the current one changed the offering dates back to the value of the last generated ecert when there are no report based reported assessments. 

### **Screenshot for the above created e2e tests:**

<img width="1360" alt="image" src="https://github.com/bcgov/SIMS/assets/7859295/b791ee5b-c105-4127-94f0-dbe5c4be5ac6">

------------------------------------------------------------------------------------------------------------------------------------------

**Note:** I have updated the `workFlowWrapUp` test file to use `restoreAllMocks` rather than the `resetAllMocks` because the `restoreAllMocks` restores the function implementation to the original (non-mocked) implementation whereas the `resetAllMocks` replaces the mock implementation with an empty function, returning undefined. The first behavior is what was needed for each test and hence used `restoreAllMocks`.

<img width="843" alt="image" src="https://github.com/bcgov/SIMS/assets/7859295/8db0244e-9063-4101-aa9b-cabcb5233e98">

Reference: https://jestjs.io/docs/mock-function-api#mockfnmockrestore