### PR TITLE
#4087 - Search Student Bug

### DIFF
--- a/sources/packages/backend/apps/api/src/services/cas-supplier/cas-supplier.service.ts
+++ b/sources/packages/backend/apps/api/src/services/cas-supplier/cas-supplier.service.ts
@@ -118,6 +118,7 @@ export class CASSupplierService {
     studentId: number,
     auditUserId: number,
   ): Promise<CASSupplier> {
+    const auditUser = { id: auditUserId } as User;
     const student = await this.studentRepo.findOne({
       select: {
         id: true,
@@ -145,10 +146,12 @@ export class CASSupplierService {
         CAS_SUPPLIER_ALREADY_IN_PENDING_SUPPLIER_VERIFICATION,
       );
     }
-    const savedStudent = await this.studentService.createPendingCASSupplier(
+    student.casSupplier = this.studentService.createPendingCASSupplier(
       studentId,
       auditUserId,
     );
+    student.modifier = auditUser;
+    const savedStudent = await this.studentRepo.save(student);
     return savedStudent.casSupplier;
   }
 }


### PR DESCRIPTION
The create student action happening when Ministry user trying to approve a student. The SIN validation table is not inserted. This causes the search to fail as it uses the below query to fetch.

![image](https://github.com/user-attachments/assets/d0138e14-e475-478e-9435-cbf944db3ebf)

This is a bug created during the cas supplier pending verification logic centralization that happened in the #3258 ticket.