### PR TITLE
#3280 - Content: Ministry: Your Profile Info: Update content for “Deny request for a student account” modal

### DIFF
--- a/sources/packages/web/src/views/aest/student/StudentAccountApplicationsApproval.vue
+++ b/sources/packages/web/src/views/aest/student/StudentAccountApplicationsApproval.vue
@@ -50,7 +50,7 @@
       ></confirm-modal>
       <confirm-modal
         title="Deny request for a student account"
-        text="Denying the request means that the student will not be able to access the system using a Basic BCeID."
+        text="Attention: Denied account requests are final and cannot be reactivated. Students will need to start over with the Basic BCeID account application process."
         ref="declineStudentAccountModal"
         okLabel="Deny request now"
         :disablePrimaryButton="notAllowed"


### PR DESCRIPTION
**User story**
As a _ministry_ user, I want to deny the request for a student account so that they have to start over with the Basic BCeID account application.


**Acceptance Criteria**
- [x] Update current text “Denying the request means that the student will not be able to access the system using a Basic BCeID” to "Attention: Denied account requests are final and cannot be reactivated. Students will need to start over with the Basic BCeID account application process."

**Supporting steps and screenshot**
A student has created a new profile and it is sitting in the Student Requests>Accounts page
Click "View"
Click "Deny request"
Message displayed needs to be updated


Sample Demo
![image](https://github.com/user-attachments/assets/d2be0018-5bc9-41f7-a5ef-55858312c6b2)
