### PR TITLE
#3594 - Email to Student - 2nd Disbursement has passed, still pending (Part 1)

### DIFF
--- a/sources/packages/backend/apps/db-migrations/src/migrations/1738021154711-InsertStudentNotificationSecondDisbursementReminder.ts
+++ b/sources/packages/backend/apps/db-migrations/src/migrations/1738021154711-InsertStudentNotificationSecondDisbursementReminder.ts
@@ -1,0 +1,24 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+import { getSQLFileData } from "../utilities/sqlLoader";
+
+export class InsertStudentNotificationSecondDisbursementReminder1738021154711
+  implements MigrationInterface
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      getSQLFileData(
+        "Insert-student-notification-second-disbursement-reminder.sql",
+        "NotificationMessages",
+      ),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      getSQLFileData(
+        "Rollback-insert-student-notification-second-disbursement-reminder.sql",
+        "NotificationMessages",
+      ),
+    );
+  }
+}

--- a/sources/packages/backend/apps/db-migrations/src/sql/NotificationMessages/Insert-student-notification-second-disbursement-reminder.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/NotificationMessages/Insert-student-notification-second-disbursement-reminder.sql
@@ -1,0 +1,8 @@
+INSERT INTO
+  sims.notification_messages(id, description, template_id)
+VALUES
+  (
+    31,
+    'Student application notification for overdue second disbursement still pending.',
+    '55fcf228-b899-49a7-ab80-9b854c0bd884'
+  );

--- a/sources/packages/backend/apps/db-migrations/src/sql/NotificationMessages/Insert-student-notification-second-disbursement-reminder.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/NotificationMessages/Insert-student-notification-second-disbursement-reminder.sql
@@ -3,6 +3,6 @@ INSERT INTO
 VALUES
   (
     31,
-    'Student application notification for overdue second disbursement still pending.',
+    'Student application notification for second disbursement still pending.',
     '55fcf228-b899-49a7-ab80-9b854c0bd884'
   );

--- a/sources/packages/backend/apps/db-migrations/src/sql/NotificationMessages/Rollback-insert-student-notification-second-disbursement-reminder.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/NotificationMessages/Rollback-insert-student-notification-second-disbursement-reminder.sql
@@ -1,0 +1,4 @@
+DELETE FROM
+  sims.notification_messages
+WHERE
+  ID = 31;

--- a/sources/packages/backend/libs/sims-db/src/entities/notification.model.ts
+++ b/sources/packages/backend/libs/sims-db/src/entities/notification.model.ts
@@ -217,4 +217,8 @@ export enum NotificationMessageType {
    * Student PD PPD Application Notification.
    */
   StudentPDPPDApplicationNotification = 30,
+  /**
+   * Student Second Disbursement Notification.
+   */
+  StudentSecondDisbursementNotification = 31,
 }


### PR DESCRIPTION
As the first part of the story PR, this PR has the following change:
- Added DB migration for inserting the record "Student application notification for overdue second disbursement still pending." to the table `notificationMessages`

### Rollback evidence
![Screenshot 2025-01-28 093728](https://github.com/user-attachments/assets/a4ecf1ca-21d3-4826-a7a3-3f604443f5d6)

Screenshot of the added record to the `notificationMessages` table
![image](https://github.com/user-attachments/assets/892de986-c768-4b25-9b57-eaf83fba927a)
