### PR TITLE
#4094 - File Issues - Comma in file name (#4153)

### DIFF
--- a/sources/packages/backend/apps/api/src/route-controllers/student/_tests_/e2e/student.aest.controller.getUploadedFile.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/student/_tests_/e2e/student.aest.controller.getUploadedFile.e2e-spec.ts
@@ -116,7 +116,7 @@ describe("StudentAESTController(e2e)-getUploadedFile", () => {
       .expect(HttpStatus.OK)
       .then((response) => {
         expect(response.headers["content-disposition"]).toBe(
-          `attachment; filename=${studentFile.fileName}`,
+          `attachment; filename=${encodeURIComponent(studentFile.fileName)}`,
         );
         expect(response.text).toStrictEqual(S3_DEFAULT_MOCKED_FILE_CONTENT);
       });

--- a/sources/packages/backend/apps/api/src/route-controllers/student/_tests_/e2e/student.students.controller.getUploadedFile.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/student/_tests_/e2e/student.students.controller.getUploadedFile.e2e-spec.ts
@@ -167,7 +167,7 @@ describe("StudentStudentsController(e2e)-getUploadedFile", () => {
       .expect(HttpStatus.OK)
       .then((response) => {
         expect(response.headers["content-disposition"]).toBe(
-          `attachment; filename=${studentFile.fileName}`,
+          `attachment; filename=${encodeURIComponent(studentFile.fileName)}`,
         );
         expect(response.text).toStrictEqual(S3_DEFAULT_MOCKED_FILE_CONTENT);
       });

--- a/sources/packages/backend/apps/api/src/route-controllers/student/student.controller.service.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/student/student.controller.service.ts
@@ -156,7 +156,7 @@ export class StudentControllerService {
 
     response.setHeader(
       "Content-Disposition",
-      `attachment; filename=${studentFile.fileName}`,
+      `attachment; filename=${encodeURIComponent(studentFile.fileName)}`,
     );
 
     try {

--- a/sources/packages/web/src/composables/useFileUtils.ts
+++ b/sources/packages/web/src/composables/useFileUtils.ts
@@ -53,7 +53,7 @@ export function useFileUtils() {
     const fileName =
       response.headers["content-disposition"].split("filename=")[1];
     link.href = linkURL;
-    link.setAttribute("download", fileName);
+    link.setAttribute("download", decodeURIComponent(fileName));
     document.body.appendChild(link);
     link.click();
     // After download, remove the element


### PR DESCRIPTION
**Technical Details**
- [x] Ensure the file name is escaped while downloading to prevent the issue with the comma and some other potential characters.
- [x] Add an E2E test with some scenarios to test different characters.
- [x] This should be added to v2.2 branch.


Demo:
Able to Download File with Comma

![image](https://github.com/user-attachments/assets/82bd65d5-ed65-41b2-b252-edad13b07fa8)

![image](https://github.com/user-attachments/assets/dca924d4-1e2a-4727-8b70-deab9b95f060)