### PR TITLE
#3789 - Fix program description on Institution PIR Page

### DIFF
--- a/sources/packages/backend/apps/api/src/route-controllers/program-info-request/models/program-info-request.dto.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/program-info-request/models/program-info-request.dto.ts
@@ -15,6 +15,7 @@ export class ProgramInfoRequestAPIOutDTO {
   applicationNumber: string;
   studentFullName: string;
   studentSelectedProgram: string;
+  studentSelectedProgramDescription?: string;
   selectedProgram?: number;
   selectedOffering?: number;
   pirStatus: ProgramInfoStatus;

--- a/sources/packages/backend/apps/api/src/route-controllers/program-info-request/program-info-request.institutions.controller.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/program-info-request/program-info-request.institutions.controller.ts
@@ -121,6 +121,8 @@ export class ProgramInfoRequestInstitutionsController extends BaseController {
     result.isActiveProgramYear = application.programYear.active;
     // Education program, if selected by the student.
     result.studentSelectedProgram = application.pirProgram?.name;
+    result.studentSelectedProgramDescription =
+      application.pirProgram?.description;
     // Original assessment to be used as a reference for the PIR (original
     // assessment always available for submitted student applications).
     // PIR process happens only during original assessment.

--- a/sources/packages/backend/apps/api/src/services/application/application.service.ts
+++ b/sources/packages/backend/apps/api/src/services/application/application.service.ts
@@ -522,6 +522,7 @@ export class ApplicationService extends RecordDataModelService<Application> {
         "user.lastName",
         "pirProgram.id",
         "pirProgram.name",
+        "pirProgram.description",
         "pirProgram.isActive",
         "pirProgram.effectiveEndDate",
         "educationProgram.id",

--- a/sources/packages/forms/src/form-definitions/programinformationrequest.json
+++ b/sources/packages/forms/src/form-definitions/programinformationrequest.json
@@ -366,7 +366,9 @@
           "addons": [],
           "tag": "p",
           "id": "ezdiowm",
-          "className": ""
+          "className": "",
+          "isNew": false,
+          "tags": []
         },
         {
           "label": "HTML",
@@ -627,7 +629,7 @@
               "value": ""
             }
           ],
-          "content": "<!--studentCustomProgramDescription value is from the application dynamic data(text field) \nand studentSelectedProgram is from the program drop down-->\n{{ data.studentCustomProgramDescription ?? data.studentSelectedProgram }}",
+          "content": "<!--studentCustomProgramDescription value is from the application dynamic data(text field) \nand studentSelectedProgram is from the program drop down-->\n{{ data.studentCustomProgramDescription ?? data.studentSelectedProgramDescription }}",
           "refreshOnChange": true,
           "customClass": "label-value",
           "hidden": false,
@@ -636,7 +638,7 @@
           "tags": [],
           "properties": {},
           "conditional": {
-            "show": null,
+            "show": "",
             "when": null,
             "eq": "",
             "json": ""
@@ -1390,7 +1392,8 @@
       "addons": [],
       "tree": false,
       "lazyLoad": false,
-      "id": "e7laqse"
+      "id": "e7laqse",
+      "isNew": false
     },
     {
       "title": "Institution entered details",


### PR DESCRIPTION
## Issue description and fix

Issue: When a program is selected in a student application but study period is not selected and submitted for PIR review, the Institution PIR page was displaying the `program name` in the `program description` section.

- [x] Fix: The formIO was neither receiving nor displaying a program description that was coming from the original program. Hence the API was enhanced and FormIO was updated to receive the program description variable. 

![image](https://github.com/user-attachments/assets/a9e9843a-c18e-4de8-b1a7-3b3373380cde)

![image](https://github.com/user-attachments/assets/5f1944df-5340-4ef7-b471-ab89cf3dd625)

