### PR TITLE
#3260 - CAS Integration 3A - Create new Supplier and Site - Refactor CAS authentication

### DIFF
--- a/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/cas-integration/_tests_/cas-supplier-integration.scheduler.e2e-spec.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/cas-integration/_tests_/cas-supplier-integration.scheduler.e2e-spec.ts
@@ -267,7 +267,7 @@ describe(describeProcessorRootTest(QueueNames.CASSupplierIntegration), () => {
     });
   });
 
-  it.only(
+  it(
     "Should create a new supplier and site on CAS and update CAS suppliers table when " +
       "the student was not found on CAS and the request to create the supplier and site was successful.",
     async () => {

--- a/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/cas-integration/_tests_/cas-supplier-integration.scheduler.e2e-spec.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/cas-integration/_tests_/cas-supplier-integration.scheduler.e2e-spec.ts
@@ -15,7 +15,6 @@ import {
 } from "../../../../../test/helpers";
 import { ContactInfo, SupplierStatus } from "@sims/sims-db";
 import {
-  CAS_LOGON_MOCKED_RESULT,
   resetCASServiceMock,
   SUPPLIER_INFO_FROM_CAS_MOCKED_RESULT,
 } from "../../../../../test/helpers/mock-utils/cas-service.mock";
@@ -84,8 +83,6 @@ describe(describeProcessorRootTest(QueueNames.CASSupplierIntegration), () => {
         "CAS supplier integration executed.",
       ]),
     ).toBe(true);
-
-    expect(casServiceMock.logon).not.toHaveBeenCalled();
     expect(casServiceMock.getSupplierInfoFromCAS).not.toHaveBeenCalled();
   });
 
@@ -124,17 +121,13 @@ describe(describeProcessorRootTest(QueueNames.CASSupplierIntegration), () => {
     expect(
       mockedJob.containLogMessages([
         "Found 1 records to be updated.",
-        "Logon successful.",
         `Processing student CAS supplier ID: ${savedCASSupplier.id}.`,
         `CAS evaluation result status: ${CASEvaluationStatus.ActiveSupplierAndSiteFound}.`,
         "Active CAS supplier and site found.",
         "Updated CAS supplier for the student.",
       ]),
     ).toBe(true);
-
-    expect(casServiceMock.logon).toHaveBeenCalled();
     expect(casServiceMock.getSupplierInfoFromCAS).toHaveBeenCalledWith(
-      CAS_LOGON_MOCKED_RESULT.access_token,
       student.sinValidation.sin,
       student.user.lastName,
     );
@@ -182,12 +175,11 @@ describe(describeProcessorRootTest(QueueNames.CASSupplierIntegration), () => {
       "Pending suppliers to update found: 1.",
       "Records updated: 1.",
       "Attention, process finalized with success but some errors and/or warnings messages may require some attention.",
-      "Error(s): 0, Warning(s): 1, Info: 12",
+      "Error(s): 0, Warning(s): 1, Info: 10",
     ]);
     expect(
       mockedJob.containLogMessages([
         "Found 1 records to be updated.",
-        "Logon successful.",
         `Not possible to retrieve CAS supplier information because some pre-validations were not fulfilled. Reason(s): ${PreValidationsFailedReason.GivenNamesNotPresent}.`,
       ]),
     ).toBe(true);
@@ -247,12 +239,11 @@ describe(describeProcessorRootTest(QueueNames.CASSupplierIntegration), () => {
       "Pending suppliers to update found: 1.",
       "Records updated: 1.",
       "Attention, process finalized with success but some errors and/or warnings messages may require some attention.",
-      "Error(s): 0, Warning(s): 1, Info: 12",
+      "Error(s): 0, Warning(s): 1, Info: 10",
     ]);
     expect(
       mockedJob.containLogMessages([
         "Found 1 records to be updated.",
-        "Logon successful.",
         `Not possible to retrieve CAS supplier information because some pre-validations were not fulfilled. Reason(s): ${PreValidationsFailedReason.NonCanadianAddress}.`,
       ]),
     ).toBe(true);
@@ -276,7 +267,7 @@ describe(describeProcessorRootTest(QueueNames.CASSupplierIntegration), () => {
     });
   });
 
-  it(
+  it.only(
     "Should create a new supplier and site on CAS and update CAS suppliers table when " +
       "the student was not found on CAS and the request to create the supplier and site was successful.",
     async () => {
@@ -311,7 +302,6 @@ describe(describeProcessorRootTest(QueueNames.CASSupplierIntegration), () => {
       expect(
         mockedJob.containLogMessages([
           "Found 1 records to be updated.",
-          "Logon successful.",
           `Processing student CAS supplier ID: ${savedCASSupplier.id}.`,
           `CAS evaluation result status: ${CASEvaluationStatus.NotFound}.`,
           `No active CAS supplier found. Reason: ${NotFoundReason.SupplierNotFound}.`,

--- a/sources/packages/backend/apps/queue-consumers/src/services/cas-supplier/cas-evaluation-result-processor/cas-active-supplier-and-site-found-processor.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/services/cas-supplier/cas-evaluation-result-processor/cas-active-supplier-and-site-found-processor.ts
@@ -28,8 +28,6 @@ export class CASActiveSupplierAndSiteFoundProcessor extends CASEvaluationResultP
    * Update student supplier based on the supplier and site information found on CAS.
    * @param studentSupplier student supplier information from SIMS.
    * @param evaluationResult evaluation result to be processed.
-   * @param _auth authentication token needed for possible
-   * CAS API interactions.
    * @param summary current process log.
    * @returns processor result.
    */

--- a/sources/packages/backend/apps/queue-consumers/src/services/cas-supplier/cas-evaluation-result-processor/cas-active-supplier-and-site-found-processor.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/services/cas-supplier/cas-evaluation-result-processor/cas-active-supplier-and-site-found-processor.ts
@@ -9,7 +9,6 @@ import {
   StudentSupplierToProcess,
 } from "../cas-supplier.models";
 import { Repository } from "typeorm";
-import { CASAuthDetails } from "@sims/integrations/cas";
 import { CASEvaluationResultProcessor, ProcessorResult } from ".";
 
 /**
@@ -37,7 +36,6 @@ export class CASActiveSupplierAndSiteFoundProcessor extends CASEvaluationResultP
   async process(
     studentSupplier: StudentSupplierToProcess,
     evaluationResult: CASEvaluationResult,
-    _auth: CASAuthDetails,
     summary: ProcessSummary,
   ): Promise<ProcessorResult> {
     if (

--- a/sources/packages/backend/apps/queue-consumers/src/services/cas-supplier/cas-evaluation-result-processor/cas-active-supplier-found-processor.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/services/cas-supplier/cas-evaluation-result-processor/cas-active-supplier-found-processor.ts
@@ -28,8 +28,6 @@ export class CASActiveSupplierFoundProcessor extends CASEvaluationResultProcesso
    * Update student supplier based on the supplier information found on CAS.
    * @param studentSupplier student supplier information from SIMS.
    * @param evaluationResult evaluation result to be processed.
-   * @param _auth authentication token needed for possible
-   * CAS API interactions.
    * @param summary current process log.
    * @returns processor result.
    */

--- a/sources/packages/backend/apps/queue-consumers/src/services/cas-supplier/cas-evaluation-result-processor/cas-active-supplier-found-processor.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/services/cas-supplier/cas-evaluation-result-processor/cas-active-supplier-found-processor.ts
@@ -9,7 +9,6 @@ import {
   StudentSupplierToProcess,
 } from "../cas-supplier.models";
 import { Repository } from "typeorm";
-import { CASAuthDetails } from "@sims/integrations/cas";
 import { CASEvaluationResultProcessor, ProcessorResult } from ".";
 
 /**
@@ -37,7 +36,6 @@ export class CASActiveSupplierFoundProcessor extends CASEvaluationResultProcesso
   async process(
     studentSupplier: StudentSupplierToProcess,
     evaluationResult: CASEvaluationResult,
-    _auth: CASAuthDetails,
     summary: ProcessSummary,
   ): Promise<ProcessorResult> {
     if (evaluationResult.status !== CASEvaluationStatus.ActiveSupplierFound) {

--- a/sources/packages/backend/apps/queue-consumers/src/services/cas-supplier/cas-evaluation-result-processor/cas-active-supplier-not-found-processor.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/services/cas-supplier/cas-evaluation-result-processor/cas-active-supplier-not-found-processor.ts
@@ -10,7 +10,6 @@ import {
 } from "../cas-supplier.models";
 import { Repository } from "typeorm";
 import {
-  CASAuthDetails,
   CASService,
   CreateSupplierAndSiteResponse,
 } from "@sims/integrations/cas";
@@ -42,7 +41,6 @@ export class CASActiveSupplierNotFoundProcessor extends CASEvaluationResultProce
   async process(
     studentSupplier: StudentSupplierToProcess,
     evaluationResult: CASEvaluationResult,
-    auth: CASAuthDetails,
     summary: ProcessSummary,
   ): Promise<ProcessorResult> {
     if (evaluationResult.status !== CASEvaluationStatus.NotFound) {
@@ -54,7 +52,7 @@ export class CASActiveSupplierNotFoundProcessor extends CASEvaluationResultProce
     let result: CreateSupplierAndSiteResponse;
     try {
       const address = studentSupplier.address;
-      result = await this.casService.createSupplierAndSite(auth.access_token, {
+      result = await this.casService.createSupplierAndSite({
         firstName: studentSupplier.firstName,
         lastName: studentSupplier.lastName,
         sin: studentSupplier.sin,

--- a/sources/packages/backend/apps/queue-consumers/src/services/cas-supplier/cas-evaluation-result-processor/cas-active-supplier-not-found-processor.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/services/cas-supplier/cas-evaluation-result-processor/cas-active-supplier-not-found-processor.ts
@@ -33,8 +33,6 @@ export class CASActiveSupplierNotFoundProcessor extends CASEvaluationResultProce
    * Create the new supplier and site on CAS using the student information.
    * @param studentSupplier student supplier information from SIMS.
    * @param evaluationResult evaluation result to be processed.
-   * @param auth authentication token needed for possible
-   * CAS API interactions.
    * @param summary current process log.
    * @returns processor result.
    */

--- a/sources/packages/backend/apps/queue-consumers/src/services/cas-supplier/cas-evaluation-result-processor/cas-evaluation-result-processor.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/services/cas-supplier/cas-evaluation-result-processor/cas-evaluation-result-processor.ts
@@ -1,5 +1,4 @@
 import { ProcessSummary } from "@sims/utilities/logger";
-import { CASAuthDetails } from "@sims/integrations/cas";
 import {
   CASEvaluationResult,
   StudentSupplierToProcess,
@@ -17,7 +16,6 @@ export abstract class CASEvaluationResultProcessor {
    * to associate a CAS supplier and a site code to a student.
    * @param studentSupplier student supplier information from SIMS.
    * @param evaluationResult evaluation result to be processed.
-   * @param auth authentication token needed for possible
    * CAS API interactions.
    * @param summary current process log.
    * @returns processor result.
@@ -25,7 +23,6 @@ export abstract class CASEvaluationResultProcessor {
   abstract process(
     studentSupplier: StudentSupplierToProcess,
     evaluationResult: CASEvaluationResult,
-    auth: CASAuthDetails,
     summary: ProcessSummary,
   ): Promise<ProcessorResult>;
 }

--- a/sources/packages/backend/apps/queue-consumers/src/services/cas-supplier/cas-evaluation-result-processor/cas-pre-validations-processor.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/services/cas-supplier/cas-evaluation-result-processor/cas-pre-validations-processor.ts
@@ -10,7 +10,6 @@ import {
 } from "../cas-supplier.models";
 import { Repository } from "typeorm";
 import { CASEvaluationResultProcessor, ProcessorResult } from ".";
-import { CASAuthDetails } from "@sims/integrations/cas";
 
 /**
  * Assert the student can be added to CAS.
@@ -30,15 +29,12 @@ export class CASPreValidationsProcessor extends CASEvaluationResultProcessor {
    * the student CAS supplier for manual intervention.
    * @param studentSupplier student supplier information from SIMS.
    * @param evaluationResult evaluation result to be processed.
-   * @param _auth authentication token needed for possible
-   * CAS API interactions.
    * @param summary current process log.
    * @returns processor result.
    */
   async process(
     studentSupplier: StudentSupplierToProcess,
     evaluationResult: CASEvaluationResult,
-    _auth: CASAuthDetails,
     summary: ProcessSummary,
   ): Promise<ProcessorResult> {
     if (evaluationResult.status !== CASEvaluationStatus.PreValidationsFailed) {

--- a/sources/packages/backend/apps/queue-consumers/src/services/cas-supplier/cas-supplier.service.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/services/cas-supplier/cas-supplier.service.ts
@@ -69,7 +69,6 @@ export class CASSupplierIntegrationService {
    * code associated.
    * @param studentSuppliers pending CAS suppliers.
    * @param parentProcessSummary parent log summary.
-   * @param auth CAS auth details.
    * @returns number of updated records.
    */
   private async processSuppliers(
@@ -137,8 +136,6 @@ export class CASSupplierIntegrationService {
    * Decide the current state of the student supplier on SIMS
    * and return the next process to be executed.
    * @param studentSupplier student CAS supplier to be evaluated.
-   * @param auth authentication token needed for possible
-   * CAS API interactions.
    * @returns evaluation result to be processed next.
    */
   private async evaluateCASSupplier(

--- a/sources/packages/backend/apps/queue-consumers/test/helpers/mock-utils/cas-service.mock.ts
+++ b/sources/packages/backend/apps/queue-consumers/test/helpers/mock-utils/cas-service.mock.ts
@@ -25,9 +25,6 @@ export function createCASServiceMock(): CASService {
  * @param mockedCASService mock to be reset.
  */
 export function resetCASServiceMock(mockedCASService: CASService): void {
-  mockedCASService.logon = jest.fn(() =>
-    Promise.resolve(CAS_LOGON_MOCKED_RESULT),
-  );
   mockedCASService.getSupplierInfoFromCAS = jest.fn(() =>
     Promise.resolve(SUPPLIER_INFO_FROM_CAS_MOCKED_RESULT),
   );

--- a/sources/packages/backend/libs/integrations/src/cas/_tests_/unit/cas.service.getSupplierInfoFromCAS.spec.ts
+++ b/sources/packages/backend/libs/integrations/src/cas/_tests_/unit/cas.service.getSupplierInfoFromCAS.spec.ts
@@ -3,6 +3,8 @@ import { TestBed, Mocked } from "@suites/unit";
 import { HttpService } from "@nestjs/axios";
 import { ConfigService } from "@sims/utilities/config";
 
+const ACCESS_TOKEN = "access_token";
+
 describe("CASService-getSupplierInfoFromCAS", () => {
   let casService: CASService;
   let httpService: Mocked<HttpService>;
@@ -13,20 +15,19 @@ describe("CASService-getSupplierInfoFromCAS", () => {
     casService = unit;
     configService = unitRef.get(ConfigService);
     httpService = unitRef.get(HttpService);
+    configService.casIntegration.baseUrl = "cas-url";
   });
 
   beforeEach(() => {
     jest.resetAllMocks();
   });
 
-  it("Should invoke CAS API with last name upper case and without special characters when last name has special characters and is not entirely upper case.", () => {
+  it("Should invoke CAS API with last name upper case and without special characters when last name has special characters and is not entirely upper case.", async () => {
     // Arrange
-    httpService.axiosRef.get = jest.fn();
-    configService.casIntegration.baseUrl = "cas-url";
+    mockAuthResponse();
 
     // Act
-    casService.getSupplierInfoFromCAS(
-      "dummy_token_value",
+    await casService.getSupplierInfoFromCAS(
       "dummy_sin_value",
       "Last name with special characters: ÁÉÍÓÚ—áéíóú",
     );
@@ -34,7 +35,20 @@ describe("CASService-getSupplierInfoFromCAS", () => {
     // Assert
     expect(httpService.axiosRef.get).toHaveBeenCalledWith(
       "cas-url/cfs/supplier/LAST NAME WITH SPECIAL CHARACTERS: AEIOU-AEIOU/lastname/dummy_sin_value/sin",
-      { headers: { Authorization: "Bearer dummy_token_value" } },
+      { headers: { Authorization: `Bearer ${ACCESS_TOKEN}` } },
     );
   });
+
+  /**
+   * Mock the first post call for authentication.
+   */
+  function mockAuthResponse(): void {
+    httpService.axiosRef.post = jest.fn().mockResolvedValueOnce({
+      data: {
+        access_token: ACCESS_TOKEN,
+        token_type: "bearer",
+        expires_in: 3600,
+      },
+    });
+  }
 });

--- a/sources/packages/backend/libs/integrations/src/cas/cas-cached-auth-details.ts
+++ b/sources/packages/backend/libs/integrations/src/cas/cas-cached-auth-details.ts
@@ -1,0 +1,28 @@
+import { CASAuthDetails } from "@sims/integrations/cas/models/cas-service.model";
+import * as dayjs from "dayjs";
+
+/**
+ * Default amount of time to a token be expired and be
+ * considered candidate to be renewed.
+ */
+const CAS_TOKEN_RENEWAL_SECONDS = 60;
+
+/**
+ * Cache the CAS token to be reused.
+ */
+export class CASCachedAuthDetails {
+  private readonly renewalTime: Date;
+  constructor(readonly authDetails: CASAuthDetails) {
+    this.renewalTime = dayjs()
+      .add(authDetails.expires_in - CAS_TOKEN_RENEWAL_SECONDS, "seconds")
+      .toDate();
+  }
+
+  /**
+   * Indicates if the token requires renewal.
+   * @returns true if must be renewed, otherwise false.
+   */
+  requiresRenewal(): boolean {
+    return dayjs().isAfter(this.renewalTime);
+  }
+}

--- a/sources/packages/backend/libs/integrations/src/cas/cas.service.ts
+++ b/sources/packages/backend/libs/integrations/src/cas/cas.service.ts
@@ -1,6 +1,5 @@
 import { Injectable, LoggerService } from "@nestjs/common";
 import {
-  CachedCASAuthDetails,
   CASAuthDetails,
   CASSupplierResponse,
   CreateSupplierAndSiteData,
@@ -19,15 +18,16 @@ import {
 import { CAS_AUTH_ERROR } from "@sims/integrations/constants";
 import { InjectLogger } from "@sims/utilities/logger";
 import {
+  CASCachedAuthDetails,
   formatAddress,
   formatCity,
   formatPostalCode,
   formatUserName,
-} from "@sims/integrations/cas";
+} from ".";
 
 @Injectable()
 export class CASService {
-  private cachedCASToken: CachedCASAuthDetails;
+  private cachedCASToken: CASCachedAuthDetails;
   private readonly casIntegrationConfig: CASIntegrationConfig;
 
   constructor(
@@ -62,7 +62,7 @@ export class CASService {
     try {
       const response = await this.httpService.axiosRef.post(url, data, config);
       // Cache the token for future requests.
-      this.cachedCASToken = new CachedCASAuthDetails(response.data);
+      this.cachedCASToken = new CASCachedAuthDetails(response.data);
       return this.cachedCASToken.authDetails;
     } catch (error: unknown) {
       this.logger.error(

--- a/sources/packages/backend/libs/integrations/src/cas/index.ts
+++ b/sources/packages/backend/libs/integrations/src/cas/index.ts
@@ -1,3 +1,4 @@
 export * from "./models/cas-service.model";
 export * from "./cas.service";
 export * from "./cas-formatters";
+export * from "./cas-cached-auth-details";

--- a/sources/packages/backend/libs/integrations/src/cas/models/cas-service.model.ts
+++ b/sources/packages/backend/libs/integrations/src/cas/models/cas-service.model.ts
@@ -1,5 +1,4 @@
 import { CASSupplierRecordStatus, CASSupplierSiteStatus } from "@sims/sims-db";
-import * as dayjs from "dayjs";
 
 export class CASSupplierResponse {
   items: CASSupplierResponseItem[];
@@ -47,32 +46,6 @@ export class CASAuthDetails {
   access_token: string;
   token_type: string;
   expires_in: number;
-}
-
-/**
- * Default amount of time to a token be expired and be
- * considered candidate to be renewed.
- */
-const CAS_TOKEN_RENEWAL_SECONDS = 60;
-
-/**
- * Cache the CAS token to be reused.
- */
-export class CachedCASAuthDetails {
-  private readonly renewalTime: Date;
-  constructor(public readonly authDetails: CASAuthDetails) {
-    this.renewalTime = dayjs()
-      .add(authDetails.expires_in - CAS_TOKEN_RENEWAL_SECONDS, "seconds")
-      .toDate();
-  }
-
-  /**
-   * Indicates if the token requires renewal.
-   * @returns true if must be renewed, otherwise false.
-   */
-  requiresRenewal(): boolean {
-    return dayjs().isAfter(this.renewalTime);
-  }
 }
 
 /**

--- a/sources/packages/backend/libs/integrations/src/cas/models/cas-service.model.ts
+++ b/sources/packages/backend/libs/integrations/src/cas/models/cas-service.model.ts
@@ -1,4 +1,5 @@
 import { CASSupplierRecordStatus, CASSupplierSiteStatus } from "@sims/sims-db";
+import * as dayjs from "dayjs";
 
 export class CASSupplierResponse {
   items: CASSupplierResponseItem[];
@@ -7,6 +8,7 @@ export class CASSupplierResponse {
   offset: number;
   count: number;
 }
+
 export class CASSupplierResponseItem {
   suppliernumber: string;
   suppliername: string;
@@ -45,6 +47,32 @@ export class CASAuthDetails {
   access_token: string;
   token_type: string;
   expires_in: number;
+}
+
+/**
+ * Default amount of time to a token be expired and be
+ * considered candidate to be renewed.
+ */
+const CAS_TOKEN_RENEWAL_SECONDS = 60;
+
+/**
+ * Cache the CAS token to be reused.
+ */
+export class CachedCASAuthDetails {
+  private readonly renewalTime: Date;
+  constructor(public readonly authDetails: CASAuthDetails) {
+    this.renewalTime = dayjs()
+      .add(authDetails.expires_in - CAS_TOKEN_RENEWAL_SECONDS, "seconds")
+      .toDate();
+  }
+
+  /**
+   * Indicates if the token requires renewal.
+   * @returns true if must be renewed, otherwise false.
+   */
+  requiresRenewal(): boolean {
+    return dayjs().isAfter(this.renewalTime);
+  }
 }
 
 /**


### PR DESCRIPTION
As agreed in the previous PR, the CAS authentication is now encapsulated inside the CAS API service and the auth token no longer needs to be passed to every method.
The current CAS token expiration is set to 1 hour and the token will be considered "about to expire" one minute before it.