### PR TITLE
#2979 - Email notification - PD/PPD Student reminder email 8 weeks before end date Hotfix

### DIFF
--- a/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/student-application-notifications/_tests_/student-application-notifications.scheduler.e2e-spec.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/student-application-notifications/_tests_/student-application-notifications.scheduler.e2e-spec.ts
@@ -64,7 +64,7 @@ describe(
           db.dataSource,
           { student },
           {
-            applicationStatus: ApplicationStatus.Completed,
+            applicationStatus: ApplicationStatus.Assessment,
             currentAssessmentInitialValues: {
               workflowData: {
                 calculatedData: {
@@ -135,7 +135,7 @@ describe(
           db.dataSource,
           { student },
           {
-            applicationStatus: ApplicationStatus.Completed,
+            applicationStatus: ApplicationStatus.Assessment,
             currentAssessmentInitialValues: {
               workflowData: {
                 calculatedData: {
@@ -209,7 +209,7 @@ describe(
           db.dataSource,
           { student },
           {
-            applicationStatus: ApplicationStatus.Completed,
+            applicationStatus: ApplicationStatus.Assessment,
             currentAssessmentInitialValues: {
               workflowData: {
                 calculatedData: {

--- a/sources/packages/backend/apps/queue-consumers/src/services/application/application.service.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/services/application/application.service.ts
@@ -214,7 +214,7 @@ export class ApplicationService {
       .innerJoin("student.user", "user")
       .innerJoin("currentAssessment.offering", "offering")
       .where("application.applicationStatus = :applicationStatus", {
-        applicationStatus: ApplicationStatus.Completed,
+        applicationStatus: ApplicationStatus.Assessment,
       })
       .andWhere("offering.studyEndDate <= :disabilityNotificationDateLimit", {
         disabilityNotificationDateLimit,


### PR DESCRIPTION
Hot Fix for Application Status in Assessment.

- [X] Select all student applications where
  - Offerings end date within 8 weeks.
  - Applications with current disbursement pending.
  - Application not archived.
  - Remove assessments where a notification was already sent.
  - With the PD/PPD mismatch
  - Application Status is in Assessment

- [x] E2E Tests suite added, E2E tests will be added in Part 3 PR
  - [x] Ensure the email will be sent once for the same assessment.
  - x] Ensure the email will be sent again for different assessments for the same application.