### PR TITLE
#3869 - Increase memory and CPU limits of queue consumers to handle jobs with more resource demand

### DIFF
--- a/devops/openshift/queue-consumers-deploy.yml
+++ b/devops/openshift/queue-consumers-deploy.yml
@@ -366,13 +366,13 @@ parameters:
   - name: SERVICE_NAME
     value: queue-consumers
   - name: CPU_LIMIT
-    value: "0.2"
+    value: "0.4"
   - name: MEMORY_LIMIT
-    value: "768M"
+    value: "1024M"
   - name: CPU_REQUEST
-    value: "0.1"
+    value: "0.2"
   - name: MEMORY_REQUEST
-    value: "512M"
+    value: "768M"
   - name: REPLICAS
     value: "2"
   - name: DB_SERVICE_KEY


### PR DESCRIPTION
# Issue

While running the federal restrictions file with bulk volume of data (139MB File), we noticed that the required resource limit is going beyond that maximum limit for both CPU and Memory. 

![image](https://github.com/user-attachments/assets/60e12a82-44bd-4f0e-ad3f-5e3dc3887932)

![image](https://github.com/user-attachments/assets/6fa5174b-d2d2-41e7-9531-296f78f390e7)
