### PR TITLE
#3666 - Queue Monitoring - Sysdig Team Update

### DIFF
--- a/.github/workflows/env-setup-sysdig-teams.yml
+++ b/.github/workflows/env-setup-sysdig-teams.yml
@@ -1,14 +1,14 @@
-name: Env Setup - Update Sysdig Teams in Openshift
-run-name: Env Setup - Update Sysdig Teams in Openshift using ${{ github.ref_name }}
+name: Env Setup - Update Sysdig Team in Openshift
+run-name: Env Setup - Update Sysdig Team in Openshift using ${{ github.ref_name }}
 
-concurrency: update-sysdig-teams
+concurrency: update-sysdig-team
 
 on:
   workflow_dispatch:
 
 jobs:
-  update-sysdig-teams:
-    name: Update Sysdig Teams
+  update-sysdig-team:
+    name: Update Sysdig Team
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Target Branch
@@ -25,4 +25,4 @@ jobs:
       - name: Delete Redis
         working-directory: "./devops/"
         run: |
-          make update-sysdig-teams
+          make update-sysdig-team

--- a/.github/workflows/env-setup-sysdig-teams.yml
+++ b/.github/workflows/env-setup-sysdig-teams.yml
@@ -1,0 +1,28 @@
+name: Env Setup - Update Sysdig Teams in Openshift
+run-name: Env Setup - Update Sysdig Teams in Openshift using ${{ github.ref_name }}
+
+concurrency: update-sysdig-teams
+
+on:
+  workflow_dispatch:
+
+jobs:
+  update-sysdig-teams:
+    name: Update Sysdig Teams
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Target Branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref_name }}
+      - name: Install CLI tools from OpenShift Mirror
+        uses: redhat-actions/openshift-tools-installer@v1
+        with:
+          oc: "4"
+      - name: Log in to OpenShift
+        run: |
+          oc login --token=${{ secrets.SA_TOKEN }} --server=${{ vars.OPENSHIFT_CLUSTER_URL }}
+      - name: Delete Redis
+        working-directory: "./devops/"
+        run: |
+          make update-sysdig-teams

--- a/devops/Makefile
+++ b/devops/Makefile
@@ -518,7 +518,7 @@ delete-redis:
 	@echo "+\n++ Removing redis and resources on $(NAMESPACE)\n+"
 	@oc delete -n $(NAMESPACE) all,rc,svc,dc,route,pvc,secret,configmap,sa -l app=redis
 
-update-sysdig-teams:
+update-sysdig-team:
 	@echo "Updating Sysdig Team for license plate 0c27fb.\n"
 	@oc project 0c27fb-tools
 	@oc process -f openshift/sysdig-team.yml -p LICENSE_PLATE=0c27fb | oc apply -f -

--- a/devops/Makefile
+++ b/devops/Makefile
@@ -517,3 +517,11 @@ deploy-forms:
 delete-redis:
 	@echo "+\n++ Removing redis and resources on $(NAMESPACE)\n+"
 	@oc delete -n $(NAMESPACE) all,rc,svc,dc,route,pvc,secret,configmap,sa -l app=redis
+
+update-sysdig-teams:
+	@echo "Updating Sysdig Team for license plate 0c27fb.\n"
+	@oc project 0c27fb-tools
+	@oc process -f openshift/sysdig-team.yml -p LICENSE_PLATE=0c27fb | oc apply -f -
+	@echo "Updating Sysdig Team for license plate a6ef19.\n"
+	@oc project a6ef19-tools
+	@oc process -f openshift/sysdig-team.yml -p LICENSE_PLATE=a6ef19 | oc apply -f -

--- a/devops/openshift/sysdig-team.yml
+++ b/devops/openshift/sysdig-team.yml
@@ -1,27 +1,39 @@
-apiVersion: ops.gov.bc.ca/v1alpha1
-kind: SysdigTeam
-metadata:
-  name: 0c27fb-sysdigteam
-  namespace: 0c27fb-tools
-spec:
-  team:
-    description: The Sysdig Team for the OpenShift Project Set SIMS
-    users:
-      - name: nino.samson@gov.bc.ca
-        role: ROLE_TEAM_EDIT
-      - name: bidyashish.kumar@gov.bc.ca
-        role: ROLE_TEAM_EDIT
-      - name: shashank.x.shekhar@gov.bc.ca
-        role: ROLE_TEAM_EDIT
-      - name: jason.tang@gov.bc.ca
-        role: ROLE_TEAM_EDIT
-      - name: gurumoorthy.mohan@aot-technologies.com
-        role: ROLE_TEAM_EDIT
-      - name: dheepak.rr@aot-technologies.com
-        role: ROLE_TEAM_EDIT
-      - name: andrew.signori@aot-technologies.com
-        role: ROLE_TEAM_EDIT
-      - name: andre.pestana@aot-technologies.com
-        role: ROLE_TEAM_STANDARD
-      - name: lewis.chen@aot-technologies.com
-        role: ROLE_TEAM_STANDARD
+apiVersion: template.openshift.io/v1
+kind: Template
+objects:
+  - apiVersion: ops.gov.bc.ca/v1alpha1
+    kind: SysdigTeam
+    metadata:
+      name: ${LICENSE_PLATE}-sysdigteam
+      namespace: ${LICENSE_PLATE}-tools
+    spec:
+      team:
+        description: The Sysdig Team for the OpenShift Project Set SIMS
+        users:
+          - name: nino.samson@gov.bc.ca
+            role: ROLE_TEAM_EDIT
+          - name: bidyashish.kumar@gov.bc.ca
+            role: ROLE_TEAM_EDIT
+          - name: shashank.x.shekhar@gov.bc.ca
+            role: ROLE_TEAM_EDIT
+          - name: carly.cotton@gov.bc.ca
+            role: ROLE_TEAM_EDIT
+          - name: joshua.lakusta@gov.bc.ca
+            role: ROLE_TEAM_STANDARD
+          - name: jason.tang@gov.bc.ca
+            role: ROLE_TEAM_EDIT
+          - name: gurumoorthy.mohan@aot-technologies.com
+            role: ROLE_TEAM_EDIT
+          - name: dheepak.rr@aot-technologies.com
+            role: ROLE_TEAM_EDIT
+          - name: andrew.signori@aot-technologies.com
+            role: ROLE_TEAM_EDIT
+          - name: andre.pestana@aot-technologies.com
+            role: ROLE_TEAM_STANDARD
+          - name: lewis.chen@aot-technologies.com
+            role: ROLE_TEAM_STANDARD
+parameters:
+  - name: LICENSE_PLATE
+    description: |
+      License plate to apply the template.
+    required: true


### PR DESCRIPTION
This ticket is to add missing team members to the sysdig as agreed during the development of the ticket #3666.
_Please note the ticket is not associated with the PR because it is closed and does not seem worth opening or creating a ticket only for this task._
The current way to update and apply the changes was manual and demanded manual editing of the file to be applied to each license plate. The intention of this PR is to make it simple.

- Converted sysdig team to a template to allow adding a parameter.
- Create a make command to execute the template in the current two license plates.

Technical documentation about Sysdig team setup: https://developer.gov.bc.ca/docs/default/component/platform-developer-docs/docs/app-monitoring/sysdig-monitor-setup-team/?utm_source=digital&utm_medium=web&utm_campaign=sysdig-monitor