### PR TITLE
#3054 - Email notification for blocked disbursement to ministry only once

### DIFF
--- a/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/esdc-integration/ecert-integration/_tests_/ecert-full-time-process-integration.scheduler.e2e-spec.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/esdc-integration/ecert-integration/_tests_/ecert-full-time-process-integration.scheduler.e2e-spec.ts
@@ -1363,10 +1363,8 @@ describe(
         expect(
           mockedJob.containLogMessages([
             "Disbursement estimated awards do not contain any amount to be disbursed.",
-            `Validating if 'Ministry Blocked Disbursement' notification should be created for disbursement ID ${disbursement.id}.`,
-            "Notification created.",
-            `Validating if 'Student Blocked Disbursement' notification should be created for disbursement ID ${disbursement.id}.`,
-            "Notification created.",
+            `Ministry Blocked Disbursement notification created for disbursement ID ${disbursement.id}.`,
+            `Student Blocked Disbursement notification created for disbursement ID ${disbursement.id}.`,
           ]),
         ).toBe(true);
         const notifications = await db.notification.find({
@@ -1443,10 +1441,8 @@ describe(
       expect(
         mockedJob.containLogMessages([
           "The step determined that the calculation should be interrupted. This disbursement will not be part of the next e-Cert generation.",
-          `Validating if 'Ministry Blocked Disbursement' notification should be created for disbursement ID ${disbursement.id}.`,
-          "Notification should not be created at this moment.",
-          `Validating if 'Student Blocked Disbursement' notification should be created for disbursement ID ${disbursement.id}.`,
-          "Notification created.",
+          `Ministry Blocked Disbursement notification should not be created at this moment for disbursement ID ${disbursement.id}.`,
+          `Student Blocked Disbursement notification created for disbursement ID ${disbursement.id}.`,
         ]),
       ).toBe(true);
       // Assert only student notification was created on DB.

--- a/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/esdc-integration/ecert-integration/_tests_/ecert-full-time-process-integration.scheduler.e2e-spec.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/esdc-integration/ecert-integration/_tests_/ecert-full-time-process-integration.scheduler.e2e-spec.ts
@@ -1436,17 +1436,10 @@ describe(
       const mockedJob = mockBullJob<void>();
 
       // Act
-      const result = await processor.processQueue(mockedJob.job);
+      await processor.processQueue(mockedJob.job);
 
-      // Assert uploaded file.
-      const uploadedFile = getUploadedFile(sftpClientMock);
-      const uploadedFileName = getUploadedFileName();
-      expect(uploadedFile.remoteFilePath).toBe(uploadedFileName);
       // Assert
-      expect(result).toStrictEqual([
-        `Generated file: ${uploadedFileName}`,
-        "Uploaded records: 0",
-      ]);
+      // Assert disbursement was blocked and expected student notification was created and ministry notification was not created.
       expect(
         mockedJob.containLogMessages([
           "The step determined that the calculation should be interrupted. This disbursement will not be part of the next e-Cert generation.",
@@ -1456,6 +1449,7 @@ describe(
           "Notification created.",
         ]),
       ).toBe(true);
+      // Assert only student notification was created on DB.
       const notifications = await db.notification.find({
         select: {
           id: true,

--- a/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/esdc-integration/ecert-integration/_tests_/ecert-full-time-process-integration.scheduler.e2e-spec.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/esdc-integration/ecert-integration/_tests_/ecert-full-time-process-integration.scheduler.e2e-spec.ts
@@ -1411,6 +1411,7 @@ describe(
           disbursementValues: [],
         },
       );
+      // Create a sent notification for Ministry.
       const ministryNotification = createFakeNotification(
         {
           user: systemUsersService.systemUser,

--- a/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/esdc-integration/ecert-integration/_tests_/ecert-part-time-process-integration.scheduler.e2e-spec.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/esdc-integration/ecert-integration/_tests_/ecert-part-time-process-integration.scheduler.e2e-spec.ts
@@ -126,10 +126,9 @@ describe(
       ]);
       expect(
         mockedJob.containLogMessages([
-          `Validating if 'Ministry Blocked Disbursement' notification should be created for disbursement ID ${disbursement.id}.`,
-          "Notification created.",
-          `Validating if 'Student Blocked Disbursement' notification should be created for disbursement ID ${disbursement.id}.`,
-          "Notification created.",
+          `Ministry Blocked Disbursement notification created for disbursement ID ${disbursement.id}.`,
+          `Student Blocked Disbursement notification created for disbursement ID ${disbursement.id}.`,
+          ,
         ]),
       ).toBe(true);
       const notifications = await db.notification.find({
@@ -193,10 +192,8 @@ describe(
         expect(
           mockedJob.containLogMessages([
             "Disbursement estimated awards do not contain any amount to be disbursed.",
-            `Validating if 'Ministry Blocked Disbursement' notification should be created for disbursement ID ${disbursement.id}.`,
-            "Notification created.",
-            `Validating if 'Student Blocked Disbursement' notification should be created for disbursement ID ${disbursement.id}.`,
-            "Notification created.",
+            `Ministry Blocked Disbursement notification created for disbursement ID ${disbursement.id}.`,
+            `Student Blocked Disbursement notification created for disbursement ID ${disbursement.id}.`,
           ]),
         ).toBe(true);
         const notifications = await db.notification.find({
@@ -294,10 +291,8 @@ describe(
       expect(
         mockedJob.containLogMessages([
           "The step determined that the calculation should be interrupted. This disbursement will not be part of the next e-Cert generation.",
-          `Validating if 'Ministry Blocked Disbursement' notification should be created for disbursement ID ${disbursement.id}.`,
-          "Notification should not be created at this moment.",
-          `Validating if 'Student Blocked Disbursement' notification should be created for disbursement ID ${disbursement.id}.`,
-          "Notification should not be created at this moment.",
+          `Ministry Blocked Disbursement notification should not be created at this moment for disbursement ID ${disbursement.id}.`,
+          `Student Blocked Disbursement notification should not be created at this moment for disbursement ID ${disbursement.id}.`,
         ]),
       ).toBe(true);
       const notificationsCount = await db.notification.count({
@@ -339,8 +334,8 @@ describe(
       ]);
       expect(
         mockedJob.containLogMessages([
-          `Creating notifications for disbursement id: ${disbursement.id} for student and ministry.`,
-          `Completed creating notifications for disbursement id: ${disbursement.id} for student and ministry.`,
+          `Ministry Blocked Disbursement notification created for disbursement ID ${disbursement.id}.`,
+          `Student Blocked Disbursement notification created for disbursement ID ${disbursement.id}.`,
         ]),
       ).toBe(true);
       const notificationsCount = await db.notification.count({

--- a/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/esdc-integration/ecert-integration/_tests_/ecert-part-time-process-integration.scheduler.e2e-spec.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/esdc-integration/ecert-integration/_tests_/ecert-part-time-process-integration.scheduler.e2e-spec.ts
@@ -333,7 +333,7 @@ describe(
       ]);
       expect(
         mockedJob.containLogMessages([
-          `Ministry Blocked Disbursement notification created for disbursement ID ${disbursement.id}.`,
+          `Ministry Blocked Disbursement notification should not be created at this moment for disbursement ID ${disbursement.id}.`,
           `Student Blocked Disbursement notification created for disbursement ID ${disbursement.id}.`,
         ]),
       ).toBe(true);
@@ -345,8 +345,8 @@ describe(
           dateSent: IsNull(),
         },
       });
-      // Checking 1 created notification for the student and 1 notification for the ministry.
-      expect(notificationsCount).toBe(2);
+      // Checking 1 created notification for the student only.
+      expect(notificationsCount).toBe(1);
     });
 
     it("Should create an e-Cert with one disbursement record for one student with one eligible schedule.", async () => {

--- a/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/esdc-integration/ecert-integration/_tests_/ecert-part-time-process-integration.scheduler.e2e-spec.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/esdc-integration/ecert-integration/_tests_/ecert-part-time-process-integration.scheduler.e2e-spec.ts
@@ -128,7 +128,6 @@ describe(
         mockedJob.containLogMessages([
           `Ministry Blocked Disbursement notification created for disbursement ID ${disbursement.id}.`,
           `Student Blocked Disbursement notification created for disbursement ID ${disbursement.id}.`,
-          ,
         ]),
       ).toBe(true);
       const notifications = await db.notification.find({

--- a/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/esdc-integration/ecert-integration/_tests_/ecert-part-time-process-integration.scheduler.e2e-spec.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/esdc-integration/ecert-integration/_tests_/ecert-part-time-process-integration.scheduler.e2e-spec.ts
@@ -126,8 +126,10 @@ describe(
       ]);
       expect(
         mockedJob.containLogMessages([
-          `Creating notifications for disbursement id: ${disbursement.id} for student and ministry.`,
-          `Completed creating notifications for disbursement id: ${disbursement.id} for student and ministry.`,
+          `Validating if 'Ministry Blocked Disbursement' notification should be created for disbursement ID ${disbursement.id}.`,
+          "Notification created.",
+          `Validating if 'Student Blocked Disbursement' notification should be created for disbursement ID ${disbursement.id}.`,
+          "Notification created.",
         ]),
       ).toBe(true);
       const notifications = await db.notification.find({
@@ -191,8 +193,10 @@ describe(
         expect(
           mockedJob.containLogMessages([
             "Disbursement estimated awards do not contain any amount to be disbursed.",
-            `Creating notifications for disbursement id: ${disbursement.id} for student and ministry.`,
-            `Completed creating notifications for disbursement id: ${disbursement.id} for student and ministry.`,
+            `Validating if 'Ministry Blocked Disbursement' notification should be created for disbursement ID ${disbursement.id}.`,
+            "Notification created.",
+            `Validating if 'Student Blocked Disbursement' notification should be created for disbursement ID ${disbursement.id}.`,
+            "Notification created.",
           ]),
         ).toBe(true);
         const notifications = await db.notification.find({
@@ -287,6 +291,15 @@ describe(
         `Generated file: ${uploadedFileName}`,
         "Uploaded records: 0",
       ]);
+      expect(
+        mockedJob.containLogMessages([
+          "The step determined that the calculation should be interrupted. This disbursement will not be part of the next e-Cert generation.",
+          `Validating if 'Ministry Blocked Disbursement' notification should be created for disbursement ID ${disbursement.id}.`,
+          "Notification should not be created at this moment.",
+          `Validating if 'Student Blocked Disbursement' notification should be created for disbursement ID ${disbursement.id}.`,
+          "Notification should not be created at this moment.",
+        ]),
+      ).toBe(true);
       const notificationsCount = await db.notification.count({
         where: {
           notificationMessage: {

--- a/sources/packages/backend/libs/integrations/src/esdc-integration/e-cert-integration/e-cert-integration.module.ts
+++ b/sources/packages/backend/libs/integrations/src/esdc-integration/e-cert-integration/e-cert-integration.module.ts
@@ -46,6 +46,10 @@ import {
 } from "@sims/integrations/services/disbursement-schedule/e-cert-calculation";
 import { FullTimeECertFileHandler } from "./full-time-e-cert-file-handler";
 import { PartTimeECertFileHandler } from "./part-time-e-cert-file-handler";
+import {
+  MinistryBlockedDisbursementNotification,
+  StudentBlockedDisbursementNotification,
+} from "@sims/integrations/services/disbursement-schedule/e-cert-notification";
 
 @Module({
   imports: [ConfigModule, SystemUserModule],
@@ -88,6 +92,8 @@ import { PartTimeECertFileHandler } from "./part-time-e-cert-file-handler";
     StudentLoanBalanceSharedService,
     ECertFeedbackErrorService,
     ECertPreValidationService,
+    MinistryBlockedDisbursementNotification,
+    StudentBlockedDisbursementNotification,
   ],
   exports: [
     FullTimeECertFileHandler,

--- a/sources/packages/backend/libs/integrations/src/services/disbursement-schedule/e-cert-calculation/e-cert-calculation-process.ts
+++ b/sources/packages/backend/libs/integrations/src/services/disbursement-schedule/e-cert-calculation/e-cert-calculation-process.ts
@@ -123,8 +123,8 @@ export abstract class ECertCalculationProcess {
               disbursementLog,
             );
             if (!shouldProceed) {
-              await this.eCertNotificationService.createDisbursementBlockedNotification(
-                eCertDisbursement.disbursement.id,
+              await this.eCertNotificationService.notifyBlockedDisbursement(
+                eCertDisbursement,
                 entityManager,
                 parentLog,
               );

--- a/sources/packages/backend/libs/integrations/src/services/disbursement-schedule/e-cert-notification/blocked-disbursement/ministry-blocked-disbursement-notification.ts
+++ b/sources/packages/backend/libs/integrations/src/services/disbursement-schedule/e-cert-notification/blocked-disbursement/ministry-blocked-disbursement-notification.ts
@@ -29,20 +29,19 @@ export class MinistryBlockedDisbursementNotification extends ECertNotification {
     eCertDisbursement: EligibleECertDisbursement,
     entityManager: EntityManager,
   ): Promise<boolean> {
-    const notification = await entityManager
+    const hasNotification = await entityManager
       .getRepository(Notification)
-      .createQueryBuilder("notification")
-      .select("count(*)::int", "count")
-      .innerJoin("notification.notificationMessage", "notificationMessage")
-      .where("notificationMessage.id = :notificationMessageId", {
-        notificationMessageId:
-          NotificationMessageType.MinistryNotificationDisbursementBlocked,
-      })
-      .andWhere("notification.metadata->>'disbursementId' = :disbursementId", {
-        disbursementId: eCertDisbursement.disbursement.id,
-      })
-      .getRawOne<{ count: number }>();
-    return notification.count === 0;
+      .exists({
+        where: {
+          notificationMessage: {
+            id: NotificationMessageType.MinistryNotificationDisbursementBlocked,
+          },
+          metadata: {
+            disbursementId: eCertDisbursement.disbursement.id,
+          },
+        },
+      });
+    return !hasNotification;
   }
 
   /**

--- a/sources/packages/backend/libs/integrations/src/services/disbursement-schedule/e-cert-notification/blocked-disbursement/ministry-blocked-disbursement-notification.ts
+++ b/sources/packages/backend/libs/integrations/src/services/disbursement-schedule/e-cert-notification/blocked-disbursement/ministry-blocked-disbursement-notification.ts
@@ -1,0 +1,86 @@
+import { Injectable } from "@nestjs/common";
+import {
+  DisbursementBlockedNotification,
+  NotificationActionsService,
+} from "@sims/services";
+import { Notification, NotificationMessageType, Student } from "@sims/sims-db";
+import { EntityManager } from "typeorm";
+import { ECertNotification } from "../e-cert-notification";
+import { EligibleECertDisbursement } from "../../disbursement-schedule.models";
+
+/**
+ * Creates a notification for a blocked disbursement for the Ministry, if required.
+ */
+@Injectable()
+export class MinistryBlockedDisbursementNotification extends ECertNotification {
+  constructor(
+    private readonly notificationActionsService: NotificationActionsService,
+  ) {
+    super("Ministry Blocked Disbursement");
+  }
+
+  /**
+   * Determines whether a notification should be created or not.
+   * @param eCertDisbursement eligible disbursement to be potentially added to an e-Cert.
+   * @param entityManager entity manager to execute in transaction.
+   * @returns true if a notification should be created, false otherwise.
+   */
+  protected async shouldCreateNotification(
+    eCertDisbursement: EligibleECertDisbursement,
+    entityManager: EntityManager,
+  ): Promise<boolean> {
+    const notification = await entityManager
+      .getRepository(Notification)
+      .createQueryBuilder("notification")
+      .select("count(*)::int", "count")
+      .innerJoin("notification.notificationMessage", "notificationMessage")
+      .where("notificationMessage.id = :notificationMessageId", {
+        notificationMessageId:
+          NotificationMessageType.MinistryNotificationDisbursementBlocked,
+      })
+      .andWhere("notification.metadata->>'disbursementId' = :disbursementId", {
+        disbursementId: eCertDisbursement.disbursement.id,
+      })
+      .getRawOne<{ count: number }>();
+    return notification.count === 0;
+  }
+
+  /**
+   * Creates a notification for the given e-Cert disbursement.
+   * @param eCertDisbursement eligible disbursement to be potentially added to an e-Cert.
+   * @param entityManager entity manager to execute in transaction.
+   */
+  protected async createNotification(
+    eCertDisbursement: EligibleECertDisbursement,
+    entityManager: EntityManager,
+  ): Promise<void> {
+    const student = await entityManager.getRepository(Student).findOne({
+      select: {
+        id: true,
+        birthDate: true,
+        user: {
+          id: true,
+          firstName: true,
+          lastName: true,
+          email: true,
+        },
+      },
+      relations: {
+        user: true,
+      },
+      where: { id: eCertDisbursement.studentId },
+    });
+    const ministryNotification: DisbursementBlockedNotification = {
+      givenNames: student.user.firstName,
+      lastName: student.user.lastName,
+      email: student.user.email,
+      birthDate: student.birthDate,
+      applicationNumber: eCertDisbursement.applicationNumber,
+    };
+    await this.notificationActionsService.saveDisbursementBlockedNotificationForMinistry(
+      ministryNotification,
+      eCertDisbursement.disbursement.id,
+      entityManager,
+    );
+  }
+}

--- a/sources/packages/backend/libs/integrations/src/services/disbursement-schedule/e-cert-notification/blocked-disbursement/student-blocked-disbursement-notification.ts
+++ b/sources/packages/backend/libs/integrations/src/services/disbursement-schedule/e-cert-notification/blocked-disbursement/student-blocked-disbursement-notification.ts
@@ -1,0 +1,105 @@
+import { Injectable } from "@nestjs/common";
+import {
+  NotificationActionsService,
+  StudentNotification,
+} from "@sims/services";
+import {
+  BLOCKED_DISBURSEMENT_MAXIMUM_NOTIFICATIONS_TO_SEND,
+  BLOCKED_DISBURSEMENT_NOTIFICATION_MIN_DAYS_INTERVAL,
+} from "@sims/services/constants";
+import { Notification, NotificationMessageType, Student } from "@sims/sims-db";
+import { dateDifference } from "@sims/utilities";
+import { EntityManager } from "typeorm";
+import { ECertNotification } from "../e-cert-notification";
+import { EligibleECertDisbursement } from "../../disbursement-schedule.models";
+
+interface NotificationData {
+  maxCreatedAt: Date;
+  notificationCount: number;
+}
+
+/**
+ * Creates a notification for a blocked disbursement for the Student, if required.
+ */
+@Injectable()
+export class StudentBlockedDisbursementNotification extends ECertNotification {
+  constructor(
+    private readonly notificationActionsService: NotificationActionsService,
+  ) {
+    super("Student Blocked Disbursement");
+  }
+
+  /**
+   * Determines whether a notification should be created or not.
+   * @param eCertDisbursement eligible disbursement to be potentially added to an e-Cert.
+   * @param entityManager entity manager to execute in transaction.
+   * @returns true if a notification should be created, false otherwise.
+   */
+  protected async shouldCreateNotification(
+    eCertDisbursement: EligibleECertDisbursement,
+    entityManager: EntityManager,
+  ): Promise<boolean> {
+    const notification = await entityManager
+      .getRepository(Notification)
+      .createQueryBuilder("notification")
+      .select("count(*)::int", "notificationCount")
+      .addSelect("max(notification.createdAt)", "maxCreatedAt")
+      .innerJoin("notification.notificationMessage", "notificationMessage")
+      .where("notificationMessage.id = :notificationMessageId", {
+        notificationMessageId:
+          NotificationMessageType.StudentNotificationDisbursementBlocked,
+      })
+      .andWhere("notification.metadata->>'disbursementId' = :disbursementId", {
+        disbursementId: eCertDisbursement.disbursement.id,
+      })
+      .getRawOne<NotificationData>();
+    const canSendNewNotification =
+      dateDifference(new Date(), notification.maxCreatedAt) >
+      BLOCKED_DISBURSEMENT_NOTIFICATION_MIN_DAYS_INTERVAL;
+    // Condition check to create notifications: Less than BLOCKED_DISBURSEMENT_MAXIMUM_NOTIFICATIONS_TO_SEND notifications are created previously and there are no failures in sending those created notifications.
+    // Plus, it has been at least BLOCKED_DISBURSEMENT_NOTIFICATION_MIN_DAYS_INTERVAL days from the last created notification for this disbursement.
+    return (
+      !notification.notificationCount ||
+      (notification.notificationCount <
+        BLOCKED_DISBURSEMENT_MAXIMUM_NOTIFICATIONS_TO_SEND &&
+        canSendNewNotification)
+    );
+  }
+
+  /**
+   * Creates a notification for the given e-Cert disbursement.
+   * @param eCertDisbursement eligible disbursement to be potentially added to an e-Cert.
+   * @param entityManager entity manager to execute in transaction.
+   */
+  protected async createNotification(
+    eCertDisbursement: EligibleECertDisbursement,
+    entityManager: EntityManager,
+  ): Promise<void> {
+    const student = await entityManager.getRepository(Student).findOne({
+      select: {
+        id: true,
+        user: {
+          id: true,
+          firstName: true,
+          lastName: true,
+          email: true,
+        },
+      },
+      relations: {
+        user: true,
+      },
+      where: { id: eCertDisbursement.studentId },
+    });
+    const studentNotification: StudentNotification = {
+      givenNames: student.user.firstName,
+      lastName: student.user.lastName,
+      toAddress: student.user.email,
+      userId: student.user.id,
+    };
+    await this.notificationActionsService.saveDisbursementBlockedNotificationForStudent(
+      studentNotification,
+      eCertDisbursement.disbursement.id,
+      entityManager,
+    );
+  }
+}

--- a/sources/packages/backend/libs/integrations/src/services/disbursement-schedule/e-cert-notification/e-cert-notification.service.ts
+++ b/sources/packages/backend/libs/integrations/src/services/disbursement-schedule/e-cert-notification/e-cert-notification.service.ts
@@ -1,169 +1,34 @@
 import { Injectable } from "@nestjs/common";
-import {
-  DisbursementBlockedNotification,
-  NotificationActionsService,
-  StudentNotification,
-} from "@sims/services";
-import {
-  BLOCKED_DISBURSEMENT_MAXIMUM_NOTIFICATIONS_TO_SEND,
-  BLOCKED_DISBURSEMENT_NOTIFICATION_MIN_DAYS_INTERVAL,
-} from "@sims/services/constants";
-import {
-  DisbursementSchedule,
-  Notification,
-  NotificationMessageType,
-} from "@sims/sims-db";
-import { dateDifference } from "@sims/utilities";
 import { ProcessSummary } from "@sims/utilities/logger";
 import { EntityManager } from "typeorm";
-
-interface NotificationData {
-  maxCreatedAt: Date;
-  notificationCount: number;
-}
+import { MinistryBlockedDisbursementNotification } from "./blocked-disbursement/ministry-blocked-disbursement-notification";
+import { StudentBlockedDisbursementNotification } from "./blocked-disbursement/student-blocked-disbursement-notification";
+import { EligibleECertDisbursement } from "../disbursement-schedule.models";
 
 @Injectable()
 export class ECertNotificationService {
   constructor(
-    private readonly notificationActionsService: NotificationActionsService,
+    private readonly ministryBlockedDisbursementNotification: MinistryBlockedDisbursementNotification,
+    private readonly studentBlockedDisbursementNotification: StudentBlockedDisbursementNotification,
   ) {}
 
   /**
-   * Checks and creates disbursement blocked notification.
-   * @param disbursementId disbursement id.
+   * Checks and creates disbursement blocked notification(s).
+   * @param eCertDisbursement eligible disbursement to be potentially added to an e-Cert.
    * @param entityManager entity manager to execute in transaction.
-   * @param parentLog cumulative process log.
+   * @param log cumulative log summary.
    */
-  async createDisbursementBlockedNotification(
-    disbursementId: number,
+  async notifyBlockedDisbursement(
+    eCertDisbursement: EligibleECertDisbursement,
     entityManager: EntityManager,
-    parentLog: ProcessSummary,
+    log: ProcessSummary,
   ): Promise<void> {
-    const shouldCreateNotification =
-      await this.shouldCreateDisbursementBlockedNotification(
-        disbursementId,
-        entityManager,
-      );
-    if (shouldCreateNotification) {
-      const notificationLog = new ProcessSummary();
-      parentLog.children(notificationLog);
-      notificationLog.info(
-        `Creating notifications for disbursement id: ${disbursementId} for student and ministry.`,
-      );
-      await this.createDisbursementBlockedNotifications(
-        disbursementId,
-        entityManager,
-      );
-      notificationLog.info(
-        `Completed creating notifications for disbursement id: ${disbursementId} for student and ministry.`,
-      );
-    }
-  }
-
-  /**
-   * Checks whether the disbursement blocked notification should be created or not.
-   * @param disbursementId disbursement id.
-   * @param entityManager entity manager to execute in transaction.
-   * @returns boolean indicating if the disbursement blocked notification should be created or not.
-   */
-  private async shouldCreateDisbursementBlockedNotification(
-    disbursementId: number,
-    entityManager: EntityManager,
-  ): Promise<boolean> {
-    const notification = await entityManager
-      .getRepository(Notification)
-      .createQueryBuilder("notification")
-      .select("count(*)::int", "notificationCount")
-      .addSelect("max(notification.createdAt)", "maxCreatedAt")
-      .innerJoin("notification.notificationMessage", "notificationMessage")
-      .where("notificationMessage.id = :notificationMessageId", {
-        notificationMessageId:
-          NotificationMessageType.StudentNotificationDisbursementBlocked,
-      })
-      .andWhere("notification.metadata->>'disbursementId' = :disbursementId", {
-        disbursementId,
-      })
-      .getRawOne<NotificationData>();
-    const canSendNewNotification =
-      dateDifference(new Date(), notification.maxCreatedAt) >
-      BLOCKED_DISBURSEMENT_NOTIFICATION_MIN_DAYS_INTERVAL;
-    // Condition check to create notifications: Less than BLOCKED_DISBURSEMENT_MAXIMUM_NOTIFICATIONS_TO_SEND notifications are created previously and there are no failures in sending those created notifications.
-    // Plus, it has been at least BLOCKED_DISBURSEMENT_NOTIFICATION_MIN_DAYS_INTERVAL days from the last created notification for this disbursement.
-    return (
-      !notification.notificationCount ||
-      (notification.notificationCount <
-        BLOCKED_DISBURSEMENT_MAXIMUM_NOTIFICATIONS_TO_SEND &&
-        canSendNewNotification)
+    const notifications = [
+      this.ministryBlockedDisbursementNotification,
+      this.studentBlockedDisbursementNotification,
+    ].map((notification) =>
+      notification.notify(eCertDisbursement, entityManager, log),
     );
-  }
-
-  /**
-   * Creates disbursement blocked notifications for student and ministry.
-   * @param disbursementId disbursement id associated with the blocked disbursement.
-   * @param entityManager entity manager to execute in transaction.
-   */
-  private async createDisbursementBlockedNotifications(
-    disbursementId: number,
-    entityManager: EntityManager,
-  ): Promise<void> {
-    const disbursement = await entityManager
-      .getRepository(DisbursementSchedule)
-      .findOne({
-        select: {
-          id: true,
-          studentAssessment: {
-            id: true,
-            application: {
-              id: true,
-              applicationNumber: true,
-              student: {
-                id: true,
-                birthDate: true,
-                user: {
-                  id: true,
-                  firstName: true,
-                  lastName: true,
-                  email: true,
-                },
-              },
-            },
-          },
-        },
-        relations: {
-          studentAssessment: { application: { student: { user: true } } },
-        },
-        where: { id: disbursementId },
-      });
-    const student = disbursement.studentAssessment.application.student;
-    const studentNotification: StudentNotification = {
-      givenNames: student.user.firstName,
-      lastName: student.user.lastName,
-      toAddress: student.user.email,
-      userId: student.user.id,
-    };
-    const ministryNotification: DisbursementBlockedNotification = {
-      givenNames: student.user.firstName,
-      lastName: student.user.lastName,
-      email: student.user.email,
-      birthDate: student.birthDate,
-      applicationNumber:
-        disbursement.studentAssessment.application.applicationNumber,
-    };
-    const disbursementBlockedNotificationForStudentPromise =
-      this.notificationActionsService.saveDisbursementBlockedNotificationForStudent(
-        studentNotification,
-        disbursementId,
-        entityManager,
-      );
-    const disbursementBlockedNotificationForMinistryPromise =
-      this.notificationActionsService.saveDisbursementBlockedNotificationForMinistry(
-        ministryNotification,
-        disbursementId,
-        entityManager,
-      );
-    await Promise.all([
-      disbursementBlockedNotificationForStudentPromise,
-      disbursementBlockedNotificationForMinistryPromise,
-    ]);
+    await Promise.all(notifications);
   }
 }

--- a/sources/packages/backend/libs/integrations/src/services/disbursement-schedule/e-cert-notification/e-cert-notification.service.ts
+++ b/sources/packages/backend/libs/integrations/src/services/disbursement-schedule/e-cert-notification/e-cert-notification.service.ts
@@ -1,9 +1,11 @@
 import { Injectable } from "@nestjs/common";
 import { ProcessSummary } from "@sims/utilities/logger";
 import { EntityManager } from "typeorm";
-import { MinistryBlockedDisbursementNotification } from "./blocked-disbursement/ministry-blocked-disbursement-notification";
-import { StudentBlockedDisbursementNotification } from "./blocked-disbursement/student-blocked-disbursement-notification";
 import { EligibleECertDisbursement } from "../disbursement-schedule.models";
+import {
+  MinistryBlockedDisbursementNotification,
+  StudentBlockedDisbursementNotification,
+} from ".";
 
 @Injectable()
 export class ECertNotificationService {

--- a/sources/packages/backend/libs/integrations/src/services/disbursement-schedule/e-cert-notification/e-cert-notification.ts
+++ b/sources/packages/backend/libs/integrations/src/services/disbursement-schedule/e-cert-notification/e-cert-notification.ts
@@ -1,0 +1,71 @@
+import { EntityManager } from "typeorm";
+import { EligibleECertDisbursement } from "../disbursement-schedule.models";
+import { ProcessSummary } from "@sims/utilities/logger";
+
+/**
+ * Provides a basic structure for creating and
+ * sending notifications related to e-Cert disbursements.
+ */
+export abstract class ECertNotification {
+  /**
+   * Initializes a new instance of {@link ECertNotification}.
+   * @param notificationName friendly name of the notification for logging
+   */
+  protected constructor(private readonly notificationName: string) {}
+
+  /**
+   * Determines whether a notification should be created or not.
+   * This method must be implemented by derived classes.
+   * @param eCertDisbursement eligible disbursement to be potentially added to an e-Cert.
+   * @param entityManager entity manager to execute in transaction.
+   * @returns true if a notification should be created, false otherwise.
+   */
+  protected abstract shouldCreateNotification(
+    eCertDisbursement: EligibleECertDisbursement,
+    entityManager: EntityManager,
+  ): Promise<boolean> | boolean;
+
+  /**
+   * Creates a notification for the given e-Cert disbursement.
+   * This method must be implemented by derived classes.
+   * @param eCertDisbursement eligible disbursement to be potentially added to an e-Cert.
+   * @param entityManager entity manager to execute in transaction.
+   */
+  protected abstract createNotification(
+    eCertDisbursement: EligibleECertDisbursement,
+    entityManager: EntityManager,
+  ): Promise<void>;
+
+  /**
+   * Creates a notification defined by {@link createNotification} if the requirements
+   * defined by {@link shouldCreateNotification} are met.
+   * @param eCertDisbursement eligible disbursement to be potentially added to an e-Cert.
+   * @param entityManager entity manager to execute in transaction.
+   * @param log cumulative log summary.
+   * @returns true if the notification is created, false otherwise.
+   */
+  async notify(
+    eCertDisbursement: EligibleECertDisbursement,
+    entityManager: EntityManager,
+    log: ProcessSummary,
+  ): Promise<boolean> {
+    const notificationLog = new ProcessSummary();
+    log.children(notificationLog);
+    notificationLog.info(
+      `Validating if '${this.notificationName}' notification should be created for disbursement ID ${eCertDisbursement.disbursement.id}.`,
+    );
+    const shouldCreateNotification = await this.shouldCreateNotification(
+      eCertDisbursement,
+      entityManager,
+    );
+    if (!shouldCreateNotification) {
+      notificationLog.info(
+        "Notification should not be created at this moment.",
+      );
+      return false;
+    }
+    await this.createNotification(eCertDisbursement, entityManager);
+    notificationLog.info("Notification created.");
+    return true;
+  }
+}

--- a/sources/packages/backend/libs/integrations/src/services/disbursement-schedule/e-cert-notification/e-cert-notification.ts
+++ b/sources/packages/backend/libs/integrations/src/services/disbursement-schedule/e-cert-notification/e-cert-notification.ts
@@ -51,21 +51,20 @@ export abstract class ECertNotification {
   ): Promise<boolean> {
     const notificationLog = new ProcessSummary();
     log.children(notificationLog);
-    notificationLog.info(
-      `Validating if '${this.notificationName}' notification should be created for disbursement ID ${eCertDisbursement.disbursement.id}.`,
-    );
     const shouldCreateNotification = await this.shouldCreateNotification(
       eCertDisbursement,
       entityManager,
     );
     if (!shouldCreateNotification) {
       notificationLog.info(
-        "Notification should not be created at this moment.",
+        `${this.notificationName} notification should not be created at this moment for disbursement ID ${eCertDisbursement.disbursement.id}.`,
       );
       return false;
     }
     await this.createNotification(eCertDisbursement, entityManager);
-    notificationLog.info("Notification created.");
+    notificationLog.info(
+      `${this.notificationName} notification created for disbursement ID ${eCertDisbursement.disbursement.id}.`,
+    );
     return true;
   }
 }

--- a/sources/packages/backend/libs/integrations/src/services/disbursement-schedule/e-cert-notification/index.ts
+++ b/sources/packages/backend/libs/integrations/src/services/disbursement-schedule/e-cert-notification/index.ts
@@ -1,0 +1,4 @@
+export * from "./blocked-disbursement/ministry-blocked-disbursement-notification";
+export * from "./blocked-disbursement/student-blocked-disbursement-notification";
+export * from "./e-cert-notification";
+export * from "./e-cert-notification.service";


### PR DESCRIPTION
- Created a base class for e-Cert notifications (`ECertNotification`) and segregated the logic to generate blocked notifications into `MinistryBlockedDisbursementNotification` and `StudentBlockedDisbursementNotification`.
- Existing logic was moved into the new files.
  - Code for the method `shouldCreateNotification` for the Students was moved and no changes were done for this PR, unless critical no comments will be addressed.
- `ECertNotification` can be used for any other e-Cert notification as required, not only blocked disbursement.

_Please note that the student data required to generate the notification is now retrieved twice in the event that the disbursement is blocked and the Ministry should be notified for the first time. The benefit of having the separation between the logic for the different notifications seems greater than an occasional extra query to the student's table. Please note that the query was simplified from what it used to be._

_Please also note that the below technical AC was not executed. The queries have different approaches, sometimes checking the existence, sometimes requiring a count, and sometimes requiring a count and a date last sent. I did not see a benefit for this PR. Please share an opinion/suggestion if needed._
```
Create a generic method to check, if the email notifications are already sent to a particular template and metadata( disbursementId).
```