### PR TITLE
#3983 - CAS Addressline1 Update - Restrict to Alpha Numeric

### DIFF
--- a/sources/packages/backend/libs/integrations/src/cas/_tests_/unit/cas.service.createSiteForExistingSupplier.spec.ts
+++ b/sources/packages/backend/libs/integrations/src/cas/_tests_/unit/cas.service.createSiteForExistingSupplier.spec.ts
@@ -35,7 +35,7 @@ describe("CASService-createSiteForExistingSupplier", () => {
       supplierNumber: "1234567",
       emailAddress: "test@test.com",
       supplierSite: {
-        addressLine1: "Street-Special Characters-ãñè-Maximum",
+        addressLine1: "{[(Street—5pecial)]},. Characters-ãñè-Maximum",
         city: "City Name Over Maximum Length",
         provinceCode: "BC",
         postalCode: "h1h h2h",
@@ -52,7 +52,7 @@ describe("CASService-createSiteForExistingSupplier", () => {
         SupplierNumber: "1234567",
         SupplierAddress: [
           {
-            AddressLine1: "STREET-SPECIAL CHARACTERS-ANE-MAXIM",
+            AddressLine1: "STREET-5PECIAL CHARACTERS-ANE-MAXIM",
             City: "City Name Over Maximum Le",
             Province: "BC",
             Country: "CA",

--- a/sources/packages/backend/libs/integrations/src/cas/_tests_/unit/cas.service.createSupplierAndSite.spec.ts
+++ b/sources/packages/backend/libs/integrations/src/cas/_tests_/unit/cas.service.createSupplierAndSite.spec.ts
@@ -35,7 +35,7 @@ describe("CASService-createSupplierAndSite", () => {
       sin: "999999999",
       emailAddress: "test@test.com",
       supplierSite: {
-        addressLine1: "Street-Special Characters-ãñè-Maximum",
+        addressLine1: "{[(Street—5pecial)]},. Characters-ãñè-Maximum",
         city: "City Name Over Maximum Length",
         provinceCode: "BC",
         postalCode: "h1h h2h",
@@ -55,7 +55,7 @@ describe("CASService-createSupplierAndSite", () => {
         Sin: "999999999",
         SupplierAddress: [
           {
-            AddressLine1: "STREET-SPECIAL CHARACTERS-ANE-MAXIM",
+            AddressLine1: "STREET-5PECIAL CHARACTERS-ANE-MAXIM",
             City: "City Name Over Maximum Le",
             Province: "BC",
             Country: "CA",

--- a/sources/packages/backend/libs/integrations/src/cas/cas-formatters.ts
+++ b/sources/packages/backend/libs/integrations/src/cas/cas-formatters.ts
@@ -29,7 +29,8 @@ export function formatAddress(address: string): string {
   return convertToASCIIString(address)
     .toUpperCase()
     .replace(/[^A-Z0-9\-\s]/g, "")
-    .substring(0, CAS_ADDRESS_MAX_LENGTH);
+    .substring(0, CAS_ADDRESS_MAX_LENGTH)
+    .trim();
 }
 
 /**

--- a/sources/packages/backend/libs/integrations/src/cas/cas-formatters.ts
+++ b/sources/packages/backend/libs/integrations/src/cas/cas-formatters.ts
@@ -26,9 +26,10 @@ export function formatUserName(firstName: string, lastName: string): string {
  * @returns formatted address.
  */
 export function formatAddress(address: string): string {
-  return convertToASCIIString(
-    address.substring(0, CAS_ADDRESS_MAX_LENGTH).trim(),
-  ).toUpperCase();
+  return convertToASCIIString(address)
+    .toUpperCase()
+    .replace(/[^A-Z0-9\-\s]/g, "")
+    .substring(0, CAS_ADDRESS_MAX_LENGTH);
 }
 
 /**


### PR DESCRIPTION
- Added `replace(/[^A-Z0-9\-\s]/g, "")` to `formatAddress()` to remove everything that is not A-Z (capital letters), hyphens or whitespace;
- Added invalid characters to unit test.