### PR TITLE
Camunda SDK and Camunda Localhost Upgrade

### DIFF
--- a/sources/Makefile
+++ b/sources/Makefile
@@ -66,9 +66,10 @@ export CRA_RESPONSE_FOLDER := $(or $(CRA_RESPONSE_FOLDER), CRA-Response)
 export CRA_PROGRAM_AREA_CODE := $(or $(CRA_PROGRAM_AREA_CODE), )
 export CRA_ENVIRONMENT_CODE := $(or $(CRA_ENVIRONMENT_CODE), )
 # Versions used by camunda-docker-compose-core.yml during the make camunda.
+# Versions upgraded following the conbination available on https://github.com/camunda/camunda-platform/blob/main/.env
 export CAMUNDA_CONNECTORS_VERSION := $(or $(CAMUNDA_CONNECTORS_VERSION), 8.5.3)
-export CAMUNDA_PLATFORM_VERSION := $(or $(CAMUNDA_PLATFORM_VERSION), 8.5.0)
-export ELASTIC_VERSION := $(or $(ELASTIC_VERSION), 8.14.0)
+export CAMUNDA_PLATFORM_VERSION := $(or $(CAMUNDA_PLATFORM_VERSION), 8.5.2)
+export ELASTIC_VERSION := $(or $(ELASTIC_VERSION), 8.14.3)
 # Camunda default values for local development.
 export CAMUNDA_OAUTH_DISABLED := $(or $(CAMUNDA_OAUTH_DISABLED), true)
 export CAMUNDA_SECURE_CONNECTION := $(or $(CAMUNDA_SECURE_CONNECTION), false)

--- a/sources/packages/backend/package-lock.json
+++ b/sources/packages/backend/package-lock.json
@@ -12,7 +12,7 @@
         "@bull-board/api": "^5.15.1",
         "@bull-board/express": "^5.15.1",
         "@bull-board/ui": "^5.15.1",
-        "@camunda8/sdk": "^8.6.7",
+        "@camunda8/sdk": "^8.6.8",
         "@golevelup/nestjs-discovery": "^4.0.0",
         "@nestjs/axios": "^3.0.2",
         "@nestjs/bull": "^10.1.0",
@@ -977,9 +977,9 @@
       }
     },
     "node_modules/@camunda8/sdk": {
-      "version": "8.6.7",
-      "resolved": "https://registry.npmjs.org/@camunda8/sdk/-/sdk-8.6.7.tgz",
-      "integrity": "sha512-YpMsrBz5SlnagV8kei53WmB7es09ejNoOg3c6Dta+zGnSumClwGjL4IEGKqSjFk0Z4eVNIBIbRYl1i8gXRdvJg==",
+      "version": "8.6.8",
+      "resolved": "https://registry.npmjs.org/@camunda8/sdk/-/sdk-8.6.8.tgz",
+      "integrity": "sha512-b4+ZD+D5T1sSXxI3VpWFdDsYt7oVbh6hl4pZ40kurGJ+VCyN0L+6LT0Zm/c8GuiCxh0F8Z7W/DZh8uBdJ8Ah4Q==",
       "dependencies": {
         "@grpc/grpc-js": "1.10.9",
         "@grpc/proto-loader": "0.7.13",

--- a/sources/packages/backend/package.json
+++ b/sources/packages/backend/package.json
@@ -45,7 +45,7 @@
     "@bull-board/api": "^5.15.1",
     "@bull-board/express": "^5.15.1",
     "@bull-board/ui": "^5.15.1",
-    "@camunda8/sdk": "^8.6.7",
+    "@camunda8/sdk": "^8.6.8",
     "@golevelup/nestjs-discovery": "^4.0.0",
     "@nestjs/axios": "^3.0.2",
     "@nestjs/bull": "^10.1.0",


### PR DESCRIPTION
- Upgraded Camunda SDK to the latest version.
- Upgraded local Camunda versions to the latest available from https://github.com/camunda/camunda-platform/blob/main/.env