### PR TITLE
#4223 - Student Bridge Match: PPD Status Not Importing

### DIFF
--- a/sources/packages/backend/libs/integrations/src/esdc-integration/e-cert-integration/full-time-e-cert-file-handler.ts
+++ b/sources/packages/backend/libs/integrations/src/esdc-integration/e-cert-integration/full-time-e-cert-file-handler.ts
@@ -15,6 +15,7 @@ import { ECertGenerationService } from "@sims/integrations/services";
 import { ECertFileHandler } from "./e-cert-file-handler";
 import { ECertFullTimeIntegrationService } from "./e-cert-full-time-integration/e-cert-full-time.integration.service";
 import { ProcessSummary } from "@sims/utilities/logger";
+import { DataSource } from "typeorm";
 
 const ECERT_FULL_TIME_SENT_FILE_SEQUENCE_GROUP = "ECERT_FT_SENT_FILE";
 
@@ -22,6 +23,7 @@ const ECERT_FULL_TIME_SENT_FILE_SEQUENCE_GROUP = "ECERT_FT_SENT_FILE";
 export class FullTimeECertFileHandler extends ECertFileHandler {
   esdcConfig: ESDCIntegrationConfig;
   constructor(
+    dataSource: DataSource,
     configService: ConfigService,
     sequenceService: SequenceControlService,
     eCertGenerationService: ECertGenerationService,
@@ -31,6 +33,7 @@ export class FullTimeECertFileHandler extends ECertFileHandler {
     private readonly eCertIntegrationService: ECertFullTimeIntegrationService,
   ) {
     super(
+      dataSource,
       configService,
       sequenceService,
       eCertGenerationService,

--- a/sources/packages/backend/libs/integrations/src/esdc-integration/e-cert-integration/part-time-e-cert-file-handler.ts
+++ b/sources/packages/backend/libs/integrations/src/esdc-integration/e-cert-integration/part-time-e-cert-file-handler.ts
@@ -15,13 +15,15 @@ import { ECertGenerationService } from "@sims/integrations/services";
 import { ECertFileHandler } from "./e-cert-file-handler";
 import { ECertPartTimeIntegrationService } from "./e-cert-part-time-integration/e-cert-part-time.integration.service";
 import { ProcessSummary } from "@sims/utilities/logger";
+import { DataSource } from "typeorm";
 
-const ECERT_PART_TIME_SENT_FILE_SEQUENCE_GROUP = "ECERT_PT_SENT_FILE";
+export const ECERT_PART_TIME_SENT_FILE_SEQUENCE_GROUP = "ECERT_PT_SENT_FILE";
 
 @Injectable()
 export class PartTimeECertFileHandler extends ECertFileHandler {
   esdcConfig: ESDCIntegrationConfig;
   constructor(
+    dataSource: DataSource,
     configService: ConfigService,
     sequenceService: SequenceControlService,
     eCertGenerationService: ECertGenerationService,
@@ -31,6 +33,7 @@ export class PartTimeECertFileHandler extends ECertFileHandler {
     private readonly eCertIntegrationService: ECertPartTimeIntegrationService,
   ) {
     super(
+      dataSource,
       configService,
       sequenceService,
       eCertGenerationService,

--- a/sources/packages/backend/libs/services/src/sfas/sfas-individual.service.ts
+++ b/sources/packages/backend/libs/services/src/sfas/sfas-individual.service.ts
@@ -30,7 +30,12 @@ export class SFASIndividualService {
   ): Promise<SFASIndividual> {
     const individual = await this.sfasIndividualRepo
       .createQueryBuilder("individual")
-      .select(["individual.id", "individual.pdStatus"])
+      .select([
+        "individual.id",
+        "individual.pdStatus",
+        "individual.ppdStatus",
+        "individual.ppdStatusDate",
+      ])
       .where("lower(individual.lastName) = :lastName", {
         lastName: lastName.toLowerCase(),
       })


### PR DESCRIPTION
### As a part of this PR, the following was fixed:

**Issue:** When a student creates a profile in SIMS and they have PPD = true in a matching `sfas_individuals` record, their `students.disability_status` status is `Not requested`.

**Fix:** The query retrieving the `sfas_individual` for a matching SIMS record was not returning the individual's `ppdStatus` and the `ppdStatusDate`. Added it to fix the issue.