### PR TITLE
#3297 - Virus Scanning - Ministry User File Interactions

### DIFF
--- a/sources/packages/backend/apps/api/src/constants/error-code.constants.ts
+++ b/sources/packages/backend/apps/api/src/constants/error-code.constants.ts
@@ -181,3 +181,13 @@ export const APPLICATION_WITHDRAWAL_INVALID_TEXT_FILE_ERROR =
  */
 export const APPLICATION_WITHDRAWAL_VALIDATION_ERROR =
   "APPLICATION_WITHDRAWAL_VALIDATION_ERROR";
+
+/**
+ * File has not been scanned yet and cannot be downloaded.
+ */
+export const FILE_HAS_NOT_BEEN_SCANNED_YET = "FILE_HAS_NOT_BEEN_SCANNED_YET";
+
+/**
+ * File has been scanned and a virus was detected.
+ */
+export const VIRUS_DETECTED = "VIRUS_DETECTED";

--- a/sources/packages/backend/apps/api/src/route-controllers/student/_tests_/e2e/student.aest.controller.getUploadedFile.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/student/_tests_/e2e/student.aest.controller.getUploadedFile.e2e-spec.ts
@@ -57,7 +57,7 @@ describe("StudentAESTController(e2e)-getUploadedFile", () => {
       .expect(HttpStatus.FORBIDDEN)
       .expect({
         message:
-          "Warning: This file has not been scanned and will be available to download once it is determined to be safe.",
+          "This file has not been scanned and will be available to download once it is determined to be safe.",
         errorType: FILE_HAS_NOT_BEEN_SCANNED_YET,
       });
   });
@@ -76,7 +76,7 @@ describe("StudentAESTController(e2e)-getUploadedFile", () => {
       .expect(HttpStatus.FORBIDDEN)
       .expect({
         message:
-          "Warning: This file has not been scanned and will be available to download once it is determined to be safe.",
+          "This file has not been scanned and will be available to download once it is determined to be safe.",
         errorType: FILE_HAS_NOT_BEEN_SCANNED_YET,
       });
   });
@@ -95,7 +95,7 @@ describe("StudentAESTController(e2e)-getUploadedFile", () => {
       .expect(HttpStatus.FORBIDDEN)
       .expect({
         message:
-          "Error: The original file was deleted due to security rules. Please re-check file and attempt to upload again.",
+          "The original file was deleted due to security rules. Please re-check file and attempt to upload again.",
         errorType: VIRUS_DETECTED,
       });
   });

--- a/sources/packages/backend/apps/api/src/route-controllers/student/_tests_/e2e/student.aest.controller.getUploadedFile.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/student/_tests_/e2e/student.aest.controller.getUploadedFile.e2e-spec.ts
@@ -1,0 +1,127 @@
+import { HttpStatus, INestApplication } from "@nestjs/common";
+import * as request from "supertest";
+import {
+  AESTGroups,
+  BEARER_AUTH_TYPE,
+  createTestingAppModule,
+  getAESTToken,
+} from "../../../../testHelpers";
+import {
+  E2EDataSources,
+  createE2EDataSources,
+  createFakeStudentFileUpload,
+  saveFakeStudentFileUpload,
+} from "@sims/test-utils";
+import {
+  FILE_HAS_NOT_BEEN_SCANNED_YET,
+  VIRUS_DETECTED,
+} from "../../../../constants";
+import { VirusScanStatus } from "@sims/sims-db/entities/virus-scan-status-type";
+
+describe("StudentAESTController(e2e)-getUploadedFile", () => {
+  let app: INestApplication;
+  let db: E2EDataSources;
+
+  beforeAll(async () => {
+    const { nestApplication, dataSource } = await createTestingAppModule();
+    app = nestApplication;
+    db = createE2EDataSources(dataSource);
+  });
+
+  it("Should throw a HttpStatus Not Found (404) error when a file is not found.", async () => {
+    // Arrange
+    const token = await getAESTToken(AESTGroups.BusinessAdministrators);
+    const endpoint = `/aest/student/files/inexistent_file.txt`;
+    // Act/Assert
+    await request(app.getHttpServer())
+      .get(endpoint)
+      .auth(token, BEARER_AUTH_TYPE)
+      .expect(HttpStatus.NOT_FOUND)
+      .expect({
+        message:
+          "Requested file was not found or the user does not have access to it.",
+        error: "Not Found",
+        statusCode: HttpStatus.NOT_FOUND,
+      });
+  });
+
+  it("Should throw a HttpStatus Forbidden (403) error when a file has not been scanned yet.", async () => {
+    // Arrange
+    const studentFile = await saveFakeStudentFileUpload(db.dataSource);
+    const token = await getAESTToken(AESTGroups.BusinessAdministrators);
+    const endpoint = `/aest/student/files/${studentFile.uniqueFileName}`;
+    // Act/Assert
+    await request(app.getHttpServer())
+      .get(endpoint)
+      .auth(token, BEARER_AUTH_TYPE)
+      .expect(HttpStatus.FORBIDDEN)
+      .expect({
+        message:
+          "Warning: This file has not been scanned and will be available to download once it is determined to be safe.",
+        errorType: FILE_HAS_NOT_BEEN_SCANNED_YET,
+      });
+  });
+
+  it("Should throw a HttpStatus Forbidden (403) error when a file scanning has not finished", async () => {
+    // Arrange
+    const studentFile = createFakeStudentFileUpload();
+    studentFile.virusScanStatus = VirusScanStatus.InProgress;
+    await db.studentFile.save(studentFile);
+    const token = await getAESTToken(AESTGroups.BusinessAdministrators);
+    const endpoint = `/aest/student/files/${studentFile.uniqueFileName}`;
+    // Act/Assert
+    await request(app.getHttpServer())
+      .get(endpoint)
+      .auth(token, BEARER_AUTH_TYPE)
+      .expect(HttpStatus.FORBIDDEN)
+      .expect({
+        message:
+          "Warning: This file has not been scanned and will be available to download once it is determined to be safe.",
+        errorType: FILE_HAS_NOT_BEEN_SCANNED_YET,
+      });
+  });
+
+  it("Should throw a HttpStatus Forbidden (403) error when a file is flagged as infected.", async () => {
+    // Arrange
+    const studentFile = createFakeStudentFileUpload();
+    studentFile.virusScanStatus = VirusScanStatus.VirusDetected;
+    await db.studentFile.save(studentFile);
+    const token = await getAESTToken(AESTGroups.BusinessAdministrators);
+    const endpoint = `/aest/student/files/${studentFile.uniqueFileName}`;
+    // Act/Assert
+    await request(app.getHttpServer())
+      .get(endpoint)
+      .auth(token, BEARER_AUTH_TYPE)
+      .expect(HttpStatus.FORBIDDEN)
+      .expect({
+        message: `Due to our security rules, the original file, ${studentFile.fileName}, was deleted. Please re-check your file and attempt to re-upload.`,
+        errorType: VIRUS_DETECTED,
+      });
+  });
+
+  it("Should download the file when a file is flagged as clean.", async () => {
+    // Arrange
+    const studentFile = createFakeStudentFileUpload();
+    studentFile.virusScanStatus = VirusScanStatus.FileIsClean;
+    studentFile.fileName = "test.jpeg";
+    studentFile.mimeType = "image/jpeg";
+    await db.studentFile.save(studentFile);
+    const token = await getAESTToken(AESTGroups.BusinessAdministrators);
+    const endpoint = `/aest/student/files/${studentFile.uniqueFileName}`;
+    // Act/Assert
+    await request(app.getHttpServer())
+      .get(endpoint)
+      .auth(token, BEARER_AUTH_TYPE)
+      .expect(HttpStatus.OK)
+      .then((response) => {
+        expect(response.headers["content-disposition"]).toBe(
+          `attachment; filename=${studentFile.fileName}`,
+        );
+        expect(response.body).toStrictEqual(studentFile.fileContent);
+      });
+  });
+
+  afterAll(async () => {
+    await app?.close();
+  });
+});

--- a/sources/packages/backend/apps/api/src/route-controllers/student/_tests_/e2e/student.aest.controller.getUploadedFile.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/student/_tests_/e2e/student.aest.controller.getUploadedFile.e2e-spec.ts
@@ -16,7 +16,7 @@ import {
   FILE_HAS_NOT_BEEN_SCANNED_YET,
   VIRUS_DETECTED,
 } from "../../../../constants";
-import { VirusScanStatus } from "@sims/sims-db/entities/virus-scan-status-type";
+import { VirusScanStatus } from "@sims/sims-db";
 
 describe("StudentAESTController(e2e)-getUploadedFile", () => {
   let app: INestApplication;
@@ -94,7 +94,8 @@ describe("StudentAESTController(e2e)-getUploadedFile", () => {
       .auth(token, BEARER_AUTH_TYPE)
       .expect(HttpStatus.FORBIDDEN)
       .expect({
-        message: `Due to our security rules, the original file, ${studentFile.fileName}, was deleted. Please re-check your file and attempt to re-upload.`,
+        message:
+          "Error: The original file was deleted due to security rules. Please re-check file and attempt to upload again.",
         errorType: VIRUS_DETECTED,
       });
   });

--- a/sources/packages/backend/apps/api/src/route-controllers/student/_tests_/e2e/student.aest.controller.searchStudents.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/student/_tests_/e2e/student.aest.controller.searchStudents.e2e-spec.ts
@@ -8,7 +8,7 @@ import {
   BEARER_AUTH_TYPE,
   AESTGroups,
   getAESTToken,
-} from "../../testHelpers";
+} from "../../../../testHelpers";
 
 describe("StudentMinistryController(e2e)-searchStudents", () => {
   let app: INestApplication;

--- a/sources/packages/backend/apps/api/src/route-controllers/student/_tests_/e2e/student.students.controller.getUploadedFile.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/student/_tests_/e2e/student.students.controller.getUploadedFile.e2e-spec.ts
@@ -34,7 +34,7 @@ describe("StudentStudentsController(e2e)-getUploadedFile", () => {
     appModule = module;
   });
 
-  it("Should throw a HttpStatus Not Found (404) error when a file does not become to the student.", async () => {
+  it("Should throw a HttpStatus Not Found (404) error when a file does not belong to the student.", async () => {
     // Arrange
     const student = await saveFakeStudent(db.dataSource);
 
@@ -84,7 +84,7 @@ describe("StudentStudentsController(e2e)-getUploadedFile", () => {
       .expect(HttpStatus.FORBIDDEN)
       .expect({
         message:
-          "Warning: This file has not been scanned and will be available to download once it is determined to be safe.",
+          "This file has not been scanned and will be available to download once it is determined to be safe.",
         errorType: FILE_HAS_NOT_BEEN_SCANNED_YET,
       });
   });
@@ -111,7 +111,7 @@ describe("StudentStudentsController(e2e)-getUploadedFile", () => {
       .expect(HttpStatus.FORBIDDEN)
       .expect({
         message:
-          "Warning: This file has not been scanned and will be available to download once it is determined to be safe.",
+          "This file has not been scanned and will be available to download once it is determined to be safe.",
         errorType: FILE_HAS_NOT_BEEN_SCANNED_YET,
       });
   });
@@ -138,7 +138,7 @@ describe("StudentStudentsController(e2e)-getUploadedFile", () => {
       .expect(HttpStatus.FORBIDDEN)
       .expect({
         message:
-          "Error: The original file was deleted due to security rules. Please re-check file and attempt to upload again.",
+          "The original file was deleted due to security rules. Please re-check file and attempt to upload again.",
         errorType: VIRUS_DETECTED,
       });
   });

--- a/sources/packages/backend/apps/api/src/route-controllers/student/_tests_/e2e/student.students.controller.getUploadedFile.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/student/_tests_/e2e/student.students.controller.getUploadedFile.e2e-spec.ts
@@ -1,0 +1,178 @@
+import { HttpStatus, INestApplication } from "@nestjs/common";
+import * as request from "supertest";
+import {
+  BEARER_AUTH_TYPE,
+  createTestingAppModule,
+  FakeStudentUsersTypes,
+  getStudentToken,
+  mockUserLoginInfo,
+} from "../../../../testHelpers";
+import {
+  E2EDataSources,
+  createE2EDataSources,
+  createFakeStudentFileUpload,
+  saveFakeStudent,
+  saveFakeStudentFileUpload,
+} from "@sims/test-utils";
+import {
+  FILE_HAS_NOT_BEEN_SCANNED_YET,
+  VIRUS_DETECTED,
+} from "../../../../constants";
+import { VirusScanStatus } from "@sims/sims-db/entities/virus-scan-status-type";
+import { TestingModule } from "@nestjs/testing";
+
+describe("StudentStudentsController(e2e)-getUploadedFile", () => {
+  let app: INestApplication;
+  let db: E2EDataSources;
+  let appModule: TestingModule;
+
+  beforeAll(async () => {
+    const { nestApplication, dataSource, module } =
+      await createTestingAppModule();
+    app = nestApplication;
+    db = createE2EDataSources(dataSource);
+    appModule = module;
+  });
+
+  it("Should throw a HttpStatus Not Found (404) error when a file does not become to the student.", async () => {
+    // Arrange
+    const student = await saveFakeStudent(db.dataSource);
+
+    // Mock user service to return the saved student.
+    await mockUserLoginInfo(appModule, student);
+
+    // Get any student user token.
+    const studentToken = await getStudentToken(
+      FakeStudentUsersTypes.FakeStudentUserType1,
+    );
+    // Student is not the owner of this file.
+    const studentFile = await saveFakeStudentFileUpload(db.dataSource);
+
+    const endpoint = `/students/student/files/${studentFile.uniqueFileName}`;
+    // Act/Assert
+    await request(app.getHttpServer())
+      .get(endpoint)
+      .auth(studentToken, BEARER_AUTH_TYPE)
+      .expect(HttpStatus.NOT_FOUND)
+      .expect({
+        message:
+          "Requested file was not found or the user does not have access to it.",
+        error: "Not Found",
+        statusCode: HttpStatus.NOT_FOUND,
+      });
+  });
+
+  it("Should throw a HttpStatus Forbidden (403) error when a file has not been scanned yet.", async () => {
+    // Arrange
+    const student = await saveFakeStudent(db.dataSource);
+
+    // Mock user service to return the saved student.
+    await mockUserLoginInfo(appModule, student);
+
+    // Get any student user token.
+    const studentToken = await getStudentToken(
+      FakeStudentUsersTypes.FakeStudentUserType1,
+    );
+    const studentFile = await saveFakeStudentFileUpload(db.dataSource, {
+      student,
+    });
+    const endpoint = `/students/student/files/${studentFile.uniqueFileName}`;
+    // Act/Assert
+    await request(app.getHttpServer())
+      .get(endpoint)
+      .auth(studentToken, BEARER_AUTH_TYPE)
+      .expect(HttpStatus.FORBIDDEN)
+      .expect({
+        message:
+          "Warning: This file has not been scanned and will be available to download once it is determined to be safe.",
+        errorType: FILE_HAS_NOT_BEEN_SCANNED_YET,
+      });
+  });
+
+  it("Should throw a HttpStatus Forbidden (403) error when a file scanning has not finished.", async () => {
+    // Arrange
+    const student = await saveFakeStudent(db.dataSource);
+
+    // Mock user service to return the saved student.
+    await mockUserLoginInfo(appModule, student);
+
+    // Get any student user token.
+    const studentToken = await getStudentToken(
+      FakeStudentUsersTypes.FakeStudentUserType1,
+    );
+    const studentFile = createFakeStudentFileUpload({ student });
+    studentFile.virusScanStatus = VirusScanStatus.InProgress;
+    await db.studentFile.save(studentFile);
+    const endpoint = `/students/student/files/${studentFile.uniqueFileName}`;
+    // Act/Assert
+    await request(app.getHttpServer())
+      .get(endpoint)
+      .auth(studentToken, BEARER_AUTH_TYPE)
+      .expect(HttpStatus.FORBIDDEN)
+      .expect({
+        message:
+          "Warning: This file has not been scanned and will be available to download once it is determined to be safe.",
+        errorType: FILE_HAS_NOT_BEEN_SCANNED_YET,
+      });
+  });
+
+  it("Should throw a HttpStatus Forbidden (403) error when a file is flagged as infected.", async () => {
+    // Arrange
+    const student = await saveFakeStudent(db.dataSource);
+
+    // Mock user service to return the saved student.
+    await mockUserLoginInfo(appModule, student);
+
+    // Get any student user token.
+    const studentToken = await getStudentToken(
+      FakeStudentUsersTypes.FakeStudentUserType1,
+    );
+    const studentFile = createFakeStudentFileUpload({ student });
+    studentFile.virusScanStatus = VirusScanStatus.VirusDetected;
+    await db.studentFile.save(studentFile);
+    const endpoint = `/students/student/files/${studentFile.uniqueFileName}`;
+    // Act/Assert
+    await request(app.getHttpServer())
+      .get(endpoint)
+      .auth(studentToken, BEARER_AUTH_TYPE)
+      .expect(HttpStatus.FORBIDDEN)
+      .expect({
+        message: `Due to our security rules, the original file, ${studentFile.fileName}, was deleted. Please re-check your file and attempt to re-upload.`,
+        errorType: VIRUS_DETECTED,
+      });
+  });
+
+  it("Should download the file when a file is flagged as clean.", async () => {
+    // Arrange
+    const student = await saveFakeStudent(db.dataSource);
+
+    // Mock user service to return the saved student.
+    await mockUserLoginInfo(appModule, student);
+
+    // Get any student user token.
+    const studentToken = await getStudentToken(
+      FakeStudentUsersTypes.FakeStudentUserType1,
+    );
+    const studentFile = createFakeStudentFileUpload({ student });
+    studentFile.virusScanStatus = VirusScanStatus.FileIsClean;
+    studentFile.fileName = "test.jpeg";
+    studentFile.mimeType = "image/jpeg";
+    await db.studentFile.save(studentFile);
+    const endpoint = `/students/student/files/${studentFile.uniqueFileName}`;
+    // Act/Assert
+    await request(app.getHttpServer())
+      .get(endpoint)
+      .auth(studentToken, BEARER_AUTH_TYPE)
+      .expect(HttpStatus.OK)
+      .then((response) => {
+        expect(response.headers["content-disposition"]).toBe(
+          `attachment; filename=${studentFile.fileName}`,
+        );
+        expect(response.body).toStrictEqual(studentFile.fileContent);
+      });
+  });
+
+  afterAll(async () => {
+    await app?.close();
+  });
+});

--- a/sources/packages/backend/apps/api/src/route-controllers/student/_tests_/e2e/student.students.controller.getUploadedFile.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/student/_tests_/e2e/student.students.controller.getUploadedFile.e2e-spec.ts
@@ -18,7 +18,7 @@ import {
   FILE_HAS_NOT_BEEN_SCANNED_YET,
   VIRUS_DETECTED,
 } from "../../../../constants";
-import { VirusScanStatus } from "@sims/sims-db/entities/virus-scan-status-type";
+import { VirusScanStatus } from "@sims/sims-db";
 import { TestingModule } from "@nestjs/testing";
 
 describe("StudentStudentsController(e2e)-getUploadedFile", () => {
@@ -137,7 +137,8 @@ describe("StudentStudentsController(e2e)-getUploadedFile", () => {
       .auth(studentToken, BEARER_AUTH_TYPE)
       .expect(HttpStatus.FORBIDDEN)
       .expect({
-        message: `Due to our security rules, the original file, ${studentFile.fileName}, was deleted. Please re-check your file and attempt to re-upload.`,
+        message:
+          "Error: The original file was deleted due to security rules. Please re-check file and attempt to upload again.",
         errorType: VIRUS_DETECTED,
       });
   });

--- a/sources/packages/backend/apps/api/src/route-controllers/student/student.aest.controller.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/student/student.aest.controller.ts
@@ -123,8 +123,8 @@ export class StudentAESTController extends BaseController {
   })
   @ApiForbiddenResponse({
     description:
-      "Warning: This file has not been scanned and will be available to download once it is determined to be safe or " +
-      "Due to our security rules, the original file, [fileName], was deleted. Please re-check your file and attempt to re-upload.",
+      "This file has not been scanned and will be available to download once it is determined to be safe or " +
+      "the original file was deleted due to security rules.",
   })
   async getUploadedFile(
     @Param() uniqueFileNameParam: UniqueFileNameParamAPIInDTO,

--- a/sources/packages/backend/apps/api/src/route-controllers/student/student.aest.controller.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/student/student.aest.controller.ts
@@ -16,6 +16,7 @@ import {
   UseInterceptors,
 } from "@nestjs/common";
 import {
+  ApiForbiddenResponse,
   ApiNotFoundResponse,
   ApiTags,
   ApiUnprocessableEntityResponse,
@@ -116,7 +117,15 @@ export class StudentAESTController extends BaseController {
    * @param response file content.
    */
   @Get("files/:uniqueFileName")
-  @ApiNotFoundResponse({ description: "Requested file was not found." })
+  @ApiNotFoundResponse({
+    description:
+      "Requested file was not found or the user does not have access to it.",
+  })
+  @ApiForbiddenResponse({
+    description:
+      "Warning: This file has not been scanned and will be available to download once it is determined to be safe or " +
+      "Due to our security rules, the original file, [fileName], was deleted. Please re-check your file and attempt to re-upload.",
+  })
   async getUploadedFile(
     @Param() uniqueFileNameParam: UniqueFileNameParamAPIInDTO,
     @Res() response: Response,

--- a/sources/packages/backend/apps/api/src/route-controllers/student/student.controller.service.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/student/student.controller.service.ts
@@ -17,7 +17,12 @@ import {
 } from "../models/pagination.dto";
 import { getUserFullName } from "../../utilities";
 import { getISODateOnlyString } from "@sims/utilities";
-import { AddressInfo, Application, Student } from "@sims/sims-db";
+import {
+  AddressInfo,
+  Application,
+  Student,
+  VirusScanStatus,
+} from "@sims/sims-db";
 import {
   ApplicationSummaryAPIOutDTO,
   SearchStudentAPIOutDTO,
@@ -27,7 +32,6 @@ import {
   InstitutionStudentProfileAPIOutDTO,
 } from "./models/student.dto";
 import { transformAddressDetailsForAddressBlockForm } from "../utils/address-utils";
-import { VirusScanStatus } from "@sims/sims-db";
 import { ApiProcessError } from "../../types";
 import { FILE_HAS_NOT_BEEN_SCANNED_YET, VIRUS_DETECTED } from "../../constants";
 

--- a/sources/packages/backend/apps/api/src/route-controllers/student/student.controller.service.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/student/student.controller.service.ts
@@ -108,7 +108,7 @@ export class StudentControllerService {
     if (studentFile.virusScanStatus === VirusScanStatus.VirusDetected) {
       throw new ForbiddenException(
         new ApiProcessError(
-          "Error: The original file was deleted due to security rules. Please re-check file and attempt to upload again.",
+          "The original file was deleted due to security rules. Please re-check file and attempt to upload again.",
           VIRUS_DETECTED,
         ),
       );
@@ -119,7 +119,7 @@ export class StudentControllerService {
     ) {
       throw new ForbiddenException(
         new ApiProcessError(
-          "Warning: This file has not been scanned and will be available to download once it is determined to be safe.",
+          "This file has not been scanned and will be available to download once it is determined to be safe.",
           FILE_HAS_NOT_BEEN_SCANNED_YET,
         ),
       );

--- a/sources/packages/backend/apps/api/src/route-controllers/student/student.controller.service.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/student/student.controller.service.ts
@@ -27,7 +27,7 @@ import {
   InstitutionStudentProfileAPIOutDTO,
 } from "./models/student.dto";
 import { transformAddressDetailsForAddressBlockForm } from "../utils/address-utils";
-import { VirusScanStatus } from "@sims/sims-db/entities/virus-scan-status-type";
+import { VirusScanStatus } from "@sims/sims-db";
 import { ApiProcessError } from "../../types";
 import { FILE_HAS_NOT_BEEN_SCANNED_YET, VIRUS_DETECTED } from "../../constants";
 

--- a/sources/packages/backend/apps/api/src/route-controllers/student/student.controller.service.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/student/student.controller.service.ts
@@ -104,7 +104,7 @@ export class StudentControllerService {
     if (studentFile.virusScanStatus === VirusScanStatus.VirusDetected) {
       throw new ForbiddenException(
         new ApiProcessError(
-          `Due to our security rules, the original file, ${studentFile.fileName}, was deleted. Please re-check your file and attempt to re-upload.`,
+          "Error: The original file was deleted due to security rules. Please re-check file and attempt to upload again.",
           VIRUS_DETECTED,
         ),
       );

--- a/sources/packages/backend/apps/api/src/route-controllers/student/student.students.controller.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/student/student.students.controller.ts
@@ -205,7 +205,6 @@ export class StudentStudentsController extends BaseController {
     @Param() uniqueFileNameParam: UniqueFileNameParamAPIInDTO,
     @Res() response: Response,
   ): Promise<void> {
-    console.log("test");
     await this.studentControllerService.writeFileToResponse(
       response,
       uniqueFileNameParam.uniqueFileName,

--- a/sources/packages/backend/apps/api/src/route-controllers/student/student.students.controller.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/student/student.students.controller.ts
@@ -197,8 +197,8 @@ export class StudentStudentsController extends BaseController {
   })
   @ApiForbiddenResponse({
     description:
-      "Warning: This file has not been scanned and will be available to download once it is determined to be safe or " +
-      "Error: The original file was deleted due to security rules. Please re-check file and attempt to upload again.",
+      "This file has not been scanned and will be available to download once it is determined to be safe or " +
+      "the original file was deleted due to security rules.",
   })
   async getUploadedFile(
     @UserToken() studentUserToken: StudentUserToken,

--- a/sources/packages/backend/apps/api/src/route-controllers/student/student.students.controller.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/student/student.students.controller.ts
@@ -195,11 +195,17 @@ export class StudentStudentsController extends BaseController {
     description:
       "Requested file was not found or the user does not have access to it.",
   })
+  @ApiForbiddenResponse({
+    description:
+      "Warning: This file has not been scanned and will be available to download once it is determined to be safe or " +
+      "Due to our security rules, the original file, [fileName], was deleted. Please re-check your file and attempt to re-upload.",
+  })
   async getUploadedFile(
     @UserToken() studentUserToken: StudentUserToken,
     @Param() uniqueFileNameParam: UniqueFileNameParamAPIInDTO,
     @Res() response: Response,
   ): Promise<void> {
+    console.log("test");
     await this.studentControllerService.writeFileToResponse(
       response,
       uniqueFileNameParam.uniqueFileName,

--- a/sources/packages/backend/apps/api/src/route-controllers/student/student.students.controller.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/student/student.students.controller.ts
@@ -198,7 +198,7 @@ export class StudentStudentsController extends BaseController {
   @ApiForbiddenResponse({
     description:
       "Warning: This file has not been scanned and will be available to download once it is determined to be safe or " +
-      "Due to our security rules, the original file, [fileName], was deleted. Please re-check your file and attempt to re-upload.",
+      "Error: The original file was deleted due to security rules. Please re-check file and attempt to upload again.",
   })
   async getUploadedFile(
     @UserToken() studentUserToken: StudentUserToken,

--- a/sources/packages/backend/apps/api/src/services/student-file/student-file.service.ts
+++ b/sources/packages/backend/apps/api/src/services/student-file/student-file.service.ts
@@ -10,8 +10,8 @@ import {
   StudentFile,
   Student,
   User,
-  FileOriginType,
   VirusScanStatus,
+  FileOriginType,
 } from "@sims/sims-db";
 import { CreateFile, FileUploadOptions } from "./student-file.model";
 import { InjectQueue } from "@nestjs/bull";

--- a/sources/packages/backend/apps/api/src/services/student-file/student-file.service.ts
+++ b/sources/packages/backend/apps/api/src/services/student-file/student-file.service.ts
@@ -11,13 +11,13 @@ import {
   Student,
   User,
   FileOriginType,
+  VirusScanStatus,
 } from "@sims/sims-db";
 import { CreateFile, FileUploadOptions } from "./student-file.model";
 import { InjectQueue } from "@nestjs/bull";
 import { QueueNames } from "@sims/utilities";
 import { Queue } from "bull";
 import { VirusScanQueueInDTO } from "@sims/services/queue";
-import { VirusScanStatus } from "@sims/sims-db";
 
 @Injectable()
 export class StudentFileService extends RecordDataModelService<StudentFile> {

--- a/sources/packages/backend/apps/api/src/services/student-file/student-file.service.ts
+++ b/sources/packages/backend/apps/api/src/services/student-file/student-file.service.ts
@@ -121,7 +121,10 @@ export class StudentFileService extends RecordDataModelService<StudentFile> {
     const studentFile = await query.getOne();
 
     // Block users to download file contents that are not scanned or infected.
-    if (studentFile.virusScanStatus !== VirusScanStatus.FileIsClean) {
+    if (
+      studentFile &&
+      studentFile.virusScanStatus !== VirusScanStatus.FileIsClean
+    ) {
       studentFile.fileContent = null;
     }
     return studentFile;

--- a/sources/packages/backend/apps/api/src/services/student-file/student-file.service.ts
+++ b/sources/packages/backend/apps/api/src/services/student-file/student-file.service.ts
@@ -16,8 +16,8 @@ import { CreateFile, FileUploadOptions } from "./student-file.model";
 import { InjectQueue } from "@nestjs/bull";
 import { QueueNames } from "@sims/utilities";
 import { Queue } from "bull";
-import { VirusScanQueueInDTO } from "@sims/services/queue/dto/virus-scan.dto";
-import { VirusScanStatus } from "@sims/sims-db/entities/virus-scan-status-type";
+import { VirusScanQueueInDTO } from "@sims/services/queue";
+import { VirusScanStatus } from "@sims/sims-db";
 
 @Injectable()
 export class StudentFileService extends RecordDataModelService<StudentFile> {

--- a/sources/packages/backend/apps/api/src/services/student-file/student-file.service.ts
+++ b/sources/packages/backend/apps/api/src/services/student-file/student-file.service.ts
@@ -109,6 +109,7 @@ export class StudentFileService extends RecordDataModelService<StudentFile> {
         "studentFile.fileName",
         "studentFile.mimeType",
         "studentFile.fileContent",
+        "studentFile.virusScanStatus",
       ])
       .where("studentFile.uniqueFileName = :uniqueFileName", {
         uniqueFileName,
@@ -117,8 +118,13 @@ export class StudentFileService extends RecordDataModelService<StudentFile> {
     if (studentId) {
       query.andWhere("studentFile.student.id = :studentId", { studentId });
     }
+    const studentFile = await query.getOne();
 
-    return query.getOne();
+    // Block users to download file contents that are not scanned or infected.
+    if (studentFile.virusScanStatus !== VirusScanStatus.FileIsClean) {
+      studentFile.fileContent = null;
+    }
+    return studentFile;
   }
 
   /**

--- a/sources/packages/backend/apps/queue-consumers/src/processors/virus-scan/_tests_/virus-scan.processor.e2e-spec.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/processors/virus-scan/_tests_/virus-scan.processor.e2e-spec.ts
@@ -74,9 +74,8 @@ describe(describeProcessorRootTest(QueueNames.FileVirusScanProcessor), () => {
     expect(scannedStudentFile.virusScanStatus).toBe(
       VirusScanStatus.VirusDetected,
     );
-    const fileName = path.parse(studentFile.fileName).name;
-    const fileExtension = path.parse(studentFile.fileName).ext;
-    const infectedFileName = `${fileName}${INFECTED_FILENAME_SUFFIX}${fileExtension}`;
+    const fileInfo = path.parse(studentFile.fileName);
+    const infectedFileName = `${fileInfo.name}${INFECTED_FILENAME_SUFFIX}${fileInfo.ext}`;
     expect(scannedStudentFile.fileName).toBe(infectedFileName);
   });
 

--- a/sources/packages/backend/apps/queue-consumers/src/processors/virus-scan/_tests_/virus-scan.processor.e2e-spec.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/processors/virus-scan/_tests_/virus-scan.processor.e2e-spec.ts
@@ -64,7 +64,6 @@ describe(describeProcessorRootTest(QueueNames.FileVirusScanProcessor), () => {
         "Log details",
         "Starting virus scan.",
         "Virus found.",
-        "Updating infected file name and status.",
         "Completed virus scanning for the file.",
       ]),
     ).toBe(true);

--- a/sources/packages/backend/apps/queue-consumers/src/processors/virus-scan/_tests_/virus-scan.processor.e2e-spec.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/processors/virus-scan/_tests_/virus-scan.processor.e2e-spec.ts
@@ -1,0 +1,123 @@
+import { INestApplication } from "@nestjs/common";
+import { QueueNames } from "@sims/utilities";
+import {
+  createTestingAppModule,
+  describeProcessorRootTest,
+  mockBullJob,
+} from "../../../../test/helpers";
+import {
+  createE2EDataSources,
+  createFakeStudentFileUpload,
+  E2EDataSources,
+} from "@sims/test-utils";
+import { ClamAVService } from "@sims/services";
+import { VirusScanQueueInDTO } from "@sims/services/queue/dto/virus-scan.dto";
+import { VirusScanProcessor } from "../virus-scan.processor";
+import { VirusScanStatus } from "@sims/sims-db/entities/virus-scan-status-type";
+import * as path from "path";
+import { INFECTED_FILENAME_SUFFIX } from "../../../services";
+
+describe(
+  describeProcessorRootTest(QueueNames.CancelApplicationAssessment),
+  () => {
+    let app: INestApplication;
+    let db: E2EDataSources;
+    let processor: VirusScanProcessor;
+    let clamAVServiceMock: ClamAVService;
+
+    beforeAll(async () => {
+      const {
+        nestApplication,
+        dataSource,
+        clamAVServiceMock: clamAVServiceFromAppModule,
+      } = await createTestingAppModule();
+      app = nestApplication;
+      // Processor under test.
+      processor = app.get(VirusScanProcessor);
+      clamAVServiceMock = clamAVServiceFromAppModule;
+      db = createE2EDataSources(dataSource);
+    });
+
+    beforeEach(() => {
+      jest.resetAllMocks();
+    });
+
+    it("Should update the file name and status when virus is detected.", async () => {
+      // Arrange
+      const studentFile = createFakeStudentFileUpload();
+      studentFile.virusScanStatus = VirusScanStatus.InProgress;
+      await db.studentFile.save(studentFile);
+      clamAVServiceMock.scanFile = jest.fn(() => Promise.resolve(true));
+      // Queued job.
+      const mockedJob = mockBullJob<VirusScanQueueInDTO>({
+        uniqueFileName: studentFile.uniqueFileName,
+        fileName: studentFile.fileName,
+      });
+
+      // Act
+      const result = await processor.performVirusScan(mockedJob.job);
+
+      expect(result).toStrictEqual({
+        fileProcessed: studentFile.fileName,
+        isInfected: true,
+      });
+      expect(
+        mockedJob.containLogMessages([
+          "Log details",
+          "Starting virus scan.",
+          "Virus found.",
+          "Updating infected file name and status.",
+          "Completed virus scanning for the file.",
+        ]),
+      ).toBe(true);
+      // Assert
+      const scannedStudentFile = await db.studentFile.findOneBy({
+        id: studentFile.id,
+      });
+      expect(scannedStudentFile.virusScanStatus).toBe(
+        VirusScanStatus.VirusDetected,
+      );
+      const fileName = path.parse(studentFile.fileName).name;
+      const fileExtension = path.parse(studentFile.fileName).ext;
+      const infectedFileName = `${fileName}${INFECTED_FILENAME_SUFFIX}${fileExtension}`;
+      expect(scannedStudentFile.fileName).toBe(infectedFileName);
+    });
+
+    it("Should update the file status when no virus is detected.", async () => {
+      // Arrange
+      const studentFile = createFakeStudentFileUpload();
+      studentFile.virusScanStatus = VirusScanStatus.InProgress;
+      await db.studentFile.save(studentFile);
+      clamAVServiceMock.scanFile = jest.fn(() => Promise.resolve(false));
+      // Queued job.
+      const mockedJob = mockBullJob<VirusScanQueueInDTO>({
+        uniqueFileName: studentFile.uniqueFileName,
+        fileName: studentFile.fileName,
+      });
+
+      // Act
+      const result = await processor.performVirusScan(mockedJob.job);
+
+      expect(result).toStrictEqual({
+        fileProcessed: studentFile.fileName,
+        isInfected: false,
+      });
+      expect(
+        mockedJob.containLogMessages([
+          "Log details",
+          "Starting virus scan.",
+          "No virus found.",
+          "Completed virus scanning for the file.",
+        ]),
+      ).toBe(true);
+      // Assert
+      const scannedStudentFile = await db.studentFile.findOneBy({
+        id: studentFile.id,
+      });
+      expect(scannedStudentFile.virusScanStatus).toBe(
+        VirusScanStatus.FileIsClean,
+      );
+      expect(scannedStudentFile.fileName).toBe(studentFile.fileName);
+    });
+  },
+);

--- a/sources/packages/backend/apps/queue-consumers/src/processors/virus-scan/_tests_/virus-scan.processor.e2e-spec.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/processors/virus-scan/_tests_/virus-scan.processor.e2e-spec.ts
@@ -11,7 +11,7 @@ import {
   E2EDataSources,
 } from "@sims/test-utils";
 import { ClamAVService } from "@sims/services";
-import { VirusScanQueueInDTO } from "@sims/services/queue/dto/virus-scan.dto";
+import { VirusScanQueueInDTO } from "@sims/services/queue";
 import { VirusScanProcessor } from "../virus-scan.processor";
 import { VirusScanStatus } from "@sims/sims-db";
 import * as path from "path";

--- a/sources/packages/backend/apps/queue-consumers/src/processors/virus-scan/_tests_/virus-scan.processor.e2e-spec.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/processors/virus-scan/_tests_/virus-scan.processor.e2e-spec.ts
@@ -17,107 +17,104 @@ import { VirusScanStatus } from "@sims/sims-db/entities/virus-scan-status-type";
 import * as path from "path";
 import { INFECTED_FILENAME_SUFFIX } from "../../../services";
 
-describe(
-  describeProcessorRootTest(QueueNames.CancelApplicationAssessment),
-  () => {
-    let app: INestApplication;
-    let db: E2EDataSources;
-    let processor: VirusScanProcessor;
-    let clamAVServiceMock: ClamAVService;
+describe(describeProcessorRootTest(QueueNames.FileVirusScanProcessor), () => {
+  let app: INestApplication;
+  let db: E2EDataSources;
+  let processor: VirusScanProcessor;
+  let clamAVServiceMock: ClamAVService;
 
-    beforeAll(async () => {
-      const {
-        nestApplication,
-        dataSource,
-        clamAVServiceMock: clamAVServiceFromAppModule,
-      } = await createTestingAppModule();
-      app = nestApplication;
-      // Processor under test.
-      processor = app.get(VirusScanProcessor);
-      clamAVServiceMock = clamAVServiceFromAppModule;
-      db = createE2EDataSources(dataSource);
+  beforeAll(async () => {
+    const {
+      nestApplication,
+      dataSource,
+      clamAVServiceMock: clamAVServiceFromAppModule,
+    } = await createTestingAppModule();
+    app = nestApplication;
+    // Processor under test.
+    processor = app.get(VirusScanProcessor);
+    clamAVServiceMock = clamAVServiceFromAppModule;
+    db = createE2EDataSources(dataSource);
+  });
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it("Should update the file name and status when virus is detected.", async () => {
+    // Arrange
+    const studentFile = createFakeStudentFileUpload();
+    studentFile.virusScanStatus = VirusScanStatus.InProgress;
+    await db.studentFile.save(studentFile);
+    clamAVServiceMock.scanFile = jest.fn(() => Promise.resolve(true));
+    // Queued job.
+    const mockedJob = mockBullJob<VirusScanQueueInDTO>({
+      uniqueFileName: studentFile.uniqueFileName,
+      fileName: studentFile.fileName,
     });
 
-    beforeEach(() => {
-      jest.resetAllMocks();
+    // Act
+    const result = await processor.performVirusScan(mockedJob.job);
+
+    expect(result).toStrictEqual({
+      fileProcessed: studentFile.fileName,
+      isInfected: true,
+    });
+    expect(
+      mockedJob.containLogMessages([
+        "Log details",
+        "Starting virus scan.",
+        "Virus found.",
+        "Updating infected file name and status.",
+        "Completed virus scanning for the file.",
+      ]),
+    ).toBe(true);
+    // Assert
+    const scannedStudentFile = await db.studentFile.findOneBy({
+      id: studentFile.id,
+    });
+    expect(scannedStudentFile.virusScanStatus).toBe(
+      VirusScanStatus.VirusDetected,
+    );
+    const fileName = path.parse(studentFile.fileName).name;
+    const fileExtension = path.parse(studentFile.fileName).ext;
+    const infectedFileName = `${fileName}${INFECTED_FILENAME_SUFFIX}${fileExtension}`;
+    expect(scannedStudentFile.fileName).toBe(infectedFileName);
+  });
+
+  it("Should update the file status when no virus is detected.", async () => {
+    // Arrange
+    const studentFile = createFakeStudentFileUpload();
+    studentFile.virusScanStatus = VirusScanStatus.InProgress;
+    await db.studentFile.save(studentFile);
+    clamAVServiceMock.scanFile = jest.fn(() => Promise.resolve(false));
+    // Queued job.
+    const mockedJob = mockBullJob<VirusScanQueueInDTO>({
+      uniqueFileName: studentFile.uniqueFileName,
+      fileName: studentFile.fileName,
     });
 
-    it("Should update the file name and status when virus is detected.", async () => {
-      // Arrange
-      const studentFile = createFakeStudentFileUpload();
-      studentFile.virusScanStatus = VirusScanStatus.InProgress;
-      await db.studentFile.save(studentFile);
-      clamAVServiceMock.scanFile = jest.fn(() => Promise.resolve(true));
-      // Queued job.
-      const mockedJob = mockBullJob<VirusScanQueueInDTO>({
-        uniqueFileName: studentFile.uniqueFileName,
-        fileName: studentFile.fileName,
-      });
+    // Act
+    const result = await processor.performVirusScan(mockedJob.job);
 
-      // Act
-      const result = await processor.performVirusScan(mockedJob.job);
-
-      expect(result).toStrictEqual({
-        fileProcessed: studentFile.fileName,
-        isInfected: true,
-      });
-      expect(
-        mockedJob.containLogMessages([
-          "Log details",
-          "Starting virus scan.",
-          "Virus found.",
-          "Updating infected file name and status.",
-          "Completed virus scanning for the file.",
-        ]),
-      ).toBe(true);
-      // Assert
-      const scannedStudentFile = await db.studentFile.findOneBy({
-        id: studentFile.id,
-      });
-      expect(scannedStudentFile.virusScanStatus).toBe(
-        VirusScanStatus.VirusDetected,
-      );
-      const fileName = path.parse(studentFile.fileName).name;
-      const fileExtension = path.parse(studentFile.fileName).ext;
-      const infectedFileName = `${fileName}${INFECTED_FILENAME_SUFFIX}${fileExtension}`;
-      expect(scannedStudentFile.fileName).toBe(infectedFileName);
+    expect(result).toStrictEqual({
+      fileProcessed: studentFile.fileName,
+      isInfected: false,
     });
-
-    it("Should update the file status when no virus is detected.", async () => {
-      // Arrange
-      const studentFile = createFakeStudentFileUpload();
-      studentFile.virusScanStatus = VirusScanStatus.InProgress;
-      await db.studentFile.save(studentFile);
-      clamAVServiceMock.scanFile = jest.fn(() => Promise.resolve(false));
-      // Queued job.
-      const mockedJob = mockBullJob<VirusScanQueueInDTO>({
-        uniqueFileName: studentFile.uniqueFileName,
-        fileName: studentFile.fileName,
-      });
-
-      // Act
-      const result = await processor.performVirusScan(mockedJob.job);
-
-      expect(result).toStrictEqual({
-        fileProcessed: studentFile.fileName,
-        isInfected: false,
-      });
-      expect(
-        mockedJob.containLogMessages([
-          "Log details",
-          "Starting virus scan.",
-          "No virus found.",
-          "Completed virus scanning for the file.",
-        ]),
-      ).toBe(true);
-      // Assert
-      const scannedStudentFile = await db.studentFile.findOneBy({
-        id: studentFile.id,
-      });
-      expect(scannedStudentFile.virusScanStatus).toBe(
-        VirusScanStatus.FileIsClean,
-      );
-      expect(scannedStudentFile.fileName).toBe(studentFile.fileName);
+    expect(
+      mockedJob.containLogMessages([
+        "Log details",
+        "Starting virus scan.",
+        "No virus found.",
+        "Completed virus scanning for the file.",
+      ]),
+    ).toBe(true);
+    // Assert
+    const scannedStudentFile = await db.studentFile.findOneBy({
+      id: studentFile.id,
     });
-  },
-);
+    expect(scannedStudentFile.virusScanStatus).toBe(
+      VirusScanStatus.FileIsClean,
+    );
+    expect(scannedStudentFile.fileName).toBe(studentFile.fileName);
+  });
+});

--- a/sources/packages/backend/apps/queue-consumers/src/processors/virus-scan/_tests_/virus-scan.processor.e2e-spec.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/processors/virus-scan/_tests_/virus-scan.processor.e2e-spec.ts
@@ -13,7 +13,7 @@ import {
 import { ClamAVService } from "@sims/services";
 import { VirusScanQueueInDTO } from "@sims/services/queue/dto/virus-scan.dto";
 import { VirusScanProcessor } from "../virus-scan.processor";
-import { VirusScanStatus } from "@sims/sims-db/entities/virus-scan-status-type";
+import { VirusScanStatus } from "@sims/sims-db";
 import * as path from "path";
 import { INFECTED_FILENAME_SUFFIX } from "../../../services";
 

--- a/sources/packages/backend/apps/queue-consumers/src/processors/virus-scan/virus-scan.processor.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/processors/virus-scan/virus-scan.processor.ts
@@ -2,10 +2,7 @@ import { Process, Processor } from "@nestjs/bull";
 import { CustomNamedError, QueueNames } from "@sims/utilities";
 import { StudentFileService } from "../../services";
 import { Job } from "bull";
-import {
-  VirusScanQueueInDTO,
-  VirusScanResult,
-} from "@sims/services/queue/dto/virus-scan.dto";
+import { VirusScanQueueInDTO, VirusScanResult } from "@sims/services/queue";
 import {
   InjectLogger,
   LoggerService,

--- a/sources/packages/backend/apps/queue-consumers/src/processors/virus-scan/virus-scan.processor.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/processors/virus-scan/virus-scan.processor.ts
@@ -36,10 +36,6 @@ export class VirusScanProcessor {
         job.data.uniqueFileName,
         processSummary,
       );
-      isInfected
-        ? processSummary.warn("Virus found.")
-        : processSummary.info("No virus found.");
-
       processSummary.info("Completed virus scanning for the file. ");
     } catch (error: unknown) {
       if (error instanceof NotFoundException) {

--- a/sources/packages/backend/apps/queue-consumers/src/processors/virus-scan/virus-scan.processor.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/processors/virus-scan/virus-scan.processor.ts
@@ -36,7 +36,7 @@ export class VirusScanProcessor {
         job.data.uniqueFileName,
         processSummary,
       );
-      processSummary.info("Completed virus scanning for the file. ");
+      processSummary.info("Completed virus scanning for the file.");
     } catch (error: unknown) {
       if (error instanceof NotFoundException) {
         // If the file is not present in the database,

--- a/sources/packages/backend/apps/queue-consumers/src/services/student-file/student-file.service.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/services/student-file/student-file.service.ts
@@ -111,7 +111,7 @@ export class StudentFileService extends RecordDataModelService<StudentFile> {
   }
 
   /**
-   * Updates the infected file status and rename file to describe an error with the file.
+   * Updates the infected file status and renames file to describe an error with the file.
    * @param studentFile student infected file to be updated.
    * @returns the update result.
    */

--- a/sources/packages/backend/apps/queue-consumers/src/services/student-file/student-file.service.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/services/student-file/student-file.service.ts
@@ -1,7 +1,10 @@
 import { Injectable, NotFoundException } from "@nestjs/common";
 import { DataSource, UpdateResult } from "typeorm";
-import { RecordDataModelService, StudentFile } from "@sims/sims-db";
-import { VirusScanStatus } from "@sims/sims-db";
+import {
+  RecordDataModelService,
+  StudentFile,
+  VirusScanStatus,
+} from "@sims/sims-db";
 import { Readable } from "stream";
 import { CustomNamedError } from "@sims/utilities";
 import { UNABLE_TO_SCAN_FILE } from "../../constants/error-code.constants";

--- a/sources/packages/backend/apps/queue-consumers/src/services/student-file/student-file.service.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/services/student-file/student-file.service.ts
@@ -58,9 +58,8 @@ export class StudentFileService extends RecordDataModelService<StudentFile> {
     }
     if (isInfected) {
       processSummary.warn("Virus found.");
-      const fileNameWithoutExtension = path.parse(studentFile.fileName).name;
-      const fileExtension = path.parse(studentFile.fileName).ext;
-      studentFile.fileName = `${fileNameWithoutExtension}${INFECTED_FILENAME_SUFFIX}${fileExtension}`;
+      const fileInfo = path.parse(studentFile.fileName);
+      studentFile.fileName = `${fileInfo.name}${INFECTED_FILENAME_SUFFIX}${fileInfo.ext}`;
     } else {
       processSummary.info("No virus found.");
     }

--- a/sources/packages/backend/apps/queue-consumers/src/services/student-file/student-file.service.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/services/student-file/student-file.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, NotFoundException } from "@nestjs/common";
 import { DataSource, UpdateResult } from "typeorm";
 import { RecordDataModelService, StudentFile } from "@sims/sims-db";
-import { VirusScanStatus } from "@sims/sims-db/entities/virus-scan-status-type";
+import { VirusScanStatus } from "@sims/sims-db";
 import { Readable } from "stream";
 import { CustomNamedError } from "@sims/utilities";
 import { UNABLE_TO_SCAN_FILE } from "../../constants/error-code.constants";

--- a/sources/packages/backend/apps/queue-consumers/src/services/student-file/student-file.service.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/services/student-file/student-file.service.ts
@@ -110,7 +110,7 @@ export class StudentFileService extends RecordDataModelService<StudentFile> {
   }
 
   /**
-   * Update the infected file status and rename file to describe an error with the file.
+   * Updates the infected file status and rename file to describe an error with the file.
    * @param studentFile student infected file to be updated.
    * @returns the update result.
    */

--- a/sources/packages/backend/apps/queue-consumers/src/services/student-file/student-file.service.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/services/student-file/student-file.service.ts
@@ -7,9 +7,9 @@ import { CustomNamedError } from "@sims/utilities";
 import { UNABLE_TO_SCAN_FILE } from "../../constants/error-code.constants";
 import { ProcessSummary } from "@sims/utilities/logger";
 import { ClamAVService } from "@sims/services";
-import path from "path";
+import * as path from "path";
 
-const INFECTED_FILENAME_SUFFIX = "-OriginalFileError";
+export const INFECTED_FILENAME_SUFFIX = "-OriginalFileError";
 
 @Injectable()
 export class StudentFileService extends RecordDataModelService<StudentFile> {
@@ -58,6 +58,7 @@ export class StudentFileService extends RecordDataModelService<StudentFile> {
       await this.updateInfectedFile(studentFile);
     } else {
       processSummary.info("No virus found.");
+      await this.updateFileScanStatus(studentFile.uniqueFileName, isInfected);
     }
     return isInfected;
   }

--- a/sources/packages/backend/apps/queue-consumers/src/services/student-file/student-file.service.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/services/student-file/student-file.service.ts
@@ -56,17 +56,18 @@ export class StudentFileService extends RecordDataModelService<StudentFile> {
         UNABLE_TO_SCAN_FILE,
       );
     }
+    let fileName = studentFile.fileName;
     if (isInfected) {
       processSummary.warn("Virus found.");
       const fileInfo = path.parse(studentFile.fileName);
-      studentFile.fileName = `${fileInfo.name}${INFECTED_FILENAME_SUFFIX}${fileInfo.ext}`;
+      fileName = `${fileInfo.name}${INFECTED_FILENAME_SUFFIX}${fileInfo.ext}`;
     } else {
       processSummary.info("No virus found.");
     }
     await this.updateFileScanStatus(
       studentFile.uniqueFileName,
       isInfected,
-      studentFile.fileName,
+      fileName,
     );
     return isInfected;
   }

--- a/sources/packages/backend/apps/queue-consumers/test/helpers/testing-modules/testing-modules-helper.ts
+++ b/sources/packages/backend/apps/queue-consumers/test/helpers/testing-modules/testing-modules-helper.ts
@@ -13,7 +13,7 @@ import * as Client from "ssh2-sftp-client";
 import { DeepMocked, createMock } from "@golevelup/ts-jest";
 import { DiscoveryModule } from "@golevelup/nestjs-discovery";
 import { QueueModule } from "@sims/services/queue";
-import { SystemUsersService, ZeebeModule } from "@sims/services";
+import { ClamAVService, SystemUsersService, ZeebeModule } from "@sims/services";
 import { ZeebeGrpcClient } from "@camunda8/sdk/dist/zeebe";
 import { createCASServiceMock } from "../mock-utils/cas-service.mock";
 import { CASService } from "@sims/integrations/cas/cas.service";
@@ -28,6 +28,7 @@ export class CreateTestingModuleResult {
   zbClient: ZeebeGrpcClient;
   sshClientMock: DeepMocked<Client>;
   casServiceMock: CASService;
+  clamAVServiceMock: ClamAVService;
 }
 
 /**
@@ -48,6 +49,8 @@ export async function createTestingAppModule(): Promise<CreateTestingModuleResul
   );
   const sshClientMock = createMock<Client>();
   const casServiceMock = createCASServiceMock();
+  const clamAVServiceMock = createClamAVServiceMock();
+
   const module: TestingModule = await Test.createTestingModule({
     imports: [QueueConsumersModule, DiscoveryModule],
   })
@@ -55,6 +58,8 @@ export async function createTestingAppModule(): Promise<CreateTestingModuleResul
     .useValue(createSSHServiceMock(sshClientMock))
     .overrideProvider(CASService)
     .useValue(casServiceMock)
+    .overrideProvider(ClamAVService)
+    .useValue(clamAVServiceMock)
     .compile();
 
   const nestApplication = module.createNestApplication();
@@ -74,5 +79,16 @@ export async function createTestingAppModule(): Promise<CreateTestingModuleResul
     zbClient,
     sshClientMock,
     casServiceMock,
+    clamAVServiceMock,
   };
+}
+
+/**
+ * Creates a mocked Clam anti-virus service.
+ * @returns a mocked Clam anti-virus service.
+ */
+function createClamAVServiceMock(): ClamAVService {
+  const mockedClamAVService = {} as ClamAVService;
+  mockedClamAVService.scanFile = jest.fn(() => Promise.resolve(false));
+  return mockedClamAVService;
 }

--- a/sources/packages/backend/libs/services/src/queue/index.ts
+++ b/sources/packages/backend/libs/services/src/queue/index.ts
@@ -2,3 +2,4 @@ export * from "./queue.module";
 export * from "./model/queue.model";
 export * from "./dto/assessment.dto";
 export * from "./queue.service";
+export * from "./dto/virus-scan.dto";

--- a/sources/packages/backend/libs/sims-db/src/entities/index.ts
+++ b/sources/packages/backend/libs/sims-db/src/entities/index.ts
@@ -94,3 +94,4 @@ export * from "./student-loan-balance.model";
 export * from "./ecert-feedback-error.model";
 export * from "./cas-supplier.model";
 export * from "./supplier-status.type";
+export * from "./virus-scan-status-type";

--- a/sources/packages/backend/libs/test-utils/src/factories/student-file-uploads.ts
+++ b/sources/packages/backend/libs/test-utils/src/factories/student-file-uploads.ts
@@ -2,7 +2,7 @@ import * as faker from "faker";
 import { FileOriginType, Student, StudentFile, User } from "@sims/sims-db";
 import { DataSource } from "typeorm";
 import { createFakeStudent } from "./student";
-import { VirusScanStatus } from "@sims/sims-db/entities/virus-scan-status-type";
+import { VirusScanStatus } from "@sims/sims-db";
 
 /**
  * Create fake student file upload object.

--- a/sources/packages/backend/libs/test-utils/src/factories/student-file-uploads.ts
+++ b/sources/packages/backend/libs/test-utils/src/factories/student-file-uploads.ts
@@ -1,8 +1,13 @@
 import * as faker from "faker";
-import { FileOriginType, Student, StudentFile, User } from "@sims/sims-db";
+import {
+  FileOriginType,
+  Student,
+  StudentFile,
+  User,
+  VirusScanStatus,
+} from "@sims/sims-db";
 import { DataSource } from "typeorm";
 import { createFakeStudent } from "./student";
-import { VirusScanStatus } from "@sims/sims-db";
 
 /**
  * Create fake student file upload object.

--- a/sources/packages/backend/libs/test-utils/src/factories/student-file-uploads.ts
+++ b/sources/packages/backend/libs/test-utils/src/factories/student-file-uploads.ts
@@ -2,6 +2,7 @@ import * as faker from "faker";
 import { FileOriginType, Student, StudentFile, User } from "@sims/sims-db";
 import { DataSource } from "typeorm";
 import { createFakeStudent } from "./student";
+import { VirusScanStatus } from "@sims/sims-db/entities/virus-scan-status-type";
 
 /**
  * Create fake student file upload object.
@@ -34,6 +35,7 @@ export function createFakeStudentFileUpload(
   studentFile.student = relations?.student ?? createFakeStudent();
   studentFile.creator = relations?.creator;
   studentFile.fileOrigin = options?.fileOrigin ?? FileOriginType.Ministry;
+  studentFile.virusScanStatus = VirusScanStatus.Pending;
   return studentFile;
 }
 

--- a/sources/packages/web/src/composables/useFileUtils.ts
+++ b/sources/packages/web/src/composables/useFileUtils.ts
@@ -2,6 +2,9 @@ import { ReportsFilterAPIInDTO } from "@/services/http/dto";
 import { StudentService } from "@/services/StudentService";
 import { ReportService } from "@/services/ReportService";
 import { AxiosResponse } from "axios";
+import { useSnackBar } from "@/composables/useSnackBar";
+import { FILE_HAS_NOT_BEEN_SCANNED_YET, VIRUS_DETECTED } from "@/constants";
+import { ApiProcessError } from "@/types";
 
 interface StudentDocument {
   uniqueFileName: string;
@@ -47,8 +50,25 @@ export function useFileUtils() {
     link.remove();
   };
 
+  /**
+   * Handles the file api process errors that may be thrown.
+   * A warn message is displayed to the user.
+   * @param error error to handled.
+   */
+  const handleFileApiProcessError = (error: unknown) => {
+    if (
+      error instanceof ApiProcessError &&
+      (error.errorType === FILE_HAS_NOT_BEEN_SCANNED_YET ||
+        error.errorType === VIRUS_DETECTED)
+    ) {
+      const snackBar = useSnackBar();
+      snackBar.warn(error.message);
+    }
+  };
+
   return {
     downloadStudentDocument,
     downloadReports,
+    handleFileApiProcessError,
   };
 }

--- a/sources/packages/web/src/constants/error-code.constants.ts
+++ b/sources/packages/web/src/constants/error-code.constants.ts
@@ -103,3 +103,13 @@ export const APPLICATION_WITHDRAWAL_INVALID_TEXT_FILE_ERROR =
  */
 export const APPLICATION_WITHDRAWAL_VALIDATION_ERROR =
   "APPLICATION_WITHDRAWAL_VALIDATION_ERROR";
+
+/**
+ * File has not been scanned yet and cannot be downloaded.
+ */
+export const FILE_HAS_NOT_BEEN_SCANNED_YET = "FILE_HAS_NOT_BEEN_SCANNED_YET";
+
+/**
+ * File has been scanned and a virus was detected.
+ */
+export const VIRUS_DETECTED = "VIRUS_DETECTED";

--- a/sources/packages/web/src/services/FormUploadService.ts
+++ b/sources/packages/web/src/services/FormUploadService.ts
@@ -61,10 +61,11 @@ export default class FormUploadService {
         size: fileContent.data.size,
       };
     } catch (error: unknown) {
-      useFileUtils().handleFileApiProcessError(error);
-      throw new Error(
-        "There was an unexpected error while downloading the file.",
-      );
+      if (!useFileUtils().handleFileScanProcessError(error)) {
+        throw new Error(
+          "There was an unexpected error while downloading the file.",
+        );
+      }
     }
   }
 }

--- a/sources/packages/web/src/services/FormUploadService.ts
+++ b/sources/packages/web/src/services/FormUploadService.ts
@@ -1,6 +1,8 @@
-import { FormUploadFileInfo } from "@/types";
+import { ApiProcessError, FormUploadFileInfo } from "@/types";
 import { AxiosRequestConfig } from "axios";
 import ApiClient from "../services/http/ApiClient";
+import { useSnackBar } from "@/composables";
+import { FILE_HAS_NOT_BEEN_SCANNED_YET, VIRUS_DETECTED } from "@/constants";
 
 /**
  * Implements the methods and signatures that are necessaries
@@ -59,7 +61,16 @@ export default class FormUploadService {
         type: fileInfo.type,
         size: fileContent.data.size,
       };
-    } catch {
+    } catch (error: unknown) {
+      if (
+        error instanceof ApiProcessError &&
+        (error.errorType === FILE_HAS_NOT_BEEN_SCANNED_YET ||
+          error.errorType === VIRUS_DETECTED)
+      ) {
+        const snackBar = useSnackBar();
+        snackBar.warn(error.message);
+        return;
+      }
       throw new Error(
         "There was an unexpected error while downloading the file.",
       );

--- a/sources/packages/web/src/services/FormUploadService.ts
+++ b/sources/packages/web/src/services/FormUploadService.ts
@@ -1,8 +1,7 @@
-import { ApiProcessError, FormUploadFileInfo } from "@/types";
+import { FormUploadFileInfo } from "@/types";
 import { AxiosRequestConfig } from "axios";
 import ApiClient from "../services/http/ApiClient";
-import { useSnackBar } from "@/composables";
-import { FILE_HAS_NOT_BEEN_SCANNED_YET, VIRUS_DETECTED } from "@/constants";
+import { useFileUtils } from "@/composables";
 
 /**
  * Implements the methods and signatures that are necessaries
@@ -62,15 +61,7 @@ export default class FormUploadService {
         size: fileContent.data.size,
       };
     } catch (error: unknown) {
-      if (
-        error instanceof ApiProcessError &&
-        (error.errorType === FILE_HAS_NOT_BEEN_SCANNED_YET ||
-          error.errorType === VIRUS_DETECTED)
-      ) {
-        const snackBar = useSnackBar();
-        snackBar.warn(error.message);
-        return;
-      }
+      useFileUtils().handleFileApiProcessError(error);
       throw new Error(
         "There was an unexpected error while downloading the file.",
       );

--- a/sources/packages/web/src/services/StudentService.ts
+++ b/sources/packages/web/src/services/StudentService.ts
@@ -1,6 +1,6 @@
 import ApiClient from "@/services/http/ApiClient";
 import { StudentProfile, SINValidations } from "@/types";
-import { useFileUtils, useFormatters } from "@/composables";
+import { useFormatters } from "@/composables";
 import {
   AESTFileUploadToStudentAPIInDTO,
   StudentFileDetailsAPIOutDTO,
@@ -146,16 +146,9 @@ export class StudentService {
   async downloadStudentFile(
     uniqueFileName: string,
   ): Promise<AxiosResponse<any>> {
-    try {
-      return await ApiClient.FileUpload.download(
-        `student/files/${uniqueFileName}`,
-      );
-    } catch (error: unknown) {
-      useFileUtils().handleFileApiProcessError(error);
-      throw new Error(
-        "There was an unexpected error while downloading the file.",
-      );
-    }
+    return await ApiClient.FileUpload.download(
+      `student/files/${uniqueFileName}`,
+    );
   }
 
   /**

--- a/sources/packages/web/src/services/StudentService.ts
+++ b/sources/packages/web/src/services/StudentService.ts
@@ -1,6 +1,6 @@
 import ApiClient from "@/services/http/ApiClient";
-import { StudentProfile, SINValidations, ApiProcessError } from "@/types";
-import { useFormatters, useSnackBar } from "@/composables";
+import { StudentProfile, SINValidations } from "@/types";
+import { useFileUtils, useFormatters } from "@/composables";
 import {
   AESTFileUploadToStudentAPIInDTO,
   StudentFileDetailsAPIOutDTO,
@@ -15,7 +15,6 @@ import {
   UpdateDisabilityStatusAPIInDTO,
 } from "@/services/http/dto";
 import { AxiosResponse } from "axios";
-import { FILE_HAS_NOT_BEEN_SCANNED_YET, VIRUS_DETECTED } from "@/constants";
 
 export class StudentService {
   // Share Instance
@@ -152,14 +151,7 @@ export class StudentService {
         `student/files/${uniqueFileName}`,
       );
     } catch (error: unknown) {
-      if (
-        error instanceof ApiProcessError &&
-        (error.errorType === FILE_HAS_NOT_BEEN_SCANNED_YET ||
-          error.errorType === VIRUS_DETECTED)
-      ) {
-        const snackBar = useSnackBar();
-        snackBar.warn(error.message);
-      }
+      useFileUtils().handleFileApiProcessError(error);
       throw new Error(
         "There was an unexpected error while downloading the file.",
       );

--- a/sources/packages/web/src/services/StudentService.ts
+++ b/sources/packages/web/src/services/StudentService.ts
@@ -1,6 +1,6 @@
 import ApiClient from "@/services/http/ApiClient";
-import { StudentProfile, SINValidations } from "@/types";
-import { useFormatters } from "@/composables";
+import { StudentProfile, SINValidations, ApiProcessError } from "@/types";
+import { useFormatters, useSnackBar } from "@/composables";
 import {
   AESTFileUploadToStudentAPIInDTO,
   StudentFileDetailsAPIOutDTO,
@@ -15,6 +15,7 @@ import {
   UpdateDisabilityStatusAPIInDTO,
 } from "@/services/http/dto";
 import { AxiosResponse } from "axios";
+import { FILE_HAS_NOT_BEEN_SCANNED_YET, VIRUS_DETECTED } from "@/constants";
 
 export class StudentService {
   // Share Instance
@@ -146,7 +147,23 @@ export class StudentService {
   async downloadStudentFile(
     uniqueFileName: string,
   ): Promise<AxiosResponse<any>> {
-    return ApiClient.FileUpload.download(`student/files/${uniqueFileName}`);
+    try {
+      return await ApiClient.FileUpload.download(
+        `student/files/${uniqueFileName}`,
+      );
+    } catch (error: unknown) {
+      if (
+        error instanceof ApiProcessError &&
+        (error.errorType === FILE_HAS_NOT_BEEN_SCANNED_YET ||
+          error.errorType === VIRUS_DETECTED)
+      ) {
+        const snackBar = useSnackBar();
+        snackBar.warn(error.message);
+      }
+      throw new Error(
+        "There was an unexpected error while downloading the file.",
+      );
+    }
   }
 
   /**

--- a/sources/packages/web/src/services/StudentService.ts
+++ b/sources/packages/web/src/services/StudentService.ts
@@ -146,9 +146,7 @@ export class StudentService {
   async downloadStudentFile(
     uniqueFileName: string,
   ): Promise<AxiosResponse<any>> {
-    return await ApiClient.FileUpload.download(
-      `student/files/${uniqueFileName}`,
-    );
+    return ApiClient.FileUpload.download(`student/files/${uniqueFileName}`);
   }
 
   /**

--- a/sources/packages/web/src/services/http/common/HttpBaseClient.ts
+++ b/sources/packages/web/src/services/http/common/HttpBaseClient.ts
@@ -109,8 +109,12 @@ export default abstract class HttpBaseClient {
           requestConfig,
         );
       }
-      return this.apiClient.get(this.addClientRoot(url), requestConfig);
+      return await this.apiClient.get(this.addClientRoot(url), requestConfig);
     } catch (error: unknown) {
+      if (error instanceof AxiosError && error.response?.data) {
+        // Parse error response data that was requested as blob.
+        error.response.data = JSON.parse(await error.response.data.text());
+      }
       this.handleRequestError(error);
       throw error;
     }

--- a/sources/packages/web/src/services/http/common/HttpBaseClient.ts
+++ b/sources/packages/web/src/services/http/common/HttpBaseClient.ts
@@ -24,7 +24,6 @@ export default abstract class HttpBaseClient {
   }
 
   protected handleRequestError(error: unknown) {
-    console.log(error);
     this.handleAPICustomError(error);
   }
 


### PR DESCRIPTION
- Added [a logic](https://github.com/bcgov/SIMS/blob/8f38efe285b71f1d3ccac08a4a63691da972c9ac/sources/packages/backend/apps/api/src/services/student-file/student-file.service.ts#L123) to block any `fileContent` to be downloaded if the file is infected;
-  Added [a logic](https://github.com/bcgov/SIMS/blob/8f38efe285b71f1d3ccac08a4a63691da972c9ac/sources/packages/backend/apps/queue-consumers/src/services/student-file/student-file.service.ts#L55) to update the name of the file along with the status for infected files;
- Created [centralized logic](https://github.com/bcgov/SIMS/blob/8f38efe285b71f1d3ccac08a4a63691da972c9ac/sources/packages/web/src/composables/useFileUtils.ts#L69) to handle file scan process errors;
- Added [clamAVServiceMock](https://github.com/bcgov/SIMS/blob/8f38efe285b71f1d3ccac08a4a63691da972c9ac/sources/packages/backend/apps/queue-consumers/test/helpers/testing-modules/testing-modules-helper.ts#L82) to TestingModule;
- Created E2E tests for the API:
  - StudentAESTController(e2e)-getUploadedFile
  - StudentStudentsController(e2e)-getUploadedFile
- Create E2E tests for the virus scan processor;
- Fixed two issues that prevented `handleRequestError` to capture the error from the response:
  - the response is a blob and couldn't parse the `response.data`;
  - there was no `await` and exceptions were not captured;
- Moved student.aest.controller.searchStudents.e2e-spec.ts to the correct folder.

![image](https://github.com/user-attachments/assets/9c8a8116-a498-41bb-beb4-e3225200969f)
![image](https://github.com/user-attachments/assets/aa87972b-ce57-42be-8a45-4baefa2fa35b)
