### PR TITLE
#4130 - Update Openshift Github Actions (#4131)

### DIFF
--- a/.github/workflows/clamav.yml
+++ b/.github/workflows/clamav.yml
@@ -33,6 +33,10 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.ref_name }}
+      - name: Install CLI tools from OpenShift Mirror
+        uses: redhat-actions/openshift-tools-installer@v1
+        with:
+          oc: "4"
       - name: Log in to OpenShift
         run: |
           oc login --token=${{ secrets.SA_TOKEN }} --server=${{ vars.OPENSHIFT_CLUSTER_URL }}

--- a/.github/workflows/crunchy-db.yml
+++ b/.github/workflows/crunchy-db.yml
@@ -38,6 +38,10 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.ref_name }}
+      - name: Install CLI tools from OpenShift Mirror
+        uses: redhat-actions/openshift-tools-installer@v1
+        with:
+          oc: "4"
       - name: Log in to OpenShift
         run: |
           oc login --token=${{ secrets.SA_TOKEN }} --server=${{ vars.OPENSHIFT_CLUSTER_URL }}

--- a/.github/workflows/env-setup-build-forms-server.yml
+++ b/.github/workflows/env-setup-build-forms-server.yml
@@ -18,10 +18,15 @@ jobs:
       BUILD_NAMESPACE: ${{ vars.BUILD_NAMESPACE }}
       FORMIO_SOURCE_REPO_TAG: ${{ inputs.formioTag }}
     steps:
+      - name: Install CLI tools from OpenShift Mirror
+        uses: redhat-actions/openshift-tools-installer@v1
+        with:
+          oc: "4"
       - name: Print env
         run: |
           echo BUILD NAMESPACE: $BUILD_NAMESPACE
           echo BRANCH: $BUILD_REF
+          echo OC CLI Version: $(oc version)
       # Checkout the PR branch
       - name: Checkout Target Branch
         uses: actions/checkout@v4

--- a/.github/workflows/env-setup-delete-redis.yml
+++ b/.github/workflows/env-setup-delete-redis.yml
@@ -23,6 +23,10 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.ref_name }}
+      - name: Install CLI tools from OpenShift Mirror
+        uses: redhat-actions/openshift-tools-installer@v1
+        with:
+          oc: "4"
       - name: Log in to OpenShift
         run: |
           oc login --token=${{ secrets.SA_TOKEN }} --server=${{ vars.OPENSHIFT_CLUSTER_URL }}

--- a/.github/workflows/env-setup-deploy-forms-server.yml
+++ b/.github/workflows/env-setup-deploy-forms-server.yml
@@ -32,10 +32,15 @@ jobs:
       TLS_KEY: ${{ secrets.TLS_KEY }}
       TLS_CA_CERTIFICATE: ${{ secrets.TLS_CA_CERTIFICATE }}
     steps:
+      - name: Install CLI tools from OpenShift Mirror
+        uses: redhat-actions/openshift-tools-installer@v1
+        with:
+          oc: "4"
       - name: Print env
         run: |
           echo NAMESPACE: $NAMESPACE
           echo HOST_PREFIX: $HOST_PREFIX
+          echo OC CLI Version: $(oc version)
       # Checkout the PR branch
       - name: Checkout Target Branch
         uses: actions/checkout@v4

--- a/.github/workflows/env-setup-deploy-redis.yml
+++ b/.github/workflows/env-setup-deploy-redis.yml
@@ -23,6 +23,10 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.ref_name }}
+      - name: Install CLI tools from OpenShift Mirror
+        uses: redhat-actions/openshift-tools-installer@v1
+        with:
+          oc: "4"
       - name: Log in to OpenShift
         run: |
           oc login --token=${{ secrets.SA_TOKEN }} --server=${{ vars.OPENSHIFT_CLUSTER_URL }}

--- a/.github/workflows/env-setup-deploy-secrets.yml
+++ b/.github/workflows/env-setup-deploy-secrets.yml
@@ -60,6 +60,10 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ inputs.gitRef }}
+      - name: Install CLI tools from OpenShift Mirror
+        uses: redhat-actions/openshift-tools-installer@v1
+        with:
+          oc: "4"
       - name: Log in to OpenShift
         run: |
           oc login --token=${{ secrets.SA_TOKEN }} --server=${{ vars.OPENSHIFT_CLUSTER_URL }}

--- a/.github/workflows/env-setup-init-redis-cluster-redis.yml
+++ b/.github/workflows/env-setup-init-redis-cluster-redis.yml
@@ -23,6 +23,10 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.ref_name }}
+      - name: Install CLI tools from OpenShift Mirror
+        uses: redhat-actions/openshift-tools-installer@v1
+        with:
+          oc: "4"
       - name: Log in to OpenShift
         run: |
           oc login --token=${{ secrets.SA_TOKEN }} --server=${{ vars.OPENSHIFT_CLUSTER_URL }}

--- a/.github/workflows/env-setup-redis-recovery.yml
+++ b/.github/workflows/env-setup-redis-recovery.yml
@@ -27,6 +27,10 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ inputs.gitRef }}
+      - name: Install CLI tools from OpenShift Mirror
+        uses: redhat-actions/openshift-tools-installer@v1
+        with:
+          oc: "4"
       - name: Log in to OpenShift
         run: |
           oc login --token=${{ secrets.SA_TOKEN }} --server=${{ vars.OPENSHIFT_CLUSTER_URL }}

--- a/.github/workflows/prune-images.yml
+++ b/.github/workflows/prune-images.yml
@@ -18,9 +18,9 @@ on:
         required: true
         default: "web-sims, api-sims, queue-consumers-sims, workers-sims"
       ocjobs:
-          description: "Comma seperated list of job Image Streams to prune"
-          required: true
-          default: "db.migrations"
+        description: "Comma seperated list of job Image Streams to prune"
+        required: true
+        default: "db.migrations"
       prefix:
         description: "Branch prefix to restrict pruning to"
         required: false
@@ -44,6 +44,11 @@ jobs:
           echo "PREFIX=${{ inputs.prefix || 'main' }}" >> $GITHUB_ENV
           echo "MIN_TAGS=${{ inputs.minTags || '10' }}" >> $GITHUB_ENV
 
+      - name: Install CLI tools from OpenShift Mirror
+        uses: redhat-actions/openshift-tools-installer@v1
+        with:
+          oc: "4"
+
       - name: Print env
         run: |
           echo "Environment: ${ENVIRONMENT}"
@@ -51,6 +56,7 @@ jobs:
           echo "Jobs: ${OCJOBS}"
           echo "Prefix: ${PREFIX}"
           echo "Minimum Tags: ${MIN_TAGS}"
+          echo "OC CLI Version: $(oc version)"
 
       - name: Checkout source code
         uses: actions/checkout@v4

--- a/.github/workflows/release-build-all.yml
+++ b/.github/workflows/release-build-all.yml
@@ -26,7 +26,6 @@ jobs:
           echo Git Ref Name: ${{ github.ref_name }}
           echo Git Head: ${{ github.event.pull_request.head.sha }}
           echo Run Number: ${{ github.run_number }}
-          echo OC CLI Version: $(oc version)
 
   # Create new tag.
   createTag:
@@ -64,10 +63,15 @@ jobs:
     env:
       BUILD_REF: ${{ needs.createTag.outputs.newTag }}
     steps:
+      - name: Install CLI tools from OpenShift Mirror
+        uses: redhat-actions/openshift-tools-installer@v1
+        with:
+          oc: "4"
       - name: Print env
         run: |
           echo BUILD NAMESPACE: $BUILD_NAMESPACE
           echo BRANCH: ${{ needs.createTag.outputs.newTag }}
+          echo OC CLI Version: $(oc version)
       - name: Checkout Target Branch
         uses: actions/checkout@v4
         with:
@@ -88,10 +92,15 @@ jobs:
     env:
       BUILD_REF: ${{ needs.createTag.outputs.newTag }}
     steps:
+      - name: Install CLI tools from OpenShift Mirror
+        uses: redhat-actions/openshift-tools-installer@v1
+        with:
+          oc: "4"
       - name: Print env
         run: |
           echo BUILD NAMESPACE: $BUILD_NAMESPACE
           echo BRANCH: ${{ needs.createTag.outputs.newTag }}
+          echo OC CLI Version: $(oc version)
       - name: Checkout Target Branch
         uses: actions/checkout@v4
         with:
@@ -112,10 +121,15 @@ jobs:
     env:
       BUILD_REF: ${{ needs.createTag.outputs.newTag }}
     steps:
+      - name: Install CLI tools from OpenShift Mirror
+        uses: redhat-actions/openshift-tools-installer@v1
+        with:
+          oc: "4"
       - name: Print env
         run: |
           echo BUILD NAMESPACE: $BUILD_NAMESPACE
           echo BRANCH: ${{ needs.createTag.outputs.newTag }}
+          echo OC CLI Version: $(oc version)
       - name: Checkout Target Branch
         uses: actions/checkout@v4
         with:
@@ -136,10 +150,15 @@ jobs:
     env:
       BUILD_REF: ${{ needs.createTag.outputs.newTag }}
     steps:
+      - name: Install CLI tools from OpenShift Mirror
+        uses: redhat-actions/openshift-tools-installer@v1
+        with:
+          oc: "4"
       - name: Print env
         run: |
           echo BUILD NAMESPACE: $BUILD_NAMESPACE
           echo BRANCH: ${{ needs.createTag.outputs.newTag }}
+          echo OC CLI Version: $(oc version)
       - name: Checkout Target Branch
         uses: actions/checkout@v4
         with:
@@ -160,10 +179,15 @@ jobs:
     env:
       BUILD_REF: ${{ needs.createTag.outputs.newTag }}
     steps:
+      - name: Install CLI tools from OpenShift Mirror
+        uses: redhat-actions/openshift-tools-installer@v1
+        with:
+          oc: "4"
       - name: Print env
         run: |
           echo BUILD NAMESPACE: $BUILD_NAMESPACE
           echo BRANCH: ${{ needs.createTag.outputs.newTag }}
+          echo OC CLI Version: $(oc version)
       - name: Checkout Target Branch
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/release-deploy-all.yml
+++ b/.github/workflows/release-deploy-all.yml
@@ -106,21 +106,23 @@ jobs:
     environment: ${{ inputs.environment }}
     runs-on: ubuntu-latest
     steps:
+      - name: Install CLI tools from OpenShift Mirror
+        uses: redhat-actions/openshift-tools-installer@v1
+        with:
+          oc: "4"
       - name: Print env
         run: |
           echo Deploy Environment: ${{ inputs.environment }}
           echo GIT REF: ${{ inputs.gitRef }}
           echo BUILD NAMESPACE: $BUILD_NAMESPACE
-
+          echo OC CLI Version: $(oc version)
       - name: Checkout Target Branch
         uses: actions/checkout@v4
         with:
           ref: ${{ inputs.gitRef }}
-
       - name: Log in to OpenShift
         run: |
           oc login --token=${{ secrets.SA_TOKEN }} --server=${{ vars.OPENSHIFT_CLUSTER_URL }}
-
       - name: Run db-migrations
         working-directory: "./devops/"
         run: |
@@ -133,21 +135,23 @@ jobs:
     runs-on: ubuntu-latest
     needs: run-db-migrations
     steps:
+      - name: Install CLI tools from OpenShift Mirror
+        uses: redhat-actions/openshift-tools-installer@v1
+        with:
+          oc: "4"
       - name: Print env
         run: |
           echo Deploy ENVIRONMENT: ${{ inputs.environment }}
           echo GIT REF: ${{ inputs.gitRef }}
           echo BUILD NAMESPACE: $BUILD_NAMESPACE
-
+          echo OC CLI Version: $(oc version)
       - name: Checkout Target Branch
         uses: actions/checkout@v4
         with:
           ref: ${{ inputs.gitRef }}
-
       - name: Log in to OpenShift
         run: |
           oc login --token=${{ secrets.SA_TOKEN }} --server=${{ vars.OPENSHIFT_CLUSTER_URL }}
-
       - name: Deploy SIMS-API
         working-directory: "./devops/"
         run: |
@@ -162,20 +166,22 @@ jobs:
     runs-on: ubuntu-latest
     needs: run-db-migrations
     steps:
+      - name: Install CLI tools from OpenShift Mirror
+        uses: redhat-actions/openshift-tools-installer@v1
+        with:
+          oc: "4"
       - name: Print env
         run: |
           echo BUILD ENVIRONMENT: ${{ inputs.environment }}
           echo GIT REF: ${{ inputs.gitRef }}
-
+          echo OC CLI Version: $(oc version)
       - name: Checkout Target Branch
         uses: actions/checkout@v4
         with:
           ref: ${{ inputs.gitRef }}
-
       - name: Log in to OpenShift
         run: |
           oc login --token=${{ secrets.SA_TOKEN }} --server=${{ vars.OPENSHIFT_CLUSTER_URL }}
-
       - name: Deploy Workers
         working-directory: "./devops/"
         run: |
@@ -188,21 +194,23 @@ jobs:
     runs-on: ubuntu-latest
     needs: run-db-migrations
     steps:
+      - name: Install CLI tools from OpenShift Mirror
+        uses: redhat-actions/openshift-tools-installer@v1
+        with:
+          oc: "4"
       - name: Print env
         run: |
           echo Deploy ENVIRONMENT: ${{ inputs.environment }}
           echo GIT REF: ${{ inputs.gitRef }}
           echo BUILD NAMESPACE: $BUILD_NAMESPACE
-
+          echo OC CLI Version: $(oc version)
       - name: Checkout Target Branch
         uses: actions/checkout@v4
         with:
           ref: ${{ inputs.gitRef }}
-
       - name: Log in to OpenShift
         run: |
           oc login --token=${{ secrets.SA_TOKEN }} --server=${{ vars.OPENSHIFT_CLUSTER_URL }}
-
       - name: Deploy Queue Consumers
         working-directory: "./devops/"
         run: |
@@ -215,21 +223,23 @@ jobs:
     runs-on: ubuntu-latest
     needs: run-db-migrations
     steps:
+      - name: Install CLI tools from OpenShift Mirror
+        uses: redhat-actions/openshift-tools-installer@v1
+        with:
+          oc: "4"
       - name: Print env
         run: |
           echo Deploy ENVIRONMENT: ${{ inputs.environment }}
           echo GIT REF: ${{ inputs.gitRef }}
           echo BUILD NAMESPACE: $BUILD_NAMESPACE
-
+          echo OC CLI Version: $(oc version)
       - name: Checkout Target Branch
         uses: actions/checkout@v4
         with:
           ref: ${{ inputs.gitRef }}
-
       - name: Log in to OpenShift
         run: |
           oc login --token=${{ secrets.SA_TOKEN }} --server=${{ vars.OPENSHIFT_CLUSTER_URL }}
-
       - name: Deploy Web/Frontend
         working-directory: "./devops/"
         run: |


### PR DESCRIPTION
- Added the [openshift-tools-installer](https://github.com/redhat-actions/openshift-tools-installer) to all action steps that require some OC iteration.
- Using the [default options](https://github.com/redhat-actions/openshift-tools-installer?tab=readme-ov-file#inputs).
- Using the fixed version "4". The current version printed is `OC CLI Version: Client Version: 4.17.9`.

Please note, for steps printing the `OC version`, the new action was added before the print step. For steps not printing the `OC version`, the new step was added right before the "Log in to OpenShift".

Sample workflow execution with the new step working: https://github.com/bcgov/SIMS/actions/runs/12378896945/job/34551860119