### PR TITLE
#3667 - Bull Scheduler - Added Global Bootstrap Synchronization

### DIFF
--- a/sources/packages/backend/libs/services/src/queue/queue.module.ts
+++ b/sources/packages/backend/libs/services/src/queue/queue.module.ts
@@ -32,34 +32,6 @@ import { DatabaseModule } from "@sims/sims-db";
 export class QueueModule {}
 
 /**
- * Shared client connection to redis cluster.
- * @see https://github.com/OptimalBits/bull/blob/develop/PATTERNS.md#reusing-redis-connections
- */
-let sharedClientRedisCluster: Cluster;
-/**
- * Shared subscriber connection to redis cluster.
- * @see https://github.com/OptimalBits/bull/blob/develop/PATTERNS.md#reusing-redis-connections
- */
-let sharedSubscriberClientRedisCluster: Cluster;
-
-/**
- * Creates a Redis cluster connection.
- * @param options the redis connection options.
- * @returns a new instance of Redis cluster connection.
- */
-function createdRedisClusterConnection(options: RedisOptions): Cluster {
-  return new Redis.Cluster(
-    [
-      {
-        host: options.host,
-        port: options.port,
-      },
-    ],
-    { redisOptions: { password: options.password } },
-  );
-}
-
-/**
  * Connection factory which returns connection properties
  * to connect redis.
  * Depending upon the environment variable it uses standalone
@@ -82,29 +54,16 @@ async function getConnectionFactory(
     };
   }
   return {
-    createClient: (
-      type: "client" | "subscriber" | "bclient",
-    ): Redis | Cluster => {
-      switch (type) {
-        case "client":
-          if (!sharedClientRedisCluster) {
-            sharedClientRedisCluster = createdRedisClusterConnection(
-              redisConnectionOptions,
-            );
-          }
-          return sharedClientRedisCluster;
-        case "subscriber":
-          if (!sharedSubscriberClientRedisCluster) {
-            sharedSubscriberClientRedisCluster = createdRedisClusterConnection(
-              redisConnectionOptions,
-            );
-          }
-          return sharedSubscriberClientRedisCluster;
-        case "bclient":
-          // bclient types should always create a new connection.
-          // @see https://github.com/OptimalBits/bull/blob/develop/PATTERNS.md#reusing-redis-connections
-          return createdRedisClusterConnection(redisConnectionOptions);
-      }
+    createClient: (): Redis | Cluster => {
+      return new Redis.Cluster(
+        [
+          {
+            host: redisConnectionOptions.host,
+            port: redisConnectionOptions.port,
+          },
+        ],
+        { redisOptions: { password: redisConnectionOptions.password } },
+      );
     },
   };
 }


### PR DESCRIPTION
Implementing the easy/fast (and stable) approach to resolve the queue initialization issues.

During the previous approach, sharing the ioredis connections (change being reverted in this PR) worked but there was also a possible false-positive memory leak warning. Further investigation will be needed if we change this approach in the feature but for now, keeping the existing approach.

The current solution extends the current  "specific queue-based" lock to an "all queues-based" lock.
The initialization is still pretty fast (around 1 second) and even if we double the number of schedulers in the future it still will be good enough (the code is executed once during queue-consumers initialization).

_Notes_: The logs before mentioned the queue-name every time and now it has changed to only the first one. The queue-name should be in the log context also but many schedulers are not "overriding" it, which should be resolved in the schedulers.

