### PR TITLE
#4076 - Queue Monitoring - Schedulers Refactor (Fed Restrictions and Receipts)

### DIFF
--- a/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/esdc-integration/ecert-integration/_tests_/disbursement-receipts-integration.scheduler.e2e-spec.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/esdc-integration/ecert-integration/_tests_/disbursement-receipts-integration.scheduler.e2e-spec.ts
@@ -136,20 +136,23 @@ describe(
           return createFileFromStructuredRecords(file);
         },
       );
-      // Queued job.
-      const { job } = mockBullJob<void>();
-
-      // Act
-      const [result] = await processor.processDisbursementReceipts(job);
-
-      // Assert
-      const downloadedFile = path.join(
+      const expectedFileName = path.join(
         process.env.ESDC_RESPONSE_FOLDER,
         FEDERAL_ONLY_FULL_TIME_FILE,
       );
-      expect(result.errorsSummary).toContain(
-        `Error downloading file ${downloadedFile}. Error: Error: Invalid file header.`,
+      // Queued job.
+      const mockedJob = mockBullJob<void>();
+
+      // Act/Assert
+      await expect(processor.processQueue(mockedJob.job)).rejects.toThrowError(
+        "One or more errors were reported during the process, please see logs for details.",
       );
+      expect(
+        mockedJob.containLogMessages([
+          `Error downloading file ${expectedFileName}.`,
+          "Invalid file header.",
+        ]),
+      ).toBe(true);
     });
 
     it("Should log 'SIN Hash validation failed' error when the footer has an invalid SIN total hash.", async () => {
@@ -167,20 +170,24 @@ describe(
           return createFileFromStructuredRecords(file);
         },
       );
-      // Queued job.
-      const { job } = mockBullJob<void>();
-
-      // Act
-      const [result] = await processor.processDisbursementReceipts(job);
-
-      // Assert
-      const downloadedFile = path.join(
+      // Expected file name.
+      const expectedFileName = path.join(
         process.env.ESDC_RESPONSE_FOLDER,
         FEDERAL_ONLY_FULL_TIME_FILE,
       );
-      expect(result.errorsSummary).toContain(
-        `Error downloading file ${downloadedFile}. Error: Error: SIN Hash validation failed.`,
+      // Queued job.
+      const mockedJob = mockBullJob<void>();
+
+      // Act/Assert
+      await expect(processor.processQueue(mockedJob.job)).rejects.toThrowError(
+        "One or more errors were reported during the process, please see logs for details.",
       );
+      expect(
+        mockedJob.containLogMessages([
+          `Error downloading file ${expectedFileName}.`,
+          "SIN Hash validation failed.",
+        ]),
+      ).toBe(true);
     });
 
     it("Should log 'Invalid file footer' error when the footer has a record code different than 'T'.", async () => {
@@ -195,20 +202,23 @@ describe(
           return createFileFromStructuredRecords(file);
         },
       );
-      // Queued job.
-      const { job } = mockBullJob<void>();
-
-      // Act
-      const [result] = await processor.processDisbursementReceipts(job);
-
-      // Assert
-      const downloadedFile = path.join(
+      const expectedFileName = path.join(
         process.env.ESDC_RESPONSE_FOLDER,
         FEDERAL_ONLY_FULL_TIME_FILE,
       );
-      expect(result.errorsSummary).toContain(
-        `Error downloading file ${downloadedFile}. Error: Error: Invalid file footer.`,
+      // Queued job.
+      const mockedJob = mockBullJob<void>();
+
+      // Act/Assert
+      await expect(processor.processQueue(mockedJob.job)).rejects.toThrow(
+        "One or more errors were reported during the process, please see logs for details.",
       );
+      expect(
+        mockedJob.containLogMessages([
+          `Error downloading file ${expectedFileName}.`,
+          "Invalid file footer.",
+        ]),
+      ).toBe(true);
     });
 
     it("Should import disbursement receipt file and create federal and provincial awards receipts with proper awards code mappings for a full-time application when the file contains federal and provincial receipts.", async () => {
@@ -222,29 +232,29 @@ describe(
       });
       mockDownloadFiles(sftpClientMock, [FEDERAL_PROVINCIAL_FULL_TIME_FILE]);
       // Queued job.
-      const { job } = mockBullJob<void>();
+      const mockedJob = mockBullJob<void>();
 
       // Act
-      const result = await processor.processDisbursementReceipts(job);
+      const result = await processor.processQueue(mockedJob.job);
 
       // Assert
+      expect(result).toStrictEqual([
+        "Completed disbursement receipts integration.",
+      ]);
       const downloadedFile = path.join(
         process.env.ESDC_RESPONSE_FOLDER,
         FEDERAL_PROVINCIAL_FULL_TIME_FILE,
       );
-      expect(result).toStrictEqual([
-        {
-          processSummary: [
-            `Processing file ${downloadedFile}.`,
-            `Record with document number ${SHARED_DOCUMENT_NUMBER} at line 2 inserted successfully.`,
-            `Record with document number ${SHARED_DOCUMENT_NUMBER} at line 3 inserted successfully.`,
-            `Processing file ${downloadedFile} completed.`,
-            `Processing provincial daily disbursement CSV file on ${FILE_DATE}.`,
-            "Provincial daily disbursement CSV report generated.",
-          ],
-          errorsSummary: [],
-        },
-      ]);
+      expect(
+        mockedJob.containLogMessages([
+          `Processing file ${downloadedFile}.`,
+          `Record with document number ${SHARED_DOCUMENT_NUMBER} at line 2 inserted successfully.`,
+          `Record with document number ${SHARED_DOCUMENT_NUMBER} at line 3 inserted successfully.`,
+          `Processing file ${downloadedFile} completed.`,
+          `Processing provincial daily disbursement CSV file on ${FILE_DATE}.`,
+          "Provincial daily disbursement CSV report generated.",
+        ]),
+      ).toBe(true);
       // Assert imported receipts.
       const { bcReceipt, feReceipt } = await getReceiptsForAssert(
         FILE_DATE,
@@ -353,27 +363,27 @@ describe(
       });
       mockDownloadFiles(sftpClientMock, [FEDERAL_ONLY_FULL_TIME_FILE]);
       // Queued job.
-      const { job } = mockBullJob<void>();
+      const mockedJob = mockBullJob<void>();
 
       // Act
-      const result = await processor.processDisbursementReceipts(job);
+      const result = await processor.processQueue(mockedJob.job);
 
       // Assert
+      expect(result).toStrictEqual([
+        "Completed disbursement receipts integration.",
+      ]);
       const downloadedFile = path.join(
         process.env.ESDC_RESPONSE_FOLDER,
         FEDERAL_ONLY_FULL_TIME_FILE,
       );
-      expect(result).toStrictEqual([
-        {
-          processSummary: [
-            `Processing file ${downloadedFile}.`,
-            `Record with document number ${SHARED_DOCUMENT_NUMBER} at line 2 inserted successfully.`,
-            `Processing file ${downloadedFile} completed.`,
-            `Processing provincial daily disbursement CSV file on ${FILE_DATE}.`,
-          ],
-          errorsSummary: [],
-        },
-      ]);
+      expect(
+        mockedJob.containLogMessages([
+          `Processing file ${downloadedFile}.`,
+          `Record with document number ${SHARED_DOCUMENT_NUMBER} at line 2 inserted successfully.`,
+          `Processing file ${downloadedFile} completed.`,
+          `Processing provincial daily disbursement CSV file on ${FILE_DATE}.`,
+        ]),
+      ).toBe(true);
       // Assert imported receipts.
       const { feReceipt, bcReceipt } = await getReceiptsForAssert(
         FILE_DATE,
@@ -430,10 +440,10 @@ describe(
       });
       mockDownloadFiles(sftpClientMock, [FEDERAL_PROVINCIAL_PART_TIME_FILE]);
       // Queued job.
-      const { job } = mockBullJob<void>();
+      const mockedJob = mockBullJob<void>();
 
       // Act
-      const result = await processor.processDisbursementReceipts(job);
+      const result = await processor.processQueue(mockedJob.job);
 
       // Assert
       const downloadedFile = path.join(
@@ -441,18 +451,18 @@ describe(
         FEDERAL_PROVINCIAL_PART_TIME_FILE,
       );
       expect(result).toStrictEqual([
-        {
-          processSummary: [
-            `Processing file ${downloadedFile}.`,
-            `Record with document number ${SHARED_DOCUMENT_NUMBER} at line 2 inserted successfully.`,
-            `Record with document number ${SHARED_DOCUMENT_NUMBER} at line 3 inserted successfully.`,
-            `Processing file ${downloadedFile} completed.`,
-            `Processing provincial daily disbursement CSV file on ${FILE_DATE}.`,
-            "Provincial daily disbursement CSV report generated.",
-          ],
-          errorsSummary: [],
-        },
+        "Completed disbursement receipts integration.",
       ]);
+      expect(
+        mockedJob.containLogMessages([
+          `Processing file ${downloadedFile}.`,
+          `Record with document number ${SHARED_DOCUMENT_NUMBER} at line 2 inserted successfully.`,
+          `Record with document number ${SHARED_DOCUMENT_NUMBER} at line 3 inserted successfully.`,
+          `Processing file ${downloadedFile} completed.`,
+          `Processing provincial daily disbursement CSV file on ${FILE_DATE}.`,
+          "Provincial daily disbursement CSV report generated.",
+        ]),
+      ).toBe(true);
       // Assert imported receipts.
       const { bpReceipt, feReceipt } = await getReceiptsForAssert(
         FILE_DATE,
@@ -563,30 +573,31 @@ describe(
         FEDERAL_PROVINCIAL_FULL_TIME_PART_TIME_FILE,
       ]);
       // Queued job.
-      const { job } = mockBullJob<void>();
+      const mockedJob = mockBullJob<void>();
 
       // Act
-      const result = await processor.processDisbursementReceipts(job);
+      const result = await processor.processQueue(mockedJob.job);
 
       // Assert
+      expect(result).toStrictEqual([
+        "Completed disbursement receipts integration.",
+      ]);
       const downloadedFile = path.join(
         process.env.ESDC_RESPONSE_FOLDER,
         FEDERAL_PROVINCIAL_FULL_TIME_PART_TIME_FILE,
       );
-      expect(result).toEqual([
-        {
-          processSummary: [
-            `Processing file ${downloadedFile}.`,
-            `Record with document number ${SHARED_DOCUMENT_NUMBER} at line 2 inserted successfully.`,
-            `Record with document number ${SHARED_DOCUMENT_NUMBER} at line 3 inserted successfully.`,
-            `Record with document number ${SHARED_DOCUMENT_NUMBER} at line 4 inserted successfully.`,
-            `Processing file ${downloadedFile} completed.`,
-            `Processing provincial daily disbursement CSV file on ${FILE_DATE}.`,
-            "Provincial daily disbursement CSV report generated.",
-          ],
-          errorsSummary: [],
-        },
-      ]);
+      expect(
+        mockedJob.containLogMessages([
+          `Processing file ${downloadedFile}.`,
+          `Record with document number ${SHARED_DOCUMENT_NUMBER} at line 2 inserted successfully.`,
+          `Record with document number ${SHARED_DOCUMENT_NUMBER} at line 3 inserted successfully.`,
+          `Record with document number ${SHARED_DOCUMENT_NUMBER} at line 4 inserted successfully.`,
+          `Processing file ${downloadedFile} completed.`,
+          `Processing provincial daily disbursement CSV file on ${FILE_DATE}.`,
+          "Provincial daily disbursement CSV report generated.",
+        ]),
+      ).toBe(true);
+
       // Assert imported receipts.
       const { feReceipt, bcReceipt, bpReceipt } = await getReceiptsForAssert(
         FILE_DATE,

--- a/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/esdc-integration/ecert-integration/disbursement-receipts-integration.scheduler.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/esdc-integration/ecert-integration/disbursement-receipts-integration.scheduler.ts
@@ -36,7 +36,6 @@ export class DisbursementReceiptsFileIntegrationScheduler extends BaseScheduler<
   }
 
   /**
-   * Logger for SFAS integration scheduler.
    * Setting the logger here allows the correct context to be set
    * during the property injection.
    * Even if the logger is not used, it is required to be set, to

--- a/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/esdc-integration/ecert-integration/disbursement-receipts-integration.scheduler.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/esdc-integration/ecert-integration/disbursement-receipts-integration.scheduler.ts
@@ -1,7 +1,6 @@
 import { InjectQueue, Processor } from "@nestjs/bull";
 import { DisbursementReceiptProcessingService } from "@sims/integrations/esdc-integration";
 import { QueueService } from "@sims/services/queue";
-import { SystemUsersService } from "@sims/services/system-users";
 import { QueueNames } from "@sims/utilities";
 import { Job, Queue } from "bull";
 import { BaseScheduler } from "../../base-scheduler";
@@ -18,7 +17,6 @@ export class DisbursementReceiptsFileIntegrationScheduler extends BaseScheduler<
     schedulerQueue: Queue<void>,
     queueService: QueueService,
     private readonly disbursementReceiptProcessingService: DisbursementReceiptProcessingService,
-    private readonly systemUsersService: SystemUsersService,
   ) {
     super(schedulerQueue, queueService);
   }
@@ -33,11 +31,7 @@ export class DisbursementReceiptsFileIntegrationScheduler extends BaseScheduler<
     _job: Job<void>,
     processSummary: ProcessSummary,
   ): Promise<string> {
-    const auditUser = this.systemUsersService.systemUser;
-    await this.disbursementReceiptProcessingService.process(
-      auditUser.id,
-      processSummary,
-    );
+    await this.disbursementReceiptProcessingService.process(processSummary);
     return "Completed disbursement receipts integration.";
   }
 

--- a/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/esdc-integration/federal-restrictions-integration/federal-restrictions-integration.scheduler.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/esdc-integration/federal-restrictions-integration/federal-restrictions-integration.scheduler.ts
@@ -36,7 +36,6 @@ export class FederalRestrictionsIntegrationScheduler extends BaseScheduler<void>
   }
 
   /**
-   * Logger for SFAS integration scheduler.
    * Setting the logger here allows the correct context to be set
    * during the property injection.
    * Even if the logger is not used, it is required to be set, to

--- a/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/esdc-integration/federal-restrictions-integration/federal-restrictions-integration.scheduler.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/esdc-integration/federal-restrictions-integration/federal-restrictions-integration.scheduler.ts
@@ -31,7 +31,6 @@ export class FederalRestrictionsIntegrationScheduler extends BaseScheduler<void>
     _job: Job<void>,
     processSummary: ProcessSummary,
   ): Promise<string> {
-    processSummary.info("Starting federal restrictions import.");
     await this.fedRestrictionProcessingService.process(processSummary);
     return "Federal restrictions import process finished.";
   }

--- a/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/esdc-integration/federal-restrictions-integration/federal-restrictions-integration.scheduler.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/esdc-integration/federal-restrictions-integration/federal-restrictions-integration.scheduler.ts
@@ -1,11 +1,14 @@
-import { InjectQueue, Process, Processor } from "@nestjs/bull";
+import { InjectQueue, Processor } from "@nestjs/bull";
 import { FedRestrictionProcessingService } from "@sims/integrations/esdc-integration";
 import { QueueService } from "@sims/services/queue";
 import { QueueNames } from "@sims/utilities";
 import { Job, Queue } from "bull";
-import { QueueProcessSummary } from "../../../models/processors.models";
 import { BaseScheduler } from "../../base-scheduler";
-import { ESDCFileResponse } from "../models/esdc.models";
+import {
+  InjectLogger,
+  LoggerService,
+  ProcessSummary,
+} from "@sims/utilities/logger";
 
 @Processor(QueueNames.FederalRestrictionsIntegration)
 export class FederalRestrictionsIntegrationScheduler extends BaseScheduler<void> {
@@ -19,46 +22,27 @@ export class FederalRestrictionsIntegrationScheduler extends BaseScheduler<void>
   }
 
   /**
-   * To be removed once the method {@link process} is implemented.
-   * This method "hides" the {@link Process} decorator from the base class.
-   */
-  async processQueue(): Promise<string | string[]> {
-    throw new Error("Method not implemented.");
-  }
-
-  /**
-   * When implemented in a derived class, process the queue job.
-   * To be implemented.
-   */
-  protected async process(): Promise<string | string[]> {
-    throw new Error("Method not implemented.");
-  }
-
-  /**
    * Federal restriction import.
-   * @params job job details.
-   * @returns Summary details of processing.
+   * @param job process job.
+   * @param processSummary process summary for logging.
+   * @returns processing result.
    */
-  @Process()
-  async processFedRestrictionsImport(
+  protected async process(
     job: Job<void>,
-  ): Promise<ESDCFileResponse> {
-    const summary = new QueueProcessSummary({
-      appLogger: this.logger,
-      jobLogger: job,
-    });
-    await summary.info(
-      `Processing federal restriction integration job ${job.id} of type ${job.name}.`,
-    );
-    await summary.info("Starting federal restrictions import...");
-    const uploadResult = await this.fedRestrictionProcessingService.process();
-    await summary.info("Federal restrictions import process finished.");
-    await summary.info(
-      `Completed federal restriction integration job ${job.id} of type ${job.name}.`,
-    );
-    return {
-      processSummary: uploadResult.processSummary,
-      errorsSummary: uploadResult.errorsSummary,
-    };
+    processSummary: ProcessSummary,
+  ): Promise<string> {
+    processSummary.info("Starting federal restrictions import.");
+    await this.fedRestrictionProcessingService.process(processSummary);
+    return "Federal restrictions import process finished.";
   }
+
+  /**
+   * Logger for SFAS integration scheduler.
+   * Setting the logger here allows the correct context to be set
+   * during the property injection.
+   * Even if the logger is not used, it is required to be set, to
+   * allow the base classes to write logs using the correct context.
+   */
+  @InjectLogger()
+  logger: LoggerService;
 }

--- a/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/esdc-integration/federal-restrictions-integration/federal-restrictions-integration.scheduler.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/esdc-integration/federal-restrictions-integration/federal-restrictions-integration.scheduler.ts
@@ -23,12 +23,12 @@ export class FederalRestrictionsIntegrationScheduler extends BaseScheduler<void>
 
   /**
    * Federal restriction import.
-   * @param job process job.
+   * @param _job process job.
    * @param processSummary process summary for logging.
    * @returns processing result.
    */
   protected async process(
-    job: Job<void>,
+    _job: Job<void>,
     processSummary: ProcessSummary,
   ): Promise<string> {
     processSummary.info("Starting federal restrictions import.");

--- a/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/sfas-integration/sims-to-sfas-integration.scheduler.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/sfas-integration/sims-to-sfas-integration.scheduler.ts
@@ -68,7 +68,6 @@ export class SIMSToSFASIntegrationScheduler extends BaseScheduler<void> {
   }
 
   /**
-   * Logger for SFAS integration scheduler.
    * Setting the logger here allows the correct context to be set
    * during the property injection.
    * Even if the logger is not used, it is required to be set, to

--- a/sources/packages/backend/apps/queue-consumers/test/helpers/mock-utils/job-mock-utils.ts
+++ b/sources/packages/backend/apps/queue-consumers/test/helpers/mock-utils/job-mock-utils.ts
@@ -11,17 +11,17 @@ export class MockBullJobResult<T> {
   ) {}
 
   /**
-   * Checks if the logs contains a entry that ends with the provided parameter.
-   * @param logMessage log message to be found using string endsWith method.
+   * Checks if the logs contains a entry that includes the provided parameter.
+   * @param logMessage log message to be found using string includes method.
    * @returns true if the log message was found. otherwise false.
    */
   containLogMessage(logMessage: string): boolean {
-    return this.logMessages.some((message) => message.endsWith(logMessage));
+    return this.logMessages.some((message) => message.includes(logMessage));
   }
 
   /**
-   * Checks if the logs contains a entry that ends with the provided parameter.
-   * @param logMessages log messages to be found using string endsWith method.
+   * Checks if the logs contains a entry that includes the provided parameter.
+   * @param logMessages log messages to be found using string includes method.
    * @returns true if the log message was found. otherwise false.
    */
   containLogMessages(logMessages: string[]): boolean {

--- a/sources/packages/backend/libs/integrations/src/esdc-integration/disbursement-receipt-integration/disbursement-receipt.processing.service.ts
+++ b/sources/packages/backend/libs/integrations/src/esdc-integration/disbursement-receipt-integration/disbursement-receipt.processing.service.ts
@@ -81,7 +81,6 @@ export class DisbursementReceiptProcessingService {
     processSummary: ProcessSummary,
   ): Promise<void> {
     processSummary.info(`Processing file ${remoteFilePath}.`);
-    this.logger.log(`Starting download of file ${remoteFilePath}.`);
     let responseData: DisbursementReceiptDownloadResponse;
     try {
       responseData = await this.integrationService.downloadResponseFile(
@@ -107,7 +106,7 @@ export class DisbursementReceiptProcessingService {
           disbursementSchedule.id),
     );
 
-    this.logger.log(
+    processSummary.info(
       "Processing all the records in file with valid data and document number that belongs to SIMS.",
     );
 
@@ -147,7 +146,6 @@ export class DisbursementReceiptProcessingService {
         const logMessage = `Unexpected error while processing disbursement receipt record at line ${response.lineNumber}`;
         this.logger.error(logMessage, error);
         processSummary.error(logMessage, error);
-        return;
       }
     }
     processSummary.info(`Processing file ${remoteFilePath} completed.`);
@@ -221,9 +219,6 @@ export class DisbursementReceiptProcessingService {
       );
       processSummary.info(
         "Provincial daily disbursement CSV report generated.",
-      );
-      this.logger.log(
-        "Completed provincial daily disbursement report generation.",
       );
     } catch (error: unknown) {
       const errorMessage =

--- a/sources/packages/backend/libs/integrations/src/esdc-integration/fed-restriction-integration/fed-restriction.processing.service.ts
+++ b/sources/packages/backend/libs/integrations/src/esdc-integration/fed-restriction-integration/fed-restriction.processing.service.ts
@@ -111,6 +111,7 @@ export class FedRestrictionProcessingService {
       const errorMessage = `Error downloading file ${remoteFilePath}.`;
       processSummary.error(errorMessage, error);
       this.logger.error(errorMessage, error);
+      return;
     }
 
     let insertedRestrictionsIDs: number[];

--- a/sources/packages/backend/libs/integrations/src/esdc-integration/fed-restriction-integration/fed-restriction.processing.service.ts
+++ b/sources/packages/backend/libs/integrations/src/esdc-integration/fed-restriction-integration/fed-restriction.processing.service.ts
@@ -132,7 +132,7 @@ export class FedRestrictionProcessingService {
         const invalidDataMessage = restriction.getInvalidDataMessage();
         if (invalidDataMessage) {
           const errorMessage = `Found record with invalid data at line number ${restriction.lineNumber}: ${invalidDataMessage}`;
-          processSummary.error(errorMessage);
+          processSummary.warn(errorMessage);
           this.logger.error(errorMessage);
         } else {
           sanitizedRestrictions.push(restriction);


### PR DESCRIPTION
- Refactored schedulers `disbursement-receipts-file-integration` and `federal-restrictions-integration`.
- Adjusted existing E2Es.
- As agreed in previous PRs
  - moving the audit user to the service instead of the processor.
  - removing the friendly start/end logs from the processor since the `BaseQueue` is already logging similar start/end logs.

### E2E `containLogMessages` changes
To allow the below check to happen the method `containLogMessages` was changed to check if the string "contains" a value instead of "endsWith" it. The `endsWith` was used to have a more precise check and remove the log initial information (e.g. context and date). Using the "contains" will still give enough assertion precision and allow inspecting errors currently serialized to a JSON.
```ts
 // Act/Assert
await expect(processor.processQueue(mockedJob.job)).rejects.toThrow(
  "One or more errors were reported during the process, please see logs for details.",
);
expect(
  mockedJob.containLogMessages([
    `Error downloading file ${expectedFileName}.`,
    "Invalid file footer.",
  ]),
).toBe(true);
```