### PR TITLE
#3596 - Bug on ministry add new SIN to student

### DIFF
--- a/sources/packages/web/src/components/common/sin/AddNewSIN.vue
+++ b/sources/packages/web/src/components/common/sin/AddNewSIN.vue
@@ -19,7 +19,8 @@
         <v-checkbox
           label="Skip the validations"
           v-model="formModel.skipValidations"
-          hide-details="auto" />
+          hide-details="auto"
+          @update:model-value="(value: boolean | null) => (formModel.skipValidations = !!value)" />
         <banner
           class="mb-4"
           v-if="formModel.skipValidations"
@@ -76,7 +77,9 @@ export default defineComponent({
       CreateSINValidationAPIInDTO | boolean
     >();
     const addNewSINForm = ref({} as VForm);
-    const formModel = reactive({} as CreateSINValidationAPIInDTO);
+    const formModel = reactive({
+      skipValidations: false,
+    } as CreateSINValidationAPIInDTO);
 
     const submit = async () => {
       const validationResult = await addNewSINForm.value.validate();
@@ -91,8 +94,6 @@ export default defineComponent({
 
     const cancel = () => {
       addNewSINForm.value.reset();
-      formModel.skipValidations = false;
-      addNewSINForm.value.resetValidation();
       resolvePromise(false);
     };
 


### PR DESCRIPTION
## Issue

The optional checkbox to `Skip the validations` returns `undefined` (When not touched) and `null` (on form reset) which is considered as bad request as the API is expecting a boolean value for `skipValidations`.

## Solution

- [x] Initialize the form-model with `skipValidations` as `false`.
- [x] On the event of model value being updated, convert the input value to boolean using the event `update:model-value`.

## Minor Refactor

- [x] Removed the call to `resetValidation()` as it has no impact after `reset()` is called.

![image](https://github.com/user-attachments/assets/d17fd370-0d7f-478d-99e4-728495be3cff)

