### PR TITLE
#3840 - Hotfix: Bulk uploads: Unexpected error while uploading the file displays when "Validate" or "Create now" are selected for valid bulk upload

### DIFF
--- a/sources/packages/web/src/views/institution/OfferingsUpload.vue
+++ b/sources/packages/web/src/views/institution/OfferingsUpload.vue
@@ -61,7 +61,7 @@
             :clearable="true"
             :accept="ACCEPTED_FILE_TYPE"
             density="compact"
-            v-model="offeringFiles"
+            v-model="offeringFile"
             label="Offering CSV file"
             variant="outlined"
             data-cy="fileUpload"
@@ -225,8 +225,8 @@ export default defineComponent({
     const snackBar = useSnackBar();
     const validationProcessing = ref(false);
     const creationProcessing = ref(false);
-    // If multiple prop is undefined or false the component returns now a File object.
-    const offeringFiles = ref<File>();
+    // If multiple prop is undefined or false for VFileInput the component returns now a File object.
+    const offeringFile = ref<File>();
     // Possible errors and warnings received upon file upload.
     const validationResults = ref([] as OfferingsUploadBulkInsert[]);
     const uploadForm = ref({} as VForm);
@@ -254,7 +254,7 @@ export default defineComponent({
         }
         const uploadResults =
           await EducationProgramOfferingService.shared.offeringBulkInsert(
-            offeringFiles.value as Blob,
+            offeringFile.value as Blob,
             validationOnly,
             (progressEvent: AxiosProgressEvent) => {
               uploadProgress.value = progressEvent;
@@ -317,7 +317,7 @@ export default defineComponent({
 
     const resetForm = () => {
       validationResults.value = [];
-      offeringFiles.value = undefined;
+      offeringFile.value = undefined;
       csvFileUploadKey.value++;
     };
 
@@ -331,7 +331,7 @@ export default defineComponent({
       creationProcessing,
       DEFAULT_PAGE_LIMIT,
       PAGINATION_LIST,
-      offeringFiles,
+      offeringFile,
       uploadFile,
       validationResults,
       fileValidationRules,

--- a/sources/packages/web/src/views/institution/OfferingsUpload.vue
+++ b/sources/packages/web/src/views/institution/OfferingsUpload.vue
@@ -226,7 +226,7 @@ export default defineComponent({
     const validationProcessing = ref(false);
     const creationProcessing = ref(false);
     // Only one will be used but the component allows multiple.
-    const offeringFiles = ref<InputFile[]>([]);
+    const offeringFiles = ref<File>();
     // Possible errors and warnings received upon file upload.
     const validationResults = ref([] as OfferingsUploadBulkInsert[]);
     const uploadForm = ref({} as VForm);
@@ -252,10 +252,9 @@ export default defineComponent({
         } else {
           creationProcessing.value = true;
         }
-        const [fileToUpload] = offeringFiles.value;
         const uploadResults =
           await EducationProgramOfferingService.shared.offeringBulkInsert(
-            fileToUpload,
+            offeringFiles.value as Blob,
             validationOnly,
             (progressEvent: AxiosProgressEvent) => {
               uploadProgress.value = progressEvent;
@@ -318,7 +317,7 @@ export default defineComponent({
 
     const resetForm = () => {
       validationResults.value = [];
-      offeringFiles.value = [];
+      offeringFiles.value = undefined;
       csvFileUploadKey.value++;
     };
 

--- a/sources/packages/web/src/views/institution/OfferingsUpload.vue
+++ b/sources/packages/web/src/views/institution/OfferingsUpload.vue
@@ -225,7 +225,7 @@ export default defineComponent({
     const snackBar = useSnackBar();
     const validationProcessing = ref(false);
     const creationProcessing = ref(false);
-    // Only one will be used but the component allows multiple.
+    // If multiple prop is undefined or false the component returns now a File object.
     const offeringFiles = ref<File>();
     // Possible errors and warnings received upon file upload.
     const validationResults = ref([] as OfferingsUploadBulkInsert[]);


### PR DESCRIPTION
In Vuetify newer versions there's a [change on how VFileInput  deals with the model value](https://vuetifyjs.com/en/api/v-file-input/#props-model-value):
  - If `multiple` prop is undefined or false, VFileInput will return a `File`. If true, it returns a `File[]`.
 
Instead of destructuring a file from an array, the model file can be used as the blob required.