### PR TITLE
#3825 - Virus Scanning - Not functioning PROD

### DIFF
--- a/sources/packages/backend/libs/services/src/clamav/services/clamav.service.ts
+++ b/sources/packages/backend/libs/services/src/clamav/services/clamav.service.ts
@@ -41,6 +41,7 @@ export class ClamAVService {
         reject(new Error("Connection timed out."));
       });
       stream.pipe(passthroughStream);
+      passthroughStream.resume();
     });
     return promise;
   }


### PR DESCRIPTION
The error was possible to be reproducible in the local development machine using 17Kb files. Any file larger than 16Kb causes the error, which means that the default chunk size allocated for the stream buffer was exceeded.

The readable streams have two reading modes: [flowing and paused](https://nodejs.org/api/stream.html#two-reading-modes).
The connection to `clamav` server was open but was not receiving data for certain files, which led to the timeout. When the `passthroughStream.resume();` was added it resulted in the data being send immediately.
The `passthroughStream.readableFlowing` was defined as null, which means the below ([source](https://nodejs.org/api/stream.html#three-states))
- readable.readableFlowing === null
- readable.readableFlowing === false
- readable.readableFlowing === true

In the [example from the clamscan](passthroughStream) package, the `passthrough` stream is piped to an output stream which also resumes the stream, as mentioned below.

> All [Readable](https://nodejs.org/api/stream.html#class-streamreadable) streams begin in paused mode but can be switched to flowing mode in one of the following ways:
> 
> Adding a ['data'](https://nodejs.org/api/stream.html#event-data) event handler.
> Calling the [stream.resume()](https://nodejs.org/api/stream.html#readableresume) method.
> Calling the [stream.pipe()](https://nodejs.org/api/stream.html#readablepipedestination-options) method to send the data to a [Writable](https://nodejs.org/api/stream.html#class-streamwritable).

Local test results:
 - a 4MB file is processed in less than 3 seconds.
- a 15 MB file is processed in approximately 15 seconds.
- queued 50 files of 15 MB and it had a total processing time of 15 minutes with no errors.

No timeouts adjusted in this PR and we may not adjust any if the tests on Openshift go well for this change.
The target of this change is to fix the current production issue only.