### PR TITLE
#2509 - Update formio server and js

### DIFF
--- a/.github/workflows/env-setup-build-forms-server.yml
+++ b/.github/workflows/env-setup-build-forms-server.yml
@@ -8,7 +8,7 @@ on:
         description: "Formio tag, please refer https://github.com/formio/formio/tags to deploy the appropriate tag."
         type: string
         required: true
-        default: "v2.5.3"
+        default: "v4.2.4"
       gitRef:
         description: "Git Ref"
         required: true

--- a/.github/workflows/env-setup-build-forms-server.yml
+++ b/.github/workflows/env-setup-build-forms-server.yml
@@ -15,10 +15,8 @@ jobs:
     name: Build Forms Server
     runs-on: ubuntu-latest
     env:
-      FORMIO_SOURCE_REPO_TAG: ${{ inputs.formioTag }}
-      SOURCE_REPOSITORY_REF: ${{ github.ref_name }}
-      BUILD_REF: ${{ inputs.formioTag }}
       BUILD_NAMESPACE: ${{ vars.BUILD_NAMESPACE }}
+      FORMIO_SOURCE_REPO_TAG: ${{ inputs.formioTag }}
     steps:
       - name: Print env
         run: |

--- a/.github/workflows/env-setup-build-forms-server.yml
+++ b/.github/workflows/env-setup-build-forms-server.yml
@@ -16,6 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       FORMIO_SOURCE_REPO_TAG: ${{ inputs.formioTag }}
+      SOURCE_REPOSITORY_REF: ${{ github.ref_name }}
       BUILD_REF: ${{ inputs.formioTag }}
       BUILD_NAMESPACE: ${{ vars.BUILD_NAMESPACE }}
     steps:

--- a/.github/workflows/env-setup-build-forms-server.yml
+++ b/.github/workflows/env-setup-build-forms-server.yml
@@ -8,7 +8,7 @@ on:
         description: "Formio tag, please refer https://github.com/formio/formio/tags to deploy the appropriate tag."
         type: string
         required: true
-        default: "v4.2.0"
+        default: "v4.2.4"
 
 jobs:
   build:

--- a/.github/workflows/env-setup-build-forms-server.yml
+++ b/.github/workflows/env-setup-build-forms-server.yml
@@ -1,5 +1,5 @@
 name: Env Setup - Build Forms Server
-run-name: Env Setup - Build forms server from ${{ inputs.gitRef }}(form.io tag ${{ inputs.formioTag }})
+run-name: Env Setup - Build forms server from ${{ github.ref_name }}(form.io tag ${{ inputs.formioTag }})
 
 on:
   workflow_dispatch:
@@ -9,10 +9,6 @@ on:
         type: string
         required: true
         default: "v4.2.4"
-      gitRef:
-        description: "Git Ref"
-        required: true
-        default: ""
 
 jobs:
   build:
@@ -31,7 +27,7 @@ jobs:
       - name: Checkout Target Branch
         uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.gitRef }}
+          ref: ${{ github.ref_name }}
       # Log in to OpenShift.
       - name: Log in to OpenShift
         run: |

--- a/.github/workflows/env-setup-build-forms-server.yml
+++ b/.github/workflows/env-setup-build-forms-server.yml
@@ -8,7 +8,7 @@ on:
         description: "Formio tag, please refer https://github.com/formio/formio/tags to deploy the appropriate tag."
         type: string
         required: true
-        default: "v4.2.4"
+        default: "v4.2.0"
 
 jobs:
   build:

--- a/.github/workflows/env-setup-deploy-forms-server.yml
+++ b/.github/workflows/env-setup-deploy-forms-server.yml
@@ -12,11 +12,7 @@ on:
         description: "Formio tag, please refer https://github.com/formio/formio/tags to deploy the appropriate tag."
         type: string
         required: true
-        default: "v2.5.3"
-      gitRef:
-        description: "Git Ref"
-        required: true
-        default: ""
+        default: "v4.2.4"
 
 jobs:
   deploy:
@@ -26,7 +22,7 @@ jobs:
     env:
       FORMS_NAME: forms
       NAMESPACE: ${{ secrets.OPENSHIFT_ENV_NAMESPACE }}
-      BUILD_REF: ${{ inputs.formioTag }}
+      FORMIO_SOURCE_REPO_TAG: ${{ inputs.formioTag }}
       HOST_PREFIX: ${{ secrets.HOST_PREFIX }}
       MONGODB_URI: ${{ secrets.MONGODB_URI }}
       FORMIO_ROOT_EMAIL: ${{ secrets.FORMS_SA_USER_NAME }}
@@ -45,7 +41,7 @@ jobs:
       - name: Checkout Target Branch
         uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.gitRef }}
+          ref: ${{ github.ref_name }}
       # Log in to OpenShift.
       - name: Log in to OpenShift
         run: |

--- a/.github/workflows/env-setup-deploy-forms-server.yml
+++ b/.github/workflows/env-setup-deploy-forms-server.yml
@@ -1,5 +1,5 @@
 name: Env Setup - Deploy Forms Server
-run-name: Env Setup - Deploy forms server from ${{ inputs.gitRef }}(form.io tag ${{ inputs.formioTag }}) to ${{ inputs.environment }}
+run-name: Env Setup - Deploy forms server from ${{ github.ref_name }}(form.io tag ${{ inputs.formioTag }}) to ${{ inputs.environment }}
 
 on:
   workflow_dispatch:

--- a/.github/workflows/env-setup-deploy-forms-server.yml
+++ b/.github/workflows/env-setup-deploy-forms-server.yml
@@ -35,7 +35,6 @@ jobs:
       - name: Print env
         run: |
           echo NAMESPACE: $NAMESPACE
-          echo BRANCH: $BUILD_REF
           echo HOST_PREFIX: $HOST_PREFIX
       # Checkout the PR branch
       - name: Checkout Target Branch

--- a/devops/Makefile
+++ b/devops/Makefile
@@ -121,7 +121,7 @@ define FORMIO_SOURCE_REPO_URL
 endef
 
 define FORMIO_SOURCE_REPO_TAG
-"v2.5.4"
+"v4.2.4"
 endef
 
 define SOURCE_CONTEXT_DIR

--- a/devops/Makefile
+++ b/devops/Makefile
@@ -39,9 +39,11 @@ export QUEUE_CONSUMERS_BUILD_REF := $(or ${QUEUE_CONSUMERS_BUILD_REF}, queue-con
 export LOAD_TEST_GATEWAY_BUILD_REF := $(or ${LOAD_TEST_GATEWAY_BUILD_REF}, load-test-gateway-${APP_NAME})
 export WEB_BUILD_REF := $(or ${WEB_BUILD_REF}, web-${APP_NAME})
 export FORMS_BUILD_REF := $(or ${FORMS_BUILD_REF}, forms)
+export FORMIO_SOURCE_REPO_TAG := $(or $(FORMIO_SOURCE_REPO_TAG), v4.2.4)
 export FORMIO_ROOT_EMAIL := $(or ${FORMIO_ROOT_EMAIL}, dev_sabc@gov.bc.ca)
 export MONGODB_URI := $(or ${MONGODB_URI}, $$MONGODB_URI)
 export QUEUE_PREFIX := $(or $(QUEUE_PREFIX), {sims-local})
+
 export MAX_WAIT=300 # Maximum wait time in seconds.
 export WAIT_TIME=0  # Initialize wait time to zero.
 
@@ -113,10 +115,6 @@ endef
 
 define FORMIO_SOURCE_REPO_URL
 "https://github.com/formio/formio.git"
-endef
-
-define FORMIO_SOURCE_REPO_TAG
-"v4.2.0"
 endef
 
 define SOURCE_CONTEXT_DIR

--- a/devops/Makefile
+++ b/devops/Makefile
@@ -42,7 +42,6 @@ export FORMS_BUILD_REF := $(or ${FORMS_BUILD_REF}, forms)
 export FORMIO_ROOT_EMAIL := $(or ${FORMIO_ROOT_EMAIL}, dev_sabc@gov.bc.ca)
 export MONGODB_URI := $(or ${MONGODB_URI}, $$MONGODB_URI)
 export QUEUE_PREFIX := $(or $(QUEUE_PREFIX), {sims-local})
-export SOURCE_REPOSITORY_REF := $(or $(SOURCE_REPOSITORY_REF), main)
 export MAX_WAIT=300 # Maximum wait time in seconds.
 export WAIT_TIME=0  # Initialize wait time to zero.
 
@@ -117,7 +116,7 @@ define FORMIO_SOURCE_REPO_URL
 endef
 
 define FORMIO_SOURCE_REPO_TAG
-"v4.2.4"
+"v4.2.0"
 endef
 
 define SOURCE_CONTEXT_DIR
@@ -529,11 +528,10 @@ build-forms:
 	test -n "$(BUILD_REF)"
 	test -n "$(SOURCE_CONTEXT_DIR)"
 	test -n "$(SOURCE_REPOSITORY_URL)"
-	test -n "$(SOURCE_REPOSITORY_REF)"
 	test -n "$(FORMIO_SOURCE_REPO_URL)"
 	test -n "$(FORMIO_SOURCE_REPO_TAG)"
-	@echo "+\n++ BUILDING $(FORMS_BUILD_REF) DIR: $(SOURCE_CONTEXT_DIR)forms BUILD_TAG:$(BUILD_REF)\n+"
-	@oc -n $(BUILD_NAMESPACE) process -f openshift/forms-build.yml -p NAME=$(FORMS_BUILD_REF) -p TAG=$(BUILD_REF) -p FORMIO_SOURCE_REPO_URL=$(FORMIO_SOURCE_REPO_URL) -p FORMIO_SOURCE_REPO_TAG=$(FORMIO_SOURCE_REPO_TAG) -p SOURCE_REPOSITORY_URL=$(SOURCE_REPOSITORY_URL) -p SOURCE_REPOSITORY_REF=$(SOURCE_REPOSITORY_REF) -p SOURCE_CONTEXT_DIR=$(SOURCE_CONTEXT_DIR)forms| oc -n $(BUILD_NAMESPACE) apply -f -
+	@echo "+\n++ BUILDING $(FORMS_BUILD_REF) DIR: $(SOURCE_CONTEXT_DIR)forms BUILD_TAG:$(FORMIO_SOURCE_REPO_TAG)\n+"
+	@oc -n $(BUILD_NAMESPACE) process -f openshift/forms-build.yml -p NAME=$(FORMS_BUILD_REF) -p TAG=$(FORMIO_SOURCE_REPO_TAG) -p FORMIO_SOURCE_REPO_URL=$(FORMIO_SOURCE_REPO_URL) -p FORMIO_SOURCE_REPO_TAG=$(FORMIO_SOURCE_REPO_TAG) -p SOURCE_REPOSITORY_URL=$(SOURCE_REPOSITORY_URL) -p SOURCE_REPOSITORY_REF=$(BUILD_REF) -p SOURCE_CONTEXT_DIR=$(SOURCE_CONTEXT_DIR)forms| oc -n $(BUILD_NAMESPACE) apply -f -
 	@oc -n $(BUILD_NAMESPACE) start-build bc/$(FORMS_BUILD_REF) --wait
 
 deploy-forms:
@@ -541,15 +539,15 @@ deploy-forms:
 	test -n "$(FORMS_NAME)"
 	test -n "$(FORMS_URL)"
 	test -n "$(BUILD_NAMESPACE)"
-	test -n "$(BUILD_REF)"
+	test -n "$(FORMIO_SOURCE_REPO_TAG)"
 	test -n "$(FORMIO_ROOT_EMAIL)"
 	test -n "$(MONGODB_URI)"
-	@echo "+\n++ Deploying forms with tag: $(BUILD_REF)\n+"
+	@echo "+\n++ Deploying forms with tag: $(FORMIO_SOURCE_REPO_TAG)\n+"
 	@oc -n $(NAMESPACE) process -f openshift/forms-deploy.yml \
 	-p NAME=$(FORMS_NAME) \
 	-p FORMS_URL=$(FORMS_URL) \
 	-p TOOLS_NAMESPACE=$(BUILD_NAMESPACE) \
-	-p IMAGE_STREAM_TAG="$(FORMS_BUILD_REF):$(BUILD_REF)" \
+	-p IMAGE_STREAM_TAG="$(FORMS_BUILD_REF):$(FORMIO_SOURCE_REPO_TAG)" \
 	-p FORMIO_ROOT_EMAIL=$(FORMIO_ROOT_EMAIL) \
 	-p FORMIO_ROOT_PASSWORD=$(FORMIO_ROOT_PASSWORD) \
 	-p MONGODB_URI=$(MONGODB_URI) \

--- a/devops/Makefile
+++ b/devops/Makefile
@@ -117,7 +117,7 @@ define FORMIO_SOURCE_REPO_URL
 endef
 
 define FORMIO_SOURCE_REPO_TAG
-"v4.2.0"
+"v4.2.4"
 endef
 
 define SOURCE_CONTEXT_DIR

--- a/devops/Makefile
+++ b/devops/Makefile
@@ -42,7 +42,7 @@ export FORMS_BUILD_REF := $(or ${FORMS_BUILD_REF}, forms)
 export FORMIO_ROOT_EMAIL := $(or ${FORMIO_ROOT_EMAIL}, dev_sabc@gov.bc.ca)
 export MONGODB_URI := $(or ${MONGODB_URI}, $$MONGODB_URI)
 export QUEUE_PREFIX := $(or $(QUEUE_PREFIX), {sims-local})
-
+export SOURCE_REPOSITORY_REF := $(or $(SOURCE_REPOSITORY_REF), main)
 export MAX_WAIT=300 # Maximum wait time in seconds.
 export WAIT_TIME=0  # Initialize wait time to zero.
 
@@ -110,10 +110,6 @@ endef
 
 define SOURCE_REPOSITORY_URL
 "https://github.com/bcgov/SIMS.git"
-endef
-
-define SOURCE_REPOSITORY_REF
-"main"
 endef
 
 define FORMIO_SOURCE_REPO_URL

--- a/devops/Makefile
+++ b/devops/Makefile
@@ -117,7 +117,7 @@ define FORMIO_SOURCE_REPO_URL
 endef
 
 define FORMIO_SOURCE_REPO_TAG
-"v4.2.4"
+"v4.2.0"
 endef
 
 define SOURCE_CONTEXT_DIR

--- a/sources/Makefile
+++ b/sources/Makefile
@@ -49,7 +49,7 @@ export SWAGGER_ENABLED := $(or ${SWAGGER_ENABLED}, true)
 export APPLICATION_ARCHIVE_DAYS := $(or ${APPLICATION_ARCHIVE_DAYS}, 43)
 #Formio forms integration
 export FORMIO_SOURCE_REPO_URL := $(or ${FORMIO_SOURCE_REPO_URL}, https://github.com/formio/formio.git)
-export FORMIO_SOURCE_REPO_TAG := $(or ${FORMIO_SOURCE_REPO_TAG}, v4.2.0)
+export FORMIO_SOURCE_REPO_TAG := $(or ${FORMIO_SOURCE_REPO_TAG}, v4.2.4)
 #ATBC Integration
 export ATBC_USERNAME := $(or $(ATBC_USERNAME), )
 export ATBC_PASSWORD := $(or $(ATBC_PASSWORD), )

--- a/sources/Makefile
+++ b/sources/Makefile
@@ -49,7 +49,7 @@ export SWAGGER_ENABLED := $(or ${SWAGGER_ENABLED}, true)
 export APPLICATION_ARCHIVE_DAYS := $(or ${APPLICATION_ARCHIVE_DAYS}, 43)
 #Formio forms integration
 export FORMIO_SOURCE_REPO_URL := $(or ${FORMIO_SOURCE_REPO_URL}, https://github.com/formio/formio.git)
-export FORMIO_SOURCE_REPO_TAG := $(or ${FORMIO_SOURCE_REPO_TAG}, v2.5.3)
+export FORMIO_SOURCE_REPO_TAG := $(or ${FORMIO_SOURCE_REPO_TAG}, v4.2.4)
 #ATBC Integration
 export ATBC_USERNAME := $(or $(ATBC_USERNAME), )
 export ATBC_PASSWORD := $(or $(ATBC_PASSWORD), )
@@ -160,7 +160,7 @@ local-clean:
 # Local DB
 postgres:
 	@echo "+\n++ Make: Run local db.\n+"
-	@docker compose -f docker-compose.yml up postgres
+	@docker compose -f docker-compose.yml up -d postgres
 
 # Local Queue
 redis:

--- a/sources/Makefile
+++ b/sources/Makefile
@@ -49,7 +49,7 @@ export SWAGGER_ENABLED := $(or ${SWAGGER_ENABLED}, true)
 export APPLICATION_ARCHIVE_DAYS := $(or ${APPLICATION_ARCHIVE_DAYS}, 43)
 #Formio forms integration
 export FORMIO_SOURCE_REPO_URL := $(or ${FORMIO_SOURCE_REPO_URL}, https://github.com/formio/formio.git)
-export FORMIO_SOURCE_REPO_TAG := $(or ${FORMIO_SOURCE_REPO_TAG}, v4.2.4)
+export FORMIO_SOURCE_REPO_TAG := $(or ${FORMIO_SOURCE_REPO_TAG}, v4.2.0)
 #ATBC Integration
 export ATBC_USERNAME := $(or $(ATBC_USERNAME), )
 export ATBC_PASSWORD := $(or $(ATBC_PASSWORD), )

--- a/sources/packages/forms/Dockerfile
+++ b/sources/packages/forms/Dockerfile
@@ -26,13 +26,15 @@ WORKDIR formio
 # Use install as-is from package.json
 RUN npm i
 
+RUN apk del git
+
 # Set this to inspect more from the application. Examples:
 #   DEBUG=formio:db (see index.js for more)
 #   DEBUG=formio:*
 ENV DEBUG=""
 
 RUN set -x \
-  && chmod -R 770 ./
+  && chmod -R 770 ./node_modules
 
 # This will initialize the application based on
 # some questions to the user (login email, password, etc.)

--- a/sources/packages/forms/Dockerfile
+++ b/sources/packages/forms/Dockerfile
@@ -4,7 +4,7 @@
 
 # Use Node image, maintained by Docker:
 # hub.docker.com/r/_/node/
-FROM artifacts.developer.gov.bc.ca/docker-remote/node:12.2.0-alpine
+FROM artifacts.developer.gov.bc.ca/docker-remote/node:20-alpine3.19
 
 WORKDIR /app
 ARG FORMIO_SOURCE_REPO_URL

--- a/sources/packages/forms/Dockerfile
+++ b/sources/packages/forms/Dockerfile
@@ -34,7 +34,7 @@ RUN apk del git
 ENV DEBUG=""
 
 RUN set -x \
-  && chmod -R 770 ./node_modules
+  && chmod -R 770 ./
 
 # This will initialize the application based on
 # some questions to the user (login email, password, etc.)

--- a/sources/packages/forms/Dockerfile
+++ b/sources/packages/forms/Dockerfile
@@ -9,6 +9,7 @@ FROM artifacts.developer.gov.bc.ca/docker-remote/node:20-alpine3.19
 ARG FORMIO_SOURCE_REPO_URL
 ARG FORMIO_SOURCE_REPO_TAG
 
+
 # "bcrypt" requires python/make/g++, all must be installed in alpine
 # (note: using pinned versions to ensure immutable build environment)
 RUN apk update && \

--- a/sources/packages/forms/Dockerfile
+++ b/sources/packages/forms/Dockerfile
@@ -10,13 +10,16 @@ RUN apk update && \
   apk upgrade && \
   apk add make=4.4.1-r2 && \
   apk add python3=3.12.6-r0 && \
-  apk add g++=13.2.1_git20240309-r0 &&\
-  apk add git=2.45.2-r0
+  apk add g++=13.2.1_git20240309-r0 && \
+  apk add git=2.45.2-r0 && \
+  apk cache clean
 
 # Clone code into formio folder, by default.
 RUN git clone ${FORMIO_SOURCE_REPO_URL} -b ${FORMIO_SOURCE_REPO_TAG} --single-branch
 
-WORKDIR formio
+RUN apk del git
+
+WORKDIR /formio
 
 # Use install as-is from package.json.
 RUN npm i

--- a/sources/packages/forms/Dockerfile
+++ b/sources/packages/forms/Dockerfile
@@ -4,7 +4,7 @@
 
 # Use Node image, maintained by Docker:
 # hub.docker.com/r/_/node/
-FROM artifacts.developer.gov.bc.ca/docker-remote/node:lts-alpine3.19
+FROM artifacts.developer.gov.bc.ca/docker-remote/node:12.2.0-alpine
 
 WORKDIR /app
 ARG FORMIO_SOURCE_REPO_URL
@@ -13,35 +13,16 @@ ARG FORMIO_SOURCE_REPO_TAG
 # "bcrypt" requires python/make/g++, all must be installed in alpine
 # (note: using pinned versions to ensure immutable build environment)
 RUN apk update && \
-    apk upgrade && \
-    apk add make && \
-    apk add python3 && \
-    apk add g++ && \
-    apk add git
+  apk upgrade && \
+  apk add make && \
+  apk add g++ &&\
+  apk add git
 
 # Clone code
 RUN git clone ${FORMIO_SOURCE_REPO_URL} -b ${FORMIO_SOURCE_REPO_TAG} --single-branch /app/
 
-# Using an alternative package install location
-# to allow overwriting the /app folder at runtime
-# stackoverflow.com/a/13021677
-ENV NPM_PACKAGES=/.npm-packages \
-  PATH=$NPM_PACKAGES/bin:$PATH \
-  NODE_PATH=$NPM_PACKAGES/lib/node_modules:$NODE_PATH
-RUN echo "prefix = $NPM_PACKAGES" >> ~/.npmrc
-
-# Include details of the required dependencies
-RUN mkdir -p $NPM_PACKAGES/
-# Include details of the required dependencies
-RUN cp package.json $NPM_PACKAGES/
-
 # Use install as-is from package.json
-RUN npm i --prefix=$NPM_PACKAGES
-
-# Link in the global install because `require()` only looks for ./node_modules
-# WARNING: This is overwritten by volume-mount at runtime!
-#          See docker-compose.yml for instructions
-RUN ln -sf $NPM_PACKAGES/node_modules node_modules
+RUN npm i
 
 # Set this to inspect more from the application. Examples:
 #   DEBUG=formio:db (see index.js for more)

--- a/sources/packages/forms/Dockerfile
+++ b/sources/packages/forms/Dockerfile
@@ -1,32 +1,25 @@
-# Used by docker-compose.yml to deploy the formio application
-# (When modified, you must include `--build` )
-# -----------------------------------------------------------
-
-# Use Node image, maintained by Docker:
-# hub.docker.com/r/_/node/
-FROM artifacts.developer.gov.bc.ca/docker-remote/node:20-alpine3.19
+# Use Node image, maintained by Docker: hub.docker.com/r/_/node.
+FROM artifacts.developer.gov.bc.ca/docker-remote/node:20-alpine3.20
 
 ARG FORMIO_SOURCE_REPO_URL
 ARG FORMIO_SOURCE_REPO_TAG
 
-
-# "bcrypt" requires python/make/g++, all must be installed in alpine
-# (note: using pinned versions to ensure immutable build environment)
+# "bcrypt" requires python/make/g++, all must be installed in alpine.
+# Note: using pinned versions to ensure immutable build environment.
 RUN apk update && \
   apk upgrade && \
-  apk add make && \
-  apk add g++ &&\
-  apk add git
+  apk add make=4.4.1-r2 && \
+  apk add python3=3.12.6-r0 && \
+  apk add g++=13.2.1_git20240309-r0 &&\
+  apk add git=2.45.2-r0
 
-# Clone code
+# Clone code into formio folder, by default.
 RUN git clone ${FORMIO_SOURCE_REPO_URL} -b ${FORMIO_SOURCE_REPO_TAG} --single-branch
 
 WORKDIR formio
 
-# Use install as-is from package.json
+# Use install as-is from package.json.
 RUN npm i
-
-RUN apk del git
 
 # Set this to inspect more from the application. Examples:
 #   DEBUG=formio:db (see index.js for more)

--- a/sources/packages/forms/Dockerfile
+++ b/sources/packages/forms/Dockerfile
@@ -4,7 +4,7 @@
 
 # Use Node image, maintained by Docker:
 # hub.docker.com/r/_/node/
-FROM artifacts.developer.gov.bc.ca/docker-remote/node:20-alpine3.19
+FROM artifacts.developer.gov.bc.ca/docker-remote/node:lts-alpine3.19
 
 WORKDIR /app
 ARG FORMIO_SOURCE_REPO_URL

--- a/sources/packages/forms/Dockerfile
+++ b/sources/packages/forms/Dockerfile
@@ -6,7 +6,6 @@
 # hub.docker.com/r/_/node/
 FROM artifacts.developer.gov.bc.ca/docker-remote/node:20-alpine3.19
 
-WORKDIR /app
 ARG FORMIO_SOURCE_REPO_URL
 ARG FORMIO_SOURCE_REPO_TAG
 
@@ -19,7 +18,9 @@ RUN apk update && \
   apk add git
 
 # Clone code
-RUN git clone ${FORMIO_SOURCE_REPO_URL} -b ${FORMIO_SOURCE_REPO_TAG} --single-branch /app/
+RUN git clone ${FORMIO_SOURCE_REPO_URL} -b ${FORMIO_SOURCE_REPO_TAG} --single-branch
+
+WORKDIR formio
 
 # Use install as-is from package.json
 RUN npm i
@@ -30,7 +31,7 @@ RUN npm i
 ENV DEBUG=""
 
 RUN set -x \
-  && chmod -R 770 /app/
+  && chmod -R 770 ./
 
 # This will initialize the application based on
 # some questions to the user (login email, password, etc.)

--- a/sources/packages/forms/Dockerfile
+++ b/sources/packages/forms/Dockerfile
@@ -13,10 +13,11 @@ ARG FORMIO_SOURCE_REPO_TAG
 # "bcrypt" requires python/make/g++, all must be installed in alpine
 # (note: using pinned versions to ensure immutable build environment)
 RUN apk update && \
-  apk upgrade && \
-  apk add make=4.2.1-r2 && \
-  apk add g++=8.3.0-r0 && \
-  apk add git
+    apk upgrade && \
+    apk add make && \
+    apk add python3 && \
+    apk add g++ && \
+    apk add git
 
 # Clone code
 RUN git clone ${FORMIO_SOURCE_REPO_URL} -b ${FORMIO_SOURCE_REPO_TAG} --single-branch /app/

--- a/sources/packages/forms/Dockerfile.dev
+++ b/sources/packages/forms/Dockerfile.dev
@@ -4,7 +4,7 @@
 
 # Use Node image, maintained by Docker:
 # hub.docker.com/r/_/node/
-FROM docker.io/node:19.2-alpine
+FROM docker.io/node:20-alpine3.19
 
 # set working directory
 WORKDIR /formio

--- a/sources/packages/forms/Dockerfile.dev
+++ b/sources/packages/forms/Dockerfile.dev
@@ -4,10 +4,7 @@
 
 # Use Node image, maintained by Docker:
 # hub.docker.com/r/_/node/
-FROM docker.io/node:20-alpine3.19
-
-# set working directory
-WORKDIR /formio
+FROM node:20-alpine3.19
 
 ARG FORMIO_SOURCE_REPO_URL
 ARG FORMIO_SOURCE_REPO_TAG
@@ -21,7 +18,9 @@ RUN apk update && \
   apk add git
 
 # Clone code
-RUN git clone $FORMIO_SOURCE_REPO_URL -b $FORMIO_SOURCE_REPO_TAG --single-branch /formio
+RUN git clone ${FORMIO_SOURCE_REPO_URL} -b ${FORMIO_SOURCE_REPO_TAG} --single-branch
+
+WORKDIR formio
 
 # Use install as-is from package.json
 RUN npm i
@@ -30,6 +29,7 @@ RUN npm i
 #   DEBUG=formio:db (see index.js for more)
 #   DEBUG=formio:*
 ENV DEBUG=""
+
 # This will initialize the application based on
 # some questions to the user (login email, password, etc.)
 ENTRYPOINT [ "node", "main" ]

--- a/sources/packages/forms/Dockerfile.dev
+++ b/sources/packages/forms/Dockerfile.dev
@@ -1,28 +1,24 @@
-# Used by docker-compose.yml to deploy the formio application
-# (When modified, you must include `--build` )
-# -----------------------------------------------------------
-
-# Use Node image, maintained by Docker:
-# hub.docker.com/r/_/node/
-FROM node:20-alpine3.19
+# Use Node image, maintained by Docker: hub.docker.com/r/_/node.
+FROM node:20-alpine3.20
 
 ARG FORMIO_SOURCE_REPO_URL
 ARG FORMIO_SOURCE_REPO_TAG
 
-# "bcrypt" requires python/make/g++, all must be installed in alpine
-# (note: using pinned versions to ensure immutable build environment)
+# "bcrypt" requires python/make/g++, all must be installed in alpine.
+# Note: using pinned versions to ensure immutable build environment.
 RUN apk update && \
   apk upgrade && \
-  apk add make && \
-  apk add g++ &&\
-  apk add git
+  apk add make=4.4.1-r2 && \
+  apk add python3=3.12.6-r0 && \
+  apk add g++=13.2.1_git20240309-r0 &&\
+  apk add git=2.45.2-r0
 
-# Clone code
+# Clone code into formio folder, by default.
 RUN git clone ${FORMIO_SOURCE_REPO_URL} -b ${FORMIO_SOURCE_REPO_TAG} --single-branch
 
 WORKDIR formio
 
-# Use install as-is from package.json
+# Use install as-is from package.json.
 RUN npm i
 
 # Set this to inspect more from the application. Examples:

--- a/sources/packages/forms/Dockerfile.dev
+++ b/sources/packages/forms/Dockerfile.dev
@@ -10,13 +10,16 @@ RUN apk update && \
   apk upgrade && \
   apk add make=4.4.1-r2 && \
   apk add python3=3.12.6-r0 && \
-  apk add g++=13.2.1_git20240309-r0 &&\
-  apk add git=2.45.2-r0
+  apk add g++=13.2.1_git20240309-r0 && \
+  apk add git=2.45.2-r0 && \
+  apk cache clean
 
 # Clone code into formio folder, by default.
 RUN git clone ${FORMIO_SOURCE_REPO_URL} -b ${FORMIO_SOURCE_REPO_TAG} --single-branch
 
-WORKDIR formio
+RUN apk del git
+
+WORKDIR /formio
 
 # Use install as-is from package.json.
 RUN npm i

--- a/sources/packages/forms/package-lock.json
+++ b/sources/packages/forms/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "UNLICENSED",
       "dependencies": {
-        "axios": "^1.6.2",
+        "axios": "^1.7.7",
         "dotenv": "^10.0.0"
       },
       "devDependencies": {
@@ -112,12 +112,33 @@
       "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
       "dev": true
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
     "node_modules/axios": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
-      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+      "version": "1.7.7",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.7.tgz",
+      "integrity": "sha512-S4kL7XrjgBmvdGut0sN3yJxqYzrDOnivkBiN0OFs6hLiUam3UPvswUo0kqGyhqUZGEOytHyumEdXsAkgCOUf3Q==",
+      "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.14.0"
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/create-require": {
@@ -125,6 +146,15 @@
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "dev": true
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
     },
     "node_modules/diff": {
       "version": "4.0.2",
@@ -162,11 +192,52 @@
         }
       }
     },
+    "node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/make-error": {
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
       "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
       "dev": true
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
     },
     "node_modules/ts-node": {
       "version": "10.9.1",
@@ -321,12 +392,27 @@
       "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
       "dev": true
     },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+    },
     "axios": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
-      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+      "version": "1.7.7",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.7.tgz",
+      "integrity": "sha512-S4kL7XrjgBmvdGut0sN3yJxqYzrDOnivkBiN0OFs6hLiUam3UPvswUo0kqGyhqUZGEOytHyumEdXsAkgCOUf3Q==",
       "requires": {
-        "follow-redirects": "^1.14.0"
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
+    "combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "requires": {
+        "delayed-stream": "~1.0.0"
       }
     },
     "create-require": {
@@ -334,6 +420,11 @@
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "dev": true
+    },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="
     },
     "diff": {
       "version": "4.0.2",
@@ -351,11 +442,39 @@
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
       "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA=="
     },
+    "form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "requires": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      }
+    },
     "make-error": {
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
       "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
       "dev": true
+    },
+    "mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="
+    },
+    "mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "requires": {
+        "mime-db": "1.52.0"
+      }
+    },
+    "proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "ts-node": {
       "version": "10.9.1",

--- a/sources/packages/forms/package.json
+++ b/sources/packages/forms/package.json
@@ -13,7 +13,7 @@
     "typescript": "^4.3.5"
   },
   "dependencies": {
-    "axios": "^1.6.2",
+    "axios": "^1.7.7",
     "dotenv": "^10.0.0"
   }
 }

--- a/sources/packages/web/package-lock.json
+++ b/sources/packages/web/package-lock.json
@@ -17,7 +17,7 @@
         "class-transformer": "^0.5.1",
         "core-js": "^3.37.0",
         "dayjs": "^1.11.10",
-        "formiojs": "^4.13.4",
+        "formiojs": "^4.21.4",
         "http-status-codes": "^2.3.0",
         "keycloak-js": "^24.0.3",
         "mitt": "^2.1.0",
@@ -1801,11 +1801,11 @@
       "dev": true
     },
     "node_modules/@babel/runtime": {
-      "version": "7.19.0",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.19.0.tgz",
-      "integrity": "sha512-eR8Lo9hnDS7tqkO7NsV+mKvCmv5boaXFSZ70DnfhcgiEne8hv9oCEd36Klw74EtizEqLsy4YnW8UWwpBVolHZA==",
+      "version": "7.25.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.6.tgz",
+      "integrity": "sha512-VBj9MYyDb9tuLq7yzqjgzt6Q+IBQLrGZfdjOekyEirZPHxXWoTSGUTMrpsfi58Up73d13NfYLv8HT9vmznjzhQ==",
       "dependencies": {
-        "regenerator-runtime": "^0.13.4"
+        "regenerator-runtime": "^0.14.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1969,27 +1969,32 @@
       }
     },
     "node_modules/@formio/bootstrap3": {
-      "version": "2.12.2",
-      "resolved": "https://registry.npmjs.org/@formio/bootstrap3/-/bootstrap3-2.12.2.tgz",
-      "integrity": "sha512-Y1WD/U22HHKRl1MzUt65bXeFHYO9Wlt+wefRqXFrOhIgbmkfTjCx6e0n2b8t/IYz9FUMg+/GTKdqaBrTZgjrTA==",
+      "version": "2.12.4-rc.1",
+      "resolved": "https://registry.npmjs.org/@formio/bootstrap3/-/bootstrap3-2.12.4-rc.1.tgz",
+      "integrity": "sha512-4B5rs+w9tAk5i+wbdw2/NrTxPqnDX7/W19tiTd9lfXnIGQmaj0ecMEVqDmOJg8pIlyU02g3c4ih6JnA/JVmUbA==",
       "dependencies": {
         "resize-observer-polyfill": "^1.5.1"
       }
     },
     "node_modules/@formio/choices.js": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/@formio/choices.js/-/choices.js-9.0.1.tgz",
-      "integrity": "sha512-+JQRWH0yhaeemVJGE1L4oPe9KPFhipzDlms3Pd31gePXpy8q7Mf3Is54/f0fc88+mWeMjK4GyIhcKIKmuGx5Xw==",
+      "version": "10.2.1",
+      "resolved": "https://registry.npmjs.org/@formio/choices.js/-/choices.js-10.2.1.tgz",
+      "integrity": "sha512-NCE5u7jG3XGokJP16MyAbVSUptKu/mpJYAxd4PPIoLiO/l9Do5uoOQ0MgNb9qG9qABJiOX+qNRE8q8RybY/SwQ==",
       "dependencies": {
-        "deepmerge": "^4.2.0",
-        "fuse.js": "^3.4.5",
-        "redux": "^4.0.4"
+        "deepmerge": "^4.2.2",
+        "fuse.js": "^6.6.2",
+        "redux": "^4.2.0"
       }
     },
     "node_modules/@formio/semantic": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@formio/semantic/-/semantic-2.6.0.tgz",
-      "integrity": "sha512-RwMEVXkyz+B6RivflrrKIqvvnGR/eZDLQs74u67StcrzO6n3/5D2J8XqTQRSUzQzr5QV6Wq0eZ51z/+mGm6THw=="
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@formio/semantic/-/semantic-2.6.1.tgz",
+      "integrity": "sha512-obp1BT5UnzD+uYBbqmnsTfO2hGxI2A2iR/cj3P5JUFLYSBpnr3TS2ShQ7Ee5GCRRtJPu0JnljuJj+YSKLCMuhg=="
+    },
+    "node_modules/@formio/text-mask-addons": {
+      "version": "3.8.0-formio.2",
+      "resolved": "https://registry.npmjs.org/@formio/text-mask-addons/-/text-mask-addons-3.8.0-formio.2.tgz",
+      "integrity": "sha512-H4Sm+1Sx59jbrlKxtKbzethhp5OIcP8Oi4JBpsvH/SB8P/KCRmtjKbN5ACqURnXmYtBHLJC6Yr9KZibOVRGxpA=="
     },
     "node_modules/@formio/vanilla-text-mask": {
       "version": "5.1.1",
@@ -4666,6 +4671,11 @@
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
+    "node_modules/abortcontroller-polyfill": {
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/abortcontroller-polyfill/-/abortcontroller-polyfill-1.7.5.tgz",
+      "integrity": "sha512-JMJ5soJWP18htbbxJjG7bG6yuI6pRhgJ0scHHTfkUjf6wjP912xZWvM+A4sJK3gqd9E8fcPbDnOefbA9Th/FIQ=="
+    },
     "node_modules/accepts": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
@@ -4829,6 +4839,11 @@
         "ajv": "^6.9.1"
       }
     },
+    "node_modules/animation-frame-polyfill": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/animation-frame-polyfill/-/animation-frame-polyfill-1.0.2.tgz",
+      "integrity": "sha512-PvO5poSMoHhaoNNgHPo+oqs/0L9UqjsUbqv0iOXVqLh6HX85fsOVQTUrzSBvjdZz7hydARlgLELyzJJKIrPJAQ=="
+    },
     "node_modules/ansi-escapes": {
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
@@ -4926,6 +4941,11 @@
       "integrity": "sha512-hNfzcOV8W4NdualtqBFPyVO+54DSJuZGY9qT4pRroB6S9e3iiido2ISIC5h9R2sPJ8H3FHCIiEnsv1lPXO3KtQ==",
       "dev": true
     },
+    "node_modules/array-from": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/array-from/-/array-from-2.1.1.tgz",
+      "integrity": "sha512-GQTc6Uupx1FCavi5mPzBvVT7nEOeWMmUA9P95wpfpW1XwMSKs+KaymD5C2Up7KAUKg/mYwbsUYzdZWcoajlNZg=="
+    },
     "node_modules/array-union": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
@@ -4976,9 +4996,9 @@
       }
     },
     "node_modules/autocompleter": {
-      "version": "6.1.3",
-      "resolved": "https://registry.npmjs.org/autocompleter/-/autocompleter-6.1.3.tgz",
-      "integrity": "sha512-Pjb5R5r+S0/zDFudLP9a8CW7/xMc7O/uVCtaTf3f+RdNLAQQ5oUG018c3IRdDJMRVvT+OeZ1NYQoUH5GHlORKQ=="
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/autocompleter/-/autocompleter-7.1.0.tgz",
+      "integrity": "sha512-uCToOnq7eAD/GJAteDbYuQ7ksDtrYWOy5CIAq43wh0dT+5frMpPlyD9tp+y5fz8KIcsP+zR2MjzoTAdW5aJESw=="
     },
     "node_modules/autoprefixer": {
       "version": "10.4.11",
@@ -5971,9 +5991,9 @@
       "dev": true
     },
     "node_modules/compare-versions": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-4.1.4.tgz",
-      "integrity": "sha512-FemMreK9xNyL8gQevsdRMrvO4lFCkQP7qbuktn1q8ndcNk1+0mz7lgE7b/sNvbhVgY4w6tMN1FDp6aADjqw2rw=="
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-5.0.3.tgz",
+      "integrity": "sha512-4UZlZP8Z99MGEY+Ovg/uJxJuvoXuN4M6B3hKaiackiHrgzQFEe3diJi1mf1PNHbFujM7FvLrK2bpgIaImbtZ1A=="
     },
     "node_modules/compressible": {
       "version": "2.0.18",
@@ -6228,6 +6248,14 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/create-point-cb": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/create-point-cb/-/create-point-cb-1.2.0.tgz",
+      "integrity": "sha512-r4l6IO/YGI7hIZRMLggOzwM6XO80+Fdcv4hx1fXCEdU+hKd7zZki6i+cbYfK9OliMwMYx1wPfQLU/snvS+Dygw==",
+      "dependencies": {
+        "type-func": "^1.0.1"
       }
     },
     "node_modules/cross-spawn": {
@@ -6904,6 +6932,19 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/dom-autoscroller": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/dom-autoscroller/-/dom-autoscroller-2.3.4.tgz",
+      "integrity": "sha512-HcAdt/2Dq9x4CG6LWXc2x9Iq0MJPAu8fuzHncclq7byufqYEYVtx9sZ/dyzR+gdj4qwEC9p27Lw1G2HRRYX6jQ==",
+      "dependencies": {
+        "animation-frame-polyfill": "^1.0.0",
+        "create-point-cb": "^1.0.0",
+        "dom-mousemove-dispatcher": "^1.0.1",
+        "dom-plane": "^1.0.1",
+        "dom-set": "^1.0.1",
+        "type-func": "^1.0.1"
+      }
+    },
     "node_modules/dom-converter": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/dom-converter/-/dom-converter-0.2.0.tgz",
@@ -6911,6 +6952,19 @@
       "dev": true,
       "dependencies": {
         "utila": "~0.4"
+      }
+    },
+    "node_modules/dom-mousemove-dispatcher": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dom-mousemove-dispatcher/-/dom-mousemove-dispatcher-1.0.1.tgz",
+      "integrity": "sha512-NMdqqMbgW8kqOdmod2hkS+9hD/v7h4XoSvwU9qqe+wAA/O+ba0jhpbfW0Kb/fCyR0RX9jf4dwfQrl04LQX4FzQ=="
+    },
+    "node_modules/dom-plane": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/dom-plane/-/dom-plane-1.0.2.tgz",
+      "integrity": "sha512-/tR67G6ZGSciXoZLsD706yLxEXvX3mG/OWE8YNYj3A1yU/RAimtPXzklVTu5Y5xoeMoloA/Y+MaNjQm9apgAww==",
+      "dependencies": {
+        "create-point-cb": "^1.0.0"
       }
     },
     "node_modules/dom-serializer": {
@@ -6925,6 +6979,16 @@
       },
       "funding": {
         "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/dom-set": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/dom-set/-/dom-set-1.1.1.tgz",
+      "integrity": "sha512-sUi2aSvRsK3Ixx++gwX9cnaWk9ZxGVFry8+HnTRVmDimybU5PaiI4wX0o00mVtjFKlQNZLmtGoPTLorYbN0+Rw==",
+      "dependencies": {
+        "array-from": "^2.1.1",
+        "is-array": "^1.0.1",
+        "iselement": "^1.1.4"
       }
     },
     "node_modules/domelementtype": {
@@ -6974,9 +7038,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.4.0.tgz",
-      "integrity": "sha512-Be9tbQMZds4a3C6xTmz68NlMfeONA//4dOavl/1rNw50E+/QO0KVpbcU0PcaW0nsQxurXls9ZocqFxk8R2mWEA=="
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.1.6.tgz",
+      "integrity": "sha512-cTOAhc36AalkjtBpfG6O8JimdTMWNXjiePT2xQH/ppBGi/4uIpmj8eKyIkMJErXWARyINV/sB38yf8JCLF5pbQ=="
     },
     "node_modules/domutils": {
       "version": "2.8.0",
@@ -8630,54 +8694,48 @@
       }
     },
     "node_modules/formiojs": {
-      "version": "4.14.8",
-      "resolved": "https://registry.npmjs.org/formiojs/-/formiojs-4.14.8.tgz",
-      "integrity": "sha512-BZucLSxCGWhBe1FQATR6GgxfHtwxEZxp2ur29DjAjo6ErlUTnl2Zbmb1IjW8NNfw0jn81SfSKtxh/SRSY5Ut7A==",
+      "version": "4.21.4",
+      "resolved": "https://registry.npmjs.org/formiojs/-/formiojs-4.21.4.tgz",
+      "integrity": "sha512-USw5aszDXz2fMeZtJypy0E+beLDL42mpQ9ewcOzk3jxvnIGID4Um7TaxZ15thFBD8JkzrpvJi9S+w7WWhRQ1gw==",
       "dependencies": {
-        "@formio/bootstrap3": "^2.12.2",
-        "@formio/choices.js": "^9.0.1",
-        "@formio/semantic": "^2.6.0",
-        "@formio/vanilla-text-mask": "^5.1.1",
-        "autocompleter": "^6.1.2",
+        "@formio/bootstrap3": "2.12.4-rc.1",
+        "@formio/choices.js": "10.2.1",
+        "@formio/semantic": "2.6.1",
+        "@formio/text-mask-addons": "^3.8.0-formio.2",
+        "@formio/vanilla-text-mask": "^5.1.1-formio.1",
+        "abortcontroller-polyfill": "^1.7.5",
+        "autocompleter": "^7.0.1",
         "browser-cookies": "^1.2.0",
         "browser-md5-file": "^1.1.1",
-        "compare-versions": "^4.1.3",
-        "core-js": "^3.21.1",
+        "compare-versions": "^5.0.1",
+        "core-js": "^3.26.1",
         "custom-event-polyfill": "^1.0.7",
         "dialog-polyfill": "^0.5.6",
-        "dompurify": "^2.3.4",
+        "dom-autoscroller": "^2.3.4",
+        "dompurify": "^3.0.5",
         "downloadjs": "^1.4.7",
         "dragula": "^3.7.3",
         "eventemitter3": "^4.0.7",
         "fast-deep-equal": "^3.1.3",
-        "fast-json-patch": "^3.1.0",
+        "fast-json-patch": "^3.1.1",
         "fetch-ponyfill": "^7.1.0",
-        "i18next": "^21.6.0",
-        "idb": "^6.1.5",
+        "i18next": "22.4.12",
+        "idb": "^7.1.1",
+        "inputmask": "^5.0.9",
         "ismobilejs": "^1.1.1",
-        "json-logic-js": "^2.0.0",
+        "json-logic-js": "^2.0.2",
         "jstimezonedetect": "^1.0.7",
         "jwt-decode": "^3.1.2",
         "lodash": "^4.17.21",
-        "moment": "^2.29.2",
-        "moment-timezone": "^0.5.34",
+        "moment": "^2.29.4",
+        "moment-timezone": "^0.5.40",
         "native-promise-only": "^0.8.1",
         "quill": "^2.0.0-dev.3",
-        "resize-observer-polyfill": "^1.5.1",
-        "signature_pad": "^4.0.4",
+        "signature_pad": "^4.1.4",
         "string-hash": "^1.1.3",
-        "text-mask-addons": "^3.8.0",
         "tippy.js": "^6.3.7",
-        "uuid": "^8.3.2",
+        "uuid": "^9.0.0",
         "vanilla-picker": "^2.12.1"
-      }
-    },
-    "node_modules/formiojs/node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "bin": {
-        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/forwarded": {
@@ -8781,11 +8839,11 @@
       }
     },
     "node_modules/fuse.js": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-3.6.1.tgz",
-      "integrity": "sha512-hT9yh/tiinkmirKrlv4KWOjztdoZo1mx9Qh4KvWqC7isoXwdUY3PNWUxceF4/qO9R6riA2C29jdTOeQOIROjgw==",
+      "version": "6.6.2",
+      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-6.6.2.tgz",
+      "integrity": "sha512-cJaJkxCCxC8qIIcPBF9yGxY0W/tVZS3uEISDxhYIdtk8OL93pe+6Zj7LjCqVV4dzbqcriOZ+kQ/NE4RXZHsIGA==",
       "engines": {
-        "node": ">=6"
+        "node": ">=10"
       }
     },
     "node_modules/gensync": {
@@ -9304,9 +9362,9 @@
       }
     },
     "node_modules/i18next": {
-      "version": "21.9.2",
-      "resolved": "https://registry.npmjs.org/i18next/-/i18next-21.9.2.tgz",
-      "integrity": "sha512-00fVrLQOwy45nm3OtC9l1WiLK3nJlIYSljgCt0qzTaAy65aciMdRy9GsuW+a2AtKtdg9/njUGfRH30LRupV7ZQ==",
+      "version": "22.4.12",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-22.4.12.tgz",
+      "integrity": "sha512-2lE+vRXxQ3lGLub1CVbwgO0IfkLHmUSDVOAVdPh22CsxttMXi+35n2qgxh2wZIkKl6t/NMzPfgFPRDiFQOmiCg==",
       "funding": [
         {
           "type": "individual",
@@ -9322,7 +9380,7 @@
         }
       ],
       "dependencies": {
-        "@babel/runtime": "^7.17.2"
+        "@babel/runtime": "^7.20.6"
       }
     },
     "node_modules/iconv-lite": {
@@ -9349,9 +9407,9 @@
       }
     },
     "node_modules/idb": {
-      "version": "6.1.5",
-      "resolved": "https://registry.npmjs.org/idb/-/idb-6.1.5.tgz",
-      "integrity": "sha512-IJtugpKkiVXQn5Y+LteyBCNk1N8xpGV3wWZk9EVtZWH8DYkjBn0bX1XnGP9RkyZF0sAcywa6unHqSWKe7q4LGw=="
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/idb/-/idb-7.1.1.tgz",
+      "integrity": "sha512-gchesWBzyvGHRO9W8tzUWFDycow5gwjvFKfyV9FF32Y7F50yZMp7mP+T2mJIWFx49zicqyC4uefHM17o6xKIVQ=="
     },
     "node_modules/ieee754": {
       "version": "1.2.1",
@@ -9459,6 +9517,11 @@
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "dev": true
     },
+    "node_modules/inputmask": {
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/inputmask/-/inputmask-5.0.9.tgz",
+      "integrity": "sha512-s0lUfqcEbel+EQXtehXqwCJGShutgieOaIImFKC/r4reYNvX3foyrChl6LOEvaEgxEbesePIrw1Zi2jhZaDZbQ=="
+    },
     "node_modules/internal-slot": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.3.tgz",
@@ -9504,6 +9567,11 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/is-array": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-array/-/is-array-1.0.1.tgz",
+      "integrity": "sha512-gxiZ+y/u67AzpeFmAmo4CbtME/bs7J2C++su5zQzvQyaxUqVzkh69DI+jN+KZuSO6JaH6TIIU6M6LhqxMjxEpw=="
     },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
@@ -9928,6 +9996,11 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
       "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
+    },
+    "node_modules/iselement": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/iselement/-/iselement-1.1.4.tgz",
+      "integrity": "sha512-4Q519eWmbHO1pbimiz7H1iJRUHVmAmfh0viSsUD+oAwVO4ntZt7gpf8i8AShVBTyOvRTZNYNBpUxOIvwZR+ffw=="
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -13070,19 +13143,19 @@
       "dev": true
     },
     "node_modules/moment": {
-      "version": "2.29.4",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
-      "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==",
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
+      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
       "engines": {
         "node": "*"
       }
     },
     "node_modules/moment-timezone": {
-      "version": "0.5.37",
-      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.37.tgz",
-      "integrity": "sha512-uEDzDNFhfaywRl+vwXxffjjq1q0Vzr+fcQpQ1bU0kbzorfS7zVtZnCnGc8mhWmF39d4g4YriF6kwA75mJKE/Zg==",
+      "version": "0.5.45",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.45.tgz",
+      "integrity": "sha512-HIWmqA86KcmCAhnMAN0wuDOARV/525R2+lOLotuGFzn4HO+FH+/645z2wx0Dt3iDv6/p61SIvKnDstISainhLQ==",
       "dependencies": {
-        "moment": ">= 2.9.0"
+        "moment": "^2.29.4"
       },
       "engines": {
         "node": "*"
@@ -14897,9 +14970,9 @@
       }
     },
     "node_modules/redux": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.0.tgz",
-      "integrity": "sha512-oSBmcKKIuIR4ME29/AeNUnl5L+hvBq7OaJWzaptTQJAntaPvxIJqfnjbaEiCzzaIz+XmVILfqAM3Ob0aXLPfjA==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.1.tgz",
+      "integrity": "sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==",
       "dependencies": {
         "@babel/runtime": "^7.9.2"
       }
@@ -14929,9 +15002,9 @@
       }
     },
     "node_modules/regenerator-runtime": {
-      "version": "0.13.9",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
-      "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA=="
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
+      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
     },
     "node_modules/regenerator-transform": {
       "version": "0.15.2",
@@ -15536,9 +15609,9 @@
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
     },
     "node_modules/signature_pad": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/signature_pad/-/signature_pad-4.0.8.tgz",
-      "integrity": "sha512-WJ2biIAa+v2EzgNEDfNrPpmbgsarZeLebks2ZxTZs7X228CAtBsRnlp2tbMshf0o4OoXGTZ80g9NBRwMtj0odA=="
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/signature_pad/-/signature_pad-4.2.0.tgz",
+      "integrity": "sha512-YLWysmaUBaC5wosAKkgbX7XI+LBv2w5L0QUcI6Jc4moHYzv9BUBJtAyNLpWzHjtjKTeWOH6bfP4a4pzf0UinfQ=="
     },
     "node_modules/sirv": {
       "version": "1.0.19",
@@ -16169,11 +16242,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/text-mask-addons": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/text-mask-addons/-/text-mask-addons-3.8.0.tgz",
-      "integrity": "sha512-VSZSdc/tKn4zGxgpJ+uNBzoW1t472AoAFIlbw1K7hSNXz0DfSBYDJNRxLqgxOfWw1BY2z6DQpm7g0sYZn5qLpg=="
-    },
     "node_modules/text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -16612,6 +16680,11 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/type-func": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/type-func/-/type-func-1.0.3.tgz",
+      "integrity": "sha512-YA90CUk+i00tWESPNRMahywXhAz+12NLJLKlOWrgHIbqaFXjdZrWstRghaibOW/IxhPjui4SmXxO/03XSGRIjA=="
     },
     "node_modules/type-is": {
       "version": "1.6.18",
@@ -19346,11 +19419,11 @@
       "dev": true
     },
     "@babel/runtime": {
-      "version": "7.19.0",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.19.0.tgz",
-      "integrity": "sha512-eR8Lo9hnDS7tqkO7NsV+mKvCmv5boaXFSZ70DnfhcgiEne8hv9oCEd36Klw74EtizEqLsy4YnW8UWwpBVolHZA==",
+      "version": "7.25.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.6.tgz",
+      "integrity": "sha512-VBj9MYyDb9tuLq7yzqjgzt6Q+IBQLrGZfdjOekyEirZPHxXWoTSGUTMrpsfi58Up73d13NfYLv8HT9vmznjzhQ==",
       "requires": {
-        "regenerator-runtime": "^0.13.4"
+        "regenerator-runtime": "^0.14.0"
       }
     },
     "@babel/template": {
@@ -19471,27 +19544,32 @@
       "dev": true
     },
     "@formio/bootstrap3": {
-      "version": "2.12.2",
-      "resolved": "https://registry.npmjs.org/@formio/bootstrap3/-/bootstrap3-2.12.2.tgz",
-      "integrity": "sha512-Y1WD/U22HHKRl1MzUt65bXeFHYO9Wlt+wefRqXFrOhIgbmkfTjCx6e0n2b8t/IYz9FUMg+/GTKdqaBrTZgjrTA==",
+      "version": "2.12.4-rc.1",
+      "resolved": "https://registry.npmjs.org/@formio/bootstrap3/-/bootstrap3-2.12.4-rc.1.tgz",
+      "integrity": "sha512-4B5rs+w9tAk5i+wbdw2/NrTxPqnDX7/W19tiTd9lfXnIGQmaj0ecMEVqDmOJg8pIlyU02g3c4ih6JnA/JVmUbA==",
       "requires": {
         "resize-observer-polyfill": "^1.5.1"
       }
     },
     "@formio/choices.js": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/@formio/choices.js/-/choices.js-9.0.1.tgz",
-      "integrity": "sha512-+JQRWH0yhaeemVJGE1L4oPe9KPFhipzDlms3Pd31gePXpy8q7Mf3Is54/f0fc88+mWeMjK4GyIhcKIKmuGx5Xw==",
+      "version": "10.2.1",
+      "resolved": "https://registry.npmjs.org/@formio/choices.js/-/choices.js-10.2.1.tgz",
+      "integrity": "sha512-NCE5u7jG3XGokJP16MyAbVSUptKu/mpJYAxd4PPIoLiO/l9Do5uoOQ0MgNb9qG9qABJiOX+qNRE8q8RybY/SwQ==",
       "requires": {
-        "deepmerge": "^4.2.0",
-        "fuse.js": "^3.4.5",
-        "redux": "^4.0.4"
+        "deepmerge": "^4.2.2",
+        "fuse.js": "^6.6.2",
+        "redux": "^4.2.0"
       }
     },
     "@formio/semantic": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@formio/semantic/-/semantic-2.6.0.tgz",
-      "integrity": "sha512-RwMEVXkyz+B6RivflrrKIqvvnGR/eZDLQs74u67StcrzO6n3/5D2J8XqTQRSUzQzr5QV6Wq0eZ51z/+mGm6THw=="
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@formio/semantic/-/semantic-2.6.1.tgz",
+      "integrity": "sha512-obp1BT5UnzD+uYBbqmnsTfO2hGxI2A2iR/cj3P5JUFLYSBpnr3TS2ShQ7Ee5GCRRtJPu0JnljuJj+YSKLCMuhg=="
+    },
+    "@formio/text-mask-addons": {
+      "version": "3.8.0-formio.2",
+      "resolved": "https://registry.npmjs.org/@formio/text-mask-addons/-/text-mask-addons-3.8.0-formio.2.tgz",
+      "integrity": "sha512-H4Sm+1Sx59jbrlKxtKbzethhp5OIcP8Oi4JBpsvH/SB8P/KCRmtjKbN5ACqURnXmYtBHLJC6Yr9KZibOVRGxpA=="
     },
     "@formio/vanilla-text-mask": {
       "version": "5.1.1",
@@ -21597,6 +21675,11 @@
       "integrity": "sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ==",
       "dev": true
     },
+    "abortcontroller-polyfill": {
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/abortcontroller-polyfill/-/abortcontroller-polyfill-1.7.5.tgz",
+      "integrity": "sha512-JMJ5soJWP18htbbxJjG7bG6yuI6pRhgJ0scHHTfkUjf6wjP912xZWvM+A4sJK3gqd9E8fcPbDnOefbA9Th/FIQ=="
+    },
     "accepts": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
@@ -21715,6 +21798,11 @@
       "dev": true,
       "requires": {}
     },
+    "animation-frame-polyfill": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/animation-frame-polyfill/-/animation-frame-polyfill-1.0.2.tgz",
+      "integrity": "sha512-PvO5poSMoHhaoNNgHPo+oqs/0L9UqjsUbqv0iOXVqLh6HX85fsOVQTUrzSBvjdZz7hydARlgLELyzJJKIrPJAQ=="
+    },
     "ansi-escapes": {
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
@@ -21777,6 +21865,11 @@
       "integrity": "sha512-hNfzcOV8W4NdualtqBFPyVO+54DSJuZGY9qT4pRroB6S9e3iiido2ISIC5h9R2sPJ8H3FHCIiEnsv1lPXO3KtQ==",
       "dev": true
     },
+    "array-from": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/array-from/-/array-from-2.1.1.tgz",
+      "integrity": "sha512-GQTc6Uupx1FCavi5mPzBvVT7nEOeWMmUA9P95wpfpW1XwMSKs+KaymD5C2Up7KAUKg/mYwbsUYzdZWcoajlNZg=="
+    },
     "array-union": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
@@ -21815,9 +21908,9 @@
       "dev": true
     },
     "autocompleter": {
-      "version": "6.1.3",
-      "resolved": "https://registry.npmjs.org/autocompleter/-/autocompleter-6.1.3.tgz",
-      "integrity": "sha512-Pjb5R5r+S0/zDFudLP9a8CW7/xMc7O/uVCtaTf3f+RdNLAQQ5oUG018c3IRdDJMRVvT+OeZ1NYQoUH5GHlORKQ=="
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/autocompleter/-/autocompleter-7.1.0.tgz",
+      "integrity": "sha512-uCToOnq7eAD/GJAteDbYuQ7ksDtrYWOy5CIAq43wh0dT+5frMpPlyD9tp+y5fz8KIcsP+zR2MjzoTAdW5aJESw=="
     },
     "autoprefixer": {
       "version": "10.4.11",
@@ -22539,9 +22632,9 @@
       "dev": true
     },
     "compare-versions": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-4.1.4.tgz",
-      "integrity": "sha512-FemMreK9xNyL8gQevsdRMrvO4lFCkQP7qbuktn1q8ndcNk1+0mz7lgE7b/sNvbhVgY4w6tMN1FDp6aADjqw2rw=="
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-5.0.3.tgz",
+      "integrity": "sha512-4UZlZP8Z99MGEY+Ovg/uJxJuvoXuN4M6B3hKaiackiHrgzQFEe3diJi1mf1PNHbFujM7FvLrK2bpgIaImbtZ1A=="
     },
     "compressible": {
       "version": "2.0.18",
@@ -22735,6 +22828,14 @@
         "parse-json": "^5.0.0",
         "path-type": "^4.0.0",
         "yaml": "^1.7.2"
+      }
+    },
+    "create-point-cb": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/create-point-cb/-/create-point-cb-1.2.0.tgz",
+      "integrity": "sha512-r4l6IO/YGI7hIZRMLggOzwM6XO80+Fdcv4hx1fXCEdU+hKd7zZki6i+cbYfK9OliMwMYx1wPfQLU/snvS+Dygw==",
+      "requires": {
+        "type-func": "^1.0.1"
       }
     },
     "cross-spawn": {
@@ -23232,6 +23333,19 @@
         "esutils": "^2.0.2"
       }
     },
+    "dom-autoscroller": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/dom-autoscroller/-/dom-autoscroller-2.3.4.tgz",
+      "integrity": "sha512-HcAdt/2Dq9x4CG6LWXc2x9Iq0MJPAu8fuzHncclq7byufqYEYVtx9sZ/dyzR+gdj4qwEC9p27Lw1G2HRRYX6jQ==",
+      "requires": {
+        "animation-frame-polyfill": "^1.0.0",
+        "create-point-cb": "^1.0.0",
+        "dom-mousemove-dispatcher": "^1.0.1",
+        "dom-plane": "^1.0.1",
+        "dom-set": "^1.0.1",
+        "type-func": "^1.0.1"
+      }
+    },
     "dom-converter": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/dom-converter/-/dom-converter-0.2.0.tgz",
@@ -23239,6 +23353,19 @@
       "dev": true,
       "requires": {
         "utila": "~0.4"
+      }
+    },
+    "dom-mousemove-dispatcher": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dom-mousemove-dispatcher/-/dom-mousemove-dispatcher-1.0.1.tgz",
+      "integrity": "sha512-NMdqqMbgW8kqOdmod2hkS+9hD/v7h4XoSvwU9qqe+wAA/O+ba0jhpbfW0Kb/fCyR0RX9jf4dwfQrl04LQX4FzQ=="
+    },
+    "dom-plane": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/dom-plane/-/dom-plane-1.0.2.tgz",
+      "integrity": "sha512-/tR67G6ZGSciXoZLsD706yLxEXvX3mG/OWE8YNYj3A1yU/RAimtPXzklVTu5Y5xoeMoloA/Y+MaNjQm9apgAww==",
+      "requires": {
+        "create-point-cb": "^1.0.0"
       }
     },
     "dom-serializer": {
@@ -23250,6 +23377,16 @@
         "domelementtype": "^2.0.1",
         "domhandler": "^4.2.0",
         "entities": "^2.0.0"
+      }
+    },
+    "dom-set": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/dom-set/-/dom-set-1.1.1.tgz",
+      "integrity": "sha512-sUi2aSvRsK3Ixx++gwX9cnaWk9ZxGVFry8+HnTRVmDimybU5PaiI4wX0o00mVtjFKlQNZLmtGoPTLorYbN0+Rw==",
+      "requires": {
+        "array-from": "^2.1.1",
+        "is-array": "^1.0.1",
+        "iselement": "^1.1.4"
       }
     },
     "domelementtype": {
@@ -23283,9 +23420,9 @@
       }
     },
     "dompurify": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.4.0.tgz",
-      "integrity": "sha512-Be9tbQMZds4a3C6xTmz68NlMfeONA//4dOavl/1rNw50E+/QO0KVpbcU0PcaW0nsQxurXls9ZocqFxk8R2mWEA=="
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.1.6.tgz",
+      "integrity": "sha512-cTOAhc36AalkjtBpfG6O8JimdTMWNXjiePT2xQH/ppBGi/4uIpmj8eKyIkMJErXWARyINV/sB38yf8JCLF5pbQ=="
     },
     "domutils": {
       "version": "2.8.0",
@@ -24504,53 +24641,48 @@
       }
     },
     "formiojs": {
-      "version": "4.14.8",
-      "resolved": "https://registry.npmjs.org/formiojs/-/formiojs-4.14.8.tgz",
-      "integrity": "sha512-BZucLSxCGWhBe1FQATR6GgxfHtwxEZxp2ur29DjAjo6ErlUTnl2Zbmb1IjW8NNfw0jn81SfSKtxh/SRSY5Ut7A==",
+      "version": "4.21.4",
+      "resolved": "https://registry.npmjs.org/formiojs/-/formiojs-4.21.4.tgz",
+      "integrity": "sha512-USw5aszDXz2fMeZtJypy0E+beLDL42mpQ9ewcOzk3jxvnIGID4Um7TaxZ15thFBD8JkzrpvJi9S+w7WWhRQ1gw==",
       "requires": {
-        "@formio/bootstrap3": "^2.12.2",
-        "@formio/choices.js": "^9.0.1",
-        "@formio/semantic": "^2.6.0",
-        "@formio/vanilla-text-mask": "^5.1.1",
-        "autocompleter": "^6.1.2",
+        "@formio/bootstrap3": "2.12.4-rc.1",
+        "@formio/choices.js": "10.2.1",
+        "@formio/semantic": "2.6.1",
+        "@formio/text-mask-addons": "^3.8.0-formio.2",
+        "@formio/vanilla-text-mask": "^5.1.1-formio.1",
+        "abortcontroller-polyfill": "^1.7.5",
+        "autocompleter": "^7.0.1",
         "browser-cookies": "^1.2.0",
         "browser-md5-file": "^1.1.1",
-        "compare-versions": "^4.1.3",
-        "core-js": "^3.21.1",
+        "compare-versions": "^5.0.1",
+        "core-js": "^3.26.1",
         "custom-event-polyfill": "^1.0.7",
         "dialog-polyfill": "^0.5.6",
-        "dompurify": "^2.3.4",
+        "dom-autoscroller": "^2.3.4",
+        "dompurify": "^3.0.5",
         "downloadjs": "^1.4.7",
         "dragula": "^3.7.3",
         "eventemitter3": "^4.0.7",
         "fast-deep-equal": "^3.1.3",
-        "fast-json-patch": "^3.1.0",
+        "fast-json-patch": "^3.1.1",
         "fetch-ponyfill": "^7.1.0",
-        "i18next": "^21.6.0",
-        "idb": "^6.1.5",
+        "i18next": "22.4.12",
+        "idb": "^7.1.1",
+        "inputmask": "^5.0.9",
         "ismobilejs": "^1.1.1",
-        "json-logic-js": "^2.0.0",
+        "json-logic-js": "^2.0.2",
         "jstimezonedetect": "^1.0.7",
         "jwt-decode": "^3.1.2",
         "lodash": "^4.17.21",
-        "moment": "^2.29.2",
-        "moment-timezone": "^0.5.34",
+        "moment": "^2.29.4",
+        "moment-timezone": "^0.5.40",
         "native-promise-only": "^0.8.1",
         "quill": "^2.0.0-dev.3",
-        "resize-observer-polyfill": "^1.5.1",
-        "signature_pad": "^4.0.4",
+        "signature_pad": "^4.1.4",
         "string-hash": "^1.1.3",
-        "text-mask-addons": "^3.8.0",
         "tippy.js": "^6.3.7",
-        "uuid": "^8.3.2",
+        "uuid": "^9.0.0",
         "vanilla-picker": "^2.12.1"
-      },
-      "dependencies": {
-        "uuid": {
-          "version": "8.3.2",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
-        }
       }
     },
     "forwarded": {
@@ -24622,9 +24754,9 @@
       "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ=="
     },
     "fuse.js": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-3.6.1.tgz",
-      "integrity": "sha512-hT9yh/tiinkmirKrlv4KWOjztdoZo1mx9Qh4KvWqC7isoXwdUY3PNWUxceF4/qO9R6riA2C29jdTOeQOIROjgw=="
+      "version": "6.6.2",
+      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-6.6.2.tgz",
+      "integrity": "sha512-cJaJkxCCxC8qIIcPBF9yGxY0W/tVZS3uEISDxhYIdtk8OL93pe+6Zj7LjCqVV4dzbqcriOZ+kQ/NE4RXZHsIGA=="
     },
     "gensync": {
       "version": "1.0.0-beta.2",
@@ -25007,11 +25139,11 @@
       "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw=="
     },
     "i18next": {
-      "version": "21.9.2",
-      "resolved": "https://registry.npmjs.org/i18next/-/i18next-21.9.2.tgz",
-      "integrity": "sha512-00fVrLQOwy45nm3OtC9l1WiLK3nJlIYSljgCt0qzTaAy65aciMdRy9GsuW+a2AtKtdg9/njUGfRH30LRupV7ZQ==",
+      "version": "22.4.12",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-22.4.12.tgz",
+      "integrity": "sha512-2lE+vRXxQ3lGLub1CVbwgO0IfkLHmUSDVOAVdPh22CsxttMXi+35n2qgxh2wZIkKl6t/NMzPfgFPRDiFQOmiCg==",
       "requires": {
-        "@babel/runtime": "^7.17.2"
+        "@babel/runtime": "^7.20.6"
       }
     },
     "iconv-lite": {
@@ -25030,9 +25162,9 @@
       "requires": {}
     },
     "idb": {
-      "version": "6.1.5",
-      "resolved": "https://registry.npmjs.org/idb/-/idb-6.1.5.tgz",
-      "integrity": "sha512-IJtugpKkiVXQn5Y+LteyBCNk1N8xpGV3wWZk9EVtZWH8DYkjBn0bX1XnGP9RkyZF0sAcywa6unHqSWKe7q4LGw=="
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/idb/-/idb-7.1.1.tgz",
+      "integrity": "sha512-gchesWBzyvGHRO9W8tzUWFDycow5gwjvFKfyV9FF32Y7F50yZMp7mP+T2mJIWFx49zicqyC4uefHM17o6xKIVQ=="
     },
     "ieee754": {
       "version": "1.2.1",
@@ -25104,6 +25236,11 @@
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "dev": true
     },
+    "inputmask": {
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/inputmask/-/inputmask-5.0.9.tgz",
+      "integrity": "sha512-s0lUfqcEbel+EQXtehXqwCJGShutgieOaIImFKC/r4reYNvX3foyrChl6LOEvaEgxEbesePIrw1Zi2jhZaDZbQ=="
+    },
     "internal-slot": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.3.tgz",
@@ -25134,6 +25271,11 @@
         "call-bind": "^1.0.2",
         "has-tostringtag": "^1.0.0"
       }
+    },
+    "is-array": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-array/-/is-array-1.0.1.tgz",
+      "integrity": "sha512-gxiZ+y/u67AzpeFmAmo4CbtME/bs7J2C++su5zQzvQyaxUqVzkh69DI+jN+KZuSO6JaH6TIIU6M6LhqxMjxEpw=="
     },
     "is-arrayish": {
       "version": "0.2.1",
@@ -25419,6 +25561,11 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
       "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
+    },
+    "iselement": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/iselement/-/iselement-1.1.4.tgz",
+      "integrity": "sha512-4Q519eWmbHO1pbimiz7H1iJRUHVmAmfh0viSsUD+oAwVO4ntZt7gpf8i8AShVBTyOvRTZNYNBpUxOIvwZR+ffw=="
     },
     "isexe": {
       "version": "2.0.0",
@@ -27758,16 +27905,16 @@
       "dev": true
     },
     "moment": {
-      "version": "2.29.4",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
-      "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w=="
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
+      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how=="
     },
     "moment-timezone": {
-      "version": "0.5.37",
-      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.37.tgz",
-      "integrity": "sha512-uEDzDNFhfaywRl+vwXxffjjq1q0Vzr+fcQpQ1bU0kbzorfS7zVtZnCnGc8mhWmF39d4g4YriF6kwA75mJKE/Zg==",
+      "version": "0.5.45",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.45.tgz",
+      "integrity": "sha512-HIWmqA86KcmCAhnMAN0wuDOARV/525R2+lOLotuGFzn4HO+FH+/645z2wx0Dt3iDv6/p61SIvKnDstISainhLQ==",
       "requires": {
-        "moment": ">= 2.9.0"
+        "moment": "^2.29.4"
       }
     },
     "mrmime": {
@@ -29062,9 +29209,9 @@
       }
     },
     "redux": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.0.tgz",
-      "integrity": "sha512-oSBmcKKIuIR4ME29/AeNUnl5L+hvBq7OaJWzaptTQJAntaPvxIJqfnjbaEiCzzaIz+XmVILfqAM3Ob0aXLPfjA==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.1.tgz",
+      "integrity": "sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==",
       "requires": {
         "@babel/runtime": "^7.9.2"
       }
@@ -29091,9 +29238,9 @@
       }
     },
     "regenerator-runtime": {
-      "version": "0.13.9",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
-      "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA=="
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
+      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
     },
     "regenerator-transform": {
       "version": "0.15.2",
@@ -29542,9 +29689,9 @@
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
     },
     "signature_pad": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/signature_pad/-/signature_pad-4.0.8.tgz",
-      "integrity": "sha512-WJ2biIAa+v2EzgNEDfNrPpmbgsarZeLebks2ZxTZs7X228CAtBsRnlp2tbMshf0o4OoXGTZ80g9NBRwMtj0odA=="
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/signature_pad/-/signature_pad-4.2.0.tgz",
+      "integrity": "sha512-YLWysmaUBaC5wosAKkgbX7XI+LBv2w5L0QUcI6Jc4moHYzv9BUBJtAyNLpWzHjtjKTeWOH6bfP4a4pzf0UinfQ=="
     },
     "sirv": {
       "version": "1.0.19",
@@ -30019,11 +30166,6 @@
         "minimatch": "^3.0.4"
       }
     },
-    "text-mask-addons": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/text-mask-addons/-/text-mask-addons-3.8.0.tgz",
-      "integrity": "sha512-VSZSdc/tKn4zGxgpJ+uNBzoW1t472AoAFIlbw1K7hSNXz0DfSBYDJNRxLqgxOfWw1BY2z6DQpm7g0sYZn5qLpg=="
-    },
     "text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -30336,6 +30478,11 @@
       "version": "0.21.3",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
       "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w=="
+    },
+    "type-func": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/type-func/-/type-func-1.0.3.tgz",
+      "integrity": "sha512-YA90CUk+i00tWESPNRMahywXhAz+12NLJLKlOWrgHIbqaFXjdZrWstRghaibOW/IxhPjui4SmXxO/03XSGRIjA=="
     },
     "type-is": {
       "version": "1.6.18",

--- a/sources/packages/web/package.json
+++ b/sources/packages/web/package.json
@@ -19,7 +19,7 @@
     "class-transformer": "^0.5.1",
     "core-js": "^3.37.0",
     "dayjs": "^1.11.10",
-    "formiojs": "^4.13.4",
+    "formiojs": "^4.21.4",
     "http-status-codes": "^2.3.0",
     "keycloak-js": "^24.0.3",
     "mitt": "^2.1.0",


### PR DESCRIPTION
- Upgraded form.io server to [v4.2.4](https://github.com/formio/formio/releases/tag/v4.2.4).
  - Updated nodejs version as required by the new form.io version (there is a check and it requires at least Nodejs 20).
  - The current redirect in the PROD docker using `NPM_PACKAGES` caused issues to a form.io package `@formio/vm`. The redirect of the `NPM_PACKAGES` was removed.
- Upgraded Vue client lib to `4.21.4`.
- Smoke test
  - New student prole;
  - New institution;
  - New location;
  - New designation agreement;
  - New program and program approval;
  - New offering and offering approval;
  - New student application.

### Fixes
- Form.io build and deploy were always happening from the main branch. They are now happening from the GitHub action target branch as the others.
- `define FORMIO_SOURCE_REPO_TAG` was overriding the form.io tag parameter in the GitHub action.

### Improvements
- Removed the input parameter `inputs.gitRef` from forms build and deploy.
- Local and PROD docker files look similar now.
- Packages downloaded using `apk` had their pinned versions updated.
- Changed `make db` to execute detached (`-d`), following others.
- Axios was updated in the forms package to remove the npm audit issue.
