### PR TITLE
#3943 - Bug - restriction view when access limited 

### DIFF
--- a/sources/packages/web/src/components/common/restriction/ViewRestriction.vue
+++ b/sources/packages/web/src/components/common/restriction/ViewRestriction.vue
@@ -73,14 +73,19 @@
         </template>
       </template>
       <template #footer>
-        <footer-buttons
-          :processing="processing"
-          :primaryLabel="allowUserToEdit ? 'Resolve restriction' : 'Close'"
-          secondaryLabel="Cancel"
-          @primaryClick="allowUserToEdit ? submit() : cancel()"
-          @secondaryClick="cancel"
-          :showSecondaryButton="allowUserToEdit"
-        />
+        <check-permission-role :role="allowedRole">
+          <template #="{ notAllowed }">
+            <footer-buttons
+              :processing="processing"
+              :primaryLabel="allowUserToEdit ? 'Resolve restriction' : 'Close'"
+              secondaryLabel="Cancel"
+              @primaryClick="allowUserToEdit ? submit() : cancel()"
+              @secondaryClick="cancel"
+              :disablePrimaryButton="allowUserToEdit && notAllowed"
+              :showSecondaryButton="allowUserToEdit"
+            />
+          </template>
+        </check-permission-role>
       </template>
     </modal-dialog-base>
   </v-form>
@@ -92,6 +97,7 @@ import ModalDialogBase from "@/components/generic/ModalDialogBase.vue";
 import ErrorSummary from "@/components/generic/ErrorSummary.vue";
 import { useFormatters, useModalDialog, useValidators } from "@/composables";
 import { Role, RestrictionType, VForm, RestrictionStatus } from "@/types";
+import CheckPermissionRole from "@/components/generic/CheckPermissionRole.vue";
 import { RestrictionDetailAPIOutDTO } from "@/services/http/dto";
 import StatusChipRestriction from "@/components/generic/StatusChipRestriction.vue";
 import TitleValue from "@/components/generic/TitleValue.vue";
@@ -99,6 +105,7 @@ import TitleValue from "@/components/generic/TitleValue.vue";
 export default defineComponent({
   components: {
     ModalDialogBase,
+    CheckPermissionRole,
     ErrorSummary,
     StatusChipRestriction,
     TitleValue,
@@ -152,8 +159,6 @@ export default defineComponent({
       }
       return "Resolution reason is required.";
     };
-
-    console.info("props.canResolveRestriction: ", props.canResolveRestriction);
 
     const allowUserToEdit = computed(
       () =>

--- a/sources/packages/web/src/components/common/restriction/ViewRestriction.vue
+++ b/sources/packages/web/src/components/common/restriction/ViewRestriction.vue
@@ -73,19 +73,14 @@
         </template>
       </template>
       <template #footer>
-        <check-permission-role :role="allowedRole">
-          <template #="{ notAllowed }">
-            <footer-buttons
-              :processing="processing"
-              :primaryLabel="allowUserToEdit ? 'Resolve restriction' : 'Close'"
-              secondaryLabel="Cancel"
-              @primaryClick="allowUserToEdit ? submit() : cancel()"
-              @secondaryClick="cancel"
-              :disablePrimaryButton="notAllowed"
-              :showSecondaryButton="allowUserToEdit"
-            />
-          </template>
-        </check-permission-role>
+        <footer-buttons
+          :processing="processing"
+          :primaryLabel="allowUserToEdit ? 'Resolve restriction' : 'Close'"
+          secondaryLabel="Cancel"
+          @primaryClick="allowUserToEdit ? submit() : cancel()"
+          @secondaryClick="cancel"
+          :showSecondaryButton="allowUserToEdit"
+        />
       </template>
     </modal-dialog-base>
   </v-form>
@@ -97,7 +92,6 @@ import ModalDialogBase from "@/components/generic/ModalDialogBase.vue";
 import ErrorSummary from "@/components/generic/ErrorSummary.vue";
 import { useFormatters, useModalDialog, useValidators } from "@/composables";
 import { Role, RestrictionType, VForm, RestrictionStatus } from "@/types";
-import CheckPermissionRole from "@/components/generic/CheckPermissionRole.vue";
 import { RestrictionDetailAPIOutDTO } from "@/services/http/dto";
 import StatusChipRestriction from "@/components/generic/StatusChipRestriction.vue";
 import TitleValue from "@/components/generic/TitleValue.vue";
@@ -105,7 +99,6 @@ import TitleValue from "@/components/generic/TitleValue.vue";
 export default defineComponent({
   components: {
     ModalDialogBase,
-    CheckPermissionRole,
     ErrorSummary,
     StatusChipRestriction,
     TitleValue,
@@ -159,6 +152,8 @@ export default defineComponent({
       }
       return "Resolution reason is required.";
     };
+
+    console.info("props.canResolveRestriction: ", props.canResolveRestriction);
 
     const allowUserToEdit = computed(
       () =>


### PR DESCRIPTION
- Removed the check-role-permission decorator to allow ministry users without designated roles to close the modal as per AC
  - The 'Close' button is not disabled for all users. Users without restriction edit access should be able to view it, not edit it and then close the modal without refreshing.

Screenshot
![image](https://github.com/user-attachments/assets/455e12e4-8c1d-45a6-82c3-7308a3091275)
