### PR TITLE
#3729 - CAS Integration 3B - Create New Site (Supplier found, Multiple Sites / No matching address)

### DIFF
--- a/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/cas-integration/_tests_/cas-supplier-integration.scheduler.e2e-spec.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/cas-integration/_tests_/cas-supplier-integration.scheduler.e2e-spec.ts
@@ -395,7 +395,7 @@ describe(describeProcessorRootTest(QueueNames.CASSupplierIntegration), () => {
           supplierAddress: savedCASSupplier.supplierAddress,
         },
       });
-    casServiceMock.createExistingSupplierSite = jest.fn(() =>
+    casServiceMock.createExistingSupplierAndSite = jest.fn(() =>
       Promise.resolve(createSupplierAndSiteResponse),
     );
 
@@ -425,7 +425,7 @@ describe(describeProcessorRootTest(QueueNames.CASSupplierIntegration), () => {
     ).toBe(true);
     // Assert the API methods were called.
     expect(casServiceMock.getSupplierInfoFromCAS).toHaveBeenCalled();
-    expect(casServiceMock.createExistingSupplierSite).toHaveBeenCalled();
+    expect(casServiceMock.createExistingSupplierAndSite).toHaveBeenCalled();
     // Assert DB was updated.
     const updateCASSupplier = await db.casSupplier.findOne({
       select: {

--- a/sources/packages/backend/apps/queue-consumers/test/helpers/mock-utils/cas-response.factory.ts
+++ b/sources/packages/backend/apps/queue-consumers/test/helpers/mock-utils/cas-response.factory.ts
@@ -20,7 +20,7 @@ import * as faker from "faker";
  */
 export function createFakeCASSupplierResponse(options?: {
   initialValues: {
-    status?: CASSupplierRecordStatus;
+    siteStatus?: CASSupplierRecordStatus;
     postalCode?: string;
   };
 }): CASSupplierResponse {
@@ -33,7 +33,7 @@ export function createFakeCASSupplierResponse(options?: {
         sin: "000000000",
         providerid: "CAS_WS_AE_PSFS_SIMS",
         businessnumber: null,
-        status: options?.initialValues?.status ?? "ACTIVE",
+        status: "ACTIVE",
         supplierprotected: null,
         standardindustryclassification: null,
         lastupdated: "2024-05-01 13:55:00",
@@ -53,7 +53,7 @@ export function createFakeCASSupplierResponse(options?: {
             banknumber: null,
             eftadvicepref: null,
             providerid: "CAS_WS_AE_PSFS_SIMS",
-            status: "ACTIVE",
+            status: options?.initialValues?.siteStatus ?? "ACTIVE",
             siteprotected: null,
             lastupdated: "2024-05-01 13:55:04",
           },

--- a/sources/packages/backend/apps/queue-consumers/test/helpers/mock-utils/cas-response.factory.ts
+++ b/sources/packages/backend/apps/queue-consumers/test/helpers/mock-utils/cas-response.factory.ts
@@ -141,8 +141,6 @@ export function createFakeCASCreateSupplierNoSiteResponse(options?: {
           AddressLine1:
             options?.initialValues?.supplierAddress.addressLine1 ??
             faker.address.streetAddress(false).toUpperCase(),
-          AddressLine2: "",
-          AddressLine3: "",
           City: options?.initialValues?.supplierAddress.city ?? "Victoria",
           Province:
             options?.initialValues?.supplierAddress.provinceState ?? "BC",

--- a/sources/packages/backend/apps/queue-consumers/test/helpers/mock-utils/cas-response.factory.ts
+++ b/sources/packages/backend/apps/queue-consumers/test/helpers/mock-utils/cas-response.factory.ts
@@ -1,6 +1,12 @@
 import {
+  formatAddress,
+  formatCity,
+  formatPostalCode,
+} from "@sims/integrations/cas";
+import {
   CASSupplierResponse,
   CreateExistingSupplierSiteResponse,
+  CreateSupplierAddressSubmittedData,
   CreateSupplierAndSiteResponse,
 } from "@sims/integrations/cas/models/cas-service.model";
 import { CASSupplierRecordStatus, SupplierAddress } from "@sims/sims-db";
@@ -14,16 +20,14 @@ import * as faker from "faker";
  */
 export function createFakeCASSupplierResponse(options?: {
   initialValues: {
-    supplierNumber?: string;
     status?: CASSupplierRecordStatus;
-    addressLine1?: string;
     postalCode?: string;
   };
 }): CASSupplierResponse {
   return {
     items: [
       {
-        suppliernumber: options?.initialValues?.supplierNumber ?? "2006124",
+        suppliernumber: "2006124",
         suppliername: "SMITH, MELANIE",
         subcategory: "INDIVIDUAL",
         sin: "000000000",
@@ -36,8 +40,7 @@ export function createFakeCASSupplierResponse(options?: {
         supplieraddress: [
           {
             suppliersitecode: "001",
-            addressline1:
-              options?.initialValues?.addressLine1 ?? "3350 DOUGLAS ST",
+            addressline1: "3350 DOUGLAS ST",
             addressline2: null,
             addressline3: null,
             city: "VICTORIA",
@@ -89,25 +92,15 @@ export function createFakeCASCreateSupplierAndSiteResponse(options?: {
     supplierAddress: SupplierAddress;
   };
 }): CreateSupplierAndSiteResponse {
+  const supplierAddress = createFakeCASSupplierAddress(
+    options?.initialValues?.supplierAddress,
+  );
   return {
     submittedData: {
       SupplierName: "DOE, JOHN",
       SubCategory: "Individual",
       Sin: faker.datatype.number({ min: 100000000, max: 999999999 }).toString(),
-      SupplierAddress: [
-        {
-          AddressLine1:
-            options?.initialValues?.supplierAddress.addressLine1 ??
-            faker.address.streetAddress(false).toUpperCase(),
-          City: options?.initialValues?.supplierAddress.city ?? "Victoria",
-          Province:
-            options?.initialValues?.supplierAddress.provinceState ?? "BC",
-          Country: options?.initialValues?.supplierAddress.country ?? "CA",
-          PostalCode:
-            options?.initialValues?.supplierAddress.postalCode ?? "H1H1H1",
-          EmailAddress: faker.internet.email(),
-        },
-      ],
+      SupplierAddress: [supplierAddress],
     },
     response: {
       supplierNumber: faker.datatype
@@ -124,7 +117,7 @@ export function createFakeCASCreateSupplierAndSiteResponse(options?: {
  * - `initialValues` fake CAS create supplier without site response values.
  * @returns fake CreateSupplierNoSite response.
  */
-export function createFakeCASCreateSupplierNoSiteResponse(options?: {
+export function createFakeCASSiteForExistingSupplierResponse(options?: {
   initialValues: {
     supplierNumber: string;
     supplierAddress: SupplierAddress;
@@ -133,28 +126,36 @@ export function createFakeCASCreateSupplierNoSiteResponse(options?: {
   const supplierNumber =
     options?.initialValues?.supplierNumber ??
     faker.datatype.number({ min: 1000000, max: 9999999 }).toString();
+  const supplierAddress = createFakeCASSupplierAddress(
+    options?.initialValues?.supplierAddress,
+  );
   return {
     submittedData: {
       SupplierNumber: supplierNumber,
-      SupplierAddress: [
-        {
-          AddressLine1:
-            options?.initialValues?.supplierAddress.addressLine1 ??
-            faker.address.streetAddress(false).toUpperCase(),
-          City: options?.initialValues?.supplierAddress.city ?? "Victoria",
-          Province:
-            options?.initialValues?.supplierAddress.provinceState ?? "BC",
-          Country: options?.initialValues?.supplierAddress.country ?? "CA",
-          PostalCode:
-            options?.initialValues?.supplierAddress.postalCode ?? "H1H1H1",
-          EmailAddress: faker.internet.email(),
-        },
-      ],
+      SupplierAddress: [supplierAddress],
     },
     response: {
       supplierNumber: supplierNumber,
-      supplierSiteCode:
-        options?.initialValues?.supplierAddress.supplierSiteCode ?? "001",
+      supplierSiteCode: "001",
     },
+  };
+}
+
+export function createFakeCASSupplierAddress(
+  supplierAddress?: SupplierAddress,
+): CreateSupplierAddressSubmittedData {
+  return {
+    AddressLine1: supplierAddress?.addressLine1
+      ? formatAddress(supplierAddress?.addressLine1)
+      : faker.address.streetAddress(false).toUpperCase(),
+    City: supplierAddress?.city
+      ? formatCity(supplierAddress?.city)
+      : "Victoria",
+    Province: supplierAddress?.provinceState ?? "BC",
+    Country: supplierAddress?.country ?? "CA",
+    PostalCode: supplierAddress?.postalCode
+      ? formatPostalCode(supplierAddress?.postalCode)
+      : "H1H1H1",
+    EmailAddress: faker.internet.email(),
   };
 }

--- a/sources/packages/backend/apps/queue-consumers/test/helpers/mock-utils/cas-response.factory.ts
+++ b/sources/packages/backend/apps/queue-consumers/test/helpers/mock-utils/cas-response.factory.ts
@@ -1,19 +1,23 @@
 import {
   CASSupplierResponse,
+  CreateExistingSupplierSiteResponse,
   CreateSupplierAndSiteResponse,
 } from "@sims/integrations/cas/models/cas-service.model";
-import { SupplierAddress } from "@sims/sims-db";
+import { CASSupplierRecordStatus, SupplierAddress } from "@sims/sims-db";
 import * as faker from "faker";
 
 /**
  * Creates a fake CAS supplier response.
+ * @param options options.
+ * - `initialValues` fake CAS supplier response values.
  * @returns a fake CAS supplier response.
  */
 export function createFakeCASSupplierResponse(options?: {
   initialValues: {
-    supplierNumber: string;
-    addressLine1: string;
-    postalCode: string;
+    supplierNumber?: string;
+    status?: CASSupplierRecordStatus;
+    addressLine1?: string;
+    postalCode?: string;
   };
 }): CASSupplierResponse {
   return {
@@ -25,7 +29,7 @@ export function createFakeCASSupplierResponse(options?: {
         sin: "000000000",
         providerid: "CAS_WS_AE_PSFS_SIMS",
         businessnumber: null,
-        status: "ACTIVE",
+        status: options?.initialValues?.status ?? "ACTIVE",
         supplierprotected: null,
         standardindustryclassification: null,
         lastupdated: "2024-05-01 13:55:00",
@@ -76,9 +80,15 @@ export function createFakeCASNotFoundSupplierResponse(): CASSupplierResponse {
 
 /**
  * Create a fake CreateSupplierAndSite response.
+ * @param options options.
+ * - `initialValues` fake CAS create supplier and site response values.
  * @returns fake CreateSupplierAndSite response.
  */
-export function createFakeCASCreateSupplierAndSiteResponse(): CreateSupplierAndSiteResponse {
+export function createFakeCASCreateSupplierAndSiteResponse(options?: {
+  initialValues: {
+    supplierAddress: SupplierAddress;
+  };
+}): CreateSupplierAndSiteResponse {
   return {
     submittedData: {
       SupplierName: "DOE, JOHN",
@@ -86,11 +96,15 @@ export function createFakeCASCreateSupplierAndSiteResponse(): CreateSupplierAndS
       Sin: faker.datatype.number({ min: 100000000, max: 999999999 }).toString(),
       SupplierAddress: [
         {
-          AddressLine1: faker.address.streetAddress(false).toUpperCase(),
-          City: "Victoria",
-          Province: "BC",
-          Country: "CA",
-          PostalCode: "H1H1H1",
+          AddressLine1:
+            options?.initialValues?.supplierAddress.addressLine1 ??
+            faker.address.streetAddress(false).toUpperCase(),
+          City: options?.initialValues?.supplierAddress.city ?? "Victoria",
+          Province:
+            options?.initialValues?.supplierAddress.provinceState ?? "BC",
+          Country: options?.initialValues?.supplierAddress.country ?? "CA",
+          PostalCode:
+            options?.initialValues?.supplierAddress.postalCode ?? "H1H1H1",
           EmailAddress: faker.internet.email(),
         },
       ],
@@ -106,6 +120,8 @@ export function createFakeCASCreateSupplierAndSiteResponse(): CreateSupplierAndS
 
 /**
  * Create a fake CreateSupplierNoSite response with missing postal code.
+ * @param options options.
+ * - `initialValues` fake CAS create supplier without site response values.
  * @returns fake CreateSupplierNoSite response.
  */
 export function createFakeCASCreateSupplierNoSiteResponse(options?: {
@@ -113,7 +129,7 @@ export function createFakeCASCreateSupplierNoSiteResponse(options?: {
     supplierNumber: string;
     supplierAddress: SupplierAddress;
   };
-}): CreateSupplierAndSiteResponse {
+}): CreateExistingSupplierSiteResponse {
   const supplierNumber =
     options?.initialValues?.supplierNumber ??
     faker.datatype.number({ min: 1000000, max: 9999999 }).toString();

--- a/sources/packages/backend/apps/queue-consumers/test/helpers/mock-utils/cas-response.factory.ts
+++ b/sources/packages/backend/apps/queue-consumers/test/helpers/mock-utils/cas-response.factory.ts
@@ -2,17 +2,24 @@ import {
   CASSupplierResponse,
   CreateSupplierAndSiteResponse,
 } from "@sims/integrations/cas/models/cas-service.model";
+import { SupplierAddress } from "@sims/sims-db";
 import * as faker from "faker";
 
 /**
  * Creates a fake CAS supplier response.
  * @returns a fake CAS supplier response.
  */
-export function createFakeCASSupplierResponse(): CASSupplierResponse {
+export function createFakeCASSupplierResponse(options?: {
+  initialValues: {
+    supplierNumber: string;
+    addressLine1: string;
+    postalCode: string;
+  };
+}): CASSupplierResponse {
   return {
     items: [
       {
-        suppliernumber: "2006124",
+        suppliernumber: options?.initialValues?.supplierNumber ?? "2006124",
         suppliername: "SMITH, MELANIE",
         subcategory: "INDIVIDUAL",
         sin: "000000000",
@@ -25,13 +32,14 @@ export function createFakeCASSupplierResponse(): CASSupplierResponse {
         supplieraddress: [
           {
             suppliersitecode: "001",
-            addressline1: "3350 DOUGLAS ST",
+            addressline1:
+              options?.initialValues?.addressLine1 ?? "3350 DOUGLAS ST",
             addressline2: null,
             addressline3: null,
             city: "VICTORIA",
             province: "BC",
             country: "CA",
-            postalcode: "V8Z7X9",
+            postalcode: options?.initialValues?.postalCode ?? "V8Z7X9",
             emailaddress: null,
             accountnumber: null,
             branchnumber: null,
@@ -92,6 +100,47 @@ export function createFakeCASCreateSupplierAndSiteResponse(): CreateSupplierAndS
         .number({ min: 1000000, max: 9999999 })
         .toString(),
       supplierSiteCode: "001",
+    },
+  };
+}
+
+/**
+ * Create a fake CreateSupplierNoSite response with missing postal code.
+ * @returns fake CreateSupplierNoSite response.
+ */
+export function createFakeCASCreateSupplierNoSiteResponse(options?: {
+  initialValues: {
+    supplierNumber: string;
+    supplierAddress: SupplierAddress;
+  };
+}): CreateSupplierAndSiteResponse {
+  const supplierNumber =
+    options?.initialValues?.supplierNumber ??
+    faker.datatype.number({ min: 1000000, max: 9999999 }).toString();
+  return {
+    submittedData: {
+      SupplierNumber: supplierNumber,
+      SupplierAddress: [
+        {
+          AddressLine1:
+            options?.initialValues?.supplierAddress.addressLine1 ??
+            faker.address.streetAddress(false).toUpperCase(),
+          AddressLine2: "",
+          AddressLine3: "",
+          City: options?.initialValues?.supplierAddress.city ?? "Victoria",
+          Province:
+            options?.initialValues?.supplierAddress.provinceState ?? "BC",
+          Country: options?.initialValues?.supplierAddress.country ?? "CA",
+          PostalCode:
+            options?.initialValues?.supplierAddress.postalCode ?? "H1H1H1",
+          EmailAddress: faker.internet.email(),
+        },
+      ],
+    },
+    response: {
+      supplierNumber: supplierNumber,
+      supplierSiteCode:
+        options?.initialValues?.supplierAddress.supplierSiteCode ?? "001",
     },
   };
 }

--- a/sources/packages/backend/libs/integrations/src/cas/_tests_/unit/cas.service.createSiteForExistingSupplier.spec.ts
+++ b/sources/packages/backend/libs/integrations/src/cas/_tests_/unit/cas.service.createSiteForExistingSupplier.spec.ts
@@ -22,7 +22,7 @@ describe("CASService-createSiteForExistingSupplier", () => {
     jest.resetAllMocks();
   });
 
-  it("Should invoke CAS API with formatted payload when all data was provided as expected.", async () => {
+  it("Should invoke CAS API createSiteForExistingSupplier with formatted payload when all data was provided as expected.", async () => {
     // Arrange
     mockAuthenticationResponseOnce(httpService).mockResolvedValue({
       data: {
@@ -53,8 +53,6 @@ describe("CASService-createSiteForExistingSupplier", () => {
         SupplierAddress: [
           {
             AddressLine1: "STREET-SPECIAL CHARACTERS-ANE-MAXIM",
-            AddressLine2: "",
-            AddressLine3: "",
             City: "City Name Over Maximum Le",
             Province: "BC",
             Country: "CA",

--- a/sources/packages/backend/libs/integrations/src/cas/_tests_/unit/cas.service.createSiteForExistingSupplier.spec.ts
+++ b/sources/packages/backend/libs/integrations/src/cas/_tests_/unit/cas.service.createSiteForExistingSupplier.spec.ts
@@ -22,7 +22,7 @@ describe("CASService-createSiteForExistingSupplier", () => {
     jest.resetAllMocks();
   });
 
-  it("Should invoke CAS API createSiteForExistingSupplier with formatted payload when all data was provided as expected.", async () => {
+  it("Should invoke CAS API to create site for existing supplier with formatted payload when all data was provided as expected.", async () => {
     // Arrange
     mockAuthenticationResponseOnce(httpService).mockResolvedValue({
       data: {

--- a/sources/packages/backend/libs/integrations/src/cas/_tests_/unit/cas.service.createSiteForExistingSupplier.spec.ts
+++ b/sources/packages/backend/libs/integrations/src/cas/_tests_/unit/cas.service.createSiteForExistingSupplier.spec.ts
@@ -1,0 +1,69 @@
+import {
+  CASService,
+  CreateExistingSupplierSiteData,
+} from "@sims/integrations/cas";
+import { Mocked } from "@suites/unit";
+import { HttpService } from "@nestjs/axios";
+import {
+  DEFAULT_CAS_AXIOS_AUTH_HEADER,
+  initializeService,
+  mockAuthenticationResponseOnce,
+} from "./cas-test.utils";
+
+describe("CASService-createSiteForExistingSupplier", () => {
+  let casService: CASService;
+  let httpService: Mocked<HttpService>;
+
+  beforeAll(async () => {
+    [casService, httpService] = await initializeService();
+  });
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it("Should invoke CAS API with formatted payload when all data was provided as expected.", async () => {
+    // Arrange
+    mockAuthenticationResponseOnce(httpService).mockResolvedValue({
+      data: {
+        SUPPLIER_NUMBER: "1234567",
+        SUPPLIER_SITE_CODE: "001",
+      },
+    });
+
+    const supplierData: CreateExistingSupplierSiteData = {
+      supplierNumber: "1234567",
+      emailAddress: "test@test.com",
+      supplierSite: {
+        addressLine1: "Street-Special Characters-ãñè-Maximum",
+        city: "City Name Over Maximum Length",
+        provinceCode: "BC",
+        postalCode: "h1h h2h",
+      },
+    };
+
+    // Act
+    await casService.createSiteForExistingSupplier(supplierData);
+
+    // Assert
+    expect(httpService.axiosRef.post).toHaveBeenCalledWith(
+      "cas-url/cfs/supplier/1234567/site",
+      {
+        SupplierNumber: "1234567",
+        SupplierAddress: [
+          {
+            AddressLine1: "STREET-SPECIAL CHARACTERS-ANE-MAXIM",
+            AddressLine2: "",
+            AddressLine3: "",
+            City: "City Name Over Maximum Le",
+            Province: "BC",
+            Country: "CA",
+            PostalCode: "H1HH2H",
+            EmailAddress: supplierData.emailAddress,
+          },
+        ],
+      },
+      DEFAULT_CAS_AXIOS_AUTH_HEADER,
+    );
+  });
+});

--- a/sources/packages/backend/libs/integrations/src/cas/cas.service.ts
+++ b/sources/packages/backend/libs/integrations/src/cas/cas.service.ts
@@ -9,6 +9,7 @@ import {
   CreateSupplierAndSiteData,
   CreateSupplierAndSiteResponse,
   CreateSupplierAndSiteSubmittedData,
+  CreateSupplierSite,
 } from "./models/cas-service.model";
 import { AxiosError, AxiosRequestConfig } from "axios";
 import { HttpService } from "@nestjs/axios";
@@ -135,6 +136,10 @@ export class CASService {
     const url = `${this.casIntegrationConfig.baseUrl}/cfs/supplier/`;
     try {
       const config = await this.getAuthConfig();
+      const supplierAddress = this.getSupplierAddress(
+        supplierData.supplierSite,
+        supplierData.emailAddress,
+      );
       const submittedData: CreateSupplierAndSiteSubmittedData = {
         SupplierName: formatUserName(
           supplierData.firstName,
@@ -142,7 +147,7 @@ export class CASService {
         ),
         SubCategory: "Individual",
         Sin: supplierData.sin,
-        SupplierAddress: [this.getSupplierAddress(supplierData)],
+        SupplierAddress: [supplierAddress],
       };
       const response = await this.httpService.axiosRef.post(
         url,
@@ -188,9 +193,13 @@ export class CASService {
     const url = `${this.casIntegrationConfig.baseUrl}/cfs/supplier/${supplierData.supplierNumber}/site`;
     try {
       const config = await this.getAuthConfig();
+      const supplierAddress = this.getSupplierAddress(
+        supplierData.supplierSite,
+        supplierData.emailAddress,
+      );
       const submittedData: CreateExistingSupplierAndSiteSubmittedData = {
         SupplierNumber: supplierData.supplierNumber,
-        SupplierAddress: [this.getSupplierAddress(supplierData)],
+        SupplierAddress: [supplierAddress],
       };
       const response = await this.httpService.axiosRef.post(
         url,
@@ -239,19 +248,21 @@ export class CASService {
   /**
    * Obtains the supplier address object for based on supplierData being either
    * the CreateSupplierAndSiteData or CreateExistingSupplierSiteData class.
-   * @param supplierData
-   * @returns
+   * @param supplierSite supplier site data to get supplier address.
+   * @param emailAddress email address for the supplier address.
+   * @returns formatted supplier address data.
    */
   private getSupplierAddress(
-    supplierData: CreateSupplierAndSiteData | CreateExistingSupplierSiteData,
+    supplierSite: CreateSupplierSite,
+    emailAddress: string,
   ): CreateSupplierAddressSubmittedData {
     const supplierAddress = {
-      AddressLine1: formatAddress(supplierData.supplierSite.addressLine1),
-      City: formatCity(supplierData.supplierSite.city),
-      Province: supplierData.supplierSite.provinceCode,
+      AddressLine1: formatAddress(supplierSite.addressLine1),
+      City: formatCity(supplierSite.city),
+      Province: supplierSite.provinceCode,
       Country: "CA",
-      PostalCode: formatPostalCode(supplierData.supplierSite.postalCode),
-      EmailAddress: supplierData.emailAddress,
+      PostalCode: formatPostalCode(supplierSite.postalCode),
+      EmailAddress: emailAddress,
     };
     return supplierAddress;
   }

--- a/sources/packages/backend/libs/integrations/src/cas/cas.service.ts
+++ b/sources/packages/backend/libs/integrations/src/cas/cas.service.ts
@@ -5,6 +5,7 @@ import {
   CreateExistingSupplierAndSiteSubmittedData,
   CreateExistingSupplierSiteData,
   CreateExistingSupplierSiteResponse,
+  CreateSupplierAddressSubmittedData,
   CreateSupplierAndSiteData,
   CreateSupplierAndSiteResponse,
   CreateSupplierAndSiteSubmittedData,
@@ -243,21 +244,15 @@ export class CASService {
    */
   private getSupplierAddress(
     supplierData: CreateSupplierAndSiteData | CreateExistingSupplierSiteData,
-  ): any {
+  ): CreateSupplierAddressSubmittedData {
     const supplierAddress = {
       AddressLine1: formatAddress(supplierData.supplierSite.addressLine1),
-      AddressLine2: "",
-      AddressLine3: "",
       City: formatCity(supplierData.supplierSite.city),
       Province: supplierData.supplierSite.provinceCode,
       Country: "CA",
       PostalCode: formatPostalCode(supplierData.supplierSite.postalCode),
       EmailAddress: supplierData.emailAddress,
     };
-    if (supplierData instanceof CreateExistingSupplierSiteData) {
-      supplierAddress["AddressLine2"] = "";
-      supplierAddress["AddressLine3"] = "";
-    }
     return supplierAddress;
   }
 

--- a/sources/packages/backend/libs/integrations/src/cas/models/cas-service.model.ts
+++ b/sources/packages/backend/libs/integrations/src/cas/models/cas-service.model.ts
@@ -62,7 +62,7 @@ export class CreateSupplierAndSiteData {
 /**
  * Information needed for existing supplier site creation on CAS.
  */
-export class CreateExistingSupplierSiteData {
+export class CreateExistingSupplierAndSiteData {
   supplierNumber: string;
   supplierSite: CreateSupplierSite;
   emailAddress: string;
@@ -93,15 +93,32 @@ export class CreateSupplierAndSiteResult {
  * the consumer, allowing it to be aware of the data actually submitted.
  */
 export class CreateSupplierAndSiteSubmittedData {
-  SupplierName?: string;
-  SubCategory?: string;
-  SupplierNumber?: string;
-  Sin?: string;
+  SupplierName: string;
+  SubCategory: string;
+  Sin: string;
   SupplierAddress: [
     {
       AddressLine1: string;
-      AddressLine2?: string;
-      AddressLine3?: string;
+      City: string;
+      Province: string;
+      Country: string;
+      PostalCode: string;
+      EmailAddress: string;
+    },
+  ];
+}
+
+/**
+ * Data used during the creation of a supplier and site on CAS for existing suppliers.
+ */
+export class CreateExistingSupplierAndSiteSubmittedData {
+  SupplierName?: string;
+  SupplierNumber: string;
+  SupplierAddress: [
+    {
+      AddressLine1: string;
+      AddressLine2: string;
+      AddressLine3: string;
       City: string;
       Province: string;
       Country: string;
@@ -116,6 +133,8 @@ export class CreateSupplierAndSiteSubmittedData {
  * submitted data and its API response.
  */
 export class CreateSupplierAndSiteResponse {
-  submittedData: CreateSupplierAndSiteSubmittedData;
+  submittedData:
+    | CreateSupplierAndSiteSubmittedData
+    | CreateExistingSupplierAndSiteSubmittedData;
   response: CreateSupplierAndSiteResult;
 }

--- a/sources/packages/backend/libs/integrations/src/cas/models/cas-service.model.ts
+++ b/sources/packages/backend/libs/integrations/src/cas/models/cas-service.model.ts
@@ -60,6 +60,15 @@ export class CreateSupplierAndSiteData {
 }
 
 /**
+ * Information needed for existing supplier site creation on CAS.
+ */
+export class CreateExistingSupplierSiteData {
+  supplierNumber: string;
+  supplierSite: CreateSupplierSite;
+  emailAddress: string;
+}
+
+/**
  * Site information needed for supplier and site creation on CAS.
  */
 export class CreateSupplierSite {
@@ -84,12 +93,15 @@ export class CreateSupplierAndSiteResult {
  * the consumer, allowing it to be aware of the data actually submitted.
  */
 export class CreateSupplierAndSiteSubmittedData {
-  SupplierName: string;
-  SubCategory: string;
-  Sin: string;
+  SupplierName?: string;
+  SubCategory?: string;
+  SupplierNumber?: string;
+  Sin?: string;
   SupplierAddress: [
     {
       AddressLine1: string;
+      AddressLine2?: string;
+      AddressLine3?: string;
       City: string;
       Province: string;
       Country: string;

--- a/sources/packages/backend/libs/integrations/src/cas/models/cas-service.model.ts
+++ b/sources/packages/backend/libs/integrations/src/cas/models/cas-service.model.ts
@@ -87,6 +87,18 @@ export class CreateSupplierAndSiteResult {
 }
 
 /**
+ * Supplier address data used during the creation of a supplier and site on CAS.
+ */
+export class CreateSupplierAddressSubmittedData {
+  AddressLine1: string;
+  City: string;
+  Province: string;
+  Country: string;
+  PostalCode: string;
+  EmailAddress: string;
+}
+
+/**
  * Data used during the creation of a supplier and site on CAS.
  * Some data transformation is needed to follow the CAS requirements.
  * This payload is used to submit the data and also to be returned to
@@ -96,16 +108,7 @@ export class CreateSupplierAndSiteSubmittedData {
   SupplierName: string;
   SubCategory: string;
   Sin: string;
-  SupplierAddress: [
-    {
-      AddressLine1: string;
-      City: string;
-      Province: string;
-      Country: string;
-      PostalCode: string;
-      EmailAddress: string;
-    },
-  ];
+  SupplierAddress: CreateSupplierAddressSubmittedData[];
 }
 
 /**
@@ -114,18 +117,7 @@ export class CreateSupplierAndSiteSubmittedData {
 export class CreateExistingSupplierAndSiteSubmittedData {
   SupplierName?: string;
   SupplierNumber: string;
-  SupplierAddress: [
-    {
-      AddressLine1: string;
-      AddressLine2: string;
-      AddressLine3: string;
-      City: string;
-      Province: string;
-      Country: string;
-      PostalCode: string;
-      EmailAddress: string;
-    },
-  ];
+  SupplierAddress: CreateSupplierAddressSubmittedData[];
 }
 
 /**

--- a/sources/packages/backend/libs/integrations/src/cas/models/cas-service.model.ts
+++ b/sources/packages/backend/libs/integrations/src/cas/models/cas-service.model.ts
@@ -62,7 +62,7 @@ export class CreateSupplierAndSiteData {
 /**
  * Information needed for existing supplier site creation on CAS.
  */
-export class CreateExistingSupplierAndSiteData {
+export class CreateExistingSupplierSiteData {
   supplierNumber: string;
   supplierSite: CreateSupplierSite;
   emailAddress: string;
@@ -133,8 +133,15 @@ export class CreateExistingSupplierAndSiteSubmittedData {
  * submitted data and its API response.
  */
 export class CreateSupplierAndSiteResponse {
-  submittedData:
-    | CreateSupplierAndSiteSubmittedData
-    | CreateExistingSupplierAndSiteSubmittedData;
+  submittedData: CreateSupplierAndSiteSubmittedData;
+  response: CreateSupplierAndSiteResult;
+}
+
+/**
+ * Combination of the existing CAS supplier site creation
+ * submitted data and its API response.
+ */
+export class CreateExistingSupplierSiteResponse {
+  submittedData: CreateExistingSupplierAndSiteSubmittedData;
   response: CreateSupplierAndSiteResult;
 }

--- a/sources/packages/backend/libs/test-utils/src/factories/cas-supplier.ts
+++ b/sources/packages/backend/libs/test-utils/src/factories/cas-supplier.ts
@@ -83,6 +83,7 @@ export function createFakeCASSupplier(
     casSupplier.supplierProtected = true;
     casSupplier.isValid = false;
   }
+  casSupplier.supplierName = `${faker.name.lastName()}, ${faker.name.firstName()}`;
   casSupplier.supplierNumber = faker.datatype
     .number({ min: 100000, max: 9999999999 })
     .toString();


### PR DESCRIPTION
- If a Get Supplier Response is Successful and returns Active Supplier and NO active Sites, **Create New Site**
- If a Get Supplier Response is Successful and returns Active Supplier and ONE OR MANY active Site, Compare the Response AddressLine1 and Postal Code to SIMS address
   - The address match logic was already added during the implementation of [#3260](https://github.com/bcgov/SIMS/issues/3260). 
- Created the new API `createExistingSupplierSite` call on CAS service.
   - Fields to include: 
     - SupplierNumber, 
     - AddressLine1: Use first addressline from SIMS. Truncate if ours is longer than supported. Convert or omit special characters (like is done with other integrations). 
     - City: Use as-is, 
     - Province: Use abbreviated versions AB,BC,MB,NB,NL,NS,NT,NU,ON,PE,QC,YT, 
     - Country, 
     - PostalCode: ALL CAPS, no space, 
     - EmailAddress: Use as-is
- Created Unit test
  - "Should invoke CAS API createSiteForExistingSupplier with formatted payload when all data was provided as expected."
- Created  E2E test
   - "Should create a new site and update the student CAS supplier when an active CAS supplier exists with no match addresses."
   - "Should create a new site and update the student CAS supplier when an inactive CAS supplier exists with matching addresses."
