### PR TITLE
#3512 - Review Impact of All Restrictions

### DIFF
--- a/sources/packages/backend/apps/db-migrations/src/migrations/1726275056327-AddStopPartTimeBCFundingRestrictionActionType.ts
+++ b/sources/packages/backend/apps/db-migrations/src/migrations/1726275056327-AddStopPartTimeBCFundingRestrictionActionType.ts
@@ -1,0 +1,24 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+import { getSQLFileData } from "../utilities/sqlLoader";
+
+export class AddStopPartTimeBCFundingRestrictionActionType1726275056327
+  implements MigrationInterface
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      getSQLFileData(
+        "Add-stop-part-time-bc-funding-restriction-action-type.sql",
+        "Types",
+      ),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      getSQLFileData(
+        "Rollback-add-stop-part-time-bc-funding-restriction-action-type.sql",
+        "Types",
+      ),
+    );
+  }
+}

--- a/sources/packages/backend/apps/db-migrations/src/migrations/1726275219662-UpdateRestrictionsReviewImpact.ts
+++ b/sources/packages/backend/apps/db-migrations/src/migrations/1726275219662-UpdateRestrictionsReviewImpact.ts
@@ -1,0 +1,21 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+import { getSQLFileData } from "../utilities/sqlLoader";
+
+export class UpdateRestrictionsReviewImpact1726275219662
+  implements MigrationInterface
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      getSQLFileData("Update-restrictions-review-impact.sql", "Restrictions"),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      getSQLFileData(
+        "Rollback-update-restrictions-review-impact.sql",
+        "Restrictions",
+      ),
+    );
+  }
+}

--- a/sources/packages/backend/apps/db-migrations/src/sql/Restrictions/Rollback-update-restrictions-review-impact.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/Restrictions/Rollback-update-restrictions-review-impact.sql
@@ -1,0 +1,76 @@
+-- Revert the updates for the restriction code 5, 7 and 9.
+UPDATE
+    sims.restrictions
+SET
+    action_type = ARRAY ['Stop full time disbursement'] :: sims.restriction_action_types []
+WHERE
+    restriction_code IN ('5', '7', '9');
+
+-- Revert the updates for the restriction code 12, O and PTWTHD.
+UPDATE
+    sims.restrictions
+SET
+    action_type = ARRAY ['Stop part time disbursement', 'Stop full time disbursement'] :: sims.restriction_action_types []
+WHERE
+    restriction_code IN ('12', 'O', 'PTWTHD');
+
+-- Revert the updates for the restriction code APPC.
+UPDATE
+    sims.restrictions
+SET
+    restriction_code = 'APPC',
+    action_type = ARRAY ['Stop full time disbursement', 'Stop part time disbursement'] :: sims.restriction_action_types []
+WHERE
+    restriction_code = 'HOLD';
+
+-- Revert the updates for the restriction code B6
+UPDATE
+    sims.restrictions
+SET
+    restriction_type = 'Federal',
+    description = 'Bankruptcy restriction on file prevent CSL/BCSL disbursements.',
+    restriction_category = 'Federal'
+WHERE
+    restriction_code = 'B6';
+
+-- Revert the updates for the restriction code B6A
+UPDATE
+    sims.restrictions
+SET
+    description = 'For reinstatment of your BCSL eligibility please complete an appeal.',
+    action_type = ARRAY ['Stop full time BC funding'] :: sims.restriction_action_types []
+WHERE
+    restriction_code = 'B6A';
+
+-- Revert the updates for the restriction code E2
+UPDATE
+    sims.restrictions
+SET
+    restriction_type = 'Federal',
+    restriction_category = 'Federal'
+WHERE
+    restriction_code = 'E2';
+
+-- Revert the updates for the restriction code PTSSR
+UPDATE
+    sims.restrictions
+SET
+    action_type = ARRAY ['Stop part time apply', 'Stop part time disbursement'] :: sims.restriction_action_types []
+WHERE
+    restriction_code = 'PTSSR';
+
+-- Revert the updates for the restriction code SSR
+UPDATE
+    sims.restrictions
+SET
+    action_type = ARRAY ['Stop full time apply', 'Stop full time disbursement'] :: sims.restriction_action_types []
+WHERE
+    restriction_code = 'SSR';
+
+-- Revert the updates for the restriction code RD
+UPDATE
+    sims.restrictions
+SET
+    action_type = ARRAY ['Stop part time disbursement', 'Stop full time disbursement'] :: sims.restriction_action_types []
+WHERE
+    restriction_code = 'RD';

--- a/sources/packages/backend/apps/db-migrations/src/sql/Restrictions/Rollback-update-restrictions-review-impact.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/Restrictions/Rollback-update-restrictions-review-impact.sql
@@ -37,7 +37,7 @@ WHERE
 UPDATE
     sims.restrictions
 SET
-    description = 'For reinstatment of your BCSL eligibility please complete an appeal.',
+    description = 'For reinstatement of your BCSL eligibility please complete an appeal.',
     action_type = ARRAY ['Stop full time BC funding'] :: sims.restriction_action_types []
 WHERE
     restriction_code = 'B6A';

--- a/sources/packages/backend/apps/db-migrations/src/sql/Restrictions/Update-restrictions-review-impact.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/Restrictions/Update-restrictions-review-impact.sql
@@ -1,0 +1,76 @@
+-- Update action_type for the restriction code 5, 7 and 9.
+UPDATE
+    sims.restrictions
+SET
+    action_type = ARRAY ['Stop full time disbursement', 'Stop part time disbursement'] :: sims.restriction_action_types []
+WHERE
+    restriction_code IN ('5', '7', '9');
+
+-- Update action_type for the restriction code 12, O and PTWTHD.
+UPDATE
+    sims.restrictions
+SET
+    action_type = ARRAY ['No effect'] :: sims.restriction_action_types []
+WHERE
+    restriction_code IN ('12', 'O', 'PTWTHD');
+
+-- Update restriction_code, action_type for the restriction code APPC.
+UPDATE
+    sims.restrictions
+SET
+    restriction_code = 'HOLD',
+    action_type = ARRAY ['Stop full time disbursement', 'Stop part time disbursement'] :: sims.restriction_action_types []
+WHERE
+    restriction_code = 'APPC';
+
+-- Update restriction_type, description, restriction_category for the restriction code B6
+UPDATE
+    sims.restrictions
+SET
+    restriction_type = 'Provincial',
+    description = 'Bankruptcy restriction on file prevent all funding.',
+    restriction_category = 'Other'
+WHERE
+    restriction_code = 'B6';
+
+-- Update description, action_type for the restriction code B6A
+UPDATE
+    sims.restrictions
+SET
+    description = 'For reinstatment of your BC funding eligibility please complete an appeal.',
+    action_type = ARRAY ['Stop full time BC funding', 'Stop part time BC funding'] :: sims.restriction_action_types []
+WHERE
+    restriction_code = 'B6A';
+
+-- Update restriction_type, restriction_category for the restriction code E2
+UPDATE
+    sims.restrictions
+SET
+    restriction_type = 'Provincial',
+    restriction_category = 'Other'
+WHERE
+    restriction_code = 'E2';
+
+-- Update action_type for the restriction code PTSSR
+UPDATE
+    sims.restrictions
+SET
+    action_type = ARRAY ['Stop part time disbursement'] :: sims.restriction_action_types []
+WHERE
+    restriction_code = 'PTSSR';
+
+-- Update action_type for the restriction code SSR
+UPDATE
+    sims.restrictions
+SET
+    action_type = ARRAY ['Stop full time disbursement'] :: sims.restriction_action_types []
+WHERE
+    restriction_code = 'SSR';
+
+-- Update action_type for the restriction code RD
+UPDATE
+    sims.restrictions
+SET
+    action_type = ARRAY ['Stop part time apply', 'Stop full time apply', 'Stop part time disbursement', 'Stop full time disbursement'] :: sims.restriction_action_types []
+WHERE
+    restriction_code = 'RD';

--- a/sources/packages/backend/apps/db-migrations/src/sql/Restrictions/Update-restrictions-review-impact.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/Restrictions/Update-restrictions-review-impact.sql
@@ -37,7 +37,7 @@ WHERE
 UPDATE
     sims.restrictions
 SET
-    description = 'For reinstatment of your BC funding eligibility please complete an appeal.',
+    description = 'For reinstatement of your BC funding eligibility please complete an appeal.',
     action_type = ARRAY ['Stop full time BC funding', 'Stop part time BC funding'] :: sims.restriction_action_types []
 WHERE
     restriction_code = 'B6A';

--- a/sources/packages/backend/apps/db-migrations/src/sql/Types/Add-stop-part-time-bc-funding-restriction-action-type.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/Types/Add-stop-part-time-bc-funding-restriction-action-type.sql
@@ -1,0 +1,24 @@
+-- Postgres allows adding new types to an enum but it causes issues when the new types added are
+-- used in another query in the same transaction, hence the team decision was to recreate the enums
+-- types when a new item must be added following the same approach already used for rollbacks.
+CREATE TYPE sims.restriction_action_types_to_be_updated AS ENUM (
+  'No effect',
+  'Stop full time BC funding',
+  'Stop part time BC funding',
+  'Stop part time apply',
+  'Stop full time apply',
+  'Stop part time disbursement',
+  'Stop full time disbursement'
+);
+
+-- Update the dependent column to start using the new enum with the expected values.
+ALTER TABLE
+  sims.restrictions
+ALTER COLUMN
+  action_type TYPE sims.restriction_action_types_to_be_updated [] USING (action_type :: TEXT) :: sims.restriction_action_types_to_be_updated [];
+
+-- Remove the entire enum that is no longer being used.
+DROP TYPE sims.restriction_action_types;
+
+-- Rename the enum to what it was in the beginning.
+ALTER TYPE sims.restriction_action_types_to_be_updated RENAME TO restriction_action_types;

--- a/sources/packages/backend/apps/db-migrations/src/sql/Types/Rollback-add-stop-part-time-bc-funding-restriction-action-type.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/Types/Rollback-add-stop-part-time-bc-funding-restriction-action-type.sql
@@ -1,5 +1,5 @@
---Removing the value Application from sims.note_types for the rollback.
---As postgres does not support removal of an Enum Value, we create a temporary enum and rename it.
+-- Removing the value 'Stop part time BC funding' from sims.restriction_action_types for the rollback.
+-- As postgres does not support removal of an Enum Value, we create a temporary enum and rename it.
 CREATE TYPE sims.restriction_action_types_to_rollback AS ENUM (
   'No effect',
   'Stop full time BC funding',

--- a/sources/packages/backend/apps/db-migrations/src/sql/Types/Rollback-add-stop-part-time-bc-funding-restriction-action-type.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/Types/Rollback-add-stop-part-time-bc-funding-restriction-action-type.sql
@@ -1,0 +1,30 @@
+--Removing the value Application from sims.note_types for the rollback.
+--As postgres does not support removal of an Enum Value, we create a temporary enum and rename it.
+CREATE TYPE sims.restriction_action_types_to_rollback AS ENUM (
+  'No effect',
+  'Stop full time BC funding',
+  'Stop part time apply',
+  'Stop full time apply',
+  'Stop part time disbursement',
+  'Stop full time disbursement'
+);
+
+-- Remove 'Stop part time BC funding' enum from any row that contains it.
+UPDATE
+  sims.restrictions
+SET
+  action_type = array_remove(action_type, 'Stop part time BC funding')
+WHERE
+  'Stop part time BC funding' = ANY(action_type);
+
+-- Update the dependent column to start using the new enum with the expected values.
+ALTER TABLE
+  sims.restrictions
+ALTER COLUMN
+  action_type TYPE sims.restriction_action_types_to_rollback [] USING (action_type :: TEXT) :: sims.restriction_action_types_to_rollback [];
+
+-- Remove the entire enum that is no longer being used.
+DROP TYPE sims.restriction_action_types;
+
+-- Rename the enum to what it was in the beginning.
+ALTER TYPE sims.restriction_action_types_to_rollback RENAME TO restriction_action_types;

--- a/sources/packages/backend/libs/sims-db/src/entities/restriction-action-type.type.ts
+++ b/sources/packages/backend/libs/sims-db/src/entities/restriction-action-type.type.ts
@@ -11,6 +11,10 @@ export enum RestrictionActionType {
    */
   StopFullTimeBCFunding = "Stop full time BC funding",
   /**
+   * Stop part time BC funding.
+   */
+  StopPartTimeBCFunding = "Stop part time BC funding",
+  /**
    * Stop student from applying part time applications.
    */
   StopPartTimeApply = "Stop part time apply",


### PR DESCRIPTION
- Created a DB migration to update the `sims.restriction_action_types` enum to include "Stop part time BC funding".
  - Used "part time" without capitalized letters for "Stop part time BC funding" to be consistent with existing convention across FT/PT restrictions.
- Created a DB migration to update the `sims.restrictions`. Updated restrictions per the spreadsheet to ensure all behaviors and names are updated. ALL CHANGES ARE IN HIGHLIGHTED CELLS
  - Updated `action_type` for the restriction code _5_, _7_ and _9_.
  - Updated `action_type` for the restriction code _12_, _O_ and _PTWTHD_.
  - Updated `restriction_code`, `action_type` for the restriction code _APPC_.
  - Updated `restriction_type`, `description`, `restriction_category` for the restriction code _B6_.
  - Updated `description`, `action_type` for the restriction code _B6A_.
  - Updated `restriction_type`, `restriction_category` for the restriction code _E2_.
  - Updated `action_type` for the restriction code _PTSSR_.
  - Updated `action_type` for the restriction code _SSR_.
  - Updated `action_type` for the restriction code _RD_.
- NOTE There are other updates to when the _PTWTHD_ restriction is applied and accordion behavior for _PTSSR_. (Effects are updated within this spreadsheet)
- Note ID #8 was previously _APPC_ and the name is being changed to _HOLD_ (**line 9 on the spreadsheet**)

#### Rollback evidence for migration AddStopPartTimeBCFundingRestrictionActionType1726275056327
![image](https://github.com/user-attachments/assets/7062de54-d230-4ad0-b426-7258b62c8cba)

#### Rollback evidence for migration UpdateRestrictionsReviewImpact1726275219662
![image](https://github.com/user-attachments/assets/416add33-bffa-4842-ab32-ba48df5eab1f)
