### PR TITLE
#3666 - Queue Monitoring - Enable Prometheus Metrics

### DIFF
--- a/devops/openshift/queue-consumers-deploy.yml
+++ b/devops/openshift/queue-consumers-deploy.yml
@@ -2,6 +2,8 @@ apiVersion: template.openshift.io/v1
 kind: Template
 metadata:
   name: ${NAME}
+  annotations:
+    prometheus.io/scrape: true
 labels:
   project: ${PROJECT}
   service: ${SERVICE_NAME}

--- a/devops/openshift/queue-consumers-deploy.yml
+++ b/devops/openshift/queue-consumers-deploy.yml
@@ -21,7 +21,7 @@ objects:
         metadata:
           annotations:
             prometheus.io/scrape: true
-            prometheus.io/port: "${{PORT}}"
+            prometheus.io/port: ${PORT}
             prometheus.io/path: /metrics
           labels:
             deploymentconfig: ${NAME}

--- a/devops/openshift/queue-consumers-deploy.yml
+++ b/devops/openshift/queue-consumers-deploy.yml
@@ -2,8 +2,6 @@ apiVersion: template.openshift.io/v1
 kind: Template
 metadata:
   name: ${NAME}
-  annotations:
-    prometheus.io/scrape: true
 labels:
   project: ${PROJECT}
   service: ${SERVICE_NAME}
@@ -21,6 +19,10 @@ objects:
         type: Rolling
       template:
         metadata:
+          annotations:
+            prometheus.io/scrape: true
+            prometheus.io/port: "${{PORT}}"
+            prometheus.io/path: /metrics
           labels:
             deploymentconfig: ${NAME}
         spec:

--- a/devops/openshift/queue-consumers-deploy.yml
+++ b/devops/openshift/queue-consumers-deploy.yml
@@ -20,7 +20,7 @@ objects:
       template:
         metadata:
           annotations:
-            prometheus.io/scrape: true
+            prometheus.io/scrape: "true"
             prometheus.io/port: ${PORT}
             prometheus.io/path: /metrics
           labels:

--- a/devops/openshift/sysdig-team.yml
+++ b/devops/openshift/sysdig-team.yml
@@ -7,37 +7,21 @@ spec:
   team:
     description: The Sysdig Team for the OpenShift Project Set SIMS
     users:
-    - name: jason.tang@gov.bc.ca
-      role: ROLE_TEAM_EDIT
-    - name: kal.marsh@gov.bc.ca
-      role: ROLE_TEAM_EDIT
-    - name: mohammed.alnahari@gov.bc.ca
-      role: ROLE_TEAM_EDIT
-    - name: john.marchesan@gov.bc.ca
-      role: ROLE_TEAM_EDIT
-    - name: harold.a.johnson@gov.bc.ca
-      role: ROLE_TEAM_EDIT
-    - name: gurumoorthy.mohan@aot-technologies.com
-      role: ROLE_TEAM_EDIT
-    - name: dheepak.rr@aot-technologies.com
-      role: ROLE_TEAM_STANDARD
-    - name: shashank.x.shekhar@gov.bc.ca
-      role: ROLE_TEAM_STANDARD
-    - name: ann.jacob@aot-technologies.com
-      role: ROLE_TEAM_STANDARD
-    - name: andrew.signori@aot-technologies.com
-      role: ROLE_TEAM_STANDARD
-    - name: aotalsp@gmail.com
-      role: ROLE_TEAM_STANDARD
-    - name: yumeng.1.wang@gov.bc.ca
-      role: ROLE_TEAM_READ
-    - name: andre.bisseck@gov.bc.ca
-      role: ROLE_TEAM_READ
-    - name: michelle.smith@gov.bc.ca
-      role: ROLE_TEAM_READ
-    - name: burke.vandrimmelen@gov.bc.ca
-      role: ROLE_TEAM_READ
-    - name: david.malcolm@gov.bc.ca
-      role: ROLE_TEAM_READ
-    - name: chinelo.udoka@gov.bc.ca
-      role: ROLE_TEAM_READ
+      - name: nino.samson@gov.bc.ca
+        role: ROLE_TEAM_EDIT
+      - name: bidyashish.kumar@gov.bc.ca
+        role: ROLE_TEAM_EDIT
+      - name: shashank.x.shekhar@gov.bc.ca
+        role: ROLE_TEAM_EDIT
+      - name: jason.tang@gov.bc.ca
+        role: ROLE_TEAM_EDIT
+      - name: gurumoorthy.mohan@aot-technologies.com
+        role: ROLE_TEAM_EDIT
+      - name: dheepak.rr@aot-technologies.com
+        role: ROLE_TEAM_EDIT
+      - name: andrew.signori@aot-technologies.com
+        role: ROLE_TEAM_EDIT
+      - name: andre.pestana@aot-technologies.com
+        role: ROLE_TEAM_STANDARD
+      - name: lewis.chen@aot-technologies.com
+        role: ROLE_TEAM_STANDARD

--- a/sources/packages/backend/apps/queue-consumers/src/controllers/index.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/controllers/index.ts
@@ -1,1 +1,2 @@
 export * from "./health-check/health.controller";
+export * from "./metrics/metrics.controller";

--- a/sources/packages/backend/apps/queue-consumers/src/controllers/metrics/metrics.controller.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/controllers/metrics/metrics.controller.ts
@@ -28,7 +28,7 @@ export class MetricsController {
     } catch (error) {
       this.logger.error("Error while getting metrics.", error);
       throw new InternalServerErrorException(
-        "Error while getting metrics. See server logs for details",
+        "Error while getting metrics. See server logs for details.",
       );
     }
   }

--- a/sources/packages/backend/apps/queue-consumers/src/controllers/metrics/metrics.controller.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/controllers/metrics/metrics.controller.ts
@@ -24,7 +24,6 @@ export class MetricsController {
   @Header("content-type", register.contentType)
   async getMetrics(): Promise<string> {
     try {
-      await this.metricsService.refreshJobCountsMetrics();
       return register.metrics();
     } catch (error) {
       this.logger.error("Error while getting metrics.", error);

--- a/sources/packages/backend/apps/queue-consumers/src/controllers/metrics/metrics.controller.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/controllers/metrics/metrics.controller.ts
@@ -1,20 +1,11 @@
 import { Controller, Get, Header } from "@nestjs/common";
-import { Registry, Counter } from "prom-client";
+import { register } from "prom-client";
 
 @Controller("metrics")
 export class MetricsController {
-  private readonly registry = new Registry();
-  private readonly requestCounter = new Counter({
-    name: "metrics_http_requests_total",
-    help: "Total number of HTTP metrics requests",
-    registers: [this.registry],
-  });
-
   @Get()
-  @Header("content-type", "text/plain")
+  @Header("content-type", register.contentType)
   async getMetrics(): Promise<string> {
-    console.log("metrics");
-    this.requestCounter.inc(Math.floor(Math.random() * 10));
-    return this.registry.metrics();
+    return register.metrics();
   }
 }

--- a/sources/packages/backend/apps/queue-consumers/src/controllers/metrics/metrics.controller.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/controllers/metrics/metrics.controller.ts
@@ -1,17 +1,39 @@
-import { Controller, Get, Header } from "@nestjs/common";
+import {
+  Controller,
+  Get,
+  Header,
+  InternalServerErrorException,
+} from "@nestjs/common";
 import { MetricsService } from "../../services";
 import { register } from "prom-client";
+import { InjectLogger, LoggerService } from "@sims/utilities/logger";
 
+/**
+ * Allows prometheus to scrape metrics from the queue-consumers.
+ * @see https://developer.gov.bc.ca/docs/default/component/platform-developer-docs/docs/app-monitoring/user-defined-monitoring/#expose-the-metrics-from-your-app
+ */
 @Controller("metrics")
 export class MetricsController {
   constructor(private readonly metricsService: MetricsService) {}
 
+  /**
+   * Exports metrics from the queue-consumers.
+   * @returns metrics in Prometheus format.
+   */
   @Get()
   @Header("content-type", register.contentType)
   async getMetrics(): Promise<string> {
-    console.time("refreshJobCountsMetrics");
-    await this.metricsService.refreshJobCountsMetrics();
-    console.timeEnd("refreshJobCountsMetrics");
-    return register.metrics();
+    try {
+      await this.metricsService.refreshJobCountsMetrics();
+      return register.metrics();
+    } catch (error) {
+      this.logger.error("Error while getting metrics.", error);
+      throw new InternalServerErrorException(
+        "Error while getting metrics. See server logs for details",
+      );
+    }
   }
+
+  @InjectLogger()
+  logger: LoggerService;
 }

--- a/sources/packages/backend/apps/queue-consumers/src/controllers/metrics/metrics.controller.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/controllers/metrics/metrics.controller.ts
@@ -1,11 +1,17 @@
 import { Controller, Get, Header } from "@nestjs/common";
+import { MetricsService } from "../../services";
 import { register } from "prom-client";
 
 @Controller("metrics")
 export class MetricsController {
+  constructor(private readonly metricsService: MetricsService) {}
+
   @Get()
   @Header("content-type", register.contentType)
   async getMetrics(): Promise<string> {
+    console.time("refreshJobCountsMetrics");
+    await this.metricsService.refreshJobCountsMetrics();
+    console.timeEnd("refreshJobCountsMetrics");
     return register.metrics();
   }
 }

--- a/sources/packages/backend/apps/queue-consumers/src/controllers/metrics/metrics.controller.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/controllers/metrics/metrics.controller.ts
@@ -4,7 +4,6 @@ import {
   Header,
   InternalServerErrorException,
 } from "@nestjs/common";
-import { MetricsService } from "../../services";
 import { register } from "prom-client";
 import { InjectLogger, LoggerService } from "@sims/utilities/logger";
 
@@ -14,8 +13,6 @@ import { InjectLogger, LoggerService } from "@sims/utilities/logger";
  */
 @Controller("metrics")
 export class MetricsController {
-  constructor(private readonly metricsService: MetricsService) {}
-
   /**
    * Exports metrics from the queue-consumers.
    * @returns metrics in Prometheus format.

--- a/sources/packages/backend/apps/queue-consumers/src/controllers/metrics/metrics.controller.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/controllers/metrics/metrics.controller.ts
@@ -1,0 +1,20 @@
+import { Controller, Get, Header } from "@nestjs/common";
+import { Registry, Counter } from "prom-client";
+
+@Controller("metrics")
+export class MetricsController {
+  private readonly registry = new Registry();
+  private readonly requestCounter = new Counter({
+    name: "metrics_http_requests_total",
+    help: "Total number of HTTP metrics requests",
+    registers: [this.registry],
+  });
+
+  @Get()
+  @Header("content-type", "text/plain")
+  async getMetrics(): Promise<string> {
+    console.log("metrics");
+    this.requestCounter.inc(Math.floor(Math.random() * 10));
+    return this.registry.metrics();
+  }
+}

--- a/sources/packages/backend/apps/queue-consumers/src/queue-consumers.module.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/queue-consumers.module.ts
@@ -72,7 +72,7 @@ import {
 import { SFASIntegrationModule } from "@sims/integrations/sfas-integration";
 import { ATBCIntegrationModule } from "@sims/integrations/atbc-integration";
 import { ECEIntegrationModule } from "@sims/integrations/institution-integration/ece-integration";
-import { HealthController } from "./controllers";
+import { HealthController, MetricsController } from "./controllers";
 import { MicroserviceHealthIndicator, TerminusModule } from "@nestjs/terminus";
 import { CASSupplierIntegrationService } from "./services/cas-supplier/cas-supplier.service";
 import { VirusScanProcessor } from "./processors/virus-scan/virus-scan.processor";
@@ -161,6 +161,6 @@ import { BullBoardQueuesModule } from "./bull-board/bull-board-queues.module";
     CASActiveSupplierFoundProcessor,
     CASActiveSupplierAndSiteFoundProcessor,
   ],
-  controllers: [HealthController],
+  controllers: [HealthController, MetricsController],
 })
 export class QueueConsumersModule {}

--- a/sources/packages/backend/apps/queue-consumers/src/queue-consumers.module.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/queue-consumers.module.ts
@@ -68,7 +68,6 @@ import {
   CASPreValidationsProcessor,
   CASActiveSupplierFoundProcessor,
   CASActiveSupplierAndSiteFoundProcessor,
-  MetricsService,
 } from "./services";
 import { SFASIntegrationModule } from "@sims/integrations/sfas-integration";
 import { ATBCIntegrationModule } from "@sims/integrations/atbc-integration";
@@ -163,7 +162,6 @@ import { QueuesMetricsModule } from "./queues-bootstrap.module";
     CASPreValidationsProcessor,
     CASActiveSupplierFoundProcessor,
     CASActiveSupplierAndSiteFoundProcessor,
-    MetricsService,
   ],
   controllers: [HealthController, MetricsController],
 })

--- a/sources/packages/backend/apps/queue-consumers/src/queue-consumers.module.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/queue-consumers.module.ts
@@ -68,6 +68,7 @@ import {
   CASPreValidationsProcessor,
   CASActiveSupplierFoundProcessor,
   CASActiveSupplierAndSiteFoundProcessor,
+  MetricsService,
 } from "./services";
 import { SFASIntegrationModule } from "@sims/integrations/sfas-integration";
 import { ATBCIntegrationModule } from "@sims/integrations/atbc-integration";
@@ -162,6 +163,7 @@ import { QueuesMetricsModule } from "./queues-bootstrap.module";
     CASPreValidationsProcessor,
     CASActiveSupplierFoundProcessor,
     CASActiveSupplierAndSiteFoundProcessor,
+    MetricsService,
   ],
   controllers: [HealthController, MetricsController],
 })

--- a/sources/packages/backend/apps/queue-consumers/src/queue-consumers.module.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/queue-consumers.module.ts
@@ -79,6 +79,7 @@ import { VirusScanProcessor } from "./processors/virus-scan/virus-scan.processor
 import { CASService } from "@sims/integrations/cas/cas.service";
 import { ObjectStorageService } from "@sims/integrations/object-storage";
 import { BullBoardQueuesModule } from "./bull-board/bull-board-queues.module";
+import { QueuesMetricsModule } from "./queues-bootstrap.module";
 
 // TODO: Removed ATBCResponseIntegrationScheduler in providers, the queuename from enum and the decorators of the processor as part of #2539.
 @Module({
@@ -87,6 +88,7 @@ import { BullBoardQueuesModule } from "./bull-board/bull-board-queues.module";
     DatabaseModule,
     QueueModule,
     BullBoardQueuesModule,
+    QueuesMetricsModule,
     ZeebeModule.forRoot(),
     IER12IntegrationModule,
     ECEIntegrationModule,

--- a/sources/packages/backend/apps/queue-consumers/src/queue-consumers.module.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/queue-consumers.module.ts
@@ -79,7 +79,7 @@ import { VirusScanProcessor } from "./processors/virus-scan/virus-scan.processor
 import { CASService } from "@sims/integrations/cas/cas.service";
 import { ObjectStorageService } from "@sims/integrations/object-storage";
 import { BullBoardQueuesModule } from "./bull-board/bull-board-queues.module";
-import { QueuesMetricsModule } from "./queues-bootstrap.module";
+import { QueuesMetricsModule } from "./queues-metrics.module.module";
 
 // TODO: Removed ATBCResponseIntegrationScheduler in providers, the queuename from enum and the decorators of the processor as part of #2539.
 @Module({

--- a/sources/packages/backend/apps/queue-consumers/src/queues-bootstrap.module.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/queues-bootstrap.module.ts
@@ -1,88 +1,23 @@
 import { Global, LoggerService, Module, OnModuleInit } from "@nestjs/common";
-import { ModuleRef } from "@nestjs/core";
-import { QueueService } from "@sims/services/queue/queue.service";
 import { InjectLogger } from "@sims/utilities/logger";
-import { getQueueToken } from "@nestjs/bull";
-import { Queue } from "bull";
-import { register, collectDefaultMetrics, Counter } from "prom-client";
-import { QueueModel } from "@sims/services/queue";
-
-/**
- * Queues metrics events.
- */
-enum QueuesMetricsEvents {
-  Error = "error",
-  Waiting = "waiting",
-  Active = "active",
-  Stalled = "stalled",
-  Completed = "completed",
-  Progress = "progress",
-  Failed = "failed",
-  Delayed = "delayed",
-  Paused = "paused",
-  Removed = "removed",
-  Resumed = "resumed",
-  Drained = "drained",
-}
-
-const DEFAULT_APP_LABEL = "queue-consumers";
+import { MetricsService } from "apps/queue-consumers/src/services";
 
 @Global()
-@Module({})
+@Module({
+  providers: [MetricsService],
+  exports: [MetricsService],
+})
 export class QueuesMetricsModule implements OnModuleInit {
+  constructor(private readonly metricsService: MetricsService) {}
+
   /**
-   * Queue events counter.
+   * Method that is invoked on application initialization and
+   * is responsible for setting up the metrics for all queues.
    */
-  private readonly eventCounter = new Counter({
-    name: "queue_event_total_count",
-    help: "Total number of the events for a queue If it is a global event, it will be emitted for every queue-consumer.",
-    labelNames: ["queueName", "queueEvent", "queueType"] as const,
-  });
-
-  constructor(
-    private readonly moduleRef: ModuleRef,
-    private readonly queueService: QueueService,
-  ) {}
-
   async onModuleInit(): Promise<void> {
     this.logger.log("Associating queue events for metrics.");
-    // Set global metrics settings.
-    register.setDefaultLabels({ app: DEFAULT_APP_LABEL });
-    collectDefaultMetrics({ labels: { app: DEFAULT_APP_LABEL } });
-    // Set queues metrics settings.
-    const queues = await this.queueService.queueConfigurationModel();
-    queues.forEach((queue) => {
-      if (!queue.isActive) {
-        this.logger.log(
-          `Queue '${queue.name}' is inactive and will not be exposing metrics.`,
-        );
-        return;
-      }
-      this.associateQueueMetrics(queue);
-    });
-  }
-
-  private associateQueueMetrics(queue: QueueModel): void {
-    const queueProvider = this.moduleRef.get<Queue>(getQueueToken(queue.name), {
-      strict: false,
-    });
-    const queueName = queue.name;
-    const queueType = queue.isScheduler ? "scheduler" : "consumer";
-    Object.values(QueuesMetricsEvents).forEach(
-      (queueEvent: QueuesMetricsEvents) => {
-        this.logger.log(
-          `Associating queue '${queueName}' event '${queueEvent}'.`,
-        );
-        queueProvider.on(queueEvent, () => {
-          this.logger.log(`Queue '${queueName}' event '${queueEvent}'.`);
-          this.eventCounter.inc({
-            queueName,
-            queueEvent,
-            queueType,
-          });
-        });
-      },
-    );
+    this.metricsService.setGlobalMetricsConfigurations();
+    await this.metricsService.associateQueueEventsCountersMetrics();
   }
 
   @InjectLogger()

--- a/sources/packages/backend/apps/queue-consumers/src/queues-bootstrap.module.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/queues-bootstrap.module.ts
@@ -4,8 +4,7 @@ import { QueueService } from "@sims/services/queue/queue.service";
 import { InjectLogger } from "@sims/utilities/logger";
 import { getQueueToken } from "@nestjs/bull";
 import { Queue } from "bull";
-import { Counter } from "prom-client";
-import { register, collectDefaultMetrics } from "prom-client";
+import { register, collectDefaultMetrics, Counter } from "prom-client";
 import { QueueModel } from "@sims/services/queue";
 
 /**
@@ -26,7 +25,6 @@ enum QueuesMetricsEvents {
   Drained = "drained",
 }
 
-const GLOBAL_QUEUE_EVENT_PREFIX = "global";
 const DEFAULT_APP_LABEL = "queue-consumers";
 
 @Global()
@@ -85,24 +83,6 @@ export class QueuesMetricsModule implements OnModuleInit {
         });
       },
     );
-    const globalCompletedEvent = `${GLOBAL_QUEUE_EVENT_PREFIX}:${QueuesMetricsEvents.Completed}`;
-    queueProvider.on(globalCompletedEvent, () => {
-      this.logger.log(`Queue '${queueName}' event '${globalCompletedEvent}'.`);
-      this.eventCounter.inc({
-        queueName,
-        queueEvent: globalCompletedEvent,
-        queueType,
-      });
-    });
-    const globalFailedEvent = `${GLOBAL_QUEUE_EVENT_PREFIX}:${QueuesMetricsEvents.Failed}`;
-    queueProvider.on(globalFailedEvent, () => {
-      this.logger.log(`Queue '${queueName}' event '${globalFailedEvent}'.`);
-      this.eventCounter.inc({
-        queueName,
-        queueEvent: globalFailedEvent,
-        queueType,
-      });
-    });
   }
 
   @InjectLogger()

--- a/sources/packages/backend/apps/queue-consumers/src/queues-bootstrap.module.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/queues-bootstrap.module.ts
@@ -1,0 +1,57 @@
+import { Global, Module, OnModuleInit } from "@nestjs/common";
+import { getQueueToken } from "@nestjs/bull";
+import { Job, Queue } from "bull";
+import { ModuleRef } from "@nestjs/core";
+import { QueueService } from "@sims/services/queue";
+
+@Global()
+@Module({})
+export class QueuesBootstrapModule implements OnModuleInit {
+  constructor(
+    private readonly moduleRef: ModuleRef,
+    private readonly queueService: QueueService,
+  ) {}
+
+  async onModuleInit(): Promise<void> {
+    console.log("Queue module initialized");
+    const queues = await this.queueService.queueConfigurationModel();
+    queues.forEach((queue) => {
+      if (!queue.isActive && queue.isScheduler) {
+        return;
+      }
+      const queueProvider = this.moduleRef.get<Queue>(
+        getQueueToken(queue.name),
+        {
+          strict: false,
+        },
+      );
+      queueProvider.on("failed", (job: Job, error: unknown) => {
+        console.error("JOB failed");
+        console.error(job.id);
+        console.error(job.queue.name);
+        console.error(new Date(job.processedOn));
+        console.error(job.failedReason);
+        console.error("Attempts made: ", job.attemptsMade);
+        console.error(error);
+      });
+      queueProvider.on("stalled", (job: Job, error: unknown) => {
+        console.error("JOB stalled");
+        console.error(job.id);
+        console.error(job.queue.name);
+        console.error(new Date(job.processedOn));
+        console.error(job.failedReason);
+        console.error("Attempts made: ", job.attemptsMade);
+        console.error(error);
+      });
+      queueProvider.on("error", (job: Job, error: unknown) => {
+        console.error("JOB Error");
+        console.error(job.id);
+        console.error(job.queue.name);
+        console.error(new Date(job.processedOn));
+        console.error(job.failedReason);
+        console.error("Attempts made: ", job.attemptsMade);
+        console.error(error);
+      });
+    });
+  }
+}

--- a/sources/packages/backend/apps/queue-consumers/src/queues-bootstrap.module.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/queues-bootstrap.module.ts
@@ -16,6 +16,7 @@ export class QueuesMetricsModule implements OnModuleInit {
    */
   async onModuleInit(): Promise<void> {
     this.logger.log("Associating queue events for metrics.");
+
     this.metricsService.setGlobalMetricsConfigurations();
     await this.metricsService.associateQueueEventsCountersMetrics();
   }

--- a/sources/packages/backend/apps/queue-consumers/src/queues-metrics.module.module.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/queues-metrics.module.module.ts
@@ -16,7 +16,6 @@ export class QueuesMetricsModule implements OnModuleInit {
    */
   async onModuleInit(): Promise<void> {
     this.logger.log("Associating queue events for metrics.");
-
     this.metricsService.setGlobalMetricsConfigurations();
     await this.metricsService.associateQueueEventsCountersMetrics();
   }

--- a/sources/packages/backend/apps/queue-consumers/src/queues-metrics.module.module.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/queues-metrics.module.module.ts
@@ -1,6 +1,6 @@
 import { Global, LoggerService, Module, OnModuleInit } from "@nestjs/common";
 import { InjectLogger } from "@sims/utilities/logger";
-import { MetricsService } from "apps/queue-consumers/src/services";
+import { MetricsService } from "./services";
 
 @Global()
 @Module({

--- a/sources/packages/backend/apps/queue-consumers/src/services/index.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/services/index.ts
@@ -4,3 +4,4 @@ export * from "./workflow/workflow-enqueuer.service";
 export * from "./cas-supplier/cas-supplier.service";
 export * from "./student-file/student-file.service";
 export * from "./cas-supplier/cas-evaluation-result-processor";
+export * from "./metrics/metrics.service";

--- a/sources/packages/backend/apps/queue-consumers/src/services/metrics/metrics.models.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/services/metrics/metrics.models.ts
@@ -1,6 +1,5 @@
 import { QueueModel } from "@sims/services/queue";
 import { Queue } from "bull";
-import { Counter, Gauge } from "prom-client";
 
 /**
  * Bull queues event names to have metrics associated.
@@ -77,21 +76,3 @@ export interface MonitoredQueue {
  * Default label added to all the metrics.
  */
 export const DEFAULT_METRICS_APP_LABEL = "queue-consumers";
-
-/**
- * Current total number of job counts for 'active', 'completed', 'failed', 'delayed', 'waiting'.
- */
-export const DEFAULT_JOBS_COUNTS_GAUGE = new Gauge({
-  name: "queue_job_counts_current_total",
-  help: "Current total number of job counts for 'active', 'completed', 'failed', 'delayed', 'waiting'.",
-  labelNames: ["queueName", "queueEvent", "queueType"] as const,
-});
-
-/**
- * Queue local events counter.
- */
-export const DEFAULT_JOBS_EVENTS_COUNTER = new Counter({
-  name: "queue_event_total_count",
-  help: "Total number of the events for a queue If it is a global event, it will be emitted for every queue-consumer.",
-  labelNames: ["queueName", "queueEvent", "queueType"] as const,
-});

--- a/sources/packages/backend/apps/queue-consumers/src/services/metrics/metrics.models.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/services/metrics/metrics.models.ts
@@ -1,0 +1,97 @@
+import { QueueModel } from "@sims/services/queue";
+import { Queue } from "bull";
+import { Counter, Gauge } from "prom-client";
+
+/**
+ * Bull queues event names to have metrics associated.
+ * @see https://github.com/OptimalBits/bull/blob/develop/REFERENCE.md#events
+ */
+export enum QueuesMetricsEvents {
+  /**
+   * An error occurred, for instance, Redis connectivity issue.
+   */
+  Error = "error",
+  /**
+   * A Job is waiting to be processed as soon as a worker is idling.
+   */
+  Waiting = "waiting",
+  /**
+   * A job has started.
+   */
+  Active = "active",
+  /**
+   * A job has been marked as stalled. This is useful for debugging job
+   * workers that crash or pause the event loop.
+   */
+  Stalled = "stalled",
+  /**
+   * A job successfully completed with a result.
+   */
+  Completed = "completed",
+  /**
+   * A job's progress was updated.
+   */
+  Progress = "progress",
+  /**
+   * A job went to failed state.
+   */
+  Failed = "failed",
+  /**
+   * The job changed to delayed state.
+   */
+  Delayed = "delayed",
+  /**
+   * The queue has been paused.
+   */
+  Paused = "paused",
+  /**
+   * A job was successfully removed.
+   */
+  Removed = "removed",
+  /**
+   * The queue has been resumed.
+   */
+  Resumed = "resumed",
+  /**
+   * Emitted every time the queue has processed all the waiting jobs
+   * (even if there can be some delayed jobs not yet processed).
+   */
+  Drained = "drained",
+  /**
+   * A job failed to extend lock. This will be useful to debug redis
+   * connection issues and jobs getting restarted because workers
+   * are not able to extend locks.
+   */
+  LockExtensionFailed = "lock-extension-failed",
+}
+
+/**
+ * Information to provide metrics to a queue.
+ */
+export interface MonitoredQueue {
+  provider: Queue;
+  queueModel: QueueModel;
+}
+
+/**
+ * Default label added to all the metrics.
+ */
+export const DEFAULT_METRICS_APP_LABEL = "queue-consumers";
+
+/**
+ * Current total number of job counts for 'active', 'completed', 'failed', 'delayed', 'waiting'.
+ */
+export const DEFAULT_JOBS_COUNTS_GAUGE = new Gauge({
+  name: "queue_job_counts_current_total",
+  help: "Current total number of job counts for 'active', 'completed', 'failed', 'delayed', 'waiting'.",
+  labelNames: ["queueName", "queueEvent", "queueType"] as const,
+});
+
+/**
+ * Queue local events counter.
+ */
+export const DEFAULT_JOBS_EVENTS_COUNTER = new Counter({
+  name: "queue_event_total_count",
+  help: "Total number of the events for a queue If it is a global event, it will be emitted for every queue-consumer.",
+  labelNames: ["queueName", "queueEvent", "queueType"] as const,
+});

--- a/sources/packages/backend/apps/queue-consumers/src/services/metrics/metrics.service.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/services/metrics/metrics.service.ts
@@ -62,9 +62,8 @@ export class MetricsService {
 
   /**
    * Refreshes the metrics job counts for all queues by retrieving the current
-   * job counts for 'active', 'completed', 'failed', 'delayed', 'waiting'. The
-   * job counts are then used to update the gauge metric for each individual
-   * queue.
+   * job counts for 'active', 'completed', 'failed', 'delayed', 'waiting'.
+   * The job counts are then used to update the gauge metric for each individual queue.
    */
   private async refreshJobCountsMetrics(): Promise<void> {
     const monitoredQueues = await this.getMonitoredQueues();

--- a/sources/packages/backend/apps/queue-consumers/src/services/metrics/metrics.service.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/services/metrics/metrics.service.ts
@@ -1,0 +1,72 @@
+import { getQueueToken } from "@nestjs/bull";
+import { Injectable, LoggerService } from "@nestjs/common";
+import { ModuleRef } from "@nestjs/core";
+import { QueueModel, QueueService } from "@sims/services/queue";
+import { processInParallel } from "@sims/utilities";
+import { InjectLogger } from "@sims/utilities/logger";
+import { Queue } from "bull";
+import { Gauge } from "prom-client";
+
+type MonitoredQueue = { provider: Queue; queueModel: QueueModel };
+
+@Injectable()
+export class MetricsService {
+  private readonly monitoredQueueProviders: MonitoredQueue[] = [];
+  private readonly jobsCountsGauge = new Gauge({
+    name: "queue_job_counts_current_total",
+    help: "Current total number of job counts for 'active', 'completed', 'failed', 'delayed', 'waiting'.",
+    labelNames: ["queueName", "queueEvent", "queueType"] as const,
+  });
+
+  constructor(
+    private readonly moduleRef: ModuleRef,
+    private readonly queueService: QueueService,
+  ) {}
+
+  async refreshJobCountsMetrics(): Promise<void> {
+    // Refresh queues metrics settings.
+    if (this.monitoredQueueProviders.length === 0) {
+      const queues = await this.queueService.queueConfigurationModel();
+      queues
+        .filter((queueModel) => queueModel.isActive)
+        .map((queueModel) => {
+          const provider = this.moduleRef.get<Queue>(
+            getQueueToken(queueModel.name),
+            {
+              strict: false,
+            },
+          );
+          this.monitoredQueueProviders.push({ provider, queueModel });
+        });
+    }
+    await processInParallel(
+      (queue: MonitoredQueue) => this.refreshQueueMetrics(queue),
+      this.monitoredQueueProviders,
+    );
+  }
+
+  private async refreshQueueMetrics(queue: MonitoredQueue): Promise<void> {
+    const queueProvider = this.moduleRef.get<Queue>(
+      getQueueToken(queue.provider.name),
+      {
+        strict: false,
+      },
+    );
+    const queueName = queue.provider.name;
+    const queueType = queue.queueModel.isScheduler ? "scheduler" : "consumer";
+    const queueJobCounts = await queueProvider.getJobCounts();
+    Object.keys(queueJobCounts).forEach((jobCountEvent: string) => {
+      this.jobsCountsGauge.set(
+        {
+          queueName,
+          queueEvent: jobCountEvent,
+          queueType,
+        },
+        queueJobCounts[jobCountEvent],
+      );
+    });
+  }
+
+  @InjectLogger()
+  logger: LoggerService;
+}

--- a/sources/packages/backend/package-lock.json
+++ b/sources/packages/backend/package-lock.json
@@ -46,6 +46,7 @@
         "passport": "^0.6.0",
         "passport-jwt": "^4.0.1",
         "pg": "^8.5.1",
+        "prom-client": "^15.1.3",
         "qs": "^6.9.6",
         "redis": "^4.6.11",
         "reflect-metadata": "^0.1.13",
@@ -3698,6 +3699,15 @@
         "npm": ">=5.0.0"
       }
     },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
+      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -5874,6 +5884,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/bintrees": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.2.tgz",
+      "integrity": "sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==",
+      "license": "MIT"
     },
     "node_modules/bl": {
       "version": "4.1.0",
@@ -11348,6 +11364,19 @@
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
     },
+    "node_modules/prom-client": {
+      "version": "15.1.3",
+      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-15.1.3.tgz",
+      "integrity": "sha512-6ZiOBfCywsD4k1BN9IX0uZhF+tJkV8q8llP64G5Hajs4JOeVLPCwpPVcpXy3BwYiUGgyJzsJJQeOIv7+hDSq8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.4.0",
+        "tdigest": "^0.1.1"
+      },
+      "engines": {
+        "node": "^16 || ^18 || >=20"
+      }
+    },
     "node_modules/promise-retry": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-2.0.1.tgz",
@@ -12518,6 +12547,15 @@
       "dev": true,
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/tdigest": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/tdigest/-/tdigest-0.1.2.tgz",
+      "integrity": "sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==",
+      "license": "MIT",
+      "dependencies": {
+        "bintrees": "1.0.2"
       }
     },
     "node_modules/terser": {

--- a/sources/packages/backend/package.json
+++ b/sources/packages/backend/package.json
@@ -79,6 +79,7 @@
     "passport": "^0.6.0",
     "passport-jwt": "^4.0.1",
     "pg": "^8.5.1",
+    "prom-client": "^15.1.3",
     "qs": "^6.9.6",
     "redis": "^4.6.11",
     "reflect-metadata": "^0.1.13",


### PR DESCRIPTION
- Enabled `/metrics` endpoint on `queue-consumers` to expose Prometheus metrics following [BC Gov docs](https://developer.gov.bc.ca/docs/default/component/platform-developer-docs/docs/app-monitoring/user-defined-monitoring/).
- Added [prom-client](https://github.com/siimon/prom-client) also following the BC Gov docs mentioned above and the one that seems largely adopted.
- Created a [Gauge metric](https://prometheus.io/docs/concepts/metric_types/#gauge) to capture the most recent summary of every active queue allowing to add to the metrics a summary of `active`, `completed`, `failed`, `delayed`, and 'waiting' jobs. This represents the same status observed in the Bull Board. The garage metrics rely on Redis queries and will always get the most updated values from Redis.
![image](https://github.com/user-attachments/assets/f5bd582a-4eba-41c5-ba03-77adb17b5584)
- Created a [Counter metric](https://prometheus.io/docs/concepts/metric_types/#counter) to capture all the local events triggered for a queue. This happens only in-memory and is captured every time the `metrics` endpoint is invoked. This metric is not needed to achieve queue monitoring but seems a great addition and useful data to support future analysis.
- Enable default [nodejs metrics](https://github.com/siimon/prom-client?tab=readme-ov-file#default-metrics) following also [Prometheus recommendations](https://prometheus.io/docs/instrumenting/writing_clientlibs/#standard-and-runtime-collectors).
- Both metrics are incremented/set using the labels `queueName`, `queueEvent`, and `queueType` to allow querying in Sysdig.

## Sysdig POCs

The Sysdig configurations are not final and were created to support the validation of the code in this PR but should not be considered final or part of the PR evaluation.

### Alerts generated for a queue with a failed job.

```
max(queue_job_counts_current_total{queueEvent="failed",kube_namespace_name="0c27fb-dev"}) by (queueName) > 0
```

![image](https://github.com/user-attachments/assets/4cd5fc0e-7001-4b76-a01b-5e50761252a7)

![image](https://github.com/user-attachments/assets/237f5d24-8da4-4a8c-9fcf-25784c554229)

### Same alerts are configured to be sent using an email channel.

![image](https://github.com/user-attachments/assets/811c5cdb-17f0-4cde-af43-dccc662c5d3e)

## Sample Dashboard

The [Queues Overview](https://app.sysdigcloud.com/#/dashboards/419533?last=3600&scope=kubernetes.namespace.name%20%3D%20%3F%220c27fb-dev%22
) dashboard has some examples of data but should not be considered final or part of the PR evaluation.

![image](https://github.com/user-attachments/assets/6a68d4f3-2890-4d28-b8e6-b718085955db)

_Note:_ the sysdig users and roles were updated and added to this PR, and it is already deployed to both tools environments. If time allows, further effort can be made to enhance the current process but any action beyond the user list update is not part of this PR.
