### PR TITLE
#3255 - CAS - deploy error fix - 2

### DIFF
--- a/devops/Makefile
+++ b/devops/Makefile
@@ -459,9 +459,6 @@ deploy-queue-consumers:
 		-p ATBC_ENDPOINT=$(ATBC_ENDPOINT) \
 		-p APPLICATION_ARCHIVE_DAYS=$(APPLICATION_ARCHIVE_DAYS) \
 		-p IS_FULLTIME_ALLOWED=$(IS_FULLTIME_ALLOWED) \
-    -p CAS_BASE_URL=$(CAS_BASE_URL) \
-    -p CAS_CLIENT_ID=$(CAS_CLIENT_ID) \
-    -p CAS_CLIENT_SECRET=$(CAS_CLIENT_SECRET) \
 		| oc -n $(NAMESPACE) apply -f -
 	$(call rollout_and_wait,dc/$(QUEUE_CONSUMERS))
 


### PR DESCRIPTION
- Removed params from the command that calls the deploy.