### PR TITLE
#4202 - Increment Sequence Header PT ECert

### DIFF
--- a/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/esdc-integration/ecert-integration/_tests_/ecert-part-time-process-integration.scheduler.e2e-spec.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/esdc-integration/ecert-integration/_tests_/ecert-part-time-process-integration.scheduler.e2e-spec.ts
@@ -84,6 +84,11 @@ describe(
       );
       // Create a Ministry user to b used, for instance, for audit.
       sharedMinistryUser = await db.user.save(createFakeUser());
+      // Create the sequence number in advance to control the file header sequence.
+      await db.sequenceControl.save({
+        sequenceName: ECERT_PART_TIME_SENT_FILE_SEQUENCE_GROUP,
+        sequenceNumber: "0",
+      });
     });
 
     beforeEach(async () => {

--- a/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/esdc-integration/ecert-integration/_tests_/ecert-part-time-process-integration.scheduler.e2e-spec.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/esdc-integration/ecert-integration/_tests_/ecert-part-time-process-integration.scheduler.e2e-spec.ts
@@ -367,7 +367,7 @@ describe(
         },
       );
       const eCertLifetimeSequence = 100000;
-      db.sequenceControl.update(
+      await db.sequenceControl.update(
         {
           sequenceName: ECERT_PART_TIME_SENT_FILE_SEQUENCE_GROUP,
         },

--- a/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/esdc-integration/ecert-integration/_tests_/ecert-part-time-process-integration.scheduler.e2e-spec.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/esdc-integration/ecert-integration/_tests_/ecert-part-time-process-integration.scheduler.e2e-spec.ts
@@ -84,11 +84,6 @@ describe(
       );
       // Create a Ministry user to b used, for instance, for audit.
       sharedMinistryUser = await db.user.save(createFakeUser());
-      // Create the sequence number in advance to control the file header sequence.
-      await db.sequenceControl.save({
-        sequenceName: ECERT_PART_TIME_SENT_FILE_SEQUENCE_GROUP,
-        sequenceNumber: "0",
-      });
     });
 
     beforeEach(async () => {
@@ -372,13 +367,12 @@ describe(
         },
       );
       const eCertLifetimeSequence = 100000;
-      await db.sequenceControl.update(
+      await db.sequenceControl.upsert(
         {
           sequenceName: ECERT_PART_TIME_SENT_FILE_SEQUENCE_GROUP,
-        },
-        {
           sequenceNumber: eCertLifetimeSequence.toString(),
         },
+        ["sequenceName"],
       );
       // Queued job.
       const { job } = mockBullJob<void>();

--- a/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/esdc-integration/ecert-integration/_tests_/ecert-part-time-process-integration.scheduler.e2e-spec.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/esdc-integration/ecert-integration/_tests_/ecert-part-time-process-integration.scheduler.e2e-spec.ts
@@ -52,6 +52,7 @@ import {
 } from "./e-cert-utils";
 import { SystemUsersService } from "@sims/services";
 import * as faker from "faker";
+import { ECERT_PART_TIME_SENT_FILE_SEQUENCE_GROUP } from "@sims/integrations/esdc-integration";
 
 describe(
   describeQueueProcessorRootTest(QueueNames.PartTimeECertIntegration),
@@ -97,7 +98,7 @@ describe(
       );
       // Reset sequence number to control the file name generated.
       await db.sequenceControl.update(
-        { sequenceName: Like("ECERT_PT_SENT_FILE_%") },
+        { sequenceName: Like("ECERT_PT_SENT_FILE%") },
         { sequenceNumber: "0" },
       );
     });
@@ -365,6 +366,15 @@ describe(
           },
         },
       );
+      const eCertLifetimeSequence = 100000;
+      db.sequenceControl.update(
+        {
+          sequenceName: ECERT_PART_TIME_SENT_FILE_SEQUENCE_GROUP,
+        },
+        {
+          sequenceNumber: eCertLifetimeSequence.toString(),
+        },
+      );
       // Queued job.
       const { job } = mockBullJob<void>();
 
@@ -386,7 +396,10 @@ describe(
 
       expect(uploadedFile.fileLines).toHaveLength(3);
       const [header, record, footer] = uploadedFile.fileLines;
+      const headerSequence = header.substring(58, 64);
       // Validate header.
+      const expectedHeaderSequence = (eCertLifetimeSequence + 1).toString();
+      expect(headerSequence).toBe(expectedHeaderSequence);
       expect(header).toContain("01BC  NEW PT ENTITLEMENT");
       // Validate footer.
       // Record Type.

--- a/sources/packages/backend/libs/integrations/src/esdc-integration/e-cert-integration/e-cert-file-handler.ts
+++ b/sources/packages/backend/libs/integrations/src/esdc-integration/e-cert-integration/e-cert-file-handler.ts
@@ -15,7 +15,7 @@ import {
   parseJSONError,
   processInParallel,
 } from "@sims/utilities";
-import { EntityManager } from "typeorm";
+import { DataSource, EntityManager } from "typeorm";
 import { ESDCFileHandler } from "../esdc-file-handler";
 import {
   Award,
@@ -55,6 +55,7 @@ type ECertFeedbackCodeMap = Record<string, ErrorDetails>;
 export abstract class ECertFileHandler extends ESDCFileHandler {
   esdcConfig: ESDCIntegrationConfig;
   constructor(
+    private readonly dataSource: DataSource,
     configService: ConfigService,
     private readonly sequenceService: SequenceControlService,
     private readonly eCertGenerationService: ECertGenerationService,
@@ -86,7 +87,7 @@ export abstract class ECertFileHandler extends ESDCFileHandler {
    * for the respective integration.
    * @param offeringIntensity disbursement offering intensity.
    * @param fileCode file code applicable for Part-Time or Full-Time.
-   * @param sequenceGroupPrefix sequence group prefix for Part-Time or Full-Time
+   * @param sequenceGroup sequence group for Part-Time or Full-Time
    * file sequence generation.
    * @param log cumulative process log.
    * @returns result of the file upload with the file generated and the
@@ -96,42 +97,46 @@ export abstract class ECertFileHandler extends ESDCFileHandler {
     eCertIntegrationService: ECertIntegrationService,
     offeringIntensity: OfferingIntensity,
     fileCode: string,
-    sequenceGroupPrefix: string,
+    sequenceGroup: string,
     log: ProcessSummary,
   ): Promise<ECertUploadResult> {
     log.info(
       `Retrieving ${offeringIntensity} disbursements to generate the e-Cert file...`,
     );
     try {
-      const sequenceGroup = `${sequenceGroupPrefix}_${getISODateOnlyString(
+      const sequenceGroupFileName = `${sequenceGroup}_${getISODateOnlyString(
         new Date(),
       )}`;
       let uploadResult: ECertUploadResult;
       let fileInfo: CreateRequestFileNameResult;
-      // Consume the next sequence number for the e-Cert filename
-      // and execute the creation of the request filename.
-      await this.sequenceService.consumeNextSequence(
-        sequenceGroup,
-        async (nextSequenceNumber: number) => {
-          // Create the request filename with the file path for the e-Cert File.
-          fileInfo = this.createRequestFileName(fileCode, nextSequenceNumber);
-        },
-      );
-      // Consume the next sequence number for the e-Cert file header
-      // and execute the processECert process.
-      await this.sequenceService.consumeNextSequence(
-        sequenceGroupPrefix,
-        async (nextSequenceNumber: number, entityManager: EntityManager) => {
-          uploadResult = await this.processECert(
-            nextSequenceNumber,
-            entityManager,
-            eCertIntegrationService,
-            offeringIntensity,
-            fileInfo,
-            log,
-          );
-        },
-      );
+      await this.dataSource.transaction(async (transactionalEntityManager) => {
+        // Consume the next sequence number for the e-Cert filename
+        // and execute the creation of the request filename.
+        await this.sequenceService.consumeNextSequenceWithExistingEntityManager(
+          sequenceGroupFileName,
+          transactionalEntityManager,
+          async (nextSequenceNumber: number) => {
+            // Create the request filename with the file path for the e-Cert File.
+            fileInfo = this.createRequestFileName(fileCode, nextSequenceNumber);
+          },
+        );
+        // Consume the next sequence number for the e-Cert file header
+        // and execute the processECert process.
+        await this.sequenceService.consumeNextSequenceWithExistingEntityManager(
+          sequenceGroup,
+          transactionalEntityManager,
+          async (nextSequenceNumber: number, entityManager: EntityManager) => {
+            uploadResult = await this.processECert(
+              nextSequenceNumber,
+              entityManager,
+              eCertIntegrationService,
+              offeringIntensity,
+              fileInfo,
+              log,
+            );
+          },
+        );
+      });
       return uploadResult;
     } catch (error: unknown) {
       if (

--- a/sources/packages/backend/libs/integrations/src/esdc-integration/e-cert-integration/full-time-e-cert-file-handler.ts
+++ b/sources/packages/backend/libs/integrations/src/esdc-integration/e-cert-integration/full-time-e-cert-file-handler.ts
@@ -15,6 +15,7 @@ import { ECertGenerationService } from "@sims/integrations/services";
 import { ECertFileHandler } from "./e-cert-file-handler";
 import { ECertFullTimeIntegrationService } from "./e-cert-full-time-integration/e-cert-full-time.integration.service";
 import { ProcessSummary } from "@sims/utilities/logger";
+import { DataSource } from "typeorm";
 
 const ECERT_FULL_TIME_SENT_FILE_SEQUENCE_GROUP = "ECERT_FT_SENT_FILE";
 
@@ -22,6 +23,7 @@ const ECERT_FULL_TIME_SENT_FILE_SEQUENCE_GROUP = "ECERT_FT_SENT_FILE";
 export class FullTimeECertFileHandler extends ECertFileHandler {
   esdcConfig: ESDCIntegrationConfig;
   constructor(
+    dataSource: DataSource,
     configService: ConfigService,
     sequenceService: SequenceControlService,
     eCertGenerationService: ECertGenerationService,
@@ -31,6 +33,7 @@ export class FullTimeECertFileHandler extends ECertFileHandler {
     private readonly eCertIntegrationService: ECertFullTimeIntegrationService,
   ) {
     super(
+      dataSource,
       configService,
       sequenceService,
       eCertGenerationService,

--- a/sources/packages/backend/libs/integrations/src/esdc-integration/e-cert-integration/part-time-e-cert-file-handler.ts
+++ b/sources/packages/backend/libs/integrations/src/esdc-integration/e-cert-integration/part-time-e-cert-file-handler.ts
@@ -15,13 +15,15 @@ import { ECertGenerationService } from "@sims/integrations/services";
 import { ECertFileHandler } from "./e-cert-file-handler";
 import { ECertPartTimeIntegrationService } from "./e-cert-part-time-integration/e-cert-part-time.integration.service";
 import { ProcessSummary } from "@sims/utilities/logger";
+import { DataSource } from "typeorm";
 
-const ECERT_PART_TIME_SENT_FILE_SEQUENCE_GROUP = "ECERT_PT_SENT_FILE";
+export const ECERT_PART_TIME_SENT_FILE_SEQUENCE_GROUP = "ECERT_PT_SENT_FILE";
 
 @Injectable()
 export class PartTimeECertFileHandler extends ECertFileHandler {
   esdcConfig: ESDCIntegrationConfig;
   constructor(
+    dataSource: DataSource,
     configService: ConfigService,
     sequenceService: SequenceControlService,
     eCertGenerationService: ECertGenerationService,
@@ -31,6 +33,7 @@ export class PartTimeECertFileHandler extends ECertFileHandler {
     private readonly eCertIntegrationService: ECertPartTimeIntegrationService,
   ) {
     super(
+      dataSource,
       configService,
       sequenceService,
       eCertGenerationService,


### PR DESCRIPTION
### As a part of this PR, the following were completed:

-  Ensured that the sequence numbers in PT and FT eCert file header is incremented as a lifetime value.
- Started the next PROD sequence number at **7 for PT eCerts** and **FT  eCerts are left as is (set to start at 1).** For this, added the following SQL to the Release 2.2 notes:

```sql
INSERT INTO sims.sequence_controls
(sequence_name, sequence_number)
VALUES ('ECERT_PT_SENT_FILE', 6), ('ECERT_FT_SENT_FILE', 0);
```

**Screenshots:**

<img width="1920" alt="image" src="https://github.com/user-attachments/assets/d7c854ae-a4f0-4163-9717-acd3e2e3c997" />

---------------------------------------------

<img width="1919" alt="image" src="https://github.com/user-attachments/assets/287fdbd3-e7f7-4a41-8a1b-06b9c20b9c16" />
