### PR TITLE
#3560 - Migration revert bug fix (#3559)

### DIFF
--- a/sources/packages/backend/apps/db-migrations/src/sql/Queue/Rollback-drop-fin-process-provincial-daily-disbursements-integration.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/Queue/Rollback-drop-fin-process-provincial-daily-disbursements-integration.sql
@@ -1,13 +1,14 @@
 INSERT INTO
-    queue_configurations(queue_name, queue_configuration)
+  sims.queue_configurations(queue_name, queue_configuration, queue_settings)
 VALUES
-    (
-        'fin-process-provincial-daily-disbursements-integration',
-        '{
-        "retry": 3,
-        "retryInterval": 180000,
-        "dashboardReadonly": false,
-        "cron": "0 18 * * *",
-        "cleanUpPeriod": 2592000000
-      }' :: json
-    );
+  (
+    'fin-process-provincial-daily-disbursements-integration',
+    '{ 
+        "retry": 3, 
+        "retryInterval": 180000, 
+        "dashboardReadonly": false, 
+        "cron": "0 18 * * *", 
+        "cleanUpPeriod": 2592000000 
+      }' :: json,
+    '{ "maxStalledCount": 0, "lockDuration": 60000, "lockRenewTime": 5000 }' :: json
+  );


### PR DESCRIPTION
### As a part of this PR, the following bug has been fixed:

**Bug:** Migration revert for
`Rollback-drop-fin-process-provincial-daily-disbursements-integration.sql` was failing on staging environment because of the missing `sims` schema name and the `queue_settings` not nullable column.

**Fix:** Fixed the query.

**Note:** Tested the migration reverts till the v1.9.0 release to ensure that all the migration reverts are happening properly.