### PR TITLE
#3825 - Virus Scanning - Empty File Check

### DIFF
--- a/sources/packages/backend/apps/queue-consumers/src/constants/error-code.constants.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/constants/error-code.constants.ts
@@ -2,6 +2,7 @@
 // One possible reason could be the ClamAV server being down.
 export const CONNECTION_FAILED = "CONNECTION_FAILED";
 export const FILE_NOT_FOUND = "FILE_NOT_FOUND";
+export const EMPTY_FILE = "EMPTY_FILE";
 export const FILE_SCANNING_FAILED = "FILE_SCANNING_FAILED";
 export const SERVER_UNAVAILABLE = "SERVER_UNAVAILABLE";
 export const UNKNOWN_ERROR = "UNKNOWN_ERROR";

--- a/sources/packages/backend/apps/queue-consumers/src/processors/virus-scan/_tests_/virus-scan.processor.e2e-spec.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/processors/virus-scan/_tests_/virus-scan.processor.e2e-spec.ts
@@ -16,28 +16,37 @@ import { VirusScanProcessor } from "../virus-scan.processor";
 import { VirusScanStatus } from "@sims/sims-db";
 import * as path from "path";
 import { INFECTED_FILENAME_SUFFIX } from "../../../services";
+import { ObjectStorageService } from "@sims/integrations/object-storage";
+import {
+  createFakeGetObjectResponse,
+  resetObjectStorageServiceMock,
+} from "@sims/test-utils/mocks";
 
 describe(describeProcessorRootTest(QueueNames.FileVirusScanProcessor), () => {
   let app: INestApplication;
   let db: E2EDataSources;
   let processor: VirusScanProcessor;
   let clamAVServiceMock: ClamAVService;
+  let objectStorageService: ObjectStorageService;
 
   beforeAll(async () => {
     const {
       nestApplication,
       dataSource,
       clamAVServiceMock: clamAVServiceFromAppModule,
+      objectStorageServiceMock,
     } = await createTestingAppModule();
     app = nestApplication;
     // Processor under test.
     processor = app.get(VirusScanProcessor);
     clamAVServiceMock = clamAVServiceFromAppModule;
     db = createE2EDataSources(dataSource);
+    objectStorageService = objectStorageServiceMock;
   });
 
   beforeEach(() => {
     jest.clearAllMocks();
+    resetObjectStorageServiceMock(objectStorageService);
   });
 
   it("Should throw an error when the student file is not found during virus scanning.", async () => {
@@ -53,6 +62,32 @@ describe(describeProcessorRootTest(QueueNames.FileVirusScanProcessor), () => {
 
     // Act
     const errorMessage = `File ${fakeUniqueFileName} is not found or has already been scanned for viruses. Scanning the file for viruses is aborted.`;
+    await expect(
+      processor.performVirusScan(mockedJob.job),
+    ).rejects.toStrictEqual(new Error(errorMessage));
+    expect(
+      mockedJob.containLogMessages([
+        "Log details",
+        "Starting virus scan.",
+        errorMessage,
+      ]),
+    ).toBe(true);
+  });
+
+  it("Should throw an error when the student file has no content.", async () => {
+    // Arrange
+    const studentFile = createFakeStudentFileUpload();
+    studentFile.virusScanStatus = VirusScanStatus.InProgress;
+    await db.studentFile.save(studentFile);
+    const mockedJob = mockBullJob<VirusScanQueueInDTO>({
+      uniqueFileName: studentFile.uniqueFileName,
+      fileName: studentFile.fileName,
+    });
+    // Mock an empty file.
+    objectStorageService.getObject = createFakeGetObjectResponse("");
+
+    // Act
+    const errorMessage = `File ${studentFile.uniqueFileName} has not content to be scanned.`;
     await expect(
       processor.performVirusScan(mockedJob.job),
     ).rejects.toStrictEqual(new Error(errorMessage));

--- a/sources/packages/backend/apps/queue-consumers/src/processors/virus-scan/_tests_/virus-scan.processor.e2e-spec.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/processors/virus-scan/_tests_/virus-scan.processor.e2e-spec.ts
@@ -87,7 +87,7 @@ describe(describeProcessorRootTest(QueueNames.FileVirusScanProcessor), () => {
     objectStorageService.getObject = createFakeGetObjectResponse("");
 
     // Act
-    const errorMessage = `File ${studentFile.uniqueFileName} has not content to be scanned.`;
+    const errorMessage = `File ${studentFile.uniqueFileName} has no content to be scanned.`;
     await expect(
       processor.performVirusScan(mockedJob.job),
     ).rejects.toStrictEqual(new Error(errorMessage));

--- a/sources/packages/backend/apps/queue-consumers/src/processors/virus-scan/virus-scan.processor.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/processors/virus-scan/virus-scan.processor.ts
@@ -9,7 +9,10 @@ import {
   ProcessSummary,
 } from "@sims/utilities/logger";
 import { logProcessSummaryToJobLogger } from "../../utilities";
-import { FILE_NOT_FOUND } from "../../constants/error-code.constants";
+import {
+  EMPTY_FILE,
+  FILE_NOT_FOUND,
+} from "../../constants/error-code.constants";
 
 @Processor(QueueNames.FileVirusScanProcessor)
 export class VirusScanProcessor {
@@ -36,7 +39,7 @@ export class VirusScanProcessor {
     } catch (error: unknown) {
       if (error instanceof CustomNamedError) {
         const errorMessage = error.message;
-        if (error.name === FILE_NOT_FOUND) {
+        if ([FILE_NOT_FOUND, EMPTY_FILE].includes(error.name)) {
           // If the file is not present in the database, remove the file from the virus scan queue.
           await job.discard();
         }

--- a/sources/packages/backend/apps/queue-consumers/src/processors/virus-scan/virus-scan.processor.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/processors/virus-scan/virus-scan.processor.ts
@@ -40,7 +40,8 @@ export class VirusScanProcessor {
       if (error instanceof CustomNamedError) {
         const errorMessage = error.message;
         if ([FILE_NOT_FOUND, EMPTY_FILE].includes(error.name)) {
-          // If the file is not present in the database, remove the file from the virus scan queue.
+          // If the file is not present in the database, or its content
+          // is empty then remove the file from the virus scan queue.
           await job.discard();
         }
         processSummary.error(errorMessage);

--- a/sources/packages/backend/apps/queue-consumers/src/services/student-file/student-file.service.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/services/student-file/student-file.service.ts
@@ -58,7 +58,7 @@ export class StudentFileService extends RecordDataModelService<StudentFile> {
     if (contentLength === 0) {
       // Empty files are not suitable for virus scanning using passthrough.
       throw new CustomNamedError(
-        `File ${uniqueFileName} has not content to be scanned.`,
+        `File ${uniqueFileName} has no content to be scanned.`,
         EMPTY_FILE,
       );
     }

--- a/sources/packages/backend/apps/queue-consumers/src/services/student-file/student-file.service.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/services/student-file/student-file.service.ts
@@ -11,6 +11,7 @@ import { ClamAVError, ClamAVService, SystemUsersService } from "@sims/services";
 import * as path from "path";
 import {
   CONNECTION_FAILED,
+  EMPTY_FILE,
   FILE_NOT_FOUND,
   FILE_SCANNING_FAILED,
   SERVER_UNAVAILABLE,
@@ -51,9 +52,16 @@ export class StudentFileService extends RecordDataModelService<StudentFile> {
     }
 
     // Retrieve the file from the object storage.
-    const { body } = await this.objectStorageService.getObject(
+    const { body, contentLength } = await this.objectStorageService.getObject(
       studentFile.uniqueFileName,
     );
+    if (contentLength === 0) {
+      // Empty files are not suitable for virus scanning using passthrough.
+      throw new CustomNamedError(
+        `File ${uniqueFileName} has not content to be scanned.`,
+        EMPTY_FILE,
+      );
+    }
     let isInfected: boolean | null;
     let errorName: string;
     let errorMessage = `Unable to scan the file ${uniqueFileName} for viruses.`;

--- a/sources/packages/backend/libs/test-utils/src/mocks/object-storage-service-mock.ts
+++ b/sources/packages/backend/libs/test-utils/src/mocks/object-storage-service-mock.ts
@@ -9,9 +9,29 @@ export const S3_DEFAULT_MOCKED_FILE_CONTENT = "Some dummy file content.";
  */
 export function createObjectStorageServiceMock(): ObjectStorageService {
   const mockedObjectStorageService = {} as ObjectStorageService;
-  mockedObjectStorageService.putObject = jest.fn(() => Promise.resolve());
-  mockedObjectStorageService.getObject = jest.fn(() => {
-    const buffer = Buffer.from(S3_DEFAULT_MOCKED_FILE_CONTENT);
+  resetObjectStorageServiceMock(mockedObjectStorageService);
+  return mockedObjectStorageService;
+}
+
+/**
+ * Resets the mocked object storage service back to its original mocks.
+ * @param mock the mocked object storage service to be reset.
+ */
+export function resetObjectStorageServiceMock(
+  mock: ObjectStorageService,
+): void {
+  mock.putObject = jest.fn(() => Promise.resolve());
+  mock.getObject = createFakeGetObjectResponse(S3_DEFAULT_MOCKED_FILE_CONTENT);
+}
+
+/**
+ * Creates a mock implementation for the getObject method of the {@linkcode ObjectStorageService}.
+ * @param fileContent the content of the file to be returned.
+ * @returns a jest mock function that resolves a promise.
+ */
+export function createFakeGetObjectResponse(fileContent: string): jest.Mock {
+  return jest.fn(() => {
+    const buffer = Buffer.from(fileContent);
     const stream = Readable.from(buffer);
     return Promise.resolve({
       contentLength: buffer.length,
@@ -19,5 +39,4 @@ export function createObjectStorageServiceMock(): ObjectStorageService {
       body: stream,
     });
   });
-  return mockedObjectStorageService;
 }


### PR DESCRIPTION
When starting a socket to send a file content to `clamav` using the passthrough and no content is sent, the connection stays open for an indefinite amount of time (over 5 minutes).
Changed queue-consumers to throw an error and remove the job, **same behavior when the file is not found**.

_We can have a separate ticket to apply validation for the file upload to avoid accepting empty files, but I considered it outside this hotfix issue._

ClamAV debug log when a empty file is send for scanning.
```
2024-10-31 08:32:55 node-clam: Initially testing socket/tcp connection to clamscan server.
2024-10-31 08:32:55 node-clam: Attempting to establish socket/TCP connection for "_ping"
2024-10-31 08:32:55 node-clam: using remote server: 172.18.0.6:3310
2024-10-31 08:32:55 node-clam: Established connection to clamscan server!
2024-10-31 08:32:55 node-clam: PONG!
2024-10-31 08:32:55 node-clam: Established connection to clamscan server!
2024-10-31 08:32:55 node-clam: Done with the full pipeline.
2024-10-31 08:32:55 node-clam: Socket/Host connection closed.
2024-10-31 08:33:00 node-clam: ClamAV has been scanning for 5 seconds...
...
2024-10-31 08:35:25 node-clam: ClamAV has been scanning for 150 seconds...
...
2024-10-31 08:45:30 node-clam: ClamAV has been scanning for 755 seconds...
...
```
