### PR TITLE
#3685 - Convert FormIO to deployment and update fetch old tags script

### DIFF
--- a/devops/Makefile
+++ b/devops/Makefile
@@ -511,7 +511,7 @@ deploy-forms:
 	-p TLS_KEY=$(TLS_KEY) \
 	-p TLS_CA_CERTIFICATE=$(TLS_CA_CERTIFICATE) \
 	| oc -n $(NAMESPACE) apply -f -
-	$(call rollout_and_wait,dc/$(FORMS_NAME))
+	$(call rollout_and_wait,deployment/$(FORMS_NAME))
 
 # Remove redis and resources including secrets from openshift namespace.
 delete-redis:

--- a/devops/openshift/forms-deploy.yml
+++ b/devops/openshift/forms-deploy.yml
@@ -37,7 +37,6 @@ objects:
           maxSurge: 25%
       template:
         metadata:
-          creationTimestamp: null
           labels:
             app: ${NAME}
         spec:
@@ -124,7 +123,6 @@ objects:
     kind: Service
     metadata:
       annotations:
-      creationTimestamp: null
       labels:
         app: ${NAME}
       name: ${NAME}

--- a/devops/openshift/forms-deploy.yml
+++ b/devops/openshift/forms-deploy.yml
@@ -16,20 +16,19 @@ objects:
       FORMS_URL: "https://${FORMS_URL}"
     type: Opaque
 
-  - apiVersion: apps.openshift.io/v1
-    kind: DeploymentConfig
+  - apiVersion: apps/v1
+    kind: Deployment
     metadata:
-      annotations:
-      creationTimestamp: null
       labels:
         app: ${NAME}
       name: ${NAME}
     spec:
       replicas: "${{REPLICAS}}"
       selector:
-        app: ${NAME}
+        matchLabels:
+          app: ${NAME}
       strategy:
-        type: Rolling
+        type: RollingUpdate
         rollingParams:
           updatePeriodSeconds: 1
           intervalSeconds: 1
@@ -120,7 +119,6 @@ objects:
               namespace: "${TOOLS_NAMESPACE}"
               name: "${IMAGE_STREAM_TAG}"
           type: ImageChange
-    status: {}
 
   - apiVersion: v1
     kind: Service
@@ -182,8 +180,8 @@ objects:
       name: ${NAME}-hpa
     spec:
       scaleTargetRef:
-        apiVersion: apps.openshift.io/v1
-        kind: DeploymentConfig
+        apiVersion: apps/v1
+        kind: Deployment
         name: ${NAME}
       minReplicas: "${{REPLICAS}}"
       maxReplicas: 6

--- a/devops/scripts/fetchOldTags.sh
+++ b/devops/scripts/fetchOldTags.sh
@@ -59,7 +59,8 @@ IS_NAMESPACE="${LICENSE_PLATE}-tools"
 DC_NAME="${ENV}-${APP_NAME}"
 
 # Lookup the dc to get the deployed container image tag
-DC_IMAGE=$(oc get dc/$DC_NAME -n $DC_NAMESPACE -o json | jq -r '.spec.template.spec.containers[].image')
+# TODO: Change the naming convention from DC to deployment if required in future.
+DC_IMAGE=$(oc get deployment/$DC_NAME -n $DC_NAMESPACE -o json | jq -r '.spec.template.spec.containers[].image')
 if [ -z "$DC_IMAGE" ]; then
   echo "DeploymentConfig image tag not found." >&2
   exit 1


### PR DESCRIPTION
## Convert to Deployment

- [x] Convert FormIO DC to deployment

## Update fetch old tags script

- [x] Updated fetch old tags script to get the deployed version of  `image steam` based on deployment instead of DC.
![image](https://github.com/user-attachments/assets/1c861633-6acc-47d6-a708-88e1a91eb3a9)

## Removed the `creationTimestamp` from metadata in form

- [x] Removed `creationTimestamp:null` in metadata from formio objects as it is not followed in other configs in our application.
