### PR TITLE
#4013 - Legacy Restriction Mapping - Student Changes

### DIFF
--- a/sims.code-workspace
+++ b/sims.code-workspace
@@ -113,6 +113,10 @@
       "golevelup",
       "Ilike",
       "lastupdated",
+      "LGCY",
+      "LGCYAAAA",
+      "LGCYBBBB",
+      "LGCYCCCC",
       "MBAL",
       "MSFAA",
       "NOAAPI",
@@ -134,9 +138,7 @@
       "timestamptz",
       "typeorm",
       "unparse",
-      "Zeebe",
-      "LGCY",
-      "SFAS"
+      "Zeebe"
     ],
     "[json]": {
       "editor.defaultFormatter": "vscode.json-language-features"

--- a/sources/packages/backend/apps/api/src/route-controllers/restriction/_tests_/e2e/restriction.students.controller.getStudentRestrictions.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/restriction/_tests_/e2e/restriction.students.controller.getStudentRestrictions.e2e-spec.ts
@@ -32,7 +32,7 @@ describe("RestrictionStudentsController(e2e)-getStudentRestrictions", () => {
     appModule = module;
   });
 
-  it("Should get the active student restrictions including legacy restrictions when the student has active student restrictions.", async () => {
+  it(`Should get the active student restrictions including legacy restrictions and skipping '${RestrictionNotificationType.NoEffect}' when the student has active student restrictions.`, async () => {
     // Arrange
     const student = await saveFakeStudent(db.dataSource);
     // Restrictions to be associated with the student.
@@ -42,8 +42,11 @@ describe("RestrictionStudentsController(e2e)-getStudentRestrictions", () => {
       },
       where: {
         restrictionCode: In([
+          // 'No effect' restrictions.
+          // RestrictionCode.LGCYAAAA,
+          RestrictionCode.AF4,
           RestrictionCode.B6A,
-          RestrictionCode.LGCYAAAA,
+          // Notification others than 'No effect' that should be returned.
           RestrictionCode.LGCYBBBB,
           RestrictionCode.LGCYCCCC,
         ]),

--- a/sources/packages/backend/apps/api/src/route-controllers/restriction/_tests_/e2e/restriction.students.controller.getStudentRestrictions.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/restriction/_tests_/e2e/restriction.students.controller.getStudentRestrictions.e2e-spec.ts
@@ -43,10 +43,10 @@ describe("RestrictionStudentsController(e2e)-getStudentRestrictions", () => {
       where: {
         restrictionCode: In([
           // 'No effect' restrictions.
-          // RestrictionCode.LGCYAAAA,
+          RestrictionCode.LGCYAAAA,
           RestrictionCode.AF4,
-          RestrictionCode.B6A,
           // Notification others than 'No effect' that should be returned.
+          RestrictionCode.B6A,
           RestrictionCode.LGCYBBBB,
           RestrictionCode.LGCYCCCC,
         ]),

--- a/sources/packages/backend/apps/api/src/route-controllers/restriction/_tests_/e2e/restriction.students.controller.getStudentRestrictions.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/restriction/_tests_/e2e/restriction.students.controller.getStudentRestrictions.e2e-spec.ts
@@ -42,7 +42,7 @@ describe("RestrictionStudentsController(e2e)-getStudentRestrictions", () => {
       },
       where: {
         restrictionCode: In([
-          RestrictionCode.AF4,
+          RestrictionCode.B6A,
           RestrictionCode.LGCYAAAA,
           RestrictionCode.LGCYBBBB,
           RestrictionCode.LGCYCCCC,

--- a/sources/packages/backend/apps/api/src/route-controllers/restriction/_tests_/e2e/restriction.students.controller.getStudentRestrictions.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/restriction/_tests_/e2e/restriction.students.controller.getStudentRestrictions.e2e-spec.ts
@@ -1,0 +1,83 @@
+import { HttpStatus, INestApplication } from "@nestjs/common";
+import * as request from "supertest";
+import {
+  BEARER_AUTH_TYPE,
+  createTestingAppModule,
+  FakeStudentUsersTypes,
+  getStudentToken,
+  mockUserLoginInfo,
+} from "../../../../testHelpers";
+import {
+  createE2EDataSources,
+  E2EDataSources,
+  RestrictionCode,
+  saveFakeStudent,
+  saveFakeStudentRestriction,
+} from "@sims/test-utils";
+import { TestingModule } from "@nestjs/testing";
+import { In } from "typeorm";
+import { RestrictionNotificationType } from "@sims/sims-db";
+
+describe("RestrictionStudentsController(e2e)-getStudentRestrictions", () => {
+  let app: INestApplication;
+  let db: E2EDataSources;
+  let appModule: TestingModule;
+  const endpoint = "/students/restriction";
+
+  beforeAll(async () => {
+    const { nestApplication, module, dataSource } =
+      await createTestingAppModule();
+    app = nestApplication;
+    db = createE2EDataSources(dataSource);
+    appModule = module;
+  });
+
+  it("Should get the active student restrictions including legacy restrictions when the student has active student restrictions.", async () => {
+    // Arrange
+    const student = await saveFakeStudent(db.dataSource);
+    // Restrictions to be associated with the student.
+    const restrictions = await db.restriction.find({
+      select: {
+        id: true,
+      },
+      where: {
+        restrictionCode: In([
+          RestrictionCode.AF4,
+          RestrictionCode.LGCYAAAA,
+          RestrictionCode.LGCYBBBB,
+          RestrictionCode.LGCYCCCC,
+        ]),
+      },
+    });
+    // Associate all restriction with the student.
+    const savePromises = restrictions.map((restriction) =>
+      saveFakeStudentRestriction(db.dataSource, {
+        restriction,
+        student,
+      }),
+    );
+    await Promise.all(savePromises);
+
+    // Mock user service to return the saved student.
+    await mockUserLoginInfo(appModule, student);
+
+    // Get any student user token.
+    const studentToken = await getStudentToken(
+      FakeStudentUsersTypes.FakeStudentUserType1,
+    );
+
+    // Act/Assert
+    await request(app.getHttpServer())
+      .get(endpoint)
+      .auth(studentToken, BEARER_AUTH_TYPE)
+      .expect(HttpStatus.OK)
+      .expect([
+        { code: RestrictionCode.B6A, type: RestrictionNotificationType.Error },
+        { code: RestrictionCode.LGCY, type: RestrictionNotificationType.Error },
+      ]);
+  });
+
+  afterAll(async () => {
+    await app?.close();
+  });
+});

--- a/sources/packages/backend/apps/api/src/route-controllers/restriction/restriction.students.controller.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/restriction/restriction.students.controller.ts
@@ -31,12 +31,12 @@ export class RestrictionStudentsController extends BaseController {
   async getStudentRestrictions(
     @UserToken() studentToken: StudentUserToken,
   ): Promise<StudentRestrictionAPIOutDTO[]> {
-    // TODO: check if filterNoEffectRestrictions should be passed.
     const studentRestrictions =
       await this.studentRestrictionService.getStudentRestrictionsById(
         studentToken.studentId,
         {
           onlyActive: true,
+          filterNoEffectRestrictions: true,
         },
       );
     // Separate the results between non-legacy and legacy restrictions.

--- a/sources/packages/backend/apps/api/src/route-controllers/restriction/restriction.students.controller.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/restriction/restriction.students.controller.ts
@@ -57,11 +57,12 @@ export class RestrictionStudentsController extends BaseController {
       const notificationOrder = Object.values(RestrictionNotificationType);
       // If any legacy restriction is present, create a generic LGCY restriction
       // with the highest notification type.
-      const [legacyRestriction] = studentRestrictions.sort(
+      studentRestrictions.sort(
         (a, b) =>
           notificationOrder.indexOf(b.restriction.notificationType) -
           notificationOrder.indexOf(a.restriction.notificationType),
       );
+      const [legacyRestriction] = studentRestrictions;
       results.push({
         code: DEFAULT_LEGACY_RESTRICTION_CODE,
         type: legacyRestriction.restriction.notificationType,

--- a/sources/packages/backend/apps/api/src/route-controllers/restriction/restriction.students.controller.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/restriction/restriction.students.controller.ts
@@ -11,6 +11,15 @@ import { RestrictionNotificationType, StudentRestriction } from "@sims/sims-db";
 import { DEFAULT_LEGACY_RESTRICTION_CODE } from "@sims/services/constants";
 
 /**
+ * Restriction notifications priority order.
+ * Priority 1 indicates the most important notification.
+ */
+const NOTIFICATION_PRIORITY_ORDER_MAP = {
+  [RestrictionNotificationType.Error]: 1,
+  [RestrictionNotificationType.Warning]: 2,
+};
+
+/**
  * Controller for Student Restrictions.
  * This consists of all Rest APIs for Student restrictions.
  */
@@ -54,13 +63,12 @@ export class RestrictionStudentsController extends BaseController {
       type: studentRestriction.restriction.notificationType,
     }));
     if (legacyRestrictions.length) {
-      const notificationOrder = Object.values(RestrictionNotificationType);
       // If any legacy restriction is present, create a generic LGCY restriction
       // with the highest notification type.
       studentRestrictions.sort(
         (a, b) =>
-          notificationOrder.indexOf(b.restriction.notificationType) -
-          notificationOrder.indexOf(a.restriction.notificationType),
+          NOTIFICATION_PRIORITY_ORDER_MAP[a.restriction.notificationType] -
+          NOTIFICATION_PRIORITY_ORDER_MAP[b.restriction.notificationType],
       );
       const [legacyRestriction] = studentRestrictions;
       results.push({

--- a/sources/packages/backend/apps/api/src/services/restriction/student-restriction.service.ts
+++ b/sources/packages/backend/apps/api/src/services/restriction/student-restriction.service.ts
@@ -62,6 +62,7 @@ export class StudentRestrictionService extends RecordDataModelService<StudentRes
         "restriction.restrictionCode",
         "restriction.description",
         "restriction.notificationType",
+        "restriction.isLegacy",
       ])
       .innerJoin("studentRestrictions.restriction", "restriction")
       .innerJoin("studentRestrictions.student", "student")

--- a/sources/packages/backend/apps/test-db-seeding/src/clean-db/clean-db.ts
+++ b/sources/packages/backend/apps/test-db-seeding/src/clean-db/clean-db.ts
@@ -9,5 +9,6 @@ export class CleanDatabase {
     // Drops the database and all its data.It will erase all your database tables and their data.
     await this.dataSource.dropDatabase();
     await this.dataSource.query("DROP EXTENSION pg_trgm");
+    await this.dataSource.query("DROP FUNCTION sims.create_history_entry");
   }
 }

--- a/sources/packages/backend/apps/test-db-seeding/src/db-seeding/restriction/basic-seeding/create-restrictions.model.ts
+++ b/sources/packages/backend/apps/test-db-seeding/src/db-seeding/restriction/basic-seeding/create-restrictions.model.ts
@@ -8,6 +8,10 @@ export interface FakeRestriction {
   description: string;
 }
 
+/**
+ * Additional data for restrictions created besides the ones
+ * already created by the regular DB migrations.
+ */
 export const RESTRICTIONS_ADDITIONAL_DATA: FakeRestriction[] = [
   {
     restrictionType: RestrictionType.Provincial,

--- a/sources/packages/backend/apps/test-db-seeding/src/db-seeding/restriction/basic-seeding/create-restrictions.model.ts
+++ b/sources/packages/backend/apps/test-db-seeding/src/db-seeding/restriction/basic-seeding/create-restrictions.model.ts
@@ -1,0 +1,33 @@
+import { RestrictionNotificationType, RestrictionType } from "@sims/sims-db";
+
+export interface FakeRestriction {
+  restrictionType: RestrictionType;
+  isLegacy: boolean;
+  restrictionCode: string;
+  notificationType: RestrictionNotificationType;
+  description: string;
+}
+
+export const RESTRICTIONS_ADDITIONAL_DATA: FakeRestriction[] = [
+  {
+    restrictionType: RestrictionType.Provincial,
+    isLegacy: true,
+    restrictionCode: "LGCY_AAAA",
+    notificationType: RestrictionNotificationType.NoEffect,
+    description: "Description for LGCY_AAAA",
+  },
+  {
+    restrictionType: RestrictionType.Provincial,
+    isLegacy: true,
+    restrictionCode: "LGCY_BBBB",
+    notificationType: RestrictionNotificationType.Warning,
+    description: "Description for LGCY_BBBB",
+  },
+  {
+    restrictionType: RestrictionType.Provincial,
+    isLegacy: true,
+    restrictionCode: "LGCY_CCCC",
+    notificationType: RestrictionNotificationType.Error,
+    description: "Description for LGCY_CCCC",
+  },
+];

--- a/sources/packages/backend/apps/test-db-seeding/src/db-seeding/restriction/basic-seeding/create-restrictions.ts
+++ b/sources/packages/backend/apps/test-db-seeding/src/db-seeding/restriction/basic-seeding/create-restrictions.ts
@@ -1,0 +1,29 @@
+import { Injectable } from "@nestjs/common";
+import { InjectRepository } from "@nestjs/typeorm";
+import { Restriction } from "@sims/sims-db";
+import {
+  DataSeed,
+  DataSeedMethod,
+  SeedPriorityOrder,
+} from "../../../seed-executors";
+import { Repository } from "typeorm";
+import { RESTRICTIONS_ADDITIONAL_DATA } from "./create-restrictions.model";
+import { createFakeRestriction } from "@sims/test-utils";
+
+@Injectable()
+@DataSeed({ order: SeedPriorityOrder.Priority1 })
+export class CreateRestrictions {
+  constructor(
+    @InjectRepository(Restriction)
+    private readonly restrictionRepo: Repository<Restriction>,
+  ) {}
+
+  @DataSeedMethod()
+  async createRestrictions(): Promise<void> {
+    const additionalRestrictions = RESTRICTIONS_ADDITIONAL_DATA.map(
+      (restrictionData) =>
+        createFakeRestriction({ initialValues: { ...restrictionData } }),
+    );
+    await this.restrictionRepo.insert(additionalRestrictions);
+  }
+}

--- a/sources/packages/backend/apps/test-db-seeding/src/db-seeding/restriction/basic-seeding/create-restrictions.ts
+++ b/sources/packages/backend/apps/test-db-seeding/src/db-seeding/restriction/basic-seeding/create-restrictions.ts
@@ -18,6 +18,9 @@ export class CreateRestrictions {
     private readonly restrictionRepo: Repository<Restriction>,
   ) {}
 
+  /**
+   * Seeds the database with additional fake restrictions.
+   */
   @DataSeedMethod()
   async createRestrictions(): Promise<void> {
     const additionalRestrictions = RESTRICTIONS_ADDITIONAL_DATA.map(

--- a/sources/packages/backend/apps/test-db-seeding/src/db-seeding/restriction/index.ts
+++ b/sources/packages/backend/apps/test-db-seeding/src/db-seeding/restriction/index.ts
@@ -1,0 +1,1 @@
+export * from "./basic-seeding/create-restrictions";

--- a/sources/packages/backend/apps/test-db-seeding/src/main.ts
+++ b/sources/packages/backend/apps/test-db-seeding/src/main.ts
@@ -32,6 +32,7 @@ const TEST_DB_NAME = "_TESTS";
       await app.get(CleanDatabase).cleanDatabase();
       console.info("Database cleaned.");
     }
+    await app.close();
     return;
   }
 
@@ -55,4 +56,5 @@ const TEST_DB_NAME = "_TESTS";
       .split(",");
   }
   await app.get(SeedExecutor).executeSeed(testClassList);
+  await app.close();
 })();

--- a/sources/packages/backend/apps/test-db-seeding/src/test-db-seeding.module.ts
+++ b/sources/packages/backend/apps/test-db-seeding/src/test-db-seeding.module.ts
@@ -16,6 +16,7 @@ import {
 import { ConfigModule } from "@sims/utilities/config";
 import { CreateAESTUsers } from "./db-seeding/aest";
 import { CreateStudentUsers } from "./db-seeding/student";
+import { CreateRestrictions } from "./db-seeding/restriction";
 
 @Module({
   imports: [DatabaseModule, ConfigModule],
@@ -31,6 +32,7 @@ import { CreateStudentUsers } from "./db-seeding/student";
     CreateInstitutionsAndAuthenticationUsers,
     CreateAESTUsers,
     CreateStudentUsers,
+    CreateRestrictions,
   ],
 })
 export class TestDbSeedingModule {}

--- a/sources/packages/backend/libs/services/src/constants/restriction.constants.ts
+++ b/sources/packages/backend/libs/services/src/constants/restriction.constants.ts
@@ -2,3 +2,7 @@
  * Restriction code of provincial default restriction.
  */
 export const PROVINCIAL_DEFAULT_RESTRICTION_CODE = "B2";
+/**
+ * Default code for a legacy restriction.
+ */
+export const DEFAULT_LEGACY_RESTRICTION_CODE = "LGCY";

--- a/sources/packages/backend/libs/test-utils/src/factories/restriction.ts
+++ b/sources/packages/backend/libs/test-utils/src/factories/restriction.ts
@@ -1,0 +1,36 @@
+import {
+  Restriction,
+  RestrictionActionType,
+  RestrictionNotificationType,
+  RestrictionType,
+} from "@sims/sims-db";
+import * as faker from "faker";
+
+/**
+ * Creates a fake restriction to be persisted.
+ * @param options - options for creating the fake restriction.
+ * - `initialValues`: initial values to override the default ones for the restriction fields.
+ * @returns fake restriction to be persisted.
+ */
+export function createFakeRestriction(options?: {
+  initialValues: Partial<Restriction>;
+}): Restriction {
+  const restriction = new Restriction();
+  restriction.restrictionType =
+    options?.initialValues.restrictionType ?? RestrictionType.Provincial;
+  restriction.restrictionCategory =
+    options?.initialValues.restrictionCategory ?? "Other";
+  restriction.restrictionCode =
+    options?.initialValues.restrictionCode ??
+    faker.random.alpha({ count: 10, upcase: true });
+  restriction.description =
+    options?.initialValues.description ?? faker.random.words(2);
+  restriction.actionType = options?.initialValues.actionType ?? [
+    RestrictionActionType.NoEffect,
+  ];
+  restriction.notificationType =
+    options?.initialValues.notificationType ??
+    RestrictionNotificationType.NoEffect;
+  restriction.isLegacy = options?.initialValues.isLegacy ?? false;
+  return restriction;
+}

--- a/sources/packages/backend/libs/test-utils/src/index.ts
+++ b/sources/packages/backend/libs/test-utils/src/index.ts
@@ -37,3 +37,4 @@ export * from "./factories/supporting-user";
 export * from "./factories/application-restriction-bypass";
 export * from "./factories/cas-supplier";
 export * from "./factories/sfas-restriction-maps";
+export * from "./factories/restriction";

--- a/sources/packages/backend/libs/test-utils/src/models/common.model.ts
+++ b/sources/packages/backend/libs/test-utils/src/models/common.model.ts
@@ -100,4 +100,19 @@ export enum RestrictionCode {
    * B6A restriction.
    */
   B6A = "B6A",
+  /**
+   * Legacy restriction added during DB seeding.
+   * Notification type as no effect.
+   */
+  LGCYAAAA = "LGCY_AAAA",
+  /**
+   * Legacy restriction added during DB seeding.
+   * Notification type as warning.
+   */
+  LGCYBBBB = "LGCY_BBBB",
+  /**
+   * Legacy restriction added during DB seeding.
+   * Notification type as error.
+   */
+  LGCYCCCC = "LGCY_CCCC",
 }

--- a/sources/packages/backend/package.json
+++ b/sources/packages/backend/package.json
@@ -25,7 +25,7 @@
     "test:watch": "jest --watch ",
     "test:cov": "cross-env ENVIRONMENT=test jest --coverage --forceExit",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
-    "test:e2e:api": "npm run db:seed:test filter=CreateInstitutionsAndAuthenticationUsers,CreateAESTUsers,CreateStudentUsers && cross-env ENVIRONMENT=test jest --collect-coverage --verbose --config ./apps/api/test/jest-e2e.json --forceExit",
+    "test:e2e:api": "npm run db:seed:test filter=CreateInstitutionsAndAuthenticationUsers,CreateAESTUsers,CreateStudentUsers,CreateRestrictions && cross-env ENVIRONMENT=test jest --collect-coverage --verbose --config ./apps/api/test/jest-e2e.json --forceExit",
     "test:e2e:api:local": "cross-env ENVIRONMENT=test TZ=UTC jest --config ./apps/api/test/jest-e2e.json --forceExit",
     "test:e2e:workers": "npm run migration:run && cross-env ENVIRONMENT=test jest --collect-coverage --verbose --config ./apps/workers/test/jest-e2e.json --forceExit",
     "test:e2e:workers:local": "cross-env ENVIRONMENT=test jest --collect-coverage --verbose --config ./apps/workers/test/jest-e2e.json --forceExit",


### PR DESCRIPTION
- Prevent API from retuning 'No effect' notifications since they are not supposed to be notified to the student.
- Consolidated `LGCY_*` restrictions into a single `LGCY` restriction code to be returned to the student. The error code returned will be the highest one present in the list of the `LGCY_*` being returned.
- Create few `LGCY_*` in the DB seed to allow the E2E to use them.
  - Fixed the `db:seed:test:clean` that was not removing the `create_history_entry` function leading to an error when the DB was populated again.
  - Close Nestjs app (`app.close()`) to avoid the `db:seed:test:clean` and `db:seed:test` to be hanging and waiting.
 
### Ministry visualization for the new legacy map

![image](https://github.com/user-attachments/assets/e50659f4-4cc1-4b9a-b6a6-de27e99c79b9)

### SQL to be manually added during release

```sql
INSERT INTO
    sims.sfas_restriction_maps (legacy_code, code, is_legacy_only)
VALUES
    ('TD', 'LGCY_TD', TRUE),
    ('B5', 'LGCY_B5', TRUE),
    ('B5A', 'LGCY_B5A', TRUE),
    ('B7', 'LGCY_B7', TRUE),
    ('SSD', 'LGCY_SSD', TRUE),
    ('Z2', 'LGCY_Z2', TRUE),
    ('M1', 'LGCY_M1', TRUE),
    ('SSRN', 'LGCY_SSRN', TRUE),
    ('B4', 'LGCY_B4', TRUE),
    ('Z1', 'LGCY_Z1', TRUE)
```
