### PR TITLE
#2741 - Ministry Filter Search Programs and Offerings [Location and Program Status Search]

### DIFF
--- a/sims.code-workspace
+++ b/sims.code-workspace
@@ -111,6 +111,7 @@
       "ESDC",
       "Formio",
       "golevelup",
+      "Ilike",
       "lastupdated",
       "MBAL",
       "MSFAA",

--- a/sources/packages/backend/apps/api/src/route-controllers/education-program/education-program.controller.service.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/education-program/education-program.controller.service.ts
@@ -18,7 +18,11 @@ import {
   EducationProgramsSummaryAPIOutDTO,
   EducationProgramAPIInDTO,
 } from "./models/education-program.dto";
-import { credentialTypeToDisplay, getUserFullName } from "../../utilities";
+import {
+  credentialTypeToDisplay,
+  getUserFullName,
+  PaginatedResults,
+} from "../../utilities";
 import { CustomNamedError, getISODateOnlyString } from "@sims/utilities";
 import { FormNames } from "../../services/form/constants";
 import {
@@ -27,7 +31,10 @@ import {
   EDUCATION_PROGRAM_INVALID_OPERATION,
 } from "../../constants";
 import { ApiProcessError } from "../../types";
-import { SaveEducationProgram } from "../../services/education-program/education-program.service.models";
+import {
+  EducationProgramsSummary,
+  SaveEducationProgram,
+} from "../../services/education-program/education-program.service.models";
 import { InstitutionService } from "../../services/institution/institution.service";
 
 @Injectable()
@@ -52,12 +59,21 @@ export class EducationProgramControllerService {
     paginationOptions: ProgramsPaginationOptionsAPIInDTO,
     locationId?: number,
   ): Promise<PaginatedResultsAPIOutDTO<EducationProgramsSummaryAPIOutDTO>> {
-    const programs = await this.programService.getProgramsSummary(
-      institutionId,
-      [OfferingTypes.Public, OfferingTypes.Private],
-      paginationOptions,
-      locationId,
-    );
+    let programs: PaginatedResults<EducationProgramsSummary>;
+    if (locationId) {
+      programs = await this.programService.getProgramsSummaryForLocation(
+        institutionId,
+        [OfferingTypes.Public, OfferingTypes.Private],
+        paginationOptions,
+        locationId,
+      );
+    } else {
+      programs = await this.programService.getProgramsSummary(
+        institutionId,
+        [OfferingTypes.Public, OfferingTypes.Private],
+        paginationOptions,
+      );
+    }
 
     return {
       results: programs.results.map((program) => ({

--- a/sources/packages/backend/apps/api/src/route-controllers/models/pagination.dto.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/models/pagination.dto.ts
@@ -1,6 +1,7 @@
 import { IsEnum, IsIn, IsOptional, Max, MaxLength, Min } from "class-validator";
 import { PAGINATION_SEARCH_MAX_LENGTH } from "../../constants";
 import { FieldSortOrder } from "@sims/utilities";
+import { ProgramStatus } from "@sims/sims-db";
 
 /**
  * Common parameters used when an API result
@@ -77,6 +78,15 @@ export class ProgramsPaginationOptionsAPIInDTO extends PaginationOptionsAPIInDTO
   @IsOptional()
   @IsIn(["submittedDate", "programName", "credentialType"])
   sortField?: string;
+  @IsOptional()
+  @MaxLength(PAGINATION_SEARCH_MAX_LENGTH)
+  programNameSearch?: string;
+  @IsOptional()
+  @MaxLength(PAGINATION_SEARCH_MAX_LENGTH)
+  locationNameSearch?: string;
+  @IsOptional()
+  @IsIn([ProgramStatus.Approved, ProgramStatus.Declined, ProgramStatus.Pending])
+  status?: string;
 }
 
 export class OfferingsPaginationOptionsAPIInDTO extends PaginationOptionsAPIInDTO {

--- a/sources/packages/backend/apps/api/src/route-controllers/models/pagination.dto.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/models/pagination.dto.ts
@@ -12,7 +12,7 @@ import { PAGINATION_SEARCH_MAX_LENGTH } from "../../constants";
 import { FieldSortOrder } from "@sims/utilities";
 import { ProgramStatus } from "@sims/sims-db";
 import { Transform } from "class-transformer";
-import { ToBoolean } from "apps/api/src/utilities/class-transform";
+import { ToBoolean } from "../../utilities/class-transform";
 
 /**
  * Common parameters used when an API result

--- a/sources/packages/backend/apps/api/src/route-controllers/models/pagination.dto.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/models/pagination.dto.ts
@@ -104,6 +104,7 @@ export class ProgramsPaginationOptionsAPIInDTO extends PaginationOptionsAPIInDTO
   @IsArray()
   @IsOptional()
   @Transform(({ value }) => value.split(","))
+  @IsEnum(ProgramStatus, { each: true })
   statusSearch?: ProgramStatus[];
   @IsOptional()
   @IsBoolean()

--- a/sources/packages/backend/apps/api/src/route-controllers/models/pagination.dto.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/models/pagination.dto.ts
@@ -1,7 +1,18 @@
-import { IsEnum, IsIn, IsOptional, Max, MaxLength, Min } from "class-validator";
+import {
+  IsArray,
+  IsBoolean,
+  IsEnum,
+  IsIn,
+  IsOptional,
+  Max,
+  MaxLength,
+  Min,
+} from "class-validator";
 import { PAGINATION_SEARCH_MAX_LENGTH } from "../../constants";
 import { FieldSortOrder } from "@sims/utilities";
 import { ProgramStatus } from "@sims/sims-db";
+import { Transform } from "class-transformer";
+import { ToBoolean } from "apps/api/src/utilities/class-transform";
 
 /**
  * Common parameters used when an API result
@@ -76,7 +87,13 @@ export class StudentAppealPendingPaginationOptionsAPIInDTO extends PaginationOpt
 
 export class ProgramsPaginationOptionsAPIInDTO extends PaginationOptionsAPIInDTO {
   @IsOptional()
-  @IsIn(["submittedDate", "programName", "credentialType"])
+  @IsIn([
+    "submittedDate",
+    "programName",
+    "locationName",
+    "programStatus",
+    "credentialType",
+  ])
   sortField?: string;
   @IsOptional()
   @MaxLength(PAGINATION_SEARCH_MAX_LENGTH)
@@ -84,9 +101,14 @@ export class ProgramsPaginationOptionsAPIInDTO extends PaginationOptionsAPIInDTO
   @IsOptional()
   @MaxLength(PAGINATION_SEARCH_MAX_LENGTH)
   locationNameSearch?: string;
+  @IsArray()
   @IsOptional()
-  @IsIn([ProgramStatus.Approved, ProgramStatus.Declined, ProgramStatus.Pending])
-  status?: string;
+  @Transform(({ value }) => value.split(","))
+  statusSearch?: ProgramStatus[];
+  @IsOptional()
+  @IsBoolean()
+  @ToBoolean()
+  inactiveProgramSearch?: boolean;
 }
 
 export class OfferingsPaginationOptionsAPIInDTO extends PaginationOptionsAPIInDTO {

--- a/sources/packages/backend/apps/api/src/services/education-program/constants.ts
+++ b/sources/packages/backend/apps/api/src/services/education-program/constants.ts
@@ -1,0 +1,2 @@
+export const OTHER_REGULATORY_BODY = "other";
+export const INACTIVE_PROGRAM_STATUS = "Inactive";

--- a/sources/packages/backend/apps/api/src/services/education-program/constants.ts
+++ b/sources/packages/backend/apps/api/src/services/education-program/constants.ts
@@ -1,2 +1,2 @@
 export const OTHER_REGULATORY_BODY = "other";
-export const INACTIVE_PROGRAM_STATUS = "Inactive";
+export const INACTIVE_PROGRAM = "Inactive";

--- a/sources/packages/backend/apps/api/src/services/education-program/education-program.service.ts
+++ b/sources/packages/backend/apps/api/src/services/education-program/education-program.service.ts
@@ -301,16 +301,6 @@ export class EducationProgramService extends RecordDataModelService<EducationPro
       });
       queryParams.push(`%${paginationOptions.locationNameSearch}%`);
     }
-    // Fix for the scenario when the status search array is empty
-    // but still shows up as [''] in the route controller handler
-    // after the transformation and validation pipes have operated
-    // on the input parameters.
-    if (
-      paginationOptions.statusSearch.length === 1 &&
-      paginationOptions.statusSearch[0] === ("" as ProgramStatus)
-    ) {
-      paginationOptions.statusSearch = undefined;
-    }
     // When both the status search and inactive search is false, nothing is returned.
     if (
       !paginationOptions.statusSearch &&

--- a/sources/packages/backend/apps/api/src/services/education-program/education-program.service.ts
+++ b/sources/packages/backend/apps/api/src/services/education-program/education-program.service.ts
@@ -394,7 +394,7 @@ export class EducationProgramService extends RecordDataModelService<EducationPro
       queryParams.push(!multiSearchPaginationOptions.inactiveProgramSearch);
     } else if (!locationId && multiSearchPaginationOptions.statusSearch) {
       paginatedProgramQuery.andWhere(
-        "programs.programStatus IN (:...programStatusSearchCriteria)",
+        "programs.programStatus IN (:...programStatusSearchCriteria) and programs.isActive = true",
         {
           programStatusSearchCriteria:
             multiSearchPaginationOptions.statusSearch,

--- a/sources/packages/backend/apps/api/src/services/education-program/education-program.service.ts
+++ b/sources/packages/backend/apps/api/src/services/education-program/education-program.service.ts
@@ -58,7 +58,7 @@ import {
   NotificationActionsService,
 } from "@sims/services";
 import {
-  INACTIVE_PROGRAM_STATUS,
+  INACTIVE_PROGRAM,
   OTHER_REGULATORY_BODY,
 } from "../education-program/constants";
 
@@ -901,7 +901,7 @@ export class EducationProgramService extends RecordDataModelService<EducationPro
     // sort
     if (paginationOptions.sortField === "programStatus") {
       paginatedProgramQuery.orderBy(
-        `CASE WHEN programs.isActive = false THEN '${INACTIVE_PROGRAM_STATUS}' ELSE programs.programStatus :: text end`,
+        `CASE WHEN programs.isActive = false THEN '${INACTIVE_PROGRAM}' ELSE programs.programStatus :: text END`,
         paginationOptions.sortOrder,
       );
     } else if (paginationOptions.sortField && paginationOptions.sortOrder) {

--- a/sources/packages/backend/apps/api/src/services/education-program/education-program.service.ts
+++ b/sources/packages/backend/apps/api/src/services/education-program/education-program.service.ts
@@ -353,7 +353,22 @@ export class EducationProgramService extends RecordDataModelService<EducationPro
       );
       queryParams.push(`%${multiSearchPaginationOptions.locationNameSearch}%`);
     }
-
+    if (
+      multiSearchPaginationOptions.statusSearch.length === 1 &&
+      multiSearchPaginationOptions.statusSearch[0] === ("" as ProgramStatus)
+    ) {
+      multiSearchPaginationOptions.statusSearch = undefined;
+    }
+    if (
+      !locationId &&
+      !multiSearchPaginationOptions.statusSearch &&
+      !multiSearchPaginationOptions.inactiveProgramSearch
+    ) {
+      return {
+        results: [],
+        count: 0,
+      };
+    }
     if (
       !locationId &&
       multiSearchPaginationOptions.statusSearch &&

--- a/sources/packages/backend/apps/api/src/services/education-program/education-program.service.ts
+++ b/sources/packages/backend/apps/api/src/services/education-program/education-program.service.ts
@@ -335,6 +335,8 @@ export class EducationProgramService extends RecordDataModelService<EducationPro
       });
       queryParams.push(`%${singleSearchPaginationOptions.searchCriteria}%`);
     }
+
+    // Program name search.
     if (!locationId && multiSearchPaginationOptions.programNameSearch) {
       paginatedProgramQuery.andWhere(
         "programs.name Ilike :programNameSearchCriteria",
@@ -344,6 +346,7 @@ export class EducationProgramService extends RecordDataModelService<EducationPro
       );
       queryParams.push(`%${multiSearchPaginationOptions.programNameSearch}%`);
     }
+    // Location name search.
     if (!locationId && multiSearchPaginationOptions.locationNameSearch) {
       paginatedProgramQuery.andWhere(
         "location.name Ilike :locationNameSearchCriteria",
@@ -353,12 +356,17 @@ export class EducationProgramService extends RecordDataModelService<EducationPro
       );
       queryParams.push(`%${multiSearchPaginationOptions.locationNameSearch}%`);
     }
+    // Fix for the scenario when the status search array is empty
+    // but still shows up as [''] in the route controller handler
+    // after the transformation and validation pipes have operated
+    // on the input parameters.
     if (
       multiSearchPaginationOptions.statusSearch.length === 1 &&
       multiSearchPaginationOptions.statusSearch[0] === ("" as ProgramStatus)
     ) {
       multiSearchPaginationOptions.statusSearch = undefined;
     }
+    // When both the status search and inactive search is false, nothing is returned.
     if (
       !locationId &&
       !multiSearchPaginationOptions.statusSearch &&
@@ -369,6 +377,9 @@ export class EducationProgramService extends RecordDataModelService<EducationPro
         count: 0,
       };
     }
+    // When the status search and inactive both are true,
+    // then fetch the inactive programs along with the ones
+    // from the program status list.
     if (
       !locationId &&
       multiSearchPaginationOptions.statusSearch &&
@@ -392,7 +403,9 @@ export class EducationProgramService extends RecordDataModelService<EducationPro
       );
       queryParams.push(...multiSearchPaginationOptions.statusSearch);
       queryParams.push(!multiSearchPaginationOptions.inactiveProgramSearch);
-    } else if (!locationId && multiSearchPaginationOptions.statusSearch) {
+    }
+    // Fetching only the active programs with the provided program status.
+    else if (!locationId && multiSearchPaginationOptions.statusSearch) {
       paginatedProgramQuery.andWhere(
         "programs.programStatus IN (:...programStatusSearchCriteria) and programs.isActive = true",
         {
@@ -401,7 +414,9 @@ export class EducationProgramService extends RecordDataModelService<EducationPro
         },
       );
       queryParams.push(...multiSearchPaginationOptions.statusSearch);
-    } else if (
+    }
+    // Fetching only the inactive status programs.
+    else if (
       !locationId &&
       multiSearchPaginationOptions.inactiveProgramSearch
     ) {

--- a/sources/packages/backend/apps/api/src/services/education-program/education-program.service.ts
+++ b/sources/packages/backend/apps/api/src/services/education-program/education-program.service.ts
@@ -897,7 +897,33 @@ export class EducationProgramService extends RecordDataModelService<EducationPro
     );
 
     // sort
-    if (paginationOptions.sortField && paginationOptions.sortOrder) {
+    if (
+      paginationOptions.sortField === "programStatus" &&
+      paginationOptions.sortOrder === "DESC"
+    ) {
+      paginatedProgramQuery.orderBy(
+        `CASE          
+          WHEN programs.programStatus = '${ProgramStatus.Pending}' and programs.isActive = true THEN ${SortPriority.Priority1}
+          WHEN programs.isActive = false THEN ${SortPriority.Priority2}
+          WHEN programs.programStatus = '${ProgramStatus.Declined}' and programs.isActive = true THEN ${SortPriority.Priority3}
+          WHEN programs.programStatus = '${ProgramStatus.Approved}' and programs.isActive = true THEN ${SortPriority.Priority4}
+          ELSE ${SortPriority.Priority5}
+        END`,
+      );
+    } else if (
+      paginationOptions.sortField === "programStatus" &&
+      paginationOptions.sortOrder === "ASC"
+    ) {
+      paginatedProgramQuery.orderBy(
+        `CASE          
+          WHEN programs.programStatus = '${ProgramStatus.Approved}' and programs.isActive = true THEN ${SortPriority.Priority1}
+          WHEN programs.programStatus = '${ProgramStatus.Declined}' and programs.isActive = true THEN ${SortPriority.Priority2}
+          WHEN programs.isActive = false THEN ${SortPriority.Priority3}
+          WHEN programs.programStatus = '${ProgramStatus.Pending}' and programs.isActive = true THEN ${SortPriority.Priority4}
+          ELSE ${SortPriority.Priority5}
+        END`,
+      );
+    } else if (paginationOptions.sortField && paginationOptions.sortOrder) {
       paginatedProgramQuery.orderBy(
         sortProgramsColumnMap(paginationOptions.sortField),
         paginationOptions.sortOrder,
@@ -906,12 +932,13 @@ export class EducationProgramService extends RecordDataModelService<EducationPro
       // Default sort and order.
       // TODO:Further investigation needed as the CASE translation does not work in orderby queries.
       paginatedProgramQuery.orderBy(
-        `CASE programs.program_status
-                WHEN '${ProgramStatus.Pending}' THEN ${SortPriority.Priority1}
-                WHEN '${ProgramStatus.Approved}' THEN ${SortPriority.Priority2}
-                WHEN '${ProgramStatus.Declined}' THEN ${SortPriority.Priority3}
-                ELSE ${SortPriority.Priority4}
-              END`,
+        `CASE           
+          WHEN programs.programStatus = '${ProgramStatus.Pending}' and programs.isActive = true THEN ${SortPriority.Priority1}
+          WHEN programs.programStatus = '${ProgramStatus.Approved}' and programs.isActive = true THEN ${SortPriority.Priority2}
+          WHEN programs.programStatus = '${ProgramStatus.Declined}' and programs.isActive = true THEN ${SortPriority.Priority3}
+          WHEN programs.isActive = false THEN ${SortPriority.Priority4}
+          ELSE ${SortPriority.Priority5}
+        END`,
       );
     }
 

--- a/sources/packages/backend/apps/api/src/services/education-program/education-program.service.ts
+++ b/sources/packages/backend/apps/api/src/services/education-program/education-program.service.ts
@@ -33,9 +33,9 @@ import {
 } from "./education-program.service.models";
 import {
   sortProgramsColumnMap,
-  PaginationOptions,
   PaginatedResults,
   SortPriority,
+  ProgramPaginationOptions,
 } from "../../utilities";
 import {
   CustomNamedError,
@@ -271,14 +271,14 @@ export class EducationProgramService extends RecordDataModelService<EducationPro
    * Gets all the programs that are associated with an institution
    * alongside with the total of offerings on locations.
    * @param institutionId id of the institution.
-   * @param paginationOptions pagination options.
+   * @param paginationOptions program related pagination options.
    * @param locationId optional location id to filter.
    * @returns paginated summary for the institution or location.
    */
   async getProgramsSummary(
     institutionId: number,
     offeringTypes: OfferingTypes[],
-    paginationOptions: PaginationOptions,
+    paginationOptions: ProgramPaginationOptions,
     locationId?: number,
   ): Promise<PaginatedResults<EducationProgramsSummary>> {
     const paginatedProgramQuery = this.repo
@@ -330,6 +330,33 @@ export class EducationProgramService extends RecordDataModelService<EducationPro
         searchCriteria: `%${paginationOptions.searchCriteria}%`,
       });
       queryParams.push(`%${paginationOptions.searchCriteria}%`);
+    }
+    if (paginationOptions.programNameSearch) {
+      paginatedProgramQuery.andWhere(
+        "programs.name Ilike :programNameSearchCriteria",
+        {
+          programNameSearchCriteria: `%${paginationOptions.programNameSearch}%`,
+        },
+      );
+      queryParams.push(`%${paginationOptions.programNameSearch}%`);
+    }
+    if (paginationOptions.locationNameSearch) {
+      paginatedProgramQuery.andWhere(
+        "location.name Ilike :locationNameSearchCriteria",
+        {
+          locationNameSearchCriteria: `%${paginationOptions.locationNameSearch}%`,
+        },
+      );
+      queryParams.push(`%${paginationOptions.locationNameSearch}%`);
+    }
+    if (paginationOptions.status) {
+      paginatedProgramQuery.andWhere(
+        "programs.programStatus Ilike :programStatusSearchCriteria",
+        {
+          programStatusSearchCriteria: `%${paginationOptions.status}%`,
+        },
+      );
+      queryParams.push(`%${paginationOptions.status}%`);
     }
 
     // For getting total raw count before pagination.

--- a/sources/packages/backend/apps/api/src/services/education-program/education-program.service.ts
+++ b/sources/packages/backend/apps/api/src/services/education-program/education-program.service.ts
@@ -335,7 +335,7 @@ export class EducationProgramService extends RecordDataModelService<EducationPro
       });
       queryParams.push(`%${singleSearchPaginationOptions.searchCriteria}%`);
     }
-    if (multiSearchPaginationOptions.programNameSearch) {
+    if (!locationId && multiSearchPaginationOptions.programNameSearch) {
       paginatedProgramQuery.andWhere(
         "programs.name Ilike :programNameSearchCriteria",
         {
@@ -344,7 +344,7 @@ export class EducationProgramService extends RecordDataModelService<EducationPro
       );
       queryParams.push(`%${multiSearchPaginationOptions.programNameSearch}%`);
     }
-    if (multiSearchPaginationOptions.locationNameSearch) {
+    if (!locationId && multiSearchPaginationOptions.locationNameSearch) {
       paginatedProgramQuery.andWhere(
         "location.name Ilike :locationNameSearchCriteria",
         {
@@ -355,11 +355,9 @@ export class EducationProgramService extends RecordDataModelService<EducationPro
     }
 
     if (
-      (!locationId &&
-        multiSearchPaginationOptions.statusSearch &&
-        multiSearchPaginationOptions.inactiveProgramSearch) ||
-      (!multiSearchPaginationOptions.statusSearch &&
-        !multiSearchPaginationOptions.inactiveProgramSearch)
+      !locationId &&
+      multiSearchPaginationOptions.statusSearch &&
+      multiSearchPaginationOptions.inactiveProgramSearch
     ) {
       paginatedProgramQuery.andWhere(
         new Brackets((qb) =>

--- a/sources/packages/backend/apps/api/src/utilities/datatable-config.ts
+++ b/sources/packages/backend/apps/api/src/utilities/datatable-config.ts
@@ -33,4 +33,5 @@ export enum SortPriority {
   Priority2 = 2,
   Priority3 = 3,
   Priority4 = 4,
+  Priority5 = 5,
 }

--- a/sources/packages/backend/apps/api/src/utilities/datatable-config.ts
+++ b/sources/packages/backend/apps/api/src/utilities/datatable-config.ts
@@ -1,3 +1,4 @@
+import { ProgramStatus } from "@sims/sims-db";
 import { FieldSortOrder } from "@sims/utilities";
 
 /**
@@ -23,7 +24,7 @@ export interface PaginationOptions extends BasePaginationOptions {
 export interface ProgramPaginationOptions extends BasePaginationOptions {
   programNameSearch?: string;
   locationNameSearch?: string;
-  statusSearch?: string;
+  statusSearch?: ProgramStatus[];
   inactiveProgramSearch?: boolean;
 }
 

--- a/sources/packages/backend/apps/api/src/utilities/datatable-config.ts
+++ b/sources/packages/backend/apps/api/src/utilities/datatable-config.ts
@@ -1,20 +1,30 @@
 import { FieldSortOrder } from "@sims/utilities";
 
 /**
- *  Pagination option.
+ *  Base Pagination option.
  */
-export interface PaginationOptions {
-  searchCriteria?: string;
+export interface BasePaginationOptions {
   sortField?: string;
   sortOrder?: FieldSortOrder;
   page: number;
   pageLimit: number;
 }
 
-export interface ProgramPaginationOptions extends PaginationOptions {
+/**
+ *  Pagination option.
+ */
+export interface PaginationOptions extends BasePaginationOptions {
+  searchCriteria?: string;
+}
+
+/**
+ * Program pagination option allowing for multiple criteria search.
+ */
+export interface ProgramPaginationOptions extends BasePaginationOptions {
   programNameSearch?: string;
   locationNameSearch?: string;
-  status?: string;
+  statusSearch?: string;
+  inactiveProgramSearch?: boolean;
 }
 
 export enum SortPriority {

--- a/sources/packages/backend/apps/api/src/utilities/datatable-config.ts
+++ b/sources/packages/backend/apps/api/src/utilities/datatable-config.ts
@@ -11,6 +11,12 @@ export interface PaginationOptions {
   pageLimit: number;
 }
 
+export interface ProgramPaginationOptions extends PaginationOptions {
+  programNameSearch?: string;
+  locationNameSearch?: string;
+  status?: string;
+}
+
 export enum SortPriority {
   Priority1 = 1,
   Priority2 = 2,

--- a/sources/packages/backend/apps/api/src/utilities/datatable-database-mapping-utils.ts
+++ b/sources/packages/backend/apps/api/src/utilities/datatable-database-mapping-utils.ts
@@ -65,6 +65,8 @@ export const sortProgramsColumnMap = (fieldName: string): string => {
     submittedDate: "programs.createdAt",
     programName: "programs.name",
     credentialType: "programs.credentialType",
+    programStatus: "programs.programStatus",
+    locationName: "location.name",
   };
   return programSortOptions[fieldName] ?? null;
 };

--- a/sources/packages/backend/apps/api/src/utilities/datatable-database-mapping-utils.ts
+++ b/sources/packages/backend/apps/api/src/utilities/datatable-database-mapping-utils.ts
@@ -65,7 +65,6 @@ export const sortProgramsColumnMap = (fieldName: string): string => {
     submittedDate: "programs.createdAt",
     programName: "programs.name",
     credentialType: "programs.credentialType",
-    programStatus: "programs.programStatus",
     locationName: "location.name",
   };
   return programSortOptions[fieldName] ?? null;

--- a/sources/packages/web/src/components/generic/StatusChipProgram.vue
+++ b/sources/packages/web/src/components/generic/StatusChipProgram.vue
@@ -6,6 +6,7 @@ import { computed, defineComponent, PropType } from "vue";
 import ChipStatus from "@/components/generic/ChipStatus.vue";
 import { useProgram } from "@/composables";
 import { ProgramStatus } from "@/types";
+import { INACTIVE_PROGRAM } from "@/constants";
 
 export default defineComponent({
   components: { ChipStatus },
@@ -23,7 +24,7 @@ export default defineComponent({
     const { mapProgramChipStatus } = useProgram();
     const overallStatusLabel = computed(() => {
       if (!props.isActive) {
-        return "Inactive";
+        return INACTIVE_PROGRAM;
       }
       return props.status.toString();
     });

--- a/sources/packages/web/src/constants/index.ts
+++ b/sources/packages/web/src/constants/index.ts
@@ -2,3 +2,4 @@ export * from "./error-code.constants";
 export * from "./system-constants";
 export * from "./ecert-constants";
 export * from "./report-constants";
+export * from "./program-constants";

--- a/sources/packages/web/src/constants/program-constants.ts
+++ b/sources/packages/web/src/constants/program-constants.ts
@@ -1,0 +1,1 @@
+export const INACTIVE_PROGRAM = "Inactive";

--- a/sources/packages/web/src/helpers/helpers/uri.ts
+++ b/sources/packages/web/src/helpers/helpers/uri.ts
@@ -88,10 +88,22 @@ export const getPaginationQueryString = (
   }
 
   // Search criteria.
-  if (paginationOptions.searchCriteria) {
+  if (
+    paginationOptions.searchCriteria &&
+    typeof paginationOptions.searchCriteria === "string"
+  ) {
     parameters.push(
       `${PaginationParams.SearchCriteria}=${paginationOptions.searchCriteria}`,
     );
+  }
+  if (
+    paginationOptions.searchCriteria &&
+    typeof paginationOptions.searchCriteria === "object"
+  ) {
+    const searchCriteria = paginationOptions.searchCriteria;
+    for (const searchCriterion in searchCriteria) {
+      parameters.push(`${searchCriterion}=${searchCriteria[searchCriterion]}`);
+    }
   }
   return parameters.join("&");
 };

--- a/sources/packages/web/src/types/contracts/DataTableContract.ts
+++ b/sources/packages/web/src/types/contracts/DataTableContract.ts
@@ -120,10 +120,13 @@ export enum PaginationParams {
 
 /**
  * Pagination Options.
+ * @param searchCriteria search criteria can be a single criterion
+ * or it can be an object with multiple search criteria (for eg. search of
+ * programs on the basis of program name, location name, status etc.)
  * todo: remove sortOrder: DataTableSortOrder when all primevue datatables are removed.
  */
 export interface PaginationOptions {
-  searchCriteria?: string | Record<string, string>;
+  searchCriteria?: string | Record<string, string | string[] | boolean>;
   sortField?: string;
   sortOrder?: DataTableSortOrder | DataTableSortByOrder;
   page: number;
@@ -402,6 +405,6 @@ export const ProgramHeaders = [
   { title: "Program Name", sortable: true, key: "programName" },
   { title: "Location", sortable: true, key: "locationName" },
   { title: "Study Periods", sortable: false, key: "totalOfferings" },
-  { title: "Status", sortable: false, key: "programStatus" },
+  { title: "Status", sortable: true, key: "programStatus" },
   { title: "Action", sortable: false, key: "action" },
 ];

--- a/sources/packages/web/src/types/contracts/DataTableContract.ts
+++ b/sources/packages/web/src/types/contracts/DataTableContract.ts
@@ -123,7 +123,7 @@ export enum PaginationParams {
  * todo: remove sortOrder: DataTableSortOrder when all primevue datatables are removed.
  */
 export interface PaginationOptions {
-  searchCriteria?: string;
+  searchCriteria?: string | Record<string, string>;
   sortField?: string;
   sortOrder?: DataTableSortOrder | DataTableSortByOrder;
   page: number;

--- a/sources/packages/web/src/views/aest/institution/Programs.vue
+++ b/sources/packages/web/src/views/aest/institution/Programs.vue
@@ -171,16 +171,26 @@ export default defineComponent({
         if (searchInactiveProgram) {
           statusSearchList.splice(statusSearchList.indexOf("Inactive"), 1);
         }
+        let searchCriteria: Record<string, string | string[] | boolean>;
+        if (statusSearchList.length) {
+          searchCriteria = {
+            programNameSearch: searchProgramName.value,
+            locationNameSearch: searchLocationName.value,
+            statusSearch: statusSearchList,
+            inactiveProgramSearch: searchInactiveProgram,
+          };
+        } else {
+          searchCriteria = {
+            programNameSearch: searchProgramName.value,
+            locationNameSearch: searchLocationName.value,
+            inactiveProgramSearch: searchInactiveProgram,
+          };
+        }
         institutionProgramsSummary.value =
           await EducationProgramService.shared.getProgramsSummaryByInstitutionId(
             institutionId,
             {
-              searchCriteria: {
-                programNameSearch: searchProgramName.value,
-                locationNameSearch: searchLocationName.value,
-                statusSearch: statusSearchList,
-                inactiveProgramSearch: searchInactiveProgram,
-              },
+              searchCriteria,
               pageLimit: rowsPerPage,
               page,
               sortField: sortColumn,

--- a/sources/packages/web/src/views/aest/institution/Programs.vue
+++ b/sources/packages/web/src/views/aest/institution/Programs.vue
@@ -7,15 +7,26 @@
           :recordsCount="institutionProgramsSummary.count"
         >
           <template #actions>
-            <v-text-field
-              density="compact"
-              v-model="searchProgramName"
-              label="Search Program Name"
-              variant="outlined"
-              @keyup.enter="goToSearchProgramName()"
-              prepend-inner-icon="mdi-magnify"
-              hide-details="auto"
-            />
+            <v-row>
+              <v-col>
+                <v-text-field
+                  density="compact"
+                  v-model="searchProgramName"
+                  label="Search Program Name"
+                  variant="outlined"
+                  @keyup.enter="goToSearch()"
+                  prepend-inner-icon="mdi-magnify"
+                  hide-details="auto" /></v-col
+              ><v-col>
+                <v-text-field
+                  density="compact"
+                  v-model="searchLocationName"
+                  label="Search Location Name"
+                  variant="outlined"
+                  @keyup.enter="goToSearch()"
+                  prepend-inner-icon="mdi-magnify"
+                  hide-details="auto" /></v-col
+            ></v-row>
           </template>
         </body-header>
       </template>
@@ -98,6 +109,7 @@ export default defineComponent({
       {} as PaginatedResults<EducationProgramsSummary>,
     );
     const searchProgramName = ref("");
+    const searchLocationName = ref("");
     const currentPage = ref();
     const currentPageLimit = ref();
     const loading = ref(true);
@@ -106,18 +118,19 @@ export default defineComponent({
       institutionId: number,
       rowsPerPage: number,
       page: number,
-      programName: string,
       sortColumn?: ProgramSummaryFields,
       sortOrder?: DataTableSortByOrder,
     ) => {
       try {
         loading.value = true;
-        searchProgramName.value = programName;
         institutionProgramsSummary.value =
           await EducationProgramService.shared.getProgramsSummaryByInstitutionId(
             institutionId,
             {
-              searchCriteria: programName,
+              searchCriteria: {
+                programNameSearch: searchProgramName.value,
+                locationNameSearch: searchLocationName.value,
+              },
               pageLimit: rowsPerPage,
               page,
               sortField: sortColumn,
@@ -133,7 +146,6 @@ export default defineComponent({
         props.institutionId,
         DEFAULT_PAGE_LIMIT,
         DEFAULT_DATATABLE_PAGE_NUMBER,
-        searchProgramName.value,
       );
     });
     const goToViewProgramDetail = (programId: number, locationId: number) => {
@@ -154,17 +166,15 @@ export default defineComponent({
         props.institutionId,
         event.itemsPerPage,
         event.page,
-        searchProgramName.value,
         sortByOptions?.key as ProgramSummaryFields,
         sortByOptions?.order,
       );
     };
-    const goToSearchProgramName = async () => {
+    const goToSearch = async () => {
       await getProgramsSummaryList(
         props.institutionId,
         currentPageLimit.value ?? DEFAULT_PAGE_LIMIT,
         currentPage.value ?? DEFAULT_DATATABLE_PAGE_NUMBER,
-        searchProgramName.value,
       );
     };
     return {
@@ -172,8 +182,9 @@ export default defineComponent({
       goToViewProgramDetail,
       DEFAULT_PAGE_LIMIT,
       pageSortEvent,
-      goToSearchProgramName,
+      goToSearch,
       searchProgramName,
+      searchLocationName,
       loading,
       ProgramSummaryFields,
       ProgramHeaders,

--- a/sources/packages/web/src/views/aest/institution/Programs.vue
+++ b/sources/packages/web/src/views/aest/institution/Programs.vue
@@ -122,8 +122,7 @@ import {
 import { AESTRoutesConst } from "@/constants/routes/RouteConstants";
 import StatusChipProgram from "@/components/generic/StatusChipProgram.vue";
 import { EducationProgramService } from "@/services/EducationProgramService";
-
-const INACTIVE_PROGRAM = "Inactive";
+import { INACTIVE_PROGRAM } from "@/constants";
 
 export default defineComponent({
   components: { StatusChipProgram },
@@ -164,27 +163,19 @@ export default defineComponent({
     ) => {
       try {
         loading.value = true;
-        const statusSearchList = JSON.parse(
-          JSON.stringify(searchProgramStatus.value),
+        const statusSearchList = searchProgramStatus.value.filter(
+          (searchItem) => searchItem !== INACTIVE_PROGRAM,
         );
-        const searchInactiveProgram = statusSearchList.indexOf("Inactive") > -1;
-        if (searchInactiveProgram) {
-          statusSearchList.splice(statusSearchList.indexOf("Inactive"), 1);
-        }
-        let searchCriteria: Record<string, string | string[] | boolean>;
+        const searchInactiveProgram = searchProgramStatus.value.some(
+          (searchItem) => searchItem === INACTIVE_PROGRAM,
+        );
+        let searchCriteria: Record<string, string | string[] | boolean> = {
+          programNameSearch: searchProgramName.value,
+          locationNameSearch: searchLocationName.value,
+          inactiveProgramSearch: searchInactiveProgram,
+        };
         if (statusSearchList.length) {
-          searchCriteria = {
-            programNameSearch: searchProgramName.value,
-            locationNameSearch: searchLocationName.value,
-            statusSearch: statusSearchList,
-            inactiveProgramSearch: searchInactiveProgram,
-          };
-        } else {
-          searchCriteria = {
-            programNameSearch: searchProgramName.value,
-            locationNameSearch: searchLocationName.value,
-            inactiveProgramSearch: searchInactiveProgram,
-          };
+          searchCriteria.statusSearch = statusSearchList;
         }
         institutionProgramsSummary.value =
           await EducationProgramService.shared.getProgramsSummaryByInstitutionId(


### PR DESCRIPTION
### As a part of the PR, the following were completed:

- Added Location Search and Program Status Search for the institution programs in the UI. Each of the searches act as an `&&` operation.
- Added sorting for the Location Name and the Program Status columns.
-  Updated the `api` to include the `location` and the program status in the pagination for the search and updated the `sql` query fetching the result.

### Screenshots:

**Location Search and Program Status Search added:**

<img width="1920" alt="image" src="https://github.com/user-attachments/assets/0cf6e1b9-3bcf-4d48-9eab-a3b6abe35df8">

-----------------------------------------------------------------------------------------

**Location Search with Program Search Empty and Program Statuses: Pending and Inactive selected:**

<img width="1920" alt="image" src="https://github.com/user-attachments/assets/9e4fd12c-83f2-4f62-a59a-02ef8df6b4c9">

------------------------------------------------------------------------------------------

**Both Location and Program Search with Program Statuses: Pending and Approved selected**

<img width="1920" alt="image" src="https://github.com/user-attachments/assets/c7db9d35-6343-47e5-bd44-90bd40c1a27c">

-------------------------------------------------------------------------------------------

**Location Search along with the Program Status: Pending selected:**

<img width="1920" alt="image" src="https://github.com/user-attachments/assets/04a575df-684a-4c49-85da-e758454e9d96">

-------------------------------------------------------------------------------------------

**Inactive Programs selected:**

<img width="1920" alt="image" src="https://github.com/user-attachments/assets/fe3e3738-cb2c-4e4c-9092-ce1e79f35088">

--------------------------------------------------------------------------------------------

**Nothing selected from the Program Status filter:**

<img width="1920" alt="image" src="https://github.com/user-attachments/assets/2e160fd8-8fab-4b4a-9a7b-993fde7c7f59">

---------------------------------------------------------------------------------------------

**Descending Sort by Program Status:**

<img width="1920" alt="image" src="https://github.com/user-attachments/assets/d11ee1fa-cf04-4180-921b-51fecc80ec90">

---------------------------------------------------------------------------------------------

**Natural Sorting (without ASC / DESC selected) on page load:**

<img width="1920" alt="image" src="https://github.com/user-attachments/assets/66a0e5dd-f465-4bf9-82e0-cd79facd37b4">

---------------------------------------------------------------------------------------------

**Ascending Sort by Program Status:**

<img width="1920" alt="image" src="https://github.com/user-attachments/assets/5a9ded38-8e2a-4cfb-b61c-16a02d9c24e9">
