### PR TITLE
#3693 - [Bug] 0 is removed from the Exceptional costs field 

### DIFF
--- a/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/sfas-integration/_tests_/sfas-integration.scheduler.e2e-spec.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/sfas-integration/_tests_/sfas-integration.scheduler.e2e-spec.ts
@@ -268,7 +268,7 @@ describe(describeProcessorRootTest(QueueNames.SFASIntegration), () => {
     },
   );
 
-  it.only(
+  it(
     "Should add SFAS individual data records when importing valid data from SFAS " +
       "when the record type is the individual data record.",
     async () => {

--- a/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/sfas-integration/_tests_/sfas-integration.scheduler.e2e-spec.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/sfas-integration/_tests_/sfas-integration.scheduler.e2e-spec.ts
@@ -268,7 +268,7 @@ describe(describeProcessorRootTest(QueueNames.SFASIntegration), () => {
     },
   );
 
-  it(
+  it.only(
     "Should add SFAS individual data records when importing valid data from SFAS " +
       "when the record type is the individual data record.",
     async () => {
@@ -408,7 +408,7 @@ describe(describeProcessorRootTest(QueueNames.SFASIntegration), () => {
         bcslOveraward: 11039,
         cmsOveraward: 0,
         grantOveraward: 0,
-        withdrawals: null,
+        withdrawals: 0,
         unsuccessfulCompletion: 0,
         partTimeMSFAANumber: null,
         partTimeMSFAAEffectiveDate: null,

--- a/sources/packages/backend/libs/sims-db/src/transformers/numeric.transformer.ts
+++ b/sources/packages/backend/libs/sims-db/src/transformers/numeric.transformer.ts
@@ -14,7 +14,7 @@ export const numericTransformer: ValueTransformer = {
    * @returns numeric/decimal string converted to a number.
    */
   from: (value: string | null): number | null => {
-    if (value !== null || value !== undefined) {
+    if (value !== null && value !== undefined) {
       return parseFloat(value);
     }
     return null;

--- a/sources/packages/backend/libs/sims-db/src/transformers/numeric.transformer.ts
+++ b/sources/packages/backend/libs/sims-db/src/transformers/numeric.transformer.ts
@@ -14,8 +14,9 @@ export const numericTransformer: ValueTransformer = {
    * @returns numeric/decimal string converted to a number.
    */
   from: (value: string | null): number | null => {
-    if (Number.isFinite(parseFloat(value))) {
-      return parseFloat(value);
+    const convertedValue = parseFloat(value);
+    if (Number.isFinite(convertedValue)) {
+      return convertedValue;
     }
     return null;
   },

--- a/sources/packages/backend/libs/sims-db/src/transformers/numeric.transformer.ts
+++ b/sources/packages/backend/libs/sims-db/src/transformers/numeric.transformer.ts
@@ -14,7 +14,7 @@ export const numericTransformer: ValueTransformer = {
    * @returns numeric/decimal string converted to a number.
    */
   from: (value: string | null): number | null => {
-    if (value) {
+    if (value !== null) {
       return parseFloat(value);
     }
     return null;

--- a/sources/packages/backend/libs/sims-db/src/transformers/numeric.transformer.ts
+++ b/sources/packages/backend/libs/sims-db/src/transformers/numeric.transformer.ts
@@ -14,7 +14,7 @@ export const numericTransformer: ValueTransformer = {
    * @returns numeric/decimal string converted to a number.
    */
   from: (value: string | null): number | null => {
-    if (value !== null && value !== undefined) {
+    if (Number.isFinite(parseFloat(value))) {
       return parseFloat(value);
     }
     return null;

--- a/sources/packages/backend/libs/sims-db/src/transformers/numeric.transformer.ts
+++ b/sources/packages/backend/libs/sims-db/src/transformers/numeric.transformer.ts
@@ -14,7 +14,7 @@ export const numericTransformer: ValueTransformer = {
    * @returns numeric/decimal string converted to a number.
    */
   from: (value: string | null): number | null => {
-    if (value !== null) {
+    if (value !== null || value !== undefined) {
       return parseFloat(value);
     }
     return null;


### PR DESCRIPTION
### As a part of this PR, the following bug was fixed: 

**Bug:**  0 is removed from the Exceptional costs field and the warning banner as shown below shows up. Likewise, for the other 3 cost fields.

![image](https://github.com/user-attachments/assets/24dfb56d-006a-4030-92be-6498f91bbaf0)

**Fix:** `numericTransformer` on receiving the value of 0 from the database was returning it as `null` rather than the numeric value `0`. Updated the code to fix it and return `0` instead of `null`. 

https://github.com/user-attachments/assets/c8831e66-1dbe-45a6-8a46-61f2357a6b8f

