### PR TITLE
#3620 - Change Request - Partner Current Year Income (financial information) option (Quick Fix)

### DIFF
--- a/sources/packages/forms/src/form-definitions/partnerinformationandincomeappeal.json
+++ b/sources/packages/forms/src/form-definitions/partnerinformationandincomeappeal.json
@@ -103,7 +103,7 @@
     },
     {
       "input": true,
-      "tableView": true,
+      "tableView": false,
       "key": "maxMoneyValue",
       "label": "Max Money Value",
       "protected": false,
@@ -118,7 +118,8 @@
       },
       "properties": {},
       "lockKey": true,
-      "calculateValue": "value = 100000000;"
+      "calculateValue": "value = 100000000;",
+      "calculateServer": true
     },
     {
       "input": true,


### PR DESCRIPTION
- Modified `maxMoneyValue` in Form.io definition "partnerinformationandincomeappeal.json" to fix the backend error due to failure in Form.io dryRun validation in my previous while submitting an appeal.
  - Unchecked "table view"
  - Checked "Calculate on server"

Screenshot of backend error due to Form.io definition
![image](https://github.com/user-attachments/assets/f1e3fd44-eb05-40c3-99da-83d0c9e58066)

Screenshot of successful backend log with the current change 
![image](https://github.com/user-attachments/assets/312aaf9e-de9e-4fed-9906-da5ea7e129a2)
