### PR TITLE
#3260 - CAS Integration 3A - Create new Supplier and Site - Process in Parallel

### DIFF
--- a/sources/packages/backend/apps/queue-consumers/src/services/cas-supplier/cas-supplier.service.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/services/cas-supplier/cas-supplier.service.ts
@@ -8,7 +8,12 @@ import {
   formatAddress,
   formatPostalCode,
 } from "@sims/integrations/cas";
-import { CustomNamedError, isAddressFromCanada } from "@sims/utilities";
+import {
+  CustomNamedError,
+  isAddressFromCanada,
+  ParallelIntensity,
+  processInParallel,
+} from "@sims/utilities";
 import { CAS_AUTH_ERROR } from "@sims/integrations/constants";
 import {
   CASEvaluationResult,
@@ -23,6 +28,7 @@ import {
   CASActiveSupplierFoundProcessor,
   CASEvaluationResultProcessor,
   CASActiveSupplierAndSiteFoundProcessor,
+  ProcessorResult,
 } from "./cas-evaluation-result-processor";
 
 @Injectable()
@@ -48,6 +54,9 @@ export class CASSupplierIntegrationService {
     parentProcessSummary: ProcessSummary,
     studentSuppliers: StudentSupplierToProcess[],
   ): Promise<number> {
+    // Force the CAS token to be acquired before starting the process.
+    await this.casService.getToken();
+    // Process each supplier in parallel.
     let suppliersUpdated = 0;
     const summary = new ProcessSummary();
     parentProcessSummary.children(summary);
@@ -69,45 +78,60 @@ export class CASSupplierIntegrationService {
    * code associated.
    * @param studentSuppliers pending CAS suppliers.
    * @param parentProcessSummary parent log summary.
-   * @returns number of updated records.
+   * @returns number of updated suppliers.
    */
   private async processSuppliers(
     studentSuppliers: StudentSupplierToProcess[],
     parentProcessSummary: ProcessSummary,
   ): Promise<number> {
-    let suppliersUpdated = 0;
-    for (const studentSupplier of studentSuppliers) {
-      const summary = new ProcessSummary();
-      parentProcessSummary.children(summary);
-      summary.info(
-        `Processing student CAS supplier ID: ${studentSupplier.casSupplierID}.`,
+    // Process each supplier in parallel.
+    const processesResults = await processInParallel(
+      (studentSupplier) =>
+        this.processSupplier(studentSupplier, parentProcessSummary),
+      studentSuppliers,
+      ParallelIntensity.High,
+    );
+    // Get the number of updated suppliers.
+    const updatedSuppliers = processesResults.filter(
+      (processResult) => !!processResult?.isSupplierUpdated,
+    ).length;
+    return updatedSuppliers;
+  }
+
+  /**
+   * Process a single student supplier.
+   * This method will not throw an error if the process fails.
+   * @param studentSupplier student supplier to be processed.
+   * @param parentProcessSummary parent log summary.
+   * @returns processor result or null if the process fails.
+   */
+  private async processSupplier(
+    studentSupplier: StudentSupplierToProcess,
+    parentProcessSummary: ProcessSummary,
+  ): Promise<ProcessorResult | null> {
+    const summary = new ProcessSummary();
+    parentProcessSummary.children(summary);
+    // Log information about the student supplier being processed.
+    summary.info(
+      `Processing student CAS supplier ID: ${studentSupplier.casSupplierID}.`,
+    );
+    try {
+      const evaluationResult = await this.evaluateCASSupplier(studentSupplier);
+      summary.info(`CAS evaluation result status: ${evaluationResult.status}.`);
+      const processor = this.getCASSupplierProcess(evaluationResult.status);
+      // Execute the process.
+      const processResult = await processor.process(
+        studentSupplier,
+        evaluationResult,
+        summary,
       );
-      try {
-        // Check the current status of the student data and its supplier information.
-        const evaluationResult = await this.evaluateCASSupplier(
-          studentSupplier,
-        );
-        summary.info(
-          `CAS evaluation result status: ${evaluationResult.status}.`,
-        );
-        // Decide the process to be executed.
-        const processor = this.getCASSupplierProcess(evaluationResult.status);
-        // Execute the process.
-        const processResult = await processor.process(
-          studentSupplier,
-          evaluationResult,
-          summary,
-        );
-        if (processResult.isSupplierUpdated) {
-          suppliersUpdated++;
-        }
-      } catch (error: unknown) {
-        // Log the error and allow the process to continue checking the
-        // remaining student suppliers.
-        summary.error("Unexpected error while processing supplier.", error);
-      }
+      return processResult;
+    } catch (error: unknown) {
+      // Log the error and allow the process to continue checking the
+      // remaining student suppliers.
+      summary.error("Unexpected error while processing supplier.", error);
+      return null;
     }
-    return suppliersUpdated;
   }
 
   /**

--- a/sources/packages/backend/apps/queue-consumers/src/services/cas-supplier/cas-supplier.service.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/services/cas-supplier/cas-supplier.service.ts
@@ -11,7 +11,6 @@ import {
 import {
   CustomNamedError,
   isAddressFromCanada,
-  ParallelIntensity,
   processInParallel,
 } from "@sims/utilities";
 import { CAS_AUTH_ERROR } from "@sims/integrations/constants";
@@ -89,7 +88,6 @@ export class CASSupplierIntegrationService {
       (studentSupplier) =>
         this.processSupplier(studentSupplier, parentProcessSummary),
       studentSuppliers,
-      ParallelIntensity.High,
     );
     // Get the number of updated suppliers.
     const updatedSuppliers = processesResults.filter(

--- a/sources/packages/backend/apps/queue-consumers/test/helpers/mock-utils/cas-service.mock.ts
+++ b/sources/packages/backend/apps/queue-consumers/test/helpers/mock-utils/cas-service.mock.ts
@@ -25,6 +25,9 @@ export function createCASServiceMock(): CASService {
  * @param mockedCASService mock to be reset.
  */
 export function resetCASServiceMock(mockedCASService: CASService): void {
+  mockedCASService.getToken = jest.fn(() =>
+    Promise.resolve(CAS_LOGON_MOCKED_RESULT),
+  );
   mockedCASService.getSupplierInfoFromCAS = jest.fn(() =>
     Promise.resolve(SUPPLIER_INFO_FROM_CAS_MOCKED_RESULT),
   );

--- a/sources/packages/backend/apps/queue-consumers/test/helpers/mock-utils/cas-service.mock.ts
+++ b/sources/packages/backend/apps/queue-consumers/test/helpers/mock-utils/cas-service.mock.ts
@@ -25,9 +25,6 @@ export function createCASServiceMock(): CASService {
  * @param mockedCASService mock to be reset.
  */
 export function resetCASServiceMock(mockedCASService: CASService): void {
-  mockedCASService.getToken = jest.fn(() =>
-    Promise.resolve(CAS_LOGON_MOCKED_RESULT),
-  );
   mockedCASService.getSupplierInfoFromCAS = jest.fn(() =>
     Promise.resolve(SUPPLIER_INFO_FROM_CAS_MOCKED_RESULT),
   );

--- a/sources/packages/backend/libs/integrations/src/cas/cas.service.ts
+++ b/sources/packages/backend/libs/integrations/src/cas/cas.service.ts
@@ -38,10 +38,12 @@ export class CASService {
   }
 
   /**
-   * Request to login on CAS API and return CAS auth details with the token used for authentication in all other requests.
+   * Request to login on CAS API and return CAS auth details with the
+   * token used for authentication in all other requests.
+   * The token is cached for future requests.
    * @returns CAS auth details.
    */
-  private async getToken(): Promise<CASAuthDetails> {
+  async getToken(): Promise<CASAuthDetails> {
     if (this.cachedCASToken && !this.cachedCASToken.requiresRenewal()) {
       // Check if there is a cached token and it is not about to expire.
       return this.cachedCASToken.authDetails;

--- a/sources/packages/backend/libs/integrations/src/cas/cas.service.ts
+++ b/sources/packages/backend/libs/integrations/src/cas/cas.service.ts
@@ -38,12 +38,10 @@ export class CASService {
   }
 
   /**
-   * Request to login on CAS API and return CAS auth details with the
-   * token used for authentication in all other requests.
-   * The token is cached for future requests.
+   * Request to login on CAS API and return CAS auth details with the token used for authentication in all other requests.
    * @returns CAS auth details.
    */
-  async getToken(): Promise<CASAuthDetails> {
+  private async getToken(): Promise<CASAuthDetails> {
     if (this.cachedCASToken && !this.cachedCASToken.requiresRenewal()) {
       // Check if there is a cached token and it is not about to expire.
       return this.cachedCASToken.authDetails;

--- a/sources/packages/backend/libs/utilities/src/parallel-processing-utils.ts
+++ b/sources/packages/backend/libs/utilities/src/parallel-processing-utils.ts
@@ -1,19 +1,4 @@
-/**
- * Number of parallel processes allowed to be started at same time.
- */
-export enum ParallelIntensity {
-  /**
-   * Used for regular processes that can be executed in parallel where the
-   * waiting time is expected to be low, for instance, for regular quick
-   * DB access.
-   */
-  Regular = 2,
-  /**
-   * Used for processes that need wait more time allowing more
-   * parallelism, for instance, slow third-party API operations.
-   */
-  High = 4,
-}
+import * as os from "os";
 
 /**
  * Execute processes in parallel during processing of high volume
@@ -27,7 +12,7 @@ export enum ParallelIntensity {
 export const processInParallel = async <P, I>(
   createPromise: (input: I) => Promise<P>,
   inputs: I[],
-  maxParallelRequests: ParallelIntensity = ParallelIntensity.Regular,
+  maxParallelRequests = os.cpus().length,
 ): Promise<P[]> => {
   const resolvedResponses: P[] = [];
 

--- a/sources/packages/backend/libs/utilities/src/parallel-processing-utils.ts
+++ b/sources/packages/backend/libs/utilities/src/parallel-processing-utils.ts
@@ -3,14 +3,16 @@
  */
 export enum ParallelIntensity {
   /**
-   * Used for regular processes that can be executed in parallel where the
-   * waiting time is expected to be low, for instance, for regular quick
-   * DB access.
+   * Used for processes that need wait more time allowing less
+   * parallelism, which means they will consume more slots from
+   * the thread pool, for instance, slow third-party API operations.
    */
   Regular = 2,
   /**
-   * Used for processes that need wait more time allowing more
-   * parallelism, for instance, slow third-party API operations.
+   * Used for regular processes that can be executed in parallel where the
+   * waiting time is expected to be low, which means they will use the slots
+   * from the thread pool for a shorter time, for instance, for regular quick
+   * DB access.
    */
   High = 4,
 }

--- a/sources/packages/backend/libs/utilities/src/parallel-processing-utils.ts
+++ b/sources/packages/backend/libs/utilities/src/parallel-processing-utils.ts
@@ -1,4 +1,19 @@
-import * as os from "os";
+/**
+ * Number of parallel processes allowed to be started at same time.
+ */
+export enum ParallelIntensity {
+  /**
+   * Used for regular processes that can be executed in parallel where the
+   * waiting time is expected to be low, for instance, for regular quick
+   * DB access.
+   */
+  Regular = 2,
+  /**
+   * Used for processes that need wait more time allowing more
+   * parallelism, for instance, slow third-party API operations.
+   */
+  High = 4,
+}
 
 /**
  * Execute processes in parallel during processing of high volume
@@ -12,7 +27,7 @@ import * as os from "os";
 export const processInParallel = async <P, I>(
   createPromise: (input: I) => Promise<P>,
   inputs: I[],
-  maxParallelRequests = os.cpus().length,
+  maxParallelRequests: ParallelIntensity = ParallelIntensity.Regular,
 ): Promise<P[]> => {
   const resolvedResponses: P[] = [];
 


### PR DESCRIPTION
- Adjusted supplier's processes to happen in parallel.
- Reduced the amount of allowed parallel processes to 2 to 4. Previously it was using the "os cores" as the default value which could potentially be up to 32 while running on Openshift.