### PR TITLE
#4023 - Additional transportation and bc residency uploaders is mandatory

### DIFF
--- a/sources/packages/forms/src/form-definitions/sfaa2022-23.json
+++ b/sources/packages/forms/src/form-definitions/sfaa2022-23.json
@@ -9309,7 +9309,7 @@
                       "attributes": {},
                       "validateOn": "change",
                       "validate": {
-                        "required": false,
+                        "required": true,
                         "custom": "",
                         "customPrivate": false,
                         "strictDateValidation": false,
@@ -31588,7 +31588,7 @@
                       "attributes": {},
                       "validateOn": "change",
                       "validate": {
-                        "required": false,
+                        "required": true,
                         "custom": "",
                         "customPrivate": false,
                         "strictDateValidation": false,

--- a/sources/packages/forms/src/form-definitions/sfaa2023-24.json
+++ b/sources/packages/forms/src/form-definitions/sfaa2023-24.json
@@ -9309,7 +9309,7 @@
                       "attributes": {},
                       "validateOn": "change",
                       "validate": {
-                        "required": false,
+                        "required": true,
                         "custom": "",
                         "customPrivate": false,
                         "strictDateValidation": false,
@@ -31588,7 +31588,7 @@
                       "attributes": {},
                       "validateOn": "change",
                       "validate": {
-                        "required": false,
+                        "required": true,
                         "custom": "",
                         "customPrivate": false,
                         "strictDateValidation": false,

--- a/sources/packages/forms/src/form-definitions/sfaa2024-25.json
+++ b/sources/packages/forms/src/form-definitions/sfaa2024-25.json
@@ -9309,7 +9309,7 @@
                       "attributes": {},
                       "validateOn": "change",
                       "validate": {
-                        "required": false,
+                        "required": true,
                         "custom": "",
                         "customPrivate": false,
                         "strictDateValidation": false,
@@ -31588,7 +31588,7 @@
                       "attributes": {},
                       "validateOn": "change",
                       "validate": {
-                        "required": false,
+                        "required": true,
                         "custom": "",
                         "customPrivate": false,
                         "strictDateValidation": false,

--- a/sources/packages/forms/src/form-definitions/sfaa2025-26.json
+++ b/sources/packages/forms/src/form-definitions/sfaa2025-26.json
@@ -10541,7 +10541,7 @@
                       "attributes": {},
                       "validateOn": "change",
                       "validate": {
-                        "required": false,
+                        "required": true,
                         "custom": "",
                         "customPrivate": false,
                         "strictDateValidation": false,
@@ -31279,7 +31279,7 @@
                       "attributes": {},
                       "validateOn": "change",
                       "validate": {
-                        "required": false,
+                        "required": true,
                         "custom": "",
                         "customPrivate": false,
                         "strictDateValidation": false,

--- a/sources/packages/forms/src/form-definitions/studentadditionaltransportationappeal.json
+++ b/sources/packages/forms/src/form-definitions/studentadditionaltransportationappeal.json
@@ -479,7 +479,7 @@
                   "scrollToTop": false,
                   "collapsible": false,
                   "key": "additionTransportationPanel",
-                  "customConditional": "show = (data.transportationCostSituation === 'noLimit' || data.transportationCostSituation === 'special' || data.transportationCostSituation === 'educationPlacement');",
+                  "customConditional": "",
                   "type": "panel",
                   "label": "Addition Transportation Panel",
                   "input": false,

--- a/sources/packages/forms/src/form-definitions/studentadditionaltransportationappeal.json
+++ b/sources/packages/forms/src/form-definitions/studentadditionaltransportationappeal.json
@@ -839,7 +839,7 @@
                       "attributes": {},
                       "validateOn": "change",
                       "validate": {
-                        "required": false,
+                        "required": true,
                         "custom": "",
                         "customPrivate": false,
                         "strictDateValidation": false,

--- a/sources/packages/forms/src/form-definitions/studentadditionaltransportationappeal.json
+++ b/sources/packages/forms/src/form-definitions/studentadditionaltransportationappeal.json
@@ -287,7 +287,7 @@
                   "key": "transportationCostSituation",
                   "conditional": {
                     "show": "",
-                    "when": "",
+                    "when": null,
                     "eq": ""
                   },
                   "type": "radio",
@@ -422,8 +422,7 @@
                   "properties": {},
                   "decimalLimit": 0,
                   "lockKey": true,
-                  "customConditional": "",
-                  "isNew": false
+                  "customConditional": ""
                 },
                 {
                   "autofocus": false,
@@ -480,7 +479,7 @@
                   "scrollToTop": false,
                   "collapsible": false,
                   "key": "additionTransportationPanel",
-                  "customConditional": "",
+                  "customConditional": "show = (data.transportationCostSituation === 'noLimit' || data.transportationCostSituation === 'special' || data.transportationCostSituation === 'educationPlacement');",
                   "type": "panel",
                   "label": "Addition Transportation Panel",
                   "input": false,


### PR DESCRIPTION
- Made the additional transportation exception document uploader field mandatory field for all options for the following areas:
  - Application
  - Change Request
- Made the BC residency exception document uploader field mandatory field for all options for the following areas:
  - Application

Screenshot for the BC residency file uploader
![image](https://github.com/user-attachments/assets/c3342473-d2c0-47cd-b455-77e6964d1fb4)

Screenshot for the additional transportation file uploader
![image](https://github.com/user-attachments/assets/6235d85e-c002-44aa-8dbb-1ff3a67df890)

