### PR TITLE
#2741 - Ministry Filter Search Programs and Offerings [Fix Expired Programs Sort Issue]

### DIFF
--- a/sources/packages/backend/apps/api/src/services/education-program/education-program.service.ts
+++ b/sources/packages/backend/apps/api/src/services/education-program/education-program.service.ts
@@ -901,7 +901,7 @@ export class EducationProgramService extends RecordDataModelService<EducationPro
     // sort
     if (paginationOptions.sortField === "programStatus") {
       paginatedProgramQuery.orderBy(
-        `CASE WHEN programs.isActive = false THEN '${INACTIVE_PROGRAM}' ELSE programs.programStatus :: text END`,
+        `CASE WHEN programs.isActive = false or (programs.effectiveEndDate is not null and programs.effectiveEndDate >= CURRENT_DATE) THEN '${INACTIVE_PROGRAM}' ELSE programs.programStatus :: text END`,
         paginationOptions.sortOrder,
       );
     } else if (paginationOptions.sortField && paginationOptions.sortOrder) {
@@ -914,10 +914,10 @@ export class EducationProgramService extends RecordDataModelService<EducationPro
       // TODO:Further investigation needed as the CASE translation does not work in orderby queries.
       paginatedProgramQuery.orderBy(
         `CASE           
-          WHEN programs.programStatus = '${ProgramStatus.Pending}' and programs.isActive = true THEN ${SortPriority.Priority1}
-          WHEN programs.programStatus = '${ProgramStatus.Approved}' and programs.isActive = true THEN ${SortPriority.Priority2}
-          WHEN programs.programStatus = '${ProgramStatus.Declined}' and programs.isActive = true THEN ${SortPriority.Priority3}
-          WHEN programs.isActive = false THEN ${SortPriority.Priority4}
+          WHEN programs.programStatus = '${ProgramStatus.Pending}' and programs.isActive = true and (programs.effectiveEndDate is null OR CURRENT_DATE < programs.effectiveEndDate) THEN ${SortPriority.Priority1}
+          WHEN programs.programStatus = '${ProgramStatus.Approved}' and programs.isActive = true and (programs.effectiveEndDate is null OR CURRENT_DATE < programs.effectiveEndDate) THEN ${SortPriority.Priority2}
+          WHEN programs.programStatus = '${ProgramStatus.Declined}' and programs.isActive = true and (programs.effectiveEndDate is null OR CURRENT_DATE < programs.effectiveEndDate) THEN ${SortPriority.Priority3}
+          WHEN programs.isActive = false or (programs.effectiveEndDate is not null and programs.effectiveEndDate >= CURRENT_DATE) THEN ${SortPriority.Priority4}
           ELSE ${SortPriority.Priority5}
         END`,
       );

--- a/sources/packages/backend/apps/api/src/services/education-program/education-program.service.ts
+++ b/sources/packages/backend/apps/api/src/services/education-program/education-program.service.ts
@@ -914,9 +914,9 @@ export class EducationProgramService extends RecordDataModelService<EducationPro
       // TODO:Further investigation needed as the CASE translation does not work in orderby queries.
       paginatedProgramQuery.orderBy(
         `CASE           
-          WHEN programs.programStatus = '${ProgramStatus.Pending}' and programs.isActive = true and (programs.effectiveEndDate is null OR CURRENT_DATE < programs.effectiveEndDate) THEN ${SortPriority.Priority1}
-          WHEN programs.programStatus = '${ProgramStatus.Approved}' and programs.isActive = true and (programs.effectiveEndDate is null OR CURRENT_DATE < programs.effectiveEndDate) THEN ${SortPriority.Priority2}
-          WHEN programs.programStatus = '${ProgramStatus.Declined}' and programs.isActive = true and (programs.effectiveEndDate is null OR CURRENT_DATE < programs.effectiveEndDate) THEN ${SortPriority.Priority3}
+          WHEN programs.programStatus = '${ProgramStatus.Pending}' and programs.isActive = true and (programs.effectiveEndDate is null OR programs.effectiveEndDate > CURRENT_DATE) THEN ${SortPriority.Priority1}
+          WHEN programs.programStatus = '${ProgramStatus.Approved}' and programs.isActive = true and (programs.effectiveEndDate is null OR programs.effectiveEndDate > CURRENT_DATE) THEN ${SortPriority.Priority2}
+          WHEN programs.programStatus = '${ProgramStatus.Declined}' and programs.isActive = true and (programs.effectiveEndDate is null OR programs.effectiveEndDate > CURRENT_DATE) THEN ${SortPriority.Priority3}
           WHEN programs.isActive = false or (programs.effectiveEndDate is not null and programs.effectiveEndDate <= CURRENT_DATE) THEN ${SortPriority.Priority4}
           ELSE ${SortPriority.Priority5}
         END`,

--- a/sources/packages/backend/apps/api/src/services/education-program/education-program.service.ts
+++ b/sources/packages/backend/apps/api/src/services/education-program/education-program.service.ts
@@ -917,7 +917,6 @@ export class EducationProgramService extends RecordDataModelService<EducationPro
       );
     } else {
       // Default sort and order.
-      // TODO:Further investigation needed as the CASE translation does not work in orderby queries.
       paginatedProgramQuery.orderBy(
         `CASE           
           WHEN programs.programStatus = '${ProgramStatus.Pending}' and programs.isActive = true and (programs.effectiveEndDate is null OR programs.effectiveEndDate > CURRENT_DATE) THEN ${SortPriority.Priority1}

--- a/sources/packages/backend/apps/api/src/services/education-program/education-program.service.ts
+++ b/sources/packages/backend/apps/api/src/services/education-program/education-program.service.ts
@@ -901,7 +901,7 @@ export class EducationProgramService extends RecordDataModelService<EducationPro
     // sort
     if (paginationOptions.sortField === "programStatus") {
       paginatedProgramQuery.orderBy(
-        `CASE WHEN programs.isActive = false or (programs.effectiveEndDate is not null and programs.effectiveEndDate >= CURRENT_DATE) THEN '${INACTIVE_PROGRAM}' ELSE programs.programStatus :: text END`,
+        `CASE WHEN programs.isActive = false or (programs.effectiveEndDate is not null and programs.effectiveEndDate <= CURRENT_DATE) THEN '${INACTIVE_PROGRAM}' ELSE programs.programStatus :: text END`,
         paginationOptions.sortOrder,
       );
     } else if (paginationOptions.sortField && paginationOptions.sortOrder) {
@@ -917,7 +917,7 @@ export class EducationProgramService extends RecordDataModelService<EducationPro
           WHEN programs.programStatus = '${ProgramStatus.Pending}' and programs.isActive = true and (programs.effectiveEndDate is null OR CURRENT_DATE < programs.effectiveEndDate) THEN ${SortPriority.Priority1}
           WHEN programs.programStatus = '${ProgramStatus.Approved}' and programs.isActive = true and (programs.effectiveEndDate is null OR CURRENT_DATE < programs.effectiveEndDate) THEN ${SortPriority.Priority2}
           WHEN programs.programStatus = '${ProgramStatus.Declined}' and programs.isActive = true and (programs.effectiveEndDate is null OR CURRENT_DATE < programs.effectiveEndDate) THEN ${SortPriority.Priority3}
-          WHEN programs.isActive = false or (programs.effectiveEndDate is not null and programs.effectiveEndDate >= CURRENT_DATE) THEN ${SortPriority.Priority4}
+          WHEN programs.isActive = false or (programs.effectiveEndDate is not null and programs.effectiveEndDate <= CURRENT_DATE) THEN ${SortPriority.Priority4}
           ELSE ${SortPriority.Priority5}
         END`,
       );


### PR DESCRIPTION
As a part of this PR, the query to retrieve the list of programs was updated to ensure that the sort order of the retrieved list of programs has the correct order where the inactive programs comprise the programs that have `isActive = false` or the ones that have the `effectiveEndDate <= CURRENT_DATE`