### PR TITLE
#2509 - Update formio server and js - Labels adjustment

### DIFF
--- a/sources/packages/forms/src/form-definitions/studentdependantsappeal.json
+++ b/sources/packages/forms/src/form-definitions/studentdependantsappeal.json
@@ -583,7 +583,7 @@
                 }
               ],
               "tableView": false,
-              "label": "<strong>Dependants</strong>",
+              "label": "Dependants",
               "key": "dependants",
               "protected": false,
               "persistent": true,

--- a/sources/packages/forms/src/form-definitions/supportingusersparent2022-2023.json
+++ b/sources/packages/forms/src/form-definitions/supportingusersparent2022-2023.json
@@ -3248,7 +3248,7 @@
                           "id": "ehv8bb"
                         },
                         {
-                          "label": "<strong>Will this dependant be attending high school or full-time post-secondary school at the start of the Student's study period?</strong>",
+                          "label": "Will this dependant be attending high school or full-time post-secondary school at the start of the Student's study period?",
                           "optionsLabelPosition": "right",
                           "inline": false,
                           "tableView": false,
@@ -3332,7 +3332,7 @@
                           "tags": []
                         },
                         {
-                          "label": "<strong>Did you claim this dependant on their 20xx Income Tax Return due to a disability?</strong>",
+                          "label": "Did you claim this dependant on their 20xx Income Tax Return due to a disability?",
                           "optionsLabelPosition": "right",
                           "inline": false,
                           "tableView": false,

--- a/sources/packages/forms/src/form-definitions/supportingusersparent2024-2025.json
+++ b/sources/packages/forms/src/form-definitions/supportingusersparent2024-2025.json
@@ -3248,7 +3248,7 @@
                           "id": "ehv8bb"
                         },
                         {
-                          "label": "<strong>Will this dependant be attending high school or full-time post-secondary school at the start of the Student's study period?</strong>",
+                          "label": "Will this dependant be attending high school or full-time post-secondary school at the start of the Student's study period?",
                           "optionsLabelPosition": "right",
                           "inline": false,
                           "tableView": false,
@@ -3332,7 +3332,7 @@
                           "tags": []
                         },
                         {
-                          "label": "<strong>Did you claim this dependant on their 20xx Income Tax Return due to a disability?</strong>",
+                          "label": "Did you claim this dependant on their 20xx Income Tax Return due to a disability?",
                           "optionsLabelPosition": "right",
                           "inline": false,
                           "tableView": false,

--- a/sources/packages/forms/src/form-definitions/supportinguserspartner2022-2023.json
+++ b/sources/packages/forms/src/form-definitions/supportinguserspartner2022-2023.json
@@ -2119,7 +2119,7 @@
                   "tags": []
                 },
                 {
-                  "label": "<strong>Will you be employed full-time or part-time during your Partner's study period</strong>",
+                  "label": "Will you be employed full-time or part-time during your Partner's study period",
                   "optionsLabelPosition": "right",
                   "inline": false,
                   "tableView": false,
@@ -2202,7 +2202,7 @@
                   "tags": []
                 },
                 {
-                  "label": "<strong>Will you be at home caring for eligible dependant children on a full-time basis during your Partner's entire study period? </strong>",
+                  "label": "Will you be at home caring for eligible dependant children on a full-time basis during your Partner's entire study period?",
                   "labelPosition": "top",
                   "labelWidth": "",
                   "labelMargin": "",
@@ -2295,7 +2295,7 @@
                   "defaultValue": ""
                 },
                 {
-                  "label": "<strong>Will you be living with your Partner during your Partner's study period?</strong>",
+                  "label": "Will you be living with your Partner during your Partner's study period?",
                   "optionsLabelPosition": "right",
                   "inline": false,
                   "tableView": false,
@@ -2378,7 +2378,7 @@
                   "tags": []
                 },
                 {
-                  "label": "<strong>Will you be a full-time post-secondary student for some or all of your Partner's study period?</strong>",
+                  "label": "Will you be a full-time post-secondary student for some or all of your Partner's study period?",
                   "optionsLabelPosition": "right",
                   "inline": false,
                   "tableView": false,
@@ -2483,7 +2483,7 @@
                   "tableView": false,
                   "components": [
                     {
-                      "label": "<strong>How many weeks will you be a full-time post-secondary student during your Partner's study period?</strong>",
+                      "label": "How many weeks will you be a full-time post-secondary student during your Partner's study period?",
                       "prefix": "Number of Weeks",
                       "mask": false,
                       "spellcheck": true,
@@ -2620,7 +2620,7 @@
                   "tags": []
                 },
                 {
-                  "label": "<strong>Will you be paying a Canada Student Loan and/or a provincial student loan regular scheduled payments during your Partner's study period?</strong>",
+                  "label": "Will you be paying a Canada Student Loan and/or a provincial student loan regular scheduled payments during your Partner's study period?",
                   "labelPosition": "top",
                   "labelWidth": "",
                   "labelMargin": "",
@@ -2745,7 +2745,7 @@
                     "height": ""
                   },
                   "type": "panel",
-                  "label": "<strong>Will you be paying a Canada Student Loan and/or a provincial student loan regular scheduled payments during the your Partner's study period?</strong>",
+                  "label": "Will you be paying a Canada Student Loan and/or a provincial student loan regular scheduled payments during the your Partner's study period?",
                   "breadcrumb": "default",
                   "buttonSettings": {
                     "previous": true,
@@ -2759,7 +2759,7 @@
                   "tableView": false,
                   "components": [
                     {
-                      "label": "<strong>Enter amount that you will pay during your Partner's study period.</strong>",
+                      "label": "Enter amount that you will pay during your Partner's study period.",
                       "prefix": "$",
                       "mask": false,
                       "spellcheck": true,
@@ -2878,7 +2878,7 @@
                   "id": "e1cacbl"
                 },
                 {
-                  "label": "<strong>Will you be paying for child support and/or spousal support during your Partner's study period?</strong>",
+                  "label": "Will you be paying for child support and/or spousal support during your Partner's study period?",
                   "optionsLabelPosition": "right",
                   "inline": false,
                   "tableView": false,
@@ -3007,7 +3007,7 @@
                   "tableView": false,
                   "components": [
                     {
-                      "label": "<strong>Enter amount that you will pay during your Partner's study period.</strong>",
+                      "label": "Enter amount that you will pay during your Partner's study period.",
                       "prefix": "$",
                       "mask": false,
                       "spellcheck": true,
@@ -3125,7 +3125,7 @@
                   "id": "e86cscg"
                 },
                 {
-                  "label": "<strong>Will you be taking care of eligible dependants during your Partner's Study Period? </strong>",
+                  "label": "Will you be taking care of eligible dependants during your Partner's Study Period?",
                   "optionsLabelPosition": "right",
                   "inline": false,
                   "tableView": false,

--- a/sources/packages/forms/src/form-definitions/supportinguserspartner2024-2025.json
+++ b/sources/packages/forms/src/form-definitions/supportinguserspartner2024-2025.json
@@ -2119,7 +2119,7 @@
                   "tags": []
                 },
                 {
-                  "label": "<strong>Will you be employed full-time or part-time during your Partner's study period</strong>",
+                  "label": "Will you be employed full-time or part-time during your Partner's study period",
                   "optionsLabelPosition": "right",
                   "inline": false,
                   "tableView": false,
@@ -2202,7 +2202,7 @@
                   "tags": []
                 },
                 {
-                  "label": "<strong>Will you be at home caring for eligible dependant children on a full-time basis during your Partner's entire study period? </strong>",
+                  "label": "Will you be at home caring for eligible dependant children on a full-time basis during your Partner's entire study period?",
                   "labelPosition": "top",
                   "labelWidth": "",
                   "labelMargin": "",
@@ -2295,7 +2295,7 @@
                   "defaultValue": ""
                 },
                 {
-                  "label": "<strong>Will you be living with your Partner during your Partner's study period?</strong>",
+                  "label": "Will you be living with your Partner during your Partner's study period?",
                   "optionsLabelPosition": "right",
                   "inline": false,
                   "tableView": false,
@@ -2378,7 +2378,7 @@
                   "tags": []
                 },
                 {
-                  "label": "<strong>Will you be a full-time post-secondary student for some or all of your Partner's study period?</strong>",
+                  "label": "Will you be a full-time post-secondary student for some or all of your Partner's study period?",
                   "optionsLabelPosition": "right",
                   "inline": false,
                   "tableView": false,
@@ -2483,7 +2483,7 @@
                   "tableView": false,
                   "components": [
                     {
-                      "label": "<strong>How many weeks will you be a full-time post-secondary student during your Partner's study period?</strong>",
+                      "label": "How many weeks will you be a full-time post-secondary student during your Partner's study period?",
                       "prefix": "Number of Weeks",
                       "mask": false,
                       "spellcheck": true,
@@ -2620,7 +2620,7 @@
                   "tags": []
                 },
                 {
-                  "label": "<strong>Will you be paying a Canada Student Loan and/or a provincial student loan regular scheduled payments during your Partner's study period?</strong>",
+                  "label": "Will you be paying a Canada Student Loan and/or a provincial student loan regular scheduled payments during your Partner's study period?",
                   "labelPosition": "top",
                   "labelWidth": "",
                   "labelMargin": "",
@@ -2745,7 +2745,7 @@
                     "height": ""
                   },
                   "type": "panel",
-                  "label": "<strong>Will you be paying a Canada Student Loan and/or a provincial student loan regular scheduled payments during the your Partner's study period?</strong>",
+                  "label": "Will you be paying a Canada Student Loan and/or a provincial student loan regular scheduled payments during the your Partner's study period?",
                   "breadcrumb": "default",
                   "buttonSettings": {
                     "previous": true,
@@ -2759,7 +2759,7 @@
                   "tableView": false,
                   "components": [
                     {
-                      "label": "<strong>Enter amount that you will pay during your Partner's study period.</strong>",
+                      "label": "Enter amount that you will pay during your Partner's study period.",
                       "prefix": "$",
                       "mask": false,
                       "spellcheck": true,
@@ -2878,7 +2878,7 @@
                   "id": "e1cacbl"
                 },
                 {
-                  "label": "<strong>Will you be paying for child support and/or spousal support during your Partner's study period?</strong>",
+                  "label": "Will you be paying for child support and/or spousal support during your Partner's study period?",
                   "optionsLabelPosition": "right",
                   "inline": false,
                   "tableView": false,
@@ -3007,7 +3007,7 @@
                   "tableView": false,
                   "components": [
                     {
-                      "label": "<strong>Enter amount that you will pay during your Partner's study period.</strong>",
+                      "label": "Enter amount that you will pay during your Partner's study period.",
                       "prefix": "$",
                       "mask": false,
                       "spellcheck": true,
@@ -3125,7 +3125,7 @@
                   "id": "e86cscg"
                 },
                 {
-                  "label": "<strong>Will you be taking care of eligible dependants during your Partner's Study Period? </strong>",
+                  "label": "Will you be taking care of eligible dependants during your Partner's Study Period?",
                   "optionsLabelPosition": "right",
                   "inline": false,
                   "tableView": false,

--- a/sources/packages/forms/src/form-definitions/uploadstudentdocuments.json
+++ b/sources/packages/forms/src/form-definitions/uploadstudentdocuments.json
@@ -339,7 +339,7 @@
             {
               "components": [
                 {
-                  "label": "<strong>Document purpose</strong>",
+                  "label": "Document purpose",
                   "widget": "choicesjs",
                   "placeholder": "-- Select --",
                   "tableView": true,
@@ -466,7 +466,7 @@
             {
               "components": [
                 {
-                  "label": "<strong>Application # </strong>",
+                  "label": "Application #",
                   "tableView": true,
                   "key": "applicationNumber",
                   "type": "textfield",


### PR DESCRIPTION
Removed the `<strong>` tags from labels content.
The change does not impact the form.io layout. As shown below the labels are still bold.
![image](https://github.com/user-attachments/assets/8b7ca61c-8dc0-4d9c-9793-05db66722f70)
