### PR TITLE
#3140 - Build Ministry-Specific Reports - Programs and Offering Status (Part 1)

### DIFF
--- a/sources/packages/backend/apps/api/src/route-controllers/institution/institution.aest.controller.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/institution/institution.aest.controller.ts
@@ -208,4 +208,14 @@ export class InstitutionAESTController extends BaseController {
   async getInstitutionTypeOptions(): Promise<OptionItemAPIOutDTO[]> {
     return this.institutionControllerService.getInstitutionTypeOptions();
   }
+
+  /**
+   * Get the list of all institutions names to be returned in an option
+   * list (key/value pair) schema.
+   * @returns institutions names in an option list (key/value pair) schema.
+   */
+  @Get("name/options-list")
+  async getAllInstitutionNameOptions(): Promise<OptionItemAPIOutDTO[]> {
+    return this.institutionControllerService.getInstitutionNameOptions();
+  }
 }

--- a/sources/packages/backend/apps/api/src/route-controllers/institution/institution.aest.controller.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/institution/institution.aest.controller.ts
@@ -215,7 +215,7 @@ export class InstitutionAESTController extends BaseController {
    * @returns institutions names in an option list (key/value pair) schema.
    */
   @Get("name/options-list")
-  async getAllInstitutionNameOptions(): Promise<OptionItemAPIOutDTO[]> {
+  async getInstitutionNameOptions(): Promise<OptionItemAPIOutDTO[]> {
     return this.institutionControllerService.getInstitutionNameOptions();
   }
 }

--- a/sources/packages/backend/apps/api/src/route-controllers/institution/institution.controller.service.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/institution/institution.controller.service.ts
@@ -86,4 +86,17 @@ export class InstitutionControllerService {
       description: institutionType.name,
     }));
   }
+
+  /**
+   * Get the list of all institutions names to be returned in an option
+   * list (key/value pair) schema.
+   * @returns institutions names in an option list (key/value pair) schema.
+   */
+  async getInstitutionNameOptions(): Promise<OptionItemAPIOutDTO[]> {
+    const institutions = await this.institutionService.getAllInstitutions();
+    return institutions.map((institution) => ({
+      id: institution.id,
+      description: institution.legalOperatingName,
+    }));
+  }
 }

--- a/sources/packages/backend/apps/api/src/route-controllers/institution/institution.controller.service.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/institution/institution.controller.service.ts
@@ -93,7 +93,7 @@ export class InstitutionControllerService {
    * @returns institutions names in an option list (key/value pair) schema.
    */
   async getInstitutionNameOptions(): Promise<OptionItemAPIOutDTO[]> {
-    const institutions = await this.institutionService.getAllInstitutions();
+    const institutions = await this.institutionService.getAllInstitutionNames();
     return institutions.map((institution) => ({
       id: institution.id,
       description: institution.legalOperatingName,

--- a/sources/packages/backend/apps/api/src/services/institution/institution.service.ts
+++ b/sources/packages/backend/apps/api/src/services/institution/institution.service.ts
@@ -998,10 +998,10 @@ export class InstitutionService extends RecordDataModelService<Institution> {
   }
 
   /**
-   * Get all institutions.
-   * @returns all institutions.
+   * Get all institution legal operating names.
+   * @returns all institution legal operating names.
    */
-  async getAllInstitutions(): Promise<Partial<Institution>[]> {
-    return this.repo.find();
+  async getAllInstitutionNames(): Promise<Partial<Institution>[]> {
+    return this.repo.find({ select: { id: true, legalOperatingName: true } });
   }
 }

--- a/sources/packages/backend/apps/api/src/services/institution/institution.service.ts
+++ b/sources/packages/backend/apps/api/src/services/institution/institution.service.ts
@@ -996,4 +996,12 @@ export class InstitutionService extends RecordDataModelService<Institution> {
     });
     return !!institutionStudentDataAccess;
   }
+
+  /**
+   * Get all institutions.
+   * @returns all institutions.
+   */
+  async getAllInstitutions(): Promise<Partial<Institution>[]> {
+    return this.repo.find();
+  }
 }

--- a/sources/packages/backend/apps/api/src/services/institution/institution.service.ts
+++ b/sources/packages/backend/apps/api/src/services/institution/institution.service.ts
@@ -1002,6 +1002,9 @@ export class InstitutionService extends RecordDataModelService<Institution> {
    * @returns all institution legal operating names.
    */
   async getAllInstitutionNames(): Promise<Partial<Institution>[]> {
-    return this.repo.find({ select: { id: true, legalOperatingName: true } });
+    return this.repo.find({
+      select: { id: true, legalOperatingName: true },
+      order: { legalOperatingName: "ASC" },
+    });
   }
 }

--- a/sources/packages/forms/src/form-definitions/exportfinancialreports.json
+++ b/sources/packages/forms/src/form-definitions/exportfinancialreports.json
@@ -308,6 +308,53 @@
               "isNew": false
             },
             {
+              "autofocus": false,
+              "input": true,
+              "tableView": true,
+              "label": "Institution Name",
+              "key": "institutionName",
+              "placeholder": "Select Institution Name",
+              "data": {
+                "values": [
+                  {
+                    "value": "",
+                    "label": ""
+                  }
+                ],
+                "json": "",
+                "url": "",
+                "resource": "",
+                "custom": ""
+              },
+              "dataSrc": "values",
+              "valueProperty": "",
+              "defaultValue": "",
+              "refreshOn": "",
+              "filter": "",
+              "authenticate": false,
+              "template": "<span>{{ item.label }}</span>",
+              "multiple": false,
+              "protected": false,
+              "unique": false,
+              "persistent": true,
+              "hidden": false,
+              "clearOnHide": true,
+              "validate": {
+                "required": true
+              },
+              "type": "select",
+              "labelPosition": "top",
+              "tags": [],
+              "conditional": {
+                "show": "true",
+                "when": "reportName",
+                "eq": "Program_And_Offering_Status"
+              },
+              "properties": {},
+              "lockKey": true,
+              "isNew": false
+            },
+            {
               "label": "Columns",
               "labelWidth": "",
               "labelMargin": "",
@@ -560,7 +607,7 @@
                 "eq": "",
                 "json": ""
               },
-              "customConditional": "show = \n    data.reportName === 'Disbursement_Forecast_Report' \n    || data.reportName === 'Disbursement_Report' \n    || data.reportName === 'Data_Inventory_Report'\n    || data.reportName === 'Institution_Designation_Report'\n    || data.reportName === 'ECert_Errors_Report'",
+              "customConditional": "show = \n    data.reportName === 'Disbursement_Forecast_Report' \n    || data.reportName === 'Disbursement_Report' \n    || data.reportName === 'Data_Inventory_Report'\n    || data.reportName === 'Institution_Designation_Report'\n    || data.reportName === 'ECert_Errors_Report'\n    || data.reportName === 'Program_And_Offering_Status'",
               "logic": [],
               "attributes": {},
               "overlay": {
@@ -618,6 +665,48 @@
               "id": "ecn2x9",
               "hideLabel": true,
               "isNew": false
+            },
+            {
+              "autofocus": false,
+              "input": true,
+              "tableView": true,
+              "inputType": "text",
+              "inputMask": "",
+              "label": "SABC Program Code",
+              "key": "sabcProgramCode",
+              "placeholder": "",
+              "prefix": "",
+              "suffix": "",
+              "multiple": false,
+              "defaultValue": "",
+              "protected": false,
+              "unique": false,
+              "persistent": true,
+              "hidden": false,
+              "clearOnHide": true,
+              "spellcheck": true,
+              "validate": {
+                "required": false,
+                "minLength": "",
+                "maxLength": 4,
+                "pattern": "",
+                "custom": "",
+                "customPrivate": false,
+                "customMessage": "Maximum 4 characters is allowed."
+              },
+              "conditional": {
+                "show": "true",
+                "when": "reportName",
+                "eq": "Program_And_Offering_Status"
+              },
+              "type": "textfield",
+              "labelPosition": "top",
+              "inputFormat": "plain",
+              "tags": [],
+              "properties": {},
+              "lockKey": true,
+              "customConditional": "",
+              "tooltip": "If it is entered, retrieve records that match. If it is left blank, show all records."
             },
             {
               "label": "Intensity",
@@ -688,7 +777,7 @@
                 "eq": "",
                 "json": ""
               },
-              "customConditional": "show = \n    data.reportName === 'Disbursement_Forecast_Report' \n    || data.reportName === 'Disbursement_Report' \n    || data.reportName === 'Data_Inventory_Report'    || data.reportName === 'ECert_Errors_Report'",
+              "customConditional": "show = \n    data.reportName === 'Disbursement_Forecast_Report' \n    || data.reportName === 'Disbursement_Report' \n    || data.reportName === 'Data_Inventory_Report' \n    || data.reportName === 'ECert_Errors_Report' \n    || data.reportName === 'Program_And_Offering_Status'",
               "logic": [],
               "attributes": {},
               "overlay": {
@@ -716,8 +805,7 @@
               "allowMultipleMasks": false,
               "addons": [],
               "fieldSet": false,
-              "id": "enqlwsq",
-              "isNew": false
+              "id": "enqlwsq"
             }
           ],
           "placeholder": "",
@@ -738,8 +826,7 @@
           "addons": [],
           "tree": true,
           "lazyLoad": false,
-          "id": "ekcfpz",
-          "isNew": false
+          "id": "ekcfpz"
         }
       ],
       "id": "eouyt8n",
@@ -889,7 +976,8 @@
       "allowMultipleMasks": false,
       "addons": [],
       "inputType": "hidden",
-      "id": "epgtnmh"
+      "id": "epgtnmh",
+      "isNew": false
     }
   ]
 }

--- a/sources/packages/forms/src/form-definitions/exportfinancialreports.json
+++ b/sources/packages/forms/src/form-definitions/exportfinancialreports.json
@@ -706,7 +706,7 @@
               "properties": {},
               "lockKey": true,
               "customConditional": "",
-              "tooltip": "If it is entered, retrieve records that match. If it is left blank, show all records."
+              "tooltip": ""
             },
             {
               "label": "Intensity",

--- a/sources/packages/forms/src/form-definitions/exportfinancialreports.json
+++ b/sources/packages/forms/src/form-definitions/exportfinancialreports.json
@@ -200,8 +200,7 @@
           },
           "id": "epfngcm",
           "defaultValue": "",
-          "lockKey": true,
-          "isNew": false
+          "lockKey": true
         },
         {
           "label": "Container",
@@ -304,8 +303,7 @@
                 "eq": "Offering_Details_Report"
               },
               "properties": {},
-              "lockKey": true,
-              "isNew": false
+              "lockKey": true
             },
             {
               "autofocus": false,
@@ -351,8 +349,7 @@
                 "eq": "Program_And_Offering_Status"
               },
               "properties": {},
-              "lockKey": true,
-              "isNew": false
+              "lockKey": true
             },
             {
               "label": "Columns",
@@ -663,50 +660,7 @@
               "tree": false,
               "lazyLoad": false,
               "id": "ecn2x9",
-              "hideLabel": true,
-              "isNew": false
-            },
-            {
-              "autofocus": false,
-              "input": true,
-              "tableView": true,
-              "inputType": "text",
-              "inputMask": "",
-              "label": "SABC Program Code",
-              "key": "sabcProgramCode",
-              "placeholder": "",
-              "prefix": "",
-              "suffix": "",
-              "multiple": false,
-              "defaultValue": "",
-              "protected": false,
-              "unique": false,
-              "persistent": true,
-              "hidden": false,
-              "clearOnHide": true,
-              "spellcheck": true,
-              "validate": {
-                "required": false,
-                "minLength": "",
-                "maxLength": 4,
-                "pattern": "",
-                "custom": "",
-                "customPrivate": false,
-                "customMessage": "Maximum 4 characters is allowed."
-              },
-              "conditional": {
-                "show": "true",
-                "when": "reportName",
-                "eq": "Program_And_Offering_Status"
-              },
-              "type": "textfield",
-              "labelPosition": "top",
-              "inputFormat": "plain",
-              "tags": [],
-              "properties": {},
-              "lockKey": true,
-              "customConditional": "",
-              "tooltip": ""
+              "hideLabel": true
             },
             {
               "label": "Intensity",
@@ -806,6 +760,48 @@
               "addons": [],
               "fieldSet": false,
               "id": "enqlwsq"
+            },
+            {
+              "autofocus": false,
+              "input": true,
+              "tableView": true,
+              "inputType": "text",
+              "inputMask": "",
+              "label": "SABC Program Code",
+              "key": "sabcProgramCode",
+              "placeholder": "",
+              "prefix": "",
+              "suffix": "",
+              "multiple": false,
+              "defaultValue": "",
+              "protected": false,
+              "unique": false,
+              "persistent": true,
+              "hidden": false,
+              "clearOnHide": true,
+              "spellcheck": true,
+              "validate": {
+                "required": false,
+                "minLength": "",
+                "maxLength": 4,
+                "pattern": "",
+                "custom": "",
+                "customPrivate": false,
+                "customMessage": "Maximum 4 characters is allowed."
+              },
+              "conditional": {
+                "show": "true",
+                "when": "reportName",
+                "eq": "Program_And_Offering_Status"
+              },
+              "type": "textfield",
+              "labelPosition": "top",
+              "inputFormat": "plain",
+              "tags": [],
+              "properties": {},
+              "lockKey": true,
+              "customConditional": "",
+              "tooltip": ""
             }
           ],
           "placeholder": "",
@@ -829,8 +825,7 @@
           "id": "ekcfpz"
         }
       ],
-      "id": "eouyt8n",
-      "isNew": false
+      "id": "eouyt8n"
     },
     {
       "label": "applicationId",
@@ -976,8 +971,7 @@
       "allowMultipleMasks": false,
       "addons": [],
       "inputType": "hidden",
-      "id": "epgtnmh",
-      "isNew": false
+      "id": "epgtnmh"
     }
   ]
 }

--- a/sources/packages/web/src/components/common/Reports.vue
+++ b/sources/packages/web/src/components/common/Reports.vue
@@ -51,6 +51,8 @@ export default defineComponent({
     const REPORT_TYPE_DROPDOWN_KEY = "reportName";
     const loading = ref(false);
     const PROGRAM_YEAR_DROPDOWN_KEY = "programYear";
+    const INSTITUTION_NAME = "institutionName";
+    const PROGRAM_AND_OFFERING_STATUS = "Program_And_Offering_Status";
     let formData: FormIOForm;
     const formLoaded = async (form: FormIOForm) => {
       formData = form;
@@ -77,6 +79,17 @@ export default defineComponent({
             form,
             PROGRAM_YEAR_DROPDOWN_KEY,
           );
+        }
+        if (event.changed.value === PROGRAM_AND_OFFERING_STATUS) {
+          const institutionName = getFirstComponent(form, INSTITUTION_NAME);
+          if (
+            institutionName._visible &&
+            !institutionName.selectOptions.length
+          ) {
+            // Load institution data if the select is visible and
+            // its items are not populated yet.
+            await formioDataLoader.loadInstitutionName(form, INSTITUTION_NAME);
+          }
         }
       }
     };

--- a/sources/packages/web/src/components/common/Reports.vue
+++ b/sources/packages/web/src/components/common/Reports.vue
@@ -51,8 +51,7 @@ export default defineComponent({
     const REPORT_TYPE_DROPDOWN_KEY = "reportName";
     const loading = ref(false);
     const PROGRAM_YEAR_DROPDOWN_KEY = "programYear";
-    const INSTITUTION_NAME = "institutionName";
-    const PROGRAM_AND_OFFERING_STATUS = "Program_And_Offering_Status";
+    const INSTITUTION_NAME_DROPDOWN_KEY = "institutionName";
     let formData: FormIOForm;
     const formLoaded = async (form: FormIOForm) => {
       formData = form;
@@ -80,16 +79,20 @@ export default defineComponent({
             PROGRAM_YEAR_DROPDOWN_KEY,
           );
         }
-        if (event.changed.value === PROGRAM_AND_OFFERING_STATUS) {
-          const institutionName = getFirstComponent(form, INSTITUTION_NAME);
-          if (
-            institutionName._visible &&
-            !institutionName.selectOptions.length
-          ) {
-            // Load institution data if the select is visible and
-            // its items are not populated yet.
-            await formioDataLoader.loadInstitutionName(form, INSTITUTION_NAME);
-          }
+        const institutionSelect = getFirstComponent(
+          form,
+          INSTITUTION_NAME_DROPDOWN_KEY,
+        );
+        if (
+          institutionSelect._visible &&
+          !institutionSelect.selectOptions.length
+        ) {
+          // Load institution data if the select is visible and
+          // its items are not populated yet.
+          await formioDataLoader.loadInstitutionName(
+            form,
+            INSTITUTION_NAME_DROPDOWN_KEY,
+          );
         }
       }
     };

--- a/sources/packages/web/src/composables/useFormioDropdownLoader.ts
+++ b/sources/packages/web/src/composables/useFormioDropdownLoader.ts
@@ -204,6 +204,16 @@ export function useFormioDropdownLoader() {
     );
   };
 
+  const loadInstitutionName = async (form: any, dropdownName: string) => {
+    // Find the dropdown to be populated with the locations.
+    const dropdown = formioUtils.getFirstComponent(form, dropdownName);
+    return loadDropdown(
+      form,
+      dropdown,
+      InstitutionService.shared.getInstitutionNameOptions(),
+    );
+  };
+
   return {
     loadLocations,
     loadProgramsForLocation,
@@ -215,5 +225,6 @@ export function useFormioDropdownLoader() {
     loadProgramYear,
     loadProgramIntensityDetails,
     loadDropdown,
+    loadInstitutionName,
   };
 }

--- a/sources/packages/web/src/composables/useFormioDropdownLoader.ts
+++ b/sources/packages/web/src/composables/useFormioDropdownLoader.ts
@@ -204,7 +204,10 @@ export function useFormioDropdownLoader() {
     );
   };
 
-  const loadInstitutionName = async (form: any, dropdownName: string) => {
+  const loadInstitutionName = async (
+    form: FormIOForm,
+    dropdownName: string,
+  ) => {
     // Find the dropdown to be populated with the locations.
     const dropdown = formioUtils.getFirstComponent(form, dropdownName);
     return loadDropdown(

--- a/sources/packages/web/src/services/InstitutionService.ts
+++ b/sources/packages/web/src/services/InstitutionService.ts
@@ -165,4 +165,13 @@ export class InstitutionService {
   async getMyInstitutionLocationsDetails() {
     return ApiClient.InstitutionLocation.getMyInstitutionLocationsDetails();
   }
+
+  /**
+   * Get the list os all institutions names to be returned in an option
+   * list (key/value pair) schema.
+   * @returns institutions names in an option list (key/value pair) schema.
+   */
+  async getInstitutionNameOptions(): Promise<OptionItemAPIOutDTO[]> {
+    return ApiClient.Institution.getInstitutionNameOptions();
+  }
 }

--- a/sources/packages/web/src/services/http/InstitutionApi.ts
+++ b/sources/packages/web/src/services/http/InstitutionApi.ts
@@ -81,6 +81,15 @@ export class InstitutionApi extends HttpBaseClient {
     return this.getCall(this.addClientRoot("institution/type/options-list"));
   }
 
+  /**
+   * Get the list os all institutions names to be returned in an option
+   * list (key/value pair) schema.
+   * @returns institutions names in an option list (key/value pair) schema.
+   */
+  async getInstitutionNameOptions(): Promise<OptionItemAPIOutDTO[]> {
+    return this.getCall(this.addClientRoot("institution/name/options-list"));
+  }
+
   async allInstitutionLocations(
     institutionId?: number,
   ): Promise<InstitutionLocationAPIOutDTO[]> {

--- a/sources/packages/web/src/types/formio.ts
+++ b/sources/packages/web/src/types/formio.ts
@@ -59,6 +59,7 @@ export interface FormIOChangeEvent {
 
 export interface FormIOChangedObject {
   component: FormIOComponent;
+  value: string;
 }
 
 /**

--- a/sources/packages/web/src/types/formio.ts
+++ b/sources/packages/web/src/types/formio.ts
@@ -59,7 +59,6 @@ export interface FormIOChangeEvent {
 
 export interface FormIOChangedObject {
   component: FormIOComponent;
-  value: string;
 }
 
 /**

--- a/sources/packages/web/src/views/aest/Reports.vue
+++ b/sources/packages/web/src/views/aest/Reports.vue
@@ -28,6 +28,10 @@ export default defineComponent({
         description: "Institution Designation",
         id: "Institution_Designation_Report",
       },
+      {
+        description: "Program and Offering Status",
+        id: "Program_And_Offering_Status",
+      },
     ];
     return { reportList };
   },


### PR DESCRIPTION
As part of this story, the frontend UI/UX and partial backend have been completed in this PR
- Added Form.io changes for the report. Update form for the filter logic specific to the report. Also related Vue changes.
- Added new options API to get the institution name dropdown values.
- Added report filters:
  - Institution operating name dropdown
  - SABC program code - Free text input restricted to 4 characters max. (Optional)

Screenshot of the Ministry Reports with new elements
![image](https://github.com/bcgov/SIMS/assets/148148914/c254ddbd-3c3c-4256-80a7-8f99e7ed2033)

Screenshot of the Institution Name dropdown content
![image](https://github.com/bcgov/SIMS/assets/148148914/c342112a-3ae3-40ea-90a0-b71f93d948f6)
