### PR TITLE
#3096 - 2.1.1 Menu Navigation- Student- Accessibility Fixes - Level A - Keyboard

### DIFF
--- a/sources/packages/web/src/views/student/AppStudent.vue
+++ b/sources/packages/web/src/views/student/AppStudent.vue
@@ -74,6 +74,7 @@
                 :value="index"
                 @click="item.command"
                 :to="item.props?.to"
+                tabindex="0"
               >
                 <v-list-item-title>
                   <span class="label-bold">{{ item.title }}</span>


### PR DESCRIPTION
- Update student portal menu so that all items can be tabbed through. Currently, after the menu is opened, tabbing closes the menu.
- Reuse the same solution from the ticket