### PR TITLE
#3691 - UX/UI for Ignore Restriction - Bypass Add/Remove - API part

### DIFF
--- a/sources/packages/backend/apps/api/src/auth/roles.enum.ts
+++ b/sources/packages/backend/apps/api/src/auth/roles.enum.ts
@@ -9,6 +9,7 @@ export enum Role {
   AESTReports = "aest-reports",
   AESTCreateInstitution = "aest-create-institution",
   AESTEditCASSupplierInfo = "aest-edit-cas-supplier-info",
+  AESTBypassStudentRestriction = "aest-bypass-student-restriction",
   StudentAddRestriction = "student-add-restriction",
   StudentResolveRestriction = "student-resolve-restriction",
   StudentUploadFile = "student-upload-file",

--- a/sources/packages/backend/apps/api/src/constants/error-code.constants.ts
+++ b/sources/packages/backend/apps/api/src/constants/error-code.constants.ts
@@ -220,7 +220,7 @@ export const STUDENT_RESTRICTION_IS_NOT_ACTIVE =
 export const STUDENT_RESTRICTION_NOT_FOUND = "STUDENT_RESTRICTION_NOT_FOUND";
 
 /**
- * Student application is invalid for application restriction bypass creation.
+ * Student application is invalid state for application restriction bypass creation.
  */
 export const APPLICATION_IN_INVALID_STATE_FOR_APPLICATION_RESTRICTION_BYPASS_CREATION =
   "APPLICATION_IN_INVALID_STATE_FOR_APPLICATION_RESTRICTION_BYPASS_CREATION";

--- a/sources/packages/backend/apps/api/src/constants/error-code.constants.ts
+++ b/sources/packages/backend/apps/api/src/constants/error-code.constants.ts
@@ -201,3 +201,38 @@ export const FILE_SAVE_ERROR = "FILE_SAVE_ERROR";
  * Beta user is invalid.
  */
 export const INVALID_BETA_USER = "INVALID_BETA_USER";
+
+/**
+ * Bypass for student restriction already exists.
+ */
+export const ACTIVE_BYPASS_FOR_STUDENT_RESTRICTION_ALREADY_EXISTS =
+  "ACTIVE_BYPASS_FOR_STUDENT_RESTRICTION_ALREADY_EXISTS";
+
+/**
+ * Student restriction is not active.
+ */
+export const STUDENT_RESTRICTION_IS_NOT_ACTIVE =
+  "STUDENT_RESTRICTION_IS_NOT_ACTIVE";
+
+/**
+ * Student restriction not found.
+ */
+export const STUDENT_RESTRICTION_NOT_FOUND = "STUDENT_RESTRICTION_NOT_FOUND";
+
+/**
+ * Student application is invalid for application restriction bypass creation.
+ */
+export const APPLICATION_IN_INVALID_STATE_FOR_APPLICATION_RESTRICTION_BYPASS_CREATION =
+  "APPLICATION_IN_INVALID_STATE_FOR_APPLICATION_RESTRICTION_BYPASS_CREATION";
+
+/**
+ * Application restriction bypass not found.
+ */
+export const APPLICATION_RESTRICTION_BYPASS_NOT_FOUND =
+  "APPLICATION_RESTRICTION_BYPASS_NOT_FOUND";
+
+/**
+ * Application restriction bypass is not active.
+ */
+export const APPLICATION_RESTRICTION_BYPASS_IS_NOT_ACTIVE =
+  "APPLICATION_RESTRICTION_BYPASS_IS_NOT_ACTIVE";

--- a/sources/packages/backend/apps/api/src/route-controllers/application-restriction-bypass/_tests_/e2e/application-restriction-bypass.aest.controller.bypassRestriction.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/application-restriction-bypass/_tests_/e2e/application-restriction-bypass.aest.controller.bypassRestriction.e2e-spec.ts
@@ -170,7 +170,6 @@ describe("ApplicationRestrictionBypassAESTController(e2e)-bypassRestriction", ()
       {
         student: application.student,
         restriction: ptssrRestriction,
-        application,
         resolutionNote: null,
         creator: sharedMinistryUser,
       },

--- a/sources/packages/backend/apps/api/src/route-controllers/application-restriction-bypass/_tests_/e2e/application-restriction-bypass.aest.controller.bypassRestriction.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/application-restriction-bypass/_tests_/e2e/application-restriction-bypass.aest.controller.bypassRestriction.e2e-spec.ts
@@ -24,6 +24,11 @@ import {
   RestrictionBypassBehaviors,
   User,
 } from "@sims/sims-db";
+import {
+  ACTIVE_BYPASS_FOR_STUDENT_RESTRICTION_ALREADY_EXISTS,
+  APPLICATION_IN_INVALID_STATE_FOR_APPLICATION_RESTRICTION_BYPASS_CREATION,
+  STUDENT_RESTRICTION_IS_NOT_ACTIVE,
+} from "../../../../constants";
 
 describe("ApplicationRestrictionBypassAESTController(e2e)-bypassRestriction", () => {
   let app: INestApplication;
@@ -149,10 +154,9 @@ describe("ApplicationRestrictionBypassAESTController(e2e)-bypassRestriction", ()
       .auth(token, BEARER_AUTH_TYPE)
       .expect(HttpStatus.UNPROCESSABLE_ENTITY)
       .expect({
-        statusCode: HttpStatus.UNPROCESSABLE_ENTITY,
         message:
           "Cannot create a bypass when there is an active bypass for the same active student restriction.",
-        error: "Unprocessable Entity",
+        errorType: ACTIVE_BYPASS_FOR_STUDENT_RESTRICTION_ALREADY_EXISTS,
       });
   });
 
@@ -191,10 +195,9 @@ describe("ApplicationRestrictionBypassAESTController(e2e)-bypassRestriction", ()
       .auth(token, BEARER_AUTH_TYPE)
       .expect(HttpStatus.UNPROCESSABLE_ENTITY)
       .expect({
-        statusCode: HttpStatus.UNPROCESSABLE_ENTITY,
         message:
           "Cannot create a bypass when student restriction is not active.",
-        error: "Unprocessable Entity",
+        errorType: STUDENT_RESTRICTION_IS_NOT_ACTIVE,
       });
   });
 
@@ -228,9 +231,9 @@ describe("ApplicationRestrictionBypassAESTController(e2e)-bypassRestriction", ()
       .auth(token, BEARER_AUTH_TYPE)
       .expect(HttpStatus.UNPROCESSABLE_ENTITY)
       .expect({
-        statusCode: HttpStatus.UNPROCESSABLE_ENTITY,
         message: "Cannot create a bypass when application is in invalid state.",
-        error: "Unprocessable Entity",
+        errorType:
+          APPLICATION_IN_INVALID_STATE_FOR_APPLICATION_RESTRICTION_BYPASS_CREATION,
       });
   });
 
@@ -264,9 +267,9 @@ describe("ApplicationRestrictionBypassAESTController(e2e)-bypassRestriction", ()
       .auth(token, BEARER_AUTH_TYPE)
       .expect(HttpStatus.UNPROCESSABLE_ENTITY)
       .expect({
-        statusCode: HttpStatus.UNPROCESSABLE_ENTITY,
         message: "Cannot create a bypass when application is in invalid state.",
-        error: "Unprocessable Entity",
+        errorType:
+          APPLICATION_IN_INVALID_STATE_FOR_APPLICATION_RESTRICTION_BYPASS_CREATION,
       });
   });
 

--- a/sources/packages/backend/apps/api/src/route-controllers/application-restriction-bypass/_tests_/e2e/application-restriction-bypass.aest.controller.bypassRestriction.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/application-restriction-bypass/_tests_/e2e/application-restriction-bypass.aest.controller.bypassRestriction.e2e-spec.ts
@@ -1,0 +1,273 @@
+import { HttpStatus, INestApplication } from "@nestjs/common";
+import {
+  E2EDataSources,
+  RestrictionCode,
+  createE2EDataSources,
+  createFakeUser,
+  saveFakeApplication,
+  saveFakeApplicationRestrictionBypass,
+  saveFakeStudentRestriction,
+} from "@sims/test-utils";
+import {
+  AESTGroups,
+  BEARER_AUTH_TYPE,
+  createTestingAppModule,
+  getAESTToken,
+} from "../../../../testHelpers";
+import * as request from "supertest";
+import {
+  ApplicationStatus,
+  NoteType,
+  OfferingIntensity,
+  Restriction,
+  RestrictionActionType,
+  RestrictionBypassBehaviors,
+  User,
+} from "@sims/sims-db";
+
+describe("ApplicationRestrictionBypassAESTController(e2e)-bypassRestriction", () => {
+  let app: INestApplication;
+  let db: E2EDataSources;
+  let sharedMinistryUser: User;
+  let ptssrRestriction: Restriction;
+  let endpoint: string;
+
+  beforeAll(async () => {
+    const { nestApplication, dataSource } = await createTestingAppModule();
+    app = nestApplication;
+    db = createE2EDataSources(dataSource);
+    sharedMinistryUser = await db.user.save(createFakeUser());
+    ptssrRestriction = await db.restriction.findOneBy({
+      restrictionCode: RestrictionCode.PTSSR,
+    });
+    endpoint = "/aest/application-restriction-bypass";
+  });
+
+  it("Should be able to create a bypass when there is not an active bypass for the same student.", async () => {
+    // Arrange
+    const application = await saveFakeApplication(db.dataSource, undefined, {
+      offeringIntensity: OfferingIntensity.partTime,
+    });
+
+    const studentRestriction = await saveFakeStudentRestriction(db.dataSource, {
+      student: application.student,
+      restriction: ptssrRestriction,
+      application,
+      resolutionNote: null,
+      creator: sharedMinistryUser,
+    });
+
+    const payload = {
+      applicationId: application.id,
+      studentRestrictionId: studentRestriction.id,
+      bypassBehavior: RestrictionBypassBehaviors.NextDisbursementOnly,
+      note: "test note",
+    };
+    const token = await getAESTToken(AESTGroups.BusinessAdministrators);
+
+    // Act/Assert
+    let applicationRestrictionBypassId: number;
+    await request(app.getHttpServer())
+      .post(endpoint)
+      .send(payload)
+      .auth(token, BEARER_AUTH_TYPE)
+      .expect(HttpStatus.CREATED)
+      .then((response) => {
+        expect(response.body.id).toBeGreaterThan(0);
+        applicationRestrictionBypassId = response.body.id;
+      });
+
+    const applicationRestrictionBypass =
+      await db.applicationRestrictionBypass.findOne({
+        select: {
+          id: true,
+          application: { id: true },
+          studentRestriction: { id: true },
+          bypassBehavior: true,
+          creationNote: { noteType: true, description: true },
+          bypassCreatedDate: true,
+          bypassRemovedDate: true,
+          createdAt: true,
+          isActive: true,
+        },
+        relations: {
+          application: true,
+          studentRestriction: true,
+          creationNote: true,
+        },
+        where: { id: applicationRestrictionBypassId },
+      });
+
+    expect(applicationRestrictionBypass).toMatchObject({
+      id: applicationRestrictionBypassId,
+      application: { id: application.id },
+      studentRestriction: { id: studentRestriction.id },
+      bypassBehavior: RestrictionBypassBehaviors.NextDisbursementOnly,
+      creationNote: {
+        noteType: NoteType.Application,
+        description: payload.note,
+      },
+      bypassCreatedDate: expect.any(Date),
+      bypassRemovedDate: null,
+      createdAt: expect.any(Date),
+      isActive: true,
+    });
+  });
+
+  it("Should throw an HTTP error while creating a bypass when there is an active bypass for the same active student restriction ID.", async () => {
+    // Arrange
+    const application = await saveFakeApplication(db.dataSource, undefined, {
+      offeringIntensity: OfferingIntensity.partTime,
+    });
+    const restrictionBypass = await saveFakeApplicationRestrictionBypass(
+      db,
+      {
+        application,
+        bypassCreatedBy: sharedMinistryUser,
+        creator: sharedMinistryUser,
+      },
+      {
+        restrictionActionType: RestrictionActionType.StopPartTimeDisbursement,
+        restrictionCode: RestrictionCode.PTSSR,
+      },
+    );
+    const payload = {
+      applicationId: application.id,
+      studentRestrictionId: restrictionBypass.studentRestriction.id,
+      bypassBehavior: RestrictionBypassBehaviors.NextDisbursementOnly,
+      note: "test note",
+    };
+    const token = await getAESTToken(AESTGroups.BusinessAdministrators);
+
+    // Act/Assert
+    await request(app.getHttpServer())
+      .post(endpoint)
+      .send(payload)
+      .auth(token, BEARER_AUTH_TYPE)
+      .expect(HttpStatus.UNPROCESSABLE_ENTITY)
+      .expect({
+        statusCode: HttpStatus.UNPROCESSABLE_ENTITY,
+        message:
+          "Cannot create a bypass when there is an active bypass for the same active student restriction ID.",
+        error: "Unprocessable Entity",
+      });
+  });
+
+  it("Should throw an HTTP error while creating a bypass when student restriction is not active.", async () => {
+    // Arrange
+    const application = await saveFakeApplication(db.dataSource, undefined, {
+      offeringIntensity: OfferingIntensity.partTime,
+    });
+
+    const studentRestriction = await saveFakeStudentRestriction(
+      db.dataSource,
+      {
+        student: application.student,
+        restriction: ptssrRestriction,
+        application,
+        resolutionNote: null,
+        creator: sharedMinistryUser,
+      },
+      {
+        isActive: false,
+      },
+    );
+
+    const payload = {
+      applicationId: application.id,
+      studentRestrictionId: studentRestriction.id,
+      bypassBehavior: RestrictionBypassBehaviors.NextDisbursementOnly,
+      note: "test note",
+    };
+    const token = await getAESTToken(AESTGroups.BusinessAdministrators);
+
+    // Act/Assert
+    await request(app.getHttpServer())
+      .post(endpoint)
+      .send(payload)
+      .auth(token, BEARER_AUTH_TYPE)
+      .expect(HttpStatus.UNPROCESSABLE_ENTITY)
+      .expect({
+        statusCode: HttpStatus.UNPROCESSABLE_ENTITY,
+        message:
+          "Cannot create a bypass when student restriction is not active.",
+        error: "Unprocessable Entity",
+      });
+  });
+
+  it("Should throw an HTTP error while creating a bypass when the student application is in draft.", async () => {
+    // Arrange
+    const application = await saveFakeApplication(db.dataSource, undefined, {
+      offeringIntensity: OfferingIntensity.partTime,
+      applicationStatus: ApplicationStatus.Draft,
+    });
+
+    const studentRestriction = await saveFakeStudentRestriction(db.dataSource, {
+      student: application.student,
+      restriction: ptssrRestriction,
+      application,
+      resolutionNote: null,
+      creator: sharedMinistryUser,
+    });
+
+    const payload = {
+      applicationId: application.id,
+      studentRestrictionId: studentRestriction.id,
+      bypassBehavior: RestrictionBypassBehaviors.NextDisbursementOnly,
+      note: "test note",
+    };
+    const token = await getAESTToken(AESTGroups.BusinessAdministrators);
+
+    // Act/Assert
+    await request(app.getHttpServer())
+      .post(endpoint)
+      .send(payload)
+      .auth(token, BEARER_AUTH_TYPE)
+      .expect(HttpStatus.UNPROCESSABLE_ENTITY)
+      .expect({
+        statusCode: HttpStatus.UNPROCESSABLE_ENTITY,
+        message: "Cannot create a bypass when application is in invalid state.",
+        error: "Unprocessable Entity",
+      });
+  });
+
+  it("Should throw an HTTP error while creating a bypass when the student application is in cancelled.", async () => {
+    // Arrange
+    const application = await saveFakeApplication(db.dataSource, undefined, {
+      offeringIntensity: OfferingIntensity.partTime,
+      applicationStatus: ApplicationStatus.Cancelled,
+    });
+
+    const studentRestriction = await saveFakeStudentRestriction(db.dataSource, {
+      student: application.student,
+      restriction: ptssrRestriction,
+      application,
+      resolutionNote: null,
+      creator: sharedMinistryUser,
+    });
+
+    const payload = {
+      applicationId: application.id,
+      studentRestrictionId: studentRestriction.id,
+      bypassBehavior: RestrictionBypassBehaviors.NextDisbursementOnly,
+      note: "test note",
+    };
+    const token = await getAESTToken(AESTGroups.BusinessAdministrators);
+
+    // Act/Assert
+    await request(app.getHttpServer())
+      .post(endpoint)
+      .send(payload)
+      .auth(token, BEARER_AUTH_TYPE)
+      .expect(HttpStatus.UNPROCESSABLE_ENTITY)
+      .expect({
+        statusCode: HttpStatus.UNPROCESSABLE_ENTITY,
+        message: "Cannot create a bypass when application is in invalid state.",
+        error: "Unprocessable Entity",
+      });
+  });
+
+  afterAll(async () => {
+    await app?.close();
+  });
+});

--- a/sources/packages/backend/apps/api/src/route-controllers/application-restriction-bypass/_tests_/e2e/application-restriction-bypass.aest.controller.bypassRestriction.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/application-restriction-bypass/_tests_/e2e/application-restriction-bypass.aest.controller.bypassRestriction.e2e-spec.ts
@@ -110,7 +110,7 @@ describe("ApplicationRestrictionBypassAESTController(e2e)-bypassRestriction", ()
         description: payload.note,
       },
       bypassCreatedDate: expect.any(Date),
-      bypassCreatedBy: { id: sharedMinistryUser.id },
+      bypassCreatedBy: { id: expect.any(Number) },
       bypassRemovedDate: null,
       createdAt: expect.any(Date),
       isActive: true,

--- a/sources/packages/backend/apps/api/src/route-controllers/application-restriction-bypass/_tests_/e2e/application-restriction-bypass.aest.controller.bypassRestriction.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/application-restriction-bypass/_tests_/e2e/application-restriction-bypass.aest.controller.bypassRestriction.e2e-spec.ts
@@ -57,7 +57,6 @@ describe("ApplicationRestrictionBypassAESTController(e2e)-bypassRestriction", ()
     const studentRestriction = await saveFakeStudentRestriction(db.dataSource, {
       student: application.student,
       restriction: ptssrRestriction,
-      application,
       resolutionNote: null,
       creator: sharedMinistryUser,
     });
@@ -211,7 +210,6 @@ describe("ApplicationRestrictionBypassAESTController(e2e)-bypassRestriction", ()
     const studentRestriction = await saveFakeStudentRestriction(db.dataSource, {
       student: application.student,
       restriction: ptssrRestriction,
-      application,
       resolutionNote: null,
       creator: sharedMinistryUser,
     });
@@ -247,7 +245,6 @@ describe("ApplicationRestrictionBypassAESTController(e2e)-bypassRestriction", ()
     const studentRestriction = await saveFakeStudentRestriction(db.dataSource, {
       student: application.student,
       restriction: ptssrRestriction,
-      application,
       resolutionNote: null,
       creator: sharedMinistryUser,
     });

--- a/sources/packages/backend/apps/api/src/route-controllers/application-restriction-bypass/_tests_/e2e/application-restriction-bypass.aest.controller.bypassRestriction.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/application-restriction-bypass/_tests_/e2e/application-restriction-bypass.aest.controller.bypassRestriction.e2e-spec.ts
@@ -199,7 +199,7 @@ describe("ApplicationRestrictionBypassAESTController(e2e)-bypassRestriction", ()
       });
   });
 
-  it("Should throw an HTTP error while creating a bypass when the student application is in draft.", async () => {
+  it("Should throw an HTTP error while creating a bypass when the student application is draft.", async () => {
     // Arrange
     const application = await saveFakeApplication(db.dataSource, undefined, {
       offeringIntensity: OfferingIntensity.partTime,
@@ -234,7 +234,7 @@ describe("ApplicationRestrictionBypassAESTController(e2e)-bypassRestriction", ()
       });
   });
 
-  it("Should throw an HTTP error while creating a bypass when the student application is in cancelled.", async () => {
+  it("Should throw an HTTP error while creating a bypass when the student application is cancelled.", async () => {
     // Arrange
     const application = await saveFakeApplication(db.dataSource, undefined, {
       offeringIntensity: OfferingIntensity.partTime,

--- a/sources/packages/backend/apps/api/src/route-controllers/application-restriction-bypass/_tests_/e2e/application-restriction-bypass.aest.controller.bypassRestriction.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/application-restriction-bypass/_tests_/e2e/application-restriction-bypass.aest.controller.bypassRestriction.e2e-spec.ts
@@ -86,6 +86,7 @@ describe("ApplicationRestrictionBypassAESTController(e2e)-bypassRestriction", ()
           bypassBehavior: true,
           creationNote: { noteType: true, description: true },
           bypassCreatedDate: true,
+          bypassCreatedBy: { id: true },
           bypassRemovedDate: true,
           createdAt: true,
           isActive: true,
@@ -94,6 +95,7 @@ describe("ApplicationRestrictionBypassAESTController(e2e)-bypassRestriction", ()
           application: true,
           studentRestriction: true,
           creationNote: true,
+          bypassCreatedBy: true,
         },
         where: { id: applicationRestrictionBypassId },
       });
@@ -102,19 +104,20 @@ describe("ApplicationRestrictionBypassAESTController(e2e)-bypassRestriction", ()
       id: applicationRestrictionBypassId,
       application: { id: application.id },
       studentRestriction: { id: studentRestriction.id },
-      bypassBehavior: RestrictionBypassBehaviors.NextDisbursementOnly,
+      bypassBehavior: payload.bypassBehavior,
       creationNote: {
         noteType: NoteType.Application,
         description: payload.note,
       },
       bypassCreatedDate: expect.any(Date),
+      bypassCreatedBy: { id: sharedMinistryUser.id },
       bypassRemovedDate: null,
       createdAt: expect.any(Date),
       isActive: true,
     });
   });
 
-  it("Should throw an HTTP error while creating a bypass when there is an active bypass for the same active student restriction ID.", async () => {
+  it("Should throw an HTTP error while creating a bypass when there is an active bypass for the same active student restriction.", async () => {
     // Arrange
     const application = await saveFakeApplication(db.dataSource, undefined, {
       offeringIntensity: OfferingIntensity.partTime,
@@ -148,7 +151,7 @@ describe("ApplicationRestrictionBypassAESTController(e2e)-bypassRestriction", ()
       .expect({
         statusCode: HttpStatus.UNPROCESSABLE_ENTITY,
         message:
-          "Cannot create a bypass when there is an active bypass for the same active student restriction ID.",
+          "Cannot create a bypass when there is an active bypass for the same active student restriction.",
         error: "Unprocessable Entity",
       });
   });

--- a/sources/packages/backend/apps/api/src/route-controllers/application-restriction-bypass/_tests_/e2e/application-restriction-bypass.aest.controller.getApplicationRestrictionBypass.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/application-restriction-bypass/_tests_/e2e/application-restriction-bypass.aest.controller.getApplicationRestrictionBypass.e2e-spec.ts
@@ -4,7 +4,6 @@ import {
   RestrictionCode,
   createE2EDataSources,
   createFakeUser,
-  saveFakeApplication,
   saveFakeApplicationRestrictionBypass,
 } from "@sims/test-utils";
 import {
@@ -14,7 +13,7 @@ import {
   getAESTToken,
 } from "../../../../testHelpers";
 import * as request from "supertest";
-import { OfferingIntensity, RestrictionActionType, User } from "@sims/sims-db";
+import { RestrictionActionType, User } from "@sims/sims-db";
 import { getUserFullName } from "../../../../utilities";
 
 describe("ApplicationRestrictionBypassAESTController(e2e)-getApplicationRestrictionBypass.", () => {
@@ -31,14 +30,10 @@ describe("ApplicationRestrictionBypassAESTController(e2e)-getApplicationRestrict
 
   it("Should get an application restriction bypass for a submitted part-time application when there is an application restriction bypass with the required id.", async () => {
     // Arrange
-    const application = await saveFakeApplication(db.dataSource, undefined, {
-      offeringIntensity: OfferingIntensity.partTime,
-    });
     const applicationRestrictionBypass =
       await saveFakeApplicationRestrictionBypass(
         db,
         {
-          application,
           bypassCreatedBy: sharedMinistryUser,
           creator: sharedMinistryUser,
         },
@@ -74,14 +69,10 @@ describe("ApplicationRestrictionBypassAESTController(e2e)-getApplicationRestrict
 
   it("Should get an inactive application restriction bypass for a submitted part-time application when there is an application restriction bypass with the required id.", async () => {
     // Arrange
-    const application = await saveFakeApplication(db.dataSource, undefined, {
-      offeringIntensity: OfferingIntensity.partTime,
-    });
     const applicationRestrictionBypass =
       await saveFakeApplicationRestrictionBypass(
         db,
         {
-          application,
           bypassCreatedBy: sharedMinistryUser,
           creator: sharedMinistryUser,
           bypassRemovedBy: sharedMinistryUser,

--- a/sources/packages/backend/apps/api/src/route-controllers/application-restriction-bypass/_tests_/e2e/application-restriction-bypass.aest.controller.getApplicationRestrictionBypass.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/application-restriction-bypass/_tests_/e2e/application-restriction-bypass.aest.controller.getApplicationRestrictionBypass.e2e-spec.ts
@@ -62,15 +62,13 @@ describe("ApplicationRestrictionBypassAESTController(e2e)-getApplicationRestrict
         restrictionCode:
           applicationRestrictionBypass.studentRestriction.restriction
             .restrictionCode,
-        applicationRestrictionBypassCreationNote:
-          applicationRestrictionBypass.creationNote.description,
-        applicationRestrictionBypassCreatedBy: getUserFullName(
+        creationNote: applicationRestrictionBypass.creationNote.description,
+        createdBy: getUserFullName(
           applicationRestrictionBypass.bypassCreatedBy,
         ),
-        applicationRestrictionBypassCreatedDate:
+        createdDate:
           applicationRestrictionBypass.bypassCreatedDate.toISOString(),
-        applicationRestrictionBypassBehavior:
-          applicationRestrictionBypass.bypassBehavior,
+        bypassBehavior: applicationRestrictionBypass.bypassBehavior,
       });
   });
 
@@ -110,22 +108,19 @@ describe("ApplicationRestrictionBypassAESTController(e2e)-getApplicationRestrict
         restrictionCode:
           applicationRestrictionBypass.studentRestriction.restriction
             .restrictionCode,
-        applicationRestrictionBypassCreationNote:
-          applicationRestrictionBypass.creationNote.description,
-        applicationRestrictionBypassRemovalNote:
-          applicationRestrictionBypass.removalNote.description,
-        applicationRestrictionBypassCreatedBy: getUserFullName(
+        creationNote: applicationRestrictionBypass.creationNote.description,
+        removalNote: applicationRestrictionBypass.removalNote.description,
+        createdBy: getUserFullName(
           applicationRestrictionBypass.bypassCreatedBy,
         ),
-        applicationRestrictionBypassCreatedDate:
+        createdDate:
           applicationRestrictionBypass.bypassCreatedDate.toISOString(),
-        applicationRestrictionBypassRemovedBy: getUserFullName(
+        removedBy: getUserFullName(
           applicationRestrictionBypass.bypassRemovedBy,
         ),
-        applicationRestrictionBypassRemovedDate:
+        removedDate:
           applicationRestrictionBypass.bypassRemovedDate.toISOString(),
-        applicationRestrictionBypassBehavior:
-          applicationRestrictionBypass.bypassBehavior,
+        bypassBehavior: applicationRestrictionBypass.bypassBehavior,
       });
   });
 

--- a/sources/packages/backend/apps/api/src/route-controllers/application-restriction-bypass/_tests_/e2e/application-restriction-bypass.aest.controller.getApplicationRestrictionBypass.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/application-restriction-bypass/_tests_/e2e/application-restriction-bypass.aest.controller.getApplicationRestrictionBypass.e2e-spec.ts
@@ -80,7 +80,6 @@ describe("ApplicationRestrictionBypassAESTController(e2e)-getApplicationRestrict
         {
           restrictionActionType: RestrictionActionType.StopPartTimeDisbursement,
           restrictionCode: RestrictionCode.PTSSR,
-
           isRemoved: true,
         },
       );

--- a/sources/packages/backend/apps/api/src/route-controllers/application-restriction-bypass/_tests_/e2e/application-restriction-bypass.aest.controller.getApplicationRestrictionBypass.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/application-restriction-bypass/_tests_/e2e/application-restriction-bypass.aest.controller.getApplicationRestrictionBypass.e2e-spec.ts
@@ -1,0 +1,135 @@
+import { HttpStatus, INestApplication } from "@nestjs/common";
+import {
+  E2EDataSources,
+  RestrictionCode,
+  createE2EDataSources,
+  createFakeUser,
+  saveFakeApplication,
+  saveFakeApplicationRestrictionBypass,
+} from "@sims/test-utils";
+import {
+  AESTGroups,
+  BEARER_AUTH_TYPE,
+  createTestingAppModule,
+  getAESTToken,
+} from "../../../../testHelpers";
+import * as request from "supertest";
+import { OfferingIntensity, RestrictionActionType, User } from "@sims/sims-db";
+import { getUserFullName } from "../../../../utilities";
+
+describe("ApplicationRestrictionBypassAESTController(e2e)-getApplicationRestrictionBypass.", () => {
+  let app: INestApplication;
+  let db: E2EDataSources;
+  let sharedMinistryUser: User;
+
+  beforeAll(async () => {
+    const { nestApplication, dataSource } = await createTestingAppModule();
+    app = nestApplication;
+    db = createE2EDataSources(dataSource);
+    sharedMinistryUser = await db.user.save(createFakeUser());
+  });
+
+  it("Should get an application restriction bypass for a submitted part-time application when there is an application restriction bypass with the required id.", async () => {
+    // Arrange
+    const application = await saveFakeApplication(db.dataSource, undefined, {
+      offeringIntensity: OfferingIntensity.partTime,
+    });
+    const applicationRestrictionBypass =
+      await saveFakeApplicationRestrictionBypass(
+        db,
+        {
+          application,
+          bypassCreatedBy: sharedMinistryUser,
+          creator: sharedMinistryUser,
+        },
+        {
+          restrictionActionType: RestrictionActionType.StopPartTimeDisbursement,
+          restrictionCode: RestrictionCode.PTSSR,
+        },
+      );
+    const endpoint = `/aest/application-restriction-bypass/${applicationRestrictionBypass.id}`;
+    const token = await getAESTToken(AESTGroups.BusinessAdministrators);
+
+    // Act/Assert
+    await request(app.getHttpServer())
+      .get(endpoint)
+      .auth(token, BEARER_AUTH_TYPE)
+      .expect(HttpStatus.OK)
+      .expect({
+        applicationRestrictionBypassId: applicationRestrictionBypass.id,
+        studentRestrictionId:
+          applicationRestrictionBypass.studentRestriction.id,
+        restrictionCode:
+          applicationRestrictionBypass.studentRestriction.restriction
+            .restrictionCode,
+        applicationRestrictionBypassCreationNote:
+          applicationRestrictionBypass.creationNote.description,
+        applicationRestrictionBypassCreatedBy: getUserFullName(
+          applicationRestrictionBypass.bypassCreatedBy,
+        ),
+        applicationRestrictionBypassCreatedDate:
+          applicationRestrictionBypass.bypassCreatedDate.toISOString(),
+        applicationRestrictionBypassBehavior:
+          applicationRestrictionBypass.bypassBehavior,
+      });
+  });
+
+  it("Should get an inactive application restriction bypass for a submitted part-time application when there is an application restriction bypass with the required id.", async () => {
+    // Arrange
+    const application = await saveFakeApplication(db.dataSource, undefined, {
+      offeringIntensity: OfferingIntensity.partTime,
+    });
+    const applicationRestrictionBypass =
+      await saveFakeApplicationRestrictionBypass(
+        db,
+        {
+          application,
+          bypassCreatedBy: sharedMinistryUser,
+          creator: sharedMinistryUser,
+          bypassRemovedBy: sharedMinistryUser,
+        },
+        {
+          restrictionActionType: RestrictionActionType.StopPartTimeDisbursement,
+          restrictionCode: RestrictionCode.PTSSR,
+
+          isRemoved: true,
+        },
+      );
+    const endpoint = `/aest/application-restriction-bypass/${applicationRestrictionBypass.id}`;
+    const token = await getAESTToken(AESTGroups.BusinessAdministrators);
+
+    // Act/Assert
+    await request(app.getHttpServer())
+      .get(endpoint)
+      .auth(token, BEARER_AUTH_TYPE)
+      .expect(HttpStatus.OK)
+      .expect({
+        applicationRestrictionBypassId: applicationRestrictionBypass.id,
+        studentRestrictionId:
+          applicationRestrictionBypass.studentRestriction.id,
+        restrictionCode:
+          applicationRestrictionBypass.studentRestriction.restriction
+            .restrictionCode,
+        applicationRestrictionBypassCreationNote:
+          applicationRestrictionBypass.creationNote.description,
+        applicationRestrictionBypassRemovalNote:
+          applicationRestrictionBypass.removalNote.description,
+        applicationRestrictionBypassCreatedBy: getUserFullName(
+          applicationRestrictionBypass.bypassCreatedBy,
+        ),
+        applicationRestrictionBypassCreatedDate:
+          applicationRestrictionBypass.bypassCreatedDate.toISOString(),
+        applicationRestrictionBypassRemovedBy: getUserFullName(
+          applicationRestrictionBypass.bypassRemovedBy,
+        ),
+        applicationRestrictionBypassRemovedDate:
+          applicationRestrictionBypass.bypassRemovedDate.toISOString(),
+        applicationRestrictionBypassBehavior:
+          applicationRestrictionBypass.bypassBehavior,
+      });
+  });
+
+  afterAll(async () => {
+    await app?.close();
+  });
+});

--- a/sources/packages/backend/apps/api/src/route-controllers/application-restriction-bypass/_tests_/e2e/application-restriction-bypass.aest.controller.getAvailableRestricitionsToBypass.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/application-restriction-bypass/_tests_/e2e/application-restriction-bypass.aest.controller.getAvailableRestricitionsToBypass.e2e-spec.ts
@@ -49,6 +49,18 @@ describe("ApplicationRestrictionBypassAESTController(e2e)-getAvailableRestrictio
       },
     );
 
+    const ptssrRestriction = await db.restriction.findOne({
+      where: { restrictionCode: RestrictionCode.PTSSR },
+    });
+    // Add a student restriction that should be available to be bypassed because the student restriction is a different one than the student restriction bypassed above.
+    const ptssrStudentRestriction = await saveFakeStudentRestriction(
+      db.dataSource,
+      {
+        student: application.student,
+        restriction: ptssrRestriction,
+      },
+    );
+
     // Add a student restriction bypassed that was removed. In other words, it is no longer active and the student restriction should be available to be bypassed again.
     const removedApplicationRestrictionsBypass =
       await saveFakeApplicationRestrictionBypass(
@@ -62,7 +74,6 @@ describe("ApplicationRestrictionBypassAESTController(e2e)-getAvailableRestrictio
         {
           restrictionActionType: RestrictionActionType.StopPartTimeDisbursement,
           restrictionCode: RestrictionCode.AF,
-
           isRemoved: true,
         },
       );
@@ -126,6 +137,12 @@ describe("ApplicationRestrictionBypassAESTController(e2e)-getAvailableRestrictio
             studentRestrictionCreatedAt:
               stopPartTimeDisbursementStudentRestriction.createdAt.toISOString(),
           },
+          {
+            studentRestrictionId: ptssrStudentRestriction.id,
+            restrictionCode: ptssrRestriction.restrictionCode,
+            studentRestrictionCreatedAt:
+              ptssrStudentRestriction.createdAt.toISOString(),
+          },
         ],
       });
   });
@@ -163,7 +180,6 @@ describe("ApplicationRestrictionBypassAESTController(e2e)-getAvailableRestrictio
         {
           restrictionActionType: RestrictionActionType.StopFullTimeDisbursement,
           restrictionCode: RestrictionCode.AF4,
-
           isRemoved: true,
         },
       );

--- a/sources/packages/backend/apps/api/src/route-controllers/application-restriction-bypass/_tests_/e2e/application-restriction-bypass.aest.controller.getAvailableRestricitionsToBypass.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/application-restriction-bypass/_tests_/e2e/application-restriction-bypass.aest.controller.getAvailableRestricitionsToBypass.e2e-spec.ts
@@ -35,7 +35,7 @@ describe("ApplicationRestrictionBypassAESTController(e2e)-getAvailableRestrictio
       offeringIntensity: OfferingIntensity.partTime,
     });
 
-    // Add a restriction bypassed.
+    // Add a student restriction bypassed that should be not available to be bypassed again.
     await saveFakeApplicationRestrictionBypass(
       db,
       {
@@ -49,7 +49,7 @@ describe("ApplicationRestrictionBypassAESTController(e2e)-getAvailableRestrictio
       },
     );
 
-    // Add a restriction bypassed that was removed. In other words, it is no longer active and the student restriction should be available to be bypassed again.
+    // Add a student restriction bypassed that was removed. In other words, it is no longer active and the student restriction should be available to be bypassed again.
     const removedApplicationRestrictionsBypass =
       await saveFakeApplicationRestrictionBypass(
         db,
@@ -67,25 +67,41 @@ describe("ApplicationRestrictionBypassAESTController(e2e)-getAvailableRestrictio
         },
       );
 
-    // Add a restriction that should not be available to be bypassed because the restriction doesn't have an action type "Stop part time disbursement".
-    const noEffectRestriction = await db.restriction.findOne({
+    const b6bRestriction = await db.restriction.findOne({
       where: { restrictionCode: RestrictionCode.B6B },
     });
+    // Add a student restriction that should not be available to be bypassed because the restriction doesn't have an action type "Stop part time disbursement".
     await saveFakeStudentRestriction(db.dataSource, {
       student: application.student,
-      restriction: noEffectRestriction,
+      restriction: b6bRestriction,
       application,
     });
 
-    // Add a restriction that should  be available to be bypassed because the restriction has an action type "Stop part time disbursement".
-    const stopPartTimeDisbursementRestriction = await db.restriction.findOne({
+    const af4Restriction = await db.restriction.findOne({
+      where: { restrictionCode: RestrictionCode.AF4 },
+    });
+    // Add a student restriction that should not be available to be bypassed because the student restriction is not active.
+    await saveFakeStudentRestriction(
+      db.dataSource,
+      {
+        student: application.student,
+        restriction: af4Restriction,
+        application,
+      },
+      {
+        isActive: false,
+      },
+    );
+
+    const ecrsRestriction = await db.restriction.findOne({
       where: { restrictionCode: RestrictionCode.ECRS },
     });
 
+    // Add a student restriction that should  be available to be bypassed because the restriction has an action type "Stop part time disbursement".
     const stopPartTimeDisbursementStudentRestriction =
       await saveFakeStudentRestriction(db.dataSource, {
         student: application.student,
-        restriction: stopPartTimeDisbursementRestriction,
+        restriction: ecrsRestriction,
         application,
       });
     const endpoint = `/aest/application-restriction-bypass/application/${application.id}/options-list`;
@@ -109,8 +125,7 @@ describe("ApplicationRestrictionBypassAESTController(e2e)-getAvailableRestrictio
           },
           {
             studentRestrictionId: stopPartTimeDisbursementStudentRestriction.id,
-            restrictionCode:
-              stopPartTimeDisbursementRestriction.restrictionCode,
+            restrictionCode: ecrsRestriction.restrictionCode,
             studentRestrictionCreatedAt:
               stopPartTimeDisbursementStudentRestriction.createdAt.toISOString(),
           },
@@ -124,7 +139,7 @@ describe("ApplicationRestrictionBypassAESTController(e2e)-getAvailableRestrictio
       offeringIntensity: OfferingIntensity.fullTime,
     });
 
-    // Add a restriction bypassed that should be not available to be bypassed.
+    // Add a student restriction bypassed that should be not available to be bypassed again.
     await saveFakeApplicationRestrictionBypass(
       db,
       {
@@ -138,7 +153,7 @@ describe("ApplicationRestrictionBypassAESTController(e2e)-getAvailableRestrictio
       },
     );
 
-    // Add a restriction bypassed that was removed. In other words, it is no longer active and the student restriction should be available to be bypassed again.
+    // Add a student restriction bypassed that was removed. In other words, it is no longer active and the student restriction should be available to be bypassed again.
     const removedApplicationRestrictionsBypass =
       await saveFakeApplicationRestrictionBypass(
         db,
@@ -156,33 +171,33 @@ describe("ApplicationRestrictionBypassAESTController(e2e)-getAvailableRestrictio
         },
       );
 
-    // Add a restriction that should not be available to be bypassed because the restriction doesn't have an action type "Stop full time disbursement" nor "Stop full time BC funding".
-    const noEffectRestriction = await db.restriction.findOne({
+    const b6bRestriction = await db.restriction.findOne({
       where: { restrictionCode: RestrictionCode.B6B },
     });
+    // Add a student restriction that should not be available to be bypassed because the restriction doesn't have an action type "Stop full time disbursement" nor "Stop full time BC funding".
     await saveFakeStudentRestriction(db.dataSource, {
       student: application.student,
-      restriction: noEffectRestriction,
+      restriction: b6bRestriction,
       application,
     });
 
     // Add a restriction that should  be available to be bypassed because the restriction has an action type "Stop full time disbursement".
-    const stopFullTimeDisbursementRestriction = await db.restriction.findOne({
+    const ssrRestriction = await db.restriction.findOne({
       where: { restrictionCode: RestrictionCode.SSR },
     });
     const stopFullTimeStudentRestriction = await saveFakeStudentRestriction(
       db.dataSource,
       {
         student: application.student,
-        restriction: stopFullTimeDisbursementRestriction,
+        restriction: ssrRestriction,
         application,
       },
     );
 
-    // Add a restriction that should  be available to be bypassed because the restriction has an action type "Stop full time BC funding".
     const stopFullTimeBCFundingRestriction = await db.restriction.findOne({
       where: { restrictionCode: RestrictionCode.BCLM },
     });
+    // Add a student restriction that should be available to be bypassed because the restriction has an action type "Stop full time BC funding".
     const stopFullTimeBCFundingStudentRestriction =
       await saveFakeStudentRestriction(db.dataSource, {
         student: application.student,
@@ -217,8 +232,7 @@ describe("ApplicationRestrictionBypassAESTController(e2e)-getAvailableRestrictio
           },
           {
             studentRestrictionId: stopFullTimeStudentRestriction.id,
-            restrictionCode:
-              stopFullTimeDisbursementRestriction.restrictionCode,
+            restrictionCode: ssrRestriction.restrictionCode,
             studentRestrictionCreatedAt:
               stopFullTimeStudentRestriction.createdAt.toISOString(),
           },

--- a/sources/packages/backend/apps/api/src/route-controllers/application-restriction-bypass/_tests_/e2e/application-restriction-bypass.aest.controller.getAvailableRestricitionsToBypass.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/application-restriction-bypass/_tests_/e2e/application-restriction-bypass.aest.controller.getAvailableRestricitionsToBypass.e2e-spec.ts
@@ -1,0 +1,232 @@
+import { HttpStatus, INestApplication } from "@nestjs/common";
+import {
+  E2EDataSources,
+  RestrictionCode,
+  createE2EDataSources,
+  createFakeUser,
+  saveFakeApplication,
+  saveFakeApplicationRestrictionBypass,
+  saveFakeStudentRestriction,
+} from "@sims/test-utils";
+import {
+  AESTGroups,
+  BEARER_AUTH_TYPE,
+  createTestingAppModule,
+  getAESTToken,
+} from "../../../../testHelpers";
+import * as request from "supertest";
+import { OfferingIntensity, RestrictionActionType, User } from "@sims/sims-db";
+
+describe("ApplicationRestrictionBypassAESTController(e2e)-getAvailableRestrictionsToBypass.", () => {
+  let app: INestApplication;
+  let db: E2EDataSources;
+  let sharedMinistryUser: User;
+
+  beforeAll(async () => {
+    const { nestApplication, dataSource } = await createTestingAppModule();
+    app = nestApplication;
+    db = createE2EDataSources(dataSource);
+    sharedMinistryUser = await db.user.save(createFakeUser());
+  });
+
+  it("Should list all student active restrictions and not already bypassed for a part-time application when there is one restriction bypassed and some others not.", async () => {
+    // Arrange
+    const application = await saveFakeApplication(db.dataSource, undefined, {
+      offeringIntensity: OfferingIntensity.partTime,
+    });
+
+    // Add a restriction bypassed.
+    await saveFakeApplicationRestrictionBypass(
+      db,
+      {
+        application,
+        bypassCreatedBy: sharedMinistryUser,
+        creator: sharedMinistryUser,
+      },
+      {
+        restrictionActionType: RestrictionActionType.StopPartTimeDisbursement,
+        restrictionCode: RestrictionCode.PTSSR,
+      },
+    );
+
+    // Add a restriction bypassed that has the bypass removed. In other words, it is no longer active and should be available to be bypassed.
+    const removedApplicationRestrictionsBypass =
+      await saveFakeApplicationRestrictionBypass(
+        db,
+        {
+          application,
+          bypassCreatedBy: sharedMinistryUser,
+          bypassRemovedBy: sharedMinistryUser,
+          creator: sharedMinistryUser,
+        },
+        {
+          restrictionActionType: RestrictionActionType.StopPartTimeDisbursement,
+          restrictionCode: RestrictionCode.AF,
+
+          isRemoved: true,
+        },
+      );
+
+    // Add a restriction that should not be available to be bypassed because the restriction doesn't have an action type "Stop part time disbursement".
+    const noEffectRestriction = await db.restriction.findOne({
+      where: { restrictionCode: RestrictionCode.B6B },
+    });
+    await saveFakeStudentRestriction(db.dataSource, {
+      student: application.student,
+      restriction: noEffectRestriction,
+      application,
+    });
+
+    // Add a restriction that should  be available to be bypassed because the restriction has an action type "Stop part time disbursement".
+    const stopPartTimeDisbursementRestriction = await db.restriction.findOne({
+      where: { restrictionCode: RestrictionCode.ECRS },
+    });
+
+    const stopPartTimeDisbursementStudentRestriction =
+      await saveFakeStudentRestriction(db.dataSource, {
+        student: application.student,
+        restriction: stopPartTimeDisbursementRestriction,
+        application,
+      });
+    const endpoint = `/aest/application-restriction-bypass/application/${application.id}/options-list`;
+    const token = await getAESTToken(AESTGroups.BusinessAdministrators);
+
+    // Act/Assert
+    await request(app.getHttpServer())
+      .get(endpoint)
+      .auth(token, BEARER_AUTH_TYPE)
+      .expect(HttpStatus.OK)
+      .expect({
+        availableRestrictionsToBypass: [
+          {
+            studentRestrictionId:
+              removedApplicationRestrictionsBypass.studentRestriction.id,
+            restrictionCode:
+              removedApplicationRestrictionsBypass.studentRestriction
+                .restriction.restrictionCode,
+            studentRestrictionCreatedAt:
+              removedApplicationRestrictionsBypass.studentRestriction.createdAt.toISOString(),
+          },
+          {
+            studentRestrictionId: stopPartTimeDisbursementStudentRestriction.id,
+            restrictionCode:
+              stopPartTimeDisbursementRestriction.restrictionCode,
+            studentRestrictionCreatedAt:
+              stopPartTimeDisbursementStudentRestriction.createdAt.toISOString(),
+          },
+        ],
+      });
+  });
+
+  it("Should list all student active restrictions for a full-time application when there is one restriction bypassed and others not.", async () => {
+    // Arrange
+    const application = await saveFakeApplication(db.dataSource, undefined, {
+      offeringIntensity: OfferingIntensity.fullTime,
+    });
+
+    // Add a restriction bypassed that should be not available to be bypassed.
+    await saveFakeApplicationRestrictionBypass(
+      db,
+      {
+        application,
+        bypassCreatedBy: sharedMinistryUser,
+        creator: sharedMinistryUser,
+      },
+      {
+        restrictionActionType: RestrictionActionType.StopFullTimeDisbursement,
+        restrictionCode: RestrictionCode.AF,
+      },
+    );
+
+    // Add a restriction bypassed that has the bypass removed. In other words, it is no longer active and should be available to be bypassed.
+    const removedApplicationRestrictionsBypass =
+      await saveFakeApplicationRestrictionBypass(
+        db,
+        {
+          application,
+          bypassCreatedBy: sharedMinistryUser,
+          bypassRemovedBy: sharedMinistryUser,
+          creator: sharedMinistryUser,
+        },
+        {
+          restrictionActionType: RestrictionActionType.StopFullTimeDisbursement,
+          restrictionCode: RestrictionCode.AF4,
+
+          isRemoved: true,
+        },
+      );
+
+    // Add a restriction that should not be available to be bypassed because the restriction doesn't have an action type "Stop full time disbursement" nor "Stop full time BC funding".
+    const noEffectRestriction = await db.restriction.findOne({
+      where: { restrictionCode: RestrictionCode.B6B },
+    });
+    await saveFakeStudentRestriction(db.dataSource, {
+      student: application.student,
+      restriction: noEffectRestriction,
+      application,
+    });
+
+    // Add a restriction that should  be available to be bypassed because the restriction has an action type "Stop full time disbursement".
+    const stopFullTimeDisbursementRestriction = await db.restriction.findOne({
+      where: { restrictionCode: RestrictionCode.SSR },
+    });
+    const stopFullTimeStudentRestriction = await saveFakeStudentRestriction(
+      db.dataSource,
+      {
+        student: application.student,
+        restriction: stopFullTimeDisbursementRestriction,
+        application,
+      },
+    );
+
+    // Add a restriction that should  be available to be bypassed because the restriction has an action type "Stop full time BC funding".
+    const stopFullTimeBCFundingRestriction = await db.restriction.findOne({
+      where: { restrictionCode: RestrictionCode.BCLM },
+    });
+    const stopFullTimeBCFundingStudentRestriction =
+      await saveFakeStudentRestriction(db.dataSource, {
+        student: application.student,
+        restriction: stopFullTimeBCFundingRestriction,
+        application,
+      });
+
+    const endpoint = `/aest/application-restriction-bypass/application/${application.id}/options-list`;
+    const token = await getAESTToken(AESTGroups.BusinessAdministrators);
+
+    // Act/Assert
+    await request(app.getHttpServer())
+      .get(endpoint)
+      .auth(token, BEARER_AUTH_TYPE)
+      .expect(HttpStatus.OK)
+      .expect({
+        availableRestrictionsToBypass: [
+          {
+            studentRestrictionId:
+              removedApplicationRestrictionsBypass.studentRestriction.id,
+            restrictionCode:
+              removedApplicationRestrictionsBypass.studentRestriction
+                .restriction.restrictionCode,
+            studentRestrictionCreatedAt:
+              removedApplicationRestrictionsBypass.studentRestriction.createdAt.toISOString(),
+          },
+          {
+            studentRestrictionId: stopFullTimeBCFundingStudentRestriction.id,
+            restrictionCode: stopFullTimeBCFundingRestriction.restrictionCode,
+            studentRestrictionCreatedAt:
+              stopFullTimeBCFundingStudentRestriction.createdAt.toISOString(),
+          },
+          {
+            studentRestrictionId: stopFullTimeStudentRestriction.id,
+            restrictionCode:
+              stopFullTimeDisbursementRestriction.restrictionCode,
+            studentRestrictionCreatedAt:
+              stopFullTimeStudentRestriction.createdAt.toISOString(),
+          },
+        ],
+      });
+  });
+
+  afterAll(async () => {
+    await app?.close();
+  });
+});

--- a/sources/packages/backend/apps/api/src/route-controllers/application-restriction-bypass/_tests_/e2e/application-restriction-bypass.aest.controller.getAvailableRestricitionsToBypass.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/application-restriction-bypass/_tests_/e2e/application-restriction-bypass.aest.controller.getAvailableRestricitionsToBypass.e2e-spec.ts
@@ -100,7 +100,6 @@ describe("ApplicationRestrictionBypassAESTController(e2e)-getAvailableRestrictio
       await saveFakeStudentRestriction(db.dataSource, {
         student: application.student,
         restriction: ecrsRestriction,
-        application,
       });
     const endpoint = `/aest/application-restriction-bypass/application/${application.id}/options-list`;
     const token = await getAESTToken(AESTGroups.BusinessAdministrators);

--- a/sources/packages/backend/apps/api/src/route-controllers/application-restriction-bypass/_tests_/e2e/application-restriction-bypass.aest.controller.getAvailableRestricitionsToBypass.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/application-restriction-bypass/_tests_/e2e/application-restriction-bypass.aest.controller.getAvailableRestricitionsToBypass.e2e-spec.ts
@@ -49,7 +49,7 @@ describe("ApplicationRestrictionBypassAESTController(e2e)-getAvailableRestrictio
       },
     );
 
-    // Add a restriction bypassed that has the bypass removed. In other words, it is no longer active and should be available to be bypassed.
+    // Add a restriction bypassed that was removed. In other words, it is no longer active and the student restriction should be available to be bypassed again.
     const removedApplicationRestrictionsBypass =
       await saveFakeApplicationRestrictionBypass(
         db,
@@ -138,7 +138,7 @@ describe("ApplicationRestrictionBypassAESTController(e2e)-getAvailableRestrictio
       },
     );
 
-    // Add a restriction bypassed that has the bypass removed. In other words, it is no longer active and should be available to be bypassed.
+    // Add a restriction bypassed that was removed. In other words, it is no longer active and the student restriction should be available to be bypassed again.
     const removedApplicationRestrictionsBypass =
       await saveFakeApplicationRestrictionBypass(
         db,

--- a/sources/packages/backend/apps/api/src/route-controllers/application-restriction-bypass/_tests_/e2e/application-restriction-bypass.aest.controller.getAvailableRestricitionsToBypass.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/application-restriction-bypass/_tests_/e2e/application-restriction-bypass.aest.controller.getAvailableRestricitionsToBypass.e2e-spec.ts
@@ -74,7 +74,6 @@ describe("ApplicationRestrictionBypassAESTController(e2e)-getAvailableRestrictio
     await saveFakeStudentRestriction(db.dataSource, {
       student: application.student,
       restriction: b6bRestriction,
-      application,
     });
 
     const af4Restriction = await db.restriction.findOne({
@@ -86,7 +85,6 @@ describe("ApplicationRestrictionBypassAESTController(e2e)-getAvailableRestrictio
       {
         student: application.student,
         restriction: af4Restriction,
-        application,
       },
       {
         isActive: false,
@@ -97,7 +95,7 @@ describe("ApplicationRestrictionBypassAESTController(e2e)-getAvailableRestrictio
       where: { restrictionCode: RestrictionCode.ECRS },
     });
 
-    // Add a student restriction that should  be available to be bypassed because the restriction has an action type "Stop part time disbursement".
+    // Add a student restriction that should be available to be bypassed because the restriction has an action type "Stop part time disbursement".
     const stopPartTimeDisbursementStudentRestriction =
       await saveFakeStudentRestriction(db.dataSource, {
         student: application.student,
@@ -178,10 +176,9 @@ describe("ApplicationRestrictionBypassAESTController(e2e)-getAvailableRestrictio
     await saveFakeStudentRestriction(db.dataSource, {
       student: application.student,
       restriction: b6bRestriction,
-      application,
     });
 
-    // Add a restriction that should  be available to be bypassed because the restriction has an action type "Stop full time disbursement".
+    // Add a restriction that should be available to be bypassed because the restriction has an action type "Stop full time disbursement".
     const ssrRestriction = await db.restriction.findOne({
       where: { restrictionCode: RestrictionCode.SSR },
     });
@@ -190,7 +187,6 @@ describe("ApplicationRestrictionBypassAESTController(e2e)-getAvailableRestrictio
       {
         student: application.student,
         restriction: ssrRestriction,
-        application,
       },
     );
 
@@ -202,7 +198,6 @@ describe("ApplicationRestrictionBypassAESTController(e2e)-getAvailableRestrictio
       await saveFakeStudentRestriction(db.dataSource, {
         student: application.student,
         restriction: stopFullTimeBCFundingRestriction,
-        application,
       });
 
     const endpoint = `/aest/application-restriction-bypass/application/${application.id}/options-list`;

--- a/sources/packages/backend/apps/api/src/route-controllers/application-restriction-bypass/_tests_/e2e/application-restriction-bypass.aest.controller.removeBypassRestriction.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/application-restriction-bypass/_tests_/e2e/application-restriction-bypass.aest.controller.removeBypassRestriction.e2e-spec.ts
@@ -69,38 +69,32 @@ describe("ApplicationRestrictionBypassAESTController(e2e)-removeBypassRestrictio
       await db.applicationRestrictionBypass.findOne({
         select: {
           id: true,
-          application: { id: true },
-          studentRestriction: { id: true },
-          bypassBehavior: true,
           removalNote: { noteType: true, description: true },
-          bypassCreatedDate: true,
           bypassRemovedDate: true,
-          createdAt: true,
+          bypassRemovedBy: { id: true },
           isActive: true,
           updatedAt: true,
+          modifier: { id: true },
         },
         relations: {
-          application: true,
-          studentRestriction: true,
+          bypassRemovedBy: true,
           removalNote: true,
+          modifier: true,
         },
         where: { id: restrictionBypass.id },
       });
 
     expect(applicationRestrictionBypass).toMatchObject({
       id: restrictionBypass.id,
-      application: { id: application.id },
-      studentRestriction: { id: restrictionBypass.studentRestriction.id },
-      bypassBehavior: restrictionBypass.bypassBehavior,
       removalNote: {
         noteType: NoteType.Application,
         description: payload.note,
       },
-      bypassCreatedDate: expect.any(Date),
       bypassRemovedDate: expect.any(Date),
-      createdAt: expect.any(Date),
+      bypassRemovedBy: { id: expect.any(Number) },
       isActive: false,
       updatedAt: expect.any(Date),
+      modifier: { id: expect.any(Number) },
     });
   });
 

--- a/sources/packages/backend/apps/api/src/route-controllers/application-restriction-bypass/_tests_/e2e/application-restriction-bypass.aest.controller.removeBypassRestriction.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/application-restriction-bypass/_tests_/e2e/application-restriction-bypass.aest.controller.removeBypassRestriction.e2e-spec.ts
@@ -1,0 +1,170 @@
+import { HttpStatus, INestApplication } from "@nestjs/common";
+import {
+  E2EDataSources,
+  RestrictionCode,
+  createE2EDataSources,
+  createFakeUser,
+  saveFakeApplication,
+  saveFakeApplicationRestrictionBypass,
+} from "@sims/test-utils";
+import {
+  AESTGroups,
+  BEARER_AUTH_TYPE,
+  createTestingAppModule,
+  getAESTToken,
+} from "../../../../testHelpers";
+import * as request from "supertest";
+import {
+  NoteType,
+  OfferingIntensity,
+  RestrictionActionType,
+  User,
+} from "@sims/sims-db";
+
+describe("ApplicationRestrictionBypassAESTController(e2e)-removeBypassRestriction", () => {
+  let app: INestApplication;
+  let db: E2EDataSources;
+  let sharedMinistryUser: User;
+
+  beforeAll(async () => {
+    const { nestApplication, dataSource } = await createTestingAppModule();
+    app = nestApplication;
+    db = createE2EDataSources(dataSource);
+    sharedMinistryUser = await db.user.save(createFakeUser());
+  });
+
+  it("Should be able to remove an active bypass when there is an active bypass.", async () => {
+    // Arrange
+    const application = await saveFakeApplication(db.dataSource, undefined, {
+      offeringIntensity: OfferingIntensity.partTime,
+    });
+
+    const restrictionBypass = await saveFakeApplicationRestrictionBypass(
+      db,
+      {
+        application,
+        bypassCreatedBy: sharedMinistryUser,
+        creator: sharedMinistryUser,
+      },
+      {
+        restrictionActionType: RestrictionActionType.StopPartTimeDisbursement,
+        restrictionCode: RestrictionCode.PTSSR,
+      },
+    );
+
+    const payload = {
+      note: "Removal note",
+    };
+    const endpoint = `/aest/application-restriction-bypass/${restrictionBypass.id}`;
+    const token = await getAESTToken(AESTGroups.BusinessAdministrators);
+
+    // Act/Assert
+    await request(app.getHttpServer())
+      .patch(endpoint)
+      .send(payload)
+      .auth(token, BEARER_AUTH_TYPE)
+      .expect(HttpStatus.OK);
+
+    const applicationRestrictionBypass =
+      await db.applicationRestrictionBypass.findOne({
+        select: {
+          id: true,
+          application: { id: true },
+          studentRestriction: { id: true },
+          bypassBehavior: true,
+          removalNote: { noteType: true, description: true },
+          bypassCreatedDate: true,
+          bypassRemovedDate: true,
+          createdAt: true,
+          isActive: true,
+          updatedAt: true,
+        },
+        relations: {
+          application: true,
+          studentRestriction: true,
+          removalNote: true,
+        },
+        where: { id: restrictionBypass.id },
+      });
+
+    expect(applicationRestrictionBypass).toMatchObject({
+      id: restrictionBypass.id,
+      application: { id: application.id },
+      studentRestriction: { id: restrictionBypass.studentRestriction.id },
+      bypassBehavior: restrictionBypass.bypassBehavior,
+      removalNote: {
+        noteType: NoteType.Application,
+        description: payload.note,
+      },
+      bypassCreatedDate: expect.any(Date),
+      bypassRemovedDate: expect.any(Date),
+      createdAt: expect.any(Date),
+      isActive: false,
+      updatedAt: expect.any(Date),
+    });
+  });
+
+  it("Should throw an HTTP error while removing a bypass when the bypass is not active.", async () => {
+    // Arrange
+    const application = await saveFakeApplication(db.dataSource, undefined, {
+      offeringIntensity: OfferingIntensity.partTime,
+    });
+    const restrictionBypass = await saveFakeApplicationRestrictionBypass(
+      db,
+      {
+        application,
+        bypassCreatedBy: sharedMinistryUser,
+        bypassRemovedBy: sharedMinistryUser,
+        creator: sharedMinistryUser,
+      },
+      {
+        restrictionActionType: RestrictionActionType.StopPartTimeDisbursement,
+        restrictionCode: RestrictionCode.PTSSR,
+        isRemoved: true,
+      },
+    );
+    const payload = {
+      note: "Removal note",
+    };
+    const endpoint = `/aest/application-restriction-bypass/${restrictionBypass.id}`;
+    const token = await getAESTToken(AESTGroups.BusinessAdministrators);
+
+    // Act/Assert
+    await request(app.getHttpServer())
+      .patch(endpoint)
+      .send(payload)
+      .auth(token, BEARER_AUTH_TYPE)
+      .expect(HttpStatus.UNPROCESSABLE_ENTITY)
+      .expect({
+        statusCode: HttpStatus.UNPROCESSABLE_ENTITY,
+        message:
+          "Cannot remove a bypass when application restriction bypass is not active.",
+        error: "Unprocessable Entity",
+      });
+  });
+
+  it("Should throw an HTTP error while removing a bypass when the bypass is not found.", async () => {
+    // Arrange
+    const payload = {
+      note: "Removal note",
+    };
+    const endpoint = "/aest/application-restriction-bypass/99999999";
+    const token = await getAESTToken(AESTGroups.BusinessAdministrators);
+
+    // Act/Assert
+    await request(app.getHttpServer())
+      .patch(endpoint)
+      .send(payload)
+      .auth(token, BEARER_AUTH_TYPE)
+      .expect(HttpStatus.NOT_FOUND)
+      .expect({
+        statusCode: HttpStatus.NOT_FOUND,
+        message: "Application restriction bypass not found.",
+        error: "Not Found",
+      });
+  });
+
+  afterAll(async () => {
+    await app?.close();
+  });
+});

--- a/sources/packages/backend/apps/api/src/route-controllers/application-restriction-bypass/_tests_/e2e/application-restriction-bypass.aest.controller.removeBypassRestriction.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/application-restriction-bypass/_tests_/e2e/application-restriction-bypass.aest.controller.removeBypassRestriction.e2e-spec.ts
@@ -20,6 +20,7 @@ import {
   RestrictionActionType,
   User,
 } from "@sims/sims-db";
+import { APPLICATION_RESTRICTION_BYPASS_IS_NOT_ACTIVE } from "../../../../constants";
 
 describe("ApplicationRestrictionBypassAESTController(e2e)-removeBypassRestriction", () => {
   let app: INestApplication;
@@ -130,10 +131,9 @@ describe("ApplicationRestrictionBypassAESTController(e2e)-removeBypassRestrictio
       .auth(token, BEARER_AUTH_TYPE)
       .expect(HttpStatus.UNPROCESSABLE_ENTITY)
       .expect({
-        statusCode: HttpStatus.UNPROCESSABLE_ENTITY,
         message:
           "Cannot remove a bypass when application restriction bypass is not active.",
-        error: "Unprocessable Entity",
+        errorType: APPLICATION_RESTRICTION_BYPASS_IS_NOT_ACTIVE,
       });
   });
 

--- a/sources/packages/backend/apps/api/src/route-controllers/application-restriction-bypass/application-restriction-bypass.aest.controller.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/application-restriction-bypass/application-restriction-bypass.aest.controller.ts
@@ -221,7 +221,7 @@ export class ApplicationRestrictionBypassAESTController extends BaseController {
     try {
       await this.applicationRestrictionBypassService.removeBypassRestriction(
         id,
-        payload,
+        payload.note,
         userToken.userId,
       );
     } catch (error) {

--- a/sources/packages/backend/apps/api/src/route-controllers/application-restriction-bypass/application-restriction-bypass.aest.controller.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/application-restriction-bypass/application-restriction-bypass.aest.controller.ts
@@ -46,11 +46,11 @@ import {
   APPLICATION_RESTRICTION_BYPASS_NOT_FOUND,
   STUDENT_RESTRICTION_IS_NOT_ACTIVE,
   STUDENT_RESTRICTION_NOT_FOUND,
-} from "../../../src/constants";
+} from "../../constants";
 import { getUserFullName } from "../../utilities";
 
 /**
- * Controller for AEST Application Restriction Bypasses.
+ * Controller for AEST Application Restriction Bypasses
  * This consists of all Rest APIs for AEST application restriction bypasses.
  */
 @AllowAuthorizedParty(AuthorizedParties.aest)

--- a/sources/packages/backend/apps/api/src/route-controllers/application-restriction-bypass/application-restriction-bypass.aest.controller.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/application-restriction-bypass/application-restriction-bypass.aest.controller.ts
@@ -50,8 +50,8 @@ import {
 import { getUserFullName } from "../../utilities";
 
 /**
- * Controller for AEST Application Restriction Bypasses
- * This consists of all Rest APIs for AEST application restriction bypasses.
+ * Controller for AEST Application Restriction Bypasses.
+ * This consists of all Rest APIs for ministry application restriction bypasses.
  */
 @AllowAuthorizedParty(AuthorizedParties.aest)
 @Groups(UserGroups.AESTUser)

--- a/sources/packages/backend/apps/api/src/route-controllers/application-restriction-bypass/application-restriction-bypass.aest.controller.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/application-restriction-bypass/application-restriction-bypass.aest.controller.ts
@@ -1,13 +1,48 @@
-import { Controller, Get, Param, ParseIntPipe } from "@nestjs/common";
+import {
+  Body,
+  Controller,
+  Get,
+  NotFoundException,
+  Param,
+  ParseIntPipe,
+  Patch,
+  Post,
+  UnprocessableEntityException,
+} from "@nestjs/common";
 import BaseController from "../BaseController";
 import { AuthorizedParties } from "../../auth/authorized-parties.enum";
 import { UserGroups } from "../../auth/user-groups.enum";
-import { AllowAuthorizedParty, Groups } from "../../auth/decorators";
-import { ApplicationRestrictionBypassHistoryAPIOutDTO } from "./models/application-restriction-bypass.dto";
+import { AllowAuthorizedParty, Groups, UserToken } from "../../auth/decorators";
+import {
+  ApplicationRestrictionBypassAPIOutDTO,
+  ApplicationRestrictionBypassHistoryAPIOutDTO,
+  AvailableStudentRestrictionAPIOutDTO,
+  BypassRestrictionAPIInDTO,
+  RemoveBypassRestrictionAPIInDTO,
+} from "./models/application-restriction-bypass.dto";
 import { ClientTypeBaseRoute } from "../../types";
-import { ApiTags } from "@nestjs/swagger";
+import {
+  ApiNotFoundResponse,
+  ApiTags,
+  ApiUnprocessableEntityResponse,
+} from "@nestjs/swagger";
 import { ApplicationRestrictionBypassService } from "../../services";
-import { ApplicationRestrictionBypass } from "@sims/sims-db";
+import {
+  ApplicationRestrictionBypass,
+  StudentRestriction,
+} from "@sims/sims-db";
+import { PrimaryIdentifierAPIOutDTO } from "../models/primary.identifier.dto";
+import { IUserToken } from "../../auth";
+import { CustomNamedError } from "@sims/utilities";
+import {
+  ACTIVE_BYPASS_FOR_STUDENT_RESTRICTION_ALREADY_EXISTS,
+  APPLICATION_IN_INVALID_STATE_FOR_APPLICATION_RESTRICTION_BYPASS_CREATION,
+  APPLICATION_RESTRICTION_BYPASS_IS_NOT_ACTIVE,
+  APPLICATION_RESTRICTION_BYPASS_NOT_FOUND,
+  STUDENT_RESTRICTION_IS_NOT_ACTIVE,
+  STUDENT_RESTRICTION_NOT_FOUND,
+} from "../../../src/constants";
+import { getUserFullName } from "../../utilities";
 
 /**
  * Controller for AEST Application Restriction Bypasses.
@@ -49,5 +84,170 @@ export class ApplicationRestrictionBypassAESTController extends BaseController {
     );
 
     return { bypasses };
+  }
+
+  /**
+   * Gets application restriction bypass for a given application restriction bypass id.
+   * @param id id of the application restriction bypass.
+   * @returns application restriction bypass.
+   */
+  @ApiNotFoundResponse({
+    description: "Application restriction bypass not found.",
+  })
+  @Get(":id")
+  async getApplicationRestrictionBypass(
+    @Param("id", ParseIntPipe) id: number,
+  ): Promise<ApplicationRestrictionBypassAPIOutDTO> {
+    const applicationRestrictionBypass =
+      await this.applicationRestrictionBypassService.getApplicationRestrictionBypass(
+        id,
+      );
+    if (!applicationRestrictionBypass) {
+      throw new NotFoundException(APPLICATION_RESTRICTION_BYPASS_NOT_FOUND);
+    }
+    return {
+      applicationRestrictionBypassId: applicationRestrictionBypass.id,
+      studentRestrictionId: applicationRestrictionBypass.studentRestriction.id,
+      restrictionCode:
+        applicationRestrictionBypass.studentRestriction.restriction
+          .restrictionCode,
+      applicationRestrictionBypassCreationNote:
+        applicationRestrictionBypass.creationNote.description,
+      applicationRestrictionBypassRemovalNote:
+        applicationRestrictionBypass.removalNote?.description,
+      applicationRestrictionBypassCreatedBy: getUserFullName(
+        applicationRestrictionBypass.bypassCreatedBy,
+      ),
+      applicationRestrictionBypassCreatedDate:
+        applicationRestrictionBypass.bypassCreatedDate.toISOString(),
+      ...(applicationRestrictionBypass.bypassRemovedBy && {
+        applicationRestrictionBypassRemovedBy: getUserFullName(
+          applicationRestrictionBypass.bypassRemovedBy,
+        ),
+      }),
+      applicationRestrictionBypassRemovedDate:
+        applicationRestrictionBypass.bypassRemovedDate?.toISOString(),
+      applicationRestrictionBypassBehavior:
+        applicationRestrictionBypass.bypassBehavior,
+    };
+  }
+
+  /**
+   * Gets available student restrictions to bypass for a given application.
+   * @param applicationId id of the application to retrieve restriction bypasses.
+   * @returns application restriction bypasses.
+   */
+  @Get("application/:applicationId/options-list")
+  async getAvailableStudentRestrictionsToBypass(
+    @Param("applicationId", ParseIntPipe) applicationId: number,
+  ): Promise<AvailableStudentRestrictionAPIOutDTO> {
+    const availableRestrictionsToBypass =
+      await this.applicationRestrictionBypassService.getAvailableStudentRestrictionsToBypass(
+        applicationId,
+      );
+    return {
+      availableRestrictionsToBypass: availableRestrictionsToBypass.map(
+        (item: StudentRestriction) => ({
+          studentRestrictionId: item.id,
+          restrictionCode: item.restriction.restrictionCode,
+          studentRestrictionCreatedAt: item.createdAt,
+        }),
+      ),
+    };
+  }
+
+  /**
+   * Creates a new application restriction bypass.
+   * @param payload payload of the application restriction bypass.
+   * @param userToken user token.
+   * @returns application restriction bypass.
+   */
+  @ApiUnprocessableEntityResponse({
+    description:
+      "Cannot create a bypass when there is an active bypass for the same active student restriction ID or " +
+      "could not find student restriction for the given ID or " +
+      "cannot create a bypass when student restriction is not active  or " +
+      "cannot create a bypass when application is in invalid state.",
+  })
+  @Post()
+  async bypassRestriction(
+    @Body() payload: BypassRestrictionAPIInDTO,
+    @UserToken() userToken: IUserToken,
+  ): Promise<PrimaryIdentifierAPIOutDTO> {
+    try {
+      const applicationRestrictionBypass =
+        await this.applicationRestrictionBypassService.bypassRestriction(
+          payload,
+          userToken.userId,
+        );
+      return { id: applicationRestrictionBypass.id };
+    } catch (error) {
+      if (error instanceof CustomNamedError) {
+        switch (error.name) {
+          case ACTIVE_BYPASS_FOR_STUDENT_RESTRICTION_ALREADY_EXISTS:
+            throw new UnprocessableEntityException(
+              "Cannot create a bypass when there is an active bypass for the same active student restriction ID.",
+            );
+          case STUDENT_RESTRICTION_NOT_FOUND:
+            throw new UnprocessableEntityException(
+              "Could not find student restriction for the given ID.",
+            );
+          case STUDENT_RESTRICTION_IS_NOT_ACTIVE:
+            throw new UnprocessableEntityException(
+              "Cannot create a bypass when student restriction is not active.",
+            );
+          case APPLICATION_IN_INVALID_STATE_FOR_APPLICATION_RESTRICTION_BYPASS_CREATION:
+            throw new UnprocessableEntityException(
+              "Cannot create a bypass when application is in invalid state.",
+            );
+          default:
+            throw error;
+        }
+      }
+      throw error;
+    }
+  }
+
+  @ApiNotFoundResponse({
+    description: "Application restriction bypass not found.",
+  })
+  @ApiUnprocessableEntityResponse({
+    description:
+      "Cannot remove a bypass when student restriction is not active or " +
+      "cannot remove a bypass when application restriction bypass is not active.",
+  })
+  @Patch(":id")
+  async removeBypassRestriction(
+    @UserToken() userToken: IUserToken,
+    @Body() payload: RemoveBypassRestrictionAPIInDTO,
+    @Param("id", ParseIntPipe) id: number,
+  ): Promise<void> {
+    try {
+      await this.applicationRestrictionBypassService.removeBypassRestriction(
+        id,
+        payload,
+        userToken.userId,
+      );
+    } catch (error) {
+      if (error instanceof CustomNamedError) {
+        switch (error.name) {
+          case APPLICATION_RESTRICTION_BYPASS_NOT_FOUND:
+            throw new NotFoundException(
+              "Application restriction bypass not found.",
+            );
+          case STUDENT_RESTRICTION_IS_NOT_ACTIVE:
+            throw new UnprocessableEntityException(
+              "Cannot remove a bypass when student restriction is not active.",
+            );
+          case APPLICATION_RESTRICTION_BYPASS_IS_NOT_ACTIVE:
+            throw new UnprocessableEntityException(
+              "Cannot remove a bypass when application restriction bypass is not active.",
+            );
+          default:
+            throw error;
+        }
+      }
+      throw error;
+    }
   }
 }

--- a/sources/packages/backend/apps/api/src/route-controllers/application-restriction-bypass/application-restriction-bypass.aest.controller.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/application-restriction-bypass/application-restriction-bypass.aest.controller.ts
@@ -186,11 +186,11 @@ export class ApplicationRestrictionBypassAESTController extends BaseController {
         switch (error.name) {
           case ACTIVE_BYPASS_FOR_STUDENT_RESTRICTION_ALREADY_EXISTS:
             throw new UnprocessableEntityException(
-              "Cannot create a bypass when there is an active bypass for the same active student restriction ID.",
+              "Cannot create a bypass when there is an active bypass for the same active student restriction.",
             );
           case STUDENT_RESTRICTION_NOT_FOUND:
             throw new UnprocessableEntityException(
-              "Could not find student restriction for the given ID.",
+              "Could not find student restriction for the given id",
             );
           case STUDENT_RESTRICTION_IS_NOT_ACTIVE:
             throw new UnprocessableEntityException(

--- a/sources/packages/backend/apps/api/src/route-controllers/application-restriction-bypass/application-restriction-bypass.aest.controller.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/application-restriction-bypass/application-restriction-bypass.aest.controller.ts
@@ -142,7 +142,13 @@ export class ApplicationRestrictionBypassAESTController extends BaseController {
         applicationId,
       );
     return {
-      availableRestrictionsToBypass: availableRestrictionsToBypass,
+      availableRestrictionsToBypass: availableRestrictionsToBypass.map(
+        (item) => ({
+          studentRestrictionId: item.studentRestrictionId,
+          restrictionCode: item.restrictionCode,
+          studentRestrictionCreatedAt: item.studentRestrictionCreatedAt,
+        }),
+      ),
     };
   }
 

--- a/sources/packages/backend/apps/api/src/route-controllers/application-restriction-bypass/application-restriction-bypass.aest.controller.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/application-restriction-bypass/application-restriction-bypass.aest.controller.ts
@@ -32,10 +32,7 @@ import {
   ApiUnprocessableEntityResponse,
 } from "@nestjs/swagger";
 import { ApplicationRestrictionBypassService } from "../../services";
-import {
-  ApplicationRestrictionBypass,
-  StudentRestriction,
-} from "@sims/sims-db";
+import { ApplicationRestrictionBypass } from "@sims/sims-db";
 import { PrimaryIdentifierAPIOutDTO } from "../models/primary.identifier.dto";
 import { IUserToken, Role } from "../../auth";
 import { CustomNamedError } from "@sims/utilities";
@@ -108,7 +105,7 @@ export class ApplicationRestrictionBypassAESTController extends BaseController {
         id,
       );
     if (!applicationRestrictionBypass) {
-      throw new NotFoundException(APPLICATION_RESTRICTION_BYPASS_NOT_FOUND);
+      throw new NotFoundException("Application restriction bypass not found.");
     }
     return {
       applicationRestrictionBypassId: applicationRestrictionBypass.id,
@@ -145,13 +142,7 @@ export class ApplicationRestrictionBypassAESTController extends BaseController {
         applicationId,
       );
     return {
-      availableRestrictionsToBypass: availableRestrictionsToBypass.map(
-        (item: StudentRestriction) => ({
-          studentRestrictionId: item.id,
-          restrictionCode: item.restriction.restrictionCode,
-          studentRestrictionCreatedAt: item.createdAt,
-        }),
-      ),
+      availableRestrictionsToBypass: availableRestrictionsToBypass,
     };
   }
 

--- a/sources/packages/backend/apps/api/src/route-controllers/application-restriction-bypass/application-restriction-bypass.aest.controller.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/application-restriction-bypass/application-restriction-bypass.aest.controller.ts
@@ -12,7 +12,12 @@ import {
 import BaseController from "../BaseController";
 import { AuthorizedParties } from "../../auth/authorized-parties.enum";
 import { UserGroups } from "../../auth/user-groups.enum";
-import { AllowAuthorizedParty, Groups, UserToken } from "../../auth/decorators";
+import {
+  AllowAuthorizedParty,
+  Groups,
+  Roles,
+  UserToken,
+} from "../../auth/decorators";
 import {
   ApplicationRestrictionBypassAPIOutDTO,
   ApplicationRestrictionBypassHistoryAPIOutDTO,
@@ -32,7 +37,7 @@ import {
   StudentRestriction,
 } from "@sims/sims-db";
 import { PrimaryIdentifierAPIOutDTO } from "../models/primary.identifier.dto";
-import { IUserToken } from "../../auth";
+import { IUserToken, Role } from "../../auth";
 import { CustomNamedError } from "@sims/utilities";
 import {
   ACTIVE_BYPASS_FOR_STUDENT_RESTRICTION_ALREADY_EXISTS,
@@ -164,11 +169,12 @@ export class ApplicationRestrictionBypassAESTController extends BaseController {
    */
   @ApiUnprocessableEntityResponse({
     description:
-      "Cannot create a bypass when there is an active bypass for the same active student restriction ID or " +
-      "could not find student restriction for the given ID or " +
+      "Cannot create a bypass when there is an active bypass for the same active student restriction id or " +
+      "could not find student restriction for the given id or " +
       "cannot create a bypass when student restriction is not active  or " +
       "cannot create a bypass when application is in invalid state.",
   })
+  @Roles(Role.AESTBypassStudentRestriction)
   @Post()
   async bypassRestriction(
     @Body() payload: BypassRestrictionAPIInDTO,
@@ -190,7 +196,7 @@ export class ApplicationRestrictionBypassAESTController extends BaseController {
             );
           case STUDENT_RESTRICTION_NOT_FOUND:
             throw new UnprocessableEntityException(
-              "Could not find student restriction for the given id",
+              "Could not find student restriction for the given id.",
             );
           case STUDENT_RESTRICTION_IS_NOT_ACTIVE:
             throw new UnprocessableEntityException(
@@ -216,6 +222,7 @@ export class ApplicationRestrictionBypassAESTController extends BaseController {
       "Cannot remove a bypass when student restriction is not active or " +
       "cannot remove a bypass when application restriction bypass is not active.",
   })
+  @Roles(Role.AESTBypassStudentRestriction)
   @Patch(":id")
   async removeBypassRestriction(
     @UserToken() userToken: IUserToken,

--- a/sources/packages/backend/apps/api/src/route-controllers/application-restriction-bypass/models/application-restriction-bypass.dto.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/application-restriction-bypass/models/application-restriction-bypass.dto.ts
@@ -47,6 +47,7 @@ export class AvailableStudentRestrictionAPIOutDTO {
     studentRestrictionCreatedAt: Date;
   }[];
 }
+
 export class ApplicationRestrictionBypassAPIOutDTO {
   applicationRestrictionBypassId: number;
   studentRestrictionId: number;

--- a/sources/packages/backend/apps/api/src/route-controllers/application-restriction-bypass/models/application-restriction-bypass.dto.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/application-restriction-bypass/models/application-restriction-bypass.dto.ts
@@ -2,7 +2,7 @@ import {
   NOTE_DESCRIPTION_MAX_LENGTH,
   RestrictionBypassBehaviors,
 } from "@sims/sims-db";
-import { IsPositive, IsEnum, IsString, MaxLength } from "class-validator";
+import { IsPositive, IsEnum, MaxLength, IsNotEmpty } from "class-validator";
 
 /**
  * DTO class for application restriction bypass summary.
@@ -29,13 +29,13 @@ export class BypassRestrictionAPIInDTO {
   studentRestrictionId: number;
   @IsEnum(RestrictionBypassBehaviors)
   bypassBehavior: RestrictionBypassBehaviors;
-  @IsString()
+  @IsNotEmpty()
   @MaxLength(NOTE_DESCRIPTION_MAX_LENGTH)
   note: string;
 }
 
 export class RemoveBypassRestrictionAPIInDTO {
-  @IsString()
+  @IsNotEmpty()
   @MaxLength(NOTE_DESCRIPTION_MAX_LENGTH)
   note: string;
 }
@@ -51,11 +51,11 @@ export class ApplicationRestrictionBypassAPIOutDTO {
   applicationRestrictionBypassId: number;
   studentRestrictionId: number;
   restrictionCode: string;
-  applicationRestrictionBypassCreatedDate: string;
-  applicationRestrictionBypassCreatedBy: string;
-  applicationRestrictionBypassCreationNote: string;
-  applicationRestrictionBypassRemovedDate?: string;
-  applicationRestrictionBypassRemovedBy?: string;
-  applicationRestrictionBypassRemovalNote?: string;
-  applicationRestrictionBypassBehavior: string;
+  createdDate: string;
+  createdBy: string;
+  creationNote: string;
+  removedDate?: string;
+  removedBy?: string;
+  removalNote?: string;
+  bypassBehavior: string;
 }

--- a/sources/packages/backend/apps/api/src/route-controllers/application-restriction-bypass/models/application-restriction-bypass.dto.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/application-restriction-bypass/models/application-restriction-bypass.dto.ts
@@ -1,3 +1,9 @@
+import {
+  NOTE_DESCRIPTION_MAX_LENGTH,
+  RestrictionBypassBehaviors,
+} from "@sims/sims-db";
+import { IsPositive, IsEnum, IsString, MaxLength } from "class-validator";
+
 /**
  * DTO class for application restriction bypass summary.
  */
@@ -14,4 +20,42 @@ export class ApplicationRestrictionBypassSummary {
  */
 export class ApplicationRestrictionBypassHistoryAPIOutDTO {
   bypasses: ApplicationRestrictionBypassSummary[];
+}
+
+export class BypassRestrictionAPIInDTO {
+  @IsPositive()
+  applicationId: number;
+  @IsPositive()
+  studentRestrictionId: number;
+  @IsEnum(RestrictionBypassBehaviors)
+  bypassBehavior: RestrictionBypassBehaviors;
+  @IsString()
+  @MaxLength(NOTE_DESCRIPTION_MAX_LENGTH)
+  note: string;
+}
+
+export class RemoveBypassRestrictionAPIInDTO {
+  @IsString()
+  @MaxLength(NOTE_DESCRIPTION_MAX_LENGTH)
+  note: string;
+}
+
+export class AvailableStudentRestrictionAPIOutDTO {
+  availableRestrictionsToBypass: {
+    studentRestrictionId: number;
+    restrictionCode: string;
+    studentRestrictionCreatedAt: Date;
+  }[];
+}
+export class ApplicationRestrictionBypassAPIOutDTO {
+  applicationRestrictionBypassId: number;
+  studentRestrictionId: number;
+  restrictionCode: string;
+  applicationRestrictionBypassCreatedDate: string;
+  applicationRestrictionBypassCreatedBy: string;
+  applicationRestrictionBypassCreationNote: string;
+  applicationRestrictionBypassRemovedDate?: string;
+  applicationRestrictionBypassRemovedBy?: string;
+  applicationRestrictionBypassRemovalNote?: string;
+  applicationRestrictionBypassBehavior: string;
 }

--- a/sources/packages/backend/apps/api/src/services/application-restriction-bypass/application-restriction-bypass.models.ts
+++ b/sources/packages/backend/apps/api/src/services/application-restriction-bypass/application-restriction-bypass.models.ts
@@ -1,0 +1,12 @@
+import { RestrictionBypassBehaviors } from "@sims/sims-db";
+
+export interface BypassRestrictionData {
+  applicationId: number;
+  studentRestrictionId: number;
+  bypassBehavior: RestrictionBypassBehaviors;
+  note: string;
+}
+
+export interface RemoveBypassRestrictionData {
+  note: string;
+}

--- a/sources/packages/backend/apps/api/src/services/application-restriction-bypass/application-restriction-bypass.models.ts
+++ b/sources/packages/backend/apps/api/src/services/application-restriction-bypass/application-restriction-bypass.models.ts
@@ -6,3 +6,9 @@ export interface BypassRestrictionData {
   bypassBehavior: RestrictionBypassBehaviors;
   note: string;
 }
+
+export class AvailableStudentRestrictionData {
+  studentRestrictionId: number;
+  restrictionCode: string;
+  studentRestrictionCreatedAt: Date;
+}

--- a/sources/packages/backend/apps/api/src/services/application-restriction-bypass/application-restriction-bypass.models.ts
+++ b/sources/packages/backend/apps/api/src/services/application-restriction-bypass/application-restriction-bypass.models.ts
@@ -6,7 +6,3 @@ export interface BypassRestrictionData {
   bypassBehavior: RestrictionBypassBehaviors;
   note: string;
 }
-
-export interface RemoveBypassRestrictionData {
-  note: string;
-}

--- a/sources/packages/backend/apps/api/src/services/application-restriction-bypass/application-restriction-bypass.service.ts
+++ b/sources/packages/backend/apps/api/src/services/application-restriction-bypass/application-restriction-bypass.service.ts
@@ -20,7 +20,7 @@ import {
   APPLICATION_RESTRICTION_BYPASS_IS_NOT_ACTIVE,
   STUDENT_RESTRICTION_NOT_FOUND,
 } from "../../constants";
-import { BypassRestrictionData } from "../../services/application-restriction-bypass/application-restriction-bypass.models";
+import { BypassRestrictionData } from "../../services/";
 import { NoteSharedService } from "@sims/services";
 
 /**

--- a/sources/packages/backend/apps/api/src/services/application-restriction-bypass/application-restriction-bypass.service.ts
+++ b/sources/packages/backend/apps/api/src/services/application-restriction-bypass/application-restriction-bypass.service.ts
@@ -10,7 +10,7 @@ import {
   StudentRestriction,
   User,
 } from "@sims/sims-db";
-import { Brackets, DataSource, Not, Repository, UpdateResult } from "typeorm";
+import { Brackets, DataSource, Repository, UpdateResult } from "typeorm";
 import { CustomNamedError } from "@sims/utilities";
 import {
   ACTIVE_BYPASS_FOR_STUDENT_RESTRICTION_ALREADY_EXISTS,
@@ -70,7 +70,6 @@ export class ApplicationRestrictionBypassService {
       where: {
         application: {
           id: applicationId,
-          applicationStatus: Not(ApplicationStatus.Draft),
         },
       },
       order: { createdAt: "DESC" },

--- a/sources/packages/backend/apps/api/src/services/application-restriction-bypass/application-restriction-bypass.service.ts
+++ b/sources/packages/backend/apps/api/src/services/application-restriction-bypass/application-restriction-bypass.service.ts
@@ -216,7 +216,7 @@ export class ApplicationRestrictionBypassService {
         },
       );
     }
-    return await query.orderBy("restriction.restrictionCode", "ASC").getMany();
+    return query.orderBy("restriction.restrictionCode", "ASC").getMany();
   }
 
   /**
@@ -252,32 +252,30 @@ export class ApplicationRestrictionBypassService {
         id: payload.applicationId,
       },
     });
-    return await this.dataSource.transaction(
-      async (transactionalEntityManager) => {
-        const noteObj = await this.noteSharedService.createStudentNote(
-          studentApplication.student.id,
-          NoteType.Application,
-          payload.note,
-          auditUserId,
-          transactionalEntityManager,
-        );
-        const now = new Date();
-        const auditUser = { id: auditUserId } as User;
-        return transactionalEntityManager
-          .getRepository(ApplicationRestrictionBypass)
-          .save({
-            application: { id: payload.applicationId },
-            studentRestriction: { id: payload.studentRestrictionId },
-            isActive: true,
-            bypassCreatedDate: now,
-            bypassCreatedBy: auditUser,
-            creator: auditUser,
-            createdAt: now,
-            bypassBehavior: payload.bypassBehavior,
-            creationNote: noteObj,
-          });
-      },
-    );
+    return this.dataSource.transaction(async (transactionalEntityManager) => {
+      const noteObj = await this.noteSharedService.createStudentNote(
+        studentApplication.student.id,
+        NoteType.Application,
+        payload.note,
+        auditUserId,
+        transactionalEntityManager,
+      );
+      const now = new Date();
+      const auditUser = { id: auditUserId } as User;
+      return transactionalEntityManager
+        .getRepository(ApplicationRestrictionBypass)
+        .save({
+          application: { id: payload.applicationId },
+          studentRestriction: { id: payload.studentRestrictionId },
+          isActive: true,
+          bypassCreatedDate: now,
+          bypassCreatedBy: auditUser,
+          creator: auditUser,
+          createdAt: now,
+          bypassBehavior: payload.bypassBehavior,
+          creationNote: noteObj,
+        });
+    });
   }
 
   /**
@@ -425,28 +423,26 @@ export class ApplicationRestrictionBypassService {
       );
     }
     const auditUser = { id: auditUserId } as User;
-    return await this.dataSource.transaction(
-      async (transactionalEntityManager) => {
-        const noteObj = await this.noteSharedService.createStudentNote(
-          applicationRestrictionBypass.application.student.id,
-          NoteType.Application,
-          removalNote,
-          auditUserId,
-          transactionalEntityManager,
+    return this.dataSource.transaction(async (transactionalEntityManager) => {
+      const noteObj = await this.noteSharedService.createStudentNote(
+        applicationRestrictionBypass.application.student.id,
+        NoteType.Application,
+        removalNote,
+        auditUserId,
+        transactionalEntityManager,
+      );
+      return transactionalEntityManager
+        .getRepository(ApplicationRestrictionBypass)
+        .update(
+          { id },
+          {
+            isActive: false,
+            bypassRemovedDate: new Date(),
+            bypassRemovedBy: auditUser,
+            removalNote: noteObj,
+            modifier: auditUser,
+          },
         );
-        return transactionalEntityManager
-          .getRepository(ApplicationRestrictionBypass)
-          .update(
-            { id },
-            {
-              isActive: false,
-              bypassRemovedDate: new Date(),
-              bypassRemovedBy: auditUser,
-              removalNote: noteObj,
-              modifier: auditUser,
-            },
-          );
-      },
-    );
+    });
   }
 }

--- a/sources/packages/backend/apps/api/src/services/application-restriction-bypass/application-restriction-bypass.service.ts
+++ b/sources/packages/backend/apps/api/src/services/application-restriction-bypass/application-restriction-bypass.service.ts
@@ -1,17 +1,50 @@
 import { Injectable } from "@nestjs/common";
+import { InjectRepository } from "@nestjs/typeorm";
 import {
+  Application,
   ApplicationRestrictionBypass,
   ApplicationStatus,
+  Note,
+  NoteType,
+  OfferingIntensity,
   RecordDataModelService,
+  RestrictionActionType,
+  StudentRestriction,
+  User,
 } from "@sims/sims-db";
-import { DataSource, Not } from "typeorm";
+import {
+  BypassRestrictionAPIInDTO,
+  RemoveBypassRestrictionAPIInDTO,
+} from "../../route-controllers/application-restriction-bypass/models/application-restriction-bypass.dto";
+import {
+  Brackets,
+  DataSource,
+  EntityManager,
+  In,
+  Not,
+  Repository,
+  UpdateResult,
+} from "typeorm";
+import { CustomNamedError } from "@sims/utilities";
+import {
+  ACTIVE_BYPASS_FOR_STUDENT_RESTRICTION_ALREADY_EXISTS,
+  APPLICATION_RESTRICTION_BYPASS_NOT_FOUND,
+  APPLICATION_IN_INVALID_STATE_FOR_APPLICATION_RESTRICTION_BYPASS_CREATION,
+  STUDENT_RESTRICTION_IS_NOT_ACTIVE,
+  APPLICATION_RESTRICTION_BYPASS_IS_NOT_ACTIVE,
+  STUDENT_RESTRICTION_NOT_FOUND,
+} from "../../constants";
 
 /**
  * Service layer for application restriction bypasses.
  */
 @Injectable()
 export class ApplicationRestrictionBypassService extends RecordDataModelService<ApplicationRestrictionBypass> {
-  constructor(dataSource: DataSource) {
+  constructor(
+    private readonly dataSource: DataSource,
+    @InjectRepository(StudentRestriction)
+    private readonly studentRestrictionRepo: Repository<StudentRestriction>,
+  ) {
     super(dataSource.getRepository(ApplicationRestrictionBypass));
   }
 
@@ -48,5 +81,371 @@ export class ApplicationRestrictionBypassService extends RecordDataModelService<
       },
       order: { createdAt: "DESC" },
     });
+  }
+
+  /**
+   * Gets an application restriction bypass by id.
+   * @param id id of the application restriction bypass to retrieve.
+   * @returns application restriction bypass.
+   */
+  getApplicationRestrictionBypass(
+    id: number,
+  ): Promise<ApplicationRestrictionBypass> {
+    return this.repo.findOne({
+      select: {
+        id: true,
+        isActive: true,
+        studentRestriction: {
+          id: true,
+          restriction: {
+            restrictionCode: true,
+          },
+        },
+        creationNote: true as unknown,
+        removalNote: true as unknown,
+        bypassCreatedBy: true as unknown,
+        bypassCreatedDate: true,
+        bypassRemovedBy: true as unknown,
+        bypassRemovedDate: true,
+        bypassBehavior: true,
+      },
+      relations: {
+        studentRestriction: { restriction: true },
+        creationNote: true,
+        removalNote: true,
+        bypassCreatedBy: true,
+        bypassRemovedBy: true,
+      },
+      where: {
+        id,
+        application: {
+          applicationStatus: Not(
+            In([
+              ApplicationStatus.Draft,
+              ApplicationStatus.Cancelled,
+              ApplicationStatus.Overwritten,
+            ]),
+          ),
+        },
+      },
+    });
+  }
+
+  /**
+   * Gets all available student restrictions to bypass for a given application.
+   * @param applicationId application id.
+   * @returns list of application restriction bypass options.
+   */
+  async getAvailableStudentRestrictionsToBypass(
+    applicationId: number,
+  ): Promise<StudentRestriction[]> {
+    return await this.studentRestrictionRepo
+      .createQueryBuilder("studentRestriction")
+      .select([
+        "studentRestriction.id",
+        "restriction.restrictionCode",
+        "studentRestriction.createdAt",
+      ])
+      .innerJoin("studentRestriction.restriction", "restriction")
+      .innerJoin("studentRestriction.application", "application")
+      .innerJoin("application.currentAssessment", "currentAssessment")
+      .innerJoin("currentAssessment.offering", "offering")
+      .where("studentRestriction.application = :applicationId", {
+        applicationId,
+      })
+      // Active application restriction bypass.
+      .andWhere((qb) => {
+        const subQuery = qb
+          .subQuery()
+          .select("applicationRestrictionBypass.id")
+          .from(ApplicationRestrictionBypass, "applicationRestrictionBypass")
+          .where("applicationRestrictionBypass.application = :applicationId", {
+            applicationId,
+          })
+          .andWhere(
+            "applicationRestrictionBypass.studentRestriction = studentRestriction.id",
+          )
+          .andWhere("applicationRestrictionBypass.isActive = true");
+        return `NOT EXISTS (${subQuery.getQuery()})`;
+      })
+      // Restriction action type condition.
+      .andWhere((qb) => {
+        const actionTypeSubQuery = qb
+          .subQuery()
+          .select("1")
+          .from(Application, "application")
+          .innerJoin("application.currentAssessment", "currentAssessment")
+          .innerJoin("currentAssessment.offering", "offering")
+          .where("application.id = :applicationId", { applicationId })
+          .andWhere(
+            new Brackets((qb) => {
+              qb.where("offering.offeringIntensity = :fullTimeIntensity", {
+                fullTimeIntensity: OfferingIntensity.fullTime,
+              })
+                .andWhere(
+                  "restriction.action_type::text[] && ARRAY[:...fullTimeActionTypes]::text[]",
+                  {
+                    fullTimeActionTypes: [
+                      RestrictionActionType.StopFullTimeBCFunding,
+                      RestrictionActionType.StopFullTimeDisbursement,
+                    ],
+                  },
+                )
+                .orWhere("offering.offeringIntensity = :partTimeIntensity", {
+                  partTimeIntensity: OfferingIntensity.partTime,
+                })
+                .andWhere(
+                  "restriction.action_type::text[] && ARRAY[:...partTimeActionTypes]::text[]",
+                  {
+                    partTimeActionTypes: [
+                      RestrictionActionType.StopPartTimeDisbursement,
+                    ],
+                  },
+                );
+            }),
+          );
+        return `EXISTS (${actionTypeSubQuery.getQuery()})`;
+      })
+      .orderBy("restriction.restrictionCode", "ASC")
+      .getMany();
+  }
+
+  /**
+   * Creates a new application restriction bypass.
+   * @param payload application restriction bypass data.
+   * @param auditUserId id of the user who is creating the bypass.
+   * @returns created application restriction bypass.
+   */
+  async bypassRestriction(
+    payload: BypassRestrictionAPIInDTO,
+    auditUserId: number,
+  ): Promise<ApplicationRestrictionBypass> {
+    const auditUser = { id: auditUserId } as User;
+    const now = new Date();
+    return await this.dataSource.transaction(
+      async (transactionalEntityManager) => {
+        await this.checkForActiveApplicationStudentRestrictionByPasses(
+          transactionalEntityManager,
+          payload.applicationId,
+          payload.studentRestrictionId,
+        );
+        await this.checkForActiveStudentRestriction(
+          transactionalEntityManager,
+          payload.studentRestrictionId,
+        );
+        await this.checkForApplicationInValidState(
+          transactionalEntityManager,
+          payload.applicationId,
+        );
+
+        const notes = new Note();
+        notes.description = payload.note;
+        notes.noteType = NoteType.Application;
+        notes.creator = auditUser;
+        notes.createdAt = now;
+        const noteObj = await transactionalEntityManager
+          .getRepository(Note)
+          .save(notes);
+
+        return await transactionalEntityManager
+          .getRepository(ApplicationRestrictionBypass)
+          .save({
+            application: { id: payload.applicationId },
+            studentRestriction: { id: payload.studentRestrictionId },
+            isActive: true,
+            bypassCreatedDate: now,
+            bypassCreatedBy: auditUser,
+            creator: auditUser,
+            createdAt: now,
+            bypassBehavior: payload.bypassBehavior,
+            creationNote: noteObj,
+          });
+      },
+    );
+  }
+
+  /**
+   * Checks if the application is in a valid state for bypass creation.
+   * Throws an error if the application is in a Draft, Cancelled,
+   * or Overwritten state.
+   * @param transactionalEntityManager transactional entity manager to execute the query.
+   * @param applicationId id of the application to check.
+   */
+  private async checkForApplicationInValidState(
+    transactionalEntityManager: EntityManager,
+    applicationId: number,
+  ) {
+    const application = await transactionalEntityManager
+      .getRepository(Application)
+      .findOne({
+        select: {
+          applicationStatus: true,
+        },
+        where: {
+          id: applicationId,
+        },
+      });
+    if (
+      [
+        ApplicationStatus.Draft,
+        ApplicationStatus.Cancelled,
+        ApplicationStatus.Overwritten,
+      ].includes(application.applicationStatus)
+    ) {
+      throw new CustomNamedError(
+        "Cannot create a bypass when application is in invalid state.",
+        APPLICATION_IN_INVALID_STATE_FOR_APPLICATION_RESTRICTION_BYPASS_CREATION,
+      );
+    }
+  }
+
+  /**
+   * Checks if a student restriction is active.
+   * Throws an error if the student restriction is not found
+   * or if it is not active.
+   * @param transactionalEntityManager transactional entity manager to execute the query.
+   * @param studentRestrictionId id of the student restriction to check.
+   */
+  private async checkForActiveStudentRestriction(
+    transactionalEntityManager: EntityManager,
+    studentRestrictionId: number,
+  ) {
+    const studentRestriction = await transactionalEntityManager
+      .getRepository(StudentRestriction)
+      .findOne({
+        select: {
+          isActive: true,
+        },
+        where: {
+          id: studentRestrictionId,
+        },
+      });
+    if (!studentRestriction) {
+      throw new CustomNamedError(
+        "Could not find student restriction for the given ID.",
+        STUDENT_RESTRICTION_NOT_FOUND,
+      );
+    }
+    if (studentRestriction.isActive === false) {
+      throw new CustomNamedError(
+        "Cannot create a bypass when student restriction is not active.",
+        STUDENT_RESTRICTION_IS_NOT_ACTIVE,
+      );
+    }
+  }
+
+  /**
+   * Checks if there is an active application student restriction bypass.
+   * Throws an error if there is an active bypass for the same active student restriction ID.
+   * @param transactionalEntityManager transactional entity manager to execute the query.
+   * @param applicationId id of the application to check.
+   * @param studentRestrictionId id of the student restriction to check.
+   */
+  private async checkForActiveApplicationStudentRestrictionByPasses(
+    transactionalEntityManager: EntityManager,
+    applicationId: number,
+    studentRestrictionId: number,
+  ) {
+    const existsActiveStudentRestriction = await transactionalEntityManager
+      .getRepository(ApplicationRestrictionBypass)
+      .exists({
+        relations: { studentRestriction: true },
+        where: {
+          application: {
+            id: applicationId,
+          },
+          studentRestriction: {
+            id: studentRestrictionId,
+          },
+          isActive: true,
+        },
+      });
+    if (existsActiveStudentRestriction) {
+      throw new CustomNamedError(
+        "There is an active bypass for the same active student restriction ID.",
+        ACTIVE_BYPASS_FOR_STUDENT_RESTRICTION_ALREADY_EXISTS,
+      );
+    }
+  }
+
+  /**
+   * Removes an application restriction bypass.
+   * @param id id of the application restriction bypass to remove.
+   * @param payload note for the removal of the application restriction bypass.
+   * @param auditUserId id of the audit user.
+   * @returns updated application restriction bypass.
+   */
+  async removeBypassRestriction(
+    id: number,
+    payload: RemoveBypassRestrictionAPIInDTO,
+    auditUserId: number,
+  ): Promise<UpdateResult> {
+    const auditUser = { id: auditUserId } as User;
+    const now = new Date();
+    return await this.dataSource.transaction(
+      async (transactionalEntityManager) => {
+        const applicationRestrictionBypass = await transactionalEntityManager
+          .getRepository(ApplicationRestrictionBypass)
+          .findOne({
+            select: {
+              id: true,
+              isActive: true,
+              studentRestriction: {
+                isActive: true,
+              },
+              application: {
+                id: true,
+                applicationStatus: true,
+              },
+            },
+            relations: { studentRestriction: true, application: true },
+            where: {
+              id,
+            },
+          });
+        if (!applicationRestrictionBypass) {
+          throw new CustomNamedError(
+            "Could not find application restriction bypass for the given ID.",
+            APPLICATION_RESTRICTION_BYPASS_NOT_FOUND,
+          );
+        }
+        if (
+          applicationRestrictionBypass.studentRestriction.isActive === false
+        ) {
+          throw new CustomNamedError(
+            "Cannot create a bypass when student restriction is not active.",
+            STUDENT_RESTRICTION_IS_NOT_ACTIVE,
+          );
+        }
+        if (applicationRestrictionBypass.isActive !== true) {
+          throw new CustomNamedError(
+            "Application restriction bypass is not active.",
+            APPLICATION_RESTRICTION_BYPASS_IS_NOT_ACTIVE,
+          );
+        }
+
+        const notes = new Note();
+        notes.description = payload.note;
+        notes.noteType = NoteType.Application;
+        notes.creator = auditUser;
+        notes.createdAt = now;
+        const noteObj = await transactionalEntityManager
+          .getRepository(Note)
+          .save(notes);
+
+        return await transactionalEntityManager
+          .getRepository(ApplicationRestrictionBypass)
+          .update(
+            { id },
+            {
+              isActive: false,
+              bypassRemovedDate: new Date(),
+              bypassRemovedBy: { id: auditUserId } as User,
+              removalNote: noteObj,
+              modifier: auditUser,
+            },
+          );
+      },
+    );
   }
 }

--- a/sources/packages/backend/apps/api/src/services/application-restriction-bypass/application-restriction-bypass.service.ts
+++ b/sources/packages/backend/apps/api/src/services/application-restriction-bypass/application-restriction-bypass.service.ts
@@ -322,7 +322,7 @@ export class ApplicationRestrictionBypassService extends RecordDataModelService<
       });
     if (!studentRestriction) {
       throw new CustomNamedError(
-        "Could not find student restriction for the given ID.",
+        "Could not find student restriction for the given id.",
         STUDENT_RESTRICTION_NOT_FOUND,
       );
     }
@@ -336,7 +336,7 @@ export class ApplicationRestrictionBypassService extends RecordDataModelService<
 
   /**
    * Checks if there is an active application student restriction bypass.
-   * Throws an error if there is an active bypass for the same active student restriction ID.
+   * Throws an error if there is an active bypass for the same active student restriction id.
    * @param transactionalEntityManager transactional entity manager to execute the query.
    * @param applicationId id of the application to check.
    * @param studentRestrictionId id of the student restriction to check.
@@ -362,7 +362,7 @@ export class ApplicationRestrictionBypassService extends RecordDataModelService<
       });
     if (existsActiveStudentRestriction) {
       throw new CustomNamedError(
-        "There is an active bypass for the same active student restriction ID.",
+        "There is an active bypass for the same active student restriction id.",
         ACTIVE_BYPASS_FOR_STUDENT_RESTRICTION_ALREADY_EXISTS,
       );
     }
@@ -405,7 +405,7 @@ export class ApplicationRestrictionBypassService extends RecordDataModelService<
           });
         if (!applicationRestrictionBypass) {
           throw new CustomNamedError(
-            "Could not find application restriction bypass for the given ID.",
+            "Could not find application restriction bypass for the given id.",
             APPLICATION_RESTRICTION_BYPASS_NOT_FOUND,
           );
         }

--- a/sources/packages/backend/apps/api/src/services/index.ts
+++ b/sources/packages/backend/apps/api/src/services/index.ts
@@ -50,3 +50,4 @@ export * from "./cas-supplier/cas-supplier.service";
 export * from "./application-restriction-bypass/application-restriction-bypass.service";
 export * from "./audit/audit.service";
 export * from "./audit/audit-event.enum";
+export * from "./application-restriction-bypass/application-restriction-bypass.models";

--- a/sources/packages/backend/libs/sims-db/src/entities/student-restriction.model.ts
+++ b/sources/packages/backend/libs/sims-db/src/entities/student-restriction.model.ts
@@ -35,6 +35,9 @@ export class StudentRestriction extends BaseRestrictionModel {
   })
   application: Application;
 
+  /**
+   * Application restriction bypasses related to this student restriction.
+   */
   @OneToMany(
     () => ApplicationRestrictionBypass,
     (applicationRestrictionBypass) =>

--- a/sources/packages/backend/libs/sims-db/src/entities/student-restriction.model.ts
+++ b/sources/packages/backend/libs/sims-db/src/entities/student-restriction.model.ts
@@ -1,7 +1,13 @@
-import { Entity, JoinColumn, ManyToOne, PrimaryGeneratedColumn } from "typeorm";
+import {
+  Entity,
+  JoinColumn,
+  ManyToOne,
+  OneToMany,
+  PrimaryGeneratedColumn,
+} from "typeorm";
 import { ColumnNames, TableNames } from "../constant";
 import { BaseRestrictionModel } from "./base-restriction.model";
-import { Student, Application } from ".";
+import { Student, Application, ApplicationRestrictionBypass } from ".";
 
 /**
  * Entity for student restrictions
@@ -28,4 +34,15 @@ export class StudentRestriction extends BaseRestrictionModel {
     referencedColumnName: ColumnNames.ID,
   })
   application: Application;
+
+  @OneToMany(
+    () => ApplicationRestrictionBypass,
+    (applicationRestrictionBypass) =>
+      applicationRestrictionBypass.studentRestriction,
+    {
+      eager: false,
+      cascade: false,
+    },
+  )
+  applicationRestrictionBypasses?: ApplicationRestrictionBypass[];
 }

--- a/sources/packages/backend/libs/test-utils/src/factories/application-restriction-bypass.ts
+++ b/sources/packages/backend/libs/test-utils/src/factories/application-restriction-bypass.ts
@@ -116,6 +116,7 @@ export async function saveFakeApplicationRestrictionBypass(
       {
         student: relations.application.student,
         restriction,
+        application: relations.application,
       },
     );
   } else {
@@ -143,7 +144,7 @@ export async function saveFakeApplicationRestrictionBypass(
       );
     }
     bypass.bypassRemovedBy = relations?.bypassRemovedBy;
-    bypass.bypassRemovedDate = options?.initialValues.bypassRemovedDate ?? now;
+    bypass.bypassRemovedDate = options?.initialValues?.bypassRemovedDate ?? now;
     bypass.isActive = false;
   }
   return db.applicationRestrictionBypass.save(bypass);

--- a/sources/packages/backend/libs/test-utils/src/factories/application-restriction-bypass.ts
+++ b/sources/packages/backend/libs/test-utils/src/factories/application-restriction-bypass.ts
@@ -116,7 +116,6 @@ export async function saveFakeApplicationRestrictionBypass(
       {
         student: relations.application.student,
         restriction,
-        application: relations.application,
       },
     );
   } else {

--- a/sources/packages/backend/libs/test-utils/src/factories/application-restriction-bypass.ts
+++ b/sources/packages/backend/libs/test-utils/src/factories/application-restriction-bypass.ts
@@ -10,6 +10,7 @@ import {
   User,
 } from "@sims/sims-db";
 import { E2EDataSources } from "@sims/test-utils/data-source/e2e-data-source";
+import { saveFakeApplication } from "@sims/test-utils/factories/application";
 import { createFakeNote } from "@sims/test-utils/factories/note";
 import { saveFakeStudentRestriction } from "@sims/test-utils/factories/student-restriction";
 import { ArrayContains, FindOneOptions } from "typeorm";
@@ -75,7 +76,7 @@ export function createFakeApplicationRestrictionBypass(relations: {
 export async function saveFakeApplicationRestrictionBypass(
   db: E2EDataSources,
   relations: {
-    application: Application;
+    application?: Application;
     studentRestriction?: StudentRestriction;
     creationNote?: Note;
     bypassCreatedBy?: User;
@@ -92,7 +93,8 @@ export async function saveFakeApplicationRestrictionBypass(
 ): Promise<ApplicationRestrictionBypass> {
   const now = new Date();
   const bypass = new ApplicationRestrictionBypass();
-  bypass.application = relations.application;
+  bypass.application =
+    relations.application ?? (await saveFakeApplication(db.dataSource));
   bypass.bypassBehavior =
     options.initialValues?.bypassBehavior ??
     RestrictionBypassBehaviors.AllDisbursements;
@@ -114,7 +116,7 @@ export async function saveFakeApplicationRestrictionBypass(
     bypass.studentRestriction = await saveFakeStudentRestriction(
       db.dataSource,
       {
-        student: relations.application.student,
+        student: bypass.application.student,
         restriction,
       },
     );

--- a/sources/packages/backend/libs/test-utils/src/factories/student-restriction.ts
+++ b/sources/packages/backend/libs/test-utils/src/factories/student-restriction.ts
@@ -21,23 +21,28 @@ import { createFakeUser } from "./user";
  * - `restrictionNote` note for restriction.
  * - `resolutionNote` note for resolution.
  * - `creator` related user relation.
+ * @param options options for student restriction.
+ * - `isActive` option for specifying if the student restriction is active.
  * @returns persisted student restriction.
  */
-export function createFakeStudentRestriction(relations: {
-  student: Student;
-  application?: Application;
-  restriction: Restriction;
-  restrictionNote?: Note;
-  resolutionNote?: Note;
-  creator?: User;
-}): StudentRestriction {
+export function createFakeStudentRestriction(
+  relations: {
+    student: Student;
+    application?: Application;
+    restriction: Restriction;
+    restrictionNote?: Note;
+    resolutionNote?: Note;
+    creator?: User;
+  },
+  options?: { isActive?: boolean },
+): StudentRestriction {
   const studentRestriction = new StudentRestriction();
   studentRestriction.student = relations.student;
   studentRestriction.application = relations.application;
   studentRestriction.restriction = relations.restriction;
   studentRestriction.restrictionNote = relations.restrictionNote;
   studentRestriction.resolutionNote = relations.resolutionNote;
-  studentRestriction.isActive = true;
+  studentRestriction.isActive = options?.isActive ?? true;
   studentRestriction.creator = relations?.creator;
   return studentRestriction;
 }
@@ -46,6 +51,8 @@ export function createFakeStudentRestriction(relations: {
  * Saves a fake student restriction.
  * @param dataSource dataSource for the application.
  * @param relations entity relations.
+ * @param options related to student restriction.
+ * - `isActive` option for specifying if the student restriction is active.
  * @returns a persisted fake student restriction.
  */
 export async function saveFakeStudentRestriction(
@@ -58,6 +65,7 @@ export async function saveFakeStudentRestriction(
     resolutionNote?: Note;
     creator?: User;
   },
+  options?: { isActive?: boolean },
 ): Promise<StudentRestriction> {
   const [restrictionNote, resolutionNote] = await saveFakeStudentNotes(
     dataSource,
@@ -75,6 +83,6 @@ export async function saveFakeStudentRestriction(
   relations.restrictionNote = restrictionNote;
   relations.resolutionNote = resolutionNote;
   const studentRestrictionRepo = dataSource.getRepository(StudentRestriction);
-  const studentRestriction = createFakeStudentRestriction(relations);
+  const studentRestriction = createFakeStudentRestriction(relations, options);
   return studentRestrictionRepo.save(studentRestriction);
 }

--- a/sources/packages/backend/libs/test-utils/src/factories/student-restriction.ts
+++ b/sources/packages/backend/libs/test-utils/src/factories/student-restriction.ts
@@ -51,6 +51,12 @@ export function createFakeStudentRestriction(
  * Saves a fake student restriction.
  * @param dataSource dataSource for the application.
  * @param relations entity relations.
+ * - `student` related student.
+ * - `application` application associated with the student.
+ * - `restriction` restriction associated with the student. If not provided, one will be created.
+ * - `restrictionNote` note for restriction.  If not provided, one will be created.
+ * - `resolutionNote` note for resolution.  If not provided, one will be created.
+ * - `creator` related user relation. If not provided, one will be created.
  * @param options related to student restriction.
  * - `isActive` option for specifying if the student restriction is active.
  * @returns a persisted fake student restriction.

--- a/sources/packages/backend/libs/test-utils/src/models/common.model.ts
+++ b/sources/packages/backend/libs/test-utils/src/models/common.model.ts
@@ -77,6 +77,10 @@ export enum RestrictionCode {
    */
   AF = "AF",
   /**
+   * Dual Funding.
+   */
+  AF4 = "AF4",
+  /**
    * Part-time scholastic standing restrictions - Student withdrew or was unsuccesful from Part Time studies.
    */
   PTWTHD = "PTWTHD",
@@ -84,4 +88,12 @@ export enum RestrictionCode {
    * Part-time scholastic standing restrictions - Not eligible for part time funding due to scholastic standing must self fund or appeal.
    */
   PTSSR = "PTSSR",
+  /**
+   * School reported early completion of studies.
+   */
+  ECRS = "ECRS",
+  /**
+   * BC lifetime maximum reached.
+   */
+  BCLM = "BCLM",
 }


### PR DESCRIPTION
- Created the api endpoints:
  - GET aest/application-restriction-bypass/:id
  - GET aest/application-restriction-bypass/application/:applicationId/options-list
  - POST aest/application-restriction-bypass
  - PATCH aest/application-restriction-bypass/:id
- Added new role "aest-bypass-student-restriction" only for business administrators;
- Added e2e tests:
  - ApplicationRestrictionBypassAESTController(e2e)-bypassRestriction
    √ Should be able to create a bypass when there is not an active bypass for the same student.                                                                                                                         
    √ Should throw an HTTP error while creating a bypass when there is an active bypass for the same active student restriction.                                                                                         
    √ Should throw an HTTP error while creating a bypass when student restriction is not active.                                                                                                                         
    √ Should throw an HTTP error while creating a bypass when the student application is in draft.                                                                                                                       
    √ Should throw an HTTP error while creating a bypass when the student application is in cancelled.            
  - ApplicationRestrictionBypassAESTController(e2e)-getApplicationRestrictionBypass.
    √ Should get an application restriction bypass for a submitted part-time application when there is an application restriction bypass with the required id.                                                           
    √ Should get an inactive application restriction bypass for a submitted part-time application when there is an application restriction bypass with the required id.         
  - ApplicationRestrictionBypassAESTController(e2e)-getAvailableRestrictionsToBypass.
    √ Should list all student active restrictions and not already bypassed for a part-time application when there is one restriction bypassed and some others not.                                       
    √ Should list all student active restrictions for a full-time application when there is one restriction bypassed and others not.    
  - ApplicationRestrictionBypassAESTController(e2e)-removeBypassRestriction
    √ Should be able to remove an active bypass when there is an active bypass.                                                                                                                          
    √ Should throw an HTTP error while removing a bypass when the bypass is not active.                                                                                                                  
    √ Should throw an HTTP error while removing a bypass when the bypass is not found.        
