### PR TITLE
#4262 - Fix part-time family size variables DMN

### DIFF
--- a/sources/packages/backend/workflow/src/workflow-definitions/parttime-assessment-decisions.dmn
+++ b/sources/packages/backend/workflow/src/workflow-definitions/parttime-assessment-decisions.dmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" xmlns:camunda="http://camunda.org/schema/1.0/dmn" id="dmnPartTimeAssessmentDecisions" name="dmnPartTimeAssessmentDecisions" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="5.29.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.1.0" camunda:diagramRelationId="1a575ead-1e6d-468c-901a-766a35569b38">
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" xmlns:camunda="http://camunda.org/schema/1.0/dmn" id="dmnPartTimeAssessmentDecisions" name="dmnPartTimeAssessmentDecisions" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="5.31.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.6.0" camunda:diagramRelationId="1a575ead-1e6d-468c-901a-766a35569b38">
   <decision id="dmnPartTimeProgramYearMaximums" name="dmnPartTimeProgramYearMaximums">
     <decisionTable id="DecisionTable_1oyvbif" hitPolicy="FIRST">
       <input id="InputClause_02zjhj9" label="programYear">
@@ -617,7 +617,7 @@
           <text>"2022-2023"</text>
         </inputEntry>
         <inputEntry id="UnaryTests_0cb65f7">
-          <text>&gt; 7</text>
+          <text>&gt;= 7</text>
         </inputEntry>
         <outputEntry id="LiteralExpression_19tnso3">
           <text>84933</text>
@@ -946,7 +946,7 @@
           <text>"2023-2024"</text>
         </inputEntry>
         <inputEntry id="UnaryTests_1q5nz0l">
-          <text>&gt; 7</text>
+          <text>&gt;= 7</text>
         </inputEntry>
         <outputEntry id="LiteralExpression_1mhcmbi">
           <text>93737</text>
@@ -1282,7 +1282,7 @@
           <text>"2024-2025"</text>
         </inputEntry>
         <inputEntry id="UnaryTests_133s2og">
-          <text>&gt; 7</text>
+          <text>&gt;= 7</text>
         </inputEntry>
         <outputEntry id="LiteralExpression_0lnlz1h">
           <text>97395</text>
@@ -1611,7 +1611,7 @@
           <text>"2025-2026"</text>
         </inputEntry>
         <inputEntry id="UnaryTests_1x0upra">
-          <text>&gt; 7</text>
+          <text>&gt;= 7</text>
         </inputEntry>
         <outputEntry id="LiteralExpression_0p7ohoj">
           <text>97395</text>

--- a/sources/packages/backend/workflow/test/2022-2023/parttime-assessment/eligibility/parttime-assessment-eligibility-CSPT.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2022-2023/parttime-assessment/eligibility/parttime-assessment-eligibility-CSPT.e2e-spec.ts
@@ -4,6 +4,12 @@ import {
   createFakeConsolidatedPartTimeData,
   executePartTimeAssessmentForProgramYear,
 } from "../../../test-utils";
+import { YesNoOptions } from "@sims/test-utils";
+import { StudentDependent } from "workflow/test/models";
+import {
+  createFakeStudentDependentEligible,
+  DependentEligibility,
+} from "../../../test-utils/factories";
 
 describe(`E2E Test Workflow parttime-assessment-${PROGRAM_YEAR}-eligibility-CSPT.`, () => {
   it(
@@ -26,6 +32,58 @@ describe(`E2E Test Workflow parttime-assessment-${PROGRAM_YEAR}-eligibility-CSPT
       expect(
         calculatedAssessment.variables.finalFederalAwardNetCSPTAmount,
       ).toBeGreaterThan(0);
+    },
+  );
+
+  describe(
+    "Should determine CSPT as eligible when total assessed need is greater than or equal to 1 " +
+      "and total family income is less than the threshold and ",
+    () => {
+      const familySizeInputs = [2, 3, 4, 5, 6, 7, 8];
+      for (const familySize of familySizeInputs) {
+        it(`family size is ${familySize}`, async () => {
+          // Arrange
+          const assessmentConsolidatedData =
+            createFakeConsolidatedPartTimeData(PROGRAM_YEAR);
+          assessmentConsolidatedData.studentDataCRAReportedIncome = 1000;
+          assessmentConsolidatedData.studentDataHasDependents =
+            YesNoOptions.Yes;
+          const dependents: StudentDependent[] = [];
+          // Considering that the student is single, add dependents to make the family size to expected number.
+          for (let i = 1; i < familySize; i++) {
+            dependents.push(
+              createFakeStudentDependentEligible(
+                DependentEligibility.Eligible0To18YearsOld,
+                {
+                  referenceDate:
+                    assessmentConsolidatedData.offeringStudyStartDate,
+                },
+              ),
+            );
+          }
+          assessmentConsolidatedData.studentDataDependants = dependents;
+
+          // Act
+          const calculatedAssessment =
+            await executePartTimeAssessmentForProgramYear(
+              PROGRAM_YEAR,
+              assessmentConsolidatedData,
+            );
+
+          // Assert
+          // Validate family size.
+          expect(calculatedAssessment.variables.calculatedDataFamilySize).toBe(
+            familySize,
+          );
+          // Validate award eligibility for family size.
+          expect(calculatedAssessment.variables.awardEligibilityCSPT).toBe(
+            true,
+          );
+          expect(
+            calculatedAssessment.variables.finalFederalAwardNetCSPTAmount,
+          ).toBeGreaterThan(0);
+        });
+      }
     },
   );
 

--- a/sources/packages/backend/workflow/test/2022-2023/parttime-assessment/eligibility/parttime-assessment-eligibility-CSPT.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2022-2023/parttime-assessment/eligibility/parttime-assessment-eligibility-CSPT.e2e-spec.ts
@@ -5,7 +5,6 @@ import {
   executePartTimeAssessmentForProgramYear,
 } from "../../../test-utils";
 import { YesNoOptions } from "@sims/test-utils";
-import { StudentDependent } from "workflow/test/models";
 import {
   createFakeStudentDependentEligible,
   DependentEligibility,
@@ -35,57 +34,56 @@ describe(`E2E Test Workflow parttime-assessment-${PROGRAM_YEAR}-eligibility-CSPT
     },
   );
 
-  describe(
-    "Should determine CSPT as eligible when total assessed need is greater than or equal to 1 " +
-      "and total family income is less than the threshold and ",
-    () => {
-      const familySizeInputs = [2, 3, 4, 5, 6, 7, 8];
-      for (const familySize of familySizeInputs) {
-        it(`family size is ${familySize}`, async () => {
-          // Arrange
-          const assessmentConsolidatedData =
-            createFakeConsolidatedPartTimeData(PROGRAM_YEAR);
-          assessmentConsolidatedData.studentDataCRAReportedIncome = 1000;
-          assessmentConsolidatedData.studentDataHasDependents =
-            YesNoOptions.Yes;
-          const dependents: StudentDependent[] = [];
-          // Considering that the student is single, add dependents to make the family size to expected number.
-          for (let i = 1; i < familySize; i++) {
-            dependents.push(
-              createFakeStudentDependentEligible(
-                DependentEligibility.Eligible0To18YearsOld,
-                {
-                  referenceDate:
-                    assessmentConsolidatedData.offeringStudyStartDate,
-                },
-              ),
-            );
-          }
-          assessmentConsolidatedData.studentDataDependants = dependents;
+  describe("Should determine CSPT as eligible when total assessed need is greater than or equal to 1 and ", () => {
+    const familySizeInputs: { familySize: number; familyIncome: number }[] = [
+      { familySize: 2, familyIncome: 40000 },
+      { familySize: 3, familyIncome: 50000 },
+      { familySize: 4, familyIncome: 60000 },
+      { familySize: 5, familyIncome: 70000 },
+      { familySize: 6, familyIncome: 75000 },
+      { familySize: 7, familyIncome: 80000 },
+      { familySize: 8, familyIncome: 80000 },
+    ];
+    for (const { familySize, familyIncome } of familySizeInputs) {
+      it(`family size is ${familySize} and family income is ${familyIncome}`, async () => {
+        // Arrange
+        const assessmentConsolidatedData =
+          createFakeConsolidatedPartTimeData(PROGRAM_YEAR);
+        assessmentConsolidatedData.studentDataCRAReportedIncome = familyIncome;
+        assessmentConsolidatedData.studentDataHasDependents = YesNoOptions.Yes;
+        // Considering that the student is single, add dependents to make the family size to expected number.
+        assessmentConsolidatedData.studentDataDependants = Array.from(
+          { length: familySize - 1 },
+          () =>
+            createFakeStudentDependentEligible(
+              DependentEligibility.Eligible0To18YearsOld,
+              {
+                referenceDate:
+                  assessmentConsolidatedData.offeringStudyStartDate,
+              },
+            ),
+        );
 
-          // Act
-          const calculatedAssessment =
-            await executePartTimeAssessmentForProgramYear(
-              PROGRAM_YEAR,
-              assessmentConsolidatedData,
-            );
+        // Act
+        const calculatedAssessment =
+          await executePartTimeAssessmentForProgramYear(
+            PROGRAM_YEAR,
+            assessmentConsolidatedData,
+          );
 
-          // Assert
-          // Validate family size.
-          expect(calculatedAssessment.variables.calculatedDataFamilySize).toBe(
-            familySize,
-          );
-          // Validate award eligibility for family size.
-          expect(calculatedAssessment.variables.awardEligibilityCSPT).toBe(
-            true,
-          );
-          expect(
-            calculatedAssessment.variables.finalFederalAwardNetCSPTAmount,
-          ).toBeGreaterThan(0);
-        });
-      }
-    },
-  );
+        // Assert
+        // Validate family size.
+        expect(calculatedAssessment.variables.calculatedDataFamilySize).toBe(
+          familySize,
+        );
+        // Validate award eligibility for family size.
+        expect(calculatedAssessment.variables.awardEligibilityCSPT).toBe(true);
+        expect(
+          calculatedAssessment.variables.finalFederalAwardNetCSPTAmount,
+        ).toBeGreaterThan(0);
+      });
+    }
+  });
 
   it("Should determine CSPT as not eligible when total family income is greater than the threshold.", async () => {
     // Arrange

--- a/sources/packages/backend/workflow/test/2023-2024/parttime-assessment/eligibility/parttime-assessment-eligibility-CSPT.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2023-2024/parttime-assessment/eligibility/parttime-assessment-eligibility-CSPT.e2e-spec.ts
@@ -4,6 +4,12 @@ import {
   createFakeConsolidatedPartTimeData,
   executePartTimeAssessmentForProgramYear,
 } from "../../../test-utils";
+import { YesNoOptions } from "@sims/test-utils";
+import { StudentDependent } from "workflow/test/models";
+import {
+  createFakeStudentDependentEligible,
+  DependentEligibility,
+} from "../../../test-utils/factories";
 
 describe(`E2E Test Workflow parttime-assessment-${PROGRAM_YEAR}-eligibility-CSPT.`, () => {
   it(
@@ -26,6 +32,58 @@ describe(`E2E Test Workflow parttime-assessment-${PROGRAM_YEAR}-eligibility-CSPT
       expect(
         calculatedAssessment.variables.finalFederalAwardNetCSPTAmount,
       ).toBeGreaterThan(0);
+    },
+  );
+
+  describe(
+    "Should determine CSPT as eligible when total assessed need is greater than or equal to 1 " +
+      "and total family income is less than the threshold and ",
+    () => {
+      const familySizeInputs = [2, 3, 4, 5, 6, 7, 8];
+      for (const familySize of familySizeInputs) {
+        it(`family size is ${familySize}`, async () => {
+          // Arrange
+          const assessmentConsolidatedData =
+            createFakeConsolidatedPartTimeData(PROGRAM_YEAR);
+          assessmentConsolidatedData.studentDataCRAReportedIncome = 1000;
+          assessmentConsolidatedData.studentDataHasDependents =
+            YesNoOptions.Yes;
+          const dependents: StudentDependent[] = [];
+          // Considering that the student is single, add dependents to make the family size to expected number.
+          for (let i = 1; i < familySize; i++) {
+            dependents.push(
+              createFakeStudentDependentEligible(
+                DependentEligibility.Eligible0To18YearsOld,
+                {
+                  referenceDate:
+                    assessmentConsolidatedData.offeringStudyStartDate,
+                },
+              ),
+            );
+          }
+          assessmentConsolidatedData.studentDataDependants = dependents;
+
+          // Act
+          const calculatedAssessment =
+            await executePartTimeAssessmentForProgramYear(
+              PROGRAM_YEAR,
+              assessmentConsolidatedData,
+            );
+
+          // Assert
+          // Validate family size.
+          expect(calculatedAssessment.variables.calculatedDataFamilySize).toBe(
+            familySize,
+          );
+          // Validate award eligibility for family size.
+          expect(calculatedAssessment.variables.awardEligibilityCSPT).toBe(
+            true,
+          );
+          expect(
+            calculatedAssessment.variables.finalFederalAwardNetCSPTAmount,
+          ).toBeGreaterThan(0);
+        });
+      }
     },
   );
 

--- a/sources/packages/backend/workflow/test/2023-2024/parttime-assessment/eligibility/parttime-assessment-eligibility-CSPT.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2023-2024/parttime-assessment/eligibility/parttime-assessment-eligibility-CSPT.e2e-spec.ts
@@ -5,7 +5,6 @@ import {
   executePartTimeAssessmentForProgramYear,
 } from "../../../test-utils";
 import { YesNoOptions } from "@sims/test-utils";
-import { StudentDependent } from "workflow/test/models";
 import {
   createFakeStudentDependentEligible,
   DependentEligibility,
@@ -35,57 +34,56 @@ describe(`E2E Test Workflow parttime-assessment-${PROGRAM_YEAR}-eligibility-CSPT
     },
   );
 
-  describe(
-    "Should determine CSPT as eligible when total assessed need is greater than or equal to 1 " +
-      "and total family income is less than the threshold and ",
-    () => {
-      const familySizeInputs = [2, 3, 4, 5, 6, 7, 8];
-      for (const familySize of familySizeInputs) {
-        it(`family size is ${familySize}`, async () => {
-          // Arrange
-          const assessmentConsolidatedData =
-            createFakeConsolidatedPartTimeData(PROGRAM_YEAR);
-          assessmentConsolidatedData.studentDataCRAReportedIncome = 1000;
-          assessmentConsolidatedData.studentDataHasDependents =
-            YesNoOptions.Yes;
-          const dependents: StudentDependent[] = [];
-          // Considering that the student is single, add dependents to make the family size to expected number.
-          for (let i = 1; i < familySize; i++) {
-            dependents.push(
-              createFakeStudentDependentEligible(
-                DependentEligibility.Eligible0To18YearsOld,
-                {
-                  referenceDate:
-                    assessmentConsolidatedData.offeringStudyStartDate,
-                },
-              ),
-            );
-          }
-          assessmentConsolidatedData.studentDataDependants = dependents;
+  describe("Should determine CSPT as eligible when total assessed need is greater than or equal to 1 and ", () => {
+    const familySizeInputs: { familySize: number; familyIncome: number }[] = [
+      { familySize: 2, familyIncome: 40000 },
+      { familySize: 3, familyIncome: 50000 },
+      { familySize: 4, familyIncome: 60000 },
+      { familySize: 5, familyIncome: 70000 },
+      { familySize: 6, familyIncome: 75000 },
+      { familySize: 7, familyIncome: 80000 },
+      { familySize: 8, familyIncome: 80000 },
+    ];
+    for (const { familySize, familyIncome } of familySizeInputs) {
+      it(`family size is ${familySize} and family income is ${familyIncome}`, async () => {
+        // Arrange
+        const assessmentConsolidatedData =
+          createFakeConsolidatedPartTimeData(PROGRAM_YEAR);
+        assessmentConsolidatedData.studentDataCRAReportedIncome = familyIncome;
+        assessmentConsolidatedData.studentDataHasDependents = YesNoOptions.Yes;
+        // Considering that the student is single, add dependents to make the family size to expected number.
+        assessmentConsolidatedData.studentDataDependants = Array.from(
+          { length: familySize - 1 },
+          () =>
+            createFakeStudentDependentEligible(
+              DependentEligibility.Eligible0To18YearsOld,
+              {
+                referenceDate:
+                  assessmentConsolidatedData.offeringStudyStartDate,
+              },
+            ),
+        );
 
-          // Act
-          const calculatedAssessment =
-            await executePartTimeAssessmentForProgramYear(
-              PROGRAM_YEAR,
-              assessmentConsolidatedData,
-            );
+        // Act
+        const calculatedAssessment =
+          await executePartTimeAssessmentForProgramYear(
+            PROGRAM_YEAR,
+            assessmentConsolidatedData,
+          );
 
-          // Assert
-          // Validate family size.
-          expect(calculatedAssessment.variables.calculatedDataFamilySize).toBe(
-            familySize,
-          );
-          // Validate award eligibility for family size.
-          expect(calculatedAssessment.variables.awardEligibilityCSPT).toBe(
-            true,
-          );
-          expect(
-            calculatedAssessment.variables.finalFederalAwardNetCSPTAmount,
-          ).toBeGreaterThan(0);
-        });
-      }
-    },
-  );
+        // Assert
+        // Validate family size.
+        expect(calculatedAssessment.variables.calculatedDataFamilySize).toBe(
+          familySize,
+        );
+        // Validate award eligibility for family size.
+        expect(calculatedAssessment.variables.awardEligibilityCSPT).toBe(true);
+        expect(
+          calculatedAssessment.variables.finalFederalAwardNetCSPTAmount,
+        ).toBeGreaterThan(0);
+      });
+    }
+  });
 
   it("Should determine CSPT as not eligible when total family income is greater than the threshold.", async () => {
     // Arrange

--- a/sources/packages/backend/workflow/test/2024-2025/parttime-assessment/eligibility/parttime-assessment-eligibility-CSPT.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2024-2025/parttime-assessment/eligibility/parttime-assessment-eligibility-CSPT.e2e-spec.ts
@@ -4,6 +4,12 @@ import {
   createFakeConsolidatedPartTimeData,
   executePartTimeAssessmentForProgramYear,
 } from "../../../test-utils";
+import { YesNoOptions } from "@sims/test-utils";
+import { StudentDependent } from "workflow/test/models";
+import {
+  createFakeStudentDependentEligible,
+  DependentEligibility,
+} from "../../../test-utils/factories";
 
 describe(`E2E Test Workflow parttime-assessment-${PROGRAM_YEAR}-eligibility-CSPT.`, () => {
   it(
@@ -26,6 +32,58 @@ describe(`E2E Test Workflow parttime-assessment-${PROGRAM_YEAR}-eligibility-CSPT
       expect(
         calculatedAssessment.variables.finalFederalAwardNetCSPTAmount,
       ).toBeGreaterThan(0);
+    },
+  );
+
+  describe(
+    "Should determine CSPT as eligible when total assessed need is greater than or equal to 1 " +
+      "and total family income is less than the threshold and ",
+    () => {
+      const familySizeInputs = [2, 3, 4, 5, 6, 7, 8];
+      for (const familySize of familySizeInputs) {
+        it(`family size is ${familySize}`, async () => {
+          // Arrange
+          const assessmentConsolidatedData =
+            createFakeConsolidatedPartTimeData(PROGRAM_YEAR);
+          assessmentConsolidatedData.studentDataCRAReportedIncome = 1000;
+          assessmentConsolidatedData.studentDataHasDependents =
+            YesNoOptions.Yes;
+          const dependents: StudentDependent[] = [];
+          // Considering that the student is single, add dependents to make the family size to expected number.
+          for (let i = 1; i < familySize; i++) {
+            dependents.push(
+              createFakeStudentDependentEligible(
+                DependentEligibility.Eligible0To18YearsOld,
+                {
+                  referenceDate:
+                    assessmentConsolidatedData.offeringStudyStartDate,
+                },
+              ),
+            );
+          }
+          assessmentConsolidatedData.studentDataDependants = dependents;
+
+          // Act
+          const calculatedAssessment =
+            await executePartTimeAssessmentForProgramYear(
+              PROGRAM_YEAR,
+              assessmentConsolidatedData,
+            );
+
+          // Assert
+          // Validate family size.
+          expect(calculatedAssessment.variables.calculatedDataFamilySize).toBe(
+            familySize,
+          );
+          // Validate award eligibility for family size.
+          expect(calculatedAssessment.variables.awardEligibilityCSPT).toBe(
+            true,
+          );
+          expect(
+            calculatedAssessment.variables.finalFederalAwardNetCSPTAmount,
+          ).toBeGreaterThan(0);
+        });
+      }
     },
   );
 

--- a/sources/packages/backend/workflow/test/2024-2025/parttime-assessment/eligibility/parttime-assessment-eligibility-CSPT.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2024-2025/parttime-assessment/eligibility/parttime-assessment-eligibility-CSPT.e2e-spec.ts
@@ -5,7 +5,6 @@ import {
   executePartTimeAssessmentForProgramYear,
 } from "../../../test-utils";
 import { YesNoOptions } from "@sims/test-utils";
-import { StudentDependent } from "workflow/test/models";
 import {
   createFakeStudentDependentEligible,
   DependentEligibility,
@@ -35,57 +34,56 @@ describe(`E2E Test Workflow parttime-assessment-${PROGRAM_YEAR}-eligibility-CSPT
     },
   );
 
-  describe(
-    "Should determine CSPT as eligible when total assessed need is greater than or equal to 1 " +
-      "and total family income is less than the threshold and ",
-    () => {
-      const familySizeInputs = [2, 3, 4, 5, 6, 7, 8];
-      for (const familySize of familySizeInputs) {
-        it(`family size is ${familySize}`, async () => {
-          // Arrange
-          const assessmentConsolidatedData =
-            createFakeConsolidatedPartTimeData(PROGRAM_YEAR);
-          assessmentConsolidatedData.studentDataCRAReportedIncome = 1000;
-          assessmentConsolidatedData.studentDataHasDependents =
-            YesNoOptions.Yes;
-          const dependents: StudentDependent[] = [];
-          // Considering that the student is single, add dependents to make the family size to expected number.
-          for (let i = 1; i < familySize; i++) {
-            dependents.push(
-              createFakeStudentDependentEligible(
-                DependentEligibility.Eligible0To18YearsOld,
-                {
-                  referenceDate:
-                    assessmentConsolidatedData.offeringStudyStartDate,
-                },
-              ),
-            );
-          }
-          assessmentConsolidatedData.studentDataDependants = dependents;
+  describe("Should determine CSPT as eligible when total assessed need is greater than or equal to 1 and ", () => {
+    const familySizeInputs: { familySize: number; familyIncome: number }[] = [
+      { familySize: 2, familyIncome: 40000 },
+      { familySize: 3, familyIncome: 50000 },
+      { familySize: 4, familyIncome: 60000 },
+      { familySize: 5, familyIncome: 70000 },
+      { familySize: 6, familyIncome: 75000 },
+      { familySize: 7, familyIncome: 80000 },
+      { familySize: 8, familyIncome: 80000 },
+    ];
+    for (const { familySize, familyIncome } of familySizeInputs) {
+      it(`family size is ${familySize} and family income is ${familyIncome}`, async () => {
+        // Arrange
+        const assessmentConsolidatedData =
+          createFakeConsolidatedPartTimeData(PROGRAM_YEAR);
+        assessmentConsolidatedData.studentDataCRAReportedIncome = familyIncome;
+        assessmentConsolidatedData.studentDataHasDependents = YesNoOptions.Yes;
+        // Considering that the student is single, add dependents to make the family size to expected number.
+        assessmentConsolidatedData.studentDataDependants = Array.from(
+          { length: familySize - 1 },
+          () =>
+            createFakeStudentDependentEligible(
+              DependentEligibility.Eligible0To18YearsOld,
+              {
+                referenceDate:
+                  assessmentConsolidatedData.offeringStudyStartDate,
+              },
+            ),
+        );
 
-          // Act
-          const calculatedAssessment =
-            await executePartTimeAssessmentForProgramYear(
-              PROGRAM_YEAR,
-              assessmentConsolidatedData,
-            );
+        // Act
+        const calculatedAssessment =
+          await executePartTimeAssessmentForProgramYear(
+            PROGRAM_YEAR,
+            assessmentConsolidatedData,
+          );
 
-          // Assert
-          // Validate family size.
-          expect(calculatedAssessment.variables.calculatedDataFamilySize).toBe(
-            familySize,
-          );
-          // Validate award eligibility for family size.
-          expect(calculatedAssessment.variables.awardEligibilityCSPT).toBe(
-            true,
-          );
-          expect(
-            calculatedAssessment.variables.finalFederalAwardNetCSPTAmount,
-          ).toBeGreaterThan(0);
-        });
-      }
-    },
-  );
+        // Assert
+        // Validate family size.
+        expect(calculatedAssessment.variables.calculatedDataFamilySize).toBe(
+          familySize,
+        );
+        // Validate award eligibility for family size.
+        expect(calculatedAssessment.variables.awardEligibilityCSPT).toBe(true);
+        expect(
+          calculatedAssessment.variables.finalFederalAwardNetCSPTAmount,
+        ).toBeGreaterThan(0);
+      });
+    }
+  });
 
   it("Should determine CSPT as not eligible when total family income is greater than the threshold.", async () => {
     // Arrange

--- a/sources/packages/backend/workflow/test/2025-2026/parttime-assessment/eligibility/parttime-assessment-eligibility-CSPT.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2025-2026/parttime-assessment/eligibility/parttime-assessment-eligibility-CSPT.e2e-spec.ts
@@ -4,6 +4,12 @@ import {
   createFakeConsolidatedPartTimeData,
   executePartTimeAssessmentForProgramYear,
 } from "../../../test-utils";
+import { YesNoOptions } from "@sims/test-utils";
+import { StudentDependent } from "workflow/test/models";
+import {
+  createFakeStudentDependentEligible,
+  DependentEligibility,
+} from "../../../test-utils/factories";
 
 describe(`E2E Test Workflow parttime-assessment-${PROGRAM_YEAR}-eligibility-CSPT.`, () => {
   it(
@@ -26,6 +32,58 @@ describe(`E2E Test Workflow parttime-assessment-${PROGRAM_YEAR}-eligibility-CSPT
       expect(
         calculatedAssessment.variables.finalFederalAwardNetCSPTAmount,
       ).toBeGreaterThan(0);
+    },
+  );
+
+  describe(
+    "Should determine CSPT as eligible when total assessed need is greater than or equal to 1 " +
+      "and total family income is less than the threshold and ",
+    () => {
+      const familySizeInputs = [2, 3, 4, 5, 6, 7, 8];
+      for (const familySize of familySizeInputs) {
+        it(`family size is ${familySize}`, async () => {
+          // Arrange
+          const assessmentConsolidatedData =
+            createFakeConsolidatedPartTimeData(PROGRAM_YEAR);
+          assessmentConsolidatedData.studentDataCRAReportedIncome = 1000;
+          assessmentConsolidatedData.studentDataHasDependents =
+            YesNoOptions.Yes;
+          const dependents: StudentDependent[] = [];
+          // Considering that the student is single, add dependents to make the family size to expected number.
+          for (let i = 1; i < familySize; i++) {
+            dependents.push(
+              createFakeStudentDependentEligible(
+                DependentEligibility.Eligible0To18YearsOld,
+                {
+                  referenceDate:
+                    assessmentConsolidatedData.offeringStudyStartDate,
+                },
+              ),
+            );
+          }
+          assessmentConsolidatedData.studentDataDependants = dependents;
+
+          // Act
+          const calculatedAssessment =
+            await executePartTimeAssessmentForProgramYear(
+              PROGRAM_YEAR,
+              assessmentConsolidatedData,
+            );
+
+          // Assert
+          // Validate family size.
+          expect(calculatedAssessment.variables.calculatedDataFamilySize).toBe(
+            familySize,
+          );
+          // Validate award eligibility for family size.
+          expect(calculatedAssessment.variables.awardEligibilityCSPT).toBe(
+            true,
+          );
+          expect(
+            calculatedAssessment.variables.finalFederalAwardNetCSPTAmount,
+          ).toBeGreaterThan(0);
+        });
+      }
     },
   );
 

--- a/sources/packages/backend/workflow/test/2025-2026/parttime-assessment/eligibility/parttime-assessment-eligibility-CSPT.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2025-2026/parttime-assessment/eligibility/parttime-assessment-eligibility-CSPT.e2e-spec.ts
@@ -5,7 +5,6 @@ import {
   executePartTimeAssessmentForProgramYear,
 } from "../../../test-utils";
 import { YesNoOptions } from "@sims/test-utils";
-import { StudentDependent } from "workflow/test/models";
 import {
   createFakeStudentDependentEligible,
   DependentEligibility,
@@ -35,57 +34,56 @@ describe(`E2E Test Workflow parttime-assessment-${PROGRAM_YEAR}-eligibility-CSPT
     },
   );
 
-  describe(
-    "Should determine CSPT as eligible when total assessed need is greater than or equal to 1 " +
-      "and total family income is less than the threshold and ",
-    () => {
-      const familySizeInputs = [2, 3, 4, 5, 6, 7, 8];
-      for (const familySize of familySizeInputs) {
-        it(`family size is ${familySize}`, async () => {
-          // Arrange
-          const assessmentConsolidatedData =
-            createFakeConsolidatedPartTimeData(PROGRAM_YEAR);
-          assessmentConsolidatedData.studentDataCRAReportedIncome = 1000;
-          assessmentConsolidatedData.studentDataHasDependents =
-            YesNoOptions.Yes;
-          const dependents: StudentDependent[] = [];
-          // Considering that the student is single, add dependents to make the family size to expected number.
-          for (let i = 1; i < familySize; i++) {
-            dependents.push(
-              createFakeStudentDependentEligible(
-                DependentEligibility.Eligible0To18YearsOld,
-                {
-                  referenceDate:
-                    assessmentConsolidatedData.offeringStudyStartDate,
-                },
-              ),
-            );
-          }
-          assessmentConsolidatedData.studentDataDependants = dependents;
+  describe("Should determine CSPT as eligible when total assessed need is greater than or equal to 1 and ", () => {
+    const familySizeInputs: { familySize: number; familyIncome: number }[] = [
+      { familySize: 2, familyIncome: 40000 },
+      { familySize: 3, familyIncome: 50000 },
+      { familySize: 4, familyIncome: 60000 },
+      { familySize: 5, familyIncome: 70000 },
+      { familySize: 6, familyIncome: 75000 },
+      { familySize: 7, familyIncome: 80000 },
+      { familySize: 8, familyIncome: 80000 },
+    ];
+    for (const { familySize, familyIncome } of familySizeInputs) {
+      it(`family size is ${familySize} and family income is ${familyIncome}`, async () => {
+        // Arrange
+        const assessmentConsolidatedData =
+          createFakeConsolidatedPartTimeData(PROGRAM_YEAR);
+        assessmentConsolidatedData.studentDataCRAReportedIncome = familyIncome;
+        assessmentConsolidatedData.studentDataHasDependents = YesNoOptions.Yes;
+        // Considering that the student is single, add dependents to make the family size to expected number.
+        assessmentConsolidatedData.studentDataDependants = Array.from(
+          { length: familySize - 1 },
+          () =>
+            createFakeStudentDependentEligible(
+              DependentEligibility.Eligible0To18YearsOld,
+              {
+                referenceDate:
+                  assessmentConsolidatedData.offeringStudyStartDate,
+              },
+            ),
+        );
 
-          // Act
-          const calculatedAssessment =
-            await executePartTimeAssessmentForProgramYear(
-              PROGRAM_YEAR,
-              assessmentConsolidatedData,
-            );
+        // Act
+        const calculatedAssessment =
+          await executePartTimeAssessmentForProgramYear(
+            PROGRAM_YEAR,
+            assessmentConsolidatedData,
+          );
 
-          // Assert
-          // Validate family size.
-          expect(calculatedAssessment.variables.calculatedDataFamilySize).toBe(
-            familySize,
-          );
-          // Validate award eligibility for family size.
-          expect(calculatedAssessment.variables.awardEligibilityCSPT).toBe(
-            true,
-          );
-          expect(
-            calculatedAssessment.variables.finalFederalAwardNetCSPTAmount,
-          ).toBeGreaterThan(0);
-        });
-      }
-    },
-  );
+        // Assert
+        // Validate family size.
+        expect(calculatedAssessment.variables.calculatedDataFamilySize).toBe(
+          familySize,
+        );
+        // Validate award eligibility for family size.
+        expect(calculatedAssessment.variables.awardEligibilityCSPT).toBe(true);
+        expect(
+          calculatedAssessment.variables.finalFederalAwardNetCSPTAmount,
+        ).toBeGreaterThan(0);
+      });
+    }
+  });
 
   it("Should determine CSPT as not eligible when total family income is greater than the threshold.", async () => {
     // Arrange


### PR DESCRIPTION
# Fix part-time family size variables DMN

- [x]  Updated the PT DMN for family size to match family size of 7. Before the update the match was missing for family size  = 7.
- [x] Updated the modeler platform version and exporter version for DMN.
- [x] Added E2E tests(Picked one of the award eligibility to satisfy all possible conditions based on family size).