### PR TITLE
#3889 - Increase Logging for SFTP and file handling

### DIFF
--- a/sources/packages/backend/apps/api/src/app.exception.filter.ts
+++ b/sources/packages/backend/apps/api/src/app.exception.filter.ts
@@ -10,9 +10,10 @@ export class AppAllExceptionsFilter extends BaseExceptionFilter {
     const request: Request = ctx.getRequest();
 
     // Logging Additional info
-    this.logger.error("Unhandled exception");
-    this.logger.error(`Request path [${request.path}]`);
-    this.logger.error(`${JSON.stringify(exception)}`);
+    this.logger.error(
+      `Unhandled exception, request path: ${request.path}`,
+      exception,
+    );
 
     // Calling super
     super.catch(exception, host);

--- a/sources/packages/backend/apps/api/src/main.ts
+++ b/sources/packages/backend/apps/api/src/main.ts
@@ -93,17 +93,13 @@ async function bootstrap() {
   await app.listen(port);
   // Logging node http server error
   app.getHttpServer().on("error", (error: unknown) => {
-    logger.error(`Application server receive ${error}`, undefined, "Bootstrap");
+    logger.error("Application server receive.", error, "Bootstrap");
     exit(1);
   });
   logger.log(`Application is listing on port ${port}`, "Bootstrap");
 }
 bootstrap().catch((error: unknown) => {
-  const logger = new LoggerService();
-  logger.error(
-    `Application bootstrap exception: ${error}`,
-    undefined,
-    "Bootstrap-Main",
-  );
+  const logger = new LoggerService("Bootstrap-Main");
+  logger.error("Application bootstrap exception.", error);
   exit(1);
 });

--- a/sources/packages/backend/libs/integrations/src/cra-integration/cra-income-verification.processing.service.ts
+++ b/sources/packages/backend/libs/integrations/src/cra-integration/cra-income-verification.processing.service.ts
@@ -13,12 +13,11 @@ import {
   CRASFTPResponseFile,
   ProcessSftpResponseResult,
 } from "./cra-integration.models";
-import { getUTCNow } from "@sims/utilities";
+import { getUTCNow, parseJSONError } from "@sims/utilities";
 import * as path from "path";
 import { ConfigService } from "@sims/utilities/config";
 import { CRAIntegrationService } from "./cra.integration.service";
 import { CRAIncomeVerificationsService } from "../services";
-import { SFTP_ARCHIVE_DIRECTORY } from "@sims/integrations/constants";
 
 const INCOME_VERIFICATION_TAG = "VERIFICATION_ID";
 
@@ -275,14 +274,15 @@ export class CRAIncomeVerificationProcessingService {
 
     try {
       // Archive file.
-      await this.craService.archiveFile(remoteFilePath, SFTP_ARCHIVE_DIRECTORY);
+      await this.craService.archiveFile(remoteFilePath);
     } catch (error) {
       // Log the error but allow the process to continue.
       // If there was an issue only during the file archiving, it will be
       // processed again and could be archived in the second attempt.
       const logMessage = `Error while archiving CRA response file: ${remoteFilePath}`;
-      this.logger.error(logMessage);
       result.errorsSummary.push(logMessage);
+      result.errorsSummary.push(parseJSONError(error));
+      this.logger.error(logMessage, error);
     }
 
     return result;

--- a/sources/packages/backend/libs/integrations/src/esdc-integration/disbursement-receipt-integration/disbursement-receipt.processing.service.ts
+++ b/sources/packages/backend/libs/integrations/src/esdc-integration/disbursement-receipt-integration/disbursement-receipt.processing.service.ts
@@ -14,8 +14,7 @@ import {
   ReportsFilterModel,
 } from "@sims/services";
 import { DAILY_DISBURSEMENT_REPORT_NAME } from "@sims/services/constants";
-import { getISODateOnlyString } from "@sims/utilities";
-import { SFTP_ARCHIVE_DIRECTORY } from "@sims/integrations/constants";
+import { getISODateOnlyString, parseJSONError } from "@sims/utilities";
 
 /**
  * Disbursement schedule map which consists of disbursement schedule id for a document number.
@@ -160,15 +159,12 @@ export class DisbursementReceiptProcessingService {
 
     try {
       // Archiving the file once it has been processed.
-      await this.integrationService.archiveFile(
-        remoteFilePath,
-        SFTP_ARCHIVE_DIRECTORY,
-      );
+      await this.integrationService.archiveFile(remoteFilePath);
     } catch (error) {
-      result.errorsSummary.push(
-        `Error while archiving disbursement receipt file: ${remoteFilePath}`,
-      );
-      result.errorsSummary.push(error);
+      const logMessage = `Unexpected error while archiving disbursement receipt file: ${remoteFilePath}.`;
+      result.errorsSummary.push(logMessage);
+      result.errorsSummary.push(parseJSONError(error));
+      this.logger.error(logMessage, error);
     }
     return result;
   }

--- a/sources/packages/backend/libs/integrations/src/esdc-integration/e-cert-integration/e-cert-file-handler.ts
+++ b/sources/packages/backend/libs/integrations/src/esdc-integration/e-cert-integration/e-cert-file-handler.ts
@@ -27,7 +27,6 @@ import { ConfigService, ESDCIntegrationConfig } from "@sims/utilities/config";
 import { ECertGenerationService } from "@sims/integrations/services";
 import { ECertResponseRecord } from "./e-cert-files/e-cert-response-record";
 import * as path from "path";
-import { SFTP_ARCHIVE_DIRECTORY } from "@sims/integrations/constants";
 
 /**
  * Used to abort the e-Cert generation process, cancel the current transaction,
@@ -521,10 +520,7 @@ export abstract class ECertFileHandler extends ESDCFileHandler {
     processSummary: ProcessSummary,
   ) {
     try {
-      await eCertIntegrationService.archiveFile(
-        filePath,
-        SFTP_ARCHIVE_DIRECTORY,
-      );
+      await eCertIntegrationService.archiveFile(filePath);
     } catch (error) {
       // Log the error but allow the process to continue.
       // If there was an issue only during the file archiving, it will be

--- a/sources/packages/backend/libs/integrations/src/esdc-integration/msfaa-integration/msfaa-response.processing.service.ts
+++ b/sources/packages/backend/libs/integrations/src/esdc-integration/msfaa-integration/msfaa-response.processing.service.ts
@@ -10,7 +10,7 @@ import {
 import { MSFAAResponseCancelledRecord } from "./msfaa-files/msfaa-response-cancelled-record";
 import { MSFAAResponseReceivedRecord } from "./msfaa-files/msfaa-response-received-record";
 import { MSFAAIntegrationService } from "./msfaa.integration.service";
-import { SFTP_ARCHIVE_DIRECTORY } from "@sims/integrations/constants";
+import { parseJSONError } from "@sims/utilities";
 
 @Injectable()
 export class MSFAAResponseProcessingService {
@@ -95,17 +95,15 @@ export class MSFAAResponseProcessingService {
     }
     try {
       // Archive file.
-      await this.msfaaService.archiveFile(
-        responseFile.filePath,
-        SFTP_ARCHIVE_DIRECTORY,
-      );
+      await this.msfaaService.archiveFile(responseFile.filePath);
     } catch (error) {
       // Log the error but allow the process to continue.
       // If there was an issue only during the file archiving, it will be
       // processed again and could be archived in the second attempt.
       const logMessage = `Error while archiving MSFAA response file: ${responseFile.filePath}`;
-      this.logger.error(logMessage);
       result.errorsSummary.push(logMessage);
+      result.errorsSummary.push(parseJSONError(error));
+      this.logger.error(logMessage, error);
     }
 
     return result;

--- a/sources/packages/backend/libs/integrations/src/esdc-integration/sin-validation/sin-validation.processing.service.ts
+++ b/sources/packages/backend/libs/integrations/src/esdc-integration/sin-validation/sin-validation.processing.service.ts
@@ -17,7 +17,7 @@ import {
   SINValidationService,
   StudentService,
 } from "@sims/integrations/services";
-import { SFTP_ARCHIVE_DIRECTORY } from "@sims/integrations/constants";
+import { parseJSONError } from "@sims/utilities";
 
 /**
  * Manages the process to generate SIN validations requests to ESDC and allow
@@ -212,17 +212,15 @@ export class SINValidationProcessingService {
 
     try {
       // Archive file.
-      await this.sinValidationIntegrationService.archiveFile(
-        remoteFilePath,
-        SFTP_ARCHIVE_DIRECTORY,
-      );
+      await this.sinValidationIntegrationService.archiveFile(remoteFilePath);
     } catch (error) {
       // Log the error but allow the process to continue.
       // If there was an issue only during the file archiving, it will be
       // processed again and could be archived in the second attempt.
-      const logMessage = `Error while archiving ESDC SIN validation response file: ${remoteFilePath}`;
-      this.logger.error(logMessage);
+      const logMessage = `Error while archiving ESDC SIN validation response file: ${remoteFilePath}.`;
       result.errorsSummary.push(logMessage);
+      result.errorsSummary.push(parseJSONError(logMessage));
+      this.logger.error(logMessage, error);
     }
 
     return result;

--- a/sources/packages/backend/libs/integrations/src/esdc-integration/student-loan-balances/student-loan-balances.processing.service.ts
+++ b/sources/packages/backend/libs/integrations/src/esdc-integration/student-loan-balances/student-loan-balances.processing.service.ts
@@ -16,7 +16,6 @@ import {
   User,
   isDatabaseConstraintError,
 } from "@sims/sims-db";
-import { SFTP_ARCHIVE_DIRECTORY } from "@sims/integrations/constants";
 
 /**
  * Manages to process the Student Loan Balances files
@@ -155,14 +154,13 @@ export class StudentLoanBalancesProcessingService {
         // Archive file.
         await this.studentLoanBalancesIntegrationService.archiveFile(
           remoteFilePath,
-          SFTP_ARCHIVE_DIRECTORY,
         );
       } catch (error: unknown) {
         // Log the error but allow the process to continue.
         // If there was an issue only during the file archiving, it will be
         // processed again and could be archived in the second attempt.
         const logMessage = `Error while archiving Student Loan Balances response file: ${remoteFilePath}`;
-        childrenProcessSummary.error(logMessage);
+        childrenProcessSummary.error(logMessage, error);
       }
     }
   }

--- a/sources/packages/backend/libs/integrations/src/institution-integration/ece-integration/ece-response.processing.service.ts
+++ b/sources/packages/backend/libs/integrations/src/institution-integration/ece-integration/ece-response.processing.service.ts
@@ -10,7 +10,6 @@ import { ProcessSummaryResult } from "@sims/integrations/models";
 import {
   ECE_RESPONSE_COE_DECLINED_REASON,
   ECE_RESPONSE_FILE_NAME,
-  SFTP_ARCHIVE_DIRECTORY,
 } from "@sims/integrations/constants";
 import { InstitutionLocationService } from "@sims/integrations/services";
 import {
@@ -18,6 +17,7 @@ import {
   CustomNamedError,
   END_OF_LINE,
   StringBuilder,
+  parseJSONError,
   processInParallel,
 } from "@sims/utilities";
 import { ECEResponseFileDetail } from "./ece-files/ece-response-file-detail";
@@ -509,17 +509,15 @@ export class ECEResponseProcessingService {
   ): Promise<void> {
     try {
       // Archiving the file once it has been processed.
-      await this.integrationService.archiveFile(
-        remoteFilePath,
-        SFTP_ARCHIVE_DIRECTORY,
-      );
+      await this.integrationService.archiveFile(remoteFilePath);
       processSummary.summary.push(
         `The file ${remoteFilePath} has been archived after processing.`,
       );
     } catch (error: unknown) {
-      processSummary.errors.push(
-        `Error while archiving the file: ${remoteFilePath}. ${error}`,
-      );
+      const logMessage = `Error while archiving the file: ${remoteFilePath}.`;
+      processSummary.errors.push(logMessage);
+      processSummary.errors.push(parseJSONError(error));
+      this.logger.error(logMessage, error);
     }
   }
 

--- a/sources/packages/backend/libs/integrations/src/services/ssh/sftp-integration-base.ts
+++ b/sources/packages/backend/libs/integrations/src/services/ssh/sftp-integration-base.ts
@@ -10,7 +10,10 @@ import {
   convertToASCII,
   FILE_DEFAULT_ENCODING,
 } from "@sims/utilities";
-import { LINE_BREAK_SPLIT_REGEX } from "@sims/integrations/constants";
+import {
+  LINE_BREAK_SPLIT_REGEX,
+  SFTP_ARCHIVE_DIRECTORY,
+} from "@sims/integrations/constants";
 
 /**
  * Provides the basic features to enable the SFTP integration.
@@ -55,15 +58,30 @@ export abstract class SFTPIntegrationBase<DownloadType> {
     remoteFilePath: string,
   ): Promise<string> {
     // Send the file to ftp.
-    this.logger.log("Creating new SFTP client to start upload...");
-    const client = await this.getClient();
+    this.logger.log(
+      `Creating new SFTP client to start upload of ${remoteFilePath}`,
+    );
+    let client: Client;
     try {
+      client = await this.getClient();
       this.logger.log(`Uploading ${remoteFilePath}`);
       return await client.put(convertToASCII(rawContent), remoteFilePath);
+    } catch (error) {
+      this.logger.error(`Error uploading file ${remoteFilePath}.`, error);
+      throw error;
     } finally {
-      this.logger.log("Finalizing SFTP client...");
-      await SshService.closeQuietly(client);
-      this.logger.log("SFTP client finalized.");
+      if (client) {
+        this.logger.log(
+          `Finalizing SFTP client crated for the upload of ${remoteFilePath}.`,
+        );
+        await SshService.closeQuietly(client);
+        this.logger.log(
+          `SFTP client finalized for upload of ${remoteFilePath}.`,
+        );
+      }
+      this.logger.log(
+        `SFTP client not initialized while uploading ${remoteFilePath}.`,
+      );
     }
   }
 
@@ -77,17 +95,24 @@ export abstract class SFTPIntegrationBase<DownloadType> {
     remoteDownloadFolder: string,
     fileRegexSearch: RegExp,
   ): Promise<string[]> {
+    this.logger.log(`Listing files from ${remoteDownloadFolder}.`);
     let filesToProcess: Client.FileInfo[];
-    const client = await this.getClient();
+    let client: Client;
     try {
+      client = await this.getClient();
       filesToProcess = await client.list(
         remoteDownloadFolder,
         (item: Client.FileInfo) => fileRegexSearch.test(item.name),
       );
+    } catch (error) {
+      this.logger.error(
+        `Error listing files from ${remoteDownloadFolder}.`,
+        error,
+      );
+      throw error;
     } finally {
       await SshService.closeQuietly(client);
     }
-
     return filesToProcess
       .map((file) => path.join(remoteDownloadFolder, file.name))
       .sort((a, b) => a.localeCompare(b));
@@ -128,8 +153,10 @@ export abstract class SFTPIntegrationBase<DownloadType> {
     remoteFilePath: string,
     options?: { checkIfFileExist: boolean },
   ): Promise<string[] | false> {
-    const client = await this.getClient();
+    this.logger.log(`Downloading ${remoteFilePath}.`);
+    let client: Client;
     try {
+      client = await this.getClient();
       if (options?.checkIfFileExist) {
         const fileExist = await client.exists(remoteFilePath);
         if (!fileExist) {
@@ -145,6 +172,9 @@ export abstract class SFTPIntegrationBase<DownloadType> {
         .toString()
         .split(LINE_BREAK_SPLIT_REGEX)
         .filter((line) => line.length > 0);
+    } catch (error) {
+      this.logger.error(`Error downloading file ${remoteFilePath}`, error);
+      throw error;
     } finally {
       await SshService.closeQuietly(client);
     }
@@ -168,9 +198,17 @@ export abstract class SFTPIntegrationBase<DownloadType> {
     remoteFilePath: string,
     newRemoteFilePath: string,
   ): Promise<void> {
-    const client = await this.getClient();
+    this.logger.log(`Renaming file ${remoteFilePath} to ${newRemoteFilePath}.`);
+    let client: Client;
     try {
+      client = await this.getClient();
       await client.rename(remoteFilePath, newRemoteFilePath);
+    } catch (error) {
+      this.logger.error(
+        `Error renaming file ${remoteFilePath} to ${newRemoteFilePath}.`,
+        error,
+      );
+      throw error;
     } finally {
       await SshService.closeQuietly(client);
     }
@@ -180,10 +218,11 @@ export abstract class SFTPIntegrationBase<DownloadType> {
    * Archives a file on SFTP .
    * @param remoteFilePath full remote file path with file name.
    * @param archiveDirectory directory name to archive the file.
+   * A default value of {@link SFTP_ARCHIVE_DIRECTORY} will be used if not specified.
    */
   async archiveFile(
     remoteFilePath: string,
-    archiveDirectory: string,
+    archiveDirectory = SFTP_ARCHIVE_DIRECTORY,
   ): Promise<void> {
     const fileInfo = path.parse(remoteFilePath);
     const timestamp = getFileNameAsExtendedCurrentTimestamp();

--- a/sources/packages/backend/libs/integrations/src/services/ssh/sftp-integration-base.ts
+++ b/sources/packages/backend/libs/integrations/src/services/ssh/sftp-integration-base.ts
@@ -58,13 +58,10 @@ export abstract class SFTPIntegrationBase<DownloadType> {
     remoteFilePath: string,
   ): Promise<string> {
     // Send the file to ftp.
-    this.logger.log(
-      `Creating new SFTP client to start upload of ${remoteFilePath}`,
-    );
+    this.logger.log(`Uploading ${remoteFilePath}.`);
     let client: Client;
     try {
       client = await this.getClient();
-      this.logger.log(`Uploading ${remoteFilePath}`);
       return await client.put(convertToASCII(rawContent), remoteFilePath);
     } catch (error) {
       this.logger.error(`Error uploading file ${remoteFilePath}.`, error);
@@ -145,7 +142,7 @@ export abstract class SFTPIntegrationBase<DownloadType> {
     remoteFilePath: string,
     options?: { checkIfFileExist: boolean },
   ): Promise<string[] | false> {
-    this.logger.log(`Downloading ${remoteFilePath}.`);
+    this.logger.log(`Downloading file ${remoteFilePath}.`);
     let client: Client;
     try {
       client = await this.getClient();

--- a/sources/packages/backend/libs/integrations/src/services/ssh/sftp-integration-base.ts
+++ b/sources/packages/backend/libs/integrations/src/services/ssh/sftp-integration-base.ts
@@ -90,6 +90,9 @@ export abstract class SFTPIntegrationBase<DownloadType> {
         remoteDownloadFolder,
         (item: Client.FileInfo) => fileRegexSearch.test(item.name),
       );
+      return filesToProcess
+        .map((file) => path.join(remoteDownloadFolder, file.name))
+        .sort((a, b) => a.localeCompare(b));
     } catch (error) {
       this.logger.error(
         `Error listing files from ${remoteDownloadFolder}.`,
@@ -102,9 +105,6 @@ export abstract class SFTPIntegrationBase<DownloadType> {
         client,
       );
     }
-    return filesToProcess
-      .map((file) => path.join(remoteDownloadFolder, file.name))
-      .sort((a, b) => a.localeCompare(b));
   }
 
   /**

--- a/sources/packages/backend/libs/integrations/src/sfas-integration/sfas-integration.processing.service.ts
+++ b/sources/packages/backend/libs/integrations/src/sfas-integration/sfas-integration.processing.service.ts
@@ -16,7 +16,6 @@ import {
 import { SFAS_IMPORT_RECORDS_PROGRESS_REPORT_PACE } from "@sims/services/constants";
 import * as os from "os";
 import { ConfigService } from "@sims/utilities/config";
-import { SFTP_ARCHIVE_DIRECTORY } from "@sims/integrations/constants";
 
 @Injectable()
 export class SFASIntegrationProcessingService {
@@ -147,10 +146,7 @@ export class SFASIntegrationProcessingService {
          * Archive the file only if it was processed with success.
          */
         try {
-          await this.sfasService.archiveFile(
-            remoteFilePath,
-            SFTP_ARCHIVE_DIRECTORY,
-          );
+          await this.sfasService.archiveFile(remoteFilePath);
         } catch (error) {
           throw new Error(
             `Error while archiving SFAS integration file: ${remoteFilePath}`,
@@ -218,8 +214,7 @@ export class SFASIntegrationProcessingService {
         "Error while wrapping up post file processing operations.";
       postFileImportResult.success = false;
       postFileImportResult.summary.push(logMessage);
-      this.logger.log(logMessage);
-      this.logger.error(error);
+      this.logger.error(logMessage, error);
     }
     return postFileImportResult;
   }

--- a/sources/packages/backend/libs/integrations/src/sfas-integration/sfas-integration.processing.service.ts
+++ b/sources/packages/backend/libs/integrations/src/sfas-integration/sfas-integration.processing.service.ts
@@ -16,6 +16,7 @@ import {
 import { SFAS_IMPORT_RECORDS_PROGRESS_REPORT_PACE } from "@sims/services/constants";
 import * as os from "os";
 import { ConfigService } from "@sims/utilities/config";
+import { parseJSONError } from "@sims/utilities";
 
 @Injectable()
 export class SFASIntegrationProcessingService {
@@ -214,6 +215,7 @@ export class SFASIntegrationProcessingService {
         "Error while wrapping up post file processing operations.";
       postFileImportResult.success = false;
       postFileImportResult.summary.push(logMessage);
+      postFileImportResult.summary.push(parseJSONError(error));
       this.logger.error(logMessage, error);
     }
     return postFileImportResult;

--- a/sources/packages/backend/libs/utilities/src/logger/logger.service.ts
+++ b/sources/packages/backend/libs/utilities/src/logger/logger.service.ts
@@ -41,7 +41,7 @@ export class LoggerService extends ConsoleLogger {
     if (error) {
       errorBuilder.appendLine(parseJSONError(error));
     }
-    super.error(errorBuilder.toString(), context);
+    super.error(errorBuilder.toString(), null, context);
   }
 
   /**

--- a/sources/packages/backend/libs/utilities/src/logger/logger.service.ts
+++ b/sources/packages/backend/libs/utilities/src/logger/logger.service.ts
@@ -1,11 +1,47 @@
 import { Injectable, ConsoleLogger, Scope } from "@nestjs/common";
 import { LogLevels, ProcessSummary } from "./process-summary";
+import { StringBuilder } from "@sims/utilities/string-builder";
+import { parseJSONError } from "@sims/utilities/parse-json";
 
 /**
  * Common log across entire solution.
  */
 @Injectable({ scope: Scope.TRANSIENT })
 export class LoggerService extends ConsoleLogger {
+  /**
+   * Log a friendly error message.
+   * @param message friendly message.
+   */
+  error(message: string): void;
+  /**
+   * Converts the object into a string and log it.
+   * @param object object to be logged.
+   */
+  error(object: unknown): void;
+  /**
+   * Log the error message and the error details.
+   * @param message friendly message.
+   * @param error error captured.
+   */
+  error(message: string, error: unknown): void;
+  /**
+   * Log the error message and the error details.
+   * @param message friendly message or object to be logged.
+   * @param error error captured.
+   */
+  error(message: unknown, error?: unknown): void {
+    const errorBuilder = new StringBuilder();
+    if (typeof message === "string") {
+      errorBuilder.appendLine(message);
+    } else {
+      errorBuilder.appendLine(parseJSONError(message));
+    }
+    if (error) {
+      errorBuilder.appendLine(parseJSONError(error));
+    }
+    super.error(errorBuilder.toString());
+  }
+
   /**
    * Writes all the log entries.
    * @param processSummary process summary logs.

--- a/sources/packages/backend/libs/utilities/src/logger/logger.service.ts
+++ b/sources/packages/backend/libs/utilities/src/logger/logger.service.ts
@@ -22,14 +22,16 @@ export class LoggerService extends ConsoleLogger {
    * Log the error message and the error details.
    * @param message friendly message.
    * @param error error captured.
+   * @param context optional log context.
    */
-  error(message: string, error: unknown): void;
+  error(message: string, error: unknown, context?: string): void;
   /**
    * Log the error message and the error details.
    * @param message friendly message or object to be logged.
    * @param error error captured.
+   * @param context optional log context.
    */
-  error(message: unknown, error?: unknown): void {
+  error(message: unknown, error?: unknown, context?: string): void {
     const errorBuilder = new StringBuilder();
     if (typeof message === "string") {
       errorBuilder.appendLine(message);
@@ -39,7 +41,7 @@ export class LoggerService extends ConsoleLogger {
     if (error) {
       errorBuilder.appendLine(parseJSONError(error));
     }
-    super.error(errorBuilder.toString());
+    super.error(errorBuilder.toString(), context);
   }
 
   /**


### PR DESCRIPTION
## Main PR Goal

- Increase the log level at the `SFTPIntegrationBase` without disrupting the consumer's methods and try to limit the amount of refactoring.
- Deploy to PROD in the next possible release to allow troubleshooting of current intermittent issues while archiving files. 

### Changes

- Adapted the `LoggerService.error` to receive a friendly error and log the error itself, keeping it compatible with the existing methods.
- Added log messages to all base SFTP operations in the `SFTPIntegrationBase`. The errors are reshown keeping the current behavior for current method consumers.
- Adjusted the API `mais.ts` that was using the log context.
- Adjusted the global error handler to generate only one log entry instead of three.
- Even though the `SFTPIntegrationBase` method is now generating more logs, the archive operation error handling was adjusted to ensure the exception details are logged.
- Small refactor to stop passing the `SFTP_ARCHIVE_DIRECTORY` for every archive method.