### PR TITLE
#1366 - Set FileOriginType for Student Application Files

### DIFF
--- a/sources/packages/backend/apps/api/src/services/application/application.service.ts
+++ b/sources/packages/backend/apps/api/src/services/application/application.service.ts
@@ -19,6 +19,7 @@ import {
   getUserFullNameLikeSearch,
   transformToApplicationEntitySortField,
   StudentAssessmentStatus,
+  FileOriginType,
 } from "@sims/sims-db";
 import { StudentFileService } from "../student-file/student-file.service";
 import {
@@ -487,6 +488,7 @@ export class ApplicationService extends RecordDataModelService<Application> {
       const fileAssociation = new ApplicationStudentFile();
       fileAssociation.studentFile = {
         id: studentStoredFile.id,
+        fileOrigin: FileOriginType.Application,
       } as StudentFile;
       return fileAssociation;
     });

--- a/sources/packages/backend/libs/sims-db/src/entities/application-student-file.model.ts
+++ b/sources/packages/backend/libs/sims-db/src/entities/application-student-file.model.ts
@@ -27,6 +27,7 @@ export class ApplicationStudentFile extends RecordDataModel {
 
   @ManyToOne(() => StudentFile, {
     eager: false,
+    cascade: ["update"],
   })
   @JoinColumn({
     name: "student_file_id",


### PR DESCRIPTION
As per the analysis, student files are never deleted, only the relationship between an application and its files is deleted while the application is in draft. Once the application is summited the file relations are no longer deleted.
According to the confirmation from @CarlyCotton and @Joshua-Lakusta, there are no concerns about keeping the current behavior since the application only starts to matter when submitted.

### Minor improvement

Student application files were never updated from their `Temporary` status because the status was added later.
This PR is now updating the file origin when an application is saved.
