### PR TITLE
#3889 - Increase Logging for SFTP and file handling - (Catch fix)

### DIFF
--- a/sources/packages/backend/libs/integrations/src/esdc-integration/sin-validation/sin-validation.processing.service.ts
+++ b/sources/packages/backend/libs/integrations/src/esdc-integration/sin-validation/sin-validation.processing.service.ts
@@ -219,7 +219,7 @@ export class SINValidationProcessingService {
       // processed again and could be archived in the second attempt.
       const logMessage = `Error while archiving ESDC SIN validation response file: ${remoteFilePath}.`;
       result.errorsSummary.push(logMessage);
-      result.errorsSummary.push(parseJSONError(logMessage));
+      result.errorsSummary.push(parseJSONError(error));
       this.logger.error(logMessage, error);
     }
 

--- a/sources/packages/backend/libs/integrations/src/sfas-integration/sfas-integration.processing.service.ts
+++ b/sources/packages/backend/libs/integrations/src/sfas-integration/sfas-integration.processing.service.ts
@@ -158,11 +158,11 @@ export class SFASIntegrationProcessingService {
         }
       }
     } catch (error) {
+      result.success = false;
       const logMessage = `Error while processing SFAS integration file: ${remoteFilePath}`;
       result.summary.push(logMessage);
-      result.success = false;
-      this.logger.error(logMessage);
-      this.logger.error(error);
+      result.summary.push(parseJSONError(error));
+      this.logger.error(logMessage, error);
     }
 
     return result;


### PR DESCRIPTION
Fix issues from the previous PR for better logging. The main log from the SFTP base would still work but ensuring the logs are added to the Job in some way makes it easier for troubleshooting.
The goal is to have all the methods following similar archive catch handling doing something closet to each other.

See the example below of a sample that will display errors and `causes`.
![image](https://github.com/user-attachments/assets/dbb7e668-38d0-4f04-95a0-6c09720f308b)
