### PR TITLE
#4082 -  2 Disbursement PT Schedules - Correct First Disbursement Date

### DIFF
--- a/sources/packages/backend/workflow/src/workflow-definitions/parttime-configure-disbursement.bpmn
+++ b/sources/packages/backend/workflow/src/workflow-definitions/parttime-configure-disbursement.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_0uxv5b2" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.25.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.1.0">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_0uxv5b2" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.28.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.1.0">
   <bpmn:process id="parttime-configure-disbursement" name="parttime-configure-disbursement" isExecutable="true">
     <bpmn:exclusiveGateway id="Gateway_0hiv6nu">
       <bpmn:incoming>Flow_16jouca</bpmn:incoming>
@@ -34,7 +34,6 @@
         <zeebe:ioMapping>
           <zeebe:output source="=disbursmenentScheduleDate2Potential" target="disbursmenentScheduleDate2" />
           <zeebe:output source="=2" target="disbursementScheduleNumber" />
-          <zeebe:output source="=today()" target="disbursmenentScheduleDate1" />
         </zeebe:ioMapping>
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_1vbepy0</bpmn:incoming>

--- a/sources/packages/backend/workflow/test/2022-2023/parttime-assessment/disbursements/parttime-assessment-disbursements.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2022-2023/parttime-assessment/disbursements/parttime-assessment-disbursements.e2e-spec.ts
@@ -363,7 +363,7 @@ describe(`E2E Test Workflow parttime-assessment-${PROGRAM_YEAR}-disbursements`, 
 
   describe("Should round down the values for the disbursement when two disbursements are expected and ", () => {
     for (const testFinalAwardNetAmount of TEST_FINAL_AWARD_NET_AMOUNTS) {
-      it.only(`the final award of each type is ${testFinalAwardNetAmount.finalAwardNetAmount}.`, async () => {
+      it(`the final award of each type is ${testFinalAwardNetAmount.finalAwardNetAmount}.`, async () => {
         // Arrange
         const configureDisbursementData =
           createFakeConfigureDisbursementPartTimeData(PROGRAM_YEAR);

--- a/sources/packages/backend/workflow/test/2022-2023/parttime-assessment/disbursements/parttime-assessment-disbursements.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2022-2023/parttime-assessment/disbursements/parttime-assessment-disbursements.e2e-spec.ts
@@ -58,8 +58,8 @@ describe(`E2E Test Workflow parttime-assessment-${PROGRAM_YEAR}-disbursements`, 
     // Assert
     expect(calculatedAssessment.variables.disbursementSchedules).toStrictEqual([
       {
-        disbursementDate: getISODateOnlyString(addDays(30)),
-        negotiatedExpiryDate: getISODateOnlyString(addDays(30)),
+        disbursementDate: configureDisbursementData.offeringStudyStartDate,
+        negotiatedExpiryDate: configureDisbursementData.offeringStudyStartDate,
         disbursements: [
           {
             awardEligibility: true,
@@ -193,8 +193,9 @@ describe(`E2E Test Workflow parttime-assessment-${PROGRAM_YEAR}-disbursements`, 
         calculatedAssessment.variables.disbursementSchedules,
       ).toStrictEqual([
         {
-          disbursementDate: getISODateOnlyString(getUTCNow()),
-          negotiatedExpiryDate: getISODateOnlyString(getUTCNow()),
+          disbursementDate: configureDisbursementData.offeringStudyStartDate,
+          negotiatedExpiryDate:
+            configureDisbursementData.offeringStudyStartDate,
           disbursements: [
             {
               awardEligibility: true,
@@ -313,8 +314,9 @@ describe(`E2E Test Workflow parttime-assessment-${PROGRAM_YEAR}-disbursements`, 
           calculatedAssessment.variables.disbursementSchedules,
         ).toStrictEqual([
           {
-            disbursementDate: getISODateOnlyString(addDays(30)),
-            negotiatedExpiryDate: getISODateOnlyString(addDays(30)),
+            disbursementDate: configureDisbursementData.offeringStudyStartDate,
+            negotiatedExpiryDate:
+              configureDisbursementData.offeringStudyStartDate,
             disbursements: [
               {
                 awardEligibility: true,
@@ -361,7 +363,7 @@ describe(`E2E Test Workflow parttime-assessment-${PROGRAM_YEAR}-disbursements`, 
 
   describe("Should round down the values for the disbursement when two disbursements are expected and ", () => {
     for (const testFinalAwardNetAmount of TEST_FINAL_AWARD_NET_AMOUNTS) {
-      it(`the final award of each type is ${testFinalAwardNetAmount.finalAwardNetAmount}.`, async () => {
+      it.only(`the final award of each type is ${testFinalAwardNetAmount.finalAwardNetAmount}.`, async () => {
         // Arrange
         const configureDisbursementData =
           createFakeConfigureDisbursementPartTimeData(PROGRAM_YEAR);
@@ -393,8 +395,9 @@ describe(`E2E Test Workflow parttime-assessment-${PROGRAM_YEAR}-disbursements`, 
           calculatedAssessment.variables.disbursementSchedules,
         ).toStrictEqual([
           {
-            disbursementDate: getISODateOnlyString(getUTCNow()),
-            negotiatedExpiryDate: getISODateOnlyString(getUTCNow()),
+            disbursementDate: configureDisbursementData.offeringStudyStartDate,
+            negotiatedExpiryDate:
+              configureDisbursementData.offeringStudyStartDate,
             disbursements: [
               {
                 awardEligibility: true,

--- a/sources/packages/backend/workflow/test/2023-2024/parttime-assessment/disbursements/parttime-assessment-disbursements.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2023-2024/parttime-assessment/disbursements/parttime-assessment-disbursements.e2e-spec.ts
@@ -363,7 +363,7 @@ describe(`E2E Test Workflow parttime-assessment-${PROGRAM_YEAR}-disbursements`, 
 
   describe("Should round down the values for the disbursement when two disbursements are expected and ", () => {
     for (const testFinalAwardNetAmount of TEST_FINAL_AWARD_NET_AMOUNTS) {
-      it.only(`the final award of each type is ${testFinalAwardNetAmount.finalAwardNetAmount}.`, async () => {
+      it(`the final award of each type is ${testFinalAwardNetAmount.finalAwardNetAmount}.`, async () => {
         // Arrange
         const configureDisbursementData =
           createFakeConfigureDisbursementPartTimeData(PROGRAM_YEAR);

--- a/sources/packages/backend/workflow/test/2023-2024/parttime-assessment/disbursements/parttime-assessment-disbursements.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2023-2024/parttime-assessment/disbursements/parttime-assessment-disbursements.e2e-spec.ts
@@ -58,8 +58,8 @@ describe(`E2E Test Workflow parttime-assessment-${PROGRAM_YEAR}-disbursements`, 
     // Assert
     expect(calculatedAssessment.variables.disbursementSchedules).toStrictEqual([
       {
-        disbursementDate: getISODateOnlyString(addDays(30)),
-        negotiatedExpiryDate: getISODateOnlyString(addDays(30)),
+        disbursementDate: configureDisbursementData.offeringStudyStartDate,
+        negotiatedExpiryDate: configureDisbursementData.offeringStudyStartDate,
         disbursements: [
           {
             awardEligibility: true,
@@ -193,8 +193,9 @@ describe(`E2E Test Workflow parttime-assessment-${PROGRAM_YEAR}-disbursements`, 
         calculatedAssessment.variables.disbursementSchedules,
       ).toStrictEqual([
         {
-          disbursementDate: getISODateOnlyString(getUTCNow()),
-          negotiatedExpiryDate: getISODateOnlyString(getUTCNow()),
+          disbursementDate: configureDisbursementData.offeringStudyStartDate,
+          negotiatedExpiryDate:
+            configureDisbursementData.offeringStudyStartDate,
           disbursements: [
             {
               awardEligibility: true,
@@ -313,8 +314,9 @@ describe(`E2E Test Workflow parttime-assessment-${PROGRAM_YEAR}-disbursements`, 
           calculatedAssessment.variables.disbursementSchedules,
         ).toStrictEqual([
           {
-            disbursementDate: getISODateOnlyString(addDays(30)),
-            negotiatedExpiryDate: getISODateOnlyString(addDays(30)),
+            disbursementDate: configureDisbursementData.offeringStudyStartDate,
+            negotiatedExpiryDate:
+              configureDisbursementData.offeringStudyStartDate,
             disbursements: [
               {
                 awardEligibility: true,
@@ -361,7 +363,7 @@ describe(`E2E Test Workflow parttime-assessment-${PROGRAM_YEAR}-disbursements`, 
 
   describe("Should round down the values for the disbursement when two disbursements are expected and ", () => {
     for (const testFinalAwardNetAmount of TEST_FINAL_AWARD_NET_AMOUNTS) {
-      it(`the final award of each type is ${testFinalAwardNetAmount.finalAwardNetAmount}.`, async () => {
+      it.only(`the final award of each type is ${testFinalAwardNetAmount.finalAwardNetAmount}.`, async () => {
         // Arrange
         const configureDisbursementData =
           createFakeConfigureDisbursementPartTimeData(PROGRAM_YEAR);
@@ -393,8 +395,9 @@ describe(`E2E Test Workflow parttime-assessment-${PROGRAM_YEAR}-disbursements`, 
           calculatedAssessment.variables.disbursementSchedules,
         ).toStrictEqual([
           {
-            disbursementDate: getISODateOnlyString(getUTCNow()),
-            negotiatedExpiryDate: getISODateOnlyString(getUTCNow()),
+            disbursementDate: configureDisbursementData.offeringStudyStartDate,
+            negotiatedExpiryDate:
+              configureDisbursementData.offeringStudyStartDate,
             disbursements: [
               {
                 awardEligibility: true,

--- a/sources/packages/backend/workflow/test/2024-2025/parttime-assessment/disbursements/parttime-assessment-disbursements.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2024-2025/parttime-assessment/disbursements/parttime-assessment-disbursements.e2e-spec.ts
@@ -363,7 +363,7 @@ describe(`E2E Test Workflow parttime-assessment-${PROGRAM_YEAR}-disbursements`, 
 
   describe("Should round down the values for the disbursement when two disbursements are expected and ", () => {
     for (const testFinalAwardNetAmount of TEST_FINAL_AWARD_NET_AMOUNTS) {
-      it.only(`the final award of each type is ${testFinalAwardNetAmount.finalAwardNetAmount}.`, async () => {
+      it(`the final award of each type is ${testFinalAwardNetAmount.finalAwardNetAmount}.`, async () => {
         // Arrange
         const configureDisbursementData =
           createFakeConfigureDisbursementPartTimeData(PROGRAM_YEAR);

--- a/sources/packages/backend/workflow/test/2024-2025/parttime-assessment/disbursements/parttime-assessment-disbursements.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2024-2025/parttime-assessment/disbursements/parttime-assessment-disbursements.e2e-spec.ts
@@ -58,8 +58,8 @@ describe(`E2E Test Workflow parttime-assessment-${PROGRAM_YEAR}-disbursements`, 
     // Assert
     expect(calculatedAssessment.variables.disbursementSchedules).toStrictEqual([
       {
-        disbursementDate: getISODateOnlyString(addDays(30)),
-        negotiatedExpiryDate: getISODateOnlyString(addDays(30)),
+        disbursementDate: configureDisbursementData.offeringStudyStartDate,
+        negotiatedExpiryDate: configureDisbursementData.offeringStudyStartDate,
         disbursements: [
           {
             awardEligibility: true,
@@ -193,8 +193,9 @@ describe(`E2E Test Workflow parttime-assessment-${PROGRAM_YEAR}-disbursements`, 
         calculatedAssessment.variables.disbursementSchedules,
       ).toStrictEqual([
         {
-          disbursementDate: getISODateOnlyString(getUTCNow()),
-          negotiatedExpiryDate: getISODateOnlyString(getUTCNow()),
+          disbursementDate: configureDisbursementData.offeringStudyStartDate,
+          negotiatedExpiryDate:
+            configureDisbursementData.offeringStudyStartDate,
           disbursements: [
             {
               awardEligibility: true,
@@ -313,8 +314,9 @@ describe(`E2E Test Workflow parttime-assessment-${PROGRAM_YEAR}-disbursements`, 
           calculatedAssessment.variables.disbursementSchedules,
         ).toStrictEqual([
           {
-            disbursementDate: getISODateOnlyString(addDays(30)),
-            negotiatedExpiryDate: getISODateOnlyString(addDays(30)),
+            disbursementDate: configureDisbursementData.offeringStudyStartDate,
+            negotiatedExpiryDate:
+              configureDisbursementData.offeringStudyStartDate,
             disbursements: [
               {
                 awardEligibility: true,
@@ -361,7 +363,7 @@ describe(`E2E Test Workflow parttime-assessment-${PROGRAM_YEAR}-disbursements`, 
 
   describe("Should round down the values for the disbursement when two disbursements are expected and ", () => {
     for (const testFinalAwardNetAmount of TEST_FINAL_AWARD_NET_AMOUNTS) {
-      it(`the final award of each type is ${testFinalAwardNetAmount.finalAwardNetAmount}.`, async () => {
+      it.only(`the final award of each type is ${testFinalAwardNetAmount.finalAwardNetAmount}.`, async () => {
         // Arrange
         const configureDisbursementData =
           createFakeConfigureDisbursementPartTimeData(PROGRAM_YEAR);
@@ -393,8 +395,9 @@ describe(`E2E Test Workflow parttime-assessment-${PROGRAM_YEAR}-disbursements`, 
           calculatedAssessment.variables.disbursementSchedules,
         ).toStrictEqual([
           {
-            disbursementDate: getISODateOnlyString(getUTCNow()),
-            negotiatedExpiryDate: getISODateOnlyString(getUTCNow()),
+            disbursementDate: configureDisbursementData.offeringStudyStartDate,
+            negotiatedExpiryDate:
+              configureDisbursementData.offeringStudyStartDate,
             disbursements: [
               {
                 awardEligibility: true,


### PR DESCRIPTION
Removed the code setting the first disbursement back for today.

### Sample application when the offering start date is ahead (2 disbursements)

![image](https://github.com/user-attachments/assets/cdf48f54-7838-457c-aa9d-240b386c17ed)

### Sample application when the offering start date is in the past (2 disbursements)

![image](https://github.com/user-attachments/assets/259e4572-449c-4baf-808b-d7d19ec7d49d)
