### PR TITLE
#3981 - Model SDPR API - Query fix

### DIFF
--- a/sources/packages/backend/apps/api/src/services/student/student.service.ts
+++ b/sources/packages/backend/apps/api/src/services/student/student.service.ts
@@ -893,7 +893,7 @@ export class StudentService extends RecordDataModelService<Student> {
         user: { id: true, firstName: true, lastName: true, email: true },
         birthDate: true,
         contactInfo: true as unknown,
-        applications: { applicationNumber: true },
+        applications: { id: true, applicationNumber: true },
       },
       relations: {
         sinValidation: true,


### PR DESCRIPTION
- Querying the id is necessary for TypeOrm to bring multiple numbers for the `applications` array. Otherwise, it brings only one application in the array in the `student` object.

![image](https://github.com/user-attachments/assets/487a0e1e-97ab-4e4e-b974-f2d92898fc09)
