### PR TITLE
#2826 - Update to Youth in Care Question (content & radio option) 

### DIFF
--- a/sources/packages/backend/workflow/test/models/assessment.model.ts
+++ b/sources/packages/backend/workflow/test/models/assessment.model.ts
@@ -89,7 +89,7 @@ export interface AssessmentConsolidatedData extends JSONDoc {
   studentDataIndigenousStatus: YesNoOptions;
   studentDataHasDependents: YesNoOptions;
   studentDataLivingWithParents: YesNoOptions;
-  studentDataYouthInCare: YesNoOptions;
+  studentDataYouthInCare: YesNoOptions | "preferNotToAnswer";
   studentTaxYear: number;
   programLocation: Provinces;
   institutionLocationProvince: Provinces;

--- a/sources/packages/forms/src/form-definitions/sfaa2022-23.json
+++ b/sources/packages/forms/src/form-definitions/sfaa2022-23.json
@@ -10139,7 +10139,7 @@
                   },
                   "properties": {},
                   "lockKey": true,
-                  "tooltip": "This means that the provincial government is currently your legal guardian if you are younger than 19 or was your legal guardian at the time of your 19th birthday.",
+                  "tooltip": "This means that the provincial government is currently your legal guardian if you are younger than 19 or was your legal guardian at the time of your 19th birthday."
                 }
               ],
               "type": "panel",

--- a/sources/packages/forms/src/form-definitions/sfaa2022-23.json
+++ b/sources/packages/forms/src/form-definitions/sfaa2022-23.json
@@ -9908,13 +9908,13 @@
               "tags": []
             },
             {
-              "label": "<strong>Are you, or were you ever considered a child or youth under government care?</strong>",
+              "label": "Are you, or were you ever considered a child or youth under government care?",
               "labelPosition": "top",
               "labelWidth": "",
               "labelMargin": "",
               "optionsLabelPosition": "right",
               "description": "",
-              "tooltip": "For a variety of reasons, the government may provide care or guardianship for a child or youth. Answer ‘YES’ to this question if you were ever considered a child or youth in the care of the Ministry of Children and Family Development (MCFD) or an Indigenous Child and Family Service Agency (ICFSA), in the Ministry of Social Development and Poverty Reduction [SDPR] Child in the Home of Relative Program, or in government care through a Canadian province or territory outside of B.C., This includes out of care and temporary care statuses, as well as continuing custody orders both in B.C. and in Canadian provinces or territories outside of B.C.",
+              "tooltip": "For a variety of reasons, the government may provide care or guardianship for a child or youth. Answer 'YES' to this question if you were ever considered a child or youth in the care of the Ministry of Children and Family Development (MCFD) or an Indigenous Child and Family Service Agency (ICFSA), in the Ministry of Social Development and Poverty Reduction [SDPR] Child in the Home of Relative Program, or in government care through a Canadian province or territory outside of B.C., This includes out of care and temporary care statuses, as well as continuing custody orders both in B.C. and in Canadian provinces or territories outside of B.C.",
               "customClass": "",
               "tabindex": "",
               "inline": false,
@@ -10019,7 +10019,7 @@
                   "value": ""
                 }
               ],
-              "content": "<strong> Based on your response, you may be eligible for the Provincial Tuition Waiver Program and the Learning for Future Grant.</strong>\n <br />This means you could have your tuition and eligible fees paid for, and you could also receive an annual grant of $3,500 to cover additional education-related costs (e.g., textbooks, computers, supplies, etc.).\n<br/>To learn more about these financial supports, please visit the StudentAid BC website or contact the Financial Aid Office at your post-secondary institution.",
+              "content": "<strong>Based on your response, you may be eligible for the Provincial Tuition Waiver Program and the Learning for Future Grant.</strong>\n<br />This means you could have your tuition and eligible fees paid for, and you could also receive an annual grant of $3,500 to cover additional education-related costs (e.g., textbooks, computers, supplies, etc.).\n<br/>To learn more about these financial supports, please visit the StudentAid BC website or contact the Financial Aid Office at your post-secondary institution.",
               "refreshOnChange": false,
               "customClass": "banner-info",
               "hidden": false,
@@ -22386,7 +22386,7 @@
               "description": "",
               "errorLabel": "",
               "tooltip": "",
-              "hideLabel": false,
+              "hideLabel": true,
               "tabindex": "",
               "disabled": false,
               "autofocus": false,
@@ -23746,7 +23746,7 @@
                   "calculateServer": false,
                   "allowCalculateOverride": false,
                   "validate": {
-                    "required": false,
+                    "required": true,
                     "onlyAvailableItems": true,
                     "customMessage": "",
                     "custom": "",
@@ -23762,7 +23762,7 @@
                   "tags": [],
                   "properties": {},
                   "conditional": {
-                    "show": true,
+                    "show": "true",
                     "when": "hasSignificantDegreeOfIncome",
                     "eq": "yes",
                     "json": ""
@@ -30347,7 +30347,7 @@
                   "attr": ""
                 }
               ],
-              "className": "alert alert-danger fa fa-ban w-100 w-100",
+              "className": "alert alert-danger fa fa-ban w-100",
               "content": "<strong> You must be a listed driver on the insurance of the vehicle you will be using to qualify for additional transportation funding.</strong>",
               "type": "htmlelement",
               "hideLabel": true,

--- a/sources/packages/forms/src/form-definitions/sfaa2022-23.json
+++ b/sources/packages/forms/src/form-definitions/sfaa2022-23.json
@@ -10019,7 +10019,7 @@
                   "value": ""
                 }
               ],
-              "content": "<strong>Based on your response, you may be eligible for the Provincial Tuition Waiver Program and the Learning for Future Grant.</strong>\n<br />This means you could have your tuition and eligible fees paid for, and you could also receive an annual grant of $3,500 to cover additional education-related costs (e.g., textbooks, computers, supplies, etc.).\n<br/>To learn more about these financial supports, please visit the StudentAid BC website or contact the Financial Aid Office at your post-secondary institution.",
+              "content": "<strong>Based on your response, you may be eligible for the Provincial Tuition Waiver Program and the Learning for Future Grant.</strong>\n<br />This means you could have your tuition and eligible fees paid for, and you could also receive an annual grant of $3,500 to cover additional education-related costs (e.g., textbooks, computers, supplies, etc.).\n<br/>To learn more about these financial supports, please visit the <a class=\"formio-href\" href=\"https://studentaidbc.ca/explore/grants-scholarships\" target=\"_blank\" rel=\"noopener noreferrer\">StudentAid BC website</a> or contact the Financial Aid Office at your post-secondary institution.",
               "refreshOnChange": false,
               "customClass": "banner-info",
               "hidden": false,
@@ -10028,12 +10028,12 @@
               "tags": [],
               "properties": {},
               "conditional": {
-                "show": "true",
-                "when": "youthInCare",
-                "eq": "preferNotToAnswer",
+                "show": "",
+                "when": null,
+                "eq": "",
                 "json": ""
               },
-              "customConditional": "",
+              "customConditional": "show = (data.youthInCare === \"yes\" || data.youthInCare === \"preferNotToAnswer\");",
               "logic": [],
               "attributes": {},
               "overlay": {

--- a/sources/packages/forms/src/form-definitions/sfaa2022-23.json
+++ b/sources/packages/forms/src/form-definitions/sfaa2022-23.json
@@ -9908,13 +9908,13 @@
               "tags": []
             },
             {
-              "label": "<strong>Were you ever considered a child or youth under government care?</strong>",
+              "label": "<strong>Are you, or were you ever considered a child or youth under government care?</strong>",
               "labelPosition": "top",
               "labelWidth": "",
               "labelMargin": "",
               "optionsLabelPosition": "right",
               "description": "",
-              "tooltip": "Ministry of Children and Family Development (MCFD) or Indigenous Child and Family Service Agency [ICFSA] care, care through the Ministry of Social Development and Poverty Reduction [SDPR] Child in the Home of Relative Program or government care through a Canadian province or territory outside of B.C.",
+              "tooltip": "For a variety of reasons, the government may provide care or guardianship for a child or youth. Answer ‘YES’ to this question if you were ever considered a child or youth in the care of the Ministry of Children and Family Development (MCFD) or an Indigenous Child and Family Service Agency (ICFSA), in the Ministry of Social Development and Poverty Reduction [SDPR] Child in the Home of Relative Program, or in government care through a Canadian province or territory outside of B.C., This includes out of care and temporary care statuses, as well as continuing custody orders both in B.C. and in Canadian provinces or territories outside of B.C.",
               "customClass": "",
               "tabindex": "",
               "inline": false,
@@ -9932,6 +9932,11 @@
                 {
                   "value": "no",
                   "label": "No",
+                  "shortcut": ""
+                },
+                {
+                  "value": "preferNotToAnswer",
+                  "label": "Prefer not to answer",
                   "shortcut": ""
                 }
               ],
@@ -10003,6 +10008,88 @@
               "defaultValue": ""
             },
             {
+              "label": "HTML",
+              "labelWidth": "",
+              "labelMargin": "",
+              "tag": "p",
+              "className": "alert alert-info fa fa-info-circle",
+              "attrs": [
+                {
+                  "attr": "",
+                  "value": ""
+                }
+              ],
+              "content": "<strong> Based on your response, you may be eligible for the Provincial Tuition Waiver Program and the Learning for Future Grant.</strong>\n <br />This means you could have your tuition and eligible fees paid for, and you could also receive an annual grant of $3,500 to cover additional education-related costs (e.g., textbooks, computers, supplies, etc.).\n<br/>To learn more about these financial supports, please visit the StudentAid BC website or contact the Financial Aid Office at your post-secondary institution.",
+              "refreshOnChange": false,
+              "customClass": "banner-info",
+              "hidden": false,
+              "modalEdit": false,
+              "key": "html43",
+              "tags": [],
+              "properties": {},
+              "conditional": {
+                "show": "true",
+                "when": "youthInCare",
+                "eq": "preferNotToAnswer",
+                "json": ""
+              },
+              "customConditional": "",
+              "logic": [],
+              "attributes": {},
+              "overlay": {
+                "style": "",
+                "page": "",
+                "left": "",
+                "top": "",
+                "width": "",
+                "height": ""
+              },
+              "type": "htmlelement",
+              "input": false,
+              "tableView": false,
+              "placeholder": "",
+              "prefix": "",
+              "suffix": "",
+              "multiple": false,
+              "defaultValue": null,
+              "protected": false,
+              "unique": false,
+              "persistent": false,
+              "clearOnHide": true,
+              "refreshOn": "",
+              "redrawOn": "",
+              "dataGridLabel": false,
+              "labelPosition": "top",
+              "description": "",
+              "errorLabel": "",
+              "tooltip": "",
+              "tabindex": "",
+              "disabled": false,
+              "autofocus": false,
+              "dbIndex": false,
+              "customDefaultValue": "",
+              "calculateValue": "",
+              "calculateServer": false,
+              "widget": null,
+              "validateOn": "change",
+              "validate": {
+                "required": false,
+                "custom": "",
+                "customPrivate": false,
+                "strictDateValidation": false,
+                "multiple": false,
+                "unique": false
+              },
+              "allowCalculateOverride": false,
+              "encrypted": false,
+              "showCharCount": false,
+              "showWordCount": false,
+              "allowMultipleMasks": false,
+              "addons": [],
+              "id": "evyzdwa",
+              "hideLabel": true
+            },
+            {
               "clearOnHide": false,
               "key": "custodyOfChildWelfareInformationPanel",
               "input": false,
@@ -10046,13 +10133,13 @@
                   "optionsLabelPosition": "right",
                   "tags": [],
                   "conditional": {
-                    "show": "true",
-                    "when": "youthInCare",
-                    "eq": "yes"
+                    "show": "",
+                    "when": null,
+                    "eq": ""
                   },
                   "properties": {},
                   "lockKey": true,
-                  "tooltip": "This means that the provincial government is currently your legal guardian if you are younger than 19 or was your legal guardian at the time of your 19th birthday."
+                  "tooltip": "This means that the provincial government is currently your legal guardian if you are younger than 19 or was your legal guardian at the time of your 19th birthday.",
                 }
               ],
               "type": "panel",
@@ -10065,7 +10152,8 @@
                 "eq": "yes"
               },
               "properties": {},
-              "lockKey": true
+              "lockKey": true,
+              "customConditional": "show = (data.howWillYouBeAttendingTheProgram !== \"Part Time\" \n       && data.youthInCare === \"yes\");"
             },
             {
               "label": "<strong>At the time of your course study start date, will you have been out of high school for 4 years?</strong>",

--- a/sources/packages/forms/src/form-definitions/sfaa2023-24.json
+++ b/sources/packages/forms/src/form-definitions/sfaa2023-24.json
@@ -22387,7 +22387,6 @@
               "description": "",
               "errorLabel": "",
               "tooltip": "",
-              "hideLabel": false,
               "tabindex": "",
               "disabled": false,
               "autofocus": false,
@@ -22411,7 +22410,8 @@
               "showWordCount": false,
               "allowMultipleMasks": false,
               "id": "ezaww3",
-              "addons": []
+              "addons": [],
+              "hideLabel": true
             },
             {
               "label": "My total income in {{data.programYear}} was:",
@@ -23747,7 +23747,7 @@
                   "calculateServer": false,
                   "allowCalculateOverride": false,
                   "validate": {
-                    "required": false,
+                    "required": true,
                     "onlyAvailableItems": true,
                     "customMessage": "",
                     "custom": "",
@@ -23763,7 +23763,7 @@
                   "tags": [],
                   "properties": {},
                   "conditional": {
-                    "show": true,
+                    "show": "true",
                     "when": "hasSignificantDegreeOfIncome",
                     "eq": "yes",
                     "json": ""
@@ -24606,7 +24606,8 @@
                   "allowMultipleMasks": false,
                   "addons": [],
                   "inputType": "hidden",
-                  "id": "e78m1ow"
+                  "id": "e78m1ow",
+                  "tags": []
                 },
                 {
                   "label": "HTML",
@@ -25024,7 +25025,8 @@
                   "properties": {},
                   "allowMultipleMasks": false,
                   "addons": [],
-                  "id": "eo1cjdj"
+                  "id": "eo1cjdj",
+                  "tags": []
                 },
                 {
                   "label": "HTML",
@@ -25099,7 +25101,8 @@
                   "addons": [],
                   "tag": "p",
                   "id": "eq7e38",
-                  "className": ""
+                  "className": "",
+                  "tags": []
                 },
                 {
                   "label": "HTML",
@@ -25174,7 +25177,8 @@
                   "addons": [],
                   "tag": "p",
                   "id": "evksdr7",
-                  "className": ""
+                  "className": "",
+                  "tags": []
                 },
                 {
                   "label": "HTML",
@@ -25249,7 +25253,8 @@
                   "addons": [],
                   "tag": "p",
                   "id": "e99y2i9",
-                  "className": ""
+                  "className": "",
+                  "tags": []
                 },
                 {
                   "label": "ExceptionalExpenseFile",
@@ -25331,7 +25336,8 @@
                   "imageSize": "200",
                   "fileMinSize": "0KB",
                   "uploadOnly": false,
-                  "id": "ea87f6w"
+                  "id": "ea87f6w",
+                  "tags": []
                 },
                 {
                   "label": "Columns",
@@ -25404,7 +25410,8 @@
                           "properties": {},
                           "allowMultipleMasks": false,
                           "addons": [],
-                          "id": "egdox9m"
+                          "id": "egdox9m",
+                          "tags": []
                         }
                       ],
                       "width": 6,
@@ -25482,7 +25489,8 @@
                           "properties": {},
                           "allowMultipleMasks": false,
                           "addons": [],
-                          "id": "ecwx4udn"
+                          "id": "ecwx4udn",
+                          "tags": []
                         }
                       ],
                       "width": 6,
@@ -25558,7 +25566,8 @@
                   "tree": false,
                   "lazyLoad": false,
                   "autoAdjust": false,
-                  "id": "eajxvgi"
+                  "id": "eajxvgi",
+                  "tags": []
                 }
               ],
               "allowPrevious": false,
@@ -30348,7 +30357,7 @@
                   "attr": ""
                 }
               ],
-              "className": "alert alert-danger fa fa-ban w-100 w-100",
+              "className": "alert alert-danger fa fa-ban w-100",
               "content": "<strong> You must be a listed driver on the insurance of the vehicle you will be using to qualify for additional transportation funding.</strong>",
               "type": "htmlelement",
               "hideLabel": true,
@@ -31502,8 +31511,7 @@
               "id": "ev5rghf"
             }
           ],
-          "id": "emvzoox",
-          "lockKey": true
+          "id": "emvzoox"
         },
         {
           "input": true,

--- a/sources/packages/forms/src/form-definitions/sfaa2023-24.json
+++ b/sources/packages/forms/src/form-definitions/sfaa2023-24.json
@@ -10139,7 +10139,7 @@
                   },
                   "properties": {},
                   "lockKey": true,
-                  "tooltip": "This means that the provincial government is currently your legal guardian if you are younger than 19 or was your legal guardian at the time of your 19th birthday.",
+                  "tooltip": "This means that the provincial government is currently your legal guardian if you are younger than 19 or was your legal guardian at the time of your 19th birthday."
                 }
               ],
               "type": "panel",

--- a/sources/packages/forms/src/form-definitions/sfaa2023-24.json
+++ b/sources/packages/forms/src/form-definitions/sfaa2023-24.json
@@ -5173,7 +5173,6 @@
           },
           "properties": {},
           "calculateValue": "const [programYear] = data.programYearStartDate ? data.programYearStartDate.split(\"-\"):[];\nvalue = programYear ? programYear:\"\";",
-          "calculateServer": true,
           "lockKey": true
         },
         {
@@ -8275,7 +8274,8 @@
               "breadcrumb": "default",
               "id": "efawj5",
               "addons": [],
-              "lazyLoad": false
+              "lazyLoad": false,
+              "tags": []
             },
             {
               "label": "<strong>Are you a resident of B.C.?</strong>",
@@ -9034,7 +9034,8 @@
                       "properties": {},
                       "allowMultipleMasks": false,
                       "addons": [],
-                      "id": "eawr0fg"
+                      "id": "eawr0fg",
+                      "tags": []
                     },
                     {
                       "label": "HTML",
@@ -9109,7 +9110,8 @@
                       "addons": [],
                       "tag": "p",
                       "id": "exvzcx",
-                      "className": ""
+                      "className": "",
+                      "tags": []
                     },
                     {
                       "label": "HTML",
@@ -9355,7 +9357,8 @@
                       "imageSize": "200",
                       "fileMinSize": "0KB",
                       "uploadOnly": false,
-                      "id": "e15yoie"
+                      "id": "e15yoie",
+                      "tags": []
                     },
                     {
                       "label": "Columns",
@@ -9428,7 +9431,8 @@
                               "properties": {},
                               "allowMultipleMasks": false,
                               "addons": [],
-                              "id": "euomj5"
+                              "id": "euomj5",
+                              "tags": []
                             }
                           ],
                           "width": 6,
@@ -9506,7 +9510,8 @@
                               "properties": {},
                               "allowMultipleMasks": false,
                               "addons": [],
-                              "id": "edp1zrf"
+                              "id": "edp1zrf",
+                              "tags": []
                             }
                           ],
                           "width": 6,
@@ -9582,7 +9587,8 @@
                       "tree": false,
                       "lazyLoad": false,
                       "autoAdjust": false,
-                      "id": "eh0xn99"
+                      "id": "eh0xn99",
+                      "tags": []
                     }
                   ],
                   "placeholder": "",

--- a/sources/packages/forms/src/form-definitions/sfaa2023-24.json
+++ b/sources/packages/forms/src/form-definitions/sfaa2023-24.json
@@ -10019,7 +10019,7 @@
                   "value": ""
                 }
               ],
-              "content": "<strong>Based on your response, you may be eligible for the Provincial Tuition Waiver Program and the Learning for Future Grant.</strong>\n<br />This means you could have your tuition and eligible fees paid for, and you could also receive an annual grant of $3,500 to cover additional education-related costs (e.g., textbooks, computers, supplies, etc.).\n<br/>To learn more about these financial supports, please visit the StudentAid BC website or contact the Financial Aid Office at your post-secondary institution.",
+              "content": "<strong>Based on your response, you may be eligible for the Provincial Tuition Waiver Program and the Learning for Future Grant.</strong>\n<br />This means you could have your tuition and eligible fees paid for, and you could also receive an annual grant of $3,500 to cover additional education-related costs (e.g., textbooks, computers, supplies, etc.).\n<br/>To learn more about these financial supports, please visit the <a class=\"formio-href\" href=\"https://studentaidbc.ca/explore/grants-scholarships\" target=\"_blank\" rel=\"noopener noreferrer\">StudentAid BC website</a> or contact the Financial Aid Office at your post-secondary institution.",
               "refreshOnChange": false,
               "customClass": "banner-info",
               "hidden": false,
@@ -10028,12 +10028,12 @@
               "tags": [],
               "properties": {},
               "conditional": {
-                "show": "true",
-                "when": "youthInCare",
-                "eq": "preferNotToAnswer",
+                "show": "",
+                "when": null,
+                "eq": "",
                 "json": ""
               },
-              "customConditional": "",
+              "customConditional": "show = (data.youthInCare === \"yes\" || data.youthInCare === \"preferNotToAnswer\");",
               "logic": [],
               "attributes": {},
               "overlay": {

--- a/sources/packages/forms/src/form-definitions/sfaa2023-24.json
+++ b/sources/packages/forms/src/form-definitions/sfaa2023-24.json
@@ -5153,8 +5153,7 @@
           "addons": [],
           "inputType": "hidden",
           "id": "eu8tkf",
-          "tags": [],
-          "lockKey": true
+          "tags": []
         },
         {
           "input": true,
@@ -5173,6 +5172,7 @@
           },
           "properties": {},
           "calculateValue": "const [programYear] = data.programYearStartDate ? data.programYearStartDate.split(\"-\"):[];\nvalue = programYear ? programYear:\"\";",
+          "calculateServer": true,
           "lockKey": true
         },
         {
@@ -8274,8 +8274,7 @@
               "breadcrumb": "default",
               "id": "efawj5",
               "addons": [],
-              "lazyLoad": false,
-              "tags": []
+              "lazyLoad": false
             },
             {
               "label": "<strong>Are you a resident of B.C.?</strong>",
@@ -9034,8 +9033,7 @@
                       "properties": {},
                       "allowMultipleMasks": false,
                       "addons": [],
-                      "id": "eawr0fg",
-                      "tags": []
+                      "id": "eawr0fg"
                     },
                     {
                       "label": "HTML",
@@ -9110,8 +9108,7 @@
                       "addons": [],
                       "tag": "p",
                       "id": "exvzcx",
-                      "className": "",
-                      "tags": []
+                      "className": ""
                     },
                     {
                       "label": "HTML",
@@ -9357,8 +9354,7 @@
                       "imageSize": "200",
                       "fileMinSize": "0KB",
                       "uploadOnly": false,
-                      "id": "e15yoie",
-                      "tags": []
+                      "id": "e15yoie"
                     },
                     {
                       "label": "Columns",
@@ -9431,8 +9427,7 @@
                               "properties": {},
                               "allowMultipleMasks": false,
                               "addons": [],
-                              "id": "euomj5",
-                              "tags": []
+                              "id": "euomj5"
                             }
                           ],
                           "width": 6,
@@ -9510,8 +9505,7 @@
                               "properties": {},
                               "allowMultipleMasks": false,
                               "addons": [],
-                              "id": "edp1zrf",
-                              "tags": []
+                              "id": "edp1zrf"
                             }
                           ],
                           "width": 6,
@@ -9587,8 +9581,7 @@
                       "tree": false,
                       "lazyLoad": false,
                       "autoAdjust": false,
-                      "id": "eh0xn99",
-                      "tags": []
+                      "id": "eh0xn99"
                     }
                   ],
                   "placeholder": "",
@@ -9915,13 +9908,13 @@
               "tags": []
             },
             {
-              "label": "<strong>Are you, or were you ever considered a child or youth under government care?</strong>",
+              "label": "Are you, or were you ever considered a child or youth under government care?",
               "labelPosition": "top",
               "labelWidth": "",
               "labelMargin": "",
               "optionsLabelPosition": "right",
               "description": "",
-              "tooltip": "For a variety of reasons, the government may provide care or guardianship for a child or youth. Answer ‘YES’ to this question if you were ever considered a child or youth in the care of the Ministry of Children and Family Development (MCFD) or an Indigenous Child and Family Service Agency (ICFSA), in the Ministry of Social Development and Poverty Reduction [SDPR] Child in the Home of Relative Program, or in government care through a Canadian province or territory outside of B.C., This includes out of care and temporary care statuses, as well as continuing custody orders both in B.C. and in Canadian provinces or territories outside of B.C.",
+              "tooltip": "For a variety of reasons, the government may provide care or guardianship for a child or youth. Answer 'YES' to this question if you were ever considered a child or youth in the care of the Ministry of Children and Family Development (MCFD) or an Indigenous Child and Family Service Agency (ICFSA), in the Ministry of Social Development and Poverty Reduction [SDPR] Child in the Home of Relative Program, or in government care through a Canadian province or territory outside of B.C., This includes out of care and temporary care statuses, as well as continuing custody orders both in B.C. and in Canadian provinces or territories outside of B.C.",
               "customClass": "",
               "tabindex": "",
               "inline": false,
@@ -10026,7 +10019,7 @@
                   "value": ""
                 }
               ],
-              "content": "<strong> Based on your response, you may be eligible for the Provincial Tuition Waiver Program and the Learning for Future Grant.</strong>\n <br />This means you could have your tuition and eligible fees paid for, and you could also receive an annual grant of $3,500 to cover additional education-related costs (e.g., textbooks, computers, supplies, etc.).\n<br/>To learn more about these financial supports, please visit the StudentAid BC website or contact the Financial Aid Office at your post-secondary institution.",
+              "content": "<strong>Based on your response, you may be eligible for the Provincial Tuition Waiver Program and the Learning for Future Grant.</strong>\n<br />This means you could have your tuition and eligible fees paid for, and you could also receive an annual grant of $3,500 to cover additional education-related costs (e.g., textbooks, computers, supplies, etc.).\n<br/>To learn more about these financial supports, please visit the StudentAid BC website or contact the Financial Aid Office at your post-secondary institution.",
               "refreshOnChange": false,
               "customClass": "banner-info",
               "hidden": false,
@@ -22393,6 +22386,7 @@
               "description": "",
               "errorLabel": "",
               "tooltip": "",
+              "hideLabel": true,
               "tabindex": "",
               "disabled": false,
               "autofocus": false,
@@ -22416,8 +22410,7 @@
               "showWordCount": false,
               "allowMultipleMasks": false,
               "id": "ezaww3",
-              "addons": [],
-              "hideLabel": true
+              "addons": []
             },
             {
               "label": "My total income in {{data.programYear}} was:",
@@ -24612,8 +24605,7 @@
                   "allowMultipleMasks": false,
                   "addons": [],
                   "inputType": "hidden",
-                  "id": "e78m1ow",
-                  "tags": []
+                  "id": "e78m1ow"
                 },
                 {
                   "label": "HTML",
@@ -25031,8 +25023,7 @@
                   "properties": {},
                   "allowMultipleMasks": false,
                   "addons": [],
-                  "id": "eo1cjdj",
-                  "tags": []
+                  "id": "eo1cjdj"
                 },
                 {
                   "label": "HTML",
@@ -25107,8 +25098,7 @@
                   "addons": [],
                   "tag": "p",
                   "id": "eq7e38",
-                  "className": "",
-                  "tags": []
+                  "className": ""
                 },
                 {
                   "label": "HTML",
@@ -25183,8 +25173,7 @@
                   "addons": [],
                   "tag": "p",
                   "id": "evksdr7",
-                  "className": "",
-                  "tags": []
+                  "className": ""
                 },
                 {
                   "label": "HTML",
@@ -25259,8 +25248,7 @@
                   "addons": [],
                   "tag": "p",
                   "id": "e99y2i9",
-                  "className": "",
-                  "tags": []
+                  "className": ""
                 },
                 {
                   "label": "ExceptionalExpenseFile",
@@ -25342,8 +25330,7 @@
                   "imageSize": "200",
                   "fileMinSize": "0KB",
                   "uploadOnly": false,
-                  "id": "ea87f6w",
-                  "tags": []
+                  "id": "ea87f6w"
                 },
                 {
                   "label": "Columns",
@@ -25416,8 +25403,7 @@
                           "properties": {},
                           "allowMultipleMasks": false,
                           "addons": [],
-                          "id": "egdox9m",
-                          "tags": []
+                          "id": "egdox9m"
                         }
                       ],
                       "width": 6,
@@ -25495,8 +25481,7 @@
                           "properties": {},
                           "allowMultipleMasks": false,
                           "addons": [],
-                          "id": "ecwx4udn",
-                          "tags": []
+                          "id": "ecwx4udn"
                         }
                       ],
                       "width": 6,
@@ -25572,8 +25557,7 @@
                   "tree": false,
                   "lazyLoad": false,
                   "autoAdjust": false,
-                  "id": "eajxvgi",
-                  "tags": []
+                  "id": "eajxvgi"
                 }
               ],
               "allowPrevious": false,
@@ -31517,7 +31501,8 @@
               "id": "ev5rghf"
             }
           ],
-          "id": "emvzoox"
+          "id": "emvzoox",
+          "lockKey": true
         },
         {
           "input": true,

--- a/sources/packages/forms/src/form-definitions/sfaa2023-24.json
+++ b/sources/packages/forms/src/form-definitions/sfaa2023-24.json
@@ -5173,6 +5173,7 @@
           },
           "properties": {},
           "calculateValue": "const [programYear] = data.programYearStartDate ? data.programYearStartDate.split(\"-\"):[];\nvalue = programYear ? programYear:\"\";",
+          "calculateServer": true,
           "lockKey": true
         },
         {
@@ -8274,8 +8275,7 @@
               "breadcrumb": "default",
               "id": "efawj5",
               "addons": [],
-              "lazyLoad": false,
-              "tags": []
+              "lazyLoad": false
             },
             {
               "label": "<strong>Are you a resident of B.C.?</strong>",
@@ -9034,8 +9034,7 @@
                       "properties": {},
                       "allowMultipleMasks": false,
                       "addons": [],
-                      "id": "eawr0fg",
-                      "tags": []
+                      "id": "eawr0fg"
                     },
                     {
                       "label": "HTML",
@@ -9110,8 +9109,7 @@
                       "addons": [],
                       "tag": "p",
                       "id": "exvzcx",
-                      "className": "",
-                      "tags": []
+                      "className": ""
                     },
                     {
                       "label": "HTML",
@@ -9357,8 +9355,7 @@
                       "imageSize": "200",
                       "fileMinSize": "0KB",
                       "uploadOnly": false,
-                      "id": "e15yoie",
-                      "tags": []
+                      "id": "e15yoie"
                     },
                     {
                       "label": "Columns",
@@ -9431,8 +9428,7 @@
                               "properties": {},
                               "allowMultipleMasks": false,
                               "addons": [],
-                              "id": "euomj5",
-                              "tags": []
+                              "id": "euomj5"
                             }
                           ],
                           "width": 6,
@@ -9510,8 +9506,7 @@
                               "properties": {},
                               "allowMultipleMasks": false,
                               "addons": [],
-                              "id": "edp1zrf",
-                              "tags": []
+                              "id": "edp1zrf"
                             }
                           ],
                           "width": 6,
@@ -9587,8 +9582,7 @@
                       "tree": false,
                       "lazyLoad": false,
                       "autoAdjust": false,
-                      "id": "eh0xn99",
-                      "tags": []
+                      "id": "eh0xn99"
                     }
                   ],
                   "placeholder": "",
@@ -9915,13 +9909,13 @@
               "tags": []
             },
             {
-              "label": "<strong>Were you ever considered a child or youth under government care?</strong>",
+              "label": "<strong>Are you, or were you ever considered a child or youth under government care?</strong>",
               "labelPosition": "top",
               "labelWidth": "",
               "labelMargin": "",
               "optionsLabelPosition": "right",
               "description": "",
-              "tooltip": "Ministry of Children and Family Development (MCFD) or Indigenous Child and Family Service Agency [ICFSA] care, care through the Ministry of Social Development and Poverty Reduction [SDPR] Child in the Home of Relative Program or government care through a Canadian province or territory outside of B.C.",
+              "tooltip": "For a variety of reasons, the government may provide care or guardianship for a child or youth. Answer ‘YES’ to this question if you were ever considered a child or youth in the care of the Ministry of Children and Family Development (MCFD) or an Indigenous Child and Family Service Agency (ICFSA), in the Ministry of Social Development and Poverty Reduction [SDPR] Child in the Home of Relative Program, or in government care through a Canadian province or territory outside of B.C., This includes out of care and temporary care statuses, as well as continuing custody orders both in B.C. and in Canadian provinces or territories outside of B.C.",
               "customClass": "",
               "tabindex": "",
               "inline": false,
@@ -9939,6 +9933,11 @@
                 {
                   "value": "no",
                   "label": "No",
+                  "shortcut": ""
+                },
+                {
+                  "value": "preferNotToAnswer",
+                  "label": "Prefer not to answer",
                   "shortcut": ""
                 }
               ],
@@ -10010,6 +10009,88 @@
               "defaultValue": ""
             },
             {
+              "label": "HTML",
+              "labelWidth": "",
+              "labelMargin": "",
+              "tag": "p",
+              "className": "alert alert-info fa fa-info-circle",
+              "attrs": [
+                {
+                  "attr": "",
+                  "value": ""
+                }
+              ],
+              "content": "<strong> Based on your response, you may be eligible for the Provincial Tuition Waiver Program and the Learning for Future Grant.</strong>\n <br />This means you could have your tuition and eligible fees paid for, and you could also receive an annual grant of $3,500 to cover additional education-related costs (e.g., textbooks, computers, supplies, etc.).\n<br/>To learn more about these financial supports, please visit the StudentAid BC website or contact the Financial Aid Office at your post-secondary institution.",
+              "refreshOnChange": false,
+              "customClass": "banner-info",
+              "hidden": false,
+              "modalEdit": false,
+              "key": "html43",
+              "tags": [],
+              "properties": {},
+              "conditional": {
+                "show": "true",
+                "when": "youthInCare",
+                "eq": "preferNotToAnswer",
+                "json": ""
+              },
+              "customConditional": "",
+              "logic": [],
+              "attributes": {},
+              "overlay": {
+                "style": "",
+                "page": "",
+                "left": "",
+                "top": "",
+                "width": "",
+                "height": ""
+              },
+              "type": "htmlelement",
+              "input": false,
+              "tableView": false,
+              "placeholder": "",
+              "prefix": "",
+              "suffix": "",
+              "multiple": false,
+              "defaultValue": null,
+              "protected": false,
+              "unique": false,
+              "persistent": false,
+              "clearOnHide": true,
+              "refreshOn": "",
+              "redrawOn": "",
+              "dataGridLabel": false,
+              "labelPosition": "top",
+              "description": "",
+              "errorLabel": "",
+              "tooltip": "",
+              "tabindex": "",
+              "disabled": false,
+              "autofocus": false,
+              "dbIndex": false,
+              "customDefaultValue": "",
+              "calculateValue": "",
+              "calculateServer": false,
+              "widget": null,
+              "validateOn": "change",
+              "validate": {
+                "required": false,
+                "custom": "",
+                "customPrivate": false,
+                "strictDateValidation": false,
+                "multiple": false,
+                "unique": false
+              },
+              "allowCalculateOverride": false,
+              "encrypted": false,
+              "showCharCount": false,
+              "showWordCount": false,
+              "allowMultipleMasks": false,
+              "addons": [],
+              "id": "evyzdwa",
+              "hideLabel": true
+            },
+            {
               "clearOnHide": false,
               "key": "custodyOfChildWelfareInformationPanel",
               "input": false,
@@ -10053,13 +10134,13 @@
                   "optionsLabelPosition": "right",
                   "tags": [],
                   "conditional": {
-                    "show": "true",
-                    "when": "youthInCare",
-                    "eq": "yes"
+                    "show": "",
+                    "when": null,
+                    "eq": ""
                   },
                   "properties": {},
                   "lockKey": true,
-                  "tooltip": "This means that the provincial government is currently your legal guardian if you are younger than 19 or was your legal guardian at the time of your 19th birthday."
+                  "tooltip": "This means that the provincial government is currently your legal guardian if you are younger than 19 or was your legal guardian at the time of your 19th birthday.",
                 }
               ],
               "type": "panel",
@@ -10072,7 +10153,8 @@
                 "eq": "yes"
               },
               "properties": {},
-              "lockKey": true
+              "lockKey": true,
+              "customConditional": "show = (data.howWillYouBeAttendingTheProgram !== \"Part Time\" \n       && data.youthInCare === \"yes\");"
             },
             {
               "label": "<strong>At the time of your course study start date, will you have been out of high school for 4 years?</strong>",
@@ -22305,6 +22387,7 @@
               "description": "",
               "errorLabel": "",
               "tooltip": "",
+              "hideLabel": false,
               "tabindex": "",
               "disabled": false,
               "autofocus": false,
@@ -22328,8 +22411,7 @@
               "showWordCount": false,
               "allowMultipleMasks": false,
               "id": "ezaww3",
-              "addons": [],
-              "hideLabel": true
+              "addons": []
             },
             {
               "label": "My total income in {{data.programYear}} was:",
@@ -23665,7 +23747,7 @@
                   "calculateServer": false,
                   "allowCalculateOverride": false,
                   "validate": {
-                    "required": true,
+                    "required": false,
                     "onlyAvailableItems": true,
                     "customMessage": "",
                     "custom": "",
@@ -23681,7 +23763,7 @@
                   "tags": [],
                   "properties": {},
                   "conditional": {
-                    "show": "true",
+                    "show": true,
                     "when": "hasSignificantDegreeOfIncome",
                     "eq": "yes",
                     "json": ""
@@ -24524,8 +24606,7 @@
                   "allowMultipleMasks": false,
                   "addons": [],
                   "inputType": "hidden",
-                  "id": "e78m1ow",
-                  "tags": []
+                  "id": "e78m1ow"
                 },
                 {
                   "label": "HTML",
@@ -24943,8 +25024,7 @@
                   "properties": {},
                   "allowMultipleMasks": false,
                   "addons": [],
-                  "id": "eo1cjdj",
-                  "tags": []
+                  "id": "eo1cjdj"
                 },
                 {
                   "label": "HTML",
@@ -25019,8 +25099,7 @@
                   "addons": [],
                   "tag": "p",
                   "id": "eq7e38",
-                  "className": "",
-                  "tags": []
+                  "className": ""
                 },
                 {
                   "label": "HTML",
@@ -25095,8 +25174,7 @@
                   "addons": [],
                   "tag": "p",
                   "id": "evksdr7",
-                  "className": "",
-                  "tags": []
+                  "className": ""
                 },
                 {
                   "label": "HTML",
@@ -25171,8 +25249,7 @@
                   "addons": [],
                   "tag": "p",
                   "id": "e99y2i9",
-                  "className": "",
-                  "tags": []
+                  "className": ""
                 },
                 {
                   "label": "ExceptionalExpenseFile",
@@ -25254,8 +25331,7 @@
                   "imageSize": "200",
                   "fileMinSize": "0KB",
                   "uploadOnly": false,
-                  "id": "ea87f6w",
-                  "tags": []
+                  "id": "ea87f6w"
                 },
                 {
                   "label": "Columns",
@@ -25328,8 +25404,7 @@
                           "properties": {},
                           "allowMultipleMasks": false,
                           "addons": [],
-                          "id": "egdox9m",
-                          "tags": []
+                          "id": "egdox9m"
                         }
                       ],
                       "width": 6,
@@ -25407,8 +25482,7 @@
                           "properties": {},
                           "allowMultipleMasks": false,
                           "addons": [],
-                          "id": "ecwx4udn",
-                          "tags": []
+                          "id": "ecwx4udn"
                         }
                       ],
                       "width": 6,
@@ -25484,8 +25558,7 @@
                   "tree": false,
                   "lazyLoad": false,
                   "autoAdjust": false,
-                  "id": "eajxvgi",
-                  "tags": []
+                  "id": "eajxvgi"
                 }
               ],
               "allowPrevious": false,
@@ -30275,7 +30348,7 @@
                   "attr": ""
                 }
               ],
-              "className": "alert alert-danger fa fa-ban w-100",
+              "className": "alert alert-danger fa fa-ban w-100 w-100",
               "content": "<strong> You must be a listed driver on the insurance of the vehicle you will be using to qualify for additional transportation funding.</strong>",
               "type": "htmlelement",
               "hideLabel": true,
@@ -31429,7 +31502,8 @@
               "id": "ev5rghf"
             }
           ],
-          "id": "emvzoox"
+          "id": "emvzoox",
+          "lockKey": true
         },
         {
           "input": true,

--- a/sources/packages/forms/src/form-definitions/sfaa2024-25.json
+++ b/sources/packages/forms/src/form-definitions/sfaa2024-25.json
@@ -22410,8 +22410,7 @@
               "showWordCount": false,
               "allowMultipleMasks": false,
               "id": "ezaww3",
-              "addons": [],
-              "hideLabel": true
+              "addons": []
             },
             {
               "label": "My total income in {data.programYear}} was:",
@@ -25025,8 +25024,7 @@
                   "properties": {},
                   "allowMultipleMasks": false,
                   "addons": [],
-                  "id": "eo1cjdj",
-                  "tags": []
+                  "id": "eo1cjdj"
                 },
                 {
                   "label": "HTML",
@@ -25101,8 +25099,7 @@
                   "addons": [],
                   "tag": "p",
                   "id": "eq7e38",
-                  "className": "",
-                  "tags": []
+                  "className": ""
                 },
                 {
                   "label": "HTML",
@@ -25177,8 +25174,7 @@
                   "addons": [],
                   "tag": "p",
                   "id": "evksdr7",
-                  "className": "",
-                  "tags": []
+                  "className": ""
                 },
                 {
                   "label": "HTML",
@@ -25253,8 +25249,7 @@
                   "addons": [],
                   "tag": "p",
                   "id": "e99y2i9",
-                  "className": "",
-                  "tags": []
+                  "className": ""
                 },
                 {
                   "label": "ExceptionalExpenseFile",
@@ -25336,8 +25331,7 @@
                   "imageSize": "200",
                   "fileMinSize": "0KB",
                   "uploadOnly": false,
-                  "id": "ea87f6w",
-                  "tags": []
+                  "id": "ea87f6w"
                 },
                 {
                   "label": "Columns",
@@ -25410,8 +25404,7 @@
                           "properties": {},
                           "allowMultipleMasks": false,
                           "addons": [],
-                          "id": "egdox9m",
-                          "tags": []
+                          "id": "egdox9m"
                         }
                       ],
                       "width": 6,
@@ -25489,8 +25482,7 @@
                           "properties": {},
                           "allowMultipleMasks": false,
                           "addons": [],
-                          "id": "ecwx4udn",
-                          "tags": []
+                          "id": "ecwx4udn"
                         }
                       ],
                       "width": 6,
@@ -25566,8 +25558,7 @@
                   "tree": false,
                   "lazyLoad": false,
                   "autoAdjust": false,
-                  "id": "eajxvgi",
-                  "tags": []
+                  "id": "eajxvgi"
                 }
               ],
               "allowPrevious": false,

--- a/sources/packages/forms/src/form-definitions/sfaa2024-25.json
+++ b/sources/packages/forms/src/form-definitions/sfaa2024-25.json
@@ -6416,8 +6416,7 @@
                       "addons": [],
                       "displayMask": "",
                       "truncateMultipleSpaces": false,
-                      "tags": [],
-                      "isNew": false
+                      "tags": []
                     },
                     {
                       "label": "Phone number",
@@ -8275,8 +8274,7 @@
               "breadcrumb": "default",
               "id": "efawj5",
               "addons": [],
-              "lazyLoad": false,
-              "tags": []
+              "lazyLoad": false
             },
             {
               "label": "<strong>Are you a resident of B.C.?</strong>",
@@ -9035,8 +9033,7 @@
                       "properties": {},
                       "allowMultipleMasks": false,
                       "addons": [],
-                      "id": "eawr0fg",
-                      "tags": []
+                      "id": "eawr0fg"
                     },
                     {
                       "label": "HTML",
@@ -9111,8 +9108,7 @@
                       "addons": [],
                       "tag": "p",
                       "id": "exvzcx",
-                      "className": "",
-                      "tags": []
+                      "className": ""
                     },
                     {
                       "label": "HTML",
@@ -9358,8 +9354,7 @@
                       "imageSize": "200",
                       "fileMinSize": "0KB",
                       "uploadOnly": false,
-                      "id": "e15yoie",
-                      "tags": []
+                      "id": "e15yoie"
                     },
                     {
                       "label": "Columns",
@@ -9432,8 +9427,7 @@
                               "properties": {},
                               "allowMultipleMasks": false,
                               "addons": [],
-                              "id": "euomj5",
-                              "tags": []
+                              "id": "euomj5"
                             }
                           ],
                           "width": 6,
@@ -9511,8 +9505,7 @@
                               "properties": {},
                               "allowMultipleMasks": false,
                               "addons": [],
-                              "id": "edp1zrf",
-                              "tags": []
+                              "id": "edp1zrf"
                             }
                           ],
                           "width": 6,
@@ -9588,8 +9581,7 @@
                       "tree": false,
                       "lazyLoad": false,
                       "autoAdjust": false,
-                      "id": "eh0xn99",
-                      "tags": []
+                      "id": "eh0xn99"
                     }
                   ],
                   "placeholder": "",
@@ -9913,7 +9905,8 @@
               "id": "ef3gfa",
               "addons": [],
               "lazyLoad": false,
-              "tags": []
+              "tags": [],
+              "isNew": false
             },
             {
               "label": "<strong>Are you, or were you ever considered a child or youth under government care?</strong>",

--- a/sources/packages/forms/src/form-definitions/sfaa2024-25.json
+++ b/sources/packages/forms/src/form-definitions/sfaa2024-25.json
@@ -5153,8 +5153,7 @@
           "addons": [],
           "inputType": "hidden",
           "id": "eu8tkf",
-          "tags": [],
-          "lockKey": true
+          "tags": []
         },
         {
           "input": true,
@@ -5173,7 +5172,6 @@
           },
           "properties": {},
           "calculateValue": "const [programYear] = data.programYearStartDate ? data.programYearStartDate.split(\"-\"):[];\nvalue = programYear ? programYear:\"\";",
-          "calculateServer": true,
           "lockKey": true
         },
         {
@@ -6417,7 +6415,9 @@
                       "id": "el67mt",
                       "addons": [],
                       "displayMask": "",
-                      "truncateMultipleSpaces": false
+                      "truncateMultipleSpaces": false,
+                      "tags": [],
+                      "isNew": false
                     },
                     {
                       "label": "Phone number",
@@ -8275,7 +8275,8 @@
               "breadcrumb": "default",
               "id": "efawj5",
               "addons": [],
-              "lazyLoad": false
+              "lazyLoad": false,
+              "tags": []
             },
             {
               "label": "<strong>Are you a resident of B.C.?</strong>",
@@ -9034,7 +9035,8 @@
                       "properties": {},
                       "allowMultipleMasks": false,
                       "addons": [],
-                      "id": "eawr0fg"
+                      "id": "eawr0fg",
+                      "tags": []
                     },
                     {
                       "label": "HTML",
@@ -9109,7 +9111,8 @@
                       "addons": [],
                       "tag": "p",
                       "id": "exvzcx",
-                      "className": ""
+                      "className": "",
+                      "tags": []
                     },
                     {
                       "label": "HTML",
@@ -9355,7 +9358,8 @@
                       "imageSize": "200",
                       "fileMinSize": "0KB",
                       "uploadOnly": false,
-                      "id": "e15yoie"
+                      "id": "e15yoie",
+                      "tags": []
                     },
                     {
                       "label": "Columns",
@@ -9428,7 +9432,8 @@
                               "properties": {},
                               "allowMultipleMasks": false,
                               "addons": [],
-                              "id": "euomj5"
+                              "id": "euomj5",
+                              "tags": []
                             }
                           ],
                           "width": 6,
@@ -9506,7 +9511,8 @@
                               "properties": {},
                               "allowMultipleMasks": false,
                               "addons": [],
-                              "id": "edp1zrf"
+                              "id": "edp1zrf",
+                              "tags": []
                             }
                           ],
                           "width": 6,
@@ -9582,7 +9588,8 @@
                       "tree": false,
                       "lazyLoad": false,
                       "autoAdjust": false,
-                      "id": "eh0xn99"
+                      "id": "eh0xn99",
+                      "tags": []
                     }
                   ],
                   "placeholder": "",
@@ -22387,7 +22394,6 @@
               "description": "",
               "errorLabel": "",
               "tooltip": "",
-              "hideLabel": false,
               "tabindex": "",
               "disabled": false,
               "autofocus": false,
@@ -22411,10 +22417,11 @@
               "showWordCount": false,
               "allowMultipleMasks": false,
               "id": "ezaww3",
-              "addons": []
+              "addons": [],
+              "hideLabel": true
             },
             {
-              "label": "My total income in {{data.programYear}} was:",
+              "label": "My total income in {data.programYear}} was:",
               "prefix": "$",
               "customClass": "font-weight-bold",
               "mask": false,
@@ -23747,7 +23754,7 @@
                   "calculateServer": false,
                   "allowCalculateOverride": false,
                   "validate": {
-                    "required": false,
+                    "required": true,
                     "onlyAvailableItems": true,
                     "customMessage": "",
                     "custom": "",
@@ -23763,7 +23770,7 @@
                   "tags": [],
                   "properties": {},
                   "conditional": {
-                    "show": true,
+                    "show": "true",
                     "when": "hasSignificantDegreeOfIncome",
                     "eq": "yes",
                     "json": ""
@@ -24606,7 +24613,8 @@
                   "allowMultipleMasks": false,
                   "addons": [],
                   "inputType": "hidden",
-                  "id": "e78m1ow"
+                  "id": "e78m1ow",
+                  "tags": []
                 },
                 {
                   "label": "HTML",
@@ -25024,7 +25032,8 @@
                   "properties": {},
                   "allowMultipleMasks": false,
                   "addons": [],
-                  "id": "eo1cjdj"
+                  "id": "eo1cjdj",
+                  "tags": []
                 },
                 {
                   "label": "HTML",
@@ -25099,7 +25108,8 @@
                   "addons": [],
                   "tag": "p",
                   "id": "eq7e38",
-                  "className": ""
+                  "className": "",
+                  "tags": []
                 },
                 {
                   "label": "HTML",
@@ -25174,7 +25184,8 @@
                   "addons": [],
                   "tag": "p",
                   "id": "evksdr7",
-                  "className": ""
+                  "className": "",
+                  "tags": []
                 },
                 {
                   "label": "HTML",
@@ -25249,7 +25260,8 @@
                   "addons": [],
                   "tag": "p",
                   "id": "e99y2i9",
-                  "className": ""
+                  "className": "",
+                  "tags": []
                 },
                 {
                   "label": "ExceptionalExpenseFile",
@@ -25331,7 +25343,8 @@
                   "imageSize": "200",
                   "fileMinSize": "0KB",
                   "uploadOnly": false,
-                  "id": "ea87f6w"
+                  "id": "ea87f6w",
+                  "tags": []
                 },
                 {
                   "label": "Columns",
@@ -25404,7 +25417,8 @@
                           "properties": {},
                           "allowMultipleMasks": false,
                           "addons": [],
-                          "id": "egdox9m"
+                          "id": "egdox9m",
+                          "tags": []
                         }
                       ],
                       "width": 6,
@@ -25482,7 +25496,8 @@
                           "properties": {},
                           "allowMultipleMasks": false,
                           "addons": [],
-                          "id": "ecwx4udn"
+                          "id": "ecwx4udn",
+                          "tags": []
                         }
                       ],
                       "width": 6,
@@ -25558,7 +25573,8 @@
                   "tree": false,
                   "lazyLoad": false,
                   "autoAdjust": false,
-                  "id": "eajxvgi"
+                  "id": "eajxvgi",
+                  "tags": []
                 }
               ],
               "allowPrevious": false,
@@ -30348,7 +30364,7 @@
                   "attr": ""
                 }
               ],
-              "className": "alert alert-danger fa fa-ban w-100 w-100",
+              "className": "alert alert-danger fa fa-ban w-100",
               "content": "<strong> You must be a listed driver on the insurance of the vehicle you will be using to qualify for additional transportation funding.</strong>",
               "type": "htmlelement",
               "hideLabel": true,
@@ -30855,7 +30871,8 @@
                       "properties": {},
                       "allowMultipleMasks": false,
                       "addons": [],
-                      "id": "esmabhd"
+                      "id": "esmabhd",
+                      "tags": []
                     },
                     {
                       "label": "HTML",
@@ -31502,8 +31519,7 @@
               "id": "ev5rghf"
             }
           ],
-          "id": "emvzoox",
-          "lockKey": true
+          "id": "emvzoox"
         },
         {
           "input": true,

--- a/sources/packages/forms/src/form-definitions/sfaa2024-25.json
+++ b/sources/packages/forms/src/form-definitions/sfaa2024-25.json
@@ -5172,6 +5172,7 @@
           },
           "properties": {},
           "calculateValue": "const [programYear] = data.programYearStartDate ? data.programYearStartDate.split(\"-\"):[];\nvalue = programYear ? programYear:\"\";",
+          "calculateServer": true,
           "lockKey": true
         },
         {
@@ -6415,8 +6416,7 @@
                       "id": "el67mt",
                       "addons": [],
                       "displayMask": "",
-                      "truncateMultipleSpaces": false,
-                      "tags": []
+                      "truncateMultipleSpaces": false
                     },
                     {
                       "label": "Phone number",
@@ -9905,17 +9905,16 @@
               "id": "ef3gfa",
               "addons": [],
               "lazyLoad": false,
-              "tags": [],
-              "isNew": false
+              "tags": []
             },
             {
-              "label": "<strong>Are you, or were you ever considered a child or youth under government care?</strong>",
+              "label": "Are you, or were you ever considered a child or youth under government care?",
               "labelPosition": "top",
               "labelWidth": "",
               "labelMargin": "",
               "optionsLabelPosition": "right",
               "description": "",
-              "tooltip": "For a variety of reasons, the government may provide care or guardianship for a child or youth. Answer ‘YES’ to this question if you were ever considered a child or youth in the care of the Ministry of Children and Family Development (MCFD) or an Indigenous Child and Family Service Agency (ICFSA), in the Ministry of Social Development and Poverty Reduction [SDPR] Child in the Home of Relative Program, or in government care through a Canadian province or territory outside of B.C., This includes out of care and temporary care statuses, as well as continuing custody orders both in B.C. and in Canadian provinces or territories outside of B.C.",
+              "tooltip": "For a variety of reasons, the government may provide care or guardianship for a child or youth. Answer 'YES' to this question if you were ever considered a child or youth in the care of the Ministry of Children and Family Development (MCFD) or an Indigenous Child and Family Service Agency (ICFSA), in the Ministry of Social Development and Poverty Reduction [SDPR] Child in the Home of Relative Program, or in government care through a Canadian province or territory outside of B.C., This includes out of care and temporary care statuses, as well as continuing custody orders both in B.C. and in Canadian provinces or territories outside of B.C.",
               "customClass": "",
               "tabindex": "",
               "inline": false,
@@ -10020,7 +10019,7 @@
                   "value": ""
                 }
               ],
-              "content": "<strong> Based on your response, you may be eligible for the Provincial Tuition Waiver Program and the Learning for Future Grant.</strong>\n <br />This means you could have your tuition and eligible fees paid for, and you could also receive an annual grant of $3,500 to cover additional education-related costs (e.g., textbooks, computers, supplies, etc.).\n<br/>To learn more about these financial supports, please visit the StudentAid BC website or contact the Financial Aid Office at your post-secondary institution.",
+              "content": "<strong>Based on your response, you may be eligible for the Provincial Tuition Waiver Program and the Learning for Future Grant.</strong>\n<br />This means you could have your tuition and eligible fees paid for, and you could also receive an annual grant of $3,500 to cover additional education-related costs (e.g., textbooks, computers, supplies, etc.).\n<br/>To learn more about these financial supports, please visit the StudentAid BC website or contact the Financial Aid Office at your post-secondary institution.",
               "refreshOnChange": false,
               "customClass": "banner-info",
               "hidden": false,
@@ -22387,7 +22386,7 @@
               "description": "",
               "errorLabel": "",
               "tooltip": "",
-              "hideLabel": false,
+              "hideLabel": true,
               "tabindex": "",
               "disabled": false,
               "autofocus": false,
@@ -22414,7 +22413,7 @@
               "addons": []
             },
             {
-              "label": "My total income in {data.programYear}} was:",
+              "label": "My total income in {{data.programYear}} was:",
               "prefix": "$",
               "customClass": "font-weight-bold",
               "mask": false,
@@ -24606,8 +24605,7 @@
                   "allowMultipleMasks": false,
                   "addons": [],
                   "inputType": "hidden",
-                  "id": "e78m1ow",
-                  "tags": []
+                  "id": "e78m1ow"
                 },
                 {
                   "label": "HTML",
@@ -30856,8 +30854,7 @@
                       "properties": {},
                       "allowMultipleMasks": false,
                       "addons": [],
-                      "id": "esmabhd",
-                      "tags": []
+                      "id": "esmabhd"
                     },
                     {
                       "label": "HTML",
@@ -31504,7 +31501,8 @@
               "id": "ev5rghf"
             }
           ],
-          "id": "emvzoox"
+          "id": "emvzoox",
+          "lockKey": true
         },
         {
           "input": true,

--- a/sources/packages/forms/src/form-definitions/sfaa2024-25.json
+++ b/sources/packages/forms/src/form-definitions/sfaa2024-25.json
@@ -10139,7 +10139,7 @@
                   },
                   "properties": {},
                   "lockKey": true,
-                  "tooltip": "This means that the provincial government is currently your legal guardian if you are younger than 19 or was your legal guardian at the time of your 19th birthday.",
+                  "tooltip": "This means that the provincial government is currently your legal guardian if you are younger than 19 or was your legal guardian at the time of your 19th birthday."
                 }
               ],
               "type": "panel",

--- a/sources/packages/forms/src/form-definitions/sfaa2024-25.json
+++ b/sources/packages/forms/src/form-definitions/sfaa2024-25.json
@@ -5153,7 +5153,8 @@
           "addons": [],
           "inputType": "hidden",
           "id": "eu8tkf",
-          "tags": []
+          "tags": [],
+          "lockKey": true
         },
         {
           "input": true,
@@ -5172,6 +5173,7 @@
           },
           "properties": {},
           "calculateValue": "const [programYear] = data.programYearStartDate ? data.programYearStartDate.split(\"-\"):[];\nvalue = programYear ? programYear:\"\";",
+          "calculateServer": true,
           "lockKey": true
         },
         {
@@ -6415,8 +6417,7 @@
                       "id": "el67mt",
                       "addons": [],
                       "displayMask": "",
-                      "truncateMultipleSpaces": false,
-                      "tags": []
+                      "truncateMultipleSpaces": false
                     },
                     {
                       "label": "Phone number",
@@ -9905,17 +9906,16 @@
               "id": "ef3gfa",
               "addons": [],
               "lazyLoad": false,
-              "tags": [],
-              "isNew": false
+              "tags": []
             },
             {
-              "label": "<strong>Were you ever considered a child or youth under government care?</strong>",
+              "label": "<strong>Are you, or were you ever considered a child or youth under government care?</strong>",
               "labelPosition": "top",
               "labelWidth": "",
               "labelMargin": "",
               "optionsLabelPosition": "right",
               "description": "",
-              "tooltip": "Ministry of Children and Family Development (MCFD) or Indigenous Child and Family Service Agency [ICFSA] care, care through the Ministry of Social Development and Poverty Reduction [SDPR] Child in the Home of Relative Program or government care through a Canadian province or territory outside of B.C.",
+              "tooltip": "For a variety of reasons, the government may provide care or guardianship for a child or youth. Answer ‘YES’ to this question if you were ever considered a child or youth in the care of the Ministry of Children and Family Development (MCFD) or an Indigenous Child and Family Service Agency (ICFSA), in the Ministry of Social Development and Poverty Reduction [SDPR] Child in the Home of Relative Program, or in government care through a Canadian province or territory outside of B.C., This includes out of care and temporary care statuses, as well as continuing custody orders both in B.C. and in Canadian provinces or territories outside of B.C.",
               "customClass": "",
               "tabindex": "",
               "inline": false,
@@ -9933,6 +9933,11 @@
                 {
                   "value": "no",
                   "label": "No",
+                  "shortcut": ""
+                },
+                {
+                  "value": "preferNotToAnswer",
+                  "label": "Prefer not to answer",
                   "shortcut": ""
                 }
               ],
@@ -10004,6 +10009,88 @@
               "defaultValue": ""
             },
             {
+              "label": "HTML",
+              "labelWidth": "",
+              "labelMargin": "",
+              "tag": "p",
+              "className": "alert alert-info fa fa-info-circle",
+              "attrs": [
+                {
+                  "attr": "",
+                  "value": ""
+                }
+              ],
+              "content": "<strong> Based on your response, you may be eligible for the Provincial Tuition Waiver Program and the Learning for Future Grant.</strong>\n <br />This means you could have your tuition and eligible fees paid for, and you could also receive an annual grant of $3,500 to cover additional education-related costs (e.g., textbooks, computers, supplies, etc.).\n<br/>To learn more about these financial supports, please visit the StudentAid BC website or contact the Financial Aid Office at your post-secondary institution.",
+              "refreshOnChange": false,
+              "customClass": "banner-info",
+              "hidden": false,
+              "modalEdit": false,
+              "key": "html43",
+              "tags": [],
+              "properties": {},
+              "conditional": {
+                "show": "true",
+                "when": "youthInCare",
+                "eq": "preferNotToAnswer",
+                "json": ""
+              },
+              "customConditional": "",
+              "logic": [],
+              "attributes": {},
+              "overlay": {
+                "style": "",
+                "page": "",
+                "left": "",
+                "top": "",
+                "width": "",
+                "height": ""
+              },
+              "type": "htmlelement",
+              "input": false,
+              "tableView": false,
+              "placeholder": "",
+              "prefix": "",
+              "suffix": "",
+              "multiple": false,
+              "defaultValue": null,
+              "protected": false,
+              "unique": false,
+              "persistent": false,
+              "clearOnHide": true,
+              "refreshOn": "",
+              "redrawOn": "",
+              "dataGridLabel": false,
+              "labelPosition": "top",
+              "description": "",
+              "errorLabel": "",
+              "tooltip": "",
+              "tabindex": "",
+              "disabled": false,
+              "autofocus": false,
+              "dbIndex": false,
+              "customDefaultValue": "",
+              "calculateValue": "",
+              "calculateServer": false,
+              "widget": null,
+              "validateOn": "change",
+              "validate": {
+                "required": false,
+                "custom": "",
+                "customPrivate": false,
+                "strictDateValidation": false,
+                "multiple": false,
+                "unique": false
+              },
+              "allowCalculateOverride": false,
+              "encrypted": false,
+              "showCharCount": false,
+              "showWordCount": false,
+              "allowMultipleMasks": false,
+              "addons": [],
+              "id": "evyzdwa",
+              "hideLabel": true
+            },
+            {
               "clearOnHide": false,
               "key": "custodyOfChildWelfareInformationPanel",
               "input": false,
@@ -10047,13 +10134,13 @@
                   "optionsLabelPosition": "right",
                   "tags": [],
                   "conditional": {
-                    "show": "true",
-                    "when": "youthInCare",
-                    "eq": "yes"
+                    "show": "",
+                    "when": null,
+                    "eq": ""
                   },
                   "properties": {},
                   "lockKey": true,
-                  "tooltip": "This means that the provincial government is currently your legal guardian if you are younger than 19 or was your legal guardian at the time of your 19th birthday."
+                  "tooltip": "This means that the provincial government is currently your legal guardian if you are younger than 19 or was your legal guardian at the time of your 19th birthday.",
                 }
               ],
               "type": "panel",
@@ -10066,7 +10153,8 @@
                 "eq": "yes"
               },
               "properties": {},
-              "lockKey": true
+              "lockKey": true,
+              "customConditional": "show = (data.howWillYouBeAttendingTheProgram !== \"Part Time\" \n       && data.youthInCare === \"yes\");"
             },
             {
               "label": "<strong>At the time of your course study start date, will you have been out of high school for 4 years?</strong>",
@@ -22255,7 +22343,7 @@
                   "value": ""
                 }
               ],
-              "content": "Enter your reported total income from line 15000 of your {{data.programYear}} income tax return. This income will be matched with Canada Revenue Agency records, which may affect your assessment of need and/or grant eligibility.  \n\nIf you did not file a {data.programYear}} income tax return, enter your total income from all sources both inside and outside of Canada.",
+              "content": "Enter your reported total income from line 15000 of your {{data.programYear}} income tax return. This income will be matched with Canada Revenue Agency records, which may affect your assessment of need and/or grant eligibility.  \n\nIf you did not file a {{data.programYear}} income tax return, enter your total income from all sources both inside and outside of Canada.",
               "refreshOnChange": false,
               "customClass": "",
               "hidden": false,
@@ -22326,7 +22414,7 @@
               "addons": []
             },
             {
-              "label": "My total income in {data.programYear}} was:",
+              "label": "My total income in {{data.programYear}} was:",
               "prefix": "$",
               "customClass": "font-weight-bold",
               "mask": false,
@@ -23659,7 +23747,7 @@
                   "calculateServer": false,
                   "allowCalculateOverride": false,
                   "validate": {
-                    "required": true,
+                    "required": false,
                     "onlyAvailableItems": true,
                     "customMessage": "",
                     "custom": "",
@@ -23675,7 +23763,7 @@
                   "tags": [],
                   "properties": {},
                   "conditional": {
-                    "show": "true",
+                    "show": true,
                     "when": "hasSignificantDegreeOfIncome",
                     "eq": "yes",
                     "json": ""
@@ -24518,8 +24606,7 @@
                   "allowMultipleMasks": false,
                   "addons": [],
                   "inputType": "hidden",
-                  "id": "e78m1ow",
-                  "tags": []
+                  "id": "e78m1ow"
                 },
                 {
                   "label": "HTML",
@@ -30261,7 +30348,7 @@
                   "attr": ""
                 }
               ],
-              "className": "alert alert-danger fa fa-ban w-100",
+              "className": "alert alert-danger fa fa-ban w-100 w-100",
               "content": "<strong> You must be a listed driver on the insurance of the vehicle you will be using to qualify for additional transportation funding.</strong>",
               "type": "htmlelement",
               "hideLabel": true,
@@ -30768,8 +30855,7 @@
                       "properties": {},
                       "allowMultipleMasks": false,
                       "addons": [],
-                      "id": "esmabhd",
-                      "tags": []
+                      "id": "esmabhd"
                     },
                     {
                       "label": "HTML",
@@ -31416,7 +31502,8 @@
               "id": "ev5rghf"
             }
           ],
-          "id": "emvzoox"
+          "id": "emvzoox",
+          "lockKey": true
         },
         {
           "input": true,

--- a/sources/packages/forms/src/form-definitions/sfaa2024-25.json
+++ b/sources/packages/forms/src/form-definitions/sfaa2024-25.json
@@ -10019,7 +10019,7 @@
                   "value": ""
                 }
               ],
-              "content": "<strong>Based on your response, you may be eligible for the Provincial Tuition Waiver Program and the Learning for Future Grant.</strong>\n<br />This means you could have your tuition and eligible fees paid for, and you could also receive an annual grant of $3,500 to cover additional education-related costs (e.g., textbooks, computers, supplies, etc.).\n<br/>To learn more about these financial supports, please visit the StudentAid BC website or contact the Financial Aid Office at your post-secondary institution.",
+              "content": "<strong>Based on your response, you may be eligible for the Provincial Tuition Waiver Program and the Learning for Future Grant.</strong>\n<br />This means you could have your tuition and eligible fees paid for, and you could also receive an annual grant of $3,500 to cover additional education-related costs (e.g., textbooks, computers, supplies, etc.).\n<br/>To learn more about these financial supports, please visit the <a class=\"formio-href\" href=\"https://studentaidbc.ca/explore/grants-scholarships\" target=\"_blank\" rel=\"noopener noreferrer\">StudentAid BC website</a> or contact the Financial Aid Office at your post-secondary institution.",
               "refreshOnChange": false,
               "customClass": "banner-info",
               "hidden": false,
@@ -10028,12 +10028,12 @@
               "tags": [],
               "properties": {},
               "conditional": {
-                "show": "true",
-                "when": "youthInCare",
-                "eq": "preferNotToAnswer",
+                "show": "",
+                "when": null,
+                "eq": "",
                 "json": ""
               },
-              "customConditional": "",
+              "customConditional": "show = (data.youthInCare === \"yes\" || data.youthInCare === \"preferNotToAnswer\");",
               "logic": [],
               "attributes": {},
               "overlay": {

--- a/sources/packages/forms/src/form-definitions/sfaa2024-25.json
+++ b/sources/packages/forms/src/form-definitions/sfaa2024-25.json
@@ -22387,6 +22387,7 @@
               "description": "",
               "errorLabel": "",
               "tooltip": "",
+              "hideLabel": false,
               "tabindex": "",
               "disabled": false,
               "autofocus": false,


### PR DESCRIPTION
Label and tooltip

![image](https://github.com/user-attachments/assets/e9fd6b9b-d8d4-4f7e-9329-6c7197c8a5a8)
![image](https://github.com/user-attachments/assets/de5d77aa-93cc-418b-b96f-0845b6e712f8)

Part time:
![image](https://github.com/user-attachments/assets/8e2ab2d2-7089-45c1-9d26-4bc24009e8fb)
Full time:
![image](https://github.com/user-attachments/assets/50d3c22c-413c-4dca-a260-b36ed7b34dbb)

- `youthInCare` is only compared to "yes" in the workflow and it's just displayed as it is in the reports, so there's no impact adding a new value to this radio set.
- Some of the changes are regarding putting SFAA* files in sync (issue from a previous PR not related to this ticket)


