### PR TITLE
#3260 - CAS Integration 3A - Create new Supplier and Site - Retry on Error and Scheduler Time

### DIFF
--- a/sources/packages/backend/apps/db-migrations/src/migrations/1729785100207-UpdateCASSupplierIntegrationScheduler.ts
+++ b/sources/packages/backend/apps/db-migrations/src/migrations/1729785100207-UpdateCASSupplierIntegrationScheduler.ts
@@ -1,0 +1,18 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+import { getSQLFileData } from "../utilities/sqlLoader";
+
+export class UpdateCASSupplierIntegrationScheduler1729785100207
+  implements MigrationInterface
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      getSQLFileData("Update-cas-supplier-integration.sql", "Queue"),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      getSQLFileData("Rollback-update-cas-supplier-integration.sql", "Queue"),
+    );
+  }
+}

--- a/sources/packages/backend/apps/db-migrations/src/sql/Queue/Rollback-update-cas-supplier-integration.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/Queue/Rollback-update-cas-supplier-integration.sql
@@ -1,0 +1,12 @@
+UPDATE
+    sims.queue_configurations
+SET
+    queue_configuration = '{
+        "cron": "0 7 * * *",
+        "retry": 3,
+        "cleanUpPeriod": 2592000000,
+        "retryInterval": 180000,
+        "dashboardReadonly": false
+    }' :: json
+WHERE
+    queue_name = 'cas-supplier-integration';

--- a/sources/packages/backend/apps/db-migrations/src/sql/Queue/Update-cas-supplier-integration.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/Queue/Update-cas-supplier-integration.sql
@@ -1,0 +1,12 @@
+UPDATE
+    sims.queue_configurations
+SET
+    queue_configuration = '{
+        "cron": "0 19 * * 1-5",
+        "retry": 3,
+        "cleanUpPeriod": 2592000000,
+        "retryInterval": 180000,
+        "dashboardReadonly": false
+    }' :: json
+WHERE
+    queue_name = 'cas-supplier-integration';

--- a/sources/packages/backend/apps/db-migrations/src/sql/Queue/Update-cas-supplier-integration.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/Queue/Update-cas-supplier-integration.sql
@@ -2,7 +2,7 @@ UPDATE
     sims.queue_configurations
 SET
     queue_configuration = '{
-        "cron": "0 19 * * 1-5",
+        "cron": "0 20 * * 1-5",
         "retry": 3,
         "cleanUpPeriod": 2592000000,
         "retryInterval": 180000,

--- a/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/cas-integration/_tests_/cas-supplier-integration.scheduler.e2e-spec.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/cas-integration/_tests_/cas-supplier-integration.scheduler.e2e-spec.ts
@@ -380,33 +380,14 @@ describe(describeProcessorRootTest(QueueNames.CASSupplierIntegration), () => {
     casServiceMock.createSupplierAndSite = jest.fn(() =>
       Promise.resolve(createFakeCASCreateSupplierAndSiteResponse()),
     );
-    // Created a student with same address line 1 and postal code from the expected CAS mocked result.
-    // Postal code has a white space that is expected to be removed.
-    const studentToFail = await saveFakeStudent(db.dataSource, undefined, {
-      initialValue: {
-        contactInfo: {
-          address: {
-            addressLine1: "3350 Douglas ST",
-            city: "Victoria",
-            country: "Canada",
-            selectedCountry: COUNTRY_CANADA,
-            provinceState: "BC",
-            postalCode: "V8Z 7X9",
-          },
-        } as ContactInfo,
-      },
-    });
-    const savedCASSupplierToFail = await saveFakeCASSupplier(db, {
-      student: studentToFail,
-    });
-
-    // Created a student with same address line 1 and postal code from the expected CAS mocked result.
-    // Postal code has a white space that is expected to be removed.
+    // Student CAS pending request expected to fail.
+    const savedCASSupplierToFail = await saveFakeCASSupplier(db);
+    // Student CAS pending request expected to succeed.
     const studentToSucceed = await saveFakeStudent(db.dataSource, undefined, {
       initialValue: {
         contactInfo: {
           address: {
-            addressLine1: "3350 DOUGLAS ST",
+            addressLine1: "3350 Douglas St",
             city: "Victoria",
             country: "Canada",
             selectedCountry: COUNTRY_CANADA,

--- a/sources/packages/backend/apps/queue-consumers/src/utilities/log-utils.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/utilities/log-utils.ts
@@ -55,7 +55,7 @@ export function getSuccessMessageWithAttentionCheck(
   processSummary: ProcessSummary,
   options?: { throwOnError?: boolean },
 ): string[] {
-  const throwOnError = options.throwOnError ?? false;
+  const throwOnError = options?.throwOnError ?? false;
   const message: string[] = [];
   message.push(...successMessages);
   const logsSum = processSummary.getLogLevelSum();

--- a/sources/packages/backend/apps/queue-consumers/src/utilities/log-utils.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/utilities/log-utils.ts
@@ -66,7 +66,7 @@ export function getSuccessMessageWithAttentionCheck(
     message.push(
       `Error(s): ${logsSum.error}, Warning(s): ${logsSum.warn}, Info: ${logsSum.info}`,
     );
-    if (throwOnError) {
+    if (logsSum.error && throwOnError) {
       throw new CustomNamedError(
         "One or more errors were reported during the process, please see logs for details.",
         PROCESS_SUMMARY_CONTAINS_ERROR,

--- a/sources/packages/backend/libs/integrations/src/cas/cas-formatters.ts
+++ b/sources/packages/backend/libs/integrations/src/cas/cas-formatters.ts
@@ -1,4 +1,4 @@
-import { convertToASCII } from "@sims/utilities";
+import { convertToASCIIString } from "@sims/utilities";
 
 const CAS_SUPPLIER_NAME_MAX_LENGTH = 80;
 const CAS_ADDRESS_MAX_LENGTH = 35;
@@ -17,7 +17,7 @@ export function formatUserName(firstName: string, lastName: string): string {
     0,
     CAS_SUPPLIER_NAME_MAX_LENGTH,
   );
-  return convertToASCII(formattedName).toUpperCase();
+  return convertToASCIIString(formattedName).toUpperCase();
 }
 
 /**
@@ -27,7 +27,7 @@ export function formatUserName(firstName: string, lastName: string): string {
  * @returns formatted address.
  */
 export function formatAddress(address: string): string {
-  return convertToASCII(
+  return convertToASCIIString(
     address.substring(0, CAS_ADDRESS_MAX_LENGTH),
   ).toUpperCase();
 }

--- a/sources/packages/backend/libs/integrations/src/cas/cas.service.ts
+++ b/sources/packages/backend/libs/integrations/src/cas/cas.service.ts
@@ -12,7 +12,7 @@ import { CASIntegrationConfig, ConfigService } from "@sims/utilities/config";
 import { stringify } from "querystring";
 import {
   CustomNamedError,
-  convertToASCII,
+  convertToASCIIString,
   parseJSONError,
 } from "@sims/utilities";
 import { CAS_AUTH_ERROR } from "@sims/integrations/constants";
@@ -98,7 +98,7 @@ export class CASService {
     sin: string,
     lastName: string,
   ): Promise<CASSupplierResponse> {
-    const convertedLastName = convertToASCII(lastName).toUpperCase();
+    const convertedLastName = convertToASCIIString(lastName).toUpperCase();
     const url = `${this.casIntegrationConfig.baseUrl}/cfs/supplier/${convertedLastName}/lastname/${sin}/sin`;
     let response: { data: CASSupplierResponse };
     try {

--- a/sources/packages/backend/libs/utilities/src/_tests_/unit/string-utils.translateToASCII.spec.ts
+++ b/sources/packages/backend/libs/utilities/src/_tests_/unit/string-utils.translateToASCII.spec.ts
@@ -1,4 +1,4 @@
-import { convertToASCII } from "@sims/utilities/string-utils";
+import { convertToASCIIString } from "@sims/utilities/string-utils";
 
 describe("StringUtils-convertToASCII", () => {
   it("Should replace the special characters when equivalent ones are present.", () => {
@@ -7,7 +7,7 @@ describe("StringUtils-convertToASCII", () => {
       "Some text with special characters: ÀÁÂÃÄÅÇÈÉÊËÌÍÎÏÑÒÓÔÕÖÙÚÛÜ—àáâãäåçèéêëìíîï-ñóòôõöùúûüýÿ";
 
     // Act
-    const translatedData = convertToASCII(textWithSpecialCharacters);
+    const translatedData = convertToASCIIString(textWithSpecialCharacters);
 
     // Assert
     expect(translatedData).toBe(
@@ -20,7 +20,7 @@ describe("StringUtils-convertToASCII", () => {
     const textWithSpecialCharacters = null;
 
     // Act
-    const translatedData = convertToASCII(textWithSpecialCharacters);
+    const translatedData = convertToASCIIString(textWithSpecialCharacters);
 
     // Assert
     expect(translatedData).toBeNull();
@@ -31,7 +31,7 @@ describe("StringUtils-convertToASCII", () => {
     const textWithSpecialCharacters = undefined;
 
     // Act
-    const translatedData = convertToASCII(textWithSpecialCharacters);
+    const translatedData = convertToASCIIString(textWithSpecialCharacters);
 
     // Assert
     expect(translatedData).toBeNull();

--- a/sources/packages/backend/libs/utilities/src/address-utils.ts
+++ b/sources/packages/backend/libs/utilities/src/address-utils.ts
@@ -5,7 +5,7 @@ import { AddressInfo } from "@sims/sims-db";
 export const OTHER_COUNTRY = "other";
 // 'selectedCountry' in the student contact info will have the value 'canada',
 // when 'Canada' is selected.
-export const COUNTRY_CANADA = "canada";
+export const COUNTRY_CANADA = "Canada";
 
 /**
  * Inspects the address info to determine if the address is from Canada.

--- a/sources/packages/backend/libs/utilities/src/string-utils.ts
+++ b/sources/packages/backend/libs/utilities/src/string-utils.ts
@@ -32,11 +32,11 @@ const ASCII_INDIRECT_CONVERSIONS: Record<string, string> = {
  * Converts input into an ASCII 7 bit buffer replacing special characters
  * by equivalent ASCII characters when possible.
  * @param rawContent raw content in string format.
- * @returns a string of the input with extended ASCII characters (ISO-8859-1)
+ * @returns a buffer of the input with extended ASCII characters (ISO-8859-1)
  * converted to equivalent ASCII characters. If null or undefined is provided,
  * null will be returned.
  */
-export function convertToASCII(rawContent?: string): string | null {
+export function convertToASCII(rawContent?: string): Buffer | null {
   if (rawContent === null || rawContent === undefined) {
     return null;
   }
@@ -140,5 +140,17 @@ export function convertToASCII(rawContent?: string): string | null {
       }
     }
   }
-  return content.toString();
+  return content;
+}
+
+/**
+ * Converts input into an ASCII 7 bit buffer replacing special characters
+ * by equivalent ASCII characters when possible.
+ * @param rawContent raw content in string format.
+ * @returns a string of the input with extended ASCII characters (ISO-8859-1)
+ * converted to equivalent ASCII characters. If null or undefined is provided,
+ * null will be returned.
+ */
+export function convertToASCIIString(rawContent?: string): string | null {
+  return convertToASCII(rawContent)?.toString() ?? null;
 }


### PR DESCRIPTION
- Changed the to allow throwing an error when some error is present in the process summary error attending the below AC.
```
If some error is present throw in the scheduler to allow it to be retried.
```
- Added the below E2E to test the above change.
  - Should throw an error for the first student and process the second one when the CAS API call failed for the first student but worked for the second one.
- Adjusted the scheduler to be executed during weekdays only attending the below AC (`0 20 * * 1-5`).
```
Schedule these to go once a day at noon during weekdays for now.
```

### Rollback
![image](https://github.com/user-attachments/assets/59a242ed-72ec-465b-a52f-8848144568f0)

### Fix
- `COUNTRY_CANADA` was defined as "canada" when it is defined as "Canada" is all form.io definitions leading to an incorrect logic.
- SFTP issue while providing the file content as a string instead of a Buffer as identified by @dheepak-aot.
