### PR TITLE
#3984 - BUG: Ministry - Change Request Form submitted by Student not displaying Year

### DIFF
--- a/sources/packages/forms/src/form-definitions/partnerinformationandincomeappeal.json
+++ b/sources/packages/forms/src/form-definitions/partnerinformationandincomeappeal.json
@@ -15,7 +15,7 @@
       "customClass": "",
       "modalEdit": false,
       "defaultValue": null,
-      "persistent": false,
+      "persistent": true,
       "protected": false,
       "dbIndex": false,
       "encrypted": false,

--- a/sources/packages/forms/src/form-definitions/studentadditionaltransportationappeal.json
+++ b/sources/packages/forms/src/form-definitions/studentadditionaltransportationappeal.json
@@ -1227,7 +1227,7 @@
           "label": "Program Year",
           "protected": false,
           "unique": false,
-          "persistent": false,
+          "persistent": true,
           "type": "hidden",
           "tags": [],
           "conditional": {

--- a/sources/packages/forms/src/form-definitions/studentdependantsappeal.json
+++ b/sources/packages/forms/src/form-definitions/studentdependantsappeal.json
@@ -885,7 +885,7 @@
           "label": "Program Year",
           "protected": false,
           "unique": false,
-          "persistent": false,
+          "persistent": true,
           "type": "hidden",
           "tags": [],
           "conditional": {

--- a/sources/packages/forms/src/form-definitions/studentdisabilityappeal.json
+++ b/sources/packages/forms/src/form-definitions/studentdisabilityappeal.json
@@ -7,9 +7,25 @@
   "tags": [
     "common"
   ],
-  "submissionAccess": [],
-  "owner": "64711d803a5a30268c17ebe1",
   "components": [
+    {
+      "input": true,
+      "tableView": false,
+      "key": "programYear",
+      "label": "Program Year",
+      "protected": false,
+      "unique": false,
+      "persistent": true,
+      "type": "hidden",
+      "tags": [],
+      "conditional": {
+        "show": "",
+        "when": null,
+        "eq": ""
+      },
+      "properties": {},
+      "lockKey": true
+    },
     {
       "label": "Disability Information",
       "labelWidth": "",

--- a/sources/packages/forms/src/form-definitions/studentfinancialinformationappeal.json
+++ b/sources/packages/forms/src/form-definitions/studentfinancialinformationappeal.json
@@ -37,7 +37,7 @@
       "label": "Program Year",
       "protected": false,
       "unique": false,
-      "persistent": false,
+      "persistent": true,
       "type": "hidden",
       "tags": [],
       "conditional": {


### PR DESCRIPTION
- Added `programYear` as a persistent value for all the appeals forms.
- Added `programYear` to the "Appeals - Student Disability Information" to ensure all the forms share the same program year hidden field that can be potentially used to adjust the forms to different program years.

_Note: we got the confirmation from the business (in the ticket comments) that there is no need to apply a fix to production data at this moment._
