### PR TITLE
#4226 - NOA Eligible to Receive - Double Counting BC Grants (#4238)

### DIFF
--- a/sources/packages/backend/apps/api/src/route-controllers/assessment/_tests_/e2e/assessment.students.controller.getAssessmentNOA.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/assessment/_tests_/e2e/assessment.students.controller.getAssessmentNOA.e2e-spec.ts
@@ -156,6 +156,124 @@ describe("AssessmentStudentsController(e2e)-getAssessmentNOA", () => {
       .expect(expectation);
   });
 
+  it("Should exclude BC Total Grant from eligible amount calculation when getting NOA details", async () => {
+    // Arrange
+    const student = await saveFakeStudent(db.dataSource);
+    await mockUserLoginInfo(appModule, student);
+
+    // Create signed MSFAA
+    const msfaaNumber = createFakeMSFAANumber(
+      { student },
+      {
+        msfaaState: MSFAAStates.Signed,
+      },
+    );
+    await db.msfaaNumber.save(msfaaNumber);
+
+    const application = await saveFakeApplicationDisbursements(
+      db.dataSource,
+      {
+        msfaaNumber,
+        student,
+        disbursementValues: [
+          // BC Total Grant (excluded from eligible amount)
+          createFakeDisbursementValue(
+            DisbursementValueType.BCTotalGrant,
+            "BCSG",
+            540,
+          ),
+          // Canada Student Loans and Grants
+          createFakeDisbursementValue(
+            DisbursementValueType.CanadaLoan,
+            "CSLF",
+            0,
+          ),
+          createFakeDisbursementValue(
+            DisbursementValueType.CanadaGrant,
+            "CSGP",
+            0,
+          ),
+          createFakeDisbursementValue(
+            DisbursementValueType.CanadaGrant,
+            "CSGF",
+            2520,
+          ),
+          // BC Grants
+          createFakeDisbursementValue(
+            DisbursementValueType.BCGrant,
+            "BCAG",
+            140,
+          ),
+          createFakeDisbursementValue(
+            DisbursementValueType.BCGrant,
+            "SBSD",
+            400,
+          ),
+        ],
+      },
+      {
+        offeringIntensity: OfferingIntensity.fullTime,
+      },
+    );
+
+    const assessment = application.currentAssessment;
+    const [disbursement] = assessment.disbursementSchedules;
+
+    const endpoint = `/students/assessment/${assessment.id}/noa`;
+    const studentUserToken = await getStudentToken(
+      FakeStudentUsersTypes.FakeStudentUserType1,
+    );
+
+    const expectedNOADetails = {
+      applicationId: application.id,
+      applicationNumber: application.applicationNumber,
+      applicationStatus: application.applicationStatus,
+      assessment: assessment.assessmentData,
+      noaApprovalStatus: assessment.noaApprovalStatus,
+      applicationCurrentAssessmentId: application.currentAssessment.id,
+      fullName: getUserFullName(application.student.user),
+      programName: assessment.offering.educationProgram.name,
+      locationName: assessment.offering.institutionLocation.name,
+      offeringIntensity: OfferingIntensity.fullTime,
+      offeringStudyEndDate: getDateOnlyFullMonthFormat(
+        assessment.offering.studyEndDate,
+      ),
+      offeringStudyStartDate: getDateOnlyFullMonthFormat(
+        assessment.offering.studyStartDate,
+      ),
+      // Sum of CSGF(2520) + BCAG(140) + SBSD(400), excluding BCSG(540)
+      eligibleAmount: 3060,
+      disbursement: {
+        disbursement1COEStatus: disbursement.coeStatus,
+        disbursement1Date: getDateOnlyFullMonthFormat(
+          disbursement.disbursementDate,
+        ),
+        disbursement1Id: disbursement.id,
+        disbursement1MSFAACancelledDate:
+          disbursement.msfaaNumber?.cancelledDate,
+        disbursement1MSFAADateSigned: disbursement.msfaaNumber?.dateSigned,
+        disbursement1MSFAAId: disbursement.msfaaNumber?.id,
+        disbursement1MSFAANumber: msfaaNumber.msfaaNumber,
+        disbursement1Status: disbursement.disbursementScheduleStatus,
+        disbursement1TuitionRemittance:
+          disbursement.tuitionRemittanceRequestedAmount,
+        disbursement1cslf: 0,
+        disbursement1csgp: 0,
+        disbursement1csgf: 2520,
+        disbursement1bcag: 140,
+        disbursement1sbsd: 400,
+      },
+      offeringName: assessment.offering.name,
+    };
+
+    // Act/Assert
+    await request(app.getHttpServer())
+      .get(endpoint)
+      .auth(studentUserToken, BEARER_AUTH_TYPE)
+      .expect(HttpStatus.OK)
+      .expect(expectedNOADetails);
+  });
+
   afterAll(async () => {
     await app?.close();
   });

--- a/sources/packages/backend/apps/api/src/route-controllers/assessment/assessment.controller.service.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/assessment/assessment.controller.service.ts
@@ -203,6 +203,10 @@ export class AssessmentControllerService {
       .flatMap(
         (disbursementSchedule) => disbursementSchedule.disbursementValues,
       )
+      .filter(
+        (disbursementValue) =>
+          disbursementValue.valueType !== DisbursementValueType.BCTotalGrant,
+      )
       .reduce(
         (accumulator, disbursementValue) =>
           accumulator + disbursementValue.valueAmount,


### PR DESCRIPTION
**Acceptance Criteria**
- [x] Update the Eligible to Receive amount to not include **BC Total Grant** from the `disbursement_values` so it's not being double counted.
- [x] Check post ecert calculation. This is when the BC Total grant is added to the table.


**Technical**
- [x] If E2E tests are in place please adjust it to cover this scenario, including the "BC Total Grant" in the data setup and asserting the expected value.

E2E test data is taken from sample data.