### PR TITLE
#3685 - Convert SIMS Web to deployment object

### DIFF
--- a/devops/Makefile
+++ b/devops/Makefile
@@ -511,7 +511,7 @@ deploy-web:
 	-p TLS_KEY=$(TLS_KEY) \
 	-p TLS_CA_CERTIFICATE=$(TLS_CA_CERTIFICATE) \
 	| oc -n $(NAMESPACE) apply -f -
-	$(call rollout_and_wait,dc/$(WEB))
+	$(call rollout_and_wait,deployment/$(WEB))
 
 create-qa-api-db:
 	test -n $(QA_DB_NAME)

--- a/devops/openshift/web-deploy.yml
+++ b/devops/openshift/web-deploy.yml
@@ -6,21 +6,24 @@ labels:
   project: ${PROJECT}
   service: ${SERVICE_NAME}
 objects:
-  - apiVersion: apps.openshift.io/v1
-    kind: DeploymentConfig
+  - apiVersion: apps/v1
+    kind: Deployment
     metadata:
+      labels:
+        app: ${NAME}
       name: ${NAME}
     spec:
       replicas: "${{REPLICAS}}"
       revisionHistoryLimit: 10
       selector:
-        deploymentconfig: ${NAME}
+        matchLabels:
+          app: ${NAME}
       strategy:
-        type: Rolling
+        type: RollingUpdate
       template:
         metadata:
           labels:
-            deploymentconfig: ${NAME}
+            app: ${NAME}
         spec:
           containers:
             - env:
@@ -69,7 +72,7 @@ objects:
           port: 80
           targetPort: ${{PORT}}
       selector:
-        deploymentconfig: ${NAME}
+        app: ${NAME}
       type: ClusterIP
   - apiVersion: route.openshift.io/v1
     kind: Route
@@ -107,8 +110,8 @@ objects:
       name: ${NAME}-hpa
     spec:
       scaleTargetRef:
-        apiVersion: apps.openshift.io/v1
-        kind: DeploymentConfig
+        apiVersion: apps/v1
+        kind: Deployment
         name: ${NAME}
       minReplicas: "${{REPLICAS}}"
       maxReplicas: 10
@@ -132,7 +135,7 @@ objects:
     spec:
       selector:
         matchLabels:
-          deploymentconfig: ${NAME}
+          app: ${NAME}
       maxUnavailable: 1
 parameters:
   - name: NAME


### PR DESCRIPTION
# Convert Deployment Config to Deployment - SIMS Web

## Resource
- [Redhat Guide](https://developers.redhat.com/learning/learn:openshift:replace-deprecated-deploymentconfigs-deployments/resource/resources:convert-deploymentconfig-deployment?mc_cid=1a844df827&mc_eid=f049851a15)
- [Kubernetes rollout status command](https://kubernetes.io/docs/reference/kubectl/generated/kubectl_rollout/kubectl_rollout_status/#:~:text=Show%20the%20status%20of%20the,continue%20watching%20the%20latest%20revision.)
![image](https://github.com/user-attachments/assets/770cc1b9-d1f5-4538-85a7-995a4b632c48)


## Updates
- [x] Converted the `DeploymentConfig` object `sims-web` to `Deployment`
- [x] The metadata label `deploymentconfig` is replaced with label `app`. This label is now used as selector.
- [x] The `HorizontalPodAutoscaler` is now attached to `Deployment` instead of `DeploymentConfig`.
- [x] The `rollout status` command is now executed on deployment.