### PR TITLE
#3268- Crunchy DB PVC size change

### DIFF
--- a/devops/helm/crunchy-postgres/Makefile
+++ b/devops/helm/crunchy-postgres/Makefile
@@ -18,7 +18,7 @@ helm-dep:
 .PHONY: install
 install: helm-dep
 install:
-	@helm install $(call arguments) --set restore.enabled=false -f values.yaml
+	@helm install $(call arguments) --set restore.enabled=false;
 
 .PHONY: upgrade
 upgrade: helm-dep
@@ -27,9 +27,9 @@ upgrade: helm-dep
 			echo "Error: RESTORE_TARGET is required when RESTORE_ENABLED is true."; \
 			exit 1; \
 		fi; \
-		helm upgrade --install $(call arguments) --set restore.enabled=${RESTORE_ENABLED} --set restore.options.target="${RESTORE_TARGET}" -f values.yaml; \
+		helm upgrade --install $(call arguments) --set restore.enabled=${RESTORE_ENABLED} --set restore.options.target="${RESTORE_TARGET}";
 	else \
-		helm upgrade --install $(call arguments) --set restore.enabled=${RESTORE_ENABLED} -f values.yaml; \
+		helm upgrade --install $(call arguments) --set restore.enabled=${RESTORE_ENABLED}; \
 	fi
 
 .PHONY: uninstall

--- a/devops/helm/crunchy-postgres/Makefile
+++ b/devops/helm/crunchy-postgres/Makefile
@@ -27,7 +27,7 @@ upgrade: helm-dep
 			echo "Error: RESTORE_TARGET is required when RESTORE_ENABLED is true."; \
 			exit 1; \
 		fi; \
-		helm upgrade --install $(call arguments) --set restore.enabled=${RESTORE_ENABLED} --set restore.options.target="${RESTORE_TARGET}";
+		helm upgrade --install $(call arguments) --set restore.enabled=${RESTORE_ENABLED} --set restore.options.target="${RESTORE_TARGET}"; \
 	else \
 		helm upgrade --install $(call arguments) --set restore.enabled=${RESTORE_ENABLED}; \
 	fi

--- a/devops/helm/crunchy-postgres/value-0c27fb-prod.yaml
+++ b/devops/helm/crunchy-postgres/value-0c27fb-prod.yaml
@@ -24,7 +24,7 @@ instances:
   name: ha # high availability
   replicas: 3
   dataVolumeClaimSpec:
-    storage: 21Gi
+    storage: 5Gi
     storageClassName: netapp-block-standard
   requests:
     cpu: 250m
@@ -57,7 +57,7 @@ pgBackRest:
       incremental: 0 0,4,12,16,20 * * *
     volume:
       accessModes: "ReadWriteOnce"
-      storage: 21Gi
+      storage: 5Gi
       storageClassName: netapp-file-backup
   repoHost:
     requests:

--- a/devops/helm/crunchy-postgres/values-0c27fb-dev.yaml
+++ b/devops/helm/crunchy-postgres/values-0c27fb-dev.yaml
@@ -24,7 +24,7 @@ instances:
   name: ha # high availability
   replicas: 3
   dataVolumeClaimSpec:
-    storage: 10Gi
+    storage: 5Gi
     storageClassName: netapp-block-standard
   requests:
     cpu: 250m
@@ -57,7 +57,7 @@ pgBackRest:
       incremental: 0 0,4,12,16,20 * * *
     volume:
       accessModes: "ReadWriteOnce"
-      storage: 10Gi
+      storage: 5Gi
       storageClassName: netapp-file-backup
   repoHost:
     requests:

--- a/devops/helm/crunchy-postgres/values-0c27fb-test.yaml
+++ b/devops/helm/crunchy-postgres/values-0c27fb-test.yaml
@@ -24,7 +24,7 @@ instances:
   name: ha # high availability
   replicas: 3
   dataVolumeClaimSpec:
-    storage: 10Gi
+    storage: 5Gi
     storageClassName: netapp-block-standard
   requests:
     cpu: 250m
@@ -57,7 +57,7 @@ pgBackRest:
       incremental: 0 0,4,12,16,20 * * *
     volume:
       accessModes: "ReadWriteOnce"
-      storage: 10Gi
+      storage: 5Gi
       storageClassName: netapp-file-backup
   repoHost:
     requests:

--- a/devops/helm/crunchy-postgres/values-a6ef19-dev.yaml
+++ b/devops/helm/crunchy-postgres/values-a6ef19-dev.yaml
@@ -24,7 +24,7 @@ instances:
   name: ha # high availability
   replicas: 3
   dataVolumeClaimSpec:
-    storage: 10Gi
+    storage: 5Gi
     storageClassName: netapp-block-standard
   requests:
     cpu: 250m
@@ -57,7 +57,7 @@ pgBackRest:
       incremental: 0 0,4,12,16,20 * * *
     volume:
       accessModes: "ReadWriteOnce"
-      storage: 10Gi
+      storage: 5Gi
       storageClassName: netapp-file-backup
   repoHost:
     requests:

--- a/devops/helm/crunchy-postgres/values-a6ef19-prod.yaml
+++ b/devops/helm/crunchy-postgres/values-a6ef19-prod.yaml
@@ -24,7 +24,7 @@ instances:
   name: ha # high availability
   replicas: 3
   dataVolumeClaimSpec:
-    storage: 21Gi
+    storage: 5Gi
     storageClassName: netapp-block-standard
   requests:
     cpu: 250m
@@ -57,7 +57,7 @@ pgBackRest:
       incremental: 0 0,4,12,16,20 * * *
     volume:
       accessModes: "ReadWriteOnce"
-      storage: 21Gi
+      storage: 5Gi
       storageClassName: netapp-file-backup
   repoHost:
     requests:

--- a/devops/helm/crunchy-postgres/values-a6ef19-test.yaml
+++ b/devops/helm/crunchy-postgres/values-a6ef19-test.yaml
@@ -24,7 +24,7 @@ instances:
   name: ha # high availability
   replicas: 3
   dataVolumeClaimSpec:
-    storage: 10Gi
+    storage: 5Gi
     storageClassName: netapp-block-standard
   requests:
     cpu: 250m
@@ -57,7 +57,7 @@ pgBackRest:
       incremental: 0 0,4,12,16,20 * * *
     volume:
       accessModes: "ReadWriteOnce"
-      storage: 10Gi
+      storage: 5Gi
       storageClassName: netapp-file-backup
   repoHost:
     requests:


### PR DESCRIPTION
- Crunchy PVC DB size changed to 5Gi as initial size.
- -f values are removed in the makefile, as it was going always to the default values.yml and it was not needed. I found while testing so changed it now.