### PR TITLE
#3666 - Queue Monitoring - Default Queue Error Handling

### DIFF
--- a/sources/packages/backend/apps/queue-consumers/src/processors/assessment/_tests_/cancel-application-assessment.processor.e2e-spec.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/processors/assessment/_tests_/cancel-application-assessment.processor.e2e-spec.ts
@@ -117,7 +117,11 @@ describe(
       expect(zbClientMock.cancelProcessInstance).toBeCalledWith(
         workflowInstanceId,
       );
-      expect(result).toBe("Assessment cancelled with success.");
+      expect(result).toEqual([
+        "Assessment cancelled with success.",
+        "Attention, process finalized with success but some errors and/or warnings messages may require some attention.",
+        "Error(s): 0, Warning(s): 1, Info: 7",
+      ]);
       expect(
         mockedJob.containLogMessages([
           `Cancelling application assessment id ${studentAssessment.id}`,
@@ -176,7 +180,7 @@ describe(
 
       // Assert
       expect(zbClientMock.cancelProcessInstance).not.toHaveBeenCalled();
-      expect(result).toBe("Assessment cancelled with success.");
+      expect(result).toEqual(["Assessment cancelled with success."]);
       expect(
         mockedJob.containLogMessage(
           "Assessment was queued to be cancelled but there is no workflow ID associated with. " +

--- a/sources/packages/backend/apps/queue-consumers/src/processors/assessment/_tests_/cancel-application-assessment.processor.e2e-spec.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/processors/assessment/_tests_/cancel-application-assessment.processor.e2e-spec.ts
@@ -180,7 +180,11 @@ describe(
 
       // Assert
       expect(zbClientMock.cancelProcessInstance).not.toHaveBeenCalled();
-      expect(result).toEqual(["Assessment cancelled with success."]);
+      expect(result).toEqual([
+        "Assessment cancelled with success.",
+        "Attention, process finalized with success but some errors and/or warnings messages may require some attention.",
+        "Error(s): 0, Warning(s): 1, Info: 7",
+      ]);
       expect(
         mockedJob.containLogMessage(
           "Assessment was queued to be cancelled but there is no workflow ID associated with. " +

--- a/sources/packages/backend/apps/queue-consumers/src/processors/assessment/_tests_/cancel-application-assessment.processor.e2e-spec.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/processors/assessment/_tests_/cancel-application-assessment.processor.e2e-spec.ts
@@ -1,11 +1,10 @@
-import { Job } from "bull";
-import { createMock } from "@golevelup/ts-jest";
 import { INestApplication } from "@nestjs/common";
 import { CancelAssessmentQueueInDTO } from "@sims/services/queue";
 import { QueueNames, addDays } from "@sims/utilities";
 import {
   createTestingAppModule,
   describeProcessorRootTest,
+  mockBullJob,
 } from "../../../../test/helpers";
 import { CancelApplicationAssessmentProcessor } from "../cancel-application-assessment.processor";
 import { DataSource, Repository } from "typeorm";
@@ -107,29 +106,31 @@ describe(
       });
       await disbursementOverawardRepo.save(overaward);
       // Queued job.
-      const job = createMock<Job<CancelAssessmentQueueInDTO>>({
-        data: { assessmentId: studentAssessment.id },
+      const mockedJob = mockBullJob<CancelAssessmentQueueInDTO>({
+        assessmentId: studentAssessment.id,
       });
 
       // Act
-      const result = await processor.cancelAssessment(job);
+      const result = await processor.processQueue(mockedJob.job);
 
       // Assert
       expect(zbClientMock.cancelProcessInstance).toBeCalledWith(
         workflowInstanceId,
       );
-      expect(result.summary).toStrictEqual([
-        `Cancelling application assessment id ${studentAssessment.id}`,
-        `Found workflow id ${workflowInstanceId}.`,
-        "Workflow instance successfully cancelled.",
-        "Changing student assessment status to Cancelled.",
-        "Assessment status updated to Cancelled.",
-        "Rolling back overawards, if any.",
-        "Overawards rollback check executed.",
-        "Assessing if there is a future impacted application that need to be reassessed.",
-        "No impacts were detected on future applications.",
-        "Assessment cancelled with success.",
-      ]);
+      expect(result).toBe("Assessment cancelled with success.");
+      expect(
+        mockedJob.containLogMessages([
+          `Cancelling application assessment id ${studentAssessment.id}`,
+          `Found workflow id ${workflowInstanceId}.`,
+          "Workflow instance successfully cancelled.",
+          "Changing student assessment status to Cancelled.",
+          "Assessment status updated to Cancelled.",
+          "Rolling back overawards, if any.",
+          "Overawards rollback check executed.",
+          "Assessing if there is a future impacted application that need to be reassessed.",
+          "No impacts were detected on future applications.",
+        ]),
+      ).toBe(true);
 
       // Assert that overawards were soft deleted.
       const updatedOveraward = await disbursementOverawardRepo.findOne({
@@ -166,19 +167,22 @@ describe(
         StudentAssessmentStatus.CancellationQueued;
       await db.studentAssessment.save(studentAssessment);
       // Queued job.
-      const job = createMock<Job<CancelAssessmentQueueInDTO>>({
-        data: { assessmentId: studentAssessment.id },
+      const mockedJob = mockBullJob<CancelAssessmentQueueInDTO>({
+        assessmentId: studentAssessment.id,
       });
 
       // Act
-      const result = await processor.cancelAssessment(job);
+      const result = await processor.processQueue(mockedJob.job);
 
       // Assert
       expect(zbClientMock.cancelProcessInstance).not.toHaveBeenCalled();
-      expect(result.warnings).toContain(
-        "Assessment was queued to be cancelled but there is no workflow id associated with.",
-      );
-      expect(result.summary).toContain("Assessment cancelled with success.");
+      expect(result).toBe("Assessment cancelled with success.");
+      expect(
+        mockedJob.containLogMessage(
+          "Assessment was queued to be cancelled but there is no workflow ID associated with. " +
+            "This is considered a normal scenario for cancellations that never transitioned to the 'In Progress' state.",
+        ),
+      ).toBe(true);
     });
 
     it(`Should log a warning message when the assessment has status different than ${StudentAssessmentStatus.CancellationQueued}.`, async () => {
@@ -187,22 +191,23 @@ describe(
       const studentAssessment = application.currentAssessment;
 
       // Queued job.
-      const job = createMock<Job<CancelAssessmentQueueInDTO>>({
-        data: { assessmentId: studentAssessment.id },
+      const mockedJob = mockBullJob<CancelAssessmentQueueInDTO>({
+        assessmentId: studentAssessment.id,
       });
 
       // Act
-      const result = await processor.cancelAssessment(job);
+      await processor.processQueue(mockedJob.job);
 
       // Assert
       expect(zbClientMock.cancelProcessInstance).not.toHaveBeenCalled();
-      expect(result.warnings).toContain(
-        `Assessment id ${job.data.assessmentId} is not in ${StudentAssessmentStatus.CancellationQueued} status.`,
+      expect(
+        mockedJob.containLogMessages([
+          `Assessment id ${mockedJob.job.data.assessmentId} is not in ${StudentAssessmentStatus.CancellationQueued} status.`,
+          "Workflow cancellation process not executed due to the assessment cancellation not being in the correct status.",
+        ]),
       );
-      expect(result.summary).toContain(
-        "Workflow cancellation process not executed due to the assessment cancellation not being in the correct status.",
-      );
-      expect(job.discard).toBeCalled();
+
+      expect(mockedJob.job.discard).toBeCalled();
     });
 
     it("Should throw an error and call job.discard when the application is not in the expected status.", async () => {
@@ -219,15 +224,15 @@ describe(
         StudentAssessmentStatus.CancellationQueued;
       await db.studentAssessment.save(studentAssessment);
       // Queued job.
-      const job = createMock<Job<CancelAssessmentQueueInDTO>>({
-        data: { assessmentId: studentAssessment.id },
+      const mockedJob = mockBullJob<CancelAssessmentQueueInDTO>({
+        assessmentId: studentAssessment.id,
       });
 
       // Act and Assert
-      await expect(processor.cancelAssessment(job)).rejects.toStrictEqual(
+      await expect(processor.processQueue(mockedJob.job)).rejects.toStrictEqual(
         expectedError,
       );
-      expect(job.discard).toBeCalled();
+      expect(mockedJob.job.discard).toBeCalled();
     });
 
     it("Should throw an error and call job.discard when the assessment id was not found.", async () => {
@@ -236,15 +241,15 @@ describe(
       const errorMessage = `Assessment id ${assessmentId} was not found.`;
       const error = new Error(errorMessage);
       // Queued job.
-      const job = createMock<Job<CancelAssessmentQueueInDTO>>({
-        data: { assessmentId },
+      const mockedJob = mockBullJob<CancelAssessmentQueueInDTO>({
+        assessmentId,
       });
 
       // Act and Assert
-      await expect(processor.cancelAssessment(job)).rejects.toStrictEqual(
+      await expect(processor.processQueue(mockedJob.job)).rejects.toStrictEqual(
         error,
       );
-      expect(job.discard).toBeCalled();
+      expect(mockedJob.job.discard).toBeCalled();
     });
 
     it("Should find an impacted application and create a reassessment when canceling an application with a assessment date set in the current assessment.", async () => {
@@ -297,17 +302,19 @@ describe(
       );
 
       // Queued job.
-      const job = createMock<Job<CancelAssessmentQueueInDTO>>({
-        data: { assessmentId: currentApplicationToCancel.currentAssessment.id },
+      const mockedJob = mockBullJob<CancelAssessmentQueueInDTO>({
+        assessmentId: currentApplicationToCancel.currentAssessment.id,
       });
 
       // Act
-      const result = await processor.cancelAssessment(job);
+      await processor.processQueue(mockedJob.job);
 
       // Asserts
-      expect(result.summary).toContain(
-        `Application id ${impactedApplication.id} was detected as impacted and will be reassessed.`,
-      );
+      expect(
+        mockedJob.containLogMessage(
+          `Application id ${impactedApplication.id} was detected as impacted and will be reassessed.`,
+        ),
+      ).toBe(true);
       // Assert that an reassessment of type 'Related application changed' was created in the future impacted application.
       const updatedImpactedApplication = await findImpactedApplication(
         impactedApplication.id,
@@ -353,17 +360,19 @@ describe(
       );
 
       // Queued job.
-      const job = createMock<Job<CancelAssessmentQueueInDTO>>({
-        data: { assessmentId: currentApplicationToCancel.currentAssessment.id },
+      const mockedJob = mockBullJob<CancelAssessmentQueueInDTO>({
+        assessmentId: currentApplicationToCancel.currentAssessment.id,
       });
 
       // Act
-      const result = await processor.cancelAssessment(job);
+      await processor.processQueue(mockedJob.job);
 
       // Asserts
-      expect(result.summary).toContain(
-        "No impacts were detected on future applications.",
-      );
+      expect(
+        mockedJob.containLogMessage(
+          "No impacts were detected on future applications.",
+        ),
+      ).toBe(true);
     });
 
     it("Should find an impacted application and create a reassessment when the impacted application original assessment calculation date is after the cancelled assessment date original assessment, including 'Overwritten' records.", async () => {
@@ -421,17 +430,19 @@ describe(
       );
 
       // Queued job.
-      const job = createMock<Job<CancelAssessmentQueueInDTO>>({
-        data: { assessmentId: currentApplicationToCancel.currentAssessment.id },
+      const mockedJob = mockBullJob<CancelAssessmentQueueInDTO>({
+        assessmentId: currentApplicationToCancel.currentAssessment.id,
       });
 
       // Act
-      const result = await processor.cancelAssessment(job);
+      await processor.processQueue(mockedJob.job);
 
       // Asserts
-      expect(result.summary).toContain(
-        `Application id ${impactedApplication.id} was detected as impacted and will be reassessed.`,
-      );
+      expect(
+        mockedJob.containLogMessage(
+          `Application id ${impactedApplication.id} was detected as impacted and will be reassessed.`,
+        ),
+      ).toBe(true);
       // Assert that an reassessment of type 'Related application changed' was created in the future impacted application.
       const updatedImpactedApplication = await findImpactedApplication(
         impactedApplication.id,
@@ -480,17 +491,19 @@ describe(
       );
 
       // Queued job.
-      const job = createMock<Job<CancelAssessmentQueueInDTO>>({
-        data: { assessmentId: currentApplicationToCancel.currentAssessment.id },
+      const mockedJob = mockBullJob<CancelAssessmentQueueInDTO>({
+        assessmentId: currentApplicationToCancel.currentAssessment.id,
       });
 
       // Act
-      const result = await processor.cancelAssessment(job);
+      await processor.processQueue(mockedJob.job);
 
       // Asserts
-      expect(result.summary).toContain(
-        "No impacts were detected on future applications.",
-      );
+      expect(
+        mockedJob.containLogMessage(
+          "No impacts were detected on future applications.",
+        ),
+      ).toBe(true);
     });
 
     it(
@@ -552,10 +565,8 @@ describe(
           impactedApplicationAssessmentBeforeCancel,
         );
         // Queued job.
-        const job = createMock<Job<CancelAssessmentQueueInDTO>>({
-          data: {
-            assessmentId: currentApplicationToCancel.currentAssessment.id,
-          },
+        const mockedJob = mockBullJob<CancelAssessmentQueueInDTO>({
+          assessmentId: currentApplicationToCancel.currentAssessment.id,
         });
         // Spy on assess impacted application method to make sure that it is not invoked.
         const assessmentSequentialProcessingService =
@@ -570,7 +581,7 @@ describe(
         );
 
         // Act
-        await processor.cancelAssessment(job);
+        await processor.processQueue(mockedJob.job);
 
         // Assert
         // Ensure that the cancellation did not create a new reassessment for the

--- a/sources/packages/backend/apps/queue-consumers/src/processors/assessment/_tests_/cancel-application-assessment.processor.e2e-spec.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/processors/assessment/_tests_/cancel-application-assessment.processor.e2e-spec.ts
@@ -117,11 +117,7 @@ describe(
       expect(zbClientMock.cancelProcessInstance).toBeCalledWith(
         workflowInstanceId,
       );
-      expect(result).toEqual([
-        "Assessment cancelled with success.",
-        "Attention, process finalized with success but some errors and/or warnings messages may require some attention.",
-        "Error(s): 0, Warning(s): 1, Info: 7",
-      ]);
+      expect(result).toEqual(["Assessment cancelled with success."]);
       expect(
         mockedJob.containLogMessages([
           `Cancelling application assessment id ${studentAssessment.id}`,

--- a/sources/packages/backend/apps/queue-consumers/src/processors/assessment/_tests_/start-application-assessment.processor.e2e-spec.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/processors/assessment/_tests_/start-application-assessment.processor.e2e-spec.ts
@@ -1,5 +1,3 @@
-import { Job } from "bull";
-import { createMock } from "@golevelup/ts-jest";
 import { INestApplication } from "@nestjs/common";
 import { StartApplicationAssessmentProcessor } from "../start-application-assessment.processor";
 import { StartAssessmentQueueInDTO } from "@sims/services/queue";
@@ -7,8 +5,8 @@ import { QueueNames } from "@sims/utilities";
 import {
   createTestingAppModule,
   describeProcessorRootTest,
+  mockBullJob,
 } from "../../../../test/helpers";
-import { LogLevels, ProcessSummary } from "@sims/utilities/logger";
 import {
   createE2EDataSources,
   E2EDataSources,
@@ -17,6 +15,7 @@ import {
 import { StudentAssessmentStatus } from "@sims/sims-db";
 import { Not } from "typeorm";
 import { ZeebeGrpcClient } from "@camunda8/sdk/dist/zeebe";
+import { resetZeebeModuleMock } from "@sims/test-utils/mocks";
 
 describe(
   describeProcessorRootTest(QueueNames.StartApplicationAssessment),
@@ -38,6 +37,7 @@ describe(
 
     beforeEach(async () => {
       jest.resetAllMocks();
+      resetZeebeModuleMock(zbClientMock);
       // Ensure that all assessments will be cancelled.
       await db.studentAssessment.update(
         {
@@ -54,80 +54,43 @@ describe(
       currentAssessment.studentAssessmentStatus =
         StudentAssessmentStatus.Queued;
       await db.studentAssessment.save(currentAssessment);
-      const dummyException = new Error("Dummy error");
-      const job = createMock<Job<StartAssessmentQueueInDTO>>({
-        data: {
-          workflowName: "dummy-workflow-name",
-          assessmentId: currentAssessment.id,
-        },
+      const dummyException = new Error();
+      const mockedJob = mockBullJob<StartAssessmentQueueInDTO>({
+        workflowName: "dummy-workflow-name",
+        assessmentId: currentAssessment.id,
       });
       zbClientMock.createProcessInstance = jest.fn().mockImplementation(() => {
         throw dummyException;
       });
-      // Capture the processSummary for later assertion.
-      let processSummary: ProcessSummary;
-      processor.logger.logProcessSummary = jest.fn((providedProcessSummary) => {
-        processSummary = providedProcessSummary;
-      });
 
-      // Act
-      const result = await processor.startAssessment(job);
-
-      // Assert.
-
-      // Assert process summary was provided.
-      expect(processSummary).toBeDefined();
-      // Assert expected result message.
-      expect(result).toBe(
-        "Unexpected error while executing the job, check logs for further details.",
+      // Act/Assert
+      await expect(processor.processQueue(mockedJob.job)).rejects.toThrow(
+        "Error while starting application assessment workflow: dummy-workflow-name",
       );
-      // Assert error message was added to the logs.
-      const hasExpectedLogErrorMessage = processSummary
-        .flattenLogs()
-        .some(
-          (log) =>
-            log.level === LogLevels.Error &&
-            log.message.includes("Dummy error"),
-        );
-      expect(hasExpectedLogErrorMessage).toBeTruthy();
     });
 
     it(`Should log a warn message when the assessment status is different than ${StudentAssessmentStatus.Queued}.`, async () => {
       // Arrange
       const application = await saveFakeApplication(db.dataSource);
-      const job = createMock<Job<StartAssessmentQueueInDTO>>({
-        data: {
-          workflowName: "workflow-name",
-          assessmentId: application.currentAssessment.id,
-        },
-      });
-
-      // Capture the processSummary for later assertion.
-      let processSummary: ProcessSummary;
-      processor.logger.logProcessSummary = jest.fn((providedProcessSummary) => {
-        processSummary = providedProcessSummary;
+      const mockedJob = mockBullJob<StartAssessmentQueueInDTO>({
+        assessmentId: application.currentAssessment.id,
       });
 
       // Act
-      const result = await processor.startAssessment(job);
+      const result = await processor.processQueue(mockedJob.job);
 
       // Assert
       // Assert expected result message.
       expect(result).toBe(
         "Workflow process not executed due to the assessment not being in the correct status.",
       );
-      // Assert warn message was added to the logs.
-      const hasExpectedLogWarnMessage = processSummary
-        .flattenLogs()
-        .some(
-          (log) =>
-            log.level === LogLevels.Warn &&
-            log.message.includes(
-              `Assessment id ${job.data.assessmentId} is not in ${StudentAssessmentStatus.Queued} status.`,
-            ),
-        );
-      expect(hasExpectedLogWarnMessage).toBeTruthy();
-      expect(job.discard).toBeCalled();
+      expect(
+        mockedJob.containLogMessages([
+          "Workflow process not executed due to the assessment not being in the correct status.",
+          `Assessment id ${mockedJob.job.data.assessmentId} is not in ${StudentAssessmentStatus.Queued} status.`,
+        ]),
+      ).toBe(true);
+      expect(mockedJob.job.discard).toBeCalled();
     });
 
     it("Should invoke the workflow create instance method with the received job parameters.", async () => {
@@ -141,15 +104,13 @@ describe(
 
       const variables = { assessmentId: currentAssessment.id };
       // Queued job.
-      const job = createMock<Job<StartAssessmentQueueInDTO>>({
-        data: {
-          workflowName,
-          assessmentId: application.currentAssessment.id,
-        },
+      const mockedJob = mockBullJob<StartAssessmentQueueInDTO>({
+        workflowName,
+        assessmentId: application.currentAssessment.id,
       });
 
       // Act
-      await processor.startAssessment(job);
+      await processor.processQueue(mockedJob.job);
 
       // Assert
       const createProcessInstancePayload = {

--- a/sources/packages/backend/apps/queue-consumers/src/processors/assessment/_tests_/start-application-assessment.processor.e2e-spec.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/processors/assessment/_tests_/start-application-assessment.processor.e2e-spec.ts
@@ -81,9 +81,11 @@ describe(
 
       // Assert
       // Assert expected result message.
-      expect(result).toBe(
+      expect(result).toEqual([
         "Workflow process not executed due to the assessment not being in the correct status.",
-      );
+        "Attention, process finalized with success but some errors and/or warnings messages may require some attention.",
+        "Error(s): 0, Warning(s): 2, Info: 2",
+      ]);
       expect(
         mockedJob.containLogMessages([
           "Workflow process not executed due to the assessment not being in the correct status.",

--- a/sources/packages/backend/apps/queue-consumers/src/processors/assessment/cancel-application-assessment.processor.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/processors/assessment/cancel-application-assessment.processor.ts
@@ -7,27 +7,32 @@ import {
   SystemUsersService,
   WorkflowClientService,
 } from "@sims/services";
-import { QueueNames } from "@sims/utilities";
+import { CustomNamedError, QueueNames } from "@sims/utilities";
 import { StudentAssessmentService } from "../../services";
 import { DataSource } from "typeorm";
 import { ZeebeGRPCError, ZeebeGRPCErrorTypes } from "@sims/services/zeebe";
-import { InjectLogger, LoggerService } from "@sims/utilities/logger";
 import {
-  QueueProcessSummary,
-  QueueProcessSummaryResult,
-} from "../models/processors.models";
+  InjectLogger,
+  LoggerService,
+  ProcessSummary,
+} from "@sims/utilities/logger";
 import {
   ApplicationStatus,
   COEStatus,
   StudentAssessment,
   StudentAssessmentStatus,
 } from "@sims/sims-db";
+import { BaseQueue } from "../../processors";
+import {
+  ASSESSMENT_NOT_FOUND,
+  INVALID_OPERATION_IN_THE_CURRENT_STATUS,
+} from "@sims/services/constants";
 
 /**
  * Process the workflow cancellation.
  */
 @Processor(QueueNames.CancelApplicationAssessment)
-export class CancelApplicationAssessmentProcessor {
+export class CancelApplicationAssessmentProcessor extends BaseQueue<CancelAssessmentQueueInDTO> {
   constructor(
     private readonly dataSource: DataSource,
     private readonly workflowClientService: WorkflowClientService,
@@ -35,22 +40,21 @@ export class CancelApplicationAssessmentProcessor {
     private readonly disbursementScheduleSharedService: DisbursementScheduleSharedService,
     private readonly assessmentSequentialProcessingService: AssessmentSequentialProcessingService,
     private readonly systemUserService: SystemUsersService,
-  ) {}
+  ) {
+    super();
+  }
 
   /**
    * Cancel the workflow instance and rollback overawards, if any.
    * @param job information to perform the process.
-   * @returns log message.
-   */
+   * @param processSummary process summary for logging.
+   * @returns processing result.   */
   @Process()
-  async cancelAssessment(
+  async process(
     job: Job<CancelAssessmentQueueInDTO>,
-  ): Promise<QueueProcessSummaryResult> {
-    const summary = new QueueProcessSummary({
-      appLogger: this.logger,
-      jobLogger: job,
-    });
-    await summary.info(
+    processSummary: ProcessSummary,
+  ): Promise<string> {
+    processSummary.info(
       `Cancelling application assessment id ${job.data.assessmentId}`,
     );
     const assessment = await this.studentAssessmentService.getAssessmentById(
@@ -58,9 +62,10 @@ export class CancelApplicationAssessmentProcessor {
     );
     if (!assessment) {
       await job.discard();
-      const errorMessage = `Assessment id ${job.data.assessmentId} was not found.`;
-      this.logger.error(errorMessage);
-      throw new Error(errorMessage);
+      throw new CustomNamedError(
+        `Assessment id ${job.data.assessmentId} was not found.`,
+        ASSESSMENT_NOT_FOUND,
+      );
     }
 
     if (
@@ -69,11 +74,8 @@ export class CancelApplicationAssessmentProcessor {
     ) {
       await job.discard();
       const warnMessage = `Assessment id ${job.data.assessmentId} is not in ${StudentAssessmentStatus.CancellationQueued} status.`;
-      summary.warn(warnMessage);
-      summary.info(
-        "Workflow cancellation process not executed due to the assessment cancellation not being in the correct status.",
-      );
-      return summary.getSummary();
+      processSummary.warn(warnMessage);
+      return "Workflow cancellation process not executed due to the assessment cancellation not being in the correct status.";
     }
 
     if (
@@ -83,21 +85,22 @@ export class CancelApplicationAssessmentProcessor {
     ) {
       await job.discard();
       const errorMessage = `Application must be in the ${ApplicationStatus.Cancelled} or ${ApplicationStatus.Overwritten} state to have the assessment cancelled.`;
-      this.logger.error(errorMessage);
-      throw new Error(errorMessage);
+      throw new CustomNamedError(
+        errorMessage,
+        INVALID_OPERATION_IN_THE_CURRENT_STATUS,
+      );
     }
 
     // Try to cancel the workflow if a workflow id is present.
-    // TODO: once the assessment has a proper status flag to be marked as completed we can check if the workflow needed to be cancelled.
     if (assessment.assessmentWorkflowId) {
-      await summary.info(
+      processSummary.info(
         `Found workflow id ${assessment.assessmentWorkflowId}.`,
       );
       try {
         await this.workflowClientService.deleteApplicationAssessment(
           assessment.assessmentWorkflowId,
         );
-        await summary.info("Workflow instance successfully cancelled.");
+        processSummary.info("Workflow instance successfully cancelled.");
       } catch (error: unknown) {
         if (
           error instanceof ZeebeGRPCError &&
@@ -108,8 +111,8 @@ export class CancelApplicationAssessmentProcessor {
           throw error;
         }
         // NOT_FOUND error means that the call to Camunda was successful but the workflow instance was not found.
-        await summary.warn(
-          "Workflow instance was not cancelled because the workflow id was not found on Camunda. " +
+        processSummary.warn(
+          "Workflow instance was not cancelled because the workflow ID was not found on Camunda. " +
             "This can happen if the workflow was already completed or if it was cancelled, for instance, manually using the workflow UI. " +
             "This is not considered an error and the cancellation can proceed.",
         );
@@ -117,12 +120,13 @@ export class CancelApplicationAssessmentProcessor {
     } else {
       // Unless there is some data integrity issue this scenario can happen only if the student application was submitted
       // and was never transitioned to the 'In Progress' state when the workflow instance is started.
-      await summary.warn(
-        "Assessment was queued to be cancelled but there is no workflow id associated with.",
+      processSummary.warn(
+        "Assessment was queued to be cancelled but there is no workflow ID associated with. " +
+          "This is considered a normal scenario for cancellations that never transitioned to the 'In Progress' state.",
       );
     }
     return this.dataSource.transaction(async (transactionEntityManager) => {
-      await summary.info(
+      processSummary.info(
         `Changing student assessment status to ${StudentAssessmentStatus.Cancelled}.`,
       );
       await transactionEntityManager
@@ -132,7 +136,7 @@ export class CancelApplicationAssessmentProcessor {
           modifier: this.systemUserService.systemUser,
           updatedAt: new Date(),
         });
-      await summary.info(
+      processSummary.info(
         `Assessment status updated to ${StudentAssessmentStatus.Cancelled}.`,
       );
       // Overawards rollback.
@@ -140,12 +144,12 @@ export class CancelApplicationAssessmentProcessor {
       // application moves from the 'In progress' status when the disbursements are generated.
       // It must be called after the workflow is cancelled to avoiding further updates on the disbursements after
       // the rollback is performed.
-      await summary.info("Rolling back overawards, if any.");
+      processSummary.info("Rolling back overawards, if any.");
       await this.disbursementScheduleSharedService.rollbackOverawards(
         assessment.id,
         transactionEntityManager,
       );
-      await summary.info("Overawards rollback check executed.");
+      processSummary.info("Overawards rollback check executed.");
       // Check if the assessment has one of the COE(s) declined.
       const hasDeclinedCOE = assessment.disbursementSchedules.some(
         (disbursement) => disbursement.coeStatus === COEStatus.declined,
@@ -159,7 +163,7 @@ export class CancelApplicationAssessmentProcessor {
         // If a COE of an application is declined, during the process of COE being declined,
         // the impacted application if exist is identified and reassessed.
         // Hence while cancelling an application with a declined COE, it must NOT be assessed for impacted application reassessment again.
-        await summary.info(
+        processSummary.info(
           "Assessing if there is a future impacted application that need to be reassessed.",
         );
         const impactedApplication =
@@ -169,17 +173,16 @@ export class CancelApplicationAssessmentProcessor {
             transactionEntityManager,
           );
         if (impactedApplication) {
-          await summary.info(
+          processSummary.info(
             `Application id ${impactedApplication.id} was detected as impacted and will be reassessed.`,
           );
         } else {
-          await summary.info(
+          processSummary.info(
             "No impacts were detected on future applications.",
           );
         }
       }
-      await summary.info("Assessment cancelled with success.");
-      return summary.getSummary();
+      return "Assessment cancelled with success.";
     });
   }
 

--- a/sources/packages/backend/apps/queue-consumers/src/processors/assessment/cancel-application-assessment.processor.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/processors/assessment/cancel-application-assessment.processor.ts
@@ -1,4 +1,4 @@
-import { Process, Processor } from "@nestjs/bull";
+import { Processor } from "@nestjs/bull";
 import { Job } from "bull";
 import { CancelAssessmentQueueInDTO } from "@sims/services/queue";
 import {
@@ -49,7 +49,6 @@ export class CancelApplicationAssessmentProcessor extends BaseQueue<CancelAssess
    * @param job information to perform the process.
    * @param processSummary process summary for logging.
    * @returns processing result.   */
-  @Process()
   async process(
     job: Job<CancelAssessmentQueueInDTO>,
     processSummary: ProcessSummary,

--- a/sources/packages/backend/apps/queue-consumers/src/processors/assessment/start-application-assessment.processor.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/processors/assessment/start-application-assessment.processor.ts
@@ -1,4 +1,4 @@
-import { Process, Processor } from "@nestjs/bull";
+import { Processor } from "@nestjs/bull";
 import { Job } from "bull";
 import { StartAssessmentQueueInDTO } from "@sims/services/queue";
 import { WorkflowClientService } from "@sims/services";
@@ -30,7 +30,6 @@ export class StartApplicationAssessmentProcessor extends BaseQueue<StartAssessme
    * @param processSummary process summary for logging.
    * @returns processing result.
    */
-  @Process()
   async process(
     job: Job<StartAssessmentQueueInDTO>,
     processSummary: ProcessSummary,

--- a/sources/packages/backend/apps/queue-consumers/src/processors/index.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/processors/index.ts
@@ -1,3 +1,4 @@
+export * from "./schedulers/base-queue";
 export * from "./assessment/start-application-assessment.processor";
 export * from "./assessment/cancel-application-assessment.processor";
 export * from "./schedulers/cra-integration/cra-process-integration.scheduler";

--- a/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/base-queue.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/base-queue.ts
@@ -6,6 +6,7 @@ import {
 } from "@sims/utilities/logger";
 import {
   PROCESS_SUMMARY_CONTAINS_ERROR,
+  getSuccessMessageWithAttentionCheck,
   logProcessSummaryToJobLogger,
 } from "../../utilities";
 import { Job } from "bull";
@@ -35,7 +36,7 @@ export abstract class BaseQueue<T> {
           PROCESS_SUMMARY_CONTAINS_ERROR,
         );
       }
-      return result;
+      return getSuccessMessageWithAttentionCheck(result, processSummary);
     } catch (error: unknown) {
       // Throw an error to force the queue to retry.
       if (error instanceof CustomNamedError) {

--- a/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/base-queue.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/base-queue.ts
@@ -9,6 +9,7 @@ import {
   logProcessSummaryToJobLogger,
 } from "../../utilities";
 import { Job } from "bull";
+import { Process } from "@nestjs/bull";
 
 /**
  * Provides basic functionality for queue processing.
@@ -20,6 +21,7 @@ export abstract class BaseQueue<T> {
    * @param job process job.
    * @returns processing result.
    */
+  @Process()
   async processQueue(job: Job<T>): Promise<string | string[]> {
     const processSummary = new ProcessSummary();
     try {

--- a/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/base-queue.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/base-queue.ts
@@ -1,0 +1,72 @@
+import { CustomNamedError, parseJSONError } from "@sims/utilities";
+import {
+  InjectLogger,
+  LoggerService,
+  ProcessSummary,
+} from "@sims/utilities/logger";
+import {
+  PROCESS_SUMMARY_CONTAINS_ERROR,
+  logProcessSummaryToJobLogger,
+} from "../../utilities";
+import { Job } from "bull";
+
+/**
+ * Provides basic functionality for queue processing.
+ */
+export abstract class BaseQueue<T> {
+  /**
+   * Wrap the queue job execution in a try/catch for the global error handling.
+   * It provides also the default {@link ProcessSummary} for logging.
+   * @param job process job.
+   * @returns processing result.
+   */
+  async processQueue(job: Job<T>): Promise<string | string[]> {
+    const processSummary = new ProcessSummary();
+    try {
+      this.logger.log(`Processing queue ${job.queue.name}, job ID ${job.id}.`);
+      const result = await this.process(job, processSummary);
+      processSummary.info(`${job.queue.name}, job ID ${job.id}, executed.`);
+      const logsSum = processSummary.getLogLevelSum();
+      if (logsSum.error) {
+        throw new CustomNamedError(
+          "One or more errors were reported during the process, please see logs for details.",
+          PROCESS_SUMMARY_CONTAINS_ERROR,
+        );
+      }
+      return result;
+    } catch (error: unknown) {
+      // Throw an error to force the queue to retry.
+      if (error instanceof CustomNamedError) {
+        throw new Error(error.message);
+      }
+      const errorMessage = `Unexpected error while executing queue ${job.queue.name}, job ID ${job.id}.`;
+      this.logger.error(errorMessage, error);
+      // Throw an error to force the queue to retry. This error will not print the stack trace
+      // if using the 'cause' property, hence the stack is added to the message.
+      throw new Error(`${errorMessage}${parseJSONError(error)}`);
+    } finally {
+      this.logger.logProcessSummary(processSummary);
+      await logProcessSummaryToJobLogger(processSummary, job);
+    }
+  }
+
+  /**
+   * When implemented in a derived class, process the queue job
+   * wrapped in a try/catch for the global error handling.
+   * It provides also the default {@link ProcessSummary} for logging.
+   * @param job process job.
+   * @param processSummary process summary for logging.
+   * @returns processing result.
+   */
+  abstract process(
+    job: Job<T>,
+    processSummary: ProcessSummary,
+  ): Promise<string | string[]>;
+
+  /**
+   * Default logger. This must be provided in the derived class
+   * to set the proper log context.
+   */
+  @InjectLogger()
+  logger: LoggerService;
+}

--- a/sources/packages/backend/apps/queue-consumers/src/utilities/log-utils.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/utilities/log-utils.ts
@@ -51,13 +51,17 @@ export async function logProcessSummaryToJobLogger(
  * attention messages appended.
  */
 export function getSuccessMessageWithAttentionCheck(
-  successMessages: string[],
+  successMessages: string[] | string,
   processSummary: ProcessSummary,
   options?: { throwOnError?: boolean },
 ): string[] {
   const throwOnError = options?.throwOnError ?? false;
   const message: string[] = [];
-  message.push(...successMessages);
+  if (Array.isArray(successMessages)) {
+    message.push(...successMessages);
+  } else {
+    message.push(successMessages);
+  }
   const logsSum = processSummary.getLogLevelSum();
   if (logsSum.error || logsSum.warn) {
     message.push(

--- a/sources/packages/backend/libs/services/src/workflow/workflow-client.service.ts
+++ b/sources/packages/backend/libs/services/src/workflow/workflow-client.service.ts
@@ -33,11 +33,9 @@ export class WorkflowClientService {
         },
       });
     } catch (error: unknown) {
-      this.logger.error(
-        `Error while starting application assessment workflow: ${workflowName}`,
-      );
-      this.logger.error(error);
-      throw error;
+      const errorMessage = `Error while starting application assessment workflow: ${workflowName}`;
+      this.logger.error(errorMessage, error);
+      throw new Error(errorMessage, { cause: error });
     }
   }
 

--- a/sources/packages/backend/libs/test-utils/src/mocks/zeebe-client-mock.ts
+++ b/sources/packages/backend/libs/test-utils/src/mocks/zeebe-client-mock.ts
@@ -10,9 +10,7 @@ import { ZeebeModule } from "@sims/services";
  */
 export function createZeebeModuleMock(): DynamicModule {
   const mockedZBClient = {} as ZeebeGrpcClient;
-  mockedZBClient.createProcessInstance = jest.fn();
-  mockedZBClient.publishMessage = jest.fn();
-  mockedZBClient.cancelProcessInstance = jest.fn();
+  resetZeebeModuleMock(mockedZBClient);
   const zeebeClientProvider: Provider = {
     provide: ZeebeGrpcClient,
     useValue: mockedZBClient,
@@ -23,4 +21,14 @@ export function createZeebeModuleMock(): DynamicModule {
     providers: [zeebeClientProvider],
     exports: [zeebeClientProvider],
   };
+}
+
+/**
+ * Resets the mocked {@link ZeebeGrpcClient} for its initial mocked values.
+ * @param mockedZBClient mocked client to be reset.
+ */
+export function resetZeebeModuleMock(mockedZBClient: ZeebeGrpcClient): void {
+  mockedZBClient.createProcessInstance = jest.fn();
+  mockedZBClient.publishMessage = jest.fn();
+  mockedZBClient.cancelProcessInstance = jest.fn();
 }

--- a/sources/packages/backend/libs/utilities/src/logger/logger.service.ts
+++ b/sources/packages/backend/libs/utilities/src/logger/logger.service.ts
@@ -41,7 +41,11 @@ export class LoggerService extends ConsoleLogger {
     if (error) {
       errorBuilder.appendLine(parseJSONError(error));
     }
-    super.error(errorBuilder.toString(), null, context);
+    if (context) {
+      super.error(errorBuilder.toString(), context);
+      return;
+    }
+    super.error(errorBuilder.toString());
   }
 
   /**


### PR DESCRIPTION
This PR is a proposal to unify the queue behavior. It contains changes for start and cancel assessments regular queues and the idea is to expand it to all schedulers.

The below image shows these points to be shared and forced for all the queues, using the CAS scheduler as an example.
1 - Return type;
2 - Provide a `processSummary`;
3 - try/catch and default start message.
4 - Error check on `processSummary` to force the jobs to fail.
5 - Error handling on `catch`.
6 - Final log activities during `finally`.
![image](https://github.com/user-attachments/assets/4b31491b-f859-4ef6-a126-67ad60bf7bb0)
_Note:_ The above will also ensure the E2E tests follow a closer approach.

Sample log for a queue using the new `BaseQueue<T>` class.

![image](https://github.com/user-attachments/assets/f42193dc-5e57-4f8a-94a8-c4a78df39084)

### Side effects
The idea is to have the BaseScheduler extend the BaseQueue which will force a change in every single scheduler (which would be the idea). To avoid the need to change every single scheduler and adapt every E2E, the methods required by BaseQueue can be implemented temporarily as below. The idea is to start the scheduler refactor still during this ticket.

```ts
/**
 * To be implemented.
 */
processQueue(_job: Job<void>): Promise<string | string[]> {
  throw new Error("Method not implemented.");
}

/**
 * To be implemented.
 */
async process(
  _job: Job<void>,
  _processSummary: ProcessSummary,
): Promise<string | string[]> {
  throw new Error("Method not implemented.");
}
```

### Error Fix
Fixed an issue with the logger service where `null` message was logged right after the regular message.
