### PR TITLE
#3595 - Ministry Login - Appeals dashboard bug

### DIFF
--- a/sources/packages/backend/apps/api/src/route-controllers/student-appeal/_tests_/e2e/student-appeal.aest.controller.getAppeals.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/student-appeal/_tests_/e2e/student-appeal.aest.controller.getAppeals.e2e-spec.ts
@@ -1,6 +1,6 @@
 import { HttpStatus, INestApplication } from "@nestjs/common";
 import * as request from "supertest";
-import { DataSource, Repository } from "typeorm";
+import { DataSource } from "typeorm";
 import {
   AESTGroups,
   BEARER_AUTH_TYPE,
@@ -12,39 +12,23 @@ import {
   createE2EDataSources,
   createFakeStudentAppeal,
   createFakeStudentAppealRequest,
-  getProviderInstanceForModule,
   saveFakeApplicationDisbursements,
   saveFakeStudent,
 } from "@sims/test-utils";
-import { TestingModule } from "@nestjs/testing";
-import {
-  Application,
-  ApplicationStatus,
-  StudentAppealRequest,
-  StudentAppealStatus,
-  StudentFile,
-} from "@sims/sims-db";
+import { ApplicationStatus, StudentAppealStatus } from "@sims/sims-db";
 import { getUserFullName } from "../../../../utilities";
 
 describe("StudentAppealAESTController(e2e)-getAppeals", () => {
   let app: INestApplication;
   let appDataSource: DataSource;
-  let appModule: TestingModule;
   let db: E2EDataSources;
-  let applicationRepo: Repository<Application>;
-  let studentAppealRequestRepo: Repository<StudentAppealRequest>;
-  let studentFileRepo: Repository<StudentFile>;
 
   beforeAll(async () => {
     const { nestApplication, module, dataSource } =
       await createTestingAppModule();
     app = nestApplication;
     appDataSource = dataSource;
-    appModule = module;
     db = createE2EDataSources(dataSource);
-    applicationRepo = dataSource.getRepository(Application);
-    studentAppealRequestRepo = dataSource.getRepository(StudentAppealRequest);
-    studentFileRepo = dataSource.getRepository(StudentFile);
   });
   it("Should return only one row in the ministry appeals dashboard when a one student creates an appeal.", async () => {
     // Arrange

--- a/sources/packages/backend/apps/api/src/route-controllers/student-appeal/_tests_/e2e/student-appeal.aest.controller.getAppeals.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/student-appeal/_tests_/e2e/student-appeal.aest.controller.getAppeals.e2e-spec.ts
@@ -24,8 +24,7 @@ describe("StudentAppealAESTController(e2e)-getAppeals", () => {
   let db: E2EDataSources;
 
   beforeAll(async () => {
-    const { nestApplication, module, dataSource } =
-      await createTestingAppModule();
+    const { nestApplication, dataSource } = await createTestingAppModule();
     app = nestApplication;
     appDataSource = dataSource;
     db = createE2EDataSources(dataSource);

--- a/sources/packages/backend/apps/api/src/route-controllers/student-appeal/_tests_/e2e/student-appeal.aest.controller.getAppeals.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/student-appeal/_tests_/e2e/student-appeal.aest.controller.getAppeals.e2e-spec.ts
@@ -41,14 +41,18 @@ describe("StudentAppealAESTController(e2e)-getAppeals", () => {
       },
       { applicationStatus: ApplicationStatus.Completed },
     );
-    // Create approved student appeal.
+    // Create pending student appeal.
     const appealRequest = createFakeStudentAppealRequest(
+      {},
+      { initialValues: { appealStatus: StudentAppealStatus.Pending } },
+    );
+    const secondAppealRequest = createFakeStudentAppealRequest(
       {},
       { initialValues: { appealStatus: StudentAppealStatus.Pending } },
     );
     const appeal = createFakeStudentAppeal({
       application,
-      appealRequests: [appealRequest],
+      appealRequests: [appealRequest, secondAppealRequest],
     });
     await db.studentAppeal.save(appeal);
 

--- a/sources/packages/backend/apps/api/src/route-controllers/student-appeal/_tests_/e2e/student-appeal.aest.controller.getAppeals.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/student-appeal/_tests_/e2e/student-appeal.aest.controller.getAppeals.e2e-spec.ts
@@ -29,7 +29,8 @@ describe("StudentAppealAESTController(e2e)-getAppeals", () => {
     appDataSource = dataSource;
     db = createE2EDataSources(dataSource);
   });
-  it("Should return only one row in the ministry appeals dashboard when a one searched for a student application that has an appeal.", async () => {
+
+  it("Should return result count as 1 when there is one pending appeal for student application with multiple appeal requests.", async () => {
     // Arrange
     // Create student to submit application.
     const student = await saveFakeStudent(appDataSource);

--- a/sources/packages/backend/apps/api/src/route-controllers/student-appeal/_tests_/e2e/student-appeal.aest.controller.getAppeals.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/student-appeal/_tests_/e2e/student-appeal.aest.controller.getAppeals.e2e-spec.ts
@@ -1,0 +1,130 @@
+import { HttpStatus, INestApplication } from "@nestjs/common";
+import * as request from "supertest";
+import { DataSource, Repository } from "typeorm";
+import {
+  BEARER_AUTH_TYPE,
+  FakeStudentUsersTypes,
+  createTestingAppModule,
+  getStudentToken,
+  mockUserLoginInfo,
+} from "../../../../testHelpers";
+import {
+  E2EDataSources,
+  createE2EDataSources,
+  getProviderInstanceForModule,
+  saveFakeApplicationDisbursements,
+  saveFakeStudent,
+} from "@sims/test-utils";
+import { TestingModule } from "@nestjs/testing";
+import {
+  Application,
+  ApplicationStatus,
+  StudentAppealRequest,
+  StudentFile,
+} from "@sims/sims-db";
+import { AppStudentsModule } from "apps/api/src/app.students.module";
+import { StudentAppealAPIInDTO } from "apps/api/src/route-controllers/student-appeal/models/student-appeal.dto";
+import { FormService } from "apps/api/src/services";
+
+describe("StudentAppealAESTController(e2e)-getAppeals", () => {
+  let app: INestApplication;
+  let appDataSource: DataSource;
+  let appModule: TestingModule;
+  let db: E2EDataSources;
+  let applicationRepo: Repository<Application>;
+  let studentAppealRequestRepo: Repository<StudentAppealRequest>;
+  let studentFileRepo: Repository<StudentFile>;
+  const FINANCIAL_INFORMATION_FORM_NAME = "studentfinancialinformationappeal";
+  const STUDENT_DISABILITY_FORM_NAME = "studentDisabilityAppeal";
+
+  beforeAll(async () => {
+    const { nestApplication, module, dataSource } =
+      await createTestingAppModule();
+    app = nestApplication;
+    appDataSource = dataSource;
+    appModule = module;
+    db = createE2EDataSources(dataSource);
+    applicationRepo = dataSource.getRepository(Application);
+    studentAppealRequestRepo = dataSource.getRepository(StudentAppealRequest);
+    studentFileRepo = dataSource.getRepository(StudentFile);
+  });
+  it(
+    "Should create 2 student appeal for a student one financial information change and disability change " +
+      "on fetching from the ministry appeals dashboard only one row and count should be displayed.",
+    async () => {
+      // Arrange
+      // Create student to submit application.
+      const student = await saveFakeStudent(appDataSource);
+      // Create application to request change.
+      const application = await saveFakeApplicationDisbursements(
+        db.dataSource,
+        {
+          student,
+        },
+        { applicationStatus: ApplicationStatus.Completed },
+      );
+      // Prepare the data to request a change of disability information.
+      const disabilityData = {
+        programYear: application.programYear.programYear,
+        studentNewPDPPDStatus: "no",
+      };
+      // Prepare the data to request a change of financial information.
+      const financialInformationData = {
+        programYear: application.programYear.programYear,
+        taxReturnIncome: 8000,
+        haveDaycareCosts12YearsOrOver: "no",
+        haveDaycareCosts11YearsOrUnder: "no",
+      };
+      const payload: StudentAppealAPIInDTO = {
+        studentAppealRequests: [
+          {
+            formName: STUDENT_DISABILITY_FORM_NAME,
+            formData: disabilityData,
+            files: [],
+          },
+          {
+            formName: FINANCIAL_INFORMATION_FORM_NAME,
+            formData: financialInformationData,
+            files: [],
+          },
+        ],
+      };
+      // Mock user service to return the saved student.
+      await mockUserLoginInfo(appModule, student);
+      // Get any student user token.
+      const studentToken = await getStudentToken(
+        FakeStudentUsersTypes.FakeStudentUserType1,
+      );
+      const formService = await getProviderInstanceForModule(
+        appModule,
+        AppStudentsModule,
+        FormService,
+      );
+      const dryRunSubmissionMock = jest.fn().mockResolvedValue({
+        valid: true,
+        formName: FINANCIAL_INFORMATION_FORM_NAME,
+        data: { data: financialInformationData },
+      });
+
+      formService.dryRunSubmission = dryRunSubmissionMock;
+
+      const endpoint = `/students/appeal/application/${application.id}`;
+
+      // Act/Assert
+      let createdAppealId: number;
+      await request(app.getHttpServer())
+        .post(endpoint)
+        .send(payload)
+        .auth(studentToken, BEARER_AUTH_TYPE)
+        .expect(HttpStatus.CREATED)
+        .then((response) => {
+          expect(response.body.id).toBeGreaterThan(0);
+          createdAppealId = +response.body.id;
+        });
+    },
+  );
+
+  afterAll(async () => {
+    await app?.close();
+  });
+});

--- a/sources/packages/backend/apps/api/src/route-controllers/student-appeal/_tests_/e2e/student-appeal.aest.controller.getAppeals.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/student-appeal/_tests_/e2e/student-appeal.aest.controller.getAppeals.e2e-spec.ts
@@ -29,7 +29,7 @@ describe("StudentAppealAESTController(e2e)-getAppeals", () => {
     appDataSource = dataSource;
     db = createE2EDataSources(dataSource);
   });
-  it("Should return only one row in the ministry appeals dashboard when a one student creates an appeal.", async () => {
+  it("Should return only one row in the ministry appeals dashboard when a one searched for a student application that has an appeal.", async () => {
     // Arrange
     // Create student to submit application.
     const student = await saveFakeStudent(appDataSource);

--- a/sources/packages/backend/apps/api/src/services/student-appeal/student-appeal.service.ts
+++ b/sources/packages/backend/apps/api/src/services/student-appeal/student-appeal.service.ts
@@ -497,6 +497,9 @@ export class StudentAppealService extends RecordDataModelService<StudentAppeal> 
         `EXISTS(${this.studentAppealRequestsService
           .appealsByStatusQueryObject(status)
           .getSql()})`,
+      )
+      .groupBy(
+        "studentAppeal.id, " + "application.id, " + "user.id, " + "student.id",
       );
     if (paginationOptions.searchCriteria) {
       studentAppealsQuery

--- a/sources/packages/backend/apps/api/src/services/student-appeal/student-appeal.service.ts
+++ b/sources/packages/backend/apps/api/src/services/student-appeal/student-appeal.service.ts
@@ -492,14 +492,10 @@ export class StudentAppealService extends RecordDataModelService<StudentAppeal> 
       .innerJoin("studentAppeal.application", "application")
       .innerJoin("application.student", "student")
       .innerJoin("student.user", "user")
-      .innerJoin("studentAppeal.appealRequests", "appealRequests")
       .where(
         `EXISTS(${this.studentAppealRequestsService
           .appealsByStatusQueryObject(status)
           .getSql()})`,
-      )
-      .groupBy(
-        "studentAppeal.id, " + "application.id, " + "user.id, " + "student.id",
       );
     if (paginationOptions.searchCriteria) {
       studentAppealsQuery

--- a/sources/packages/backend/libs/test-utils/src/factories/student-appeal-request.ts
+++ b/sources/packages/backend/libs/test-utils/src/factories/student-appeal-request.ts
@@ -33,7 +33,7 @@ export function createFakeStudentAppealRequest(
   appealRequest.studentAppeal = relations?.studentAppeal;
   appealRequest.submittedFormName = "SomeFormioFormName";
   appealRequest.appealStatus =
-    options.initialValues.appealStatus ?? StudentAppealStatus.Approved;
+    options?.initialValues?.appealStatus ?? StudentAppealStatus.Approved;
   appealRequest.submittedData = {};
   appealRequest.assessedDate = null;
   appealRequest.assessedBy = relations?.assessedBy;

--- a/sources/packages/backend/libs/test-utils/src/factories/student-appeal-request.ts
+++ b/sources/packages/backend/libs/test-utils/src/factories/student-appeal-request.ts
@@ -14,18 +14,26 @@ import {
  * - `assessedBy` related Ministry user assessing the appeal request.
  * - `application` related student application.
  * - `studentAssessment` related assessment.
+ * @param options options:
+ * - `initialValues` values to be used instead of the default ones.
  * @returns a student appeal request record ready to be saved to the database.
  */
-export function createFakeStudentAppealRequest(relations?: {
-  studentAppeal?: StudentAppeal;
-  assessedBy?: User;
-  application?: Application;
-  studentAssessment?: StudentAssessment;
-}): StudentAppealRequest {
+export function createFakeStudentAppealRequest(
+  relations?: {
+    studentAppeal?: StudentAppeal;
+    assessedBy?: User;
+    application?: Application;
+    studentAssessment?: StudentAssessment;
+  },
+  options?: {
+    initialValues?: Partial<StudentAppealRequest>;
+  },
+): StudentAppealRequest {
   const appealRequest = new StudentAppealRequest();
   appealRequest.studentAppeal = relations?.studentAppeal;
   appealRequest.submittedFormName = "SomeFormioFormName";
-  appealRequest.appealStatus = StudentAppealStatus.Approved;
+  appealRequest.appealStatus =
+    options.initialValues.appealStatus ?? StudentAppealStatus.Approved;
   appealRequest.submittedData = {};
   appealRequest.assessedDate = null;
   appealRequest.assessedBy = relations?.assessedBy;

--- a/sources/packages/web/src/views/aest/student/StudentApplicationAppeals.vue
+++ b/sources/packages/web/src/views/aest/student/StudentApplicationAppeals.vue
@@ -5,7 +5,7 @@
     </template>
     <body-header
       title="Requested appeals"
-      :recordsCount="applicationAppeals.results?.length"
+      :recordsCount="applicationAppeals.count"
       subTitle="Make a determination on requested change(s) that may require a reassessment"
     >
       <template #actions>


### PR DESCRIPTION
Appeals Tab as a Ministry User is not displaying the number of appeals properly.
Fix is done on the query returned on the appeals, removed the unwanted join on the appealRequests table.
The count that is passed on the header to show the total appeals, is fixed.