### PR TITLE
#3697 - View Assessment Updates

### DIFF
--- a/sources/packages/web/src/components/common/AssessmentAwardDetails.vue
+++ b/sources/packages/web/src/components/common/AssessmentAwardDetails.vue
@@ -5,7 +5,7 @@
       v-if="isSecondDisbursementAvailable"
       class="category-header-medium secondary-color my-3"
     >
-      First Payment
+      First disbursement
     </h3>
     <v-row>
       <v-col>
@@ -141,7 +141,9 @@
   </div>
   <!-- Estimated and actual award details of second disbursement. -->
   <div v-if="isSecondDisbursementAvailable">
-    <h3 class="category-header-medium secondary-color my-3">Second Payment</h3>
+    <h3 class="category-header-medium secondary-color my-3">
+      Second disbursement
+    </h3>
     <v-row>
       <v-col>
         <content-group>

--- a/sources/packages/web/src/components/common/AwardTable.vue
+++ b/sources/packages/web/src/components/common/AwardTable.vue
@@ -59,14 +59,13 @@ export default defineComponent({
       if (awardValue === null) {
         return "-";
       }
-      // If the award in not defined at all it means that the award is not eligible and it was not
-      // part of the disbursement calculations output.
-      // '$'+ (data.disbursement.disbursement1cspt).toLocaleString('en-CA', { minimumFractionDigits: 2 })
       if (awardValue) {
         return (
           "$" + awardValue.toLocaleString("en-CA", { minimumFractionDigits: 2 })
         );
       }
+      // If the award in not defined at all it means that the award is not eligible and it was not
+      // part of the disbursement calculations output.
       return "(Not eligible)";
     };
 

--- a/sources/packages/web/src/components/common/AwardTable.vue
+++ b/sources/packages/web/src/components/common/AwardTable.vue
@@ -70,7 +70,10 @@ export default defineComponent({
     };
 
     const getAwardType = (awardType: string): string => {
-      return PartTimeAwardTypesObject[awardType];
+      if (props.offeringIntensity === OfferingIntensity.partTime) {
+        return PartTimeAwardTypesObject[awardType];
+      }
+      return awardType;
     };
 
     return {

--- a/sources/packages/web/src/components/common/AwardTable.vue
+++ b/sources/packages/web/src/components/common/AwardTable.vue
@@ -9,7 +9,7 @@
     <tbody>
       <tr v-for="award in awards" :key="award.awardType">
         <td>
-          {{ award.awardType }}
+          {{ getAwardType(award.awardType) }}
           <tooltip-icon>{{ award.description }}</tooltip-icon>
         </td>
         <td>
@@ -22,7 +22,11 @@
 <script lang="ts">
 import { PropType, defineComponent, computed } from "vue";
 import { OfferingIntensity } from "@/types";
-import { AWARDS, AwardDetail } from "@/constants/award-constants";
+import {
+  AWARDS,
+  AwardDetail,
+  PartTimeAwardTypesObject,
+} from "@/constants/award-constants";
 import { DynamicAwardValue } from "@/services/http/dto";
 
 export default defineComponent({
@@ -57,11 +61,19 @@ export default defineComponent({
       }
       // If the award in not defined at all it means that the award is not eligible and it was not
       // part of the disbursement calculations output.
-      return awardValue ?? "(Not eligible)";
+      if (awardValue) {
+        return Number(awardValue).toFixed(2);
+      }
+      return "(Not eligible)";
+    };
+
+    const getAwardType = (awardType: string): string => {
+      return PartTimeAwardTypesObject[awardType];
     };
 
     return {
       getAwardValue,
+      getAwardType,
       awards,
     };
   },

--- a/sources/packages/web/src/components/common/AwardTable.vue
+++ b/sources/packages/web/src/components/common/AwardTable.vue
@@ -48,11 +48,12 @@ export default defineComponent({
         (award) => award.offeringIntensity === props.offeringIntensity,
       ),
     );
-    const { getFormattedAwardValue } = useFormatters();
+    const { getFormattedMoneyValue } = useFormatters();
 
     const getAwardValue = (awardType: string): string | number | Date => {
-      const awardValue =
-        props.awardDetails[`${props.identifier}${awardType.toLowerCase()}`];
+      const awardValue = props.awardDetails[
+        `${props.identifier}${awardType.toLowerCase()}`
+      ] as number;
       // If the award is defined but no values are present it means that a receipt value is missing.
       if (awardValue === null) {
         return "-";
@@ -62,7 +63,7 @@ export default defineComponent({
       if (awardValue === undefined) {
         return "(Not eligible)";
       }
-      return getFormattedAwardValue(awardValue);
+      return getFormattedMoneyValue(awardValue);
     };
 
     return {

--- a/sources/packages/web/src/components/common/AwardTable.vue
+++ b/sources/packages/web/src/components/common/AwardTable.vue
@@ -61,8 +61,11 @@ export default defineComponent({
       }
       // If the award in not defined at all it means that the award is not eligible and it was not
       // part of the disbursement calculations output.
+      // '$'+ (data.disbursement.disbursement1cspt).toLocaleString('en-CA', { minimumFractionDigits: 2 })
       if (awardValue) {
-        return Number(awardValue).toFixed(2);
+        return (
+          "$" + awardValue.toLocaleString("en-CA", { minimumFractionDigits: 2 })
+        );
       }
       return "(Not eligible)";
     };

--- a/sources/packages/web/src/components/common/AwardTable.vue
+++ b/sources/packages/web/src/components/common/AwardTable.vue
@@ -9,7 +9,7 @@
     <tbody>
       <tr v-for="award in awards" :key="award.awardType">
         <td>
-          {{ getAwardType(award.awardType) }}
+          {{ award.awardTypeDisplay }}
           <tooltip-icon>{{ award.description }}</tooltip-icon>
         </td>
         <td>
@@ -22,12 +22,9 @@
 <script lang="ts">
 import { PropType, defineComponent, computed } from "vue";
 import { OfferingIntensity } from "@/types";
-import {
-  AWARDS,
-  AwardDetail,
-  PartTimeAwardTypesObject,
-} from "@/constants/award-constants";
+import { AWARDS, AwardDetail } from "@/constants/award-constants";
 import { DynamicAwardValue } from "@/services/http/dto";
+import { useFormatters } from "@/composables";
 
 export default defineComponent({
   props: {
@@ -51,6 +48,7 @@ export default defineComponent({
         (award) => award.offeringIntensity === props.offeringIntensity,
       ),
     );
+    const { getFormattedAwardValue } = useFormatters();
 
     const getAwardValue = (awardType: string): string | number | Date => {
       const awardValue =
@@ -59,26 +57,16 @@ export default defineComponent({
       if (awardValue === null) {
         return "-";
       }
-      if (awardValue) {
-        return (
-          "$" + awardValue.toLocaleString("en-CA", { minimumFractionDigits: 2 })
-        );
-      }
       // If the award in not defined at all it means that the award is not eligible and it was not
       // part of the disbursement calculations output.
-      return "(Not eligible)";
-    };
-
-    const getAwardType = (awardType: string): string => {
-      if (props.offeringIntensity === OfferingIntensity.partTime) {
-        return PartTimeAwardTypesObject[awardType];
+      if (awardValue === undefined) {
+        return "(Not eligible)";
       }
-      return awardType;
+      return getFormattedAwardValue(awardValue);
     };
 
     return {
       getAwardValue,
-      getAwardType,
       awards,
     };
   },

--- a/sources/packages/web/src/components/common/AwardTable.vue
+++ b/sources/packages/web/src/components/common/AwardTable.vue
@@ -60,10 +60,9 @@ export default defineComponent({
       }
       // If the award in not defined at all it means that the award is not eligible and it was not
       // part of the disbursement calculations output.
-      if (awardValue === undefined) {
-        return "(Not eligible)";
-      }
-      return getFormattedMoneyValue(awardValue);
+      return awardValue === undefined
+        ? "(Not eligible)"
+        : getFormattedMoneyValue(awardValue);
     };
 
     return {

--- a/sources/packages/web/src/components/common/students/applicationDetails/AssessmentAward.vue
+++ b/sources/packages/web/src/components/common/students/applicationDetails/AssessmentAward.vue
@@ -1,7 +1,7 @@
 <template>
   <body-header
-    title="Summary"
-    subTitle="Below is the summary from your assessment. To view your entire assessment, click on View assessment."
+    title="Funding summary"
+    subTitle="Below is the summary from your assessment. To view your Notice of Assessment, click on view assessment"
   >
     <template #actions>
       <v-btn

--- a/sources/packages/web/src/components/common/students/applicationDetails/AssessmentAward.vue
+++ b/sources/packages/web/src/components/common/students/applicationDetails/AssessmentAward.vue
@@ -1,7 +1,7 @@
 <template>
   <body-header
     title="Funding summary"
-    subTitle="Below is the summary from your assessment. To view your Notice of Assessment, click on view assessment"
+    subTitle="Below is the summary from your assessment. To view your Notice of Assessment, click on view assessment."
   >
     <template #actions>
       <v-btn

--- a/sources/packages/web/src/composables/useFormatters.ts
+++ b/sources/packages/web/src/composables/useFormatters.ts
@@ -397,14 +397,12 @@ export function useFormatters() {
   };
 
   /**
-   * Format the award value to the form ##,###.00
-   * @param awardValue award value to be formatted.
-   * @returns the formatted award value.
+   * Format the money value to the form ##,###.00
+   * @param moneyValue money value to be formatted.
+   * @returns the formatted money value.
    */
-  const getFormattedAwardValue = (
-    awardValue: string | number | Date,
-  ): string => {
-    return `$${awardValue.toLocaleString("en-CA", {
+  const getFormattedMoneyValue = (moneyValue: number): string => {
+    return `$${moneyValue.toLocaleString("en-CA", {
       minimumFractionDigits: 2,
     })}`;
   };
@@ -431,6 +429,6 @@ export function useFormatters() {
     isBeforeDateOnly,
     disabilityStatusToDisplay,
     applicationDisabilityStatusToDisplay,
-    getFormattedAwardValue,
+    getFormattedMoneyValue,
   };
 }

--- a/sources/packages/web/src/composables/useFormatters.ts
+++ b/sources/packages/web/src/composables/useFormatters.ts
@@ -396,6 +396,19 @@ export function useFormatters() {
     return "No disability funding types included on assessment.";
   };
 
+  /**
+   * Format the award value to the form ##,###.00
+   * @param awardValue award value to be formatted.
+   * @returns the formatted award value.
+   */
+  const getFormattedAwardValue = (
+    awardValue: string | number | Date,
+  ): string => {
+    return `$${awardValue.toLocaleString("en-CA", {
+      minimumFractionDigits: 2,
+    })}`;
+  };
+
   return {
     dateOnlyLongString,
     dateOnlyLongPeriodString,
@@ -418,5 +431,6 @@ export function useFormatters() {
     isBeforeDateOnly,
     disabilityStatusToDisplay,
     applicationDisabilityStatusToDisplay,
+    getFormattedAwardValue,
   };
 }

--- a/sources/packages/web/src/constants/award-constants.ts
+++ b/sources/packages/web/src/constants/award-constants.ts
@@ -55,7 +55,7 @@ export const AWARDS: AwardDetail[] = [
   },
   {
     awardType: PartTimeAwardTypes.CSLP,
-    description: "Canada Student Loan for Part-Time Students",
+    description: "Canada Student Loan for Part-time Students",
     offeringIntensity: OfferingIntensity.partTime,
   },
   {

--- a/sources/packages/web/src/constants/award-constants.ts
+++ b/sources/packages/web/src/constants/award-constants.ts
@@ -2,6 +2,7 @@ import { OfferingIntensity } from "@/types";
 
 export interface AwardDetail {
   awardType: FullTimeAwardTypes | PartTimeAwardTypes;
+  awardTypeDisplay: string;
   description: string;
   offeringIntensity: OfferingIntensity;
 }
@@ -27,89 +28,104 @@ export enum PartTimeAwardTypes {
   SBSD = "SBSD",
 }
 
+enum PartTimeAwardTypeDisplays {
+  CSLP = "CSL-PT",
+  CSGP = "CSG-PD",
+  CSPT = "CSG-PT",
+  CSGD = "CSG-PTDEP",
+  BCAG = "BCAG-PT",
+  SBSD = "SBSD",
+}
+
 export const AWARDS: AwardDetail[] = [
   {
     awardType: FullTimeAwardTypes.CSLF,
+    awardTypeDisplay: FullTimeAwardTypes.CSLF,
     description: "Canada Student Loan for Full-time Studies",
     offeringIntensity: OfferingIntensity.fullTime,
   },
   {
     awardType: FullTimeAwardTypes.CSGP,
+    awardTypeDisplay: FullTimeAwardTypes.CSGP,
     description: "Canada Student Grant for Student with Permanent Disability",
     offeringIntensity: OfferingIntensity.fullTime,
   },
   {
     awardType: FullTimeAwardTypes.CSGD,
+    awardTypeDisplay: FullTimeAwardTypes.CSGD,
     description: "Canada Student Grant for Students with Dependents",
     offeringIntensity: OfferingIntensity.fullTime,
   },
   {
     awardType: FullTimeAwardTypes.CSGF,
+    awardTypeDisplay: FullTimeAwardTypes.CSGF,
     description: "Canada Student Grant for Full-time Studies",
     offeringIntensity: OfferingIntensity.fullTime,
   },
   {
     awardType: FullTimeAwardTypes.CSGT,
+    awardTypeDisplay: FullTimeAwardTypes.CSGT,
     description: "Canada Student Grant for Full-time Top-up",
     offeringIntensity: OfferingIntensity.fullTime,
   },
   {
-    awardType: PartTimeAwardTypes.CSLP,
-    description: "Canada Student Loan for Part-time Students",
-    offeringIntensity: OfferingIntensity.partTime,
-  },
-  {
-    awardType: PartTimeAwardTypes.CSGP,
-    description: "Canada Student Grant for Students with Disabilities",
-    offeringIntensity: OfferingIntensity.partTime,
-  },
-  {
-    awardType: PartTimeAwardTypes.CSPT,
-    description: "Canada Student Grant for Part-time Students",
-    offeringIntensity: OfferingIntensity.partTime,
-  },
-  {
-    awardType: PartTimeAwardTypes.CSGD,
-    description: "Canada Student Grant for Students with Dependants",
-    offeringIntensity: OfferingIntensity.partTime,
-  },
-  {
     awardType: FullTimeAwardTypes.BCSL,
+    awardTypeDisplay: FullTimeAwardTypes.BCSL,
     description: "B.C. Student Loan",
     offeringIntensity: OfferingIntensity.fullTime,
   },
   {
     awardType: FullTimeAwardTypes.BCAG,
+    awardTypeDisplay: FullTimeAwardTypes.BCAG,
     description: "B.C. Access Grant",
     offeringIntensity: OfferingIntensity.fullTime,
   },
   {
     awardType: FullTimeAwardTypes.BGPD,
+    awardTypeDisplay: FullTimeAwardTypes.BGPD,
     description: "B.C. Permanent Disability Grant",
     offeringIntensity: OfferingIntensity.fullTime,
   },
   {
     awardType: FullTimeAwardTypes.SBSD,
+    awardTypeDisplay: FullTimeAwardTypes.SBSD,
     description: "B.C. Supplemental Bursary with Disabilities",
     offeringIntensity: OfferingIntensity.fullTime,
   },
   {
+    awardType: PartTimeAwardTypes.CSGP,
+    awardTypeDisplay: PartTimeAwardTypeDisplays.CSGP,
+    description: "Canada Student Grant for Students with Disabilities",
+    offeringIntensity: OfferingIntensity.partTime,
+  },
+  {
+    awardType: PartTimeAwardTypes.CSPT,
+    awardTypeDisplay: PartTimeAwardTypeDisplays.CSPT,
+    description: "Canada Student Grant for Part-time Students",
+    offeringIntensity: OfferingIntensity.partTime,
+  },
+  {
+    awardType: PartTimeAwardTypes.CSGD,
+    awardTypeDisplay: PartTimeAwardTypeDisplays.CSGD,
+    description: "Canada Student Grant for Students with Dependants",
+    offeringIntensity: OfferingIntensity.partTime,
+  },
+  {
     awardType: PartTimeAwardTypes.BCAG,
+    awardTypeDisplay: PartTimeAwardTypeDisplays.BCAG,
     description: "B.C. Access Grant for Part-time Studies",
     offeringIntensity: OfferingIntensity.partTime,
   },
   {
+    awardType: PartTimeAwardTypes.CSLP,
+    awardTypeDisplay: PartTimeAwardTypeDisplays.CSLP,
+    description: "Canada Student Loan for Part-time Students",
+    offeringIntensity: OfferingIntensity.partTime,
+  },
+  {
     awardType: PartTimeAwardTypes.SBSD,
+    awardTypeDisplay: PartTimeAwardTypeDisplays.SBSD,
     description: "B.C. Supplemental Bursary for Students with Disabilities",
     offeringIntensity: OfferingIntensity.partTime,
   },
 ];
-
-export const PartTimeAwardTypesObject = {
-  CSLP: "CSL-PT",
-  CSGP: "CSG-PD",
-  CSPT: "CSG-PT",
-  CSGD: "CSG-PTDEP",
-  BCAG: "BCAG-PT",
-  SBSD: "SBSD",
-};

--- a/sources/packages/web/src/constants/award-constants.ts
+++ b/sources/packages/web/src/constants/award-constants.ts
@@ -115,7 +115,7 @@ export const AWARDS: AwardDetail[] = [
   },
   {
     awardType: PartTimeAwardTypes.SBSD,
-    awardTypeDisplay: "SBSD",
+    awardTypeDisplay: PartTimeAwardTypes.SBSD,
     description: "B.C. Supplemental Bursary for Students with Disabilities",
     offeringIntensity: OfferingIntensity.partTime,
   },

--- a/sources/packages/web/src/constants/award-constants.ts
+++ b/sources/packages/web/src/constants/award-constants.ts
@@ -55,22 +55,22 @@ export const AWARDS: AwardDetail[] = [
   },
   {
     awardType: PartTimeAwardTypes.CSLP,
-    description: "Canada Student Loan for Part-time Studies",
+    description: "Canada Student Loan for Part-Time Students",
     offeringIntensity: OfferingIntensity.partTime,
   },
   {
     awardType: PartTimeAwardTypes.CSGP,
-    description: "Canada Student Grant for Student with Permanent Disability",
+    description: "Canada Student Grant for Students with Disabilities",
     offeringIntensity: OfferingIntensity.partTime,
   },
   {
     awardType: PartTimeAwardTypes.CSPT,
-    description: "Canada Student Grant for Part-time Studies",
+    description: "Canada Student Grant for Part-time Students",
     offeringIntensity: OfferingIntensity.partTime,
   },
   {
     awardType: PartTimeAwardTypes.CSGD,
-    description: "Canada Student Grant for Students with Dependents",
+    description: "Canada Student Grant for Students with Dependants",
     offeringIntensity: OfferingIntensity.partTime,
   },
   {
@@ -95,12 +95,21 @@ export const AWARDS: AwardDetail[] = [
   },
   {
     awardType: PartTimeAwardTypes.BCAG,
-    description: "B.C. Access Grant",
+    description: "B.C. Access Grant for Part-time Studies",
     offeringIntensity: OfferingIntensity.partTime,
   },
   {
     awardType: PartTimeAwardTypes.SBSD,
-    description: "B.C. Supplemental Bursary with Disabilities",
+    description: "B.C. Supplemental Bursary for Students with Disabilities",
     offeringIntensity: OfferingIntensity.partTime,
   },
 ];
+
+export const PartTimeAwardTypesObject = {
+  CSLP: "CSL-PT",
+  CSGP: "CSG-PD",
+  CSPT: "CSG-PT",
+  CSGD: "CSG-PTDEP",
+  BCAG: "BCAG-PT",
+  SBSD: "SBSD",
+};

--- a/sources/packages/web/src/constants/award-constants.ts
+++ b/sources/packages/web/src/constants/award-constants.ts
@@ -28,15 +28,6 @@ export enum PartTimeAwardTypes {
   SBSD = "SBSD",
 }
 
-enum PartTimeAwardTypeDisplays {
-  CSLP = "CSL-PT",
-  CSGP = "CSG-PD",
-  CSPT = "CSG-PT",
-  CSGD = "CSG-PTDEP",
-  BCAG = "BCAG-PT",
-  SBSD = "SBSD",
-}
-
 export const AWARDS: AwardDetail[] = [
   {
     awardType: FullTimeAwardTypes.CSLF,
@@ -94,37 +85,37 @@ export const AWARDS: AwardDetail[] = [
   },
   {
     awardType: PartTimeAwardTypes.CSGP,
-    awardTypeDisplay: PartTimeAwardTypeDisplays.CSGP,
+    awardTypeDisplay: "CSG-PD",
     description: "Canada Student Grant for Students with Disabilities",
     offeringIntensity: OfferingIntensity.partTime,
   },
   {
     awardType: PartTimeAwardTypes.CSPT,
-    awardTypeDisplay: PartTimeAwardTypeDisplays.CSPT,
+    awardTypeDisplay: "CSG-PT",
     description: "Canada Student Grant for Part-time Students",
     offeringIntensity: OfferingIntensity.partTime,
   },
   {
     awardType: PartTimeAwardTypes.CSGD,
-    awardTypeDisplay: PartTimeAwardTypeDisplays.CSGD,
+    awardTypeDisplay: "CSG-PTDEP",
     description: "Canada Student Grant for Students with Dependants",
     offeringIntensity: OfferingIntensity.partTime,
   },
   {
     awardType: PartTimeAwardTypes.BCAG,
-    awardTypeDisplay: PartTimeAwardTypeDisplays.BCAG,
+    awardTypeDisplay: "BCAG-PT",
     description: "B.C. Access Grant for Part-time Studies",
     offeringIntensity: OfferingIntensity.partTime,
   },
   {
     awardType: PartTimeAwardTypes.CSLP,
-    awardTypeDisplay: PartTimeAwardTypeDisplays.CSLP,
+    awardTypeDisplay: "CSL-PT",
     description: "Canada Student Loan for Part-time Students",
     offeringIntensity: OfferingIntensity.partTime,
   },
   {
     awardType: PartTimeAwardTypes.SBSD,
-    awardTypeDisplay: PartTimeAwardTypeDisplays.SBSD,
+    awardTypeDisplay: "SBSD",
     description: "B.C. Supplemental Bursary for Students with Disabilities",
     offeringIntensity: OfferingIntensity.partTime,
   },


### PR DESCRIPTION
- Revised "Summary" to "Funding summary"
- Revised "To view your entire assessment....." to "To view your Notice of Assessment, click on view assessment".
- Format all values: $##,###.00
- Updated the following grant names, reorder based on the list below, apply changes to both estimated and final award.
  - CSGP
    - Revised "CSGP" to "CSG-PD"
    - Updated tooltip: "Canada Student Grant for Students with Disabilities"
  - CSPT
    - Revised "CSPT" to "CSG-PT"
    - Updated tooltip: "Canada Student Grant for Part-time Students"
  - CSGD
    - Revised "CSGD" to "CSG-PTDEP"
    - Updated tooltip: "Canada Student Grant for Students with Dependants"
  - BCAG
    - Revised "BCAG" to "BCAG-PT"
    - Updated tooltip: "B.C. Access Grant for Part-time Studies"
  - CSLP
    - Revise: "CSLP" to "CSL-PT"
    - Updated tooltip: "Canada Student Loan for Part-Time Students"
  - SBSD
    - Updated SBSD tooltip: "B.C. Supplemental Bursary for Students with Disabilities"

Screenshot for the first disbursement for part-time applications
![image](https://github.com/user-attachments/assets/66fa331e-e42b-41f8-92a7-4f84335fbec0)

Screenshot for the first disbursement for full-time applications
![image](https://github.com/user-attachments/assets/ce97974d-2d7e-4265-992e-3df8454c18f3)