### PR TITLE
#3254 - CAS AP Invoice - Invoices and Batches - Scheduler

### DIFF
--- a/sources/packages/backend/apps/db-migrations/src/migrations/1738006674395-AddQueueCASInvoicesBatchesCreation.ts
+++ b/sources/packages/backend/apps/db-migrations/src/migrations/1738006674395-AddQueueCASInvoicesBatchesCreation.ts
@@ -1,0 +1,18 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+import { getSQLFileData } from "../utilities/sqlLoader";
+
+export class AddQueueCASInvoicesBatchesCreation1738006674395
+  implements MigrationInterface
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      getSQLFileData("Add-cas-invoices-batches-creation.sql", "Queue"),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      getSQLFileData("Rollback-add-cas-invoices-batches-creation.sql", "Queue"),
+    );
+  }
+}

--- a/sources/packages/backend/apps/db-migrations/src/sql/Queue/Add-cas-invoices-batches-creation.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/Queue/Add-cas-invoices-batches-creation.sql
@@ -1,0 +1,18 @@
+INSERT INTO
+  sims.queue_configurations(queue_name, queue_configuration, queue_settings)
+VALUES
+  (
+    'cas-invoices-batches-creation',
+    '{
+        "cron": "0 4 * * 1-5",
+        "retry": 3,
+        "cleanUpPeriod": 2592000000,
+        "retryInterval": 180000,
+        "dashboardReadonly": false
+     }',
+    '{
+        "maxStalledCount": 0,
+        "lockDuration": 60000,
+        "lockRenewTime": 5000
+      }'
+  );

--- a/sources/packages/backend/apps/db-migrations/src/sql/Queue/Rollback-add-cas-invoices-batches-creation.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/Queue/Rollback-add-cas-invoices-batches-creation.sql
@@ -1,0 +1,4 @@
+DELETE FROM
+  sims.queue_configurations
+WHERE
+  queue_name = 'cas-invoices-batches-creation';

--- a/sources/packages/backend/apps/queue-consumers/Dockerfile.dev
+++ b/sources/packages/backend/apps/queue-consumers/Dockerfile.dev
@@ -20,6 +20,7 @@ RUN npm ci
 # Copying sources.
 COPY ./apps/queue-consumers ./apps/queue-consumers
 COPY ./apps/db-migrations ./apps/db-migrations
+COPY ./apps/test-db-seeding ./apps/test-db-seeding
 COPY ./libs ./libs
 
 # Building app
@@ -28,6 +29,8 @@ RUN npm run build queue-consumers
 # Exposing queue port
 EXPOSE ${PORT}
 
+# Ensure that the non-root user can build the test-db-seeding.
+RUN mkdir -p /app/dist/apps/test-db-seeding/ && chown node /app/dist/apps/test-db-seeding/
 # Ensure that the non-root user will be able to write the coverage report.
 RUN mkdir -p /app/apps/queue-consumers/coverage/ && chown node /app/apps/queue-consumers/coverage/
 

--- a/sources/packages/backend/apps/queue-consumers/Dockerfile.dev
+++ b/sources/packages/backend/apps/queue-consumers/Dockerfile.dev
@@ -29,10 +29,9 @@ RUN npm run build queue-consumers
 # Exposing queue port
 EXPOSE ${PORT}
 
-# Ensure that the non-root user can build the test-db-seeding.
-RUN mkdir -p /app/dist/apps/test-db-seeding/ && chown node /app/dist/apps/test-db-seeding/
-# Ensure that the non-root user will be able to write the coverage report.
-RUN mkdir -p /app/apps/queue-consumers/coverage/ && chown node /app/apps/queue-consumers/coverage/
+# Ensure that the non-root user will be able to execute the test-db-seeding and write the coverage report.
+RUN mkdir -p /app/dist/apps/test-db-seeding/ && chown node /app/dist/apps/test-db-seeding/ \
+    && mkdir -p /app/apps/queue-consumers/coverage/ && chown node /app/apps/queue-consumers/coverage/
 
 # Executing the image with a non-root user.
 USER node

--- a/sources/packages/backend/apps/queue-consumers/src/processors/index.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/processors/index.ts
@@ -30,3 +30,4 @@ export * from "./schedulers/cas-integration/cas-supplier-integration.scheduler";
 export * from "./schedulers/esdc-integration/application-changes-report-integration/application-changes-report-integration.scheduler";
 export * from "./schedulers/student-application-notifications/student-application-notifications.scheduler";
 export * from "./schedulers/sfas-integration/sims-to-sfas-integration.scheduler";
+export * from "./schedulers/cas-integration/cas-invoices-batches-creation.scheduler";

--- a/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/cas-integration/_tests_/cas-invoices-batches-creation.scheduler.e2e-spec.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/cas-integration/_tests_/cas-invoices-batches-creation.scheduler.e2e-spec.ts
@@ -1,0 +1,268 @@
+import { INestApplication } from "@nestjs/common";
+import {
+  createE2EDataSources,
+  createFakeDisbursementValue,
+  E2EDataSources,
+  saveFakeApplicationDisbursements,
+  saveFakeCASSupplier,
+  saveFakeDisbursementReceiptsFromDisbursementSchedule,
+  saveFakeStudent,
+} from "@sims/test-utils";
+import { QueueNames } from "@sims/utilities";
+import { CASSupplierIntegrationScheduler } from "../cas-supplier-integration.scheduler";
+import {
+  createTestingAppModule,
+  describeProcessorRootTest,
+  mockBullJob,
+} from "../../../../../test/helpers";
+import {
+  CASInvoiceBatchApprovalStatus,
+  CASInvoiceStatus,
+  DisbursementValueType,
+  SupplierStatus,
+} from "@sims/sims-db";
+import { SystemUsersService } from "@sims/services";
+import { CASInvoicesBatchesCreationScheduler } from "../cas-invoices-batches-creation.scheduler";
+
+const CAS_INVOICE_BATCH_SEQUENCE_NAME = "CAS_INVOICE_BATCH";
+const CAS_INVOICE_SEQUENCE_NAME = "CAS_INVOICE";
+
+describe(
+  describeProcessorRootTest(QueueNames.CASInvoicesBatchesCreation),
+  () => {
+    let app: INestApplication;
+    let processor: CASSupplierIntegrationScheduler;
+    let db: E2EDataSources;
+    let systemUsersService: SystemUsersService;
+
+    beforeAll(async () => {
+      const { nestApplication, dataSource } = await createTestingAppModule();
+      app = nestApplication;
+      systemUsersService = nestApplication.get(SystemUsersService);
+      db = createE2EDataSources(dataSource);
+      // Processor under test.
+      processor = app.get(CASInvoicesBatchesCreationScheduler);
+    });
+
+    beforeEach(async () => {
+      jest.clearAllMocks();
+      // Update existing records to avoid conflicts between tests.
+      await db.disbursementReceiptValue.update(
+        {
+          grantType: "BCSG",
+        },
+        { grantAmount: 0 },
+      );
+      // Delete all existing invoices and related data.
+      await db.casInvoiceDetail.delete({});
+      await db.casInvoice.delete({});
+      await db.casInvoiceBatch.delete({});
+      // Reset sequence numbers.
+      await db.sequenceControl.delete({
+        sequenceName: CAS_INVOICE_BATCH_SEQUENCE_NAME,
+      });
+      await db.sequenceControl.delete({
+        sequenceName: CAS_INVOICE_SEQUENCE_NAME,
+      });
+    });
+
+    it("Should create a new CAS invoice batch for a full-time receipt when there is a e-Cert receipt with no invoice associated.", async () => {
+      // Arrange
+      const casSupplier = await saveFakeCASSupplier(db, undefined, {
+        initialValues: {
+          supplierStatus: SupplierStatus.VerifiedManually,
+        },
+      });
+      const student = await saveFakeStudent(db.dataSource, { casSupplier });
+      const application = await saveFakeApplicationDisbursements(
+        db.dataSource,
+        {
+          student,
+          disbursementValues: [
+            createFakeDisbursementValue(
+              DisbursementValueType.CanadaLoan,
+              "CSLF",
+              1000,
+            ),
+            createFakeDisbursementValue(
+              DisbursementValueType.CanadaGrant,
+              "CSGD",
+              500,
+            ),
+            createFakeDisbursementValue(
+              DisbursementValueType.BCLoan,
+              "BCSL",
+              901,
+              {
+                effectiveAmount: 900,
+              },
+            ),
+            createFakeDisbursementValue(
+              DisbursementValueType.BCGrant,
+              "BCAG",
+              351,
+              { effectiveAmount: 350 },
+            ),
+            createFakeDisbursementValue(
+              DisbursementValueType.BCGrant,
+              "SBSD",
+              201,
+              { effectiveAmount: 200 },
+            ),
+            createFakeDisbursementValue(
+              DisbursementValueType.BCTotalGrant,
+              "BCSG",
+              350,
+              { effectiveAmount: 350 },
+            ),
+          ],
+        },
+      );
+      const [firstDisbursementSchedule] =
+        application.currentAssessment.disbursementSchedules;
+      const { provincial: provincialDisbursementReceipt } =
+        await saveFakeDisbursementReceiptsFromDisbursementSchedule(
+          db,
+          firstDisbursementSchedule,
+        );
+
+      // Queued job.
+      const mockedJob = mockBullJob<void>();
+
+      // Act
+      const result = await processor.processQueue(mockedJob.job);
+
+      // Assert
+      expect(result).toStrictEqual([
+        "Batch created: SIMS-BATCH-1.",
+        "Invoices created: 1.",
+      ]);
+      // Assert the created batch on DB and its related data.
+      const createdBatches = await db.casInvoiceBatch.find({
+        select: {
+          batchName: true,
+          batchDate: true,
+          approvalStatus: true,
+          approvalStatusUpdatedBy: { id: true },
+          approvalStatusUpdatedOn: true,
+          casInvoices: {
+            id: true,
+            disbursementReceipt: {
+              id: true,
+            },
+            casSupplier: {
+              id: true,
+            },
+            invoiceNumber: true,
+            invoiceStatus: true,
+            invoiceStatusUpdatedOn: true,
+            casInvoiceDetails: {
+              id: true,
+              valueAmount: true,
+              casDistributionAccount: {
+                id: true,
+                operationCode: true,
+                awardValueCode: true,
+                offeringIntensity: true,
+                distributionAccount: true,
+              },
+            },
+          },
+        },
+        relations: {
+          approvalStatusUpdatedBy: true,
+          casInvoices: {
+            disbursementReceipt: true,
+            casSupplier: true,
+            casInvoiceDetails: {
+              casDistributionAccount: true,
+            },
+          },
+        },
+      });
+      expect(createdBatches.length).toEqual(1);
+      const [expectedBatch] = createdBatches;
+      // Assert batch, invoices and its details.
+      expect(expectedBatch).toEqual({
+        batchName: "SIMS-BATCH-1",
+        batchDate: expect.any(Date),
+        approvalStatus: CASInvoiceBatchApprovalStatus.Pending,
+        approvalStatusUpdatedOn: expect.any(Date),
+        approvalStatusUpdatedBy: {
+          id: systemUsersService.systemUser.id,
+        },
+        casInvoices: [
+          {
+            id: expect.any(Number),
+            invoiceNumber: `SIMS-INVOICE-1-${casSupplier.supplierNumber}`,
+            invoiceStatus: CASInvoiceStatus.Pending,
+            invoiceStatusUpdatedOn: expect.any(Date),
+            disbursementReceipt: {
+              id: provincialDisbursementReceipt.id,
+            },
+            casSupplier: { id: casSupplier.id },
+            casInvoiceDetails: expect.arrayContaining([
+              {
+                id: expect.any(Number),
+                valueAmount: 350,
+                casDistributionAccount: {
+                  id: expect.any(Number),
+                  awardValueCode: "BCAG",
+                  offeringIntensity: "Full Time",
+                  operationCode: "CR",
+                  distributionAccount:
+                    "100.CR.FULL-TIME.00000.0000.0000000.0000",
+                },
+              },
+              {
+                id: expect.any(Number),
+                valueAmount: 350,
+                casDistributionAccount: {
+                  id: expect.any(Number),
+                  awardValueCode: "BCAG",
+                  offeringIntensity: "Full Time",
+                  operationCode: "DR",
+                  distributionAccount:
+                    "101.DR.FULL-TIME.00000.0000.0000000.0000",
+                },
+              },
+              {
+                id: expect.any(Number),
+                valueAmount: 200,
+                casDistributionAccount: {
+                  id: expect.any(Number),
+                  awardValueCode: "SBSD",
+                  offeringIntensity: "Full Time",
+                  operationCode: "CR",
+                  distributionAccount:
+                    "104.CR.FULL-TIME.00000.0000.0000000.0000",
+                },
+              },
+              {
+                id: expect.any(Number),
+                valueAmount: 200,
+                casDistributionAccount: {
+                  id: expect.any(Number),
+                  awardValueCode: "SBSD",
+                  offeringIntensity: "Full Time",
+                  operationCode: "DR",
+                  distributionAccount:
+                    "105.DR.FULL-TIME.00000.0000.0000000.0000",
+                },
+              },
+            ]),
+          },
+        ],
+      });
+      const currentInvoiceSequenceNumber = await db.sequenceControl.findOne({
+        select: {
+          sequenceNumber: true,
+        },
+        where: {
+          sequenceName: CAS_INVOICE_SEQUENCE_NAME,
+        },
+      });
+      expect(currentInvoiceSequenceNumber.sequenceNumber).toEqual("2");
+    });
+  },
+);

--- a/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/cas-integration/_tests_/cas-invoices-batches-creation.scheduler.e2e-spec.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/cas-integration/_tests_/cas-invoices-batches-creation.scheduler.e2e-spec.ts
@@ -227,7 +227,7 @@ describe(
                   offeringIntensity: "Full Time",
                   operationCode: "CR",
                   distributionAccount:
-                    "100.CR.FULL-TIME.00000.0000.0000000.0000",
+                    "BCAG.CR.FULL-TIME.0000000000000000000000",
                 },
               },
               {
@@ -239,7 +239,7 @@ describe(
                   offeringIntensity: "Full Time",
                   operationCode: "DR",
                   distributionAccount:
-                    "101.DR.FULL-TIME.00000.0000.0000000.0000",
+                    "BCAG.DR.FULL-TIME.0000000000000000000000",
                 },
               },
               {
@@ -251,7 +251,7 @@ describe(
                   offeringIntensity: "Full Time",
                   operationCode: "CR",
                   distributionAccount:
-                    "104.CR.FULL-TIME.00000.0000.0000000.0000",
+                    "SBSD.CR.FULL-TIME.0000000000000000000000",
                 },
               },
               {
@@ -263,7 +263,7 @@ describe(
                   offeringIntensity: "Full Time",
                   operationCode: "DR",
                   distributionAccount:
-                    "105.DR.FULL-TIME.00000.0000.0000000.0000",
+                    "SBSD.DR.FULL-TIME.0000000000000000000000",
                 },
               },
             ]),

--- a/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/cas-integration/_tests_/cas-invoices-batches-creation.scheduler.e2e-spec.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/cas-integration/_tests_/cas-invoices-batches-creation.scheduler.e2e-spec.ts
@@ -74,6 +74,8 @@ describe(
         },
       });
       const student = await saveFakeStudent(db.dataSource, { casSupplier });
+      // Created a full-time application with Federal and Provincial loans and grants
+      // to ensure that only expected awards (BC grants) will have invoices generated.
       const application = await saveFakeApplicationDisbursements(
         db.dataSource,
         {
@@ -137,6 +139,20 @@ describe(
         "Batch created: SIMS-BATCH-1.",
         "Invoices created: 1.",
       ]);
+      expect(
+        mockedJob.containLogMessages([
+          "Executing CAS invoices batches creation.",
+          "Checking for pending receipts.",
+          "Found 1 pending receipts.",
+          `Creating invoice for receipt ID ${provincialDisbursementReceipt.id}.`,
+          `Invoice SIMS-INVOICE-1-${casSupplier.supplierNumber} created for receipt ID ${provincialDisbursementReceipt.id}.`,
+          `Created invoice detail for award BCAG(CR).`,
+          `Created invoice detail for award BCAG(DR).`,
+          `Created invoice detail for award SBSD(CR).`,
+          `Created invoice detail for award SBSD(DR).`,
+          `CAS invoices batches creation process executed.`,
+        ]),
+      ).toBe(true);
       // Assert the created batch on DB and its related data.
       const createdBatches = await db.casInvoiceBatch.find({
         select: {

--- a/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/cas-integration/cas-invoices-batches-creation.scheduler.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/cas-integration/cas-invoices-batches-creation.scheduler.ts
@@ -1,0 +1,54 @@
+import { InjectQueue, Processor } from "@nestjs/bull";
+import { QueueService } from "@sims/services/queue";
+import { QueueNames } from "@sims/utilities";
+import {
+  InjectLogger,
+  LoggerService,
+  ProcessSummary,
+} from "@sims/utilities/logger";
+import { Job, Queue } from "bull";
+import { BaseScheduler } from "../base-scheduler";
+import { CASInvoiceBatchService } from "../../../services";
+
+/**
+ * Scheduler to generate batches for CAS invoices for e-Cert receipts.
+ */
+@Processor(QueueNames.CASInvoicesBatchesCreation)
+export class CASInvoicesBatchesCreationScheduler extends BaseScheduler<void> {
+  constructor(
+    @InjectQueue(QueueNames.CASSupplierIntegration)
+    schedulerQueue: Queue<void>,
+    queueService: QueueService,
+    private readonly casInvoiceBatchService: CASInvoiceBatchService,
+  ) {
+    super(schedulerQueue, queueService);
+  }
+
+  /**
+   * Checks received e-Cert receipts with no invoice associated
+   * and create invoice records to be sent to CAS.
+   * @param _job process job.
+   * @param processSummary process summary for logging.
+   * @returns process summary.
+   */
+  protected async process(
+    _job: Job<void>,
+    processSummary: ProcessSummary,
+  ): Promise<string[] | string> {
+    processSummary.info("Executing CAS invoices batches creation.");
+    const createdBatch = await this.casInvoiceBatchService.createInvoiceBatch(
+      processSummary,
+    );
+    processSummary.info("CAS invoices batches creation process executed.");
+    if (!createdBatch) {
+      return "No batch was generated.";
+    }
+    return [
+      `Batch created: ${createdBatch.batchName}.`,
+      `Invoices created: ${createdBatch.casInvoices.length}.`,
+    ];
+  }
+
+  @InjectLogger()
+  logger: LoggerService;
+}

--- a/sources/packages/backend/apps/queue-consumers/src/queue-consumers.module.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/queue-consumers.module.ts
@@ -169,7 +169,6 @@ import { QueuesMetricsModule } from "./queues-metrics.module.module";
     CASKnownErrorsProcessor,
     CASSupplierSharedService,
     CASInvoiceBatchService,
-    CASInvoiceBatchService,
     CASInvoicesBatchesCreationScheduler,
   ],
   controllers: [HealthController, MetricsController],

--- a/sources/packages/backend/apps/queue-consumers/src/queue-consumers.module.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/queue-consumers.module.ts
@@ -30,6 +30,7 @@ import {
   ApplicationChangesReportIntegrationScheduler,
   StudentApplicationNotificationsScheduler,
   SIMSToSFASIntegrationScheduler,
+  CASInvoicesBatchesCreationScheduler,
 } from "./processors";
 import {
   DisbursementScheduleSharedService,
@@ -70,6 +71,7 @@ import {
   CASActiveSupplierFoundProcessor,
   CASActiveSupplierAndSiteFoundProcessor,
   CASKnownErrorsProcessor,
+  CASInvoiceBatchService,
 } from "./services";
 import { SFASIntegrationModule } from "@sims/integrations/sfas-integration";
 import { ATBCIntegrationModule } from "@sims/integrations/atbc-integration";
@@ -166,6 +168,9 @@ import { QueuesMetricsModule } from "./queues-metrics.module.module";
     CASActiveSupplierAndSiteFoundProcessor,
     CASKnownErrorsProcessor,
     CASSupplierSharedService,
+    CASInvoiceBatchService,
+    CASInvoiceBatchService,
+    CASInvoicesBatchesCreationScheduler,
   ],
   controllers: [HealthController, MetricsController],
 })

--- a/sources/packages/backend/apps/queue-consumers/src/services/cas-invoice-batch/cas-invoice-batch.service.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/services/cas-invoice-batch/cas-invoice-batch.service.ts
@@ -10,6 +10,7 @@ import {
   DisbursementReceipt,
   DisbursementValue,
   DisbursementValueType,
+  RECEIPT_FUNDING_TYPE_FEDERAL,
 } from "@sims/sims-db";
 import { DataSource, EntityManager } from "typeorm";
 import { SequenceControlService, SystemUsersService } from "@sims/services";
@@ -235,7 +236,10 @@ export class CASInvoiceBatchService {
       .innerJoin("studentAssessment.application", "application")
       .innerJoin("application.student", "student")
       .innerJoin("student.casSupplier", "casSupplier")
-      .where("disbursementReceiptValue.grantType = :grantType", {
+      .where("disbursementReceipt.fundingType != :federalFundingType", {
+        federalFundingType: RECEIPT_FUNDING_TYPE_FEDERAL,
+      })
+      .andWhere("disbursementReceiptValue.grantType = :grantType", {
         grantType: BC_TOTAL_GRANT_AWARD_CODE,
       })
       .andWhere("disbursementReceiptValue.grantAmount > 0")

--- a/sources/packages/backend/apps/queue-consumers/src/services/cas-invoice-batch/cas-invoice-batch.service.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/services/cas-invoice-batch/cas-invoice-batch.service.ts
@@ -7,7 +7,6 @@ import {
   CASInvoiceBatchApprovalStatus,
   CASInvoiceDetail,
   CASInvoiceStatus,
-  CASSupplier,
   DisbursementReceipt,
   DisbursementValue,
   DisbursementValueType,

--- a/sources/packages/backend/apps/queue-consumers/src/services/cas-invoice-batch/cas-invoice-batch.service.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/services/cas-invoice-batch/cas-invoice-batch.service.ts
@@ -1,0 +1,194 @@
+import { Injectable } from "@nestjs/common";
+import { InjectRepository } from "@nestjs/typeorm";
+import { BC_TOTAL_GRANT_AWARD_CODE } from "@sims/services/constants";
+import {
+  CASDistributionAccount,
+  CASInvoice,
+  CASInvoiceBatch,
+  CASInvoiceBatchApprovalStatus,
+  CASInvoiceDetail,
+  CASInvoiceStatus,
+  DisbursementReceipt,
+  DisbursementValueType,
+} from "@sims/sims-db";
+import { DataSource, Repository } from "typeorm";
+import { SequenceControlService, SystemUsersService } from "@sims/services";
+import { ProcessSummary } from "@sims/utilities/logger";
+
+/**
+ * Chunk size for inserting invoices. The invoices (and its details) will
+ * be grouped in chunks to be inserted in the database.
+ */
+const INVOICES_CHUNK_SIZE_INSERTS = 150;
+
+Injectable();
+export class CASInvoiceBatchService {
+  constructor(
+    @InjectRepository(CASDistributionAccount)
+    private readonly casDistributionAccountRepo: Repository<CASDistributionAccount>,
+    @InjectRepository(CASInvoice)
+    private readonly casInvoiceRepo: Repository<CASInvoice>,
+    @InjectRepository(DisbursementReceipt)
+    private readonly disbursementReceiptRepo: Repository<DisbursementReceipt>,
+    private readonly sequenceControlService: SequenceControlService,
+    private readonly systemUsersService: SystemUsersService,
+    private readonly dataSource: DataSource,
+  ) {}
+
+  async createInvoiceBatch(
+    processSummary: ProcessSummary,
+  ): Promise<CASInvoiceBatch> {
+    return this.dataSource.transaction(async (entityManager) => {
+      let newBatchUniqueSequence: number;
+      // Consumes the next sequence number and prevent concurrent access.
+      await this.sequenceControlService.consumeNextSequenceWithExistingEntityManager(
+        "CAS_INVOICE_BATCH",
+        entityManager,
+        async (nextSequenceNumber: number) => {
+          newBatchUniqueSequence = nextSequenceNumber;
+        },
+      );
+      processSummary.info("Checking for pending receipts.");
+      const pendingReceipts = await this.getPendingReceiptsForInvoiceBatch();
+      if (!pendingReceipts.length) {
+        processSummary.info("No pending receipts found.");
+        // Cancels the transaction to rollback the batch number.
+        entityManager.queryRunner.rollbackTransaction();
+        return null;
+      }
+      processSummary.info(`Found ${pendingReceipts.length} pending receipts.`);
+      const now = new Date();
+      // Create the new invoice batch.
+      const invoiceBatch = new CASInvoiceBatch();
+      invoiceBatch.batchName = `SIMS-BATCH-${newBatchUniqueSequence}`;
+      invoiceBatch.batchDate = now;
+      invoiceBatch.approvalStatus = CASInvoiceBatchApprovalStatus.Pending;
+      invoiceBatch.approvalStatusUpdatedOn = now;
+      invoiceBatch.approvalStatusUpdatedBy = this.systemUsersService.systemUser;
+      invoiceBatch.creator = this.systemUsersService.systemUser;
+      // Save the invoice batch to allow the ID to be known as associate with every new
+      // invoice created. It would allow the invoices to be saved in chunks.
+      await entityManager.getRepository(CASInvoiceBatch).save(invoiceBatch);
+      // Accumulates the invoices to be saved.
+      const casInvoices: CASInvoice[] = [];
+      // Get distribution accounts to be associated with each invoice detail.
+      const distributionAccounts = await this.getActiveDistributionAccounts();
+      await this.sequenceControlService.consumeNextSequenceWithExistingEntityManager(
+        "CAS_INVOICE",
+        entityManager,
+        async (nextSequenceNumber: number) => {
+          let newInvoiceSequence = nextSequenceNumber;
+          // Start processing the invoices for each pending receipt.
+          for (const receipt of pendingReceipts) {
+            const student =
+              receipt.disbursementSchedule.studentAssessment.application
+                .student;
+            const offeringIntensity =
+              receipt.disbursementSchedule.studentAssessment.offering
+                .offeringIntensity;
+            // New invoice creation.
+            const invoice = new CASInvoice();
+            invoice.casInvoiceBatch = invoiceBatch;
+            invoice.disbursementReceipt = receipt;
+            invoice.casSupplier = student.casSupplier;
+            invoice.invoiceNumber = `SIMS-INVOICE-${newInvoiceSequence++}-${
+              student.casSupplier.supplierNumber
+            }`;
+            invoice.invoiceStatus = CASInvoiceStatus.Pending;
+            invoice.invoiceStatusUpdatedOn = now;
+            invoice.creator = this.systemUsersService.systemUser;
+            invoice.casInvoiceDetails = [];
+            // Add the invoice to the invoice batch to be returned.
+            casInvoices.push(invoice);
+            const disbursedAwards =
+              receipt.disbursementSchedule.disbursementValues;
+            for (const disbursedAward of disbursedAwards) {
+              // Find the distribution accounts for the award.
+              const accounts = distributionAccounts.filter(
+                (account) =>
+                  account.awardValueCode === disbursedAward.valueCode &&
+                  account.offeringIntensity === offeringIntensity,
+              );
+              // Create invoice details for each distribution account.
+              const awardInvoiceDetails = accounts.map((account) => {
+                const invoiceDetail = new CASInvoiceDetail();
+                invoiceDetail.casInvoice = invoice;
+                invoiceDetail.casDistributionAccount = account;
+                invoiceDetail.valueAmount = disbursedAward.effectiveAmount;
+                invoiceDetail.creator = this.systemUsersService.systemUser;
+                return invoiceDetail;
+              });
+              invoice.casInvoiceDetails.push(...awardInvoiceDetails);
+            }
+          }
+          return newInvoiceSequence;
+        },
+      );
+      await entityManager.getRepository(CASInvoice).save(casInvoices, {
+        chunk: INVOICES_CHUNK_SIZE_INSERTS,
+      });
+      invoiceBatch.casInvoices = casInvoices;
+      return invoiceBatch;
+    });
+  }
+
+  private async getActiveDistributionAccounts(): Promise<
+    CASDistributionAccount[]
+  > {
+    return this.casDistributionAccountRepo.find({
+      select: { id: true, awardValueCode: true, offeringIntensity: true },
+      where: { isActive: true },
+    });
+  }
+
+  private async getPendingReceiptsForInvoiceBatch(): Promise<
+    DisbursementReceipt[]
+  > {
+    const existsInvoice = this.casInvoiceRepo
+      .createQueryBuilder("casInvoice")
+      .select("1")
+      .where("casInvoice.disbursementReceipt.id = disbursementReceipt.id")
+      .getSql();
+    return this.disbursementReceiptRepo
+      .createQueryBuilder("disbursementReceipt")
+      .select([
+        "disbursementReceipt.id",
+        "disbursementSchedule.id",
+        "studentAssessment.id",
+        "offering.id",
+        "offering.offeringIntensity",
+        "application.id",
+        "student.id",
+        "casSupplier.id",
+        "casSupplier.supplierNumber",
+        "disbursementValue.id",
+        "disbursementValue.valueCode",
+        "disbursementValue.effectiveAmount",
+      ])
+      .innerJoin(
+        "disbursementReceipt.disbursementReceiptValues",
+        "disbursementReceiptValue",
+      )
+      .innerJoin(
+        "disbursementReceipt.disbursementSchedule",
+        "disbursementSchedule",
+      )
+      .innerJoin("disbursementSchedule.disbursementValues", "disbursementValue")
+      .innerJoin("disbursementSchedule.studentAssessment", "studentAssessment")
+      .innerJoin("studentAssessment.offering", "offering")
+      .innerJoin("studentAssessment.application", "application")
+      .innerJoin("application.student", "student")
+      .innerJoin("student.casSupplier", "casSupplier")
+      .where("disbursementReceiptValue.grantType = :grantType", {
+        grantType: BC_TOTAL_GRANT_AWARD_CODE,
+      })
+      .andWhere("disbursementReceiptValue.grantAmount > 0")
+      .andWhere("disbursementValue.valueType = :valueType", {
+        valueType: DisbursementValueType.BCGrant,
+      })
+      .andWhere("disbursementValue.effectiveAmount > 0")
+      .andWhere("casSupplier.isValid = true")
+      .andWhere(`NOT EXISTS (${existsInvoice})`)
+      .getMany();
+  }
+}

--- a/sources/packages/backend/apps/queue-consumers/src/services/cas-invoice-batch/cas-invoice-batch.service.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/services/cas-invoice-batch/cas-invoice-batch.service.ts
@@ -22,7 +22,7 @@ import { ProcessSummary } from "@sims/utilities/logger";
  */
 const INVOICES_CHUNK_SIZE_INSERTS = 150;
 
-Injectable();
+@Injectable()
 export class CASInvoiceBatchService {
   constructor(
     private readonly dataSource: DataSource,
@@ -182,8 +182,8 @@ export class CASInvoiceBatchService {
         return invoiceDetail;
       });
       invoice.casInvoiceDetails.push(...awardInvoiceDetails);
-      return invoice;
     }
+    return invoice;
   }
 
   /**
@@ -195,7 +195,12 @@ export class CASInvoiceBatchService {
     entityManager: EntityManager,
   ): Promise<CASDistributionAccount[]> {
     return entityManager.getRepository(CASDistributionAccount).find({
-      select: { id: true, awardValueCode: true, offeringIntensity: true },
+      select: {
+        id: true,
+        awardValueCode: true,
+        offeringIntensity: true,
+        operationCode: true,
+      },
       where: { isActive: true },
     });
   }

--- a/sources/packages/backend/apps/queue-consumers/src/services/index.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/services/index.ts
@@ -6,3 +6,4 @@ export * from "./student-file/student-file.service";
 export * from "./cas-supplier/cas-evaluation-result-processor";
 export * from "./metrics/metrics.service";
 export * from "./metrics/metrics.models";
+export * from "./cas-invoice-batch/cas-invoice-batch.service";

--- a/sources/packages/backend/apps/test-db-seeding/src/db-seeding/aest/basic-seeding/create-cas-distribution-accounts.models.ts
+++ b/sources/packages/backend/apps/test-db-seeding/src/db-seeding/aest/basic-seeding/create-cas-distribution-accounts.models.ts
@@ -4,7 +4,6 @@ export interface CASDistributionAccountBaseData {
   awardValueCode: string;
   offeringIntensity: OfferingIntensity;
   operationCode: "CR" | "DR";
-  distributionAccount: string;
 }
 
 export const CAS_DISTRIBUTION_ACCOUNTS_INITIAL_DATE: CASDistributionAccountBaseData[] =
@@ -13,60 +12,50 @@ export const CAS_DISTRIBUTION_ACCOUNTS_INITIAL_DATE: CASDistributionAccountBaseD
       awardValueCode: "BCAG",
       operationCode: "CR",
       offeringIntensity: OfferingIntensity.fullTime,
-      distributionAccount: "100.CR.FULL-TIME.00000.0000.0000000.0000",
     },
     {
       awardValueCode: "BCAG",
       operationCode: "DR",
       offeringIntensity: OfferingIntensity.fullTime,
-      distributionAccount: "101.DR.FULL-TIME.00000.0000.0000000.0000",
     },
     {
       awardValueCode: "BGPD",
       operationCode: "CR",
       offeringIntensity: OfferingIntensity.fullTime,
-      distributionAccount: "102.CR.FULL-TIME.00000.0000.0000000.0000",
     },
     {
       awardValueCode: "BGPD",
       operationCode: "DR",
       offeringIntensity: OfferingIntensity.fullTime,
-      distributionAccount: "103.DR.FULL-TIME.00000.0000.0000000.0000",
     },
     {
       awardValueCode: "SBSD",
       operationCode: "CR",
       offeringIntensity: OfferingIntensity.fullTime,
-      distributionAccount: "104.CR.FULL-TIME.00000.0000.0000000.0000",
     },
     {
       awardValueCode: "SBSD",
       operationCode: "DR",
       offeringIntensity: OfferingIntensity.fullTime,
-      distributionAccount: "105.DR.FULL-TIME.00000.0000.0000000.0000",
     },
     {
       awardValueCode: "BCAG",
       operationCode: "CR",
       offeringIntensity: OfferingIntensity.partTime,
-      distributionAccount: "106.CR.PART-TIME.00000.0000.0000000.0000",
     },
     {
       awardValueCode: "BCAG",
       operationCode: "DR",
       offeringIntensity: OfferingIntensity.partTime,
-      distributionAccount: "107.DR.PART-TIME.00000.0000.0000000.0000",
     },
     {
       awardValueCode: "SBSD",
       operationCode: "CR",
       offeringIntensity: OfferingIntensity.partTime,
-      distributionAccount: "108.CR.PART-TIME.00000.0000.0000000.0000",
     },
     {
       awardValueCode: "SBSD",
       operationCode: "DR",
       offeringIntensity: OfferingIntensity.partTime,
-      distributionAccount: "109.DR.PART-TIME.00000.0000.0000000.0000",
     },
   ];

--- a/sources/packages/backend/apps/test-db-seeding/src/db-seeding/aest/basic-seeding/create-cas-distribution-accounts.models.ts
+++ b/sources/packages/backend/apps/test-db-seeding/src/db-seeding/aest/basic-seeding/create-cas-distribution-accounts.models.ts
@@ -1,0 +1,72 @@
+import { OfferingIntensity } from "@sims/sims-db";
+
+export interface CASDistributionAccountBaseData {
+  awardValueCode: string;
+  offeringIntensity: OfferingIntensity;
+  operationCode: "CR" | "DR";
+  distributionAccount: string;
+}
+
+export const CAS_DISTRIBUTION_ACCOUNTS_INITIAL_DATE: CASDistributionAccountBaseData[] =
+  [
+    {
+      awardValueCode: "BCAG",
+      operationCode: "CR",
+      offeringIntensity: OfferingIntensity.fullTime,
+      distributionAccount: "100.CR.FULL-TIME.00000.0000.0000000.0000",
+    },
+    {
+      awardValueCode: "BCAG",
+      operationCode: "DR",
+      offeringIntensity: OfferingIntensity.fullTime,
+      distributionAccount: "101.DR.FULL-TIME.00000.0000.0000000.0000",
+    },
+    {
+      awardValueCode: "BGPD",
+      operationCode: "CR",
+      offeringIntensity: OfferingIntensity.fullTime,
+      distributionAccount: "102.CR.FULL-TIME.00000.0000.0000000.0000",
+    },
+    {
+      awardValueCode: "BGPD",
+      operationCode: "DR",
+      offeringIntensity: OfferingIntensity.fullTime,
+      distributionAccount: "103.DR.FULL-TIME.00000.0000.0000000.0000",
+    },
+    {
+      awardValueCode: "SBSD",
+      operationCode: "CR",
+      offeringIntensity: OfferingIntensity.fullTime,
+      distributionAccount: "104.CR.FULL-TIME.00000.0000.0000000.0000",
+    },
+    {
+      awardValueCode: "SBSD",
+      operationCode: "DR",
+      offeringIntensity: OfferingIntensity.fullTime,
+      distributionAccount: "105.DR.FULL-TIME.00000.0000.0000000.0000",
+    },
+    {
+      awardValueCode: "BCAG",
+      operationCode: "CR",
+      offeringIntensity: OfferingIntensity.partTime,
+      distributionAccount: "106.CR.PART-TIME.00000.0000.0000000.0000",
+    },
+    {
+      awardValueCode: "BCAG",
+      operationCode: "DR",
+      offeringIntensity: OfferingIntensity.partTime,
+      distributionAccount: "107.DR.PART-TIME.00000.0000.0000000.0000",
+    },
+    {
+      awardValueCode: "SBSD",
+      operationCode: "CR",
+      offeringIntensity: OfferingIntensity.partTime,
+      distributionAccount: "108.CR.PART-TIME.00000.0000.0000000.0000",
+    },
+    {
+      awardValueCode: "SBSD",
+      operationCode: "DR",
+      offeringIntensity: OfferingIntensity.partTime,
+      distributionAccount: "109.DR.PART-TIME.00000.0000.0000000.0000",
+    },
+  ];

--- a/sources/packages/backend/apps/test-db-seeding/src/db-seeding/aest/basic-seeding/create-cas-distribution-accounts.ts
+++ b/sources/packages/backend/apps/test-db-seeding/src/db-seeding/aest/basic-seeding/create-cas-distribution-accounts.ts
@@ -22,7 +22,7 @@ export class CreateCASDistributionAccounts {
   ) {}
 
   /**
-   * Create AEST users used for tests.
+   * Creates and saves CAS distribution accounts using initial data.
    */
   @DataSeedMethod()
   async createCASDistributionAccounts(): Promise<void> {

--- a/sources/packages/backend/apps/test-db-seeding/src/db-seeding/aest/basic-seeding/create-cas-distribution-accounts.ts
+++ b/sources/packages/backend/apps/test-db-seeding/src/db-seeding/aest/basic-seeding/create-cas-distribution-accounts.ts
@@ -1,0 +1,39 @@
+import { Injectable } from "@nestjs/common";
+import { InjectRepository } from "@nestjs/typeorm";
+import { CASDistributionAccount, User } from "@sims/sims-db";
+import {
+  DataSeed,
+  DataSeedMethod,
+  SeedPriorityOrder,
+} from "../../../seed-executors";
+import { Repository } from "typeorm";
+import { CAS_DISTRIBUTION_ACCOUNTS_INITIAL_DATE } from "./create-cas-distribution-accounts.models";
+
+import { createFakeCASDistributionAccount } from "@sims/test-utils";
+import { SystemUsersService } from "@sims/services";
+
+@Injectable()
+@DataSeed({ order: SeedPriorityOrder.Priority1 })
+export class CreateCASDistributionAccounts {
+  constructor(
+    @InjectRepository(CASDistributionAccount)
+    private readonly casDistributionAccount: Repository<CASDistributionAccount>,
+    private readonly systemUserService: SystemUsersService,
+  ) {}
+
+  /**
+   * Create AEST users used for tests.
+   */
+  @DataSeedMethod()
+  async createCASDistributionAccounts(): Promise<void> {
+    // Create CAS distribution accounts.
+    const accountsToSave = CAS_DISTRIBUTION_ACCOUNTS_INITIAL_DATE.map((data) =>
+      createFakeCASDistributionAccount(
+        { creator: this.systemUserService.systemUser },
+        { initialValues: data },
+      ),
+    );
+    // Save accounts.
+    await this.casDistributionAccount.save(accountsToSave);
+  }
+}

--- a/sources/packages/backend/apps/test-db-seeding/src/db-seeding/aest/basic-seeding/create-cas-distribution-accounts.ts
+++ b/sources/packages/backend/apps/test-db-seeding/src/db-seeding/aest/basic-seeding/create-cas-distribution-accounts.ts
@@ -8,7 +8,6 @@ import {
 } from "../../../seed-executors";
 import { Repository } from "typeorm";
 import { CAS_DISTRIBUTION_ACCOUNTS_INITIAL_DATE } from "./create-cas-distribution-accounts.models";
-
 import { createFakeCASDistributionAccount } from "@sims/test-utils";
 import { SystemUsersService } from "@sims/services";
 

--- a/sources/packages/backend/apps/test-db-seeding/src/db-seeding/aest/basic-seeding/create-cas-distribution-accounts.ts
+++ b/sources/packages/backend/apps/test-db-seeding/src/db-seeding/aest/basic-seeding/create-cas-distribution-accounts.ts
@@ -1,6 +1,6 @@
 import { Injectable } from "@nestjs/common";
 import { InjectRepository } from "@nestjs/typeorm";
-import { CASDistributionAccount, User } from "@sims/sims-db";
+import { CASDistributionAccount } from "@sims/sims-db";
 import {
   DataSeed,
   DataSeedMethod,
@@ -29,7 +29,9 @@ export class CreateCASDistributionAccounts {
     const accountsToSave = CAS_DISTRIBUTION_ACCOUNTS_INITIAL_DATE.map((data) =>
       createFakeCASDistributionAccount(
         { creator: this.systemUserService.systemUser },
-        { initialValues: data },
+        {
+          initialValues: data,
+        },
       ),
     );
     // Save accounts.

--- a/sources/packages/backend/apps/test-db-seeding/src/db-seeding/aest/index.ts
+++ b/sources/packages/backend/apps/test-db-seeding/src/db-seeding/aest/index.ts
@@ -1,1 +1,2 @@
 export * from "./basic-seeding/create-aest-users";
+export * from "./basic-seeding/create-cas-distribution-accounts";

--- a/sources/packages/backend/apps/test-db-seeding/src/test-db-seeding.module.ts
+++ b/sources/packages/backend/apps/test-db-seeding/src/test-db-seeding.module.ts
@@ -14,12 +14,17 @@ import {
   UserTypeRoleHelperService,
 } from "./services";
 import { ConfigModule } from "@sims/utilities/config";
-import { CreateAESTUsers } from "./db-seeding/aest";
+import {
+  CreateAESTUsers,
+  CreateCASDistributionAccounts,
+} from "./db-seeding/aest";
 import { CreateStudentUsers } from "./db-seeding/student";
 import { CreateRestrictions } from "./db-seeding/restriction";
+import { SystemUserModule } from "@sims/services";
+import { LoggerModule } from "@sims/utilities/logger";
 
 @Module({
-  imports: [DatabaseModule, ConfigModule],
+  imports: [DatabaseModule, LoggerModule, SystemUserModule, ConfigModule],
   providers: [
     DesignationAgreementService,
     SeedExecutor,
@@ -33,6 +38,7 @@ import { CreateRestrictions } from "./db-seeding/restriction";
     CreateAESTUsers,
     CreateStudentUsers,
     CreateRestrictions,
+    CreateCASDistributionAccounts,
   ],
 })
 export class TestDbSeedingModule {}

--- a/sources/packages/backend/libs/test-utils/src/data-source/e2e-data-source.ts
+++ b/sources/packages/backend/libs/test-utils/src/data-source/e2e-data-source.ts
@@ -57,6 +57,10 @@ import {
   BetaUsersAuthorizations,
   SFASBridgeLog,
   SFASRestrictionMap,
+  CASInvoiceBatch,
+  CASInvoice,
+  CASInvoiceDetail,
+  CASDistributionAccount,
 } from "@sims/sims-db";
 import { DataSource, Repository } from "typeorm";
 
@@ -80,6 +84,10 @@ export function createE2EDataSources(dataSource: DataSource): E2EDataSources {
     ),
     betaUsersAuthorizations: dataSource.getRepository(BetaUsersAuthorizations),
     casSupplier: dataSource.getRepository(CASSupplier),
+    casInvoiceBatch: dataSource.getRepository(CASInvoiceBatch),
+    casInvoice: dataSource.getRepository(CASInvoice),
+    casInvoiceDetail: dataSource.getRepository(CASInvoiceDetail),
+    casDistributionAccount: dataSource.getRepository(CASDistributionAccount),
     coeDeniedReason: dataSource.getRepository(COEDeniedReason),
     craIncomeVerification: dataSource.getRepository(CRAIncomeVerification),
     designationAgreement: dataSource.getRepository(DesignationAgreement),
@@ -166,6 +174,10 @@ export interface E2EDataSources {
   applicationRestrictionBypass: Repository<ApplicationRestrictionBypass>;
   betaUsersAuthorizations: Repository<BetaUsersAuthorizations>;
   casSupplier: Repository<CASSupplier>;
+  casInvoiceBatch: Repository<CASInvoiceBatch>;
+  casInvoice: Repository<CASInvoice>;
+  casInvoiceDetail: Repository<CASInvoiceDetail>;
+  casDistributionAccount: Repository<CASDistributionAccount>;
   coeDeniedReason: Repository<COEDeniedReason>;
   craIncomeVerification: Repository<CRAIncomeVerification>;
   designationAgreement: Repository<DesignationAgreement>;

--- a/sources/packages/backend/libs/test-utils/src/factories/cas-distribution-account.ts
+++ b/sources/packages/backend/libs/test-utils/src/factories/cas-distribution-account.ts
@@ -1,6 +1,14 @@
 import { CASDistributionAccount, OfferingIntensity, User } from "@sims/sims-db";
 import * as faker from "faker";
 
+/**
+ * Creates a fake CAS distribution account ready to be saved to the database.
+ * @param relations dependencies.
+ * - `creator` the user that created the CAS distribution account.
+ * @param options options.
+ * - `initialValues` CAS distribution account values.
+ * @returns a fake CAS distribution account.
+ */
 export function createFakeCASDistributionAccount(
   relations: { creator: User },
   options?: {

--- a/sources/packages/backend/libs/test-utils/src/factories/cas-distribution-account.ts
+++ b/sources/packages/backend/libs/test-utils/src/factories/cas-distribution-account.ts
@@ -1,0 +1,23 @@
+import { CASDistributionAccount, OfferingIntensity, User } from "@sims/sims-db";
+import * as faker from "faker";
+
+export function createFakeCASDistributionAccount(
+  relations: { creator: User },
+  options?: {
+    initialValues: Partial<CASDistributionAccount>;
+  },
+): CASDistributionAccount {
+  const casDistributionAccount = new CASDistributionAccount();
+  casDistributionAccount.awardValueCode =
+    options?.initialValues?.awardValueCode ?? "BCSG";
+  casDistributionAccount.offeringIntensity =
+    options?.initialValues?.offeringIntensity ?? OfferingIntensity.fullTime;
+  casDistributionAccount.operationCode =
+    options?.initialValues?.operationCode ?? "DR";
+  casDistributionAccount.distributionAccount =
+    options?.initialValues?.distributionAccount ??
+    faker.random.alphaNumeric(40);
+  casDistributionAccount.isActive = options?.initialValues?.isActive ?? true;
+  casDistributionAccount.creator = relations.creator;
+  return casDistributionAccount;
+}

--- a/sources/packages/backend/libs/test-utils/src/factories/cas-distribution-account.ts
+++ b/sources/packages/backend/libs/test-utils/src/factories/cas-distribution-account.ts
@@ -1,5 +1,4 @@
 import { CASDistributionAccount, OfferingIntensity, User } from "@sims/sims-db";
-import * as faker from "faker";
 
 /**
  * Creates a fake CAS distribution account ready to be saved to the database.

--- a/sources/packages/backend/libs/test-utils/src/factories/cas-distribution-account.ts
+++ b/sources/packages/backend/libs/test-utils/src/factories/cas-distribution-account.ts
@@ -15,16 +15,22 @@ export function createFakeCASDistributionAccount(
     initialValues: Partial<CASDistributionAccount>;
   },
 ): CASDistributionAccount {
-  const casDistributionAccount = new CASDistributionAccount();
-  casDistributionAccount.awardValueCode =
-    options?.initialValues?.awardValueCode ?? "BCSG";
-  casDistributionAccount.offeringIntensity =
+  const awardValueCode = options?.initialValues?.awardValueCode ?? "BCAG";
+  const offeringIntensity =
     options?.initialValues?.offeringIntensity ?? OfferingIntensity.fullTime;
-  casDistributionAccount.operationCode =
-    options?.initialValues?.operationCode ?? "DR";
-  casDistributionAccount.distributionAccount =
+  const operationCode = options?.initialValues?.operationCode ?? "DR";
+  const distributionAccount =
     options?.initialValues?.distributionAccount ??
-    faker.random.alphaNumeric(40);
+    `${awardValueCode}.${operationCode}.${
+      offeringIntensity === OfferingIntensity.fullTime
+        ? "FULL-TIME"
+        : "PART-TIME"
+    }.`.padEnd(40, "0");
+  const casDistributionAccount = new CASDistributionAccount();
+  casDistributionAccount.awardValueCode = awardValueCode;
+  casDistributionAccount.offeringIntensity = offeringIntensity;
+  casDistributionAccount.operationCode = operationCode;
+  casDistributionAccount.distributionAccount = distributionAccount;
   casDistributionAccount.isActive = options?.initialValues?.isActive ?? true;
   casDistributionAccount.creator = relations.creator;
   return casDistributionAccount;

--- a/sources/packages/backend/libs/test-utils/src/index.ts
+++ b/sources/packages/backend/libs/test-utils/src/index.ts
@@ -38,3 +38,4 @@ export * from "./factories/application-restriction-bypass";
 export * from "./factories/cas-supplier";
 export * from "./factories/sfas-restriction-maps";
 export * from "./factories/restriction";
+export * from "./factories/cas-distribution-account";

--- a/sources/packages/backend/libs/utilities/src/queue.constant.ts
+++ b/sources/packages/backend/libs/utilities/src/queue.constant.ts
@@ -29,6 +29,7 @@ export enum QueueNames {
   AssessmentWorkflowQueueRetry = "assessment-workflow-queue-retry",
   StudentLoanBalancesPartTimeIntegration = "student-loan-balances-part-time-integration",
   CASSupplierIntegration = "cas-supplier-integration",
+  CASInvoicesBatchesCreation = "cas-invoices-batches-creation",
   ApplicationChangesReportIntegration = "application-changes-report-integration",
   StudentApplicationNotifications = "student-application-notifications",
   SIMSToSFASIntegration = "sims-to-sfas-integration",

--- a/sources/packages/backend/package.json
+++ b/sources/packages/backend/package.json
@@ -31,7 +31,7 @@
     "test:e2e:workers:local": "cross-env ENVIRONMENT=test jest --collect-coverage --verbose --config ./apps/workers/test/jest-e2e.json --forceExit",
     "test:e2e:workflow": "npm run deploy:camunda:definitions && cross-env ENVIRONMENT=test jest --verbose --config ./workflow/test/jest-e2e.json --forceExit",
     "test:e2e:workflow:local": "cross-env ENVIRONMENT=test TZ=UTC jest --verbose --config ./workflow/test/jest-e2e.json --forceExit",
-    "test:e2e:queue-consumers": "npm run db:seed:test filter=CreateCASDistributionAccounts && npm run migration:run && cross-env ENVIRONMENT=test jest --collect-coverage --verbose --config ./apps/queue-consumers/test/jest-e2e.json --runInBand --forceExit",
+    "test:e2e:queue-consumers": "npm run db:seed:test filter=CreateCASDistributionAccounts && cross-env ENVIRONMENT=test jest --collect-coverage --verbose --config ./apps/queue-consumers/test/jest-e2e.json --runInBand --forceExit",
     "test:e2e:queue-consumers:local": "cross-env ENVIRONMENT=test TZ=UTC jest --verbose --config ./apps/queue-consumers/test/jest-e2e.json --runInBand --forceExit",
     "migration:run": "node --abort-on-uncaught-exception --require ts-node/register apps/db-migrations/src/main.ts",
     "migration:create": "cd apps/db-migrations/src/migrations && npx typeorm-ts-node-commonjs migration:create",

--- a/sources/packages/backend/package.json
+++ b/sources/packages/backend/package.json
@@ -31,7 +31,7 @@
     "test:e2e:workers:local": "cross-env ENVIRONMENT=test jest --collect-coverage --verbose --config ./apps/workers/test/jest-e2e.json --forceExit",
     "test:e2e:workflow": "npm run deploy:camunda:definitions && cross-env ENVIRONMENT=test jest --verbose --config ./workflow/test/jest-e2e.json --forceExit",
     "test:e2e:workflow:local": "cross-env ENVIRONMENT=test TZ=UTC jest --verbose --config ./workflow/test/jest-e2e.json --forceExit",
-    "test:e2e:queue-consumers": "npm run migration:run && cross-env ENVIRONMENT=test jest --collect-coverage --verbose --config ./apps/queue-consumers/test/jest-e2e.json --runInBand --forceExit",
+    "test:e2e:queue-consumers": "npm run db:seed:test filter=CreateCASDistributionAccounts && npm run migration:run && cross-env ENVIRONMENT=test jest --collect-coverage --verbose --config ./apps/queue-consumers/test/jest-e2e.json --runInBand --forceExit",
     "test:e2e:queue-consumers:local": "cross-env ENVIRONMENT=test TZ=UTC jest --verbose --config ./apps/queue-consumers/test/jest-e2e.json --runInBand --forceExit",
     "migration:run": "node --abort-on-uncaught-exception --require ts-node/register apps/db-migrations/src/main.ts",
     "migration:create": "cd apps/db-migrations/src/migrations && npx typeorm-ts-node-commonjs migration:create",


### PR DESCRIPTION
- Created the new scheduler default setup including DB migrations.
  - Added information in the wiki with the agreed time with the business.
  - Created only the first E2E to allow some testing. Adding further E2E is planned but it will also demand adding more factories hence this was a point to stop for now.
- Created DB seeding for the new CAS distribution accounts to allow easy execution assertions on expected distribution accounts. It may be shared with API when API tests are created.
  - _Note:_ DB seeding was never enabled for queue-consumers and few files were modified to allow it following the same already in place for the API.
  - Minor refactors were executed in the DB seeding to allow the system user to be retrieved and the default logger to be used instead of `console`.
- The `sequence-control` service was changed to allow outside control of the sequence increment.

## Pending Receipts Query

- Query to retrieve the pending receipts was kept as "query builder" to enforce the inner joins (even if some of them would work as left joins enforced by the where condition).
- Query to retrieve the pending receipts currently does not have a stop date to look for pending disbursements and is just retrieving anything that is pending.

## Saving Operations

The method to save the invoices is using a single transaction and chunk inserts. The 150-chunk size was determined by local tests using 50 to 500-chunk sizes. The tests were realized with 1000 invoice records and each one had 4 invoice details where it took around 1 second to complete the DB persistence operation. In terms of SQL parameters, Postgres can accept a maximum of [65K parameters](https://www.postgresql.org/docs/current/limits.html) in a single command.

The save operation in chunks was not logging any additional select and was grouping the insert operations as below for invoices and similar for invoice details.

```sql
INSERT INTO
    "sims"."cas_invoices"("created_at", "updated_at", "invoice_number", "invoice_status", "invoice_status_updated_on", "errors", "creator", "modifier", "cas_invoice_batch_id", "disbursement_receipt_id", "cas_supplier_id")
VALUES 
    (DEFAULT, DEFAULT, $1, $2, $3, DEFAULT, $4, DEFAULT, $5, $6, $7),
    (DEFAULT, DEFAULT, $8, $9, $10, DEFAULT, $11, DEFAULT, $12, $13, $14),
    (DEFAULT, DEFAULT, $15, $16, $17, DEFAULT, $18, DEFAULT, $19, $20, $21),
    (DEFAULT, DEFAULT, $22, $23, $24, DEFAULT, $25, DEFAULT, $26, $27, $28),
    (DEFAULT, DEFAULT, $29, $30, $31, DEFAULT, $32, DEFAULT, $33, $34, $35),
    (DEFAULT, DEFAULT, $36, $37, $38, DEFAULT, $39, DEFAULT, $40, $41, $42)
    (...)
```
## Migration revert

![image](https://github.com/user-attachments/assets/fd09ab19-eb45-43d3-91a3-19e57b661120)
