### PR TITLE
#3525 - Remove Overawards Deductions from PT e-Cert

### DIFF
--- a/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/esdc-integration/ecert-integration/_tests_/ecert-part-time-process-integration.scheduler.e2e-spec.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/esdc-integration/ecert-integration/_tests_/ecert-part-time-process-integration.scheduler.e2e-spec.ts
@@ -26,6 +26,7 @@ import {
   saveFakeApplicationRestrictionBypass,
   createFakeUser,
   saveFakeStudentRestriction,
+  createFakeDisbursementOveraward,
 } from "@sims/test-utils";
 import { getUploadedFile } from "@sims/test-utils/mocks";
 import { ArrayContains, IsNull, Like, Not } from "typeorm";
@@ -322,7 +323,6 @@ describe(
       expect(recordParsed.disbursementAmount).toBe("000123500");
       // TODO include other fields as needed.
 
-      // Assert Canada Loan overawards were deducted.
       const [firstSchedule] =
         application.currentAssessment.disbursementSchedules;
       // Assert schedule is updated to 'sent' with the dateSent defined.
@@ -1101,6 +1101,109 @@ describe(
       }
       await db.notification.save(notifications);
     }
+
+    it("Should create an e-Cert with no overaward deductions when the student has overawards.", async () => {
+      // Overawards deductions should not be considered at this time.
+
+      // Arrange
+
+      // Student with valid SIN.
+      const student = await saveFakeStudent(db.dataSource);
+      // Valid MSFAA Number.
+      const msfaaNumber = await db.msfaaNumber.save(
+        createFakeMSFAANumber(
+          { student },
+          {
+            msfaaState: MSFAAStates.Signed,
+            msfaaInitialValues: {
+              offeringIntensity: OfferingIntensity.partTime,
+            },
+          },
+        ),
+      );
+      // Student application eligible for e-Cert.
+      const application = await saveFakeApplicationDisbursements(
+        db.dataSource,
+        {
+          student,
+          msfaaNumber,
+          firstDisbursementValues: [
+            createFakeDisbursementValue(
+              DisbursementValueType.CanadaLoan,
+              "CSLP",
+              1000,
+            ),
+          ],
+        },
+        {
+          offeringIntensity: OfferingIntensity.partTime,
+          applicationStatus: ApplicationStatus.Completed,
+          currentAssessmentInitialValues: {
+            assessmentData: { weeks: 5 } as Assessment,
+            assessmentDate: new Date(),
+          },
+          firstDisbursementInitialValues: {
+            coeStatus: COEStatus.completed,
+          },
+        },
+      );
+      // Create fake overawards.
+      const fakeCanadaLoanOverawardBalance = createFakeDisbursementOveraward({
+        student,
+      });
+      fakeCanadaLoanOverawardBalance.disbursementValueCode = "CSLP";
+      fakeCanadaLoanOverawardBalance.overawardValue = 750;
+      const cslpOveraward = await db.disbursementOveraward.save(
+        fakeCanadaLoanOverawardBalance,
+      );
+      // Queued job.
+      const { job } = mockBullJob<void>();
+
+      // Act
+      await processor.processECert(job);
+
+      // Assert
+      // Assert uploaded file.
+      const [firstSchedule] =
+        application.currentAssessment.disbursementSchedules;
+      // Assert schedule is updated to 'sent' with the dateSent defined.
+      const schedule = await db.disbursementSchedule.findOne({
+        select: {
+          id: true,
+          disbursementScheduleStatus: true,
+          disbursementValues: { effectiveAmount: true },
+        },
+        relations: {
+          disbursementValues: true,
+        },
+        where: {
+          id: firstSchedule.id,
+          dateSent: Not(IsNull()),
+          disbursementScheduleStatus: DisbursementScheduleStatus.Sent,
+          disbursementValues: {
+            valueCode: "CSLP",
+          },
+        },
+      });
+      expect(schedule.disbursementScheduleStatus).toBe(
+        DisbursementScheduleStatus.Sent,
+      );
+      const [cslpDisbursementValue] = schedule.disbursementValues;
+      expect(cslpDisbursementValue.effectiveAmount).toEqual(1000);
+      // Validate if overaward was not impacted.
+      const nonUpdatedCSLPOveraward = await db.disbursementOveraward.findOne({
+        select: {
+          id: true,
+          overawardValue: true,
+        },
+        where: {
+          id: cslpOveraward.id,
+          disbursementValueCode: "CSLP",
+          overawardValue: 1000,
+        },
+      });
+      expect(nonUpdatedCSLPOveraward.overawardValue).toBe(true);
+    });
 
     /**
      * Creates the test data required for the individual tests.

--- a/sources/packages/backend/apps/workers/src/controllers/disbursement/_tests_/e2e/disbursement.controller.saveDisbursementSchedules.e2e-spec.ts
+++ b/sources/packages/backend/apps/workers/src/controllers/disbursement/_tests_/e2e/disbursement.controller.saveDisbursementSchedules.e2e-spec.ts
@@ -123,6 +123,7 @@ describe("DisbursementController(e2e)-saveDisbursementSchedules", () => {
     const saveDisbursementSchedulesPayload =
       createFakeSaveDisbursementSchedulesPayload({
         assessmentId: savedReassessment.id,
+        createSecondDisbursement: true,
       });
     const saveResult = await disbursementController.saveDisbursementSchedules(
       saveDisbursementSchedulesPayload,

--- a/sources/packages/backend/apps/workers/src/controllers/disbursement/_tests_/e2e/disbursement.controller.saveDisbursementSchedules.e2e-spec.ts
+++ b/sources/packages/backend/apps/workers/src/controllers/disbursement/_tests_/e2e/disbursement.controller.saveDisbursementSchedules.e2e-spec.ts
@@ -1,11 +1,13 @@
 import {
   ApplicationStatus,
   AssessmentTriggerType,
+  COEStatus,
   DisbursementOveraward,
   DisbursementOverawardOriginType,
   DisbursementSchedule,
   DisbursementScheduleStatus,
   DisbursementValueType,
+  OfferingIntensity,
 } from "@sims/sims-db";
 import {
   createE2EDataSources,
@@ -16,6 +18,7 @@ import {
   createFakeStudentAssessment,
   createFakeUser,
   E2EDataSources,
+  saveFakeApplicationDisbursements,
 } from "@sims/test-utils";
 import { createFakeDisbursementSchedule } from "@sims/test-utils/factories/disbursement-schedule";
 import { createFakeDisbursementValue } from "@sims/test-utils/factories/disbursement-value";
@@ -118,7 +121,9 @@ describe("DisbursementController(e2e)-saveDisbursementSchedules", () => {
 
     // Act
     const saveDisbursementSchedulesPayload =
-      createFakeSaveDisbursementSchedulesPayload(savedReassessment.id);
+      createFakeSaveDisbursementSchedulesPayload({
+        assessmentId: savedReassessment.id,
+      });
     const saveResult = await disbursementController.saveDisbursementSchedules(
       saveDisbursementSchedulesPayload,
     );
@@ -198,6 +203,144 @@ describe("DisbursementController(e2e)-saveDisbursementSchedules", () => {
     expect(grantOveraward).toBeUndefined();
     // Assert overaward creation.
     assertOveraward(overawards, "BCSL", 150);
+  });
+
+  it("Should generate an overaward and deduct grants already paid for a part-time application when a reassessment happens and the student is entitled to less money.", async () => {
+    // Arrange
+
+    // Save the application with the original disbursement sent.
+    const savedApplication = await saveFakeApplicationDisbursements(
+      db.dataSource,
+      {
+        firstDisbursementValues: [
+          createFakeDisbursementValue(
+            DisbursementValueType.CanadaLoan,
+            "CSLP",
+            5000,
+            { effectiveAmount: 5000 },
+          ),
+          createFakeDisbursementValue(
+            DisbursementValueType.CanadaGrant,
+            "CSGP",
+            4000,
+            { effectiveAmount: 4000 },
+          ),
+          createFakeDisbursementValue(
+            DisbursementValueType.BCGrant,
+            "BCAG",
+            3000,
+            { effectiveAmount: 3000 },
+          ),
+        ],
+      },
+      {
+        offeringIntensity: OfferingIntensity.partTime,
+        applicationStatus: ApplicationStatus.Completed,
+        firstDisbursementInitialValues: {
+          coeStatus: COEStatus.completed,
+          disbursementScheduleStatus: DisbursementScheduleStatus.Sent,
+        },
+      },
+    );
+    // Create the reassessment.
+    savedApplication.currentAssessment = createFakeStudentAssessment(
+      {
+        auditUser: savedApplication.student.user,
+        application: savedApplication,
+        offering: savedApplication.currentAssessment.offering,
+      },
+      {
+        initialValue: { triggerType: AssessmentTriggerType.ManualReassessment },
+      },
+    );
+    await db.application.save(savedApplication);
+    const reassessment = savedApplication.currentAssessment;
+    // Schedules to be saved to the reassessment.
+    const saveDisbursementSchedulesPayload =
+      createFakeSaveDisbursementSchedulesPayload({
+        assessmentId: reassessment.id,
+        firstDisbursementAwards: [
+          {
+            // Expected 300 overaward generated.
+            valueCode: "CSLP",
+            valueType: DisbursementValueType.CanadaLoan,
+            valueAmount: 4700,
+          },
+          {
+            // Expected 500 grant to be paid since 4000 was already sent.
+            valueCode: "CSGP",
+            valueType: DisbursementValueType.CanadaGrant,
+            valueAmount: 4500,
+          },
+          {
+            // No value expected because it was already sent 3000.
+            valueCode: "BCAG",
+            valueType: DisbursementValueType.BCGrant,
+            valueAmount: 2000,
+          },
+        ],
+      });
+
+    // Act
+    const saveResult = await disbursementController.saveDisbursementSchedules(
+      saveDisbursementSchedulesPayload,
+    );
+
+    // Asserts
+    expect(saveResult).toHaveProperty(
+      FAKE_WORKER_JOB_RESULT_PROPERTY,
+      MockedZeebeJobResult.Complete,
+    );
+
+    // Assert disbursement already paid subtracted.
+    const createdDisbursements = await db.disbursementSchedule.find({
+      select: {
+        id: true,
+        disbursementValues: {
+          id: true,
+          valueType: true,
+          valueAmount: true,
+          disbursedAmountSubtracted: true,
+        },
+      },
+      relations: {
+        disbursementValues: true,
+      },
+      where: {
+        studentAssessment: { id: reassessment.id },
+      },
+    });
+    expect(createdDisbursements).toBeDefined();
+    expect(createdDisbursements).toHaveLength(1);
+    const [firstDisbursement] = createdDisbursements;
+    // Expected 300 overaward generated since 5000 was already sent.
+    assertAwardDeduction(firstDisbursement, DisbursementValueType.CanadaLoan, {
+      valueAmount: 4700,
+      disbursedAmountSubtracted: 4700,
+    });
+    // Expected 500 grant to be paid since 4000 was already sent.
+    assertAwardDeduction(firstDisbursement, DisbursementValueType.CanadaGrant, {
+      valueAmount: 4500,
+      disbursedAmountSubtracted: 4000,
+    });
+    // No value expected because it was already sent 3000.
+    assertAwardDeduction(firstDisbursement, DisbursementValueType.BCGrant, {
+      valueAmount: 2000,
+      disbursedAmountSubtracted: 2000,
+    });
+    // Overaward asserts.
+    const overawards = await db.disbursementOveraward.find({
+      select: {
+        id: true,
+        disbursementValueCode: true,
+        overawardValue: true,
+        originType: true,
+      },
+      where: { student: { id: savedApplication.student.id } },
+    });
+    // Assert overaward creation.
+    // Part-time overawards are created but are not deducted during e-Cert generation.
+    assertOveraward(overawards, "CSLP", 300);
   });
 
   function assertAwardDeduction(

--- a/sources/packages/backend/libs/integrations/src/services/disbursement-schedule/e-cert-calculation/part-time-calculation-process.ts
+++ b/sources/packages/backend/libs/integrations/src/services/disbursement-schedule/e-cert-calculation/part-time-calculation-process.ts
@@ -3,7 +3,6 @@ import { ECertProcessStep } from "../e-cert-processing-steps/e-cert-steps-models
 import { ECertCalculationProcess } from "./e-cert-calculation-process";
 import { DataSource } from "typeorm";
 import {
-  ApplyOverawardsDeductionsStep,
   CalculateEffectiveValueStep,
   CalculateTuitionRemittanceEffectiveAmountStep,
   CreateBCTotalGrantsStep,
@@ -26,7 +25,6 @@ export class PartTimeCalculationProcess extends ECertCalculationProcess {
     eCertNotificationService: ECertNotificationService,
     private readonly eCertGenerationService: ECertGenerationService,
     private readonly validateDisbursementPartTimeStep: ValidateDisbursementPartTimeStep,
-    private readonly applyOverawardsDeductionsStep: ApplyOverawardsDeductionsStep,
     private readonly calculateEffectiveValueStep: CalculateEffectiveValueStep,
     private readonly calculateTuitionRemittanceEffectiveAmountStep: CalculateTuitionRemittanceEffectiveAmountStep,
     private readonly createBCTotalGrantsStep: CreateBCTotalGrantsStep,
@@ -58,7 +56,6 @@ export class PartTimeCalculationProcess extends ECertCalculationProcess {
   protected calculationSteps(): ECertProcessStep[] {
     return [
       this.validateDisbursementPartTimeStep,
-      this.applyOverawardsDeductionsStep,
       this.calculateEffectiveValueStep,
       this.calculateTuitionRemittanceEffectiveAmountStep,
       this.createBCTotalGrantsStep,


### PR DESCRIPTION
- Removed the `applyOverawardsDeductionsStep` from part-time e-Cert process.
- Created the below E2E tests.
  - `queue-consumers`: Should create an e-Cert with no overaward deductions when the student has overawards.
  - `workers`: Should generate an overaward and deduct grants already paid for a part-time application when a reassessment happens and the student is entitled to less money.