### PR TITLE
#3054 - Email notification for blocked disbursement to ministry only once - Change log hierarchy

### DIFF
--- a/sources/packages/backend/libs/integrations/src/services/disbursement-schedule/e-cert-calculation/e-cert-calculation-process.ts
+++ b/sources/packages/backend/libs/integrations/src/services/disbursement-schedule/e-cert-calculation/e-cert-calculation-process.ts
@@ -113,20 +113,26 @@ export abstract class ECertCalculationProcess {
           let stepNumber = 1;
           // Execute all steps sequentially. The order of execution is important since the
           // disbursement data is potentially changed along the steps till it is persisted.
+          const stepsLog = new ProcessSummary();
+          disbursementLog.children(stepsLog);
+          stepsLog.info("Executing e-Cert calculation steps.");
           for (const step of steps) {
-            disbursementLog.info(
+            stepsLog.info(
               `Executing step ${stepNumber++} out of ${steps.length}.`,
             );
             const shouldProceed = await step.executeStep(
               eCertDisbursement,
               entityManager,
-              disbursementLog,
+              stepsLog,
             );
             if (!shouldProceed) {
+              stepsLog.info(
+                `Checking if blocked disbursement notifications should be generated.`,
+              );
               await this.eCertNotificationService.notifyBlockedDisbursement(
                 eCertDisbursement,
                 entityManager,
-                parentLog,
+                stepsLog,
               );
               disbursementLog.info(
                 "The step determined that the calculation should be interrupted. This disbursement will not be part of the next e-Cert generation.",


### PR DESCRIPTION
The blocked notifications logs were using the parent log instead of the child log some hierarchy was added now as below. This was an existing issue and it was causing multiple logs from multiple children to be appended to the same hierarchy.

### Log sample with the new hierarchy
```
INFO: Executing e-Cert calculations for all eligible disbursements.'
INFO: Retrieving eligible disbursements(s).'
INFO: Found 1 eligible disbursement(s) for 1 student(s).'
--INFO: Log details'
--INFO: Processing application number 5906924436, disbursement id 41 scheduled for 2025-01-16.'
----INFO: Log details'
----INFO: Executing e-Cert calculation steps.'
----INFO: Executing step 1 out of 9.'
----INFO: Executing full-time disbursement validations.'
----INFO: Disbursement estimated awards do not contain any amount to be disbursed.'
----INFO: There are no active restriction bypasses.'
----INFO: Checking if blocked disbursement notifications should be generated.'
------INFO: Log details'
------INFO: Ministry Blocked Disbursement notification should not be created at this moment for disbursement ID 41.'
------INFO: Log details'
------INFO: Student Blocked Disbursement notification created for disbursement ID 41.'
--INFO: The step determined that the calculation should be interrupted. This disbursement will not be part of the next e-Cert generation.'
INFO: Sending e-Cert file.'
INFO: Retrieving Full Time disbursements to generate the e-Cert file...'
INFO: Found 0 Full Time disbursements schedules.'
INFO: Creating Full Time e-Cert file content...'
INFO: Uploading Full Time content...'
INFO: Generated file: MSFT-Request\\DPBC.EDU.FTECERTS.20250116.001'
```