### PR TITLE
#3721 - PT Assessment - Books and Supplies Limit

### DIFF
--- a/sources/packages/backend/workflow/src/workflow-definitions/parttime-assessment-2022-2023.bpmn
+++ b/sources/packages/backend/workflow/src/workflow-definitions/parttime-assessment-2022-2023.bpmn
@@ -866,7 +866,7 @@ dmnX (comes from dmn)</bpmn:text>
     <bpmn:intermediateThrowEvent id="Event_0tjlor6" name="Define minimum transport weekly limit">
       <bpmn:extensionElements>
         <zeebe:ioMapping>
-          <zeebe:output source="=// If student is in onsite courses they get a minimum per study week, otherwise 0&#10;if(offeringDelivered = &#34;onsite&#34; or offeringDelivered = &#34;blended&#34;)&#10;then &#10; dmnPartTimeProgramYearMaximums.limitTransportationAllowance&#10;else&#10;  0" target="calculatedDataWeeklyMinTransport" />
+          <zeebe:output source="=// If student is in onsite or blended courses they get a minimum per study week, otherwise 0&#10;if(offeringDelivered = &#34;onsite&#34; or offeringDelivered = &#34;blended&#34;)&#10;then &#10; dmnPartTimeProgramYearMaximums.limitTransportationAllowance&#10;else&#10;  0" target="calculatedDataWeeklyMinTransport" />
         </zeebe:ioMapping>
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_0onzs1l</bpmn:incoming>

--- a/sources/packages/backend/workflow/src/workflow-definitions/parttime-assessment-2022-2023.bpmn
+++ b/sources/packages/backend/workflow/src/workflow-definitions/parttime-assessment-2022-2023.bpmn
@@ -866,7 +866,7 @@ dmnX (comes from dmn)</bpmn:text>
     <bpmn:intermediateThrowEvent id="Event_0tjlor6" name="Define minimum transport weekly limit">
       <bpmn:extensionElements>
         <zeebe:ioMapping>
-          <zeebe:output source="=// If student is in onsite courses they get a minimum per study week, otherwise 0&#10;if(offeringDelivered = &#34;onsite&#34;)&#10;then &#10; dmnPartTimeProgramYearMaximums.limitTransportationAllowance&#10;else&#10;  0" target="calculatedDataWeeklyMinTransport" />
+          <zeebe:output source="=// If student is in onsite courses they get a minimum per study week, otherwise 0&#10;if(offeringDelivered = &#34;onsite&#34; or offeringDelivered = &#34;blended&#34;)&#10;then &#10; dmnPartTimeProgramYearMaximums.limitTransportationAllowance&#10;else&#10;  0" target="calculatedDataWeeklyMinTransport" />
         </zeebe:ioMapping>
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_0onzs1l</bpmn:incoming>
@@ -925,7 +925,7 @@ dmnX (comes from dmn)</bpmn:text>
     <bpmn:scriptTask id="Activity_0twtlpj" name="Calculate total transportation Allowance">
       <bpmn:extensionElements>
         <zeebe:ioMapping>
-          <zeebe:input source="=// Accounts for students who requested additional transport for weeks than their offering weeks.&#10;if(offeringDelivered = &#34;onsite&#34;)&#10;then &#10;  offeringWeeks - calculatedDataAdditionalTransportWeeks&#10;else &#10;  0" target="inputDataRemainingTransportWeeks" />
+          <zeebe:input source="=// Accounts for students who requested additional transport for weeks than their offering weeks.&#10;if(offeringDelivered = &#34;onsite&#34; or offeringDelivered = &#34;blended&#34;)&#10;then &#10;  offeringWeeks - calculatedDataAdditionalTransportWeeks&#10;else &#10;  0" target="inputDataRemainingTransportWeeks" />
         </zeebe:ioMapping>
         <zeebe:script expression="=calculatedDataTotalAdditionalTransportationAllowance + (inputDataRemainingTransportWeeks * calculatedDataWeeklyMinTransport)" resultVariable="calculatedDataTotalTransportationAllowance" />
       </bpmn:extensionElements>
@@ -944,7 +944,7 @@ dmnX (comes from dmn)</bpmn:text>
     <bpmn:intermediateThrowEvent id="Event_10lg4rt" name="Calculate total transportation Allowance">
       <bpmn:extensionElements>
         <zeebe:ioMapping>
-          <zeebe:output source="=if(offeringDelivered = &#34;onsite&#34;)&#10;then &#10;  offeringWeeks * dmnPartTimeProgramYearMaximums.limitTransportationAllowance&#10;else&#10;  0" target="calculatedDataTotalTransportationAllowance" />
+          <zeebe:output source="=if(offeringDelivered = &#34;onsite&#34; or offeringDelivered = &#34;blended&#34;)&#10;then &#10;  offeringWeeks * dmnPartTimeProgramYearMaximums.limitTransportationAllowance&#10;else&#10;  0" target="calculatedDataTotalTransportationAllowance" />
         </zeebe:ioMapping>
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_0ra2rum</bpmn:incoming>

--- a/sources/packages/backend/workflow/src/workflow-definitions/parttime-assessment-2022-2023.bpmn
+++ b/sources/packages/backend/workflow/src/workflow-definitions/parttime-assessment-2022-2023.bpmn
@@ -268,7 +268,7 @@ dmnX (comes from dmn)</bpmn:text>
         <zeebe:ioMapping>
           <zeebe:output source="=offeringActualTuitionCosts" target="calculatedDataActualTuitionCosts" />
           <zeebe:output source="=offeringMandatoryFees" target="calculatedDataMandatoryFees" />
-          <zeebe:output source="=offeringProgramRelatedCosts" target="calculatedDataProgramRelatedCosts" />
+          <zeebe:output source="=min(offeringProgramRelatedCosts, dmnPartTimeProgramYearMaximums.limitWeeklyBooksAndSupplies * offeringWeeks)" target="calculatedDataProgramRelatedCosts" />
         </zeebe:ioMapping>
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_08xi7o2</bpmn:incoming>
@@ -1227,20 +1227,20 @@ dmnX (comes from dmn)</bpmn:text>
         <dc:Bounds x="160" y="80" width="7708" height="2892" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Lane_1gxyyjh_di" bpmnElement="Lane_1gxyyjh" isHorizontal="true">
-        <dc:Bounds x="190" y="80" width="7678" height="1147" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Lane_0ejpwa7_di" bpmnElement="Lane_0ejpwa7" isHorizontal="true">
         <dc:Bounds x="190" y="1227" width="7678" height="1745" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Lane_0pbg2l1_di" bpmnElement="Lane_0pbg2l1" isHorizontal="true">
+        <dc:Bounds x="220" y="1227" width="7648" height="1053" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Lane_0l32w49_di" bpmnElement="Lane_0l32w49" isHorizontal="true">
         <dc:Bounds x="220" y="2280" width="7648" height="692" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Lane_0pbg2l1_di" bpmnElement="Lane_0pbg2l1" isHorizontal="true">
-        <dc:Bounds x="220" y="1227" width="7648" height="1053" />
+      <bpmndi:BPMNShape id="Lane_1gxyyjh_di" bpmnElement="Lane_1gxyyjh" isHorizontal="true">
+        <dc:Bounds x="190" y="80" width="7678" height="1147" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_1sg75ph_di" bpmnElement="Event_1sg75ph">
@@ -2320,90 +2320,6 @@ dmnX (comes from dmn)</bpmn:text>
         <di:waypoint x="2110" y="940" />
         <di:waypoint x="2110" y="895" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Association_0jm8vsl_di" bpmnElement="Association_0jm8vsl">
-        <di:waypoint x="2561" y="1030" />
-        <di:waypoint x="2556" y="971" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Association_0cp4qvu_di" bpmnElement="Association_0cp4qvu">
-        <di:waypoint x="980" y="735" />
-        <di:waypoint x="980" y="852" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Association_1i7iirc_di" bpmnElement="Association_1i7iirc">
-        <di:waypoint x="730" y="852" />
-        <di:waypoint x="730" y="742" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Association_0eiso39_di" bpmnElement="Association_0eiso39">
-        <di:waypoint x="830" y="888" />
-        <di:waypoint x="830" y="980" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Association_0ptatj5_di" bpmnElement="Association_0ptatj5">
-        <di:waypoint x="7200" y="2625" />
-        <di:waypoint x="7239" y="2570" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Association_1nid8vk_di" bpmnElement="Association_1nid8vk">
-        <di:waypoint x="7107" y="2624" />
-        <di:waypoint x="7133" y="2570" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Association_0gzo1wo_di" bpmnElement="Association_0gzo1wo">
-        <di:waypoint x="7020" y="2622" />
-        <di:waypoint x="7020" y="2550" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Association_1vdevsr_di" bpmnElement="Association_1vdevsr">
-        <di:waypoint x="6544" y="2623" />
-        <di:waypoint x="6557" y="2570" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Association_18qf11c_di" bpmnElement="Association_18qf11c">
-        <di:waypoint x="7449" y="2624" />
-        <di:waypoint x="7481" y="2570" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Association_1gi7mg0_di" bpmnElement="Association_1gi7mg0">
-        <di:waypoint x="7451" y="2756" />
-        <di:waypoint x="7471" y="2730" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Association_1mr7raq_di" bpmnElement="Association_1mr7raq">
-        <di:waypoint x="6639" y="2624" />
-        <di:waypoint x="6672" y="2570" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Association_01prvbh_di" bpmnElement="Association_01prvbh">
-        <di:waypoint x="5748" y="1628" />
-        <di:waypoint x="5846" y="1607" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Association_0k52tdi_di" bpmnElement="Association_0k52tdi">
-        <di:waypoint x="5747" y="1705" />
-        <di:waypoint x="5846" y="1682" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Association_1kl6b20_di" bpmnElement="Association_1kl6b20">
-        <di:waypoint x="5747" y="1783" />
-        <di:waypoint x="5846" y="1745" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Association_1ledsf9_di" bpmnElement="Association_1ledsf9">
-        <di:waypoint x="5747" y="1873" />
-        <di:waypoint x="5846" y="1833" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Association_1y0l2mk_di" bpmnElement="Association_1y0l2mk">
-        <di:waypoint x="5747" y="1956" />
-        <di:waypoint x="5846" y="1936" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Association_0rsi8j4_di" bpmnElement="Association_0rsi8j4">
-        <di:waypoint x="3279" y="1372" />
-        <di:waypoint x="3279" y="1351" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Association_0hwwkv8_di" bpmnElement="Association_0hwwkv8">
-        <di:waypoint x="3930" y="1350" />
-        <di:waypoint x="3930" y="1314" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Association_1skh123_di" bpmnElement="Association_1skh123">
-        <di:waypoint x="4070" y="1350" />
-        <di:waypoint x="4070" y="1314" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Association_1p9iqwc_di" bpmnElement="Association_1p9iqwc">
-        <di:waypoint x="3180" y="1372" />
-        <di:waypoint x="3180" y="1324" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Association_0hybcza_di" bpmnElement="Association_0hybcza">
-        <di:waypoint x="3754" y="1608" />
-        <di:waypoint x="3799" y="1570" />
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="BPMNShape_0hjhvfj" bpmnElement="TextAnnotation_15vd5py">
         <dc:Bounds x="7429" y="2700" width="100" height="30" />
         <bpmndi:BPMNLabel />
@@ -2498,6 +2414,90 @@ dmnX (comes from dmn)</bpmn:text>
         <dc:Bounds x="4020" y="1242" width="180" height="72" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Association_1gi7mg0_di" bpmnElement="Association_1gi7mg0">
+        <di:waypoint x="7451" y="2756" />
+        <di:waypoint x="7471" y="2730" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Association_1mr7raq_di" bpmnElement="Association_1mr7raq">
+        <di:waypoint x="6639" y="2624" />
+        <di:waypoint x="6672" y="2570" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Association_18qf11c_di" bpmnElement="Association_18qf11c">
+        <di:waypoint x="7449" y="2624" />
+        <di:waypoint x="7481" y="2570" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Association_0ptatj5_di" bpmnElement="Association_0ptatj5">
+        <di:waypoint x="7200" y="2625" />
+        <di:waypoint x="7239" y="2570" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Association_1nid8vk_di" bpmnElement="Association_1nid8vk">
+        <di:waypoint x="7107" y="2624" />
+        <di:waypoint x="7133" y="2570" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Association_1vdevsr_di" bpmnElement="Association_1vdevsr">
+        <di:waypoint x="6544" y="2623" />
+        <di:waypoint x="6557" y="2570" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Association_01prvbh_di" bpmnElement="Association_01prvbh">
+        <di:waypoint x="5748" y="1628" />
+        <di:waypoint x="5846" y="1607" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Association_1ledsf9_di" bpmnElement="Association_1ledsf9">
+        <di:waypoint x="5747" y="1873" />
+        <di:waypoint x="5846" y="1833" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Association_1kl6b20_di" bpmnElement="Association_1kl6b20">
+        <di:waypoint x="5747" y="1783" />
+        <di:waypoint x="5846" y="1745" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Association_0k52tdi_di" bpmnElement="Association_0k52tdi">
+        <di:waypoint x="5747" y="1705" />
+        <di:waypoint x="5846" y="1682" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Association_0gzo1wo_di" bpmnElement="Association_0gzo1wo">
+        <di:waypoint x="7020" y="2622" />
+        <di:waypoint x="7020" y="2550" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Association_1i7iirc_di" bpmnElement="Association_1i7iirc">
+        <di:waypoint x="730" y="852" />
+        <di:waypoint x="730" y="742" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Association_0eiso39_di" bpmnElement="Association_0eiso39">
+        <di:waypoint x="830" y="888" />
+        <di:waypoint x="830" y="980" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Association_1y0l2mk_di" bpmnElement="Association_1y0l2mk">
+        <di:waypoint x="5747" y="1956" />
+        <di:waypoint x="5846" y="1936" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Association_0jm8vsl_di" bpmnElement="Association_0jm8vsl">
+        <di:waypoint x="2561" y="1030" />
+        <di:waypoint x="2556" y="971" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Association_0cp4qvu_di" bpmnElement="Association_0cp4qvu">
+        <di:waypoint x="980" y="735" />
+        <di:waypoint x="980" y="852" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Association_1p9iqwc_di" bpmnElement="Association_1p9iqwc">
+        <di:waypoint x="3180" y="1372" />
+        <di:waypoint x="3180" y="1324" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Association_0rsi8j4_di" bpmnElement="Association_0rsi8j4">
+        <di:waypoint x="3279" y="1372" />
+        <di:waypoint x="3279" y="1351" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Association_0hwwkv8_di" bpmnElement="Association_0hwwkv8">
+        <di:waypoint x="3930" y="1350" />
+        <di:waypoint x="3930" y="1314" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Association_0hybcza_di" bpmnElement="Association_0hybcza">
+        <di:waypoint x="3754" y="1608" />
+        <di:waypoint x="3799" y="1570" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Association_1skh123_di" bpmnElement="Association_1skh123">
+        <di:waypoint x="4070" y="1350" />
+        <di:waypoint x="4070" y="1314" />
+      </bpmndi:BPMNEdge>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>
 </bpmn:definitions>

--- a/sources/packages/backend/workflow/src/workflow-definitions/parttime-assessment-2023-2024.bpmn
+++ b/sources/packages/backend/workflow/src/workflow-definitions/parttime-assessment-2023-2024.bpmn
@@ -866,7 +866,7 @@ dmnX (comes from dmn)</bpmn:text>
     <bpmn:intermediateThrowEvent id="Event_0tjlor6" name="Define minimum transport weekly limit">
       <bpmn:extensionElements>
         <zeebe:ioMapping>
-          <zeebe:output source="=// If student is in onsite courses they get a minimum per study week, otherwise 0&#10;if(offeringDelivered = &#34;onsite&#34; or offeringDelivered = &#34;blended&#34;)&#10;then &#10; dmnPartTimeProgramYearMaximums.limitTransportationAllowance&#10;else&#10;  0" target="calculatedDataWeeklyMinTransport" />
+          <zeebe:output source="=// If student is in onsite or blended courses they get a minimum per study week, otherwise 0&#10;if(offeringDelivered = &#34;onsite&#34; or offeringDelivered = &#34;blended&#34;)&#10;then &#10; dmnPartTimeProgramYearMaximums.limitTransportationAllowance&#10;else&#10;  0" target="calculatedDataWeeklyMinTransport" />
         </zeebe:ioMapping>
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_0onzs1l</bpmn:incoming>

--- a/sources/packages/backend/workflow/src/workflow-definitions/parttime-assessment-2023-2024.bpmn
+++ b/sources/packages/backend/workflow/src/workflow-definitions/parttime-assessment-2023-2024.bpmn
@@ -866,7 +866,7 @@ dmnX (comes from dmn)</bpmn:text>
     <bpmn:intermediateThrowEvent id="Event_0tjlor6" name="Define minimum transport weekly limit">
       <bpmn:extensionElements>
         <zeebe:ioMapping>
-          <zeebe:output source="=// If student is in onsite courses they get a minimum per study week, otherwise 0&#10;if(offeringDelivered = &#34;onsite&#34;)&#10;then &#10; dmnPartTimeProgramYearMaximums.limitTransportationAllowance&#10;else&#10;  0" target="calculatedDataWeeklyMinTransport" />
+          <zeebe:output source="=// If student is in onsite courses they get a minimum per study week, otherwise 0&#10;if(offeringDelivered = &#34;onsite&#34; or offeringDelivered = &#34;blended&#34;)&#10;then &#10; dmnPartTimeProgramYearMaximums.limitTransportationAllowance&#10;else&#10;  0" target="calculatedDataWeeklyMinTransport" />
         </zeebe:ioMapping>
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_0onzs1l</bpmn:incoming>
@@ -925,7 +925,7 @@ dmnX (comes from dmn)</bpmn:text>
     <bpmn:scriptTask id="Activity_0twtlpj" name="Calculate total transportation Allowance">
       <bpmn:extensionElements>
         <zeebe:ioMapping>
-          <zeebe:input source="=// Accounts for students who requested additional transport for weeks than their offering weeks.&#10;if(offeringDelivered = &#34;onsite&#34;)&#10;then &#10;  offeringWeeks - calculatedDataAdditionalTransportWeeks&#10;else &#10;  0" target="inputDataRemainingTransportWeeks" />
+          <zeebe:input source="=// Accounts for students who requested additional transport for weeks than their offering weeks.&#10;if(offeringDelivered = &#34;onsite&#34; or offeringDelivered = &#34;blended&#34;)&#10;then &#10;  offeringWeeks - calculatedDataAdditionalTransportWeeks&#10;else &#10;  0" target="inputDataRemainingTransportWeeks" />
         </zeebe:ioMapping>
         <zeebe:script expression="=calculatedDataTotalAdditionalTransportationAllowance + (inputDataRemainingTransportWeeks * calculatedDataWeeklyMinTransport)" resultVariable="calculatedDataTotalTransportationAllowance" />
       </bpmn:extensionElements>
@@ -944,7 +944,7 @@ dmnX (comes from dmn)</bpmn:text>
     <bpmn:intermediateThrowEvent id="Event_10lg4rt" name="Calculate total transportation Allowance">
       <bpmn:extensionElements>
         <zeebe:ioMapping>
-          <zeebe:output source="=if(offeringDelivered = &#34;onsite&#34;)&#10;then &#10;  offeringWeeks * dmnPartTimeProgramYearMaximums.limitTransportationAllowance&#10;else&#10;  0" target="calculatedDataTotalTransportationAllowance" />
+          <zeebe:output source="=if(offeringDelivered = &#34;onsite&#34; or offeringDelivered = &#34;blended&#34;)&#10;then &#10;  offeringWeeks * dmnPartTimeProgramYearMaximums.limitTransportationAllowance&#10;else&#10;  0" target="calculatedDataTotalTransportationAllowance" />
         </zeebe:ioMapping>
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_0ra2rum</bpmn:incoming>

--- a/sources/packages/backend/workflow/src/workflow-definitions/parttime-assessment-2023-2024.bpmn
+++ b/sources/packages/backend/workflow/src/workflow-definitions/parttime-assessment-2023-2024.bpmn
@@ -268,7 +268,7 @@ dmnX (comes from dmn)</bpmn:text>
         <zeebe:ioMapping>
           <zeebe:output source="=offeringActualTuitionCosts" target="calculatedDataActualTuitionCosts" />
           <zeebe:output source="=offeringMandatoryFees" target="calculatedDataMandatoryFees" />
-          <zeebe:output source="=offeringProgramRelatedCosts" target="calculatedDataProgramRelatedCosts" />
+          <zeebe:output source="=min(offeringProgramRelatedCosts, dmnPartTimeProgramYearMaximums.limitWeeklyBooksAndSupplies * offeringWeeks)" target="calculatedDataProgramRelatedCosts" />
         </zeebe:ioMapping>
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_08xi7o2</bpmn:incoming>
@@ -1227,20 +1227,20 @@ dmnX (comes from dmn)</bpmn:text>
         <dc:Bounds x="160" y="80" width="7708" height="2892" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Lane_1gxyyjh_di" bpmnElement="Lane_1gxyyjh" isHorizontal="true">
-        <dc:Bounds x="190" y="80" width="7678" height="1147" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Lane_0ejpwa7_di" bpmnElement="Lane_0ejpwa7" isHorizontal="true">
         <dc:Bounds x="190" y="1227" width="7678" height="1745" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Lane_0pbg2l1_di" bpmnElement="Lane_0pbg2l1" isHorizontal="true">
+        <dc:Bounds x="220" y="1227" width="7648" height="1053" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Lane_0l32w49_di" bpmnElement="Lane_0l32w49" isHorizontal="true">
         <dc:Bounds x="220" y="2280" width="7648" height="692" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Lane_0pbg2l1_di" bpmnElement="Lane_0pbg2l1" isHorizontal="true">
-        <dc:Bounds x="220" y="1227" width="7648" height="1053" />
+      <bpmndi:BPMNShape id="Lane_1gxyyjh_di" bpmnElement="Lane_1gxyyjh" isHorizontal="true">
+        <dc:Bounds x="190" y="80" width="7678" height="1147" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_1sg75ph_di" bpmnElement="Event_1sg75ph">
@@ -2320,90 +2320,6 @@ dmnX (comes from dmn)</bpmn:text>
         <di:waypoint x="2110" y="940" />
         <di:waypoint x="2110" y="895" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Association_0jm8vsl_di" bpmnElement="Association_0jm8vsl">
-        <di:waypoint x="2561" y="1030" />
-        <di:waypoint x="2556" y="971" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Association_0cp4qvu_di" bpmnElement="Association_0cp4qvu">
-        <di:waypoint x="980" y="735" />
-        <di:waypoint x="980" y="852" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Association_1i7iirc_di" bpmnElement="Association_1i7iirc">
-        <di:waypoint x="730" y="852" />
-        <di:waypoint x="730" y="742" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Association_0eiso39_di" bpmnElement="Association_0eiso39">
-        <di:waypoint x="830" y="888" />
-        <di:waypoint x="830" y="980" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Association_0ptatj5_di" bpmnElement="Association_0ptatj5">
-        <di:waypoint x="7200" y="2625" />
-        <di:waypoint x="7239" y="2570" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Association_1nid8vk_di" bpmnElement="Association_1nid8vk">
-        <di:waypoint x="7107" y="2624" />
-        <di:waypoint x="7133" y="2570" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Association_0gzo1wo_di" bpmnElement="Association_0gzo1wo">
-        <di:waypoint x="7020" y="2622" />
-        <di:waypoint x="7020" y="2550" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Association_1vdevsr_di" bpmnElement="Association_1vdevsr">
-        <di:waypoint x="6544" y="2623" />
-        <di:waypoint x="6557" y="2570" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Association_18qf11c_di" bpmnElement="Association_18qf11c">
-        <di:waypoint x="7449" y="2624" />
-        <di:waypoint x="7481" y="2570" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Association_1gi7mg0_di" bpmnElement="Association_1gi7mg0">
-        <di:waypoint x="7451" y="2756" />
-        <di:waypoint x="7471" y="2730" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Association_1mr7raq_di" bpmnElement="Association_1mr7raq">
-        <di:waypoint x="6639" y="2624" />
-        <di:waypoint x="6672" y="2570" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Association_01prvbh_di" bpmnElement="Association_01prvbh">
-        <di:waypoint x="5748" y="1628" />
-        <di:waypoint x="5846" y="1607" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Association_0k52tdi_di" bpmnElement="Association_0k52tdi">
-        <di:waypoint x="5747" y="1705" />
-        <di:waypoint x="5846" y="1682" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Association_1kl6b20_di" bpmnElement="Association_1kl6b20">
-        <di:waypoint x="5747" y="1783" />
-        <di:waypoint x="5846" y="1745" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Association_1ledsf9_di" bpmnElement="Association_1ledsf9">
-        <di:waypoint x="5747" y="1873" />
-        <di:waypoint x="5846" y="1833" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Association_1y0l2mk_di" bpmnElement="Association_1y0l2mk">
-        <di:waypoint x="5747" y="1956" />
-        <di:waypoint x="5846" y="1936" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Association_0rsi8j4_di" bpmnElement="Association_0rsi8j4">
-        <di:waypoint x="3279" y="1372" />
-        <di:waypoint x="3279" y="1351" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Association_0hwwkv8_di" bpmnElement="Association_0hwwkv8">
-        <di:waypoint x="3930" y="1350" />
-        <di:waypoint x="3930" y="1314" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Association_1skh123_di" bpmnElement="Association_1skh123">
-        <di:waypoint x="4070" y="1350" />
-        <di:waypoint x="4070" y="1314" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Association_1p9iqwc_di" bpmnElement="Association_1p9iqwc">
-        <di:waypoint x="3180" y="1372" />
-        <di:waypoint x="3180" y="1324" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Association_0hybcza_di" bpmnElement="Association_0hybcza">
-        <di:waypoint x="3754" y="1608" />
-        <di:waypoint x="3799" y="1570" />
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="BPMNShape_0hjhvfj" bpmnElement="TextAnnotation_15vd5py">
         <dc:Bounds x="7429" y="2700" width="100" height="30" />
         <bpmndi:BPMNLabel />
@@ -2498,6 +2414,90 @@ dmnX (comes from dmn)</bpmn:text>
         <dc:Bounds x="4020" y="1242" width="180" height="72" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Association_1gi7mg0_di" bpmnElement="Association_1gi7mg0">
+        <di:waypoint x="7451" y="2756" />
+        <di:waypoint x="7471" y="2730" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Association_1mr7raq_di" bpmnElement="Association_1mr7raq">
+        <di:waypoint x="6639" y="2624" />
+        <di:waypoint x="6672" y="2570" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Association_18qf11c_di" bpmnElement="Association_18qf11c">
+        <di:waypoint x="7449" y="2624" />
+        <di:waypoint x="7481" y="2570" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Association_0ptatj5_di" bpmnElement="Association_0ptatj5">
+        <di:waypoint x="7200" y="2625" />
+        <di:waypoint x="7239" y="2570" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Association_1nid8vk_di" bpmnElement="Association_1nid8vk">
+        <di:waypoint x="7107" y="2624" />
+        <di:waypoint x="7133" y="2570" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Association_1vdevsr_di" bpmnElement="Association_1vdevsr">
+        <di:waypoint x="6544" y="2623" />
+        <di:waypoint x="6557" y="2570" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Association_01prvbh_di" bpmnElement="Association_01prvbh">
+        <di:waypoint x="5748" y="1628" />
+        <di:waypoint x="5846" y="1607" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Association_1ledsf9_di" bpmnElement="Association_1ledsf9">
+        <di:waypoint x="5747" y="1873" />
+        <di:waypoint x="5846" y="1833" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Association_1kl6b20_di" bpmnElement="Association_1kl6b20">
+        <di:waypoint x="5747" y="1783" />
+        <di:waypoint x="5846" y="1745" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Association_0k52tdi_di" bpmnElement="Association_0k52tdi">
+        <di:waypoint x="5747" y="1705" />
+        <di:waypoint x="5846" y="1682" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Association_0gzo1wo_di" bpmnElement="Association_0gzo1wo">
+        <di:waypoint x="7020" y="2622" />
+        <di:waypoint x="7020" y="2550" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Association_1i7iirc_di" bpmnElement="Association_1i7iirc">
+        <di:waypoint x="730" y="852" />
+        <di:waypoint x="730" y="742" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Association_0eiso39_di" bpmnElement="Association_0eiso39">
+        <di:waypoint x="830" y="888" />
+        <di:waypoint x="830" y="980" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Association_1y0l2mk_di" bpmnElement="Association_1y0l2mk">
+        <di:waypoint x="5747" y="1956" />
+        <di:waypoint x="5846" y="1936" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Association_0jm8vsl_di" bpmnElement="Association_0jm8vsl">
+        <di:waypoint x="2561" y="1030" />
+        <di:waypoint x="2556" y="971" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Association_0cp4qvu_di" bpmnElement="Association_0cp4qvu">
+        <di:waypoint x="980" y="735" />
+        <di:waypoint x="980" y="852" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Association_1p9iqwc_di" bpmnElement="Association_1p9iqwc">
+        <di:waypoint x="3180" y="1372" />
+        <di:waypoint x="3180" y="1324" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Association_0rsi8j4_di" bpmnElement="Association_0rsi8j4">
+        <di:waypoint x="3279" y="1372" />
+        <di:waypoint x="3279" y="1351" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Association_0hwwkv8_di" bpmnElement="Association_0hwwkv8">
+        <di:waypoint x="3930" y="1350" />
+        <di:waypoint x="3930" y="1314" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Association_0hybcza_di" bpmnElement="Association_0hybcza">
+        <di:waypoint x="3754" y="1608" />
+        <di:waypoint x="3799" y="1570" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Association_1skh123_di" bpmnElement="Association_1skh123">
+        <di:waypoint x="4070" y="1350" />
+        <di:waypoint x="4070" y="1314" />
+      </bpmndi:BPMNEdge>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>
 </bpmn:definitions>

--- a/sources/packages/backend/workflow/src/workflow-definitions/parttime-assessment-2024-2025.bpmn
+++ b/sources/packages/backend/workflow/src/workflow-definitions/parttime-assessment-2024-2025.bpmn
@@ -866,7 +866,7 @@ dmnX (comes from dmn)</bpmn:text>
     <bpmn:intermediateThrowEvent id="Event_0tjlor6" name="Define minimum transport weekly limit">
       <bpmn:extensionElements>
         <zeebe:ioMapping>
-          <zeebe:output source="=// If student is in onsite courses they get a minimum per study week, otherwise 0&#10;if(offeringDelivered = &#34;onsite&#34; or offeringDelivered = &#34;blended&#34;)&#10;then &#10; dmnPartTimeProgramYearMaximums.limitTransportationAllowance&#10;else&#10;  0" target="calculatedDataWeeklyMinTransport" />
+          <zeebe:output source="=// If student is in onsite or blended courses they get a minimum per study week, otherwise 0&#10;if(offeringDelivered = &#34;onsite&#34; or offeringDelivered = &#34;blended&#34;)&#10;then &#10; dmnPartTimeProgramYearMaximums.limitTransportationAllowance&#10;else&#10;  0" target="calculatedDataWeeklyMinTransport" />
         </zeebe:ioMapping>
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_0onzs1l</bpmn:incoming>

--- a/sources/packages/backend/workflow/src/workflow-definitions/parttime-assessment-2024-2025.bpmn
+++ b/sources/packages/backend/workflow/src/workflow-definitions/parttime-assessment-2024-2025.bpmn
@@ -866,7 +866,7 @@ dmnX (comes from dmn)</bpmn:text>
     <bpmn:intermediateThrowEvent id="Event_0tjlor6" name="Define minimum transport weekly limit">
       <bpmn:extensionElements>
         <zeebe:ioMapping>
-          <zeebe:output source="=// If student is in onsite courses they get a minimum per study week, otherwise 0&#10;if(offeringDelivered = &#34;onsite&#34;)&#10;then &#10; dmnPartTimeProgramYearMaximums.limitTransportationAllowance&#10;else&#10;  0" target="calculatedDataWeeklyMinTransport" />
+          <zeebe:output source="=// If student is in onsite courses they get a minimum per study week, otherwise 0&#10;if(offeringDelivered = &#34;onsite&#34; or offeringDelivered = &#34;blended&#34;)&#10;then &#10; dmnPartTimeProgramYearMaximums.limitTransportationAllowance&#10;else&#10;  0" target="calculatedDataWeeklyMinTransport" />
         </zeebe:ioMapping>
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_0onzs1l</bpmn:incoming>
@@ -925,7 +925,7 @@ dmnX (comes from dmn)</bpmn:text>
     <bpmn:scriptTask id="Activity_0twtlpj" name="Calculate total transportation Allowance">
       <bpmn:extensionElements>
         <zeebe:ioMapping>
-          <zeebe:input source="=// Accounts for students who requested additional transport for weeks than their offering weeks.&#10;if(offeringDelivered = &#34;onsite&#34;)&#10;then &#10;  offeringWeeks - calculatedDataAdditionalTransportWeeks&#10;else &#10;  0" target="inputDataRemainingTransportWeeks" />
+          <zeebe:input source="=// Accounts for students who requested additional transport for weeks than their offering weeks.&#10;if(offeringDelivered = &#34;onsite&#34; or offeringDelivered = &#34;blended&#34;)&#10;then &#10;  offeringWeeks - calculatedDataAdditionalTransportWeeks&#10;else &#10;  0" target="inputDataRemainingTransportWeeks" />
         </zeebe:ioMapping>
         <zeebe:script expression="=calculatedDataTotalAdditionalTransportationAllowance + (inputDataRemainingTransportWeeks * calculatedDataWeeklyMinTransport)" resultVariable="calculatedDataTotalTransportationAllowance" />
       </bpmn:extensionElements>
@@ -944,7 +944,7 @@ dmnX (comes from dmn)</bpmn:text>
     <bpmn:intermediateThrowEvent id="Event_10lg4rt" name="Calculate total transportation Allowance">
       <bpmn:extensionElements>
         <zeebe:ioMapping>
-          <zeebe:output source="=if(offeringDelivered = &#34;onsite&#34;)&#10;then &#10;  offeringWeeks * dmnPartTimeProgramYearMaximums.limitTransportationAllowance&#10;else&#10;  0" target="calculatedDataTotalTransportationAllowance" />
+          <zeebe:output source="=if(offeringDelivered = &#34;onsite&#34; or offeringDelivered = &#34;blended&#34;)&#10;then &#10;  offeringWeeks * dmnPartTimeProgramYearMaximums.limitTransportationAllowance&#10;else&#10;  0" target="calculatedDataTotalTransportationAllowance" />
         </zeebe:ioMapping>
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_0ra2rum</bpmn:incoming>

--- a/sources/packages/backend/workflow/src/workflow-definitions/parttime-assessment-2024-2025.bpmn
+++ b/sources/packages/backend/workflow/src/workflow-definitions/parttime-assessment-2024-2025.bpmn
@@ -268,7 +268,7 @@ dmnX (comes from dmn)</bpmn:text>
         <zeebe:ioMapping>
           <zeebe:output source="=offeringActualTuitionCosts" target="calculatedDataActualTuitionCosts" />
           <zeebe:output source="=offeringMandatoryFees" target="calculatedDataMandatoryFees" />
-          <zeebe:output source="=offeringProgramRelatedCosts" target="calculatedDataProgramRelatedCosts" />
+          <zeebe:output source="=min(offeringProgramRelatedCosts, dmnPartTimeProgramYearMaximums.limitWeeklyBooksAndSupplies * offeringWeeks)" target="calculatedDataProgramRelatedCosts" />
         </zeebe:ioMapping>
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_08xi7o2</bpmn:incoming>
@@ -1227,20 +1227,20 @@ dmnX (comes from dmn)</bpmn:text>
         <dc:Bounds x="160" y="80" width="7708" height="2892" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Lane_1gxyyjh_di" bpmnElement="Lane_1gxyyjh" isHorizontal="true">
-        <dc:Bounds x="190" y="80" width="7678" height="1147" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Lane_0ejpwa7_di" bpmnElement="Lane_0ejpwa7" isHorizontal="true">
         <dc:Bounds x="190" y="1227" width="7678" height="1745" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Lane_0pbg2l1_di" bpmnElement="Lane_0pbg2l1" isHorizontal="true">
+        <dc:Bounds x="220" y="1227" width="7648" height="1053" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Lane_0l32w49_di" bpmnElement="Lane_0l32w49" isHorizontal="true">
         <dc:Bounds x="220" y="2280" width="7648" height="692" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Lane_0pbg2l1_di" bpmnElement="Lane_0pbg2l1" isHorizontal="true">
-        <dc:Bounds x="220" y="1227" width="7648" height="1053" />
+      <bpmndi:BPMNShape id="Lane_1gxyyjh_di" bpmnElement="Lane_1gxyyjh" isHorizontal="true">
+        <dc:Bounds x="190" y="80" width="7678" height="1147" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_1sg75ph_di" bpmnElement="Event_1sg75ph">
@@ -2320,90 +2320,6 @@ dmnX (comes from dmn)</bpmn:text>
         <di:waypoint x="2110" y="940" />
         <di:waypoint x="2110" y="895" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Association_0jm8vsl_di" bpmnElement="Association_0jm8vsl">
-        <di:waypoint x="2561" y="1030" />
-        <di:waypoint x="2556" y="971" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Association_0cp4qvu_di" bpmnElement="Association_0cp4qvu">
-        <di:waypoint x="980" y="735" />
-        <di:waypoint x="980" y="852" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Association_1i7iirc_di" bpmnElement="Association_1i7iirc">
-        <di:waypoint x="730" y="852" />
-        <di:waypoint x="730" y="742" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Association_0eiso39_di" bpmnElement="Association_0eiso39">
-        <di:waypoint x="830" y="888" />
-        <di:waypoint x="830" y="980" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Association_0ptatj5_di" bpmnElement="Association_0ptatj5">
-        <di:waypoint x="7200" y="2625" />
-        <di:waypoint x="7239" y="2570" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Association_1nid8vk_di" bpmnElement="Association_1nid8vk">
-        <di:waypoint x="7107" y="2624" />
-        <di:waypoint x="7133" y="2570" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Association_0gzo1wo_di" bpmnElement="Association_0gzo1wo">
-        <di:waypoint x="7020" y="2622" />
-        <di:waypoint x="7020" y="2550" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Association_1vdevsr_di" bpmnElement="Association_1vdevsr">
-        <di:waypoint x="6544" y="2623" />
-        <di:waypoint x="6557" y="2570" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Association_18qf11c_di" bpmnElement="Association_18qf11c">
-        <di:waypoint x="7449" y="2624" />
-        <di:waypoint x="7481" y="2570" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Association_1gi7mg0_di" bpmnElement="Association_1gi7mg0">
-        <di:waypoint x="7451" y="2756" />
-        <di:waypoint x="7471" y="2730" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Association_1mr7raq_di" bpmnElement="Association_1mr7raq">
-        <di:waypoint x="6639" y="2624" />
-        <di:waypoint x="6672" y="2570" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Association_01prvbh_di" bpmnElement="Association_01prvbh">
-        <di:waypoint x="5748" y="1628" />
-        <di:waypoint x="5846" y="1607" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Association_0k52tdi_di" bpmnElement="Association_0k52tdi">
-        <di:waypoint x="5747" y="1705" />
-        <di:waypoint x="5846" y="1682" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Association_1kl6b20_di" bpmnElement="Association_1kl6b20">
-        <di:waypoint x="5747" y="1783" />
-        <di:waypoint x="5846" y="1745" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Association_1ledsf9_di" bpmnElement="Association_1ledsf9">
-        <di:waypoint x="5747" y="1873" />
-        <di:waypoint x="5846" y="1833" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Association_1y0l2mk_di" bpmnElement="Association_1y0l2mk">
-        <di:waypoint x="5747" y="1956" />
-        <di:waypoint x="5846" y="1936" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Association_0rsi8j4_di" bpmnElement="Association_0rsi8j4">
-        <di:waypoint x="3279" y="1372" />
-        <di:waypoint x="3279" y="1351" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Association_0hwwkv8_di" bpmnElement="Association_0hwwkv8">
-        <di:waypoint x="3930" y="1350" />
-        <di:waypoint x="3930" y="1314" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Association_1skh123_di" bpmnElement="Association_1skh123">
-        <di:waypoint x="4070" y="1350" />
-        <di:waypoint x="4070" y="1314" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Association_1p9iqwc_di" bpmnElement="Association_1p9iqwc">
-        <di:waypoint x="3180" y="1372" />
-        <di:waypoint x="3180" y="1324" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Association_0hybcza_di" bpmnElement="Association_0hybcza">
-        <di:waypoint x="3754" y="1608" />
-        <di:waypoint x="3799" y="1570" />
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="BPMNShape_0hjhvfj" bpmnElement="TextAnnotation_15vd5py">
         <dc:Bounds x="7429" y="2700" width="100" height="30" />
         <bpmndi:BPMNLabel />
@@ -2498,6 +2414,90 @@ dmnX (comes from dmn)</bpmn:text>
         <dc:Bounds x="4020" y="1242" width="180" height="72" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Association_1gi7mg0_di" bpmnElement="Association_1gi7mg0">
+        <di:waypoint x="7451" y="2756" />
+        <di:waypoint x="7471" y="2730" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Association_1mr7raq_di" bpmnElement="Association_1mr7raq">
+        <di:waypoint x="6639" y="2624" />
+        <di:waypoint x="6672" y="2570" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Association_18qf11c_di" bpmnElement="Association_18qf11c">
+        <di:waypoint x="7449" y="2624" />
+        <di:waypoint x="7481" y="2570" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Association_0ptatj5_di" bpmnElement="Association_0ptatj5">
+        <di:waypoint x="7200" y="2625" />
+        <di:waypoint x="7239" y="2570" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Association_1nid8vk_di" bpmnElement="Association_1nid8vk">
+        <di:waypoint x="7107" y="2624" />
+        <di:waypoint x="7133" y="2570" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Association_1vdevsr_di" bpmnElement="Association_1vdevsr">
+        <di:waypoint x="6544" y="2623" />
+        <di:waypoint x="6557" y="2570" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Association_01prvbh_di" bpmnElement="Association_01prvbh">
+        <di:waypoint x="5748" y="1628" />
+        <di:waypoint x="5846" y="1607" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Association_1ledsf9_di" bpmnElement="Association_1ledsf9">
+        <di:waypoint x="5747" y="1873" />
+        <di:waypoint x="5846" y="1833" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Association_1kl6b20_di" bpmnElement="Association_1kl6b20">
+        <di:waypoint x="5747" y="1783" />
+        <di:waypoint x="5846" y="1745" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Association_0k52tdi_di" bpmnElement="Association_0k52tdi">
+        <di:waypoint x="5747" y="1705" />
+        <di:waypoint x="5846" y="1682" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Association_0gzo1wo_di" bpmnElement="Association_0gzo1wo">
+        <di:waypoint x="7020" y="2622" />
+        <di:waypoint x="7020" y="2550" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Association_1i7iirc_di" bpmnElement="Association_1i7iirc">
+        <di:waypoint x="730" y="852" />
+        <di:waypoint x="730" y="742" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Association_0eiso39_di" bpmnElement="Association_0eiso39">
+        <di:waypoint x="830" y="888" />
+        <di:waypoint x="830" y="980" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Association_1y0l2mk_di" bpmnElement="Association_1y0l2mk">
+        <di:waypoint x="5747" y="1956" />
+        <di:waypoint x="5846" y="1936" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Association_0jm8vsl_di" bpmnElement="Association_0jm8vsl">
+        <di:waypoint x="2561" y="1030" />
+        <di:waypoint x="2556" y="971" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Association_0cp4qvu_di" bpmnElement="Association_0cp4qvu">
+        <di:waypoint x="980" y="735" />
+        <di:waypoint x="980" y="852" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Association_1p9iqwc_di" bpmnElement="Association_1p9iqwc">
+        <di:waypoint x="3180" y="1372" />
+        <di:waypoint x="3180" y="1324" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Association_0rsi8j4_di" bpmnElement="Association_0rsi8j4">
+        <di:waypoint x="3279" y="1372" />
+        <di:waypoint x="3279" y="1351" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Association_0hwwkv8_di" bpmnElement="Association_0hwwkv8">
+        <di:waypoint x="3930" y="1350" />
+        <di:waypoint x="3930" y="1314" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Association_0hybcza_di" bpmnElement="Association_0hybcza">
+        <di:waypoint x="3754" y="1608" />
+        <di:waypoint x="3799" y="1570" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Association_1skh123_di" bpmnElement="Association_1skh123">
+        <di:waypoint x="4070" y="1350" />
+        <di:waypoint x="4070" y="1314" />
+      </bpmndi:BPMNEdge>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>
 </bpmn:definitions>

--- a/sources/packages/backend/workflow/src/workflow-definitions/parttime-assessment-decisions.dmn
+++ b/sources/packages/backend/workflow/src/workflow-definitions/parttime-assessment-decisions.dmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" xmlns:camunda="http://camunda.org/schema/1.0/dmn" id="dmnPartTimeAssessmentDecisions" name="dmnPartTimeAssessmentDecisions" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="5.25.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.1.0" camunda:diagramRelationId="1a575ead-1e6d-468c-901a-766a35569b38">
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" xmlns:camunda="http://camunda.org/schema/1.0/dmn" id="dmnPartTimeAssessmentDecisions" name="dmnPartTimeAssessmentDecisions" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="5.27.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.1.0" camunda:diagramRelationId="1a575ead-1e6d-468c-901a-766a35569b38">
   <decision id="dmnPartTimeProgramYearMaximums" name="dmnPartTimeProgramYearMaximums">
     <decisionTable id="DecisionTable_1oyvbif" hitPolicy="FIRST">
       <input id="InputClause_02zjhj9" label="programYear">
@@ -16,6 +16,7 @@
       <output id="OutputClause_13hw5pm" label="limitAdditionalTransportationPlacement" name="limitAdditionalTransportationPlacement" typeRef="string" />
       <output id="OutputClause_063ippa" label="limitAdditionalTransportationKMReduction" name="limitAdditionalTransportationKMReduction" typeRef="string" />
       <output id="OutputClause_1bvdo70" name="limitAdditionalTransportationNonOwner" typeRef="string" />
+      <output id="OutputClause_0zceqx7" name="limitWeeklyBooksAndSupplies" typeRef="string" />
       <rule id="DecisionRule_0bfepni">
         <inputEntry id="UnaryTests_1s74yiy">
           <text>"2022-2023"</text>
@@ -46,6 +47,9 @@
         </outputEntry>
         <outputEntry id="LiteralExpression_00fe5q2">
           <text>69</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_14vh234">
+          <text>58</text>
         </outputEntry>
       </rule>
       <rule id="DecisionRule_1176l6s">
@@ -79,6 +83,9 @@
         <outputEntry id="LiteralExpression_06qc618">
           <text>69</text>
         </outputEntry>
+        <outputEntry id="LiteralExpression_029jy41">
+          <text>58</text>
+        </outputEntry>
       </rule>
       <rule id="DecisionRule_132jsxw">
         <inputEntry id="UnaryTests_1vimth4">
@@ -110,6 +117,9 @@
         </outputEntry>
         <outputEntry id="LiteralExpression_0m35hdb">
           <text>69</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_14cpou1">
+          <text>58</text>
         </outputEntry>
       </rule>
     </decisionTable>

--- a/sources/packages/backend/workflow/test/2022-2023/parttime-assessment/awards-amounts/parttime-assessment-awards-amount-CSLP.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2022-2023/parttime-assessment/awards-amounts/parttime-assessment-awards-amount-CSLP.e2e-spec.ts
@@ -27,7 +27,7 @@ describe(`E2E Test Workflow part-time-assessment-${PROGRAM_YEAR}-awards-amount-C
     expect(calculatedAssessment.variables.latestCSLPBalance).toBe(0);
     expect(
       calculatedAssessment.variables.calculatedDataTotalRemainingNeed4,
-    ).toBe(21778);
+    ).toBe(17647);
     expect(calculatedAssessment.variables.federalAwardNetCSLPAmount).toBe(
       10000,
     );
@@ -52,7 +52,7 @@ describe(`E2E Test Workflow part-time-assessment-${PROGRAM_YEAR}-awards-amount-C
     expect(calculatedAssessment.variables.latestCSLPBalance).toBe(1000);
     expect(
       calculatedAssessment.variables.calculatedDataTotalRemainingNeed4,
-    ).toBe(21778);
+    ).toBe(17647);
     expect(calculatedAssessment.variables.federalAwardNetCSLPAmount).toBe(9000);
     expect(calculatedAssessment.variables.finalFederalAwardNetCSLPAmount).toBe(
       9000,

--- a/sources/packages/backend/workflow/test/2022-2023/parttime-assessment/costs/parttime-assessment-costs-program-related-costs.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2022-2023/parttime-assessment/costs/parttime-assessment-costs-program-related-costs.e2e-spec.ts
@@ -1,0 +1,61 @@
+import { PROGRAM_YEAR } from "../../constants/program-year.constants";
+import {
+  ZeebeMockedClient,
+  createFakeConsolidatedPartTimeData,
+  executePartTimeAssessmentForProgramYear,
+} from "../../../test-utils";
+
+describe(`E2E Test Workflow parttime-assessment-${PROGRAM_YEAR}-program-related-costs.`, () => {
+  it(
+    "Should use minimum (offering program related costs) " +
+      "when dmn limit for books and supplies * number of offering weeks has a higher value.",
+    async () => {
+      // Arrange
+      const assessmentConsolidatedData =
+        createFakeConsolidatedPartTimeData(PROGRAM_YEAR);
+      assessmentConsolidatedData.offeringWeeks = 30;
+      // A lower value than dmnPartTimeProgramYearMaximums.limitWeeklyBooksAndSupplies * offeringWeeks.
+      assessmentConsolidatedData.offeringProgramRelatedCosts = 1730;
+
+      // Act
+      const calculatedAssessment =
+        await executePartTimeAssessmentForProgramYear(
+          PROGRAM_YEAR,
+          assessmentConsolidatedData,
+        );
+      // Assert
+      expect(
+        calculatedAssessment.variables.calculatedDataTotalAssessedNeed,
+      ).toBe(22962);
+    },
+  );
+
+  it(
+    "Should use minimum (dmn limit for books and supplies * number of offering weeks) " +
+      "when offering program related costs has a higher value.",
+    async () => {
+      // Arrange
+      const assessmentConsolidatedData =
+        createFakeConsolidatedPartTimeData(PROGRAM_YEAR);
+      assessmentConsolidatedData.offeringWeeks = 30;
+      // A higher value than dmnPartTimeProgramYearMaximums.limitWeeklyBooksAndSupplies * offeringWeeks.
+      assessmentConsolidatedData.offeringProgramRelatedCosts = 1750;
+
+      // Act
+      const calculatedAssessment =
+        await executePartTimeAssessmentForProgramYear(
+          PROGRAM_YEAR,
+          assessmentConsolidatedData,
+        );
+      // Assert
+      expect(
+        calculatedAssessment.variables.calculatedDataTotalAssessedNeed,
+      ).toBe(22972);
+    },
+  );
+
+  afterAll(async () => {
+    // Closes the singleton instance created during test executions.
+    await ZeebeMockedClient.getMockedZeebeInstance().close();
+  });
+});

--- a/sources/packages/backend/workflow/test/2022-2023/parttime-assessment/costs/parttime-assessment-costs-program-related-costs.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2022-2023/parttime-assessment/costs/parttime-assessment-costs-program-related-costs.e2e-spec.ts
@@ -7,8 +7,8 @@ import {
 
 describe(`E2E Test Workflow parttime-assessment-${PROGRAM_YEAR}-program-related-costs.`, () => {
   it(
-    "Should use minimum (offering program related costs) " +
-      "when dmn limit for books and supplies * number of offering weeks has a higher value.",
+    "Should get program related costs as offering program related costs when the DMN limit for books and supplies " +
+      "multiplied by offering weeks has the greater value.",
     async () => {
       // Arrange
       const assessmentConsolidatedData =
@@ -31,7 +31,7 @@ describe(`E2E Test Workflow parttime-assessment-${PROGRAM_YEAR}-program-related-
   );
 
   it(
-    "Should use minimum (dmn limit for books and supplies * number of offering weeks) " +
+    "Should get DMN limit for books and supplies multiplied by offering weeks " +
       "when offering program related costs has a higher value.",
     async () => {
       // Arrange

--- a/sources/packages/backend/workflow/test/2022-2023/parttime-assessment/costs/parttime-assessment-transportation-costs.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2022-2023/parttime-assessment/costs/parttime-assessment-transportation-costs.e2e-spec.ts
@@ -8,16 +8,16 @@ import { OfferingDeliveryOptions, YesNoOptions } from "@sims/test-utils";
 
 describe(`E2E Test Workflow parttime-assessment-${PROGRAM_YEAR}-transportation-costs.`, () => {
   describe("Should determine total transportation allowance when student does not require additional transportation.", () => {
-    it(
-      "Should determine transportation allowance when there is no additional transportation needed " +
-        "for an offering delivered onsite.",
-      async () => {
+    for (const offeringDelivery of [
+      OfferingDeliveryOptions.Onsite,
+      OfferingDeliveryOptions.Blended,
+    ]) {
+      it(`Should determine transportation allowance when there is no additional transportation needed for an offering delivered ${offeringDelivery}.`, async () => {
         // Arrange
         const assessmentConsolidatedData =
           createFakeConsolidatedPartTimeData(PROGRAM_YEAR);
         assessmentConsolidatedData.offeringWeeks = 30;
-        assessmentConsolidatedData.offeringDelivered =
-          OfferingDeliveryOptions.Onsite;
+        assessmentConsolidatedData.offeringDelivered = offeringDelivery;
         // Act
         const calculatedAssessment =
           await executePartTimeAssessmentForProgramYear(
@@ -35,8 +35,8 @@ describe(`E2E Test Workflow parttime-assessment-${PROGRAM_YEAR}-transportation-c
           calculatedAssessment.variables
             .calculatedDataTotalTransportationAllowance,
         ).toBe(390);
-      },
-    );
+      });
+    }
 
     it(
       "Should calculate transportation allowance as 0 when there is no additional transportation needed " +

--- a/sources/packages/backend/workflow/test/2022-2023/parttime-assessment/costs/parttime-assessment-transportation-costs.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2022-2023/parttime-assessment/costs/parttime-assessment-transportation-costs.e2e-spec.ts
@@ -150,6 +150,17 @@ describe(`E2E Test Workflow parttime-assessment-${PROGRAM_YEAR}-transportation-c
     },
     {
       offeringWeeks: 16,
+      offeringDelivered: OfferingDeliveryOptions.Blended,
+      additionalTransportOwner: YesNoOptions.Yes,
+      additionalTransportKm: 300,
+      additionalTransportWeeks: 10,
+      additionalTransportPlacement: YesNoOptions.No,
+      expectedWeeklyAdditionalTransportCost: 94,
+      expectedTotalAdditionalTransportAllowance: 940,
+      expectedTotalTransportAllowance: 1018,
+    },
+    {
+      offeringWeeks: 16,
       offeringDelivered: OfferingDeliveryOptions.Online,
       additionalTransportOwner: YesNoOptions.Yes,
       additionalTransportKm: 280,

--- a/sources/packages/backend/workflow/test/2023-2024/parttime-assessment/awards-amounts/parttime-assessment-awards-amount-CSLP.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2023-2024/parttime-assessment/awards-amounts/parttime-assessment-awards-amount-CSLP.e2e-spec.ts
@@ -27,7 +27,7 @@ describe(`E2E Test Workflow parttime-assessment-${PROGRAM_YEAR}-awards-amount-CS
     expect(calculatedAssessment.variables.latestCSLPBalance).toBe(0);
     expect(
       calculatedAssessment.variables.calculatedDataTotalRemainingNeed4,
-    ).toBe(22858);
+    ).toBe(18727);
     expect(calculatedAssessment.variables.federalAwardNetCSLPAmount).toBe(
       10000,
     );

--- a/sources/packages/backend/workflow/test/2023-2024/parttime-assessment/awards-amounts/parttime-assessment-awards-amount-CSLP.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2023-2024/parttime-assessment/awards-amounts/parttime-assessment-awards-amount-CSLP.e2e-spec.ts
@@ -52,7 +52,7 @@ describe(`E2E Test Workflow parttime-assessment-${PROGRAM_YEAR}-awards-amount-CS
     expect(calculatedAssessment.variables.latestCSLPBalance).toBe(1000);
     expect(
       calculatedAssessment.variables.calculatedDataTotalRemainingNeed4,
-    ).toBe(22858);
+    ).toBe(18727);
     expect(calculatedAssessment.variables.federalAwardNetCSLPAmount).toBe(9000);
     expect(calculatedAssessment.variables.finalFederalAwardNetCSLPAmount).toBe(
       9000,

--- a/sources/packages/backend/workflow/test/2023-2024/parttime-assessment/costs/parttime-assessment-costs-program-related-costs.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2023-2024/parttime-assessment/costs/parttime-assessment-costs-program-related-costs.e2e-spec.ts
@@ -1,0 +1,61 @@
+import { PROGRAM_YEAR } from "../../constants/program-year.constants";
+import {
+  ZeebeMockedClient,
+  createFakeConsolidatedPartTimeData,
+  executePartTimeAssessmentForProgramYear,
+} from "../../../test-utils";
+
+describe(`E2E Test Workflow parttime-assessment-${PROGRAM_YEAR}-program-related-costs.`, () => {
+  it(
+    "Should use minimum (offering program related costs) " +
+      "when dmn limit for books and supplies * number of offering weeks has a higher value.",
+    async () => {
+      // Arrange
+      const assessmentConsolidatedData =
+        createFakeConsolidatedPartTimeData(PROGRAM_YEAR);
+      assessmentConsolidatedData.offeringWeeks = 30;
+      // A lower value than dmnPartTimeProgramYearMaximums.limitWeeklyBooksAndSupplies * offeringWeeks.
+      assessmentConsolidatedData.offeringProgramRelatedCosts = 1730;
+
+      // Act
+      const calculatedAssessment =
+        await executePartTimeAssessmentForProgramYear(
+          PROGRAM_YEAR,
+          assessmentConsolidatedData,
+        );
+      // Assert
+      expect(
+        calculatedAssessment.variables.calculatedDataTotalAssessedNeed,
+      ).toBe(22962);
+    },
+  );
+
+  it(
+    "Should use minimum (dmn limit for books and supplies * number of offering weeks) " +
+      "when offering program related costs has a higher value.",
+    async () => {
+      // Arrange
+      const assessmentConsolidatedData =
+        createFakeConsolidatedPartTimeData(PROGRAM_YEAR);
+      assessmentConsolidatedData.offeringWeeks = 30;
+      // A higher value than dmnPartTimeProgramYearMaximums.limitWeeklyBooksAndSupplies * offeringWeeks.
+      assessmentConsolidatedData.offeringProgramRelatedCosts = 1750;
+
+      // Act
+      const calculatedAssessment =
+        await executePartTimeAssessmentForProgramYear(
+          PROGRAM_YEAR,
+          assessmentConsolidatedData,
+        );
+      // Assert
+      expect(
+        calculatedAssessment.variables.calculatedDataTotalAssessedNeed,
+      ).toBe(22972);
+    },
+  );
+
+  afterAll(async () => {
+    // Closes the singleton instance created during test executions.
+    await ZeebeMockedClient.getMockedZeebeInstance().close();
+  });
+});

--- a/sources/packages/backend/workflow/test/2023-2024/parttime-assessment/costs/parttime-assessment-costs-program-related-costs.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2023-2024/parttime-assessment/costs/parttime-assessment-costs-program-related-costs.e2e-spec.ts
@@ -7,8 +7,8 @@ import {
 
 describe(`E2E Test Workflow parttime-assessment-${PROGRAM_YEAR}-program-related-costs.`, () => {
   it(
-    "Should use minimum (offering program related costs) " +
-      "when dmn limit for books and supplies * number of offering weeks has a higher value.",
+    "Should get program related costs as offering program related costs when the DMN limit for books and supplies " +
+      "multiplied by offering weeks has the greater value.",
     async () => {
       // Arrange
       const assessmentConsolidatedData =
@@ -31,7 +31,7 @@ describe(`E2E Test Workflow parttime-assessment-${PROGRAM_YEAR}-program-related-
   );
 
   it(
-    "Should use minimum (dmn limit for books and supplies * number of offering weeks) " +
+    "Should get DMN limit for books and supplies multiplied by offering weeks " +
       "when offering program related costs has a higher value.",
     async () => {
       // Arrange

--- a/sources/packages/backend/workflow/test/2023-2024/parttime-assessment/costs/parttime-assessment-transportation-costs.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2023-2024/parttime-assessment/costs/parttime-assessment-transportation-costs.e2e-spec.ts
@@ -8,35 +8,36 @@ import { OfferingDeliveryOptions, YesNoOptions } from "@sims/test-utils";
 
 describe(`E2E Test Workflow parttime-assessment-${PROGRAM_YEAR}-transportation-costs.`, () => {
   describe("Should determine total transportation allowance when student does not require additional transportation.", () => {
-    it(
-      "Should determine transportation allowance when there is no additional transportation needed " +
-        "for an offering delivered onsite.",
-      async () => {
-        // Arrange
-        const assessmentConsolidatedData =
-          createFakeConsolidatedPartTimeData(PROGRAM_YEAR);
-        assessmentConsolidatedData.offeringWeeks = 30;
-        assessmentConsolidatedData.offeringDelivered =
-          OfferingDeliveryOptions.Onsite;
-        // Act
-        const calculatedAssessment =
-          await executePartTimeAssessmentForProgramYear(
-            PROGRAM_YEAR,
-            assessmentConsolidatedData,
-          );
-        // Assert
-        // Expect the additional transportation allowance to be 0.
-        expect(
-          calculatedAssessment.variables
-            .calculatedDataTotalAdditionalTransportationAllowance,
-        ).toBe(0);
-        // Expect the transportation allowance to be calculated.
-        expect(
-          calculatedAssessment.variables
-            .calculatedDataTotalTransportationAllowance,
-        ).toBe(390);
-      },
-    );
+    describe("Should determine total transportation allowance when student does not require additional transportation.", () => {
+      for (const offeringDelivery of [
+        OfferingDeliveryOptions.Onsite,
+        OfferingDeliveryOptions.Blended,
+      ]) {
+        it(`Should determine transportation allowance when there is no additional transportation needed for an offering delivered ${offeringDelivery}.`, async () => {
+          // Arrange
+          const assessmentConsolidatedData =
+            createFakeConsolidatedPartTimeData(PROGRAM_YEAR);
+          assessmentConsolidatedData.offeringWeeks = 30;
+          assessmentConsolidatedData.offeringDelivered = offeringDelivery;
+          // Act
+          const calculatedAssessment =
+            await executePartTimeAssessmentForProgramYear(
+              PROGRAM_YEAR,
+              assessmentConsolidatedData,
+            );
+          // Assert
+          // Expect the additional transportation allowance to be 0.
+          expect(
+            calculatedAssessment.variables
+              .calculatedDataTotalAdditionalTransportationAllowance,
+          ).toBe(0);
+          // Expect the transportation allowance to be calculated.
+          expect(
+            calculatedAssessment.variables
+              .calculatedDataTotalTransportationAllowance,
+          ).toBe(390);
+        });
+      }
 
     it(
       "Should calculate transportation allowance as 0 when there is no additional transportation needed " +

--- a/sources/packages/backend/workflow/test/2023-2024/parttime-assessment/costs/parttime-assessment-transportation-costs.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2023-2024/parttime-assessment/costs/parttime-assessment-transportation-costs.e2e-spec.ts
@@ -8,36 +8,35 @@ import { OfferingDeliveryOptions, YesNoOptions } from "@sims/test-utils";
 
 describe(`E2E Test Workflow parttime-assessment-${PROGRAM_YEAR}-transportation-costs.`, () => {
   describe("Should determine total transportation allowance when student does not require additional transportation.", () => {
-    describe("Should determine total transportation allowance when student does not require additional transportation.", () => {
-      for (const offeringDelivery of [
-        OfferingDeliveryOptions.Onsite,
-        OfferingDeliveryOptions.Blended,
-      ]) {
-        it(`Should determine transportation allowance when there is no additional transportation needed for an offering delivered ${offeringDelivery}.`, async () => {
-          // Arrange
-          const assessmentConsolidatedData =
-            createFakeConsolidatedPartTimeData(PROGRAM_YEAR);
-          assessmentConsolidatedData.offeringWeeks = 30;
-          assessmentConsolidatedData.offeringDelivered = offeringDelivery;
-          // Act
-          const calculatedAssessment =
-            await executePartTimeAssessmentForProgramYear(
-              PROGRAM_YEAR,
-              assessmentConsolidatedData,
-            );
-          // Assert
-          // Expect the additional transportation allowance to be 0.
-          expect(
-            calculatedAssessment.variables
-              .calculatedDataTotalAdditionalTransportationAllowance,
-          ).toBe(0);
-          // Expect the transportation allowance to be calculated.
-          expect(
-            calculatedAssessment.variables
-              .calculatedDataTotalTransportationAllowance,
-          ).toBe(390);
-        });
-      }
+    for (const offeringDelivery of [
+      OfferingDeliveryOptions.Onsite,
+      OfferingDeliveryOptions.Blended,
+    ]) {
+      it(`Should determine transportation allowance when there is no additional transportation needed for an offering delivered ${offeringDelivery}.`, async () => {
+        // Arrange
+        const assessmentConsolidatedData =
+          createFakeConsolidatedPartTimeData(PROGRAM_YEAR);
+        assessmentConsolidatedData.offeringWeeks = 30;
+        assessmentConsolidatedData.offeringDelivered = offeringDelivery;
+        // Act
+        const calculatedAssessment =
+          await executePartTimeAssessmentForProgramYear(
+            PROGRAM_YEAR,
+            assessmentConsolidatedData,
+          );
+        // Assert
+        // Expect the additional transportation allowance to be 0.
+        expect(
+          calculatedAssessment.variables
+            .calculatedDataTotalAdditionalTransportationAllowance,
+        ).toBe(0);
+        // Expect the transportation allowance to be calculated.
+        expect(
+          calculatedAssessment.variables
+            .calculatedDataTotalTransportationAllowance,
+        ).toBe(390);
+      });
+    }
 
     it(
       "Should calculate transportation allowance as 0 when there is no additional transportation needed " +
@@ -141,6 +140,17 @@ describe(`E2E Test Workflow parttime-assessment-${PROGRAM_YEAR}-transportation-c
     {
       offeringWeeks: 16,
       offeringDelivered: OfferingDeliveryOptions.Onsite,
+      additionalTransportOwner: YesNoOptions.Yes,
+      additionalTransportKm: 300,
+      additionalTransportWeeks: 10,
+      additionalTransportPlacement: YesNoOptions.No,
+      expectedWeeklyAdditionalTransportCost: 94,
+      expectedTotalAdditionalTransportAllowance: 940,
+      expectedTotalTransportAllowance: 1018,
+    },
+    {
+      offeringWeeks: 16,
+      offeringDelivered: OfferingDeliveryOptions.Blended,
       additionalTransportOwner: YesNoOptions.Yes,
       additionalTransportKm: 300,
       additionalTransportWeeks: 10,

--- a/sources/packages/backend/workflow/test/2024-2025/parttime-assessment/awards-amounts/parttime-assessment-awards-amount-CSLP.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2024-2025/parttime-assessment/awards-amounts/parttime-assessment-awards-amount-CSLP.e2e-spec.ts
@@ -27,7 +27,7 @@ describe(`E2E Test Workflow parttime-assessment-${PROGRAM_YEAR}-awards-amount-CS
     expect(calculatedAssessment.variables.latestCSLPBalance).toBe(0);
     expect(
       calculatedAssessment.variables.calculatedDataTotalRemainingNeed4,
-    ).toBe(22858);
+    ).toBe(18727);
     expect(calculatedAssessment.variables.federalAwardNetCSLPAmount).toBe(
       10000,
     );
@@ -52,7 +52,7 @@ describe(`E2E Test Workflow parttime-assessment-${PROGRAM_YEAR}-awards-amount-CS
     expect(calculatedAssessment.variables.latestCSLPBalance).toBe(1000);
     expect(
       calculatedAssessment.variables.calculatedDataTotalRemainingNeed4,
-    ).toBe(22858);
+    ).toBe(18727);
     expect(calculatedAssessment.variables.federalAwardNetCSLPAmount).toBe(9000);
     expect(calculatedAssessment.variables.finalFederalAwardNetCSLPAmount).toBe(
       9000,

--- a/sources/packages/backend/workflow/test/2024-2025/parttime-assessment/costs/parttime-assessment-costs-program-related-costs.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2024-2025/parttime-assessment/costs/parttime-assessment-costs-program-related-costs.e2e-spec.ts
@@ -1,0 +1,61 @@
+import { PROGRAM_YEAR } from "../../constants/program-year.constants";
+import {
+  ZeebeMockedClient,
+  createFakeConsolidatedPartTimeData,
+  executePartTimeAssessmentForProgramYear,
+} from "../../../test-utils";
+
+describe(`E2E Test Workflow parttime-assessment-${PROGRAM_YEAR}-program-related-costs.`, () => {
+  it(
+    "Should use minimum (offering program related costs) " +
+      "when dmn limit for books and supplies * number of offering weeks has a higher value.",
+    async () => {
+      // Arrange
+      const assessmentConsolidatedData =
+        createFakeConsolidatedPartTimeData(PROGRAM_YEAR);
+      assessmentConsolidatedData.offeringWeeks = 30;
+      // A lower value than dmnPartTimeProgramYearMaximums.limitWeeklyBooksAndSupplies * offeringWeeks.
+      assessmentConsolidatedData.offeringProgramRelatedCosts = 1730;
+
+      // Act
+      const calculatedAssessment =
+        await executePartTimeAssessmentForProgramYear(
+          PROGRAM_YEAR,
+          assessmentConsolidatedData,
+        );
+      // Assert
+      expect(
+        calculatedAssessment.variables.calculatedDataTotalAssessedNeed,
+      ).toBe(22962);
+    },
+  );
+
+  it(
+    "Should use minimum (dmn limit for books and supplies * number of offering weeks) " +
+      "when offering program related costs has a higher value.",
+    async () => {
+      // Arrange
+      const assessmentConsolidatedData =
+        createFakeConsolidatedPartTimeData(PROGRAM_YEAR);
+      assessmentConsolidatedData.offeringWeeks = 30;
+      // A higher value than dmnPartTimeProgramYearMaximums.limitWeeklyBooksAndSupplies * offeringWeeks.
+      assessmentConsolidatedData.offeringProgramRelatedCosts = 1750;
+
+      // Act
+      const calculatedAssessment =
+        await executePartTimeAssessmentForProgramYear(
+          PROGRAM_YEAR,
+          assessmentConsolidatedData,
+        );
+      // Assert
+      expect(
+        calculatedAssessment.variables.calculatedDataTotalAssessedNeed,
+      ).toBe(22972);
+    },
+  );
+
+  afterAll(async () => {
+    // Closes the singleton instance created during test executions.
+    await ZeebeMockedClient.getMockedZeebeInstance().close();
+  });
+});

--- a/sources/packages/backend/workflow/test/2024-2025/parttime-assessment/costs/parttime-assessment-costs-program-related-costs.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2024-2025/parttime-assessment/costs/parttime-assessment-costs-program-related-costs.e2e-spec.ts
@@ -7,8 +7,8 @@ import {
 
 describe(`E2E Test Workflow parttime-assessment-${PROGRAM_YEAR}-program-related-costs.`, () => {
   it(
-    "Should use minimum (offering program related costs) " +
-      "when dmn limit for books and supplies * number of offering weeks has a higher value.",
+    "Should get program related costs as offering program related costs when the DMN limit for books and supplies " +
+      "multiplied by offering weeks has the greater value.",
     async () => {
       // Arrange
       const assessmentConsolidatedData =
@@ -31,7 +31,7 @@ describe(`E2E Test Workflow parttime-assessment-${PROGRAM_YEAR}-program-related-
   );
 
   it(
-    "Should use minimum (dmn limit for books and supplies * number of offering weeks) " +
+    "Should get DMN limit for books and supplies multiplied by offering weeks " +
       "when offering program related costs has a higher value.",
     async () => {
       // Arrange

--- a/sources/packages/backend/workflow/test/2024-2025/parttime-assessment/costs/parttime-assessment-transportation-costs.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2024-2025/parttime-assessment/costs/parttime-assessment-transportation-costs.e2e-spec.ts
@@ -8,35 +8,36 @@ import { OfferingDeliveryOptions, YesNoOptions } from "@sims/test-utils";
 
 describe(`E2E Test Workflow parttime-assessment-${PROGRAM_YEAR}-transportation-costs.`, () => {
   describe("Should determine total transportation allowance when student does not require additional transportation.", () => {
-    it(
-      "Should determine transportation allowance when there is no additional transportation needed " +
-        "for an offering delivered onsite.",
-      async () => {
-        // Arrange
-        const assessmentConsolidatedData =
-          createFakeConsolidatedPartTimeData(PROGRAM_YEAR);
-        assessmentConsolidatedData.offeringWeeks = 30;
-        assessmentConsolidatedData.offeringDelivered =
-          OfferingDeliveryOptions.Onsite;
-        // Act
-        const calculatedAssessment =
-          await executePartTimeAssessmentForProgramYear(
-            PROGRAM_YEAR,
-            assessmentConsolidatedData,
-          );
-        // Assert
-        // Expect the additional transportation allowance to be 0.
-        expect(
-          calculatedAssessment.variables
-            .calculatedDataTotalAdditionalTransportationAllowance,
-        ).toBe(0);
-        // Expect the transportation allowance to be calculated.
-        expect(
-          calculatedAssessment.variables
-            .calculatedDataTotalTransportationAllowance,
-        ).toBe(390);
-      },
-    );
+    describe("Should determine total transportation allowance when student does not require additional transportation.", () => {
+      for (const offeringDelivery of [
+        OfferingDeliveryOptions.Onsite,
+        OfferingDeliveryOptions.Blended,
+      ]) {
+        it(`Should determine transportation allowance when there is no additional transportation needed for an offering delivered ${offeringDelivery}.`, async () => {
+          // Arrange
+          const assessmentConsolidatedData =
+            createFakeConsolidatedPartTimeData(PROGRAM_YEAR);
+          assessmentConsolidatedData.offeringWeeks = 30;
+          assessmentConsolidatedData.offeringDelivered = offeringDelivery;
+          // Act
+          const calculatedAssessment =
+            await executePartTimeAssessmentForProgramYear(
+              PROGRAM_YEAR,
+              assessmentConsolidatedData,
+            );
+          // Assert
+          // Expect the additional transportation allowance to be 0.
+          expect(
+            calculatedAssessment.variables
+              .calculatedDataTotalAdditionalTransportationAllowance,
+          ).toBe(0);
+          // Expect the transportation allowance to be calculated.
+          expect(
+            calculatedAssessment.variables
+              .calculatedDataTotalTransportationAllowance,
+          ).toBe(390);
+        });
+      }
 
     it(
       "Should calculate transportation allowance as 0 when there is no additional transportation needed " +

--- a/sources/packages/backend/workflow/test/2024-2025/parttime-assessment/costs/parttime-assessment-transportation-costs.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2024-2025/parttime-assessment/costs/parttime-assessment-transportation-costs.e2e-spec.ts
@@ -8,36 +8,35 @@ import { OfferingDeliveryOptions, YesNoOptions } from "@sims/test-utils";
 
 describe(`E2E Test Workflow parttime-assessment-${PROGRAM_YEAR}-transportation-costs.`, () => {
   describe("Should determine total transportation allowance when student does not require additional transportation.", () => {
-    describe("Should determine total transportation allowance when student does not require additional transportation.", () => {
-      for (const offeringDelivery of [
-        OfferingDeliveryOptions.Onsite,
-        OfferingDeliveryOptions.Blended,
-      ]) {
-        it(`Should determine transportation allowance when there is no additional transportation needed for an offering delivered ${offeringDelivery}.`, async () => {
-          // Arrange
-          const assessmentConsolidatedData =
-            createFakeConsolidatedPartTimeData(PROGRAM_YEAR);
-          assessmentConsolidatedData.offeringWeeks = 30;
-          assessmentConsolidatedData.offeringDelivered = offeringDelivery;
-          // Act
-          const calculatedAssessment =
-            await executePartTimeAssessmentForProgramYear(
-              PROGRAM_YEAR,
-              assessmentConsolidatedData,
-            );
-          // Assert
-          // Expect the additional transportation allowance to be 0.
-          expect(
-            calculatedAssessment.variables
-              .calculatedDataTotalAdditionalTransportationAllowance,
-          ).toBe(0);
-          // Expect the transportation allowance to be calculated.
-          expect(
-            calculatedAssessment.variables
-              .calculatedDataTotalTransportationAllowance,
-          ).toBe(390);
-        });
-      }
+    for (const offeringDelivery of [
+      OfferingDeliveryOptions.Onsite,
+      OfferingDeliveryOptions.Blended,
+    ]) {
+      it(`Should determine transportation allowance when there is no additional transportation needed for an offering delivered ${offeringDelivery}.`, async () => {
+        // Arrange
+        const assessmentConsolidatedData =
+          createFakeConsolidatedPartTimeData(PROGRAM_YEAR);
+        assessmentConsolidatedData.offeringWeeks = 30;
+        assessmentConsolidatedData.offeringDelivered = offeringDelivery;
+        // Act
+        const calculatedAssessment =
+          await executePartTimeAssessmentForProgramYear(
+            PROGRAM_YEAR,
+            assessmentConsolidatedData,
+          );
+        // Assert
+        // Expect the additional transportation allowance to be 0.
+        expect(
+          calculatedAssessment.variables
+            .calculatedDataTotalAdditionalTransportationAllowance,
+        ).toBe(0);
+        // Expect the transportation allowance to be calculated.
+        expect(
+          calculatedAssessment.variables
+            .calculatedDataTotalTransportationAllowance,
+        ).toBe(390);
+      });
+    }
 
     it(
       "Should calculate transportation allowance as 0 when there is no additional transportation needed " +
@@ -141,6 +140,17 @@ describe(`E2E Test Workflow parttime-assessment-${PROGRAM_YEAR}-transportation-c
     {
       offeringWeeks: 16,
       offeringDelivered: OfferingDeliveryOptions.Onsite,
+      additionalTransportOwner: YesNoOptions.Yes,
+      additionalTransportKm: 300,
+      additionalTransportWeeks: 10,
+      additionalTransportPlacement: YesNoOptions.No,
+      expectedWeeklyAdditionalTransportCost: 94,
+      expectedTotalAdditionalTransportAllowance: 940,
+      expectedTotalTransportAllowance: 1018,
+    },
+    {
+      offeringWeeks: 16,
+      offeringDelivered: OfferingDeliveryOptions.Blended,
       additionalTransportOwner: YesNoOptions.Yes,
       additionalTransportKm: 300,
       additionalTransportWeeks: 10,

--- a/sources/packages/backend/workflow/test/models/assessment.model.ts
+++ b/sources/packages/backend/workflow/test/models/assessment.model.ts
@@ -251,7 +251,9 @@ export interface CalculatedAssessmentModel {
   awardNetFederalTotalAward: number;
   calculatedDataTotalTransportationCost: number;
   calculatedDataTotalSecondResidence: number;
+  // TODO: Fix typo used in FT applications.
   caclulatedDataTotalAssessedNeed: number;
+  calculatedDataTotalAssessedNeed: number;
   calculatedDataTotalBookCost: number;
   awardNetProvincialTotalAward: number;
   calculatedDataTotalChildSpousalSupport: number;

--- a/sources/packages/forms/Dockerfile.dev
+++ b/sources/packages/forms/Dockerfile.dev
@@ -10,8 +10,8 @@ RUN apk update && \
   apk upgrade && \
   apk add make && \
   apk add python3 && \
-  apk add g++=13.2.1_git20240309-r0 && \
-  apk add git=2.45.2-r0 && \
+  apk add g++ && \
+  apk add git && \
   apk cache clean
 
 # Clone code into formio folder, by default.

--- a/sources/packages/forms/Dockerfile.dev
+++ b/sources/packages/forms/Dockerfile.dev
@@ -8,7 +8,7 @@ ARG FORMIO_SOURCE_REPO_TAG
 # Note: using pinned versions to ensure immutable build environment.
 RUN apk update && \
   apk upgrade && \
-  apk add make=4.4.1-r2 && \
+  apk add make && \
   apk add python3 && \
   apk add g++=13.2.1_git20240309-r0 && \
   apk add git=2.45.2-r0 && \

--- a/sources/packages/forms/Dockerfile.dev
+++ b/sources/packages/forms/Dockerfile.dev
@@ -9,7 +9,7 @@ ARG FORMIO_SOURCE_REPO_TAG
 RUN apk update && \
   apk upgrade && \
   apk add make=4.4.1-r2 && \
-  apk add python3=3.12.6-r0 && \
+  apk add python3 && \
   apk add g++=13.2.1_git20240309-r0 && \
   apk add git=2.45.2-r0 && \
   apk cache clean


### PR DESCRIPTION
- Added `limitWeeklyBooksAndSupplies` to `dmnPartTimeProgramYearMaximums`:
![image](https://github.com/user-attachments/assets/959b8854-00b7-41c6-90a4-679652e3b476)

- Changed calculatedDataProgramRelatedCosts to check the minimum between `offeringProgramRelatedCosts` and `dmnPartTimeProgramYearMaximums.limitWeeklyBooksAndSupplies * offeringWeeks`:
![image](https://github.com/user-attachments/assets/dd532458-f62f-4f1f-8ddb-9bbebb3b67f0)

- Added offering delivery "blended" to allow  `calculatedDataWeeklyMinTransport` to receive `dmnPartTimeProgramYearMaximums.limitTransportationAllowance`:
![image](https://github.com/user-attachments/assets/91af34e3-10fb-477c-8285-6c48a0706f9b)

- Added offering delivery "blended" to allow  `inputDataRemainingTransportWeeks` to receive the value of `offeringWeeks - calculatedDataAdditionalTransportWeeks`
![image](https://github.com/user-attachments/assets/7d91447b-4025-4450-b97e-6712d383334c)

- Added offering delivery "blended" to allow  `calculatedDataTotalTransportationAllowance` to receive the value of `offeringWeeks * dmnPartTimeProgramYearMaximums.limitTransportationAllowance`
![image](https://github.com/user-attachments/assets/640c0d8e-351d-4063-871e-aa3b51715881)


- Added tests to check program related costs impacted by books and supply costs;
- Added tests to check transportation costs when the offering delivery is blended;
- Added `calculatedDataTotalAssessedNeed` to [assessment.model.ts](https://github.com/bcgov/SIMS/pull/3771/files#diff-4cbd9602bdc302ca9d2093481096678ec9bdeada644a88152a74124fa413c49f) as this variable has a typo for FT and it is correct for PT. Added a TODO to be done in another ticket;
- Removed the python3 and make versions to fix a problem with local forms container (not related to this ticket).