### PR TITLE
#4128 - Persist uploaded documents and exception triggering for dependants with disability 

### DIFF
--- a/sources/packages/forms/src/form-definitions/sfaa2022-23.json
+++ b/sources/packages/forms/src/form-definitions/sfaa2022-23.json
@@ -1742,8 +1742,7 @@
                     "threshold": 0.3
                   },
                   "id": "eopfm7h",
-                  "defaultValue": "",
-                  "isNew": false
+                  "defaultValue": ""
                 },
                 {
                   "label": "Select your program of study:",
@@ -1823,8 +1822,7 @@
                   "truncateMultipleSpaces": false,
                   "id": "easelit",
                   "tags": [],
-                  "lockKey": true,
-                  "isNew": false
+                  "lockKey": true
                 },
                 {
                   "label": "Your program is not listed",
@@ -2505,8 +2503,7 @@
                               "addons": [],
                               "inputType": "text",
                               "id": "ehmio79",
-                              "defaultValue": "",
-                              "isNew": false
+                              "defaultValue": ""
                             }
                           ],
                           "width": 6,
@@ -3689,8 +3686,7 @@
                   "truncateMultipleSpaces": false,
                   "id": "e9w4l3n",
                   "tags": [],
-                  "lockKey": true,
-                  "isNew": false
+                  "lockKey": true
                 },
                 {
                   "label": "Your study dates are not listed",
@@ -13441,8 +13437,8 @@
                           "hideLabel": true,
                           "key": "uploadPanel",
                           "conditional": {
-                            "show": true,
-                            "when": "dependants.declaredOnTaxes",
+                            "show": "true",
+                            "when": "declaredOnTaxes",
                             "eq": "yes"
                           },
                           "type": "panel",
@@ -13891,7 +13887,7 @@
                               "unique": false,
                               "persistent": true,
                               "hidden": false,
-                              "clearOnHide": true,
+                              "clearOnHide": false,
                               "refreshOn": "",
                               "modalEdit": false,
                               "dataGridLabel": false,
@@ -13911,7 +13907,7 @@
                               "attributes": {},
                               "validateOn": "change",
                               "conditional": {
-                                "show": null,
+                                "show": "",
                                 "when": null,
                                 "eq": ""
                               },
@@ -14220,7 +14216,8 @@
                           "lazyLoad": false,
                           "theme": "default",
                           "breadcrumb": "default",
-                          "id": "ec900o"
+                          "id": "ec900o",
+                          "tags": []
                         }
                       ],
                       "id": "eja9nnp000000000000000000",
@@ -14981,7 +14978,8 @@
                   "allowMultipleMasks": false,
                   "addons": [],
                   "privateDownload": false,
-                  "id": "e90zuwt"
+                  "id": "e90zuwt",
+                  "isNew": false
                 },
                 {
                   "label": "Columns",
@@ -15266,7 +15264,9 @@
               "lazyLoad": false,
               "theme": "default",
               "breadcrumb": "default",
-              "id": "e88jxwl"
+              "id": "e88jxwl",
+              "isNew": false,
+              "tags": []
             }
           ],
           "placeholder": "",

--- a/sources/packages/forms/src/form-definitions/sfaa2023-24.json
+++ b/sources/packages/forms/src/form-definitions/sfaa2023-24.json
@@ -1742,8 +1742,7 @@
                     "threshold": 0.3
                   },
                   "id": "eopfm7h",
-                  "defaultValue": "",
-                  "isNew": false
+                  "defaultValue": ""
                 },
                 {
                   "label": "Select your program of study:",
@@ -1823,8 +1822,7 @@
                   "truncateMultipleSpaces": false,
                   "id": "easelit",
                   "tags": [],
-                  "lockKey": true,
-                  "isNew": false
+                  "lockKey": true
                 },
                 {
                   "label": "Your program is not listed",
@@ -2505,8 +2503,7 @@
                               "addons": [],
                               "inputType": "text",
                               "id": "ehmio79",
-                              "defaultValue": "",
-                              "isNew": false
+                              "defaultValue": ""
                             }
                           ],
                           "width": 6,
@@ -3689,8 +3686,7 @@
                   "truncateMultipleSpaces": false,
                   "id": "e9w4l3n",
                   "tags": [],
-                  "lockKey": true,
-                  "isNew": false
+                  "lockKey": true
                 },
                 {
                   "label": "Your study dates are not listed",
@@ -13441,8 +13437,8 @@
                           "hideLabel": true,
                           "key": "uploadPanel",
                           "conditional": {
-                            "show": true,
-                            "when": "dependants.declaredOnTaxes",
+                            "show": "true",
+                            "when": "declaredOnTaxes",
                             "eq": "yes"
                           },
                           "type": "panel",
@@ -13891,7 +13887,7 @@
                               "unique": false,
                               "persistent": true,
                               "hidden": false,
-                              "clearOnHide": true,
+                              "clearOnHide": false,
                               "refreshOn": "",
                               "modalEdit": false,
                               "dataGridLabel": false,
@@ -13911,7 +13907,7 @@
                               "attributes": {},
                               "validateOn": "change",
                               "conditional": {
-                                "show": null,
+                                "show": "",
                                 "when": null,
                                 "eq": ""
                               },
@@ -14220,7 +14216,8 @@
                           "lazyLoad": false,
                           "theme": "default",
                           "breadcrumb": "default",
-                          "id": "ec900o"
+                          "id": "ec900o",
+                          "tags": []
                         }
                       ],
                       "id": "eja9nnp000000000000000000",
@@ -15266,7 +15263,9 @@
               "lazyLoad": false,
               "theme": "default",
               "breadcrumb": "default",
-              "id": "e88jxwl"
+              "id": "e88jxwl",
+              "isNew": false,
+              "tags": []
             }
           ],
           "placeholder": "",

--- a/sources/packages/forms/src/form-definitions/sfaa2024-25.json
+++ b/sources/packages/forms/src/form-definitions/sfaa2024-25.json
@@ -1742,8 +1742,7 @@
                     "threshold": 0.3
                   },
                   "id": "eopfm7h",
-                  "defaultValue": "",
-                  "isNew": false
+                  "defaultValue": ""
                 },
                 {
                   "label": "Select your program of study:",
@@ -1823,8 +1822,7 @@
                   "truncateMultipleSpaces": false,
                   "id": "easelit",
                   "tags": [],
-                  "lockKey": true,
-                  "isNew": false
+                  "lockKey": true
                 },
                 {
                   "label": "Your program is not listed",
@@ -2505,8 +2503,7 @@
                               "addons": [],
                               "inputType": "text",
                               "id": "ehmio79",
-                              "defaultValue": "",
-                              "isNew": false
+                              "defaultValue": ""
                             }
                           ],
                           "width": 6,
@@ -3689,8 +3686,7 @@
                   "truncateMultipleSpaces": false,
                   "id": "e9w4l3n",
                   "tags": [],
-                  "lockKey": true,
-                  "isNew": false
+                  "lockKey": true
                 },
                 {
                   "label": "Your study dates are not listed",
@@ -13441,8 +13437,8 @@
                           "hideLabel": true,
                           "key": "uploadPanel",
                           "conditional": {
-                            "show": true,
-                            "when": "dependants.declaredOnTaxes",
+                            "show": "true",
+                            "when": "declaredOnTaxes",
                             "eq": "yes"
                           },
                           "type": "panel",
@@ -13891,7 +13887,7 @@
                               "unique": false,
                               "persistent": true,
                               "hidden": false,
-                              "clearOnHide": true,
+                              "clearOnHide": false,
                               "refreshOn": "",
                               "modalEdit": false,
                               "dataGridLabel": false,
@@ -13911,7 +13907,7 @@
                               "attributes": {},
                               "validateOn": "change",
                               "conditional": {
-                                "show": null,
+                                "show": "",
                                 "when": null,
                                 "eq": ""
                               },
@@ -14220,7 +14216,8 @@
                           "lazyLoad": false,
                           "theme": "default",
                           "breadcrumb": "default",
-                          "id": "ec900o"
+                          "id": "ec900o",
+                          "tags": []
                         }
                       ],
                       "id": "eja9nnp000000000000000000",
@@ -14391,7 +14388,9 @@
               "lazyLoad": false,
               "theme": "default",
               "breadcrumb": "default",
-              "id": "esww5zq"
+              "id": "esww5zq",
+              "isNew": false,
+              "tags": []
             },
             {
               "label": "Are any of the dependants listed above supported by you financially but not under your sole custody?",


### PR DESCRIPTION
- Removed key "Clear value when hidden" for file component "pdDependentUpload" for program years 
  - 2022-23
  - 2023-24
  - 2024-25
- Ensured that the file will reappear when reactivated with future edits.
- Ensured that the declared on taxes exception is triggered when file is required but not provided for a dependant.

Screenshot for when the declared on taxes exception is triggered
![image](https://github.com/user-attachments/assets/2b5984d3-d56a-40ef-ab9a-eac6436ca853)

Screenshot for files successfully submitted and reappeared with future edits
![image](https://github.com/user-attachments/assets/dabcfb72-6c07-4fd0-a758-89ae377e5d39)

Screenshot of the dependant component with files on ministry portal
![image](https://github.com/user-attachments/assets/71f679dc-4837-4840-a24e-9c58310af85c)
