### PR TITLE
#3067 - Assessment History: Update to show most recent assessment

### DIFF
--- a/sources/packages/backend/apps/api/src/services/student-assessment/student-assessment.service.ts
+++ b/sources/packages/backend/apps/api/src/services/student-assessment/student-assessment.service.ts
@@ -275,8 +275,7 @@ export class StudentAssessmentService extends RecordDataModelService<StudentAsse
       });
     }
     return assessmentHistoryQuery
-      .orderBy("assessment.studentAssessmentStatus", "ASC")
-      .addOrderBy("assessment.submittedDate", "DESC")
+      .orderBy("assessment.submittedDate", "DESC")
       .getMany();
   }
 

--- a/sources/packages/backend/apps/api/src/services/student-assessment/student-assessment.service.ts
+++ b/sources/packages/backend/apps/api/src/services/student-assessment/student-assessment.service.ts
@@ -275,7 +275,7 @@ export class StudentAssessmentService extends RecordDataModelService<StudentAsse
       });
     }
     return assessmentHistoryQuery
-      .orderBy("assessment.studentAssessmentStatus", "DESC")
+      .orderBy("assessment.studentAssessmentStatus", "ASC")
       .addOrderBy("assessment.submittedDate", "DESC")
       .getMany();
   }

--- a/sources/packages/web/src/components/aest/students/assessment/History.vue
+++ b/sources/packages/web/src/components/aest/students/assessment/History.vue
@@ -55,7 +55,7 @@
               :sortable="true"
               ><template #body="slotProps">
                 <span v-if="slotProps.data.assessmentDate">{{
-                  dateOnlyLongString(slotProps.data.assessmentDate)
+                  getISODateHourMinuteString(slotProps.data.assessmentDate)
                 }}</span
                 ><span v-else>-</span></template
               ></Column
@@ -116,7 +116,7 @@ export default defineComponent({
     },
   },
   setup(props, context) {
-    const { dateOnlyLongString } = useFormatters();
+    const { dateOnlyLongString, getISODateHourMinuteString } = useFormatters();
     const assessmentHistory = ref([] as AssessmentHistorySummaryAPIOutDTO[]);
     onMounted(async () => {
       assessmentHistory.value =
@@ -185,6 +185,7 @@ export default defineComponent({
       PAGINATION_LIST,
       assessmentHistory,
       dateOnlyLongString,
+      getISODateHourMinuteString,
       viewRequest,
       canShowViewRequest,
       getViewRequestLabel,


### PR DESCRIPTION
### As a part of this PR, the following were completed:

- Added the TIME (HH:MM 24hr) to the Assessment date in the history view.
- Ensured that the table is always ordered by submitted date descending.
- Confirmed that the changes apply to the Ministry view, Student view and the Institution view.

### **Screenshots:**

**Institution View:**

<img width="1920" alt="image" src="https://github.com/user-attachments/assets/d6e403ee-ddbc-4ca9-ab8a-e3e7410a1959" />

-------------------------------------------

**Student View:**

<img width="1920" alt="image" src="https://github.com/user-attachments/assets/a606fa92-dea6-4f31-b87b-b925bcf43e05" />

-------------------------------------------

**Ministry View:**

<img width="1919" alt="image" src="https://github.com/user-attachments/assets/f06ab9c6-bf40-44b9-875a-55089047e34e" />

