### PR TITLE
#4223 - Student Bridge Match - PPD Status Not Importing

### DIFF
--- a/sources/packages/backend/libs/services/src/sfas/sfas-individual.service.ts
+++ b/sources/packages/backend/libs/services/src/sfas/sfas-individual.service.ts
@@ -30,7 +30,12 @@ export class SFASIndividualService {
   ): Promise<SFASIndividual> {
     const individual = await this.sfasIndividualRepo
       .createQueryBuilder("individual")
-      .select(["individual.id", "individual.pdStatus"])
+      .select([
+        "individual.id",
+        "individual.pdStatus",
+        "individual.ppdStatus",
+        "individual.ppdStatusDate",
+      ])
       .where("lower(individual.lastName) = :lastName", {
         lastName: lastName.toLowerCase(),
       })


### PR DESCRIPTION
### As a part of this PR, the following was fixed:

**Issue:** When a student creates a profile in SIMS and they have PPD = true in a matching `sfas_individuals` record, their `students.disability_status` status is `Not requested`.

**Fix:** The query retrieving the `sfas_individual` for a matching SIMS record was not returning the individual's `ppdStatus` and the `ppdStatusDate`. Added it to fix the issue.

**Fix Screenshot:**

<img width="1729" alt="image" src="https://github.com/user-attachments/assets/80e5165f-0097-4777-ace1-363819e4cff9" />

---------------------------------------------------------------------------------------------------------

<img width="1727" alt="image" src="https://github.com/user-attachments/assets/5c996748-53ba-4ae3-ab7c-2e58b63541b4" />
