### PR TITLE
#3668 - Send the invalid beta user immediately to login page

### DIFF
--- a/sources/packages/web/src/services/AuthService.ts
+++ b/sources/packages/web/src/services/AuthService.ts
@@ -267,14 +267,13 @@ export class AuthService {
         break;
       }
       case ClientIdType.Student: {
-        // Send the user to login page with invalid beta user message instead of dashboard.
-        this.priorityRedirect = {
-          name: StudentRoutesConst.INVALID_BETA_USER,
-        };
-        // Allow the application detect it is not an authenticated user and redirect user to login page.
-        this.keycloak.authenticated = false;
-
         if (options?.invalidBetaUser) {
+          // Send the user to login page with invalid beta user message instead of dashboard.
+          this.priorityRedirect = {
+            name: StudentRoutesConst.INVALID_BETA_USER,
+          };
+          // Allow the application detect it is not an authenticated user and redirect user to login page.
+          this.keycloak.authenticated = false;
           redirectUri += "/login/invalid-beta-user";
         }
         // BCeIDBoth user.

--- a/sources/packages/web/src/services/AuthService.ts
+++ b/sources/packages/web/src/services/AuthService.ts
@@ -267,6 +267,13 @@ export class AuthService {
         break;
       }
       case ClientIdType.Student: {
+        // Send the user to login page with invalid beta user message instead of dashboard.
+        this.priorityRedirect = {
+          name: StudentRoutesConst.INVALID_BETA_USER,
+        };
+        // Allow the application detect it is not an authenticated user and redirect user to login page.
+        this.keycloak.authenticated = false;
+
         if (options?.invalidBetaUser) {
           redirectUri += "/login/invalid-beta-user";
         }


### PR DESCRIPTION
The invalid beta user was being sent to the dashboard before being redirected to the login page with an invalid beta user message.