### PR TITLE
#3131 - Fix content length to be based on byte lenth

### DIFF
--- a/sources/packages/backend/apps/api/src/route-controllers/report/report.controller.service.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/report/report.controller.service.ts
@@ -101,10 +101,10 @@ export class ReportControllerService {
       `attachment; filename=${filename}`,
     );
     response.setHeader("Content-Type", "text/csv");
-    response.setHeader("Content-Length", fileContent.toString().length);
+    response.setHeader("Content-Length", Buffer.from(fileContent).byteLength);
 
     const stream = new Readable();
-    stream.push(fileContent.toString());
+    stream.push(fileContent);
     stream.push(null);
     stream.pipe(response);
   }

--- a/sources/packages/backend/apps/api/src/route-controllers/report/report.controller.service.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/report/report.controller.service.ts
@@ -11,6 +11,7 @@ import {
 import {
   getFileNameAsCurrentTimestamp,
   CustomNamedError,
+  UTF8_BYTE_ORDER_MARK,
 } from "@sims/utilities";
 import { Response } from "express";
 import { Readable } from "stream";
@@ -96,15 +97,23 @@ export class ReportControllerService {
   ) {
     const timestamp = getFileNameAsCurrentTimestamp();
     const filename = `${reportName}_${timestamp}.csv`;
+    // Adding byte order mark characters to the original file content as applications
+    // like excel would look for BOM characters to view the file as UTF8 encoded.
+    const byteOrderMarkBuffer = Buffer.from(UTF8_BYTE_ORDER_MARK);
+    const fileContentBuffer = Buffer.from(fileContent);
+    const responseBuffer = Buffer.concat([
+      byteOrderMarkBuffer,
+      fileContentBuffer,
+    ]);
     response.setHeader(
       "Content-Disposition",
       `attachment; filename=${filename}`,
     );
     response.setHeader("Content-Type", "text/csv");
-    response.setHeader("Content-Length", Buffer.from(fileContent).byteLength);
+    response.setHeader("Content-Length", responseBuffer.byteLength);
 
     const stream = new Readable();
-    stream.push(fileContent);
+    stream.push(responseBuffer);
     stream.push(null);
     stream.pipe(response);
   }

--- a/sources/packages/backend/libs/utilities/src/system-configurations-constants.ts
+++ b/sources/packages/backend/libs/utilities/src/system-configurations-constants.ts
@@ -57,3 +57,5 @@ export const ORM_CACHE_REDIS_RETRY_INTERVAL = 60 * 1000;
 export const COE_WINDOW = 21;
 
 export const COE_DENIED_REASON_OTHER_ID = 1;
+
+export const UTF8_BYTE_ORDER_MARK = [239, 187, 191];


### PR DESCRIPTION
# FIX CONTENT LENTH HEADER ON REPORTS CONTROLLER

## Problem statement
Currently, in reports controller we set the `Content-Length` header value as length of the csv string.  
Due to this, we have an issue when the string involves special characters as the size of these characters are more than one byte.

e.g. When a string of length 100 characters has one special character like `â` in it, then string length is `100` but the byte length is `101`. Hence when this is set in API response it eliminates any characters which is more than set content length. 

Like this

![image](https://github.com/user-attachments/assets/565166cc-8b51-4345-8da5-9da87b07e02e)


## Solution
Set `content-length` header with byte length.