### PR TITLE
#3223 - Create history/journal tables for auditing purposes

### DIFF
--- a/sources/packages/backend/apps/api/src/route-controllers/supporting-user/supporting-user.supporting-users.controller.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/supporting-user/supporting-user.supporting-users.controller.ts
@@ -237,7 +237,7 @@ export class SupportingUserSupportingUsersController extends BaseController {
       const updatedUser = await this.supportingUserService.updateSupportingUser(
         application.id,
         supportingUserType,
-        userToken.userId,
+        user.id,
         {
           contactInfo,
           sin: submissionResult.data.data.sin,

--- a/sources/packages/backend/apps/db-migrations/src/migrations/1723231015871-CreateHistoryEntryFunction.ts
+++ b/sources/packages/backend/apps/db-migrations/src/migrations/1723231015871-CreateHistoryEntryFunction.ts
@@ -1,0 +1,21 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+import { getSQLFileData } from "../utilities/sqlLoader";
+
+export class CreateHistoryEntryFunction1723231015871
+  implements MigrationInterface
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      getSQLFileData("Create-function-create-history-entry.sql", "Functions"),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      getSQLFileData(
+        "Rollback-create-function-create-history-entry.sql",
+        "Functions",
+      ),
+    );
+  }
+}

--- a/sources/packages/backend/apps/db-migrations/src/migrations/1723231119349-CreateUsersHistoryTable.ts
+++ b/sources/packages/backend/apps/db-migrations/src/migrations/1723231119349-CreateUsersHistoryTable.ts
@@ -1,0 +1,18 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+import { getSQLFileData } from "../utilities/sqlLoader";
+
+export class CreateUsersHistoryTable1723231119349
+  implements MigrationInterface
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      getSQLFileData("Create-user-history-table.sql", "User"),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      getSQLFileData("Rollback-create-user-history-table.sql", "User"),
+    );
+  }
+}

--- a/sources/packages/backend/apps/db-migrations/src/migrations/1723239334876-CreateStudentsHistoryTable.ts
+++ b/sources/packages/backend/apps/db-migrations/src/migrations/1723239334876-CreateStudentsHistoryTable.ts
@@ -1,0 +1,18 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+import { getSQLFileData } from "../utilities/sqlLoader";
+
+export class CreateStudentsHistoryTable1723239334876
+  implements MigrationInterface
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      getSQLFileData("Create-student-history-table.sql", "Student"),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      getSQLFileData("Rollback-create-student-history-table.sql", "Student"),
+    );
+  }
+}

--- a/sources/packages/backend/apps/db-migrations/src/migrations/1723494302501-CreateSupportingUsersHistoryTable.ts
+++ b/sources/packages/backend/apps/db-migrations/src/migrations/1723494302501-CreateSupportingUsersHistoryTable.ts
@@ -1,0 +1,24 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+import { getSQLFileData } from "../utilities/sqlLoader";
+
+export class CreateSupportingUsersHistoryTable1723494302501
+  implements MigrationInterface
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      getSQLFileData(
+        "Create-supporting-users-history-table.sql",
+        "SupportingUsers",
+      ),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      getSQLFileData(
+        "Rollback-create-supporting-users-history-table.sql",
+        "SupportingUsers",
+      ),
+    );
+  }
+}

--- a/sources/packages/backend/apps/db-migrations/src/migrations/1723494314291-CreateInstitutionsHistoryTable.ts
+++ b/sources/packages/backend/apps/db-migrations/src/migrations/1723494314291-CreateInstitutionsHistoryTable.ts
@@ -1,0 +1,21 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+import { getSQLFileData } from "../utilities/sqlLoader";
+
+export class CreateInstitutionsHistoryTable1723494314291
+  implements MigrationInterface
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      getSQLFileData("Create-institutions-history-table.sql", "Institution"),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      getSQLFileData(
+        "Rollback-create-institutions-history-table.sql",
+        "Institution",
+      ),
+    );
+  }
+}

--- a/sources/packages/backend/apps/db-migrations/src/migrations/1723494323451-CreateInstitutionLocationsHistoryTable.ts
+++ b/sources/packages/backend/apps/db-migrations/src/migrations/1723494323451-CreateInstitutionLocationsHistoryTable.ts
@@ -1,0 +1,24 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+import { getSQLFileData } from "../utilities/sqlLoader";
+
+export class CreateInstitutionLocationsHistoryTable1723494323451
+  implements MigrationInterface
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      getSQLFileData(
+        "Create-institution-locations-history-table.sql",
+        "InstitutionLocations",
+      ),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      getSQLFileData(
+        "Rollback-create-institution-locations-history-table.sql",
+        "InstitutionLocations",
+      ),
+    );
+  }
+}

--- a/sources/packages/backend/apps/db-migrations/src/migrations/1723494334204-CreateEducationProgramsHistoryTable.ts
+++ b/sources/packages/backend/apps/db-migrations/src/migrations/1723494334204-CreateEducationProgramsHistoryTable.ts
@@ -1,0 +1,24 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+import { getSQLFileData } from "../utilities/sqlLoader";
+
+export class CreateEducationProgramsHistoryTable1723494334204
+  implements MigrationInterface
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      getSQLFileData(
+        "Create-education-programs-history-table.sql",
+        "EducationPrograms",
+      ),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      getSQLFileData(
+        "Rollback-create-education-programs-history-table.sql",
+        "EducationPrograms",
+      ),
+    );
+  }
+}

--- a/sources/packages/backend/apps/db-migrations/src/migrations/1723494349958-CreateEducationProgramsOfferingsHistoryTable.ts
+++ b/sources/packages/backend/apps/db-migrations/src/migrations/1723494349958-CreateEducationProgramsOfferingsHistoryTable.ts
@@ -1,0 +1,24 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+import { getSQLFileData } from "../utilities/sqlLoader";
+
+export class CreateEducationProgramsOfferingsHistoryTable1723494349958
+  implements MigrationInterface
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      getSQLFileData(
+        "Create-education-programs-offerings-history-table.sql",
+        "EducationProgramsOfferings",
+      ),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      getSQLFileData(
+        "Rollback-create-education-programs-offerings-history-table.sql",
+        "EducationProgramsOfferings",
+      ),
+    );
+  }
+}

--- a/sources/packages/backend/apps/db-migrations/src/sql/EducationPrograms/Create-education-programs-history-table.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/EducationPrograms/Create-education-programs-history-table.sql
@@ -1,0 +1,139 @@
+-- Table to keep historical data.
+-- Columns history_timestamp and history_operation should be default columns for all the history tables.
+-- Columns other than the above-mentioned should reflect the columns from the original table without constraints and relationships.
+-- The order of the columns below follow the exact same order from the existing table.
+CREATE TABLE sims.education_programs_history AS
+SELECT
+  CURRENT_TIMESTAMP AS history_date,
+  '' :: varchar(50) AS history_operation,
+  *
+FROM
+  sims.education_programs
+WHERE
+  false;
+
+CREATE INDEX education_programs_history_timestamp ON sims.education_programs_history(history_timestamp);
+
+COMMENT ON INDEX sims.education_programs_history_timestamp IS 'Historical data index to improve point-in-time data retrieval.';
+
+COMMENT ON TABLE sims.education_programs_history IS 'Historical data generated after records are inserted or updated.';
+
+COMMENT ON COLUMN sims.education_programs_history.history_timestamp IS 'Date and time the history record was inserted.';
+
+COMMENT ON COLUMN sims.education_programs_history.history_operation IS 'Database operation that generates the history.';
+
+COMMENT ON COLUMN sims.education_programs_history.id IS 'Historical data from the original table. See original table comments for details.';
+
+COMMENT ON COLUMN sims.education_programs_history.program_name IS 'Historical data from the original table. See original table comments for details.';
+
+COMMENT ON COLUMN sims.education_programs_history.program_description IS 'Historical data from the original table. See original table comments for details.';
+
+COMMENT ON COLUMN sims.education_programs_history.credential_type IS 'Historical data from the original table. See original table comments for details.';
+
+COMMENT ON COLUMN sims.education_programs_history.cip_code IS 'Historical data from the original table. See original table comments for details.';
+
+COMMENT ON COLUMN sims.education_programs_history.noc_code IS 'Historical data from the original table. See original table comments for details.';
+
+COMMENT ON COLUMN sims.education_programs_history.sabc_code IS 'Historical data from the original table. See original table comments for details.';
+
+COMMENT ON COLUMN sims.education_programs_history.regulatory_body IS 'Historical data from the original table. See original table comments for details.';
+
+COMMENT ON COLUMN sims.education_programs_history.delivered_on_site IS 'Historical data from the original table. See original table comments for details.';
+
+COMMENT ON COLUMN sims.education_programs_history.delivered_online IS 'Historical data from the original table. See original table comments for details.';
+
+COMMENT ON COLUMN sims.education_programs_history.delivered_online_also_onsite IS 'Historical data from the original table. See original table comments for details.';
+
+COMMENT ON COLUMN sims.education_programs_history.same_online_credits_earned IS 'Historical data from the original table. See original table comments for details.';
+
+COMMENT ON COLUMN sims.education_programs_history.earn_academic_credits_other_institution IS 'Historical data from the original table. See original table comments for details.';
+
+COMMENT ON COLUMN sims.education_programs_history.course_load_calculation IS 'Historical data from the original table. See original table comments for details.';
+
+COMMENT ON COLUMN sims.education_programs_history.completion_years IS 'Historical data from the original table. See original table comments for details.';
+
+COMMENT ON COLUMN sims.education_programs_history.esl_eligibility IS 'Historical data from the original table. See original table comments for details.';
+
+COMMENT ON COLUMN sims.education_programs_history.has_joint_institution IS 'Historical data from the original table. See original table comments for details.';
+
+COMMENT ON COLUMN sims.education_programs_history.has_joint_designated_institution IS 'Historical data from the original table. See original table comments for details.';
+
+COMMENT ON COLUMN sims.education_programs_history.program_status IS 'Historical data from the original table. See original table comments for details.';
+
+COMMENT ON COLUMN sims.education_programs_history.institution_id IS 'Historical data from the original table. See original table comments for details.';
+
+COMMENT ON COLUMN sims.education_programs_history.created_at IS 'Historical data from the original table. See original table comments for details.';
+
+COMMENT ON COLUMN sims.education_programs_history.updated_at IS 'Historical data from the original table. See original table comments for details.';
+
+COMMENT ON COLUMN sims.education_programs_history.creator IS 'Historical data from the original table. See original table comments for details.';
+
+COMMENT ON COLUMN sims.education_programs_history.modifier IS 'Historical data from the original table. See original table comments for details.';
+
+COMMENT ON COLUMN sims.education_programs_history.program_intensity IS 'Historical data from the original table. See original table comments for details.';
+
+COMMENT ON COLUMN sims.education_programs_history.institution_program_code IS 'Historical data from the original table. See original table comments for details.';
+
+COMMENT ON COLUMN sims.education_programs_history.min_hours_week IS 'Historical data from the original table. See original table comments for details.';
+
+COMMENT ON COLUMN sims.education_programs_history.is_aviation_program IS 'Historical data from the original table. See original table comments for details.';
+
+COMMENT ON COLUMN sims.education_programs_history.min_hours_week_avi IS 'Historical data from the original table. See original table comments for details.';
+
+COMMENT ON COLUMN sims.education_programs_history.has_minimum_age IS 'Historical data from the original table. See original table comments for details.';
+
+COMMENT ON COLUMN sims.education_programs_history.min_high_school IS 'Historical data from the original table. See original table comments for details.';
+
+COMMENT ON COLUMN sims.education_programs_history.requirements_by_institution IS 'Historical data from the original table. See original table comments for details.';
+
+COMMENT ON COLUMN sims.education_programs_history.requirements_by_bcita IS 'Historical data from the original table. See original table comments for details.';
+
+COMMENT ON COLUMN sims.education_programs_history.has_wil_component IS 'Historical data from the original table. See original table comments for details.';
+
+COMMENT ON COLUMN sims.education_programs_history.is_wil_approved IS 'Historical data from the original table. See original table comments for details.';
+
+COMMENT ON COLUMN sims.education_programs_history.wil_program_eligibility IS 'Historical data from the original table. See original table comments for details.';
+
+COMMENT ON COLUMN sims.education_programs_history.has_travel IS 'Historical data from the original table. See original table comments for details.';
+
+COMMENT ON COLUMN sims.education_programs_history.travel_program_eligibility IS 'Historical data from the original table. See original table comments for details.';
+
+COMMENT ON COLUMN sims.education_programs_history.has_intl_exchange IS 'Historical data from the original table. See original table comments for details.';
+
+COMMENT ON COLUMN sims.education_programs_history.intl_exchange_program_eligibility IS 'Historical data from the original table. See original table comments for details.';
+
+COMMENT ON COLUMN sims.education_programs_history.program_declaration IS 'Historical data from the original table. See original table comments for details.';
+
+COMMENT ON COLUMN sims.education_programs_history.submitted_date IS 'Historical data from the original table. See original table comments for details.';
+
+COMMENT ON COLUMN sims.education_programs_history.assessed_date IS 'Historical data from the original table. See original table comments for details.';
+
+COMMENT ON COLUMN sims.education_programs_history.effective_end_date IS 'Historical data from the original table. See original table comments for details.';
+
+COMMENT ON COLUMN sims.education_programs_history.program_note IS 'Historical data from the original table. See original table comments for details.';
+
+COMMENT ON COLUMN sims.education_programs_history.assessed_by IS 'Historical data from the original table. See original table comments for details.';
+
+COMMENT ON COLUMN sims.education_programs_history.submitted_by IS 'Historical data from the original table. See original table comments for details.';
+
+COMMENT ON COLUMN sims.education_programs_history.field_of_study_code IS 'Historical data from the original table. See original table comments for details.';
+
+COMMENT ON COLUMN sims.education_programs_history.other_regulatory_body IS 'Historical data from the original table. See original table comments for details.';
+
+COMMENT ON COLUMN sims.education_programs_history.none_of_entrance_requirements IS 'Historical data from the original table. See original table comments for details.';
+
+COMMENT ON COLUMN sims.education_programs_history.is_active IS 'Historical data from the original table. See original table comments for details.';
+
+COMMENT ON COLUMN sims.education_programs_history.is_active_updated_by IS 'Historical data from the original table. See original table comments for details.';
+
+COMMENT ON COLUMN sims.education_programs_history.is_active_updated_on IS 'Historical data from the original table. See original table comments for details.';
+
+-- Creates the trigger to have the table populated using the shared create_history_entry function.
+CREATE TRIGGER education_programs_history_trigger
+AFTER
+INSERT
+  OR
+UPDATE
+  ON sims.education_programs FOR EACH ROW EXECUTE PROCEDURE sims.create_history_entry();
+
+COMMENT ON TRIGGER education_programs_history_trigger ON sims.education_programs IS 'Creates historical data for the education_programs table.';

--- a/sources/packages/backend/apps/db-migrations/src/sql/EducationPrograms/Create-education-programs-history-table.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/EducationPrograms/Create-education-programs-history-table.sql
@@ -12,6 +12,18 @@ FROM
 WHERE
   false;
 
+-- Set history columns as NOT NULL.
+ALTER TABLE
+  sims.education_programs_history
+ALTER COLUMN
+  history_timestamp
+SET
+  NOT NULL,
+ALTER COLUMN
+  history_operation
+SET
+  NOT NULL;
+
 CREATE INDEX education_programs_history_timestamp ON sims.education_programs_history(history_timestamp);
 
 COMMENT ON INDEX sims.education_programs_history_timestamp IS 'Historical data index to improve point-in-time data retrieval.';

--- a/sources/packages/backend/apps/db-migrations/src/sql/EducationPrograms/Create-education-programs-history-table.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/EducationPrograms/Create-education-programs-history-table.sql
@@ -4,7 +4,7 @@
 -- The order of the columns below follow the exact same order from the existing table.
 CREATE TABLE sims.education_programs_history AS
 SELECT
-  CURRENT_TIMESTAMP AS history_date,
+  CURRENT_TIMESTAMP AS history_timestamp,
   '' :: varchar(50) AS history_operation,
   *
 FROM

--- a/sources/packages/backend/apps/db-migrations/src/sql/EducationPrograms/Rollback-create-education-programs-history-table.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/EducationPrograms/Rollback-create-education-programs-history-table.sql
@@ -1,0 +1,3 @@
+DROP TABLE sims.education_programs_history;
+
+DROP TRIGGER education_programs_history_trigger ON sims.education_programs;

--- a/sources/packages/backend/apps/db-migrations/src/sql/EducationProgramsOfferings/Create-education-programs-offerings-history-table.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/EducationProgramsOfferings/Create-education-programs-offerings-history-table.sql
@@ -4,7 +4,7 @@
 -- The order of the columns below follow the exact same order from the existing table.
 CREATE TABLE sims.education_programs_offerings_history AS
 SELECT
-  CURRENT_TIMESTAMP AS history_date,
+  CURRENT_TIMESTAMP AS history_timestamp,
   '' :: varchar(50) AS history_operation,
   *
 FROM

--- a/sources/packages/backend/apps/db-migrations/src/sql/EducationProgramsOfferings/Create-education-programs-offerings-history-table.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/EducationProgramsOfferings/Create-education-programs-offerings-history-table.sql
@@ -1,0 +1,95 @@
+-- Table to keep historical data.
+-- Columns history_timestamp and history_operation should be default columns for all the history tables.
+-- Columns other than the above-mentioned should reflect the columns from the original table without constraints and relationships.
+-- The order of the columns below follow the exact same order from the existing table.
+CREATE TABLE sims.education_programs_offerings_history AS
+SELECT
+  CURRENT_TIMESTAMP AS history_date,
+  '' :: varchar(50) AS history_operation,
+  *
+FROM
+  sims.education_programs_offerings
+WHERE
+  false;
+
+CREATE INDEX education_programs_offerings_history_timestamp ON sims.education_programs_offerings_history(history_timestamp);
+
+COMMENT ON INDEX sims.education_programs_offerings_history_timestamp IS 'Historical data index to improve point-in-time data retrieval.';
+
+COMMENT ON TABLE sims.education_programs_offerings_history IS 'Historical data generated after records are inserted or updated.';
+
+COMMENT ON COLUMN sims.education_programs_offerings_history.history_timestamp IS 'Date and time the history record was inserted.';
+
+COMMENT ON COLUMN sims.education_programs_offerings_history.history_operation IS 'Database operation that generates the history.';
+
+COMMENT ON COLUMN sims.education_programs_offerings_history.id IS 'Historical data from the original table. See original table comments for details.';
+
+COMMENT ON COLUMN sims.education_programs_offerings_history.offering_name IS 'Historical data from the original table. See original table comments for details.';
+
+COMMENT ON COLUMN sims.education_programs_offerings_history.study_start_date IS 'Historical data from the original table. See original table comments for details.';
+
+COMMENT ON COLUMN sims.education_programs_offerings_history.study_end_date IS 'Historical data from the original table. See original table comments for details.';
+
+COMMENT ON COLUMN sims.education_programs_offerings_history.actual_tuition_costs IS 'Historical data from the original table. See original table comments for details.';
+
+COMMENT ON COLUMN sims.education_programs_offerings_history.program_related_costs IS 'Historical data from the original table. See original table comments for details.';
+
+COMMENT ON COLUMN sims.education_programs_offerings_history.mandatory_fees IS 'Historical data from the original table. See original table comments for details.';
+
+COMMENT ON COLUMN sims.education_programs_offerings_history.exceptional_expenses IS 'Historical data from the original table. See original table comments for details.';
+
+COMMENT ON COLUMN sims.education_programs_offerings_history.offering_delivered IS 'Historical data from the original table. See original table comments for details.';
+
+COMMENT ON COLUMN sims.education_programs_offerings_history.lacks_study_breaks IS 'Historical data from the original table. See original table comments for details.';
+
+COMMENT ON COLUMN sims.education_programs_offerings_history.program_id IS 'Historical data from the original table. See original table comments for details.';
+
+COMMENT ON COLUMN sims.education_programs_offerings_history.location_id IS 'Historical data from the original table. See original table comments for details.';
+
+COMMENT ON COLUMN sims.education_programs_offerings_history.created_at IS 'Historical data from the original table. See original table comments for details.';
+
+COMMENT ON COLUMN sims.education_programs_offerings_history.updated_at IS 'Historical data from the original table. See original table comments for details.';
+
+COMMENT ON COLUMN sims.education_programs_offerings_history.creator IS 'Historical data from the original table. See original table comments for details.';
+
+COMMENT ON COLUMN sims.education_programs_offerings_history.modifier IS 'Historical data from the original table. See original table comments for details.';
+
+COMMENT ON COLUMN sims.education_programs_offerings_history.offering_type IS 'Historical data from the original table. See original table comments for details.';
+
+COMMENT ON COLUMN sims.education_programs_offerings_history.offering_intensity IS 'Historical data from the original table. See original table comments for details.';
+
+COMMENT ON COLUMN sims.education_programs_offerings_history.year_of_study IS 'Historical data from the original table. See original table comments for details.';
+
+COMMENT ON COLUMN sims.education_programs_offerings_history.has_offering_wil_component IS 'Historical data from the original table. See original table comments for details.';
+
+COMMENT ON COLUMN sims.education_programs_offerings_history.offering_wil_type IS 'Historical data from the original table. See original table comments for details.';
+
+COMMENT ON COLUMN sims.education_programs_offerings_history.study_breaks IS 'Historical data from the original table. See original table comments for details.';
+
+COMMENT ON COLUMN sims.education_programs_offerings_history.offering_declaration IS 'Historical data from the original table. See original table comments for details.';
+
+COMMENT ON COLUMN sims.education_programs_offerings_history.offering_status IS 'Historical data from the original table. See original table comments for details.';
+
+COMMENT ON COLUMN sims.education_programs_offerings_history.assessed_by IS 'Historical data from the original table. See original table comments for details.';
+
+COMMENT ON COLUMN sims.education_programs_offerings_history.assessed_date IS 'Historical data from the original table. See original table comments for details.';
+
+COMMENT ON COLUMN sims.education_programs_offerings_history.submitted_date IS 'Historical data from the original table. See original table comments for details.';
+
+COMMENT ON COLUMN sims.education_programs_offerings_history.offering_note IS 'Historical data from the original table. See original table comments for details.';
+
+COMMENT ON COLUMN sims.education_programs_offerings_history.course_load IS 'Historical data from the original table. See original table comments for details.';
+
+COMMENT ON COLUMN sims.education_programs_offerings_history.parent_offering_id IS 'Historical data from the original table. See original table comments for details.';
+
+COMMENT ON COLUMN sims.education_programs_offerings_history.preceding_offering_id IS 'Historical data from the original table. See original table comments for details.';
+
+-- Creates the trigger to have the table populated using the shared create_history_entry function.
+CREATE TRIGGER education_programs_offerings_history_trigger
+AFTER
+INSERT
+  OR
+UPDATE
+  ON sims.education_programs_offerings FOR EACH ROW EXECUTE PROCEDURE sims.create_history_entry();
+
+COMMENT ON TRIGGER education_programs_offerings_history_trigger ON sims.education_programs_offerings IS 'Creates historical data for the education_programs_offerings table.';

--- a/sources/packages/backend/apps/db-migrations/src/sql/EducationProgramsOfferings/Create-education-programs-offerings-history-table.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/EducationProgramsOfferings/Create-education-programs-offerings-history-table.sql
@@ -12,6 +12,18 @@ FROM
 WHERE
   false;
 
+-- Set history columns as NOT NULL.
+ALTER TABLE
+  sims.education_programs_offerings_history
+ALTER COLUMN
+  history_timestamp
+SET
+  NOT NULL,
+ALTER COLUMN
+  history_operation
+SET
+  NOT NULL;
+
 CREATE INDEX education_programs_offerings_history_timestamp ON sims.education_programs_offerings_history(history_timestamp);
 
 COMMENT ON INDEX sims.education_programs_offerings_history_timestamp IS 'Historical data index to improve point-in-time data retrieval.';

--- a/sources/packages/backend/apps/db-migrations/src/sql/EducationProgramsOfferings/Rollback-create-education-programs-offerings-history-table.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/EducationProgramsOfferings/Rollback-create-education-programs-offerings-history-table.sql
@@ -1,0 +1,3 @@
+DROP TABLE sims.education_programs_offerings_history;
+
+DROP TRIGGER education_programs_offerings_history_trigger ON sims.education_programs_offerings;

--- a/sources/packages/backend/apps/db-migrations/src/sql/Functions/Create-function-create-history-entry.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/Functions/Create-function-create-history-entry.sql
@@ -1,0 +1,14 @@
+-- Generic function to be associated with table triggers to allow historical records creation.
+CREATE FUNCTION sims.create_history_entry() RETURNS trigger
+    LANGUAGE plpgsql
+AS
+$func$
+DECLARE
+    history_table_name text := TG_TABLE_SCHEMA || '.' || TG_TABLE_NAME || '_history';
+BEGIN
+    EXECUTE 'INSERT INTO ' || history_table_name || ' SELECT CURRENT_TIMESTAMP, $1, ($2).*;' using TG_OP, NEW;
+    RETURN NULL;
+END;
+$func$;
+
+COMMENT ON FUNCTION sims.create_history_entry() IS 'Generic function to create modification history for required tables.';

--- a/sources/packages/backend/apps/db-migrations/src/sql/Functions/Rollback-create-function-create-history-entry.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/Functions/Rollback-create-function-create-history-entry.sql
@@ -1,0 +1,1 @@
+DROP FUNCTION sims.create_history_entry();

--- a/sources/packages/backend/apps/db-migrations/src/sql/Institution/Create-institutions-history-table.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/Institution/Create-institutions-history-table.sql
@@ -1,0 +1,67 @@
+-- Table to keep historical data.
+-- Columns history_timestamp and history_operation should be default columns for all the history tables.
+-- Columns other than the above-mentioned should reflect the columns from the original table without constraints and relationships.
+-- The order of the columns below follow the exact same order from the existing table.
+CREATE TABLE sims.institutions_history AS
+SELECT
+  CURRENT_TIMESTAMP AS history_date,
+  '' :: varchar(50) AS history_operation,
+  *
+FROM
+  sims.institutions
+WHERE
+  false;
+
+CREATE INDEX institutions_history_timestamp ON sims.institutions_history(history_timestamp);
+
+COMMENT ON INDEX sims.institutions_history_timestamp IS 'Historical data index to improve point-in-time data retrieval.';
+
+COMMENT ON TABLE sims.institutions_history IS 'Historical data generated after records are inserted or updated.';
+
+COMMENT ON COLUMN sims.institutions_history.history_timestamp IS 'Date and time the history record was inserted.';
+
+COMMENT ON COLUMN sims.institutions_history.history_operation IS 'Database operation that generates the history.';
+
+COMMENT ON COLUMN sims.institutions_history.id IS 'Historical data from the original table. See original table comments for details.';
+
+COMMENT ON COLUMN sims.institutions_history.business_guid IS 'Historical data from the original table. See original table comments for details.';
+
+COMMENT ON COLUMN sims.institutions_history.legal_operating_name IS 'Historical data from the original table. See original table comments for details.';
+
+COMMENT ON COLUMN sims.institutions_history.operating_name IS 'Historical data from the original table. See original table comments for details.';
+
+COMMENT ON COLUMN sims.institutions_history.primary_phone IS 'Historical data from the original table. See original table comments for details.';
+
+COMMENT ON COLUMN sims.institutions_history.primary_email IS 'Historical data from the original table. See original table comments for details.';
+
+COMMENT ON COLUMN sims.institutions_history.website IS 'Historical data from the original table. See original table comments for details.';
+
+COMMENT ON COLUMN sims.institutions_history.regulating_body IS 'Historical data from the original table. See original table comments for details.';
+
+COMMENT ON COLUMN sims.institutions_history.established_date IS 'Historical data from the original table. See original table comments for details.';
+
+COMMENT ON COLUMN sims.institutions_history.primary_contact IS 'Historical data from the original table. See original table comments for details.';
+
+COMMENT ON COLUMN sims.institutions_history.institution_address IS 'Historical data from the original table. See original table comments for details.';
+
+COMMENT ON COLUMN sims.institutions_history.created_at IS 'Historical data from the original table. See original table comments for details.';
+
+COMMENT ON COLUMN sims.institutions_history.updated_at IS 'Historical data from the original table. See original table comments for details.';
+
+COMMENT ON COLUMN sims.institutions_history.creator IS 'Historical data from the original table. See original table comments for details.';
+
+COMMENT ON COLUMN sims.institutions_history.modifier IS 'Historical data from the original table. See original table comments for details.';
+
+COMMENT ON COLUMN sims.institutions_history.institution_type_id IS 'Historical data from the original table. See original table comments for details.';
+
+COMMENT ON COLUMN sims.institutions_history.other_regulating_body IS 'Historical data from the original table. See original table comments for details.';
+
+-- Creates the trigger to have the table populated using the shared create_history_entry function.
+CREATE TRIGGER institutions_history_trigger
+AFTER
+INSERT
+  OR
+UPDATE
+  ON sims.institutions FOR EACH ROW EXECUTE PROCEDURE sims.create_history_entry();
+
+COMMENT ON TRIGGER institutions_history_trigger ON sims.institutions IS 'Creates historical data for the institutions table.';

--- a/sources/packages/backend/apps/db-migrations/src/sql/Institution/Create-institutions-history-table.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/Institution/Create-institutions-history-table.sql
@@ -4,7 +4,7 @@
 -- The order of the columns below follow the exact same order from the existing table.
 CREATE TABLE sims.institutions_history AS
 SELECT
-  CURRENT_TIMESTAMP AS history_date,
+  CURRENT_TIMESTAMP AS history_timestamp,
   '' :: varchar(50) AS history_operation,
   *
 FROM

--- a/sources/packages/backend/apps/db-migrations/src/sql/Institution/Create-institutions-history-table.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/Institution/Create-institutions-history-table.sql
@@ -12,6 +12,18 @@ FROM
 WHERE
   false;
 
+-- Set history columns as NOT NULL.
+ALTER TABLE
+  sims.institutions_history
+ALTER COLUMN
+  history_timestamp
+SET
+  NOT NULL,
+ALTER COLUMN
+  history_operation
+SET
+  NOT NULL;
+
 CREATE INDEX institutions_history_timestamp ON sims.institutions_history(history_timestamp);
 
 COMMENT ON INDEX sims.institutions_history_timestamp IS 'Historical data index to improve point-in-time data retrieval.';

--- a/sources/packages/backend/apps/db-migrations/src/sql/Institution/Rollback-create-institutions-history-table.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/Institution/Rollback-create-institutions-history-table.sql
@@ -1,0 +1,3 @@
+DROP TABLE sims.institutions_history;
+
+DROP TRIGGER institutions_history_trigger ON sims.institutions;

--- a/sources/packages/backend/apps/db-migrations/src/sql/InstitutionLocations/Create-institution-locations-history-table.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/InstitutionLocations/Create-institution-locations-history-table.sql
@@ -12,6 +12,18 @@ FROM
 WHERE
   false;
 
+-- Set history columns as NOT NULL.
+ALTER TABLE
+  sims.institution_locations_history
+ALTER COLUMN
+  history_timestamp
+SET
+  NOT NULL,
+ALTER COLUMN
+  history_operation
+SET
+  NOT NULL;
+
 CREATE INDEX institution_locations_history_timestamp ON sims.institution_locations_history(history_timestamp);
 
 COMMENT ON INDEX sims.institution_locations_history_timestamp IS 'Historical data index to improve point-in-time data retrieval.';

--- a/sources/packages/backend/apps/db-migrations/src/sql/InstitutionLocations/Create-institution-locations-history-table.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/InstitutionLocations/Create-institution-locations-history-table.sql
@@ -4,7 +4,7 @@
 -- The order of the columns below follow the exact same order from the existing table.
 CREATE TABLE sims.institution_locations_history AS
 SELECT
-  CURRENT_TIMESTAMP AS history_date,
+  CURRENT_TIMESTAMP AS history_timestamp,
   '' :: varchar(50) AS history_operation,
   *
 FROM

--- a/sources/packages/backend/apps/db-migrations/src/sql/InstitutionLocations/Create-institution-locations-history-table.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/InstitutionLocations/Create-institution-locations-history-table.sql
@@ -1,0 +1,57 @@
+-- Table to keep historical data.
+-- Columns history_timestamp and history_operation should be default columns for all the history tables.
+-- Columns other than the above-mentioned should reflect the columns from the original table without constraints and relationships.
+-- The order of the columns below follow the exact same order from the existing table.
+CREATE TABLE sims.institution_locations_history AS
+SELECT
+  CURRENT_TIMESTAMP AS history_date,
+  '' :: varchar(50) AS history_operation,
+  *
+FROM
+  sims.institution_locations
+WHERE
+  false;
+
+CREATE INDEX institution_locations_history_timestamp ON sims.institution_locations_history(history_timestamp);
+
+COMMENT ON INDEX sims.institution_locations_history_timestamp IS 'Historical data index to improve point-in-time data retrieval.';
+
+COMMENT ON TABLE sims.institution_locations_history IS 'Historical data generated after records are inserted or updated.';
+
+COMMENT ON COLUMN sims.institution_locations_history.history_timestamp IS 'Date and time the history record was inserted.';
+
+COMMENT ON COLUMN sims.institution_locations_history.history_operation IS 'Database operation that generates the history.';
+
+COMMENT ON COLUMN sims.institution_locations_history.id IS 'Historical data from the original table. See original table comments for details.';
+
+COMMENT ON COLUMN sims.institution_locations_history.name IS 'Historical data from the original table. See original table comments for details.';
+
+COMMENT ON COLUMN sims.institution_locations_history.info IS 'Historical data from the original table. See original table comments for details.';
+
+COMMENT ON COLUMN sims.institution_locations_history.institution_id IS 'Historical data from the original table. See original table comments for details.';
+
+COMMENT ON COLUMN sims.institution_locations_history.created_at IS 'Historical data from the original table. See original table comments for details.';
+
+COMMENT ON COLUMN sims.institution_locations_history.updated_at IS 'Historical data from the original table. See original table comments for details.';
+
+COMMENT ON COLUMN sims.institution_locations_history.creator IS 'Historical data from the original table. See original table comments for details.';
+
+COMMENT ON COLUMN sims.institution_locations_history.modifier IS 'Historical data from the original table. See original table comments for details.';
+
+COMMENT ON COLUMN sims.institution_locations_history.institution_code IS 'Historical data from the original table. See original table comments for details.';
+
+COMMENT ON COLUMN sims.institution_locations_history.primary_contact IS 'Historical data from the original table. See original table comments for details.';
+
+COMMENT ON COLUMN sims.institution_locations_history.has_integration IS 'Historical data from the original table. See original table comments for details.';
+
+COMMENT ON COLUMN sims.institution_locations_history.integration_contacts IS 'Historical data from the original table. See original table comments for details.';
+
+-- Creates the trigger to have the table populated using the shared create_history_entry function.
+CREATE TRIGGER institution_locations_history_trigger
+AFTER
+INSERT
+  OR
+UPDATE
+  ON sims.institution_locations FOR EACH ROW EXECUTE PROCEDURE sims.create_history_entry();
+
+COMMENT ON TRIGGER institution_locations_history_trigger ON sims.institution_locations IS 'Creates historical data for the institution_locations table.';

--- a/sources/packages/backend/apps/db-migrations/src/sql/InstitutionLocations/Rollback-create-institution-locations-history-table.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/InstitutionLocations/Rollback-create-institution-locations-history-table.sql
@@ -1,0 +1,3 @@
+DROP TABLE sims.institution_locations_history;
+
+DROP TRIGGER institution_locations_history_trigger ON sims.institution_locations;

--- a/sources/packages/backend/apps/db-migrations/src/sql/Student/Create-student-history-table.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/Student/Create-student-history-table.sql
@@ -4,7 +4,7 @@
 -- The order of the columns below follow the exact same order from the existing table.
 CREATE TABLE sims.students_history AS
 SELECT
-  CURRENT_TIMESTAMP AS history_date,
+  CURRENT_TIMESTAMP AS history_timestamp,
   '' :: varchar(50) AS history_operation,
   *
 FROM

--- a/sources/packages/backend/apps/db-migrations/src/sql/Student/Create-student-history-table.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/Student/Create-student-history-table.sql
@@ -12,6 +12,18 @@ FROM
 WHERE
   false;
 
+-- Set history columns as NOT NULL.
+ALTER TABLE
+  sims.students_history
+ALTER COLUMN
+  history_timestamp
+SET
+  NOT NULL,
+ALTER COLUMN
+  history_operation
+SET
+  NOT NULL;
+
 CREATE INDEX students_history_timestamp ON sims.students_history(history_timestamp);
 
 COMMENT ON INDEX sims.students_history_timestamp IS 'Historical data index to improve point-in-time data retrieval.';

--- a/sources/packages/backend/apps/db-migrations/src/sql/Student/Create-student-history-table.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/Student/Create-student-history-table.sql
@@ -1,0 +1,65 @@
+-- Table to keep historical data.
+-- Columns history_timestamp and history_operation should be default columns for all the history tables.
+-- Columns other than the above-mentioned should reflect the columns from the original table without constraints and relationships.
+-- The order of the columns below follow the exact same order from the existing table.
+CREATE TABLE sims.students_history AS
+SELECT
+  CURRENT_TIMESTAMP AS history_date,
+  '' :: varchar(50) AS history_operation,
+  *
+FROM
+  sims.students
+WHERE
+  false;
+
+CREATE INDEX students_history_timestamp ON sims.students_history(history_timestamp);
+
+COMMENT ON INDEX sims.students_history_timestamp IS 'Historical data index to improve point-in-time data retrieval.';
+
+COMMENT ON TABLE sims.students_history IS 'Historical data generated after records are inserted or updated.';
+
+COMMENT ON COLUMN sims.students_history.history_timestamp IS 'Date and time the history record was inserted.';
+
+COMMENT ON COLUMN sims.students_history.history_operation IS 'Database operation that generates the history.';
+
+COMMENT ON COLUMN sims.students_history.id IS 'Historical data from the original table. See original table comments for details.';
+
+COMMENT ON COLUMN sims.students_history.contact_info IS 'Historical data from the original table. See original table comments for details.';
+
+COMMENT ON COLUMN sims.students_history.user_id IS 'Historical data from the original table. See original table comments for details.';
+
+COMMENT ON COLUMN sims.students_history.created_at IS 'Historical data from the original table. See original table comments for details.';
+
+COMMENT ON COLUMN sims.students_history.updated_at IS 'Historical data from the original table. See original table comments for details.';
+
+COMMENT ON COLUMN sims.students_history.creator IS 'Historical data from the original table. See original table comments for details.';
+
+COMMENT ON COLUMN sims.students_history.modifier IS 'Historical data from the original table. See original table comments for details.';
+
+COMMENT ON COLUMN sims.students_history.birth_date IS 'Historical data from the original table. See original table comments for details.';
+
+COMMENT ON COLUMN sims.students_history.gender IS 'Historical data from the original table. See original table comments for details.';
+
+COMMENT ON COLUMN sims.students_history.pd_date_sent IS 'Historical data from the original table. See original table comments for details.';
+
+COMMENT ON COLUMN sims.students_history.pd_date_update IS 'Historical data from the original table. See original table comments for details.';
+
+COMMENT ON COLUMN sims.students_history.sin_validation_id IS 'Historical data from the original table. See original table comments for details.';
+
+COMMENT ON COLUMN sims.students_history.sin_consent IS 'Historical data from the original table. See original table comments for details.';
+
+COMMENT ON COLUMN sims.students_history.disability_status IS 'Historical data from the original table. See original table comments for details.';
+
+COMMENT ON COLUMN sims.students_history.disability_status_effective_date IS 'Historical data from the original table. See original table comments for details.';
+
+COMMENT ON COLUMN sims.students_history.cas_supplier_id IS 'Historical data from the original table. See original table comments for details.';
+
+-- Creates the trigger to have the table populated using the shared create_history_entry function.
+CREATE TRIGGER students_history_trigger
+AFTER
+INSERT
+  OR
+UPDATE
+  ON sims.students FOR EACH ROW EXECUTE PROCEDURE sims.create_history_entry();
+
+COMMENT ON TRIGGER students_history_trigger ON sims.students IS 'Creates historical data for the students table.';

--- a/sources/packages/backend/apps/db-migrations/src/sql/Student/Rollback-create-student-history-table.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/Student/Rollback-create-student-history-table.sql
@@ -1,0 +1,3 @@
+DROP TABLE sims.students_history;
+
+DROP TRIGGER students_history_trigger ON sims.students;

--- a/sources/packages/backend/apps/db-migrations/src/sql/SupportingUsers/Create-supporting-users-history-table.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/SupportingUsers/Create-supporting-users-history-table.sql
@@ -1,0 +1,57 @@
+-- Table to keep historical data.
+-- Columns history_timestamp and history_operation should be default columns for all the history tables.
+-- Columns other than the above-mentioned should reflect the columns from the original table without constraints and relationships.
+-- The order of the columns below follow the exact same order from the existing table.
+CREATE TABLE sims.supporting_users_history AS
+SELECT
+  CURRENT_TIMESTAMP AS history_date,
+  '' :: varchar(50) AS history_operation,
+  *
+FROM
+  sims.supporting_users
+WHERE
+  false;
+
+CREATE INDEX supporting_users_history_timestamp ON sims.supporting_users_history(history_timestamp);
+
+COMMENT ON INDEX sims.supporting_users_history_timestamp IS 'Historical data index to improve point-in-time data retrieval.';
+
+COMMENT ON TABLE sims.supporting_users_history IS 'Historical data generated after records are inserted or updated.';
+
+COMMENT ON COLUMN sims.supporting_users_history.history_timestamp IS 'Date and time the history record was inserted.';
+
+COMMENT ON COLUMN sims.supporting_users_history.history_operation IS 'Database operation that generates the history.';
+
+COMMENT ON COLUMN sims.supporting_users_history.id IS 'Historical data from the original table. See original table comments for details.';
+
+COMMENT ON COLUMN sims.supporting_users_history.contact_info IS 'Historical data from the original table. See original table comments for details.';
+
+COMMENT ON COLUMN sims.supporting_users_history.sin IS 'Historical data from the original table. See original table comments for details.';
+
+COMMENT ON COLUMN sims.supporting_users_history.birth_date IS 'Historical data from the original table. See original table comments for details.';
+
+COMMENT ON COLUMN sims.supporting_users_history.supporting_data IS 'Historical data from the original table. See original table comments for details.';
+
+COMMENT ON COLUMN sims.supporting_users_history.supporting_user_type IS 'Historical data from the original table. See original table comments for details.';
+
+COMMENT ON COLUMN sims.supporting_users_history.user_id IS 'Historical data from the original table. See original table comments for details.';
+
+COMMENT ON COLUMN sims.supporting_users_history.application_id IS 'Historical data from the original table. See original table comments for details.';
+
+COMMENT ON COLUMN sims.supporting_users_history.created_at IS 'Historical data from the original table. See original table comments for details.';
+
+COMMENT ON COLUMN sims.supporting_users_history.updated_at IS 'Historical data from the original table. See original table comments for details.';
+
+COMMENT ON COLUMN sims.supporting_users_history.creator IS 'Historical data from the original table. See original table comments for details.';
+
+COMMENT ON COLUMN sims.supporting_users_history.modifier IS 'Historical data from the original table. See original table comments for details.';
+
+-- Creates the trigger to have the table populated using the shared create_history_entry function.
+CREATE TRIGGER supporting_users_history_trigger
+AFTER
+INSERT
+  OR
+UPDATE
+  ON sims.supporting_users FOR EACH ROW EXECUTE PROCEDURE sims.create_history_entry();
+
+COMMENT ON TRIGGER supporting_users_history_trigger ON sims.supporting_users IS 'Creates historical data for the supporting_users table.';

--- a/sources/packages/backend/apps/db-migrations/src/sql/SupportingUsers/Create-supporting-users-history-table.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/SupportingUsers/Create-supporting-users-history-table.sql
@@ -12,6 +12,18 @@ FROM
 WHERE
   false;
 
+-- Set history columns as NOT NULL.
+ALTER TABLE
+  sims.supporting_users_history
+ALTER COLUMN
+  history_timestamp
+SET
+  NOT NULL,
+ALTER COLUMN
+  history_operation
+SET
+  NOT NULL;
+
 CREATE INDEX supporting_users_history_timestamp ON sims.supporting_users_history(history_timestamp);
 
 COMMENT ON INDEX sims.supporting_users_history_timestamp IS 'Historical data index to improve point-in-time data retrieval.';

--- a/sources/packages/backend/apps/db-migrations/src/sql/SupportingUsers/Create-supporting-users-history-table.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/SupportingUsers/Create-supporting-users-history-table.sql
@@ -4,7 +4,7 @@
 -- The order of the columns below follow the exact same order from the existing table.
 CREATE TABLE sims.supporting_users_history AS
 SELECT
-  CURRENT_TIMESTAMP AS history_date,
+  CURRENT_TIMESTAMP AS history_timestamp,
   '' :: varchar(50) AS history_operation,
   *
 FROM

--- a/sources/packages/backend/apps/db-migrations/src/sql/SupportingUsers/Rollback-create-supporting-users-history-table.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/SupportingUsers/Rollback-create-supporting-users-history-table.sql
@@ -1,0 +1,3 @@
+DROP TABLE sims.supporting_users_history;
+
+DROP TRIGGER supporting_users_history_trigger ON sims.supporting_users;

--- a/sources/packages/backend/apps/db-migrations/src/sql/User/Create-user-history-table.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/User/Create-user-history-table.sql
@@ -4,7 +4,7 @@
 -- The order of the columns below follow the exact same order from the existing table.
 CREATE TABLE sims.users_history AS
 SELECT
-  CURRENT_TIMESTAMP AS history_date,
+  CURRENT_TIMESTAMP AS history_timestamp,
   '' :: varchar(50) AS history_operation,
   *
 FROM

--- a/sources/packages/backend/apps/db-migrations/src/sql/User/Create-user-history-table.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/User/Create-user-history-table.sql
@@ -12,6 +12,18 @@ FROM
 WHERE
   false;
 
+-- Set history columns as NOT NULL.
+ALTER TABLE
+  sims.users_history
+ALTER COLUMN
+  history_timestamp
+SET
+  NOT NULL,
+ALTER COLUMN
+  history_operation
+SET
+  NOT NULL;
+
 CREATE INDEX users_history_timestamp ON sims.users_history(history_timestamp);
 
 COMMENT ON INDEX sims.users_history_timestamp IS 'Historical data index to improve point-in-time data retrieval.';

--- a/sources/packages/backend/apps/db-migrations/src/sql/User/Create-user-history-table.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/User/Create-user-history-table.sql
@@ -1,0 +1,55 @@
+-- Table to keep historical data.
+-- Columns history_timestamp and history_operation should be default columns for all the history tables.
+-- Columns other than the above-mentioned should reflect the columns from the original table without constraints and relationships.
+-- The order of the columns below follow the exact same order from the existing table.
+CREATE TABLE sims.users_history AS
+SELECT
+  CURRENT_TIMESTAMP AS history_date,
+  '' :: varchar(50) AS history_operation,
+  *
+FROM
+  sims.users
+WHERE
+  false;
+
+CREATE INDEX users_history_timestamp ON sims.users_history(history_timestamp);
+
+COMMENT ON INDEX sims.users_history_timestamp IS 'Historical data index to improve point-in-time data retrieval.';
+
+COMMENT ON TABLE sims.users_history IS 'Historical data generated after records are inserted or updated.';
+
+COMMENT ON COLUMN sims.users_history.history_timestamp IS 'Date and time the history record was inserted.';
+
+COMMENT ON COLUMN sims.users_history.history_operation IS 'Database operation that generates the history.';
+
+COMMENT ON COLUMN sims.users_history.id IS 'Historical data from the original table. See original table comments for details.';
+
+COMMENT ON COLUMN sims.users_history.user_name IS 'Historical data from the original table. See original table comments for details.';
+
+COMMENT ON COLUMN sims.users_history.email IS 'Historical data from the original table. See original table comments for details.';
+
+COMMENT ON COLUMN sims.users_history.first_name IS 'Historical data from the original table. See original table comments for details.';
+
+COMMENT ON COLUMN sims.users_history.last_name IS 'Historical data from the original table. See original table comments for details.';
+
+COMMENT ON COLUMN sims.users_history.created_at IS 'Historical data from the original table. See original table comments for details.';
+
+COMMENT ON COLUMN sims.users_history.updated_at IS 'Historical data from the original table. See original table comments for details.';
+
+COMMENT ON COLUMN sims.users_history.is_active IS 'Historical data from the original table. See original table comments for details.';
+
+COMMENT ON COLUMN sims.users_history.creator IS 'Historical data from the original table. See original table comments for details.';
+
+COMMENT ON COLUMN sims.users_history.modifier IS 'Historical data from the original table. See original table comments for details.';
+
+COMMENT ON COLUMN sims.users_history.identity_provider_type IS 'Historical data from the original table. See original table comments for details.';
+
+-- Creates the trigger to have the table populated using the shared create_history_entry function.
+CREATE TRIGGER users_history_trigger
+AFTER
+INSERT
+  OR
+UPDATE
+  ON sims.users FOR EACH ROW EXECUTE PROCEDURE sims.create_history_entry();
+
+COMMENT ON TRIGGER users_history_trigger ON sims.users IS 'Creates historical data for the users table.';

--- a/sources/packages/backend/apps/db-migrations/src/sql/User/Rollback-create-user-history-table.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/User/Rollback-create-user-history-table.sql
@@ -1,0 +1,3 @@
+DROP TABLE sims.users_history;
+
+DROP TRIGGER users_history_trigger ON sims.users;

--- a/sources/packages/backend/apps/workers/src/services/supporting-user/supporting-user.service.ts
+++ b/sources/packages/backend/apps/workers/src/services/supporting-user/supporting-user.service.ts
@@ -6,10 +6,14 @@ import {
   SupportingUser,
   SupportingUserType,
 } from "@sims/sims-db";
+import { SystemUsersService } from "@sims/services";
 
 @Injectable()
 export class SupportingUserService extends RecordDataModelService<SupportingUser> {
-  constructor(dataSource: DataSource) {
+  constructor(
+    dataSource: DataSource,
+    private readonly systemUserService: SystemUsersService,
+  ) {
     super(dataSource.getRepository(SupportingUser));
   }
 
@@ -64,6 +68,7 @@ export class SupportingUserService extends RecordDataModelService<SupportingUser
       const newSupportingUser = new SupportingUser();
       newSupportingUser.application = application;
       newSupportingUser.supportingUserType = supportingUserType;
+      newSupportingUser.creator = this.systemUserService.systemUser;
       return newSupportingUser;
     });
     return entityManager.getRepository(SupportingUser).save(newSupportingUsers);


### PR DESCRIPTION
This PR is the result a cherry-pick from reverted PRs #3618 and #3627. These PRs were reverted by #3631 to allow the history tables to be created following exactly the same column orders from the DB it is being deployed.
The only real change not reviewed previously is the below. All other files were kept as they were. The description below is also a combination from the previous reverted PRs (the rollback evidences are new).
```sql
CREATE TABLE sims.supporting_users_history AS
SELECT
  CURRENT_TIMESTAMP AS history_timestamp,
  '' :: varchar(50) AS history_operation,
  *
FROM
  sims.supporting_users
WHERE
  false;
```

## Proposed Solution
- Created a generic function `create_history_entry` to be associated with every table that would need a history.
- Created the history tables for the required tables.
  - Tables were appended with `_history`.
  - New column `history_timestamp` to save the time when the entry was created.
  - New column `history_operation` to save the operation as `INSERT` or `UPDATE`.
  - Index created on `history_timestamp`.
  - `NOT NULL` constraints and relationships were dropped to keep the table as plain as possible.
  - _Migration scripts for the new history table were placed inside the same folder as the target table. When columns need to be added or dropped, the idea would be to use the same SQL script file to manage both tables to keep it simple._

## Sample `sims.user` table
![image](https://github.com/user-attachments/assets/968e3a94-b7d0-4931-b696-71ec33725a14)

### Pros

- Generic table eliminates the need for the creation of individual functions to deal with different table structures.
- Creation of new columns would not demand changes in the trigger function.
- The tables could be individually configured for the triggers, for instance, a table like `education_programs_offerings` can be configured to generate history only for the `UPDATE` for performance considerations during bulk inserts.

### Cons

- When adding new columns we should be mindful about adding the columns to both tables at the same time to ensure the proper insert order (it may be in the "pros" list 😄 ).
- If new columns need to be added to the `_history` table we must ensure they will be introduced at the beginning of the table which would demand recreation of the `_history` table since there is no mechanism to add a table in the specific order.

#### Minor Audit-Related Fix

- Supporting users were not saving the audit user (system user) during the record creation.
- While providing supporting user data, the user was not saved when the authenticated user was new, which means the user token ID was never populated leaving the `modifier` blank.

### Migrations rollback evidence

![image](https://github.com/user-attachments/assets/469b86ef-497a-41e6-b898-c5a1229470b4)

![image](https://github.com/user-attachments/assets/5a5c6646-caa9-4e91-adcf-99c4b9cfe6d8)

![image](https://github.com/user-attachments/assets/9d1349cb-96f1-4c6e-81ef-303134dc73df)

![image](https://github.com/user-attachments/assets/eb80b864-08fc-4f06-85cb-e78b4c551877)

![image](https://github.com/user-attachments/assets/e733f4bc-1798-41c3-a928-36fb2f17238d)

![image](https://github.com/user-attachments/assets/edf6c751-2689-4711-911c-2ef0dd5c9975)

![image](https://github.com/user-attachments/assets/e2d81691-bef3-4624-86d4-956aac9c3a7d)

![image](https://github.com/user-attachments/assets/098518b6-0d8c-4c88-bf64-8e0b757a78e8)







