### PR TITLE
#3105 - Camunda Definitions Deployment Healthy Check

### DIFF
--- a/sources/packages/backend/workflow/src/deploy.ts
+++ b/sources/packages/backend/workflow/src/deploy.ts
@@ -64,13 +64,11 @@ const JSON_LOG_INDENTATION = 2;
     const topology = await zeebeClient.topology();
     console.debug(`Current topology:`);
     console.debug(JSON.stringify(topology, null, JSON_LOG_INDENTATION));
-    isHealthy = topology.brokers.every(
-      (broker) =>
-        broker.partitions.length > 0 &&
-        broker.partitions.every(
-          (partition) =>
-            partition.health.toString() === ZEEBE_PARTITION_HEALTH_STATUS,
-        ),
+    isHealthy = topology.brokers.some((broker) =>
+      broker.partitions.some(
+        (partition) =>
+          partition.health.toString() === ZEEBE_PARTITION_HEALTH_STATUS,
+      ),
     );
     if (isHealthy) {
       console.info("Zeebe is ready.");


### PR DESCRIPTION
Changed the Zeebe healthy check to wait till some partition is healthy instead of using `every`.
`every` returns true when the array is empty, which is not desirable in this situation.
Using `some` will ensure that at least one partition is available to accept the deploy commands.

### Zeebe healthy (`partitionId: 1` is HEALTHY) - this is the expected.

```json
{
  "brokers": [
    {
      "partitions": [
        {
          "partitionId": 1,
          "role": "LEADER",
          "health": "HEALTHY"
        }
      ],
      "nodeId": 0,
      "host": "172.18.0.2",
      "port": 26501,
      "version": "8.5.0"
    }
  ],
  "clusterSize": 1,
  "partitionsCount": 1,
  "replicationFactor": 1,
  "gatewayVersion": "8.5.0"
}
```

### Zeebe not ready: no brokers nor partitions present

```json
{
  "brokers": [],
  "clusterSize": 1,
  "partitionsCount": 1,
  "replicationFactor": 1,
  "gatewayVersion": "8.5.0"
}
```

### Zeebe not ready: broker is present but no partitions present

```json
{
  "brokers": [
    {
      "partitions": [],
      "nodeId": 0,
      "host": "172.18.0.2",
      "port": 26501,
      "version": "8.5.0"
    }
  ],
  "clusterSize": 1,
  "partitionsCount": 1,
  "replicationFactor": 1,
  "gatewayVersion": "8.5.0"
}
```