### PR TITLE
#4041 - Ignore Cancelled Legacy Applications on SIMS Validations and Calculations

### DIFF
--- a/sources/packages/backend/apps/api/src/route-controllers/application/_tests_/application.students.controller.submitApplication.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/application/_tests_/application.students.controller.submitApplication.e2e-spec.ts
@@ -155,7 +155,7 @@ describe("ApplicationStudentsController(e2e)-submitApplication", () => {
       });
   });
 
-  it("Should throw study dates overlap error when a part time application submitted for a student via the SFAS system has overlapping study start or study end dates with another application.", async () => {
+  it("Should throw study dates overlap error when a part-time application submitted for a student via the SFAS system has overlapping study start or study end dates with another application.", async () => {
     // Arrange
     const student = await saveFakeStudent(db.dataSource);
     const sfasIndividual = await saveFakeSFASIndividual(db.dataSource, {
@@ -252,7 +252,7 @@ describe("ApplicationStudentsController(e2e)-submitApplication", () => {
       });
   });
 
-  it("Should throw study dates overlap error when a full time application is submitted for a student via the SFAS system has overlapping study start or study end dates with another application.", async () => {
+  it("Should throw study dates overlap error when a full-time application is submitted for a student via the SFAS system has overlapping study start or study end dates with another application.", async () => {
     // Arrange
     const student = await saveFakeStudent(db.dataSource);
     const sfasIndividual = await saveFakeSFASIndividual(db.dataSource, {
@@ -436,7 +436,7 @@ describe("ApplicationStudentsController(e2e)-submitApplication", () => {
   });
 
   it(
-    "Should submit an application for a student when there is a cancelled full time application in SFAS with overlapping study dates" +
+    "Should submit an application for a student when there is a cancelled full-time application in SFAS with overlapping study dates" +
       " ignoring the cancelled SFAS application.",
     async () => {
       // Arrange

--- a/sources/packages/backend/apps/api/src/route-controllers/application/_tests_/application.students.controller.submitApplication.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/application/_tests_/application.students.controller.submitApplication.e2e-spec.ts
@@ -32,6 +32,7 @@ import { SystemUsersService } from "@sims/services";
 import { FormNames, FormService } from "../../../services";
 import { AppStudentsModule } from "../../../app.students.module";
 import { createFakeSFASPartTimeApplication } from "@sims/test-utils/factories/sfas-part-time-application";
+import { createFakeSFASApplication } from "@sims/test-utils/factories/sfas-application";
 
 describe("ApplicationStudentsController(e2e)-submitApplication", () => {
   let app: INestApplication;
@@ -154,7 +155,100 @@ describe("ApplicationStudentsController(e2e)-submitApplication", () => {
       });
   });
 
-  it("Should throw study dates overlap error when an application submitted for a student via the SFAS system has overlapping study start or study end dates with another application.", async () => {
+  it("Should throw study dates overlap error when a full time application is submitted for a student via the SFAS system has overlapping study start or study end dates with another application.", async () => {
+    // Arrange
+    const student = await saveFakeStudent(db.dataSource);
+    const sfasIndividual = await saveFakeSFASIndividual(db.dataSource, {
+      initialValues: {
+        lastName: student.user.lastName,
+        birthDate: student.birthDate,
+        sin: student.sinValidation.sin,
+      },
+    });
+
+    const sfasFullTimeApplication = createFakeSFASApplication(
+      { individual: sfasIndividual },
+      {
+        initialValues: {
+          startDate: getISODateOnlyString(new Date()),
+          endDate: getISODateOnlyString(addDays(50)),
+        },
+      },
+    );
+    await db.sfasApplication.save(sfasFullTimeApplication);
+    // Create a fake offering for the second application.
+    const auditUser = await db.user.save(createFakeUser());
+
+    // SIMS Offering having overlapping study period with SFAS.
+    const simsApplicationOfferingInitialValues = {
+      studyStartDate: getISODateOnlyString(addDays(40)),
+      studyEndDate: getISODateOnlyString(addDays(90)),
+      offeringIntensity: OfferingIntensity.partTime,
+    };
+    const fakeOffering = createFakeEducationProgramOffering(
+      {
+        auditUser,
+      },
+      {
+        initialValues: simsApplicationOfferingInitialValues,
+      },
+    );
+    const savedOffering = await db.educationProgramOffering.save(fakeOffering);
+    const simsApplication = createFakeApplication(
+      {
+        student,
+        location: fakeOffering.institutionLocation,
+      },
+      {
+        initialValue: {
+          data: {},
+          applicationStatus: ApplicationStatus.Draft,
+          applicationStatusUpdatedOn: new Date(),
+          creator: systemUsersService.systemUser,
+          createdAt: new Date(),
+        } as Application,
+      },
+    );
+    const secondDraftApplication = await db.application.save(simsApplication);
+    const applicationData = {
+      selectedOfferingDate: simsApplicationOfferingInitialValues.studyStartDate,
+      selectedOfferingEndDate:
+        simsApplicationOfferingInitialValues.studyEndDate,
+      howWillYouBeAttendingTheProgram:
+        simsApplicationOfferingInitialValues.offeringIntensity,
+      selectedProgram: savedOffering.educationProgram.id,
+      selectedOffering: savedOffering.id,
+    };
+    const payload = {
+      associatedFiles: [],
+      data: applicationData,
+      programYearId: simsApplication.programYear.id,
+    } as SaveApplicationAPIInDTO;
+    const endpoint = `/students/application/${secondDraftApplication.id}/submit`;
+    const token = await getStudentToken(
+      FakeStudentUsersTypes.FakeStudentUserType1,
+    );
+    const dryRunSubmissionMock = jest.fn().mockResolvedValue({
+      valid: true,
+      formName: FormNames.Application,
+      data: { data: applicationData },
+    });
+    formService.dryRunSubmission = dryRunSubmissionMock;
+    await mockUserLoginInfo(appModule, student);
+    // Act/Assert
+    await request(app.getHttpServer())
+      .patch(endpoint)
+      .send(payload)
+      .auth(token, BEARER_AUTH_TYPE)
+      .expect(HttpStatus.UNPROCESSABLE_ENTITY)
+      .expect({
+        message:
+          "There is an existing application already with overlapping study period or a pending PIR.",
+        errorType: "STUDY_DATE_OVERLAP_ERROR",
+      });
+  });
+
+  it("Should throw study dates overlap error when a part time application submitted for a student via the SFAS system has overlapping study start or study end dates with another application.", async () => {
     // Arrange
     const student = await saveFakeStudent(db.dataSource);
     const sfasIndividual = await saveFakeSFASIndividual(db.dataSource, {
@@ -340,6 +434,103 @@ describe("ApplicationStudentsController(e2e)-submitApplication", () => {
       .expect(HttpStatus.OK)
       .expect({});
   });
+
+  it(
+    "Should submit an application for a student when there is a cancelled full time application in SFAS with overlapping study dates" +
+      " ignoring the cancelled SFAS application.",
+    async () => {
+      // Arrange
+      const student = await saveFakeStudent(db.dataSource);
+      const sfasIndividual = await saveFakeSFASIndividual(db.dataSource, {
+        initialValues: {
+          lastName: student.user.lastName,
+          birthDate: student.birthDate,
+          sin: student.sinValidation.sin,
+        },
+      });
+      // Cancelled SFAS full time application with overlapping study dates.
+      const sfasFullTimeApplication = createFakeSFASApplication(
+        { individual: sfasIndividual },
+        {
+          initialValues: {
+            startDate: getISODateOnlyString(new Date()),
+            endDate: getISODateOnlyString(addDays(50)),
+            applicationCancelDate: getISODateOnlyString(new Date()),
+          },
+        },
+      );
+      await db.sfasApplication.save(sfasFullTimeApplication);
+
+      // SIMS Offering having overlapping study period with SFAS.
+      const simsApplicationOfferingInitialValues = {
+        studyStartDate: getISODateOnlyString(addDays(30)),
+        studyEndDate: getISODateOnlyString(addDays(90)),
+        offeringIntensity: OfferingIntensity.partTime,
+      };
+      const simsApplication = createFakeApplication(
+        {
+          student,
+        },
+        {
+          initialValue: {
+            data: {},
+            applicationStatus: ApplicationStatus.Draft,
+            applicationStatusUpdatedOn: new Date(),
+            creator: systemUsersService.systemUser,
+            createdAt: new Date(),
+          } as Application,
+        },
+      );
+      const simsDraftApplication = await db.application.save(simsApplication);
+      const auditUser = await db.user.save(createFakeUser());
+      const simsApplicationOffering = await db.educationProgramOffering.save(
+        createFakeEducationProgramOffering(
+          {
+            auditUser,
+            institutionLocation: simsApplication.location,
+          },
+          {
+            initialValues: simsApplicationOfferingInitialValues,
+          },
+        ),
+      );
+      const secondApplicationProgram = simsApplicationOffering.educationProgram;
+      const applicationData = {
+        selectedOfferingDate:
+          simsApplicationOfferingInitialValues.studyStartDate,
+        selectedOfferingEndDate:
+          simsApplicationOfferingInitialValues.studyEndDate,
+        howWillYouBeAttendingTheProgram:
+          simsApplicationOfferingInitialValues.offeringIntensity,
+        selectedProgram: secondApplicationProgram.id,
+        selectedOffering: simsApplicationOffering.id,
+        selectedLocation: simsApplication.location.id,
+      };
+      const payload = {
+        associatedFiles: [],
+        data: applicationData,
+        programYearId: simsApplication.programYear.id,
+      } as SaveApplicationAPIInDTO;
+      const endpoint = `/students/application/${simsDraftApplication.id}/submit`;
+      const token = await getStudentToken(
+        FakeStudentUsersTypes.FakeStudentUserType1,
+      );
+      const dryRunSubmissionMock = jest.fn().mockResolvedValue({
+        valid: true,
+        formName: FormNames.Application,
+        data: { data: applicationData },
+      });
+      formService.dryRunSubmission = dryRunSubmissionMock;
+      await mockUserLoginInfo(appModule, student);
+      // Act/Assert
+      await request(app.getHttpServer())
+        .patch(endpoint)
+        .send(payload)
+        .auth(token, BEARER_AUTH_TYPE)
+        .expect(HttpStatus.OK)
+        .expect({});
+    },
+  );
 
   afterAll(async () => {
     await app?.close();

--- a/sources/packages/backend/apps/api/src/route-controllers/application/_tests_/application.students.controller.submitApplication.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/application/_tests_/application.students.controller.submitApplication.e2e-spec.ts
@@ -455,6 +455,7 @@ describe("ApplicationStudentsController(e2e)-submitApplication", () => {
           initialValues: {
             startDate: getISODateOnlyString(new Date()),
             endDate: getISODateOnlyString(addDays(50)),
+            // The SFAS application is cancelled.
             applicationCancelDate: getISODateOnlyString(new Date()),
           },
         },

--- a/sources/packages/backend/apps/api/src/route-controllers/application/_tests_/application.students.controller.submitApplication.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/application/_tests_/application.students.controller.submitApplication.e2e-spec.ts
@@ -155,99 +155,6 @@ describe("ApplicationStudentsController(e2e)-submitApplication", () => {
       });
   });
 
-  it("Should throw study dates overlap error when a full time application is submitted for a student via the SFAS system has overlapping study start or study end dates with another application.", async () => {
-    // Arrange
-    const student = await saveFakeStudent(db.dataSource);
-    const sfasIndividual = await saveFakeSFASIndividual(db.dataSource, {
-      initialValues: {
-        lastName: student.user.lastName,
-        birthDate: student.birthDate,
-        sin: student.sinValidation.sin,
-      },
-    });
-
-    const sfasFullTimeApplication = createFakeSFASApplication(
-      { individual: sfasIndividual },
-      {
-        initialValues: {
-          startDate: getISODateOnlyString(new Date()),
-          endDate: getISODateOnlyString(addDays(50)),
-        },
-      },
-    );
-    await db.sfasApplication.save(sfasFullTimeApplication);
-    // Create a fake offering for the second application.
-    const auditUser = await db.user.save(createFakeUser());
-
-    // SIMS Offering having overlapping study period with SFAS.
-    const simsApplicationOfferingInitialValues = {
-      studyStartDate: getISODateOnlyString(addDays(40)),
-      studyEndDate: getISODateOnlyString(addDays(90)),
-      offeringIntensity: OfferingIntensity.partTime,
-    };
-    const fakeOffering = createFakeEducationProgramOffering(
-      {
-        auditUser,
-      },
-      {
-        initialValues: simsApplicationOfferingInitialValues,
-      },
-    );
-    const savedOffering = await db.educationProgramOffering.save(fakeOffering);
-    const simsApplication = createFakeApplication(
-      {
-        student,
-        location: fakeOffering.institutionLocation,
-      },
-      {
-        initialValue: {
-          data: {},
-          applicationStatus: ApplicationStatus.Draft,
-          applicationStatusUpdatedOn: new Date(),
-          creator: systemUsersService.systemUser,
-          createdAt: new Date(),
-        } as Application,
-      },
-    );
-    const secondDraftApplication = await db.application.save(simsApplication);
-    const applicationData = {
-      selectedOfferingDate: simsApplicationOfferingInitialValues.studyStartDate,
-      selectedOfferingEndDate:
-        simsApplicationOfferingInitialValues.studyEndDate,
-      howWillYouBeAttendingTheProgram:
-        simsApplicationOfferingInitialValues.offeringIntensity,
-      selectedProgram: savedOffering.educationProgram.id,
-      selectedOffering: savedOffering.id,
-    };
-    const payload = {
-      associatedFiles: [],
-      data: applicationData,
-      programYearId: simsApplication.programYear.id,
-    } as SaveApplicationAPIInDTO;
-    const endpoint = `/students/application/${secondDraftApplication.id}/submit`;
-    const token = await getStudentToken(
-      FakeStudentUsersTypes.FakeStudentUserType1,
-    );
-    const dryRunSubmissionMock = jest.fn().mockResolvedValue({
-      valid: true,
-      formName: FormNames.Application,
-      data: { data: applicationData },
-    });
-    formService.dryRunSubmission = dryRunSubmissionMock;
-    await mockUserLoginInfo(appModule, student);
-    // Act/Assert
-    await request(app.getHttpServer())
-      .patch(endpoint)
-      .send(payload)
-      .auth(token, BEARER_AUTH_TYPE)
-      .expect(HttpStatus.UNPROCESSABLE_ENTITY)
-      .expect({
-        message:
-          "There is an existing application already with overlapping study period or a pending PIR.",
-        errorType: "STUDY_DATE_OVERLAP_ERROR",
-      });
-  });
-
   it("Should throw study dates overlap error when a part time application submitted for a student via the SFAS system has overlapping study start or study end dates with another application.", async () => {
     // Arrange
     const student = await saveFakeStudent(db.dataSource);
@@ -320,6 +227,99 @@ describe("ApplicationStudentsController(e2e)-submitApplication", () => {
       associatedFiles: [],
       data: applicationData,
       programYearId: secondApplication.programYear.id,
+    } as SaveApplicationAPIInDTO;
+    const endpoint = `/students/application/${secondDraftApplication.id}/submit`;
+    const token = await getStudentToken(
+      FakeStudentUsersTypes.FakeStudentUserType1,
+    );
+    const dryRunSubmissionMock = jest.fn().mockResolvedValue({
+      valid: true,
+      formName: FormNames.Application,
+      data: { data: applicationData },
+    });
+    formService.dryRunSubmission = dryRunSubmissionMock;
+    await mockUserLoginInfo(appModule, student);
+    // Act/Assert
+    await request(app.getHttpServer())
+      .patch(endpoint)
+      .send(payload)
+      .auth(token, BEARER_AUTH_TYPE)
+      .expect(HttpStatus.UNPROCESSABLE_ENTITY)
+      .expect({
+        message:
+          "There is an existing application already with overlapping study period or a pending PIR.",
+        errorType: "STUDY_DATE_OVERLAP_ERROR",
+      });
+  });
+
+  it("Should throw study dates overlap error when a full time application is submitted for a student via the SFAS system has overlapping study start or study end dates with another application.", async () => {
+    // Arrange
+    const student = await saveFakeStudent(db.dataSource);
+    const sfasIndividual = await saveFakeSFASIndividual(db.dataSource, {
+      initialValues: {
+        lastName: student.user.lastName,
+        birthDate: student.birthDate,
+        sin: student.sinValidation.sin,
+      },
+    });
+
+    const sfasFullTimeApplication = createFakeSFASApplication(
+      { individual: sfasIndividual },
+      {
+        initialValues: {
+          startDate: getISODateOnlyString(new Date()),
+          endDate: getISODateOnlyString(addDays(50)),
+        },
+      },
+    );
+    await db.sfasApplication.save(sfasFullTimeApplication);
+    // Create a fake offering for the second application.
+    const auditUser = await db.user.save(createFakeUser());
+
+    // SIMS Offering having overlapping study period with SFAS.
+    const simsApplicationOfferingInitialValues = {
+      studyStartDate: getISODateOnlyString(addDays(40)),
+      studyEndDate: getISODateOnlyString(addDays(90)),
+      offeringIntensity: OfferingIntensity.partTime,
+    };
+    const fakeOffering = createFakeEducationProgramOffering(
+      {
+        auditUser,
+      },
+      {
+        initialValues: simsApplicationOfferingInitialValues,
+      },
+    );
+    const savedOffering = await db.educationProgramOffering.save(fakeOffering);
+    const simsApplication = createFakeApplication(
+      {
+        student,
+        location: fakeOffering.institutionLocation,
+      },
+      {
+        initialValue: {
+          data: {},
+          applicationStatus: ApplicationStatus.Draft,
+          applicationStatusUpdatedOn: new Date(),
+          creator: systemUsersService.systemUser,
+          createdAt: new Date(),
+        } as Application,
+      },
+    );
+    const secondDraftApplication = await db.application.save(simsApplication);
+    const applicationData = {
+      selectedOfferingDate: simsApplicationOfferingInitialValues.studyStartDate,
+      selectedOfferingEndDate:
+        simsApplicationOfferingInitialValues.studyEndDate,
+      howWillYouBeAttendingTheProgram:
+        simsApplicationOfferingInitialValues.offeringIntensity,
+      selectedProgram: savedOffering.educationProgram.id,
+      selectedOffering: savedOffering.id,
+    };
+    const payload = {
+      associatedFiles: [],
+      data: applicationData,
+      programYearId: simsApplication.programYear.id,
     } as SaveApplicationAPIInDTO;
     const endpoint = `/students/application/${secondDraftApplication.id}/submit`;
     const token = await getStudentToken(

--- a/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/esdc-integration/ecert-integration/_tests_/ecert-full-time-process-integration.scheduler.e2e-spec.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/esdc-integration/ecert-integration/_tests_/ecert-full-time-process-integration.scheduler.e2e-spec.ts
@@ -586,7 +586,7 @@ describe(
 
     it(
       "Should disburse BC funding for a close-to-maximum disbursement and reduce BC funding to not exceed the maximum limit and apply BC Funding Stop Restriction" +
-        " when a student reaches maximum BC life time loan amount ignoring the legacy SFAS applications that are cancelled. ",
+        " when a student reaches maximum BC life time loan amount ignoring the legacy SFAS applications that are cancelled.",
       async () => {
         // Arrange
         // Student with valid SIN.

--- a/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/esdc-integration/ecert-integration/_tests_/ecert-full-time-process-integration.scheduler.e2e-spec.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/esdc-integration/ecert-integration/_tests_/ecert-full-time-process-integration.scheduler.e2e-spec.ts
@@ -25,6 +25,7 @@ import {
   createFakeUser,
   saveFakeApplicationDisbursements,
   saveFakeApplicationRestrictionBypass,
+  saveFakeSFASIndividual,
   saveFakeStudent,
   saveFakeStudentRestriction,
 } from "@sims/test-utils";
@@ -53,6 +54,7 @@ import {
   loadAwardValues,
 } from "./e-cert-utils";
 import { RestrictionCode, SystemUsersService } from "@sims/services";
+import { createFakeSFASApplication } from "@sims/test-utils/factories/sfas-application";
 
 describe(
   describeQueueProcessorRootTest(QueueNames.FullTimeECertIntegration),
@@ -63,6 +65,7 @@ describe(
     let sftpClientMock: DeepMocked<Client>;
     let systemUsersService: SystemUsersService;
     let sharedMinistryUser: User;
+    const MAX_LIFE_TIME_BC_LOAN_AMOUNT = 50000;
 
     beforeAll(async () => {
       // Env variable required for querying the eligible e-Cert records.
@@ -362,7 +365,6 @@ describe(
 
     it("Should disburse BC funding for a close-to-maximum disbursement, reduce BC funding when passing the maximum, and withhold BC Funding when a restriction was applied due to the maximum configured value for the year was reached.", async () => {
       // Arrange
-      const MAX_LIFE_TIME_BC_LOAN_AMOUNT = 50000;
       // Ensure the right disbursement order for the 3 disbursements.
       const [disbursementDate1, disbursementDate2, disbursementDate3] = [
         getISODateOnlyString(addDays(1)),
@@ -581,6 +583,163 @@ describe(
         }),
       ).toBe(true);
     });
+
+    it.only(
+      "Should disburse BC funding for a close-to-maximum disbursement and reduce BC funding to not exceed the maximum limit and apply BC Funding Stop Restriction" +
+        " when a student reaches maximum BC life time loan amount ignoring the legacy SFAS applications that are cancelled. ",
+      async () => {
+        // Arrange
+        // Student with valid SIN.
+        const student = await saveFakeStudent(db.dataSource);
+        // Valid MSFAA Number.
+        const msfaaNumber = await db.msfaaNumber.save(
+          createFakeMSFAANumber(
+            { student },
+            { msfaaState: MSFAAStates.Signed },
+          ),
+        );
+
+        // SFAS Individual.
+        const sfasIndividual = await saveFakeSFASIndividual(db.dataSource, {
+          initialValues: {
+            student: student,
+          },
+        });
+        // SFAS Application reaching close to maximum BC Student Loan value.
+        const activeFakeSFASApplication = createFakeSFASApplication(
+          { individual: sfasIndividual },
+          {
+            initialValues: {
+              bslAward: MAX_LIFE_TIME_BC_LOAN_AMOUNT - 100,
+            },
+          },
+        );
+        // SFAS Application which is cancelled and expected to be ignored.
+        const cancelledFakeSFASApplication = createFakeSFASApplication(
+          { individual: sfasIndividual },
+          {
+            initialValues: {
+              bslAward: 100,
+              applicationCancelDate: getISODateOnlyString(new Date()),
+            },
+          },
+        );
+        await db.sfasApplication.save([
+          activeFakeSFASApplication,
+          cancelledFakeSFASApplication,
+        ]);
+
+        // The current application for the student which reaches the maximum BC life time loan amount.
+        const currentApplication = await saveFakeApplicationDisbursements(
+          db.dataSource,
+          {
+            student,
+            msfaaNumber,
+            firstDisbursementValues: [
+              createFakeDisbursementValue(
+                DisbursementValueType.CanadaLoan,
+                "CSLF",
+                199,
+              ),
+              // Should be disbursed because it is a federal grant.
+              createFakeDisbursementValue(
+                DisbursementValueType.CanadaGrant,
+                "CSGP",
+                299,
+              ),
+              // Should not be disbursed due to student exceeding the maximum BC life time loan amount.
+              createFakeDisbursementValue(
+                DisbursementValueType.BCLoan,
+                "BCSL",
+                399,
+              ),
+              // Should not be disbursed due to student exceeding the maximum BC life time loan amount.
+              createFakeDisbursementValue(
+                DisbursementValueType.BCGrant,
+                "BCAG",
+                200,
+              ),
+            ],
+          },
+          {
+            offeringIntensity: OfferingIntensity.fullTime,
+            applicationStatus: ApplicationStatus.Completed,
+            currentAssessmentInitialValues: {
+              assessmentData: { weeks: 5 } as Assessment,
+              assessmentDate: new Date(),
+            },
+            firstDisbursementInitialValues: {
+              coeStatus: COEStatus.completed,
+              coeUpdatedAt: new Date(),
+              disbursementDate: getISODateOnlyString(addDays(1)),
+            },
+          },
+        );
+
+        // Updating program year maximum to ensure the expect value.
+        currentApplication.programYear.maxLifetimeBCLoanAmount =
+          MAX_LIFE_TIME_BC_LOAN_AMOUNT;
+        await db.programYear.save(currentApplication.programYear);
+
+        // Queued job.
+        const mockedJob = mockBullJob<void>();
+
+        // Act
+        const result = await processor.processECert(mockedJob.job);
+        // Assert
+        expect(
+          mockedJob.containLogMessages([
+            "New BCLM restriction was added to the student account.",
+          ]),
+        ).toBe(true);
+
+        // Assert uploaded file.
+        const uploadedFile = getUploadedFile(sftpClientMock);
+        const fileDate = dayjs().format("YYYYMMDD");
+        expect(uploadedFile.remoteFilePath).toBe(
+          `MSFT-Request\\DPBC.EDU.FTECERTS.${fileDate}.001`,
+        );
+        expect(uploadedFile.fileLines).toHaveLength(3);
+        const uploadedFileName = `MSFT-Request\\DPBC.EDU.FTECERTS.${fileDate}.001`;
+        expect(uploadedFile.remoteFilePath).toBe(uploadedFileName);
+        expect(result).toStrictEqual([
+          "Process finalized with success.",
+          `Generated file: ${uploadedFileName}`,
+          "Uploaded records: 1",
+        ]);
+
+        const [header, record1, footer] = uploadedFile.fileLines;
+        // Validate header.
+        expect(header).toContain("100BC  NEW ENTITLEMENT");
+        // Validate footer.
+        expect(footer.substring(0, 3)).toBe("999");
+        // Check record 1 when the maximum is about to be reached but not yet.
+        const record1Parsed = new FullTimeCertRecordParser(record1);
+        expect(record1Parsed.hasUser(student.user)).toBe(true);
+        expect(record1Parsed.cslfAmount).toBe(199);
+        expect(record1Parsed.grantAmount("CSGP")).toBe(299);
+        // The estimated award for BCSL is 399, but only 100 will be disbursed as the maximum is reached.
+        expect(record1Parsed.bcslAmount).toBe(100);
+        // Check for the total BC grants value.
+        expect(record1Parsed.grantAmount("BCSG")).toBe(200);
+
+        const [currentApplicationDisbursement] =
+          currentApplication.currentAssessment.disbursementSchedules;
+        // Select the BCSL to validate the values impacted by the restriction.
+        const record1Awards = await loadAwardValues(
+          db,
+          currentApplicationDisbursement.id,
+          { valueCode: ["BCSL"] },
+        );
+        expect(
+          awardAssert(record1Awards, "BCSL", {
+            valueAmount: 399,
+            restrictionAmountSubtracted: 299,
+            effectiveAmount: 100,
+          }),
+        ).toBe(true);
+      },
+    );
 
     it("Should not generate disbursement if the Student assessment contains PD/PPD application flag is yes and Student profile PD/PPD missing approval", async () => {
       // Arrange

--- a/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/esdc-integration/ecert-integration/_tests_/ecert-full-time-process-integration.scheduler.e2e-spec.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/esdc-integration/ecert-integration/_tests_/ecert-full-time-process-integration.scheduler.e2e-spec.ts
@@ -584,7 +584,7 @@ describe(
       ).toBe(true);
     });
 
-    it.only(
+    it(
       "Should disburse BC funding for a close-to-maximum disbursement and reduce BC funding to not exceed the maximum limit and apply BC Funding Stop Restriction" +
         " when a student reaches maximum BC life time loan amount ignoring the legacy SFAS applications that are cancelled. ",
       async () => {
@@ -598,7 +598,6 @@ describe(
             { msfaaState: MSFAAStates.Signed },
           ),
         );
-
         // SFAS Individual.
         const sfasIndividual = await saveFakeSFASIndividual(db.dataSource, {
           initialValues: {
@@ -647,13 +646,13 @@ describe(
                 "CSGP",
                 299,
               ),
-              // Should not be disbursed due to student exceeding the maximum BC life time loan amount.
+              // Should disburse only 100 as the student will reach the maximum BC life time loan amount.
               createFakeDisbursementValue(
                 DisbursementValueType.BCLoan,
                 "BCSL",
                 399,
               ),
-              // Should not be disbursed due to student exceeding the maximum BC life time loan amount.
+              // BC Grants should still be disbursed since BCSL has some value.
               createFakeDisbursementValue(
                 DisbursementValueType.BCGrant,
                 "BCAG",
@@ -713,7 +712,7 @@ describe(
         expect(header).toContain("100BC  NEW ENTITLEMENT");
         // Validate footer.
         expect(footer.substring(0, 3)).toBe("999");
-        // Check record 1 when the maximum is about to be reached but not yet.
+        // Check record 1 values.
         const record1Parsed = new FullTimeCertRecordParser(record1);
         expect(record1Parsed.hasUser(student.user)).toBe(true);
         expect(record1Parsed.cslfAmount).toBe(199);

--- a/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/esdc-integration/ecert-integration/_tests_/parsers/full-time-e-cert-record-parser.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/esdc-integration/ecert-integration/_tests_/parsers/full-time-e-cert-record-parser.ts
@@ -24,7 +24,7 @@ export class FullTimeCertRecordParser extends ECertRecordParser {
         // Read till find an empty award.
         break;
       }
-      const awardAmount = record.substring(i + 4, i + 14);
+      const awardAmount = record.substring(i + 4, i + 10);
       this.awards[awardCode] = +awardAmount;
     }
   }

--- a/sources/packages/backend/apps/workers/src/controllers/assessment/_tests_/e2e/assessment.controller-verifyAssessmentCalculationOrder.e2e-spec.ts
+++ b/sources/packages/backend/apps/workers/src/controllers/assessment/_tests_/e2e/assessment.controller-verifyAssessmentCalculationOrder.e2e-spec.ts
@@ -526,6 +526,83 @@ describe("AssessmentController(e2e)-verifyAssessmentCalculationOrder", () => {
     });
   });
 
+  it("Should skip the awards from past SFAS full time cancelled application(s) for the same student and program year when calculating the program year award totals.", async () => {
+    // Arrange
+
+    // Create the student and program year to be shared across the applications.
+    const student = await saveFakeStudent(db.dataSource);
+    // Get the program year for the start date.
+    const programYear = await db.programYear.findOne({ where: { id: 2 } });
+
+    // Current application having the first assessment in progress.
+    const currentApplication = await saveFakeApplicationDisbursements(
+      db.dataSource,
+      { student },
+      {
+        offeringIntensity: OfferingIntensity.partTime,
+        applicationStatus: ApplicationStatus.InProgress,
+        currentAssessmentInitialValues: {
+          assessmentWorkflowId: "some fake id",
+          studentAssessmentStatus: StudentAssessmentStatus.InProgress,
+          assessmentDate: addDays(30, programYear.startDate),
+        },
+      },
+    );
+    const currentApplicationAssessmentDate =
+      currentApplication.currentAssessment.assessmentDate;
+    // The start date for the SFAS full time application record is set to the date before the first assessment date of the current application.
+    const firstLegacyApplicationStartDate = faker.date.between(
+      programYear.startDate,
+      addDays(-1, currentApplicationAssessmentDate),
+    );
+    const firstLegacyApplicationEndDate = addDays(
+      30,
+      currentApplicationAssessmentDate,
+    );
+    await db.application.save(currentApplication);
+
+    // SFAS Individual.
+    const sfasIndividual = await saveFakeSFASIndividual(db.dataSource, {
+      initialValues: {
+        lastName: student.user.lastName,
+        birthDate: student.birthDate,
+        sin: student.sinValidation.sin,
+      },
+    });
+    // Past SFAS application with the start date before the first assessment date of the current application.
+    const pastFakeSFASApplication = createFakeSFASApplication(
+      { individual: sfasIndividual },
+      {
+        initialValues: {
+          startDate: getISODateOnlyString(firstLegacyApplicationStartDate),
+          endDate: getISODateOnlyString(firstLegacyApplicationEndDate),
+          csgdAward: 9,
+          csgpAward: 10,
+          sbsdAward: 12,
+          bcagAward: 13,
+          // The SFAS application is cancelled.
+          applicationCancelDate: getISODateOnlyString(new Date()),
+        },
+      },
+    );
+    await db.sfasApplication.save(pastFakeSFASApplication);
+    // Act
+    const result = await assessmentController.verifyAssessmentCalculationOrder(
+      createFakeVerifyAssessmentCalculationOrderPayload(
+        currentApplication.currentAssessment.id,
+      ),
+    );
+    // Assert
+    expect(FakeWorkerJobResult.getResultType(result)).toBe(
+      MockedZeebeJobResult.Complete,
+    );
+    // The calculation will skip the SFAS full time awards as the SFAS application is cancelled.
+    expect(FakeWorkerJobResult.getOutputVariables(result)).toStrictEqual({
+      isReadyForCalculation: true,
+      latestCSLPBalance: 0,
+    });
+  });
+
   it("Should sum the awards from SFAS and SFAS part time applications data when there is no past SIMS application for the same student and program year.", async () => {
     // Arrange
 

--- a/sources/packages/backend/libs/services/src/sfas/sfas-application.service.ts
+++ b/sources/packages/backend/libs/services/src/sfas/sfas-application.service.ts
@@ -38,7 +38,10 @@ export class SFASApplicationService extends DataModelService<SFASApplication> {
       .createQueryBuilder("sfasApplication")
       .select(["sfasApplication.id"])
       .innerJoin("sfasApplication.individual", "sfasFTstudent")
-      .where("lower(sfasFTstudent.lastName) = lower(:lastName)", { lastName })
+      .where("sfasApplication.applicationCancelDate IS NULL")
+      .andWhere("lower(sfasFTstudent.lastName) = lower(:lastName)", {
+        lastName,
+      })
       .andWhere("sfasFTstudent.sin = :sin", { sin })
       .andWhere("sfasFTstudent.birthDate = :birthDate", { birthDate })
       .andWhere(
@@ -75,6 +78,7 @@ export class SFASApplicationService extends DataModelService<SFASApplication> {
       .select("SUM(sfasApplication.bslAward)")
       .innerJoin("sfasApplication.individual", "sfasFTstudent")
       .where("sfasFTstudent.id = :studentId", { studentId })
+      .andWhere("sfasApplication.applicationCancelDate IS NULL")
       .getRawOne<{ sum?: number }>();
     return +(total?.sum ?? 0);
   }

--- a/sources/packages/backend/libs/services/src/sfas/sfas-application.service.ts
+++ b/sources/packages/backend/libs/services/src/sfas/sfas-application.service.ts
@@ -76,10 +76,10 @@ export class SFASApplicationService extends DataModelService<SFASApplication> {
     const total = await this.repo
       .createQueryBuilder("sfasApplication")
       .select("SUM(sfasApplication.bslAward)")
-      .innerJoin("sfasApplication.individual", "sfasFTstudent")
-      .innerJoin("sfasFTstudent.student", "simsStudent")
+      .innerJoin("sfasApplication.individual", "individual")
+      .innerJoin("individual.student", "student")
       .where("sfasApplication.applicationCancelDate IS NULL")
-      .andWhere("simsStudent.id = :studentId", { studentId })
+      .andWhere("student.id = :studentId", { studentId })
       .getRawOne<{ sum?: number }>();
     return +(total?.sum ?? 0);
   }

--- a/sources/packages/backend/libs/services/src/sfas/sfas-application.service.ts
+++ b/sources/packages/backend/libs/services/src/sfas/sfas-application.service.ts
@@ -77,8 +77,8 @@ export class SFASApplicationService extends DataModelService<SFASApplication> {
       .createQueryBuilder("sfasApplication")
       .select("SUM(sfasApplication.bslAward)")
       .innerJoin("sfasApplication.individual", "sfasFTstudent")
-      .where("sfasFTstudent.id = :studentId", { studentId })
-      .andWhere("sfasApplication.applicationCancelDate IS NULL")
+      .where("sfasApplication.applicationCancelDate IS NULL")
+      .andWhere("sfasFTstudent.id = :studentId", { studentId })
       .getRawOne<{ sum?: number }>();
     return +(total?.sum ?? 0);
   }

--- a/sources/packages/backend/libs/services/src/sfas/sfas-application.service.ts
+++ b/sources/packages/backend/libs/services/src/sfas/sfas-application.service.ts
@@ -77,8 +77,9 @@ export class SFASApplicationService extends DataModelService<SFASApplication> {
       .createQueryBuilder("sfasApplication")
       .select("SUM(sfasApplication.bslAward)")
       .innerJoin("sfasApplication.individual", "sfasFTstudent")
+      .innerJoin("sfasFTstudent.student", "simsStudent")
       .where("sfasApplication.applicationCancelDate IS NULL")
-      .andWhere("sfasFTstudent.id = :studentId", { studentId })
+      .andWhere("simsStudent.id = :studentId", { studentId })
       .getRawOne<{ sum?: number }>();
     return +(total?.sum ?? 0);
   }

--- a/sources/packages/backend/libs/services/src/students-assessments/assessment-sequential-processing.service.ts
+++ b/sources/packages/backend/libs/services/src/students-assessments/assessment-sequential-processing.service.ts
@@ -418,7 +418,8 @@ export class AssessmentSequentialProcessingService {
       .addSelect("SUM(sfasApplication.csgdAward)", "CSGD")
       .addSelect("SUM(sfasApplication.bcagAward)", "BCAG")
       .innerJoin("sfasApplication.individual", "sfasStudent")
-      .where("lower(sfasStudent.lastName) = lower(:lastName)", { lastName })
+      .where("sfasApplication.applicationCancelDate IS NULL")
+      .andWhere("lower(sfasStudent.lastName) = lower(:lastName)", { lastName })
       .andWhere("sfasStudent.sin = :sin", { sin })
       .andWhere("sfasStudent.birthDate = :birthDate", { birthDate })
       .andWhere("sfasApplication.startDate >= :startDate", {

--- a/sources/packages/backend/libs/test-utils/src/factories/sfas-application.ts
+++ b/sources/packages/backend/libs/test-utils/src/factories/sfas-application.ts
@@ -39,5 +39,7 @@ export function createFakeSFASApplication(
   sfasApplication.createdAt = faker.date.past(18);
   sfasApplication.updatedAt = faker.date.past(18);
   sfasApplication.extractedAt = faker.date.past(18);
+  sfasApplication.applicationCancelDate =
+    options?.initialValues?.applicationCancelDate ?? null;
   return sfasApplication;
 }


### PR DESCRIPTION
##  Ignore Cancelled Legacy Applications on SIMS Validations and Calculations

- [x] Updated the condition to validate study period overlap ignoring the SFAS FT applications with a cancelled date.
- [x] Updated the condition to calculate program year award totals ignoring the SFAS FT applications with a cancelled date.
- [x] Updated the condition to calculate legacy BCSL total ignoring the SFAS FT applications with a cancelled date.

## FT Legacy BCSL Bug Fix

- [x] Updated the `totalLegacyBCSLAmount` method to query based on student id and not the `sfas_individual_id`.

![image](https://github.com/user-attachments/assets/d94f19cb-bf6f-48c8-83e1-7a638f5b3067)


## E2E

- [x] Added API E2E test for ignoring SFAS FT applications with a cancelled date during  study period overlap.
- [x] Added Worker E2E test for ignoring SFAS FT application(s) with a cancelled date during  program year awards total calculation.
- [x] Added Queue Consumers E2E Test for life time maximum BCSL including the awards from Legacy.