### PR TITLE
#3500 - Upload supporting documents bug fix

### DIFF
--- a/sources/packages/forms/src/form-definitions/sfaa2022-23.json
+++ b/sources/packages/forms/src/form-definitions/sfaa2022-23.json
@@ -5405,8 +5405,7 @@
           },
           "properties": {},
           "lockKey": true,
-          "defaultValue": "365",
-          "isNew": false
+          "defaultValue": "365"
         }
       ],
       "input": false,
@@ -8576,8 +8575,8 @@
                       "shortcut": ""
                     },
                     {
-                      "label": "you will have finished 4 years of full-time, postsecondary study in B.C. before the first day of your study period.",
-                      "value": "youWillHaveFinished4YearsOfFullTimePostsecondaryStudyInBCBeforeTheFirstDayOfYourStudyPeriod",
+                      "label": "You will have completed 4 years of full-time post-secondary study in B.C. before the first day of your study period.",
+                      "value": "youWillHaveCompleted4YearsOfFullTimePostSecondaryStudyInBCBeforeTheFirstDayOfYourStudyPeriod",
                       "shortcut": ""
                     },
                     {
@@ -8614,7 +8613,7 @@
                   "tags": [],
                   "properties": {},
                   "conditional": {
-                    "show": true,
+                    "show": "true",
                     "when": "bcResident",
                     "eq": "no",
                     "json": ""
@@ -8845,12 +8844,12 @@
                   "key": "uploadSupportingDocuments",
                   "tags": [],
                   "properties": {},
-                  "customConditional": "",
+                  "customConditional": "show = data['bclivingSituation'];",
                   "conditional": {
                     "json": "",
-                    "show": true,
-                    "when": "bclivingSituation",
-                    "eq": "other"
+                    "show": "",
+                    "when": "",
+                    "eq": ""
                   },
                   "logic": [],
                   "attributes": {},

--- a/sources/packages/forms/src/form-definitions/sfaa2023-24.json
+++ b/sources/packages/forms/src/form-definitions/sfaa2023-24.json
@@ -8575,8 +8575,8 @@
                       "shortcut": ""
                     },
                     {
-                      "label": "you will have finished 4 years of full-time, postsecondary study in B.C. before the first day of your study period.",
-                      "value": "youWillHaveFinished4YearsOfFullTimePostsecondaryStudyInBCBeforeTheFirstDayOfYourStudyPeriod",
+                      "label": "You will have completed 4 years of full-time post-secondary study in B.C. before the first day of your study period.",
+                      "value": "youWillHaveCompleted4YearsOfFullTimePostSecondaryStudyInBCBeforeTheFirstDayOfYourStudyPeriod",
                       "shortcut": ""
                     },
                     {
@@ -8613,7 +8613,7 @@
                   "tags": [],
                   "properties": {},
                   "conditional": {
-                    "show": true,
+                    "show": "true",
                     "when": "bcResident",
                     "eq": "no",
                     "json": ""
@@ -8844,12 +8844,12 @@
                   "key": "uploadSupportingDocuments",
                   "tags": [],
                   "properties": {},
-                  "customConditional": "",
+                  "customConditional": "show = data['bclivingSituation'];",
                   "conditional": {
                     "json": "",
-                    "show": true,
-                    "when": "bclivingSituation",
-                    "eq": "other"
+                    "show": "",
+                    "when": "",
+                    "eq": ""
                   },
                   "logic": [],
                   "attributes": {},

--- a/sources/packages/forms/src/form-definitions/sfaa2024-25.json
+++ b/sources/packages/forms/src/form-definitions/sfaa2024-25.json
@@ -8575,8 +8575,8 @@
                       "shortcut": ""
                     },
                     {
-                      "label": "you will have finished 4 years of full-time, postsecondary study in B.C. before the first day of your study period.",
-                      "value": "youWillHaveFinished4YearsOfFullTimePostsecondaryStudyInBCBeforeTheFirstDayOfYourStudyPeriod",
+                      "label": "You will have completed 4 years of full-time post-secondary study in B.C. before the first day of your study period.",
+                      "value": "youWillHaveCompleted4YearsOfFullTimePostSecondaryStudyInBCBeforeTheFirstDayOfYourStudyPeriod",
                       "shortcut": ""
                     },
                     {
@@ -8613,7 +8613,7 @@
                   "tags": [],
                   "properties": {},
                   "conditional": {
-                    "show": true,
+                    "show": "true",
                     "when": "bcResident",
                     "eq": "no",
                     "json": ""
@@ -8844,12 +8844,12 @@
                   "key": "uploadSupportingDocuments",
                   "tags": [],
                   "properties": {},
-                  "customConditional": "",
+                  "customConditional": "show = data['bclivingSituation'];",
                   "conditional": {
                     "json": "",
-                    "show": true,
-                    "when": "bclivingSituation",
-                    "eq": "other"
+                    "show": "",
+                    "when": "",
+                    "eq": ""
                   },
                   "logic": [],
                   "attributes": {},


### PR DESCRIPTION
### As a part of this PR, the following were completed:

- Uploader is now shown for all the 4 radio options when either of them is selected as shown below:

<img width="1920" alt="image" src="https://github.com/user-attachments/assets/f5df044a-0ae0-4663-b4c0-e7a45a2426f5">

Likewise, the uploader will show for the other radio buttons as well.

- Fixed the radio option text as below:
`You will have completed 4 years of full-time post-secondary study in B.C. before the first day of your study period.` 