### PR TITLE
#3910 - Show application edit history ministry view

### DIFF
--- a/sources/packages/backend/apps/api/src/route-controllers/application/_tests_/application.aest.controller.getApplicationVersionHistory.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/application/_tests_/application.aest.controller.getApplicationVersionHistory.e2e-spec.ts
@@ -1,0 +1,97 @@
+import { HttpStatus, INestApplication } from "@nestjs/common";
+import * as request from "supertest";
+import {
+  AESTGroups,
+  BEARER_AUTH_TYPE,
+  createTestingAppModule,
+  getAESTToken,
+} from "../../../testHelpers";
+import {
+  createE2EDataSources,
+  E2EDataSources,
+  saveFakeApplication,
+} from "@sims/test-utils";
+import { ApplicationStatus } from "@sims/sims-db";
+import { addDays, getPSTPDTDateHourMinute } from "@sims/utilities";
+
+describe("ApplicationAESTController(e2e)-getApplicationVersionHistory", () => {
+  let app: INestApplication;
+  let db: E2EDataSources;
+
+  beforeAll(async () => {
+    const { nestApplication, dataSource } = await createTestingAppModule();
+    app = nestApplication;
+    db = createE2EDataSources(dataSource);
+  });
+
+  it("Should get an array of application versions when there is a previous application associated with the given application.", async () => {
+    // Arrange
+    const application = await saveFakeApplication(db.dataSource, undefined, {
+      submittedDate: new Date(),
+    });
+
+    const previousApplication = await saveFakeApplication(
+      db.dataSource,
+      {
+        institution:
+          application.currentAssessment.offering.institutionLocation
+            .institution,
+        institutionLocation:
+          application.currentAssessment.offering.institutionLocation,
+        student: application.student,
+        program: application.currentAssessment.offering.educationProgram,
+        offering: application.currentAssessment.offering,
+        programYear: application.programYear,
+      },
+      {
+        applicationStatus: ApplicationStatus.Overwritten,
+        applicationNumber: application.applicationNumber,
+        offeringIntensity:
+          application.currentAssessment.offering.offeringIntensity,
+        pirStatus: application.pirStatus,
+        submittedDate: addDays(-10),
+      },
+    );
+
+    const token = await getAESTToken(AESTGroups.BusinessAdministrators);
+
+    const endpoint = `/aest/application/${application.id}/versions`;
+
+    // Act/Assert
+    await request(app.getHttpServer())
+      .get(endpoint)
+      .auth(token, BEARER_AUTH_TYPE)
+      .expect(HttpStatus.OK)
+      .expect({
+        applicationVersions: [
+          {
+            applicationId: previousApplication.id,
+            submittedDate: getPSTPDTDateHourMinute(
+              previousApplication.submittedDate,
+            ),
+          },
+        ],
+      });
+  });
+
+  it("Should throw not found error when an application is not found.", async () => {
+    // Arrange
+    const endpoint = "/aest/application/99999999/progress-details";
+    const token = await getAESTToken(AESTGroups.BusinessAdministrators);
+
+    // Act/Assert
+    await request(app.getHttpServer())
+      .get(endpoint)
+      .auth(token, BEARER_AUTH_TYPE)
+      .expect(HttpStatus.NOT_FOUND)
+      .expect({
+        statusCode: HttpStatus.NOT_FOUND,
+        message: "Application id 99999999 was not found.",
+        error: "Not Found",
+      });
+  });
+
+  afterAll(async () => {
+    await app?.close();
+  });
+});

--- a/sources/packages/backend/apps/api/src/route-controllers/application/models/application.dto.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/application/models/application.dto.ts
@@ -211,3 +211,8 @@ export class ApplicationWarningsAPIOutDTO {
   eCertFailedValidations: ECertFailedValidation[];
   canAcceptAssessment: boolean;
 }
+
+export class ApplicationVersionAPIOutDTO {
+  id: number;
+  submittedDate: string;
+}

--- a/sources/packages/backend/libs/test-utils/src/factories/application.ts
+++ b/sources/packages/backend/libs/test-utils/src/factories/application.ts
@@ -67,6 +67,7 @@ export function createFakeApplication(
   application.location = relations?.location ?? createFakeInstitutionLocation();
   application.pirStatus = options?.initialValue?.pirStatus;
   application.isArchived = options?.initialValue?.isArchived;
+  application.submittedDate = options?.initialValue?.submittedDate;
   return application;
 }
 
@@ -259,12 +260,14 @@ export async function saveFakeApplication(
   },
   options?: {
     applicationStatus?: ApplicationStatus;
+    applicationNumber?: string;
     offeringIntensity?: OfferingIntensity;
     applicationData?: ApplicationData;
     pirStatus?: ProgramInfoStatus;
     isArchived?: boolean;
     currentAssessmentInitialValues?: Partial<StudentAssessment>;
     offeringInitialValues?: Partial<EducationProgramOffering>;
+    submittedDate?: Date;
   },
 ): Promise<Application> {
   const userRepo = dataSource.getRepository(User);
@@ -296,6 +299,8 @@ export async function saveFakeApplication(
         data: options?.applicationData,
         pirStatus: options?.pirStatus,
         isArchived: options?.isArchived ? options?.isArchived : false,
+        applicationNumber: options?.applicationNumber,
+        submittedDate: options?.submittedDate,
       },
     },
   );

--- a/sources/packages/backend/libs/utilities/src/date-utils.ts
+++ b/sources/packages/backend/libs/utilities/src/date-utils.ts
@@ -22,6 +22,7 @@ export const DATE_ONLY_ISO_FORMAT = "YYYY-MM-DD";
 export const DATE_ONLY_FORMAT = "MMM DD YYYY";
 export const DATE_ONLY_FULL_MONTH_FORMAT = "MMMM D, YYYY";
 export const DATE_TIME_FORMAT = "YYYY-MM-DD HH:mm:ss";
+export const DATE_HOUR_MINUTE_FORMAT = "MMM DD YYYY HH:mm";
 export const TIMESTAMP_CONTINUOUS_FORMAT = "YYYY-MM-DD_HH.mm.ss";
 export const TIMESTAMP_CONTINUOUS_EXTENDED_FORMAT = "YYYYMMDD-HHmmssSSS";
 export const PST_TIMEZONE = "America/Vancouver";
@@ -97,6 +98,25 @@ export const getPSTPDTDateTime = (
   local = false,
 ): string => {
   return dayjs(new Date(date)).tz(PST_TIMEZONE, local).format(DATE_TIME_FORMAT);
+};
+
+/**
+ * Convert the date to (PST: UTC−08:00/PDT: UTC−07:00).
+ * @param date date to be converted to PST.
+ * @param local, if local is set to true,
+ * then the offset will be directly append to the date without
+ * converting to the timezone actual date,
+ * if set to false, the date will be converted
+ * to the actual timezone time with offset.
+ * @returns date in MMM DD YYYY HH:mm format.
+ */
+export const getPSTPDTDateHourMinute = (
+  date: string | Date,
+  local = false,
+): string => {
+  return dayjs(new Date(date))
+    .tz(PST_TIMEZONE, local)
+    .format(DATE_HOUR_MINUTE_FORMAT);
 };
 
 /**

--- a/sources/packages/web/src/components/layouts/aest/AESTApplicationSideBar.vue
+++ b/sources/packages/web/src/components/layouts/aest/AESTApplicationSideBar.vue
@@ -41,6 +41,27 @@
       :title="studentMenu.applicationStatus.title"
       @click="studentMenu.applicationStatus.command"
     />
+    <v-list v-if="applicationHistory.length" density="compact" nav>
+      <v-list-group
+        v-for="application in applicationHistory"
+        :key="application.title"
+        :prepend-icon="application.props?.prependIcon"
+        :title="application.title"
+        :value="application.title"
+      >
+        <template v-slot:activator="{ props }">
+          <v-list-item v-bind="props" :title="application.title"></v-list-item>
+        </template>
+
+        <v-list-item
+          v-for="child in application.children"
+          :key="child.title"
+          :title="child.title"
+          :prepend-icon="child.props?.prependIcon"
+          @click="child.command"
+        ></v-list-item>
+      </v-list-group>
+    </v-list>
   </v-navigation-drawer>
 </template>
 
@@ -50,6 +71,7 @@ import { ref, onMounted, defineComponent } from "vue";
 import { AESTRoutesConst } from "@/constants/routes/RouteConstants";
 import { MenuItemModel, SupportingUserType } from "@/types";
 import { SupportingUsersService } from "@/services/SupportingUserService";
+import { ApplicationService } from "@/services/ApplicationService";
 
 export interface StudentApplicationMenu {
   studentApplication: MenuItemModel;
@@ -72,6 +94,7 @@ export default defineComponent({
   setup(props) {
     const router = useRouter();
     const relatedParentPartners = ref([] as MenuItemModel[]);
+    const applicationHistory = ref([] as MenuItemModel[]);
     const studentMenu = ref<StudentApplicationMenu>({
       studentApplication: {
         title: "Application",
@@ -138,6 +161,16 @@ export default defineComponent({
       });
     };
 
+    const goToApplicationVersion = (applicationId: number) => {
+      router.push({
+        name: AESTRoutesConst.APPLICATION_DETAILS,
+        params: {
+          studentId: props.studentId,
+          applicationId: applicationId,
+        },
+      });
+    };
+
     onMounted(async () => {
       const supportingUsers =
         await SupportingUsersService.shared.getSupportingUsersForSideBar(
@@ -159,11 +192,31 @@ export default defineComponent({
           });
         }
       });
+      const applicationVersionHistory =
+        await ApplicationService.shared.getApplicationVersionHistory(
+          props.applicationId,
+        );
+      if (applicationVersionHistory.length) {
+        applicationVersionHistory.forEach((application) => {
+          applicationHistory.value.push({
+            title: `${application.submittedDate}`,
+            props: { prependIcon: "mdi-update" },
+            children: [
+              {
+                title: "Application",
+                props: { prependIcon: "mdi-school-outline" },
+                command: () => goToApplicationVersion(application.id),
+              },
+            ],
+          });
+        });
+      }
     });
 
     return {
       studentMenu,
       relatedParentPartners,
+      applicationHistory,
     };
   },
 });

--- a/sources/packages/web/src/services/ApplicationService.ts
+++ b/sources/packages/web/src/services/ApplicationService.ts
@@ -20,6 +20,7 @@ import {
   CompletedApplicationDetailsAPIOutDTO,
   ApplicationAssessmentStatusDetailsAPIOutDTO,
   ApplicationSupplementalDataAPIOutDTO,
+  ApplicationVersionAPIOutDTO,
 } from "@/services/http/dto";
 
 export class ApplicationService {
@@ -200,5 +201,17 @@ export class ApplicationService {
     return ApiClient.Application.getApplicationAssessmentStatusDetails(
       applicationId,
     );
+  }
+
+  /**
+   * Get history of application versions for an application
+   * where the current application is excluded.
+   * @param applicationId, application id.
+   * @returns history of application versions.
+   */
+  async getApplicationVersionHistory(
+    applicationId: number,
+  ): Promise<ApplicationVersionAPIOutDTO[]> {
+    return ApiClient.Application.getApplicationVersionHistory(applicationId);
   }
 }

--- a/sources/packages/web/src/services/http/ApplicationApi.ts
+++ b/sources/packages/web/src/services/http/ApplicationApi.ts
@@ -21,6 +21,7 @@ import {
   CompletedApplicationDetailsAPIOutDTO,
   ApplicationAssessmentStatusDetailsAPIOutDTO,
   ApplicationSupplementalDataAPIOutDTO,
+  ApplicationVersionAPIOutDTO,
 } from "@/services/http/dto";
 
 export class ApplicationApi extends HttpBaseClient {
@@ -220,6 +221,21 @@ export class ApplicationApi extends HttpBaseClient {
   ): Promise<ApplicationAssessmentStatusDetailsAPIOutDTO> {
     return this.getCall(
       this.addClientRoot(`application/${applicationId}/assessment-details`),
+    );
+  }
+
+  /**
+   * Get history of application versions for an application
+   * where the current application is excluded.
+   * @param applicationId, application id.
+   * @returns application version list.
+   */
+  public async getApplicationVersionHistory(
+    applicationId: number,
+  ): Promise<ApplicationVersionAPIOutDTO[]> {
+    const endpoint = `application/${applicationId}/versions`;
+    return this.getCall<ApplicationVersionAPIOutDTO[]>(
+      this.addClientRoot(endpoint),
     );
   }
 }

--- a/sources/packages/web/src/services/http/dto/Application.dto.ts
+++ b/sources/packages/web/src/services/http/dto/Application.dto.ts
@@ -162,3 +162,8 @@ export interface ApplicationWarningsAPIOutDTO {
   eCertFailedValidations: ECertFailedValidation[];
   canAcceptAssessment: boolean;
 }
+
+export interface ApplicationVersionAPIOutDTO {
+  id: number;
+  submittedDate: string;
+}


### PR DESCRIPTION
- Created the menu on demand, only if any historical application exists.
   - Modify application view screen to have all versions of the app history on the left hand side.
   - Each version of the app will be a expandable selection.
   - Each app version will appear in descending order based on date time stamp.
- Added a new API endpoint for fetching historical applications to populate the menu.
- Changed the API to allow the overwritten application information needed to build the menu for Ministry User.
   - Ensured API would allow the overwritten applications to be retrieved.
- Modified and added E2E tests for the changed API endpoints.

Screenshot of the historical application items
![image](https://github.com/user-attachments/assets/815d2dff-abd8-41f3-bc87-72d341b0ed63)
