### PR TITLE
#3610 - Missing check for SRI (Subresource Integrity) support

### DIFF
--- a/sources/packages/web/public/index.html
+++ b/sources/packages/web/public/index.html
@@ -13,8 +13,7 @@
     <link id="favicon-32" rel="icon" type="image/png" sizes="32x32" href="<%= BASE_URL %>favicon-32x32.png">
     <link id="favicon-apple" rel="apple-touch-icon" type="image/png" sizes="180x180" href="<%= BASE_URL %>apple-touch-icon.png">
     <link id="favicon-masked" rel="mask-icon" color="#5bbad5" href="<%= BASE_URL %>safari-pinned-tab.svg">
-    <link rel='stylesheet' href='https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/css/bootstrap.min.css'>
-    <link rel='stylesheet' href='https://cdn.form.io/formiojs/formio.full.min.css'>
+    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/css/bootstrap.min.css" integrity="sha384-Vkoo8x4CGsO3+Hhxv8T/Q5PaXtkKtu6ug5TOeNV6gBiFeWPGFN9MuhOf23Q9Ifjh" crossorigin="anonymous">
     <title>StudentAid BC</title>
   </head>
   <body style="margin: 0px;">

--- a/sources/packages/web/src/main.ts
+++ b/sources/packages/web/src/main.ts
@@ -6,6 +6,7 @@ import "primevue/resources/themes/md-light-indigo/theme.css";
 import "primevue/resources/primevue.min.css";
 import "primeicons/primeicons.css";
 import "primeflex/primeflex.css";
+import "formiojs/dist/formio.full.min.css";
 
 import "reflect-metadata";
 import { createApp } from "vue";


### PR DESCRIPTION
### Bootstrap CDN
- Added the `integraty` and `crossorigin` following the WAVA scan recommendation.

### Form.io CSS

Checked the BC Gov for other projects using the same `.css` ([see search results](https://github.com/search?q=org%3Abcgov%20formio.full.min.css&type=code)).

No other projects are using the `integrity` property. Please see below com of the CDNs used.
- https://cdn.jsdelivr.net/npm/formiojs@4.13.1/dist/formio.full.min.css
- https://cdn.form.io/formiojs/4.13.1/formio.full.min.css
- https://cdn.form.io/formiojs/formio.full.min.css

We can use the CSS directly imported from the package in the web app. Right now the decision was to have it imported in the `main.ts` following the same from other packages dependent on styles.
```ts
import "formiojs/dist/formio.full.min.css";
```
 Or we can use a CDN as below.
```html
<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/formiojs@4.13.4/dist/formio.full.min.css" integrity="sha384-GRYK3A0dP+QESmsRZGzbJ8J4hUBmSnq9Z22NoN6HPXD3BZqXQusDWv9DFn92GG/Y" crossorigin="anonymous">
```

_Currently the CSS referred is not linked with the formiojs version and it would be good to have it aligned._




