### PR TITLE
#4262 - Family size that is exactly 7 is not represented in our DMN tables  Part 1

### DIFF
--- a/sources/packages/backend/workflow/src/workflow-definitions/parttime-assessment-decisions.dmn
+++ b/sources/packages/backend/workflow/src/workflow-definitions/parttime-assessment-decisions.dmn
@@ -617,7 +617,7 @@
           <text>"2022-2023"</text>
         </inputEntry>
         <inputEntry id="UnaryTests_0cb65f7">
-          <text>&gt; 7</text>
+          <text>&gt;= 7</text>
         </inputEntry>
         <outputEntry id="LiteralExpression_19tnso3">
           <text>84933</text>
@@ -946,7 +946,7 @@
           <text>"2023-2024"</text>
         </inputEntry>
         <inputEntry id="UnaryTests_1q5nz0l">
-          <text>&gt; 7</text>
+          <text>&gt;= 7</text>
         </inputEntry>
         <outputEntry id="LiteralExpression_1mhcmbi">
           <text>93737</text>
@@ -1282,7 +1282,7 @@
           <text>"2024-2025"</text>
         </inputEntry>
         <inputEntry id="UnaryTests_133s2og">
-          <text>&gt; 7</text>
+          <text>&gt;= 7</text>
         </inputEntry>
         <outputEntry id="LiteralExpression_0lnlz1h">
           <text>97395</text>
@@ -1611,7 +1611,7 @@
           <text>"2025-2026"</text>
         </inputEntry>
         <inputEntry id="UnaryTests_1x0upra">
-          <text>&gt; 7</text>
+          <text>&gt;= 7</text>
         </inputEntry>
         <outputEntry id="LiteralExpression_0p7ohoj">
           <text>97395</text>


### PR DESCRIPTION
**Acceptance Criteria**
- [x] Add an option into the dmn for a family size of exactly 7 (change the greater then 7 to greater then or equal to 7)

![image](https://github.com/user-attachments/assets/1f3d215d-f9c9-4c6e-9896-ba41286d90ac)
