### PR TITLE
#4202 - Increment Sequence Header for PT ecert

### DIFF
--- a/sources/packages/backend/libs/integrations/src/esdc-integration/e-cert-integration/e-cert-file-handler.ts
+++ b/sources/packages/backend/libs/integrations/src/esdc-integration/e-cert-integration/e-cert-file-handler.ts
@@ -88,12 +88,16 @@ export abstract class ECertFileHandler extends ESDCFileHandler {
     log.info(
       `Retrieving ${offeringIntensity} disbursements to generate the e-Cert file...`,
     );
+    const fileNameSequenceGroup = `${sequenceGroupPrefix}_${getISODateOnlyString(
+      new Date(),
+    )}`;
     let uploadResult: ECertUploadResult;
     await this.sequenceService.consumeNextSequence(
       sequenceGroup,
       async (nextSequenceNumber: number, entityManager: EntityManager) => {
         uploadResult = await this.processECert(
           nextSequenceNumber,
+          fileNameSequenceGroup
           entityManager,
           eCertIntegrationService,
           offeringIntensity,
@@ -108,6 +112,7 @@ export abstract class ECertFileHandler extends ESDCFileHandler {
   /**
    * Prepare the disbursements for e-Cert generation and upload the e-Cert file.
    * @param sequenceNumber e-Cert sequence number.
+   * @param fileNameSequenceGroup e-Cert file name sequence group.
    * @param entityManager manages the current DB transaction.
    * @param eCertIntegrationService Full-Time/Part-Time integration responsible
    * for the respective integration.
@@ -118,6 +123,7 @@ export abstract class ECertFileHandler extends ESDCFileHandler {
    */
   private async processECert(
     sequenceNumber: number,
+    fileNameSequenceGroup: number,
     entityManager: EntityManager,
     eCertIntegrationService: ECertIntegrationService,
     offeringIntensity: OfferingIntensity,
@@ -143,7 +149,7 @@ export abstract class ECertFileHandler extends ESDCFileHandler {
     );
 
     // Create the request filename with the file path for the e-Cert File.
-    const fileInfo = this.createRequestFileName(fileCode, sequenceNumber);
+    const fileInfo = this.createRequestFileName(fileCode, fileNameSequenceGroup);
     log.info(`Uploading ${offeringIntensity} content...`);
     await eCertIntegrationService.uploadContent(fileContent, fileInfo.filePath);
     // Mark all disbursements as sent.

--- a/sources/packages/backend/libs/integrations/src/esdc-integration/e-cert-integration/e-cert-file-handler.ts
+++ b/sources/packages/backend/libs/integrations/src/esdc-integration/e-cert-integration/e-cert-file-handler.ts
@@ -9,7 +9,7 @@ import {
   ECertFeedbackErrorService,
 } from "../../services";
 import { SequenceControlService, SystemUsersService } from "@sims/services";
-import { processInParallel } from "@sims/utilities";
+import { getISODateOnlyString, processInParallel } from "@sims/utilities";
 import { EntityManager } from "typeorm";
 import { ESDCFileHandler } from "../esdc-file-handler";
 import {
@@ -88,7 +88,7 @@ export abstract class ECertFileHandler extends ESDCFileHandler {
     log.info(
       `Retrieving ${offeringIntensity} disbursements to generate the e-Cert file...`,
     );
-    const fileNameSequenceGroup = `${sequenceGroupPrefix}_${getISODateOnlyString(
+    const fileNameSequenceGroup = `${sequenceGroup}_${getISODateOnlyString(
       new Date(),
     )}`;
     let uploadResult: ECertUploadResult;
@@ -97,7 +97,7 @@ export abstract class ECertFileHandler extends ESDCFileHandler {
       async (nextSequenceNumber: number, entityManager: EntityManager) => {
         uploadResult = await this.processECert(
           nextSequenceNumber,
-          fileNameSequenceGroup
+          fileNameSequenceGroup,
           entityManager,
           eCertIntegrationService,
           offeringIntensity,
@@ -123,7 +123,7 @@ export abstract class ECertFileHandler extends ESDCFileHandler {
    */
   private async processECert(
     sequenceNumber: number,
-    fileNameSequenceGroup: number,
+    fileNameSequenceGroup: string,
     entityManager: EntityManager,
     eCertIntegrationService: ECertIntegrationService,
     offeringIntensity: OfferingIntensity,
@@ -149,7 +149,10 @@ export abstract class ECertFileHandler extends ESDCFileHandler {
     );
 
     // Create the request filename with the file path for the e-Cert File.
-    const fileInfo = this.createRequestFileName(fileCode, fileNameSequenceGroup);
+    const fileInfo = this.createRequestFileName(
+      fileCode,
+      fileNameSequenceGroup,
+    );
     log.info(`Uploading ${offeringIntensity} content...`);
     await eCertIntegrationService.uploadContent(fileContent, fileInfo.filePath);
     // Mark all disbursements as sent.

--- a/sources/packages/backend/libs/integrations/src/esdc-integration/e-cert-integration/e-cert-file-handler.ts
+++ b/sources/packages/backend/libs/integrations/src/esdc-integration/e-cert-integration/e-cert-file-handler.ts
@@ -72,7 +72,7 @@ export abstract class ECertFileHandler extends ESDCFileHandler {
    * for the respective integration.
    * @param offeringIntensity disbursement offering intensity.
    * @param fileCode file code applicable for Part-Time or Full-Time.
-   * @param sequenceGroupPrefix sequence group prefix for Part-Time or Full-Time
+   * @param sequenceGroup sequence group for Part-Time or Full-Time
    * file sequence generation.
    * @param log cumulative process log.
    * @returns result of the file upload with the file generated and the
@@ -82,16 +82,12 @@ export abstract class ECertFileHandler extends ESDCFileHandler {
     eCertIntegrationService: ECertIntegrationService,
     offeringIntensity: OfferingIntensity,
     fileCode: string,
-    sequenceGroupPrefix: string,
+    sequenceGroup: string,
     log: ProcessSummary,
   ): Promise<ECertUploadResult> {
     log.info(
       `Retrieving ${offeringIntensity} disbursements to generate the e-Cert file...`,
     );
-
-    const sequenceGroup = `${sequenceGroupPrefix}_${getISODateOnlyString(
-      new Date(),
-    )}`;
     let uploadResult: ECertUploadResult;
     await this.sequenceService.consumeNextSequence(
       sequenceGroup,

--- a/sources/packages/backend/libs/integrations/src/esdc-integration/e-cert-integration/e-cert-file-handler.ts
+++ b/sources/packages/backend/libs/integrations/src/esdc-integration/e-cert-integration/e-cert-file-handler.ts
@@ -9,7 +9,7 @@ import {
   ECertFeedbackErrorService,
 } from "../../services";
 import { SequenceControlService, SystemUsersService } from "@sims/services";
-import { getISODateOnlyString, processInParallel } from "@sims/utilities";
+import { processInParallel } from "@sims/utilities";
 import { EntityManager } from "typeorm";
 import { ESDCFileHandler } from "../esdc-file-handler";
 import {


### PR DESCRIPTION
### As a part of this PR, the following were completed:

-  Ensured that the sequence numbers in PT and FT eCert file header is incremented as a lifetime value.
- Started the next PROD sequence number at **7 for PT eCerts** and **FT  eCerts are left as is (set to start at 1).** For this, added the following SQL to the Release 2.2 notes:

```sql
INSERT INTO sims.sequence_controls
(sequence_name, sequence_number)
VALUES ('ECERT_PT_SENT_FILE', 6), ('ECERT_FT_SENT_FILE', 0);
```