### PR TITLE
#3377- Virus Scanning bug Fix

### DIFF
--- a/devops/openshift/queue-consumers-deploy.yml
+++ b/devops/openshift/queue-consumers-deploy.yml
@@ -351,7 +351,7 @@ parameters:
   - name: CLAMAV_SERVICE
     value: clamav
   - name: CLAMAV_PORT
-    value: 3310
+    required: true
   - name: REDIS_SECRET_NAME
     value: redis-creds
   - name: REDIS_PASSWORD_KEY


### PR DESCRIPTION
### The following bug was fixed as a part of this PR:

- Since the ClamAV port is passed from the Makefile, it should be set to `required: true` in the queue-consumers-deploy.yml