### PR TITLE
#3453 - COE for $0/Not Eligible Assessments

### DIFF
--- a/sources/packages/backend/apps/api/src/route-controllers/application/_tests_/application.students.controller.getApplicationWarnings.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/application/_tests_/application.students.controller.getApplicationWarnings.e2e-spec.ts
@@ -252,7 +252,7 @@ describe("ApplicationStudentsController(e2e)-getApplicationWarnings", () => {
     },
   );
 
-  it("Should return a failed ecert validations array with no estimated awardAmounts when no disbursements values are present.", async () => {
+  it("Should return a failed ecert validations array with no estimated award amounts when no disbursements values are present.", async () => {
     // Arrange
     const student = await saveFakeStudent(db.dataSource);
     const msfaaNumber = createFakeMSFAANumber(
@@ -277,6 +277,7 @@ describe("ApplicationStudentsController(e2e)-getApplicationWarnings", () => {
         firstDisbursementInitialValues: {
           coeStatus: COEStatus.completed,
           disbursementScheduleStatus: DisbursementScheduleStatus.Pending,
+          hasEstimatedAwards: false,
         },
       },
     );
@@ -298,8 +299,8 @@ describe("ApplicationStudentsController(e2e)-getApplicationWarnings", () => {
   });
 
   it(
-    "Should return a failed ecert validations array with no estimated awardAmounts when " +
-      "disbursement values are present but the total amount to be disbursed is 0(zero).",
+    "Should return a failed ecert validations array with no estimated award amounts when " +
+      "disbursement values are present but the disbursements don't have estimated awards.",
     async () => {
       // Arrange
       const student = await saveFakeStudent(db.dataSource);
@@ -340,6 +341,7 @@ describe("ApplicationStudentsController(e2e)-getApplicationWarnings", () => {
           firstDisbursementInitialValues: {
             coeStatus: COEStatus.completed,
             disbursementScheduleStatus: DisbursementScheduleStatus.Pending,
+            hasEstimatedAwards: false,
           },
         },
       );

--- a/sources/packages/backend/apps/api/src/services/disbursement-schedule/disbursement-schedule-service.ts
+++ b/sources/packages/backend/apps/api/src/services/disbursement-schedule/disbursement-schedule-service.ts
@@ -67,7 +67,8 @@ export class DisbursementScheduleService extends RecordDataModelService<Disburse
       .andWhere("location.id = :locationId", { locationId })
       .andWhere("application.applicationStatus IN (:...status)", {
         status: [ApplicationStatus.Enrolment, ApplicationStatus.Completed],
-      });
+      })
+      .andWhere("disbursementSchedule.hasEstimatedAwards = true");
     if (enrollmentPeriod === EnrollmentPeriod.Upcoming) {
       coeQuery.andWhere(
         new Brackets((qb) => {

--- a/sources/packages/backend/apps/db-migrations/src/migrations/1732577112272-DisbursementSchedulesAddHasEstimatedAwards.ts
+++ b/sources/packages/backend/apps/db-migrations/src/migrations/1732577112272-DisbursementSchedulesAddHasEstimatedAwards.ts
@@ -1,0 +1,24 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+import { getSQLFileData } from "../utilities/sqlLoader";
+
+export class DisbursementSchedulesAddHasEstimatedAwards1732577112272
+  implements MigrationInterface
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      getSQLFileData(
+        "Add-has-estimated-awards-col.sql",
+        "DisbursementSchedules",
+      ),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      getSQLFileData(
+        "Rollback-add-has-estimated-awards-col.sql",
+        "DisbursementSchedules",
+      ),
+    );
+  }
+}

--- a/sources/packages/backend/apps/db-migrations/src/migrations/1732581060213-UpdateHasEstimatedAwardsForCOERequestsReport.ts
+++ b/sources/packages/backend/apps/db-migrations/src/migrations/1732581060213-UpdateHasEstimatedAwardsForCOERequestsReport.ts
@@ -1,0 +1,18 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+import { getSQLFileData } from "../utilities/sqlLoader";
+
+export class UpdateHasEstimatedAwardsForCOERequestsReport1732581060213
+  implements MigrationInterface
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      getSQLFileData("Update-coe-requests-report.sql", "Reports"),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      getSQLFileData("Rollback-update-coe-requests-report.sql", "Reports"),
+    );
+  }
+}

--- a/sources/packages/backend/apps/db-migrations/src/sql/DisbursementSchedules/Add-has-estimated-awards-col.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/DisbursementSchedules/Add-has-estimated-awards-col.sql
@@ -1,0 +1,6 @@
+ALTER TABLE
+    sims.disbursement_schedules
+ADD
+    COLUMN has_estimated_awards BOOLEAN NOT NULL DEFAULT TRUE;
+
+COMMENT ON COLUMN sims.disbursement_schedules.has_estimated_awards IS 'Indication for whether the disbursement has estimated awards against the $0 total disbursement value.';

--- a/sources/packages/backend/apps/db-migrations/src/sql/DisbursementSchedules/Rollback-add-has-estimated-awards-col.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/DisbursementSchedules/Rollback-add-has-estimated-awards-col.sql
@@ -1,0 +1,2 @@
+ALTER TABLE
+    sims.disbursement_schedules DROP COLUMN has_estimated_awards;

--- a/sources/packages/backend/apps/db-migrations/src/sql/Reports/Rollback-update-coe-requests-report.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/Reports/Rollback-update-coe-requests-report.sql
@@ -1,0 +1,59 @@
+UPDATE
+  sims.report_configs
+SET
+  report_sql = (
+    'SELECT
+      student_user.first_name AS "Student First Name",
+      student_user.last_name AS "Student Last Name",
+      sin_validation.sin AS "SIN",
+      application.data ->> ''studentNumber'' AS "Student Number",
+      student_user.email AS "Student Email Address",
+      student.contact_info ->> ''phone'' AS "Student Phone Number",
+      application.application_number AS "Application Number",
+      TO_CHAR((assessment.assessment_date AT TIME ZONE ''America/Vancouver''), ''YYYY-MM-DD HH24:MI:SS'') AS "Assessment Date",
+      program.program_name AS "Program Name",
+      offering.offering_name AS "Offering Name",
+      offering.offering_intensity AS "Study Intensity",
+      student.disability_status AS "Profile Disability Status",
+      assessment.workflow_data -> ''calculatedData'' ->> ''pdppdStatus'' AS "Application Disability Status",
+      TO_CHAR(offering.study_start_date, ''YYYY-MM-DD'') AS "Study Start Date",
+      TO_CHAR(offering.study_end_date, ''YYYY-MM-DD'') AS "Study End Date",
+      disbursement.coe_status AS "COE Status",
+      TO_CHAR((disbursement.coe_updated_at AT TIME ZONE ''America/Vancouver''), ''YYYY-MM-DD HH24:MI:SS'') AS "COE Actioned",
+      disbursement.tuition_remittance_requested_amount AS "Remittance Requested",
+      disbursement.tuition_remittance_effective_amount AS "Remittance Disbursed",
+      (
+        SELECT
+          SUM(disbursement_value.value_amount)
+        FROM
+          sims.disbursement_values disbursement_value
+        WHERE
+          disbursement_value.disbursement_schedule_id = disbursement.id
+          AND disbursement_value.value_code != ''BCSG''
+      ) AS "Estimated Disbursement Amount",
+      TO_CHAR(COALESCE(disbursement.date_sent, disbursement.disbursement_date), ''YYYY-MM-DD'') AS "Disbursement Date"
+    FROM
+      sims.disbursement_schedules disbursement
+      INNER JOIN sims.student_assessments assessment ON disbursement.student_assessment_id = assessment.id
+      INNER JOIN sims.education_programs_offerings offering ON assessment.offering_id = offering.id
+      INNER JOIN sims.education_programs program ON offering.program_id = program.id
+      INNER JOIN sims.applications application ON application.current_assessment_id = assessment.id
+      INNER JOIN sims.students student ON application.student_id = student.id
+      INNER JOIN sims.users student_user ON student.user_id = student_user.id
+      INNER JOIN sims.sin_validations sin_validation ON student.sin_validation_id = sin_validation.id
+    WHERE
+      application.application_status IN (''Enrolment'', ''Completed'')
+      AND application.is_archived = FALSE
+      AND application.program_year_id = :programYear
+      AND offering.offering_intensity = ANY(:offeringIntensity)
+      AND program.institution_id = :institutionId
+    ORDER BY
+      CASE
+        WHEN disbursement.coe_status = ''Required'' THEN 0
+        WHEN disbursement.coe_status = ''Completed'' THEN 1
+        ELSE 2
+      END,
+      disbursement.created_at;'
+  )
+WHERE
+  report_name = 'COE_Requests';

--- a/sources/packages/backend/apps/db-migrations/src/sql/Reports/Update-coe-requests-report.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/Reports/Update-coe-requests-report.sql
@@ -1,0 +1,60 @@
+UPDATE
+  sims.report_configs
+SET
+  report_sql = (
+    'SELECT
+      student_user.first_name AS "Student First Name",
+      student_user.last_name AS "Student Last Name",
+      sin_validation.sin AS "SIN",
+      application.data ->> ''studentNumber'' AS "Student Number",
+      student_user.email AS "Student Email Address",
+      student.contact_info ->> ''phone'' AS "Student Phone Number",
+      application.application_number AS "Application Number",
+      TO_CHAR((assessment.assessment_date AT TIME ZONE ''America/Vancouver''), ''YYYY-MM-DD HH24:MI:SS'') AS "Assessment Date",
+      program.program_name AS "Program Name",
+      offering.offering_name AS "Offering Name",
+      offering.offering_intensity AS "Study Intensity",
+      student.disability_status AS "Profile Disability Status",
+      assessment.workflow_data -> ''calculatedData'' ->> ''pdppdStatus'' AS "Application Disability Status",
+      TO_CHAR(offering.study_start_date, ''YYYY-MM-DD'') AS "Study Start Date",
+      TO_CHAR(offering.study_end_date, ''YYYY-MM-DD'') AS "Study End Date",
+      disbursement.coe_status AS "COE Status",
+      TO_CHAR((disbursement.coe_updated_at AT TIME ZONE ''America/Vancouver''), ''YYYY-MM-DD HH24:MI:SS'') AS "COE Actioned",
+      disbursement.tuition_remittance_requested_amount AS "Remittance Requested",
+      disbursement.tuition_remittance_effective_amount AS "Remittance Disbursed",
+      (
+        SELECT
+          SUM(disbursement_value.value_amount)
+        FROM
+          sims.disbursement_values disbursement_value
+        WHERE
+          disbursement_value.disbursement_schedule_id = disbursement.id
+          AND disbursement_value.value_code != ''BCSG''
+      ) AS "Estimated Disbursement Amount",
+      TO_CHAR(COALESCE(disbursement.date_sent, disbursement.disbursement_date), ''YYYY-MM-DD'') AS "Disbursement Date"
+    FROM
+      sims.disbursement_schedules disbursement
+      INNER JOIN sims.student_assessments assessment ON disbursement.student_assessment_id = assessment.id
+      INNER JOIN sims.education_programs_offerings offering ON assessment.offering_id = offering.id
+      INNER JOIN sims.education_programs program ON offering.program_id = program.id
+      INNER JOIN sims.applications application ON application.current_assessment_id = assessment.id
+      INNER JOIN sims.students student ON application.student_id = student.id
+      INNER JOIN sims.users student_user ON student.user_id = student_user.id
+      INNER JOIN sims.sin_validations sin_validation ON student.sin_validation_id = sin_validation.id
+    WHERE
+      application.application_status IN (''Enrolment'', ''Completed'')
+      AND application.is_archived = FALSE
+      AND application.program_year_id = :programYear
+      AND offering.offering_intensity = ANY(:offeringIntensity)
+      AND program.institution_id = :institutionId
+      AND disbursement.has_estimated_awards = TRUE
+    ORDER BY
+      CASE
+        WHEN disbursement.coe_status = ''Required'' THEN 0
+        WHEN disbursement.coe_status = ''Completed'' THEN 1
+        ELSE 2
+      END,
+      disbursement.created_at;'
+  )
+WHERE
+  report_name = 'COE_Requests';

--- a/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/esdc-integration/ecert-integration/_tests_/e-cert-utils.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/esdc-integration/ecert-integration/_tests_/e-cert-utils.ts
@@ -139,6 +139,7 @@ export async function createBlockedDisbursementTestData(
     isValidSIN?: boolean;
     disbursementValues?: DisbursementValue[];
     msfaaState?: MSFAAStates;
+    firstDisbursementInitialValues?: Partial<DisbursementSchedule>;
   },
 ): Promise<{
   student: Student;
@@ -183,6 +184,8 @@ export async function createBlockedDisbursementTestData(
       applicationStatus: ApplicationStatus.Completed,
       firstDisbursementInitialValues: {
         coeStatus: COEStatus.completed,
+        hasEstimatedAwards:
+          options?.firstDisbursementInitialValues?.hasEstimatedAwards,
       },
     },
   );

--- a/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/esdc-integration/ecert-integration/_tests_/ecert-full-time-process-integration.scheduler.e2e-spec.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/esdc-integration/ecert-integration/_tests_/ecert-full-time-process-integration.scheduler.e2e-spec.ts
@@ -77,6 +77,11 @@ describe(
       systemUsersService = app.get(SystemUsersService);
       // Create a Ministry user to b used, for instance, for audit.
       sharedMinistryUser = await db.user.save(createFakeUser());
+      // Insert a fake email contact to send ministry email.
+      await db.notificationMessage.update(
+        { id: NotificationMessageType.MinistryNotificationDisbursementBlocked },
+        { emailContacts: ["dummy@some.domain"] },
+      );
     });
 
     beforeEach(async () => {
@@ -1162,7 +1167,7 @@ describe(
     );
 
     it(
-      "Should create a notification for the ministry and student for a blocked disbursement when the total assessed award is 0" +
+      "Should create a notification for the ministry and student for a blocked disbursement when it doesn't have estimated awards" +
         " and there are no previously existing notifications for the disbursement.",
       async () => {
         // Arrange
@@ -1171,6 +1176,7 @@ describe(
             offeringIntensity: OfferingIntensity.fullTime,
             isValidSIN: true,
             disbursementValues: [],
+            firstDisbursementInitialValues: { hasEstimatedAwards: false },
           });
         // Queued job.
         const mockedJob = mockBullJob<void>();

--- a/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/esdc-integration/ecert-integration/_tests_/ecert-part-time-process-integration.scheduler.e2e-spec.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/esdc-integration/ecert-integration/_tests_/ecert-part-time-process-integration.scheduler.e2e-spec.ts
@@ -158,7 +158,7 @@ describe(
       ]);
     });
     it(
-      "Should create a notification for the ministry and student for a blocked disbursement when the total assessed award is 0" +
+      "Should create a notification for the ministry and student for a blocked disbursement when it doesn't have estimated awards" +
         " and there are no previously existing notifications for the disbursement.",
       async () => {
         // Arrange
@@ -166,6 +166,7 @@ describe(
           await createBlockedDisbursementTestData(db, {
             isValidSIN: true,
             disbursementValues: [],
+            firstDisbursementInitialValues: { hasEstimatedAwards: false },
           });
         // Queued job.
         const mockedJob = mockBullJob<void>();

--- a/sources/packages/backend/apps/workers/src/controllers/assessment/assessment.controller.ts
+++ b/sources/packages/backend/apps/workers/src/controllers/assessment/assessment.controller.ts
@@ -22,7 +22,10 @@ import {
   UpdateNOAStatusJobInDTO,
   VerifyAssessmentCalculationOrderJobOutDTO,
 } from "..";
-import { StudentAssessmentService } from "../../services";
+import {
+  DisbursementScheduleService,
+  StudentAssessmentService,
+} from "../../services";
 import {
   ApplicationStatus,
   CRAIncomeVerification,
@@ -74,6 +77,7 @@ export class AssessmentController {
     private readonly assessmentSequentialProcessingService: AssessmentSequentialProcessingService,
     private readonly systemUsersService: SystemUsersService,
     private readonly studentLoanBalanceSharedService: StudentLoanBalanceSharedService,
+    private readonly disbursementScheduleService: DisbursementScheduleService,
   ) {}
 
   /**
@@ -197,6 +201,10 @@ export class AssessmentController {
       await this.studentAssessmentService.updateAssessmentData(
         job.variables.assessmentId,
         job.variables.assessmentData,
+      );
+      await this.disbursementScheduleService.updateDisbursementsHasEstimatedAwards(
+        job.variables.assessmentId,
+        job.variables.assessmentData["finalAwardTotal"],
       );
       jobLogger.log("Assessment data saved.");
       return job.complete();

--- a/sources/packages/backend/apps/workers/src/services/disbursement-schedule/disbursement-schedule.service.ts
+++ b/sources/packages/backend/apps/workers/src/services/disbursement-schedule/disbursement-schedule.service.ts
@@ -83,6 +83,38 @@ export class DisbursementScheduleService extends RecordDataModelService<Disburse
   }
 
   /**
+   * Update the has_estimated_awards property to false for any disbursement schedule
+   * for the assessment id if the final award total is $0.
+   * @param assessmentId assessment id.
+   * @param finalAwardTotal final award total from the assessment data.
+   */
+  async updateDisbursementsHasEstimatedAwards(
+    assessmentId: number,
+    finalAwardTotal: number,
+  ): Promise<void> {
+    const disbursements = await this.repo.find({
+      select: {
+        id: true,
+      },
+      where: {
+        studentAssessment: { id: assessmentId },
+      },
+    });
+    if (disbursements.length > 0 && finalAwardTotal === 0) {
+      disbursements.forEach(async (disbursement) => {
+        await this.repo.update(
+          {
+            id: disbursement.id,
+          },
+          {
+            hasEstimatedAwards: false,
+          },
+        );
+      });
+    }
+  }
+
+  /**
    * Get the disbursement schedules for the assessment id.
    * @param assessmentId assessment id.
    * @returns disbursement schedules.

--- a/sources/packages/backend/libs/integrations/src/services/disbursement-schedule/e-cert-generation.service.ts
+++ b/sources/packages/backend/libs/integrations/src/services/disbursement-schedule/e-cert-generation.service.ts
@@ -74,6 +74,7 @@ export class ECertGenerationService {
         "disbursementSchedule.disbursementDate",
         "disbursementSchedule.tuitionRemittanceRequestedAmount",
         "disbursementSchedule.coeStatus",
+        "disbursementSchedule.hasEstimatedAwards",
         "disbursementValue.id",
         "disbursementValue.valueType",
         "disbursementValue.valueCode",

--- a/sources/packages/backend/libs/integrations/src/services/disbursement-schedule/e-cert-processing-steps/validate-disbursement-base.ts
+++ b/sources/packages/backend/libs/integrations/src/services/disbursement-schedule/e-cert-processing-steps/validate-disbursement-base.ts
@@ -55,13 +55,9 @@ export abstract class ValidateDisbursementBase {
       );
     }
     // No estimated awards amounts to be disbursed.
-    const totalEstimatedAwards =
-      eCertDisbursement.disbursement.disbursementValues.reduce(
-        (totalEstimatedAward, currentAward) =>
-          totalEstimatedAward + currentAward.valueAmount,
-        0,
-      );
-    if (!totalEstimatedAwards) {
+    const hasEstimatedAwards =
+      eCertDisbursement.disbursement.hasEstimatedAwards;
+    if (!hasEstimatedAwards) {
       log.info(
         "Disbursement estimated awards do not contain any amount to be disbursed.",
       );

--- a/sources/packages/backend/libs/sims-db/src/entities/disbursement-schedule.model.ts
+++ b/sources/packages/backend/libs/sims-db/src/entities/disbursement-schedule.model.ts
@@ -239,4 +239,15 @@ export class DisbursementSchedule extends RecordDataModel {
     },
   )
   disbursementFeedbackErrors?: DisbursementFeedbackErrors[];
+
+  /**
+   * Indication for whether the disbursement has estimated awards
+   * against the $0 total disbursement value.
+   */
+  @Column({
+    name: "has_estimated_awards",
+    type: "boolean",
+    nullable: false,
+  })
+  hasEstimatedAwards: boolean;
 }

--- a/sources/packages/backend/libs/test-utils/src/factories/disbursement-schedule.ts
+++ b/sources/packages/backend/libs/test-utils/src/factories/disbursement-schedule.ts
@@ -56,5 +56,7 @@ export function createFakeDisbursementSchedule(
     options?.initialValues?.disbursementScheduleStatus ??
     DisbursementScheduleStatus.Pending;
   schedule.msfaaNumber = relations?.msfaaNumber;
+  schedule.hasEstimatedAwards =
+    options?.initialValues?.hasEstimatedAwards ?? true;
   return schedule;
 }


### PR DESCRIPTION
- Created a new flag `has_estimated_awards` in the disbursement table to indicate the $0 disbursement during the saving assessments in the workers.
  - Added method `updateDisbursementsHasEstimatedAwards` to update `has_estimated_awards` for each disbursement in `saveAssessmentData`.
- Used the flag for the e-Cert validations.
  - Modified the implementation with the new flag for the e-Cert validation method in `ValidateDisbursementBase`
- Used this new flag to ensure the business ACs.
  - Do not show $0/Ineligible disbursements to Institution users, even if COE is "Required"
  - Do not show $0/Ineligible requests in the COE Requests Report.
  - Do not send ECE requests to institutions for $0/Ineligible COE requests.
- Modified the SQL script for the "COE Requests" report to fetch data with `has_estimated_awards = true`
- Added E2E tests for API.
  - "Should get the count of COE current summary as zero when there is 1 COE that doesn't have estimated awards."
  - "Should generate the COE Requests report without application(s) that don't have estimated awards when one or more applications exist for the given institution."
- Adjusted impacted E2E tests for ECE and API.

#### Rollback Evidence for "DisbursementSchedulesAddHasEstimatedAwards"
![image](https://github.com/user-attachments/assets/e87c5065-b9c5-49af-97b5-6aed1d61cd4d)

#### Rollback Evidence for "UpdateHasEstimatedAwardsForCOERequestsReport"
![image](https://github.com/user-attachments/assets/dab3d1de-8f49-45b6-9ad4-fe7169fe109e)
