### PR TITLE
#3668 - Fix for logout BCSC user bug

### DIFF
--- a/sources/packages/web/src/services/AuthService.ts
+++ b/sources/packages/web/src/services/AuthService.ts
@@ -270,9 +270,15 @@ export class AuthService {
         if (options?.invalidBetaUser) {
           redirectUri += "/login/invalid-beta-user";
         }
+        // BCeIDBoth user.
         if (this.userToken?.identityProvider === IdentityProviders.BCeIDBoth) {
           await this.executeSiteminderLogoff(redirectUri);
+          break;
         }
+        // BCSC user.
+        await this.keycloak.logout({
+          redirectUri,
+        });
         break;
       }
       default:


### PR DESCRIPTION
The BCSC user needs to be redirected to keycloak's logout url while BCeID users do a `executeSiteminderLogoff()`.