### PR TITLE
#4132 - Update Form IO (Fix Eligible Amount)

### DIFF
--- a/sources/packages/forms/src/form-definitions/noticeofassessment.json
+++ b/sources/packages/forms/src/form-definitions/noticeofassessment.json
@@ -717,7 +717,7 @@
                 }
               ],
               "content": "You are eligible to receive: ${{ (data.eligibleAmount)?.toLocaleString('en-CA', { minimumFractionDigits: 2 }) }}",
-              "refreshOnChange": false,
+              "refreshOnChange": true,
               "customClass": "",
               "hidden": false,
               "modalEdit": false,

--- a/sources/packages/web/src/views/student/financial-aid-application/FullTimeApplication.vue
+++ b/sources/packages/web/src/views/student/financial-aid-application/FullTimeApplication.vue
@@ -16,7 +16,7 @@
             {{ savingDraft ? "Saving..." : "Save draft" }}</v-btn
           >
           <v-btn
-            v-if="!isReadOnly && !isFirstPage"
+            v-if="!isReadOnly && isLastPage"
             class="ml-2"
             :disabled="submittingApplication"
             color="primary"


### PR DESCRIPTION
- Set `"refreshOnChange": true` to display eligible amount.

![image](https://github.com/user-attachments/assets/47b34354-5772-4079-b5e7-eb75350c7246)

- Removed "Submit application" button for pages before the last page.

![image](https://github.com/user-attachments/assets/c79d9fd7-7863-4eee-ab9e-ce253f756f0b)
