### PR TITLE
#3738 - E2E Tests SIMS to SFAS

### DIFF
--- a/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/sfas-integration/_tests_/sims-to-sfas-integration.scheduler.e2e-spec.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/sfas-integration/_tests_/sims-to-sfas-integration.scheduler.e2e-spec.ts
@@ -99,11 +99,11 @@ describe(describeProcessorRootTest(QueueNames.SIMSToSFASIntegration), () => {
 
       // Assert
       // Assert process result.
-      expect(processingResult).toContain("Process finalized with success.");
-      expect(processingResult).toContain("Student records sent: 1.");
-      expect(processingResult).toContain(
+      expect(processingResult).toEqual([
+        "Process finalized with success.",
+        "Student records sent: 1.",
         `Uploaded file name: ${expectedFileName}.`,
-      );
+      ]);
       expect(
         mockedJob.containLogMessages([
           `Processing data since ${latestBridgeFileDate} until ${mockedCurrentDate}.`,
@@ -154,9 +154,11 @@ describe(describeProcessorRootTest(QueueNames.SIMSToSFASIntegration), () => {
 
       // Assert
       // Assert process result.
-      expect(processingResult).toContain("Process finalized with success.");
-      expect(processingResult).toContain("Student records sent: 0.");
-      expect(processingResult).toContain("Uploaded file name: none.");
+      expect(processingResult).toEqual([
+        "Process finalized with success.",
+        "Student records sent: 0.",
+        "Uploaded file name: none.",
+      ]);
       expect(
         mockedJob.containLogMessages([
           "There is no SIMS to SFAS updates to process.",

--- a/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/sfas-integration/_tests_/sims-to-sfas-integration.scheduler.e2e-spec.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/sfas-integration/_tests_/sims-to-sfas-integration.scheduler.e2e-spec.ts
@@ -28,6 +28,9 @@ describe(describeProcessorRootTest(QueueNames.SIMSToSFASIntegration), () => {
   let processor: SIMSToSFASIntegrationScheduler;
   let db: E2EDataSources;
   let sftpClientMock: DeepMocked<Client>;
+  let latestBridgeFileDate: Date;
+  let simsDataUpdatedDate: Date;
+  let mockedCurrentDate: Date;
   const DATE_FORMAT = "YYYYMMDD";
 
   beforeAll(async () => {
@@ -43,6 +46,11 @@ describe(describeProcessorRootTest(QueueNames.SIMSToSFASIntegration), () => {
   beforeEach(async () => {
     // Reset all SFAS bridge logs.
     await db.sfasBridgeLog.delete({ id: MoreThan(0) });
+    // Set the start date and end date of the bridge file to be after 10 years
+    // to ensure that data produced by other tests will not affect the results of this test.
+    latestBridgeFileDate = addYears(10);
+    simsDataUpdatedDate = addMilliSeconds(10, latestBridgeFileDate);
+    mockedCurrentDate = addMilliSeconds(10, simsDataUpdatedDate);
   });
 
   afterEach(async () => {
@@ -55,11 +63,6 @@ describe(describeProcessorRootTest(QueueNames.SIMSToSFASIntegration), () => {
       " between the most recent bridge file date and the current bridge file execution date.",
     async () => {
       // Arrange
-      // Set the start date and end date of the bridge file to be after 10 years
-      // to ensure that data produced by other tests will not affect the results of this test.
-      const latestBridgeFileDate = addYears(10);
-      const simsDataUpdatedDate = addMilliSeconds(10, latestBridgeFileDate);
-      const mockedCurrentDate = addMilliSeconds(10, simsDataUpdatedDate);
       // Create bridge file log.
       await db.sfasBridgeLog.insert({
         referenceDate: latestBridgeFileDate,
@@ -124,11 +127,6 @@ describe(describeProcessorRootTest(QueueNames.SIMSToSFASIntegration), () => {
       " does not have any submitted application.",
     async () => {
       // Arrange
-      // Set the start date and end date of the bridge file to be after 10 years
-      // to ensure that data produced by other tests will not affect the results of this test.
-      const latestBridgeFileDate = addYears(10);
-      const simsDataUpdatedDate = addMilliSeconds(10, latestBridgeFileDate);
-      const mockedCurrentDate = addMilliSeconds(10, simsDataUpdatedDate);
       // Create bridge file log.
       await db.sfasBridgeLog.insert({
         referenceDate: latestBridgeFileDate,

--- a/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/sfas-integration/_tests_/sims-to-sfas-integration.scheduler.e2e-spec.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/sfas-integration/_tests_/sims-to-sfas-integration.scheduler.e2e-spec.ts
@@ -49,6 +49,10 @@ describe(describeProcessorRootTest(QueueNames.SIMSToSFASIntegration), () => {
     // Set the start date and end date of the bridge file to be after 10 years
     // to ensure that data produced by other tests will not affect the results of this test.
     latestBridgeFileDate = addYears(10);
+    // Set the data updated date and mocked current date in milliseconds later than
+    // the latest bridge file date to ensure that it holds integrity only for the particular test scenario
+    // and not having to update the database for each test case
+    // which could potentially have various columns to be updated.
     simsDataUpdatedDate = addMilliSeconds(10, latestBridgeFileDate);
     mockedCurrentDate = addMilliSeconds(10, simsDataUpdatedDate);
   });
@@ -111,7 +115,7 @@ describe(describeProcessorRootTest(QueueNames.SIMSToSFASIntegration), () => {
       const uploadedFile = getUploadedFile(sftpClientMock);
       const [header, studentRecord, footer] = uploadedFile.fileLines;
       expect(header).toBe(buildHeader(mockedCurrentDate));
-      expect(footer).toBe(`999000000001`);
+      expect(footer).toBe("999000000001");
       expect(studentRecord).toBe(buildStudentRecord(student));
       // Check the database for creation of SFAS bridge log.
       const uploadedFileLog = await db.sfasBridgeLog.findOneBy({
@@ -152,7 +156,7 @@ describe(describeProcessorRootTest(QueueNames.SIMSToSFASIntegration), () => {
       // Assert process result.
       expect(processingResult).toContain("Process finalized with success.");
       expect(processingResult).toContain("Student records sent: 0.");
-      expect(processingResult).toContain(`Uploaded file name: none.`);
+      expect(processingResult).toContain("Uploaded file name: none.");
       expect(
         mockedJob.containLogMessages([
           "There is no SIMS to SFAS updates to process.",

--- a/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/sfas-integration/_tests_/sims-to-sfas-integration.scheduler.e2e-spec.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/sfas-integration/_tests_/sims-to-sfas-integration.scheduler.e2e-spec.ts
@@ -20,7 +20,6 @@ import * as Client from "ssh2-sftp-client";
 import { SIMSToSFASIntegrationScheduler } from "../sims-to-sfas-integration.scheduler";
 import { OfferingIntensity, Student, SupplierStatus } from "@sims/sims-db";
 import { getUploadedFile } from "@sims/test-utils/mocks";
-import { MoreThan } from "typeorm";
 import { addMilliSeconds, addYears } from "@sims/test-utils/utils";
 
 describe(describeProcessorRootTest(QueueNames.SIMSToSFASIntegration), () => {
@@ -45,7 +44,7 @@ describe(describeProcessorRootTest(QueueNames.SIMSToSFASIntegration), () => {
 
   beforeEach(async () => {
     // Reset all SFAS bridge logs.
-    await db.sfasBridgeLog.delete({ id: MoreThan(0) });
+    await db.sfasBridgeLog.delete({});
     // Set the start date and end date of the bridge file to be after 10 years
     // to ensure that data produced by other tests will not affect the results of this test.
     latestBridgeFileDate = addYears(10);
@@ -63,8 +62,8 @@ describe(describeProcessorRootTest(QueueNames.SIMSToSFASIntegration), () => {
   });
 
   it(
-    "Should generate a SIMS to SFAS bridge file when there is an update on student data" +
-      " between the most recent bridge file date and the current bridge file execution date.",
+    "Should generate a SIMS to SFAS bridge file when there is an update on student data " +
+      "between the most recent bridge file date and the current bridge file execution date.",
     async () => {
       // Arrange
       // Create bridge file log.
@@ -118,17 +117,17 @@ describe(describeProcessorRootTest(QueueNames.SIMSToSFASIntegration), () => {
       expect(footer).toBe("999000000001");
       expect(studentRecord).toBe(buildStudentRecord(student));
       // Check the database for creation of SFAS bridge log.
-      const uploadedFileLog = await db.sfasBridgeLog.findOneBy({
+      const uploadedFileLog = await db.sfasBridgeLog.existsBy({
         generatedFileName: expectedFileName,
         referenceDate: mockedCurrentDate,
       });
-      expect(uploadedFileLog.id).toBeGreaterThan(0);
+      expect(uploadedFileLog).toBe(true);
     },
   );
 
   it(
     "Should not generate a SIMS to SFAS bridge file when there is an update on student data but the student " +
-      " does not have any submitted application.",
+      "does not have any submitted application.",
     async () => {
       // Arrange
       // Create bridge file log.

--- a/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/sfas-integration/_tests_/sims-to-sfas-integration.scheduler.e2e-spec.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/sfas-integration/_tests_/sims-to-sfas-integration.scheduler.e2e-spec.ts
@@ -1,0 +1,251 @@
+import { DeepMocked } from "@golevelup/ts-jest";
+import MockDate from "mockdate";
+import { INestApplication } from "@nestjs/common";
+import { formatDate, QueueNames } from "@sims/utilities";
+import {
+  createTestingAppModule,
+  describeProcessorRootTest,
+  mockBullJob,
+} from "../../../../../test/helpers";
+import {
+  E2EDataSources,
+  createE2EDataSources,
+  createFakeUser,
+  saveFakeApplicationDisbursements,
+  saveFakeStudent,
+} from "@sims/test-utils";
+import * as Client from "ssh2-sftp-client";
+import { SIMSToSFASIntegrationScheduler } from "../sims-to-sfas-integration.scheduler";
+import { OfferingIntensity, Student } from "@sims/sims-db";
+import { getUploadedFile } from "@sims/test-utils/mocks";
+import { MoreThan } from "typeorm";
+import { addMilliSeconds, addYears } from "@sims/test-utils/utils";
+
+describe(describeProcessorRootTest(QueueNames.SIMSToSFASIntegration), () => {
+  let app: INestApplication;
+  let processor: SIMSToSFASIntegrationScheduler;
+  let db: E2EDataSources;
+  let sftpClientMock: DeepMocked<Client>;
+  const DATE_FORMAT = "YYYYMMDD";
+
+  beforeAll(async () => {
+    const { nestApplication, dataSource, sshClientMock } =
+      await createTestingAppModule();
+    app = nestApplication;
+    db = createE2EDataSources(dataSource);
+    sftpClientMock = sshClientMock;
+    // Processor under test.
+    processor = app.get(SIMSToSFASIntegrationScheduler);
+  });
+
+  afterEach(async () => {
+    MockDate.reset();
+    // Reset all SFAS bridge logs.
+    await db.sfasBridgeLog.delete({ id: MoreThan(0) });
+  });
+
+  it(
+    "Should generate a SIMS to SFAS bridge file when there is an update on student data" +
+      " between the most recent bridge file date and the current bridge file execution date.",
+    async () => {
+      // Arrange
+      // Set the start date and end date of the bridge file to be after 10 years
+      // to ensure that data produced by other tests will not affect the results of this test.
+      const latestBridgeFileDate = addYears(10);
+      const simsDataUpdatedDate = addMilliSeconds(100, latestBridgeFileDate);
+      const mockedCurrentDate = addMilliSeconds(100, simsDataUpdatedDate);
+      // Create bridge file log.
+      await db.sfasBridgeLog.insert({
+        referenceDate: latestBridgeFileDate,
+        generatedFileName: "DummyFileName.TXT",
+      });
+
+      // Student created with expected first name, last name and more importantly the updated date
+      // to fall between the most recent bridge file date and the mocked current date.
+      const student = await createStudentWithExpectedData(
+        "FakeFirstName",
+        "FakeLastName",
+        simsDataUpdatedDate,
+      );
+      // Student has submitted an application.
+      await saveFakeApplicationDisbursements(
+        db.dataSource,
+        { student },
+        { offeringIntensity: OfferingIntensity.partTime },
+      );
+
+      // Queued job.
+      const mockedJob = mockBullJob<void>();
+
+      // Mock the current date.
+      MockDate.set(mockedCurrentDate);
+
+      // Expected file name.
+      const expectedFileName = buildExpectedFileName(mockedCurrentDate);
+
+      // Act
+      const processingResult = await processor.generateSFASBridgeFile(
+        mockedJob.job,
+      );
+
+      // Assert
+      // Assert process result.
+      expect(processingResult).toContain("Process finalized with success.");
+      expect(processingResult).toContain("Student records sent: 1.");
+      expect(processingResult).toContain(
+        `Uploaded file name: ${expectedFileName}.`,
+      );
+      expect(
+        mockedJob.containLogMessages([
+          `Processing data since ${latestBridgeFileDate} until ${mockedCurrentDate}.`,
+          "Found 1 student(s) with updates.",
+          `SIMS to SFAS file ${expectedFileName} has been uploaded successfully.`,
+          `SIMS to SFAS file log has been created with file name ${expectedFileName} and reference date ${mockedCurrentDate}.`,
+        ]),
+      ).toBe(true);
+      const uploadedFile = getUploadedFile(sftpClientMock);
+      const [header, studentRecord, footer] = uploadedFile.fileLines;
+      expect(header).toBe(buildHeader(mockedCurrentDate));
+      expect(footer).toBe(`999000000001`);
+      expect(studentRecord).toBe(buildStudentRecord(student));
+      // Check the database for creation of SFAS bridge log.
+      const uploadedFileLog = await db.sfasBridgeLog.findOneBy({
+        generatedFileName: expectedFileName,
+        referenceDate: mockedCurrentDate,
+      });
+      expect(uploadedFileLog.id).toBeGreaterThan(0);
+    },
+  );
+
+  /**
+   * Creates a student with expected first name, last name and updated date.
+   * @param expectedFirstName expected first name.
+   * @param expectedLastName expected last name.
+   * @param expectedUpdatedDate expected updated date.
+   * @param options optional params.
+   * - `expectedCASDetails` expected CAS details.
+   * @returns created student.
+   */
+  async function createStudentWithExpectedData(
+    expectedFirstName: string,
+    expectedLastName: string,
+    expectedUpdatedDate: Date,
+    options?: {
+      expectedCASDetails?: { supplierNumber: string; supplierSiteCode: string };
+    },
+  ): Promise<Student> {
+    const user = createFakeUser();
+    user.firstName = expectedFirstName;
+    user.lastName = expectedLastName;
+    // Create student with expected first name, last name and updated date.
+    const student = await saveFakeStudent(
+      db.dataSource,
+      { user },
+      { initialValue: { updatedAt: expectedUpdatedDate } },
+    );
+    // Set the student profile updated date to fall between the most recent bridge file date and the mocked current date.
+    // The updated date if set externally during the creation of the student
+    // is not being updated by typeorm with the external value.
+    await db.student.update(
+      { id: student.id },
+      { updatedAt: expectedUpdatedDate },
+    );
+    // Update CAS details as expected.
+    await db.casSupplier.update(
+      { id: student.casSupplier.id },
+      {
+        supplierNumber: options?.expectedCASDetails?.supplierNumber ?? null,
+        supplierAddress: {
+          supplierSiteCode:
+            options?.expectedCASDetails?.supplierSiteCode ?? null,
+        },
+      },
+    );
+    return student;
+  }
+
+  it(
+    "Should not generate a SIMS to SFAS bridge file when there is an update on student data but the student " +
+      " does not have any submitted application.",
+    async () => {
+      // Arrange
+      // Set the start date and end date of the bridge file to be after 10 years
+      // to ensure that data produced by other tests will not affect the results of this test.
+      const latestBridgeFileDate = addYears(10);
+      const simsDataUpdatedDate = addMilliSeconds(100, latestBridgeFileDate);
+      const mockedCurrentDate = addMilliSeconds(100, simsDataUpdatedDate);
+      // Create bridge file log.
+      await db.sfasBridgeLog.insert({
+        referenceDate: latestBridgeFileDate,
+        generatedFileName: "DummyFileName.TXT",
+      });
+
+      // Student created with expected first name, last name and more importantly the updated date
+      // to fall between the most recent bridge file date and the mocked current date.
+      await createStudentWithExpectedData(
+        "FakeFirstName",
+        "FakeLastName",
+        simsDataUpdatedDate,
+      );
+
+      // Queued job.
+      const mockedJob = mockBullJob<void>();
+
+      // Mock the current date.
+      MockDate.set(mockedCurrentDate);
+
+      // Act
+      const processingResult = await processor.generateSFASBridgeFile(
+        mockedJob.job,
+      );
+
+      // Assert
+      // Assert process result.
+      expect(processingResult).toContain("Process finalized with success.");
+      expect(processingResult).toContain("Student records sent: 0.");
+      expect(processingResult).toContain(`Uploaded file name: none.`);
+      expect(
+        mockedJob.containLogMessages([
+          "There is no SIMS to SFAS updates to process.",
+        ]),
+      ).toBe(true);
+    },
+  );
+  /**
+   * Build expected file name.
+   * @param bridgeFileExtractedDate bridge file extracted date.
+   * @returns expected file name.
+   */
+  function buildExpectedFileName(bridgeFileExtractedDate: Date) {
+    return `SIMS-TO-SFAS-${formatDate(
+      bridgeFileExtractedDate,
+      "YYYYMMDD-HHmmss",
+    )}.TXT`;
+  }
+
+  /**
+   * Build header.
+   * @param bridgeFileExtractedDate bridge file extracted date.
+   * @returns header.
+   */
+  function buildHeader(bridgeFileExtractedDate: Date) {
+    const creationDate = formatDate(bridgeFileExtractedDate, "YYYYMMDDHHmmss");
+    return `100PSFSSIMS to SFAS BRIDGE                     ${creationDate}`;
+  }
+
+  /**
+   * Build student record.
+   * @param student student.
+   * @returns student record.
+   */
+  function buildStudentRecord(student: Student): string {
+    return `200${student.id
+      .toString()
+      .padStart(10, "0")}FakeFirstName  FakeLastName             ${formatDate(
+      student.birthDate,
+      DATE_FORMAT,
+    )}${
+      student.sinValidation.sin
+    }N        N                                                      000000000000000000000000000000`;
+  }
+});

--- a/sources/packages/backend/libs/integrations/src/sfas-integration/index.ts
+++ b/sources/packages/backend/libs/integrations/src/sfas-integration/index.ts
@@ -1,4 +1,3 @@
-export * from "./sfas-integration.models";
 export * from "./sfas-integration.processing.service";
 export * from "./sims-to-sfas.integration.service";
 export * from "./sims-to-sfas.processing.service";

--- a/sources/packages/backend/libs/integrations/src/sfas-integration/index.ts
+++ b/sources/packages/backend/libs/integrations/src/sfas-integration/index.ts
@@ -1,3 +1,4 @@
+export * from "./sfas-integration.models";
 export * from "./sfas-integration.processing.service";
 export * from "./sims-to-sfas.integration.service";
 export * from "./sims-to-sfas.processing.service";

--- a/sources/packages/backend/libs/integrations/src/sfas-integration/sims-to-sfas.processing.service.ts
+++ b/sources/packages/backend/libs/integrations/src/sfas-integration/sims-to-sfas.processing.service.ts
@@ -65,7 +65,7 @@ export class SIMSToSFASProcessingService {
     }
 
     processSummary.info(
-      `Found ${uniqueStudentIds.length} students with updates.`,
+      `Found ${uniqueStudentIds.length} student(s) with updates.`,
     );
     const studentDetails =
       await this.simsToSFASService.getStudentRecordsByStudentIds(

--- a/sources/packages/backend/libs/test-utils/src/data-source/e2e-data-source.ts
+++ b/sources/packages/backend/libs/test-utils/src/data-source/e2e-data-source.ts
@@ -55,6 +55,7 @@ import {
   CASSupplier,
   ApplicationRestrictionBypass,
   BetaUsersAuthorizations,
+  SFASBridgeLog,
 } from "@sims/sims-db";
 import { DataSource, Repository } from "typeorm";
 
@@ -147,6 +148,7 @@ export function createE2EDataSources(dataSource: DataSource): E2EDataSources {
     ),
     studentLoanBalance: dataSource.getRepository(StudentLoanBalance),
     eCertFeedbackError: dataSource.getRepository(ECertFeedbackError),
+    sfasBridgeLog: dataSource.getRepository(SFASBridgeLog),
   };
 }
 
@@ -211,4 +213,5 @@ export interface E2EDataSources {
   applicationOfferingChangeRequest: Repository<ApplicationOfferingChangeRequest>;
   studentLoanBalance: Repository<StudentLoanBalance>;
   eCertFeedbackError: Repository<ECertFeedbackError>;
+  sfasBridgeLog: Repository<SFASBridgeLog>;
 }

--- a/sources/packages/backend/libs/test-utils/src/factories/student.ts
+++ b/sources/packages/backend/libs/test-utils/src/factories/student.ts
@@ -1,13 +1,6 @@
 import * as faker from "faker";
-import {
-  CASSupplier,
-  DisabilityStatus,
-  SINValidation,
-  Student,
-  SupplierStatus,
-  User,
-} from "@sims/sims-db";
-import { createFakeCASSupplier, createFakeUser } from "@sims/test-utils";
+import { DisabilityStatus, SINValidation, Student, User } from "@sims/sims-db";
+import { createFakeUser } from "@sims/test-utils";
 import { DataSource } from "typeorm";
 import { createFakeSINValidation } from "./sin-validation";
 import { COUNTRY_CANADA, getISODateOnlyString } from "@sims/utilities";
@@ -59,7 +52,6 @@ export async function saveFakeStudent(
     student?: Student;
     user?: User;
     sinValidation?: SINValidation;
-    casSupplier?: CASSupplier;
   },
   options?: {
     initialValue?: Partial<Student>;
@@ -79,15 +71,6 @@ export async function saveFakeStudent(
     createFakeSINValidation(
       { student },
       { initialValue: options?.sinValidationInitialValue },
-    );
-  // Save CAS Supplier.
-  student.casSupplier =
-    relations?.casSupplier ??
-    createFakeCASSupplier(
-      { student, auditUser: student.user },
-      {
-        supplierStatus: SupplierStatus.Verified,
-      },
     );
   return studentRepo.save(student);
 }

--- a/sources/packages/backend/libs/test-utils/src/factories/student.ts
+++ b/sources/packages/backend/libs/test-utils/src/factories/student.ts
@@ -1,6 +1,13 @@
 import * as faker from "faker";
-import { DisabilityStatus, SINValidation, Student, User } from "@sims/sims-db";
-import { createFakeUser } from "@sims/test-utils";
+import {
+  CASSupplier,
+  DisabilityStatus,
+  SINValidation,
+  Student,
+  SupplierStatus,
+  User,
+} from "@sims/sims-db";
+import { createFakeCASSupplier, createFakeUser } from "@sims/test-utils";
 import { DataSource } from "typeorm";
 import { createFakeSINValidation } from "./sin-validation";
 import { COUNTRY_CANADA, getISODateOnlyString } from "@sims/utilities";
@@ -48,7 +55,12 @@ export function createFakeStudent(
  */
 export async function saveFakeStudent(
   dataSource: DataSource,
-  relations?: { student?: Student; user?: User; sinValidation?: SINValidation },
+  relations?: {
+    student?: Student;
+    user?: User;
+    sinValidation?: SINValidation;
+    casSupplier?: CASSupplier;
+  },
   options?: {
     initialValue?: Partial<Student>;
     sinValidationInitialValue?: Partial<SINValidation>;
@@ -67,6 +79,15 @@ export async function saveFakeStudent(
     createFakeSINValidation(
       { student },
       { initialValue: options?.sinValidationInitialValue },
+    );
+  // Save CAS Supplier.
+  student.casSupplier =
+    relations?.casSupplier ??
+    createFakeCASSupplier(
+      { student, auditUser: student.user },
+      {
+        supplierStatus: SupplierStatus.Verified,
+      },
     );
   return studentRepo.save(student);
 }

--- a/sources/packages/backend/libs/test-utils/src/utils/date-utils.ts
+++ b/sources/packages/backend/libs/test-utils/src/utils/date-utils.ts
@@ -15,7 +15,7 @@ export function isValidFileTimestamp(timestamp: string): boolean {
  * @returns a new date with years added.
  */
 export const addYears = (yearsToAdd: number, date?: Date | string): Date => {
-  return dayjs(date ? date : new Date())
+  return dayjs(date ?? new Date())
     .add(yearsToAdd, "year")
     .toDate();
 };
@@ -30,7 +30,7 @@ export const addMilliSeconds = (
   milliSecondsToAdd: number,
   date?: Date | string,
 ): Date => {
-  return dayjs(date ? date : new Date())
+  return dayjs(date ?? new Date())
     .add(milliSecondsToAdd, "millisecond")
     .toDate();
 };

--- a/sources/packages/backend/libs/test-utils/src/utils/date-utils.ts
+++ b/sources/packages/backend/libs/test-utils/src/utils/date-utils.ts
@@ -12,7 +12,7 @@ export function isValidFileTimestamp(timestamp: string): boolean {
 /**
  * Add years to a given date.
  * @param yearsToAdd number of years to be added.
- * @param date  date.
+ * @param date date.
  * @returns a new date with years added.
  */
 export const addYears = (yearsToAdd: number, date?: Date | string): Date => {
@@ -24,7 +24,7 @@ export const addYears = (yearsToAdd: number, date?: Date | string): Date => {
 /**
  * Add milliseconds to a given date.
  * @param yearsToAdd number of years to be added.
- * @param date  date.
+ * @param date date.
  * @returns a new date with years added.
  */
 export const addMilliSeconds = (

--- a/sources/packages/backend/libs/test-utils/src/utils/date-utils.ts
+++ b/sources/packages/backend/libs/test-utils/src/utils/date-utils.ts
@@ -8,6 +8,7 @@ import * as dayjs from "dayjs";
 export function isValidFileTimestamp(timestamp: string): boolean {
   return dayjs(timestamp, "YYYYMMDD-HHmmssSSS").isValid();
 }
+
 /**
  * Add years to a given date.
  * @param yearsToAdd number of years to be added.

--- a/sources/packages/backend/libs/test-utils/src/utils/date-utils.ts
+++ b/sources/packages/backend/libs/test-utils/src/utils/date-utils.ts
@@ -8,3 +8,29 @@ import * as dayjs from "dayjs";
 export function isValidFileTimestamp(timestamp: string): boolean {
   return dayjs(timestamp, "YYYYMMDD-HHmmssSSS").isValid();
 }
+/**
+ * Add years to a given date.
+ * @param yearsToAdd number of years to be added.
+ * @param date  date.
+ * @returns a new date with years added.
+ */
+export const addYears = (yearsToAdd: number, date?: Date | string): Date => {
+  return dayjs(date ? date : new Date())
+    .add(yearsToAdd, "year")
+    .toDate();
+};
+
+/**
+ * Add milliseconds to a given date.
+ * @param yearsToAdd number of years to be added.
+ * @param date  date.
+ * @returns a new date with years added.
+ */
+export const addMilliSeconds = (
+  milliSecondsToAdd: number,
+  date?: Date | string,
+): Date => {
+  return dayjs(date ? date : new Date())
+    .add(milliSecondsToAdd, "millisecond")
+    .toDate();
+};

--- a/sources/packages/backend/package-lock.json
+++ b/sources/packages/backend/package-lock.json
@@ -85,6 +85,7 @@
         "faker": "^5.2.0",
         "find-config": "^1.0.0",
         "jest": "^29.6.4",
+        "mockdate": "^3.0.5",
         "prettier": "^2.1.2",
         "supertest": "^6.3.3",
         "ts-jest": "^29.1.1",
@@ -10315,6 +10316,12 @@
       "bin": {
         "mkdirp": "bin/cmd.js"
       }
+    },
+    "node_modules/mockdate": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/mockdate/-/mockdate-3.0.5.tgz",
+      "integrity": "sha512-iniQP4rj1FhBdBYS/+eQv7j1tadJ9lJtdzgOpvsOHng/GbcDh2Fhdeq+ZRldrPYdXvCyfFUmFeEwEGXZB5I/AQ==",
+      "dev": true
     },
     "node_modules/ms": {
       "version": "2.1.2",

--- a/sources/packages/backend/package.json
+++ b/sources/packages/backend/package.json
@@ -118,6 +118,7 @@
     "faker": "^5.2.0",
     "find-config": "^1.0.0",
     "jest": "^29.6.4",
+    "mockdate": "^3.0.5",
     "prettier": "^2.1.2",
     "supertest": "^6.3.3",
     "ts-jest": "^29.1.1",


### PR DESCRIPTION
# SIMS TO SFAS E2E TESTS

## TEST SCENARIOS

- [x] Created a test to validate the file generation when there is a student data update, between the most recent bridge file date and current bridge execution date.
- [x] Created a test to validate no generation of bridge file, when there is an update on student data but the student does not have any submitted application.

![image](https://github.com/user-attachments/assets/3f7fa224-b7c4-4f37-a1d9-9407987e4840)


## New Library for mocking the current date retuned by the code

- To mock the current date(`new Date()`) returned, a new library [mockdate](https://www.npmjs.com/package/mockdate) has been added. 



