### PR TITLE
#3254 - CAS AP Invoice - Invoices and Batches - E2E Tests

### DIFF
--- a/sources/packages/backend/apps/api/src/route-controllers/cas-invoice-batch/_tests_/e2e/cas-invoice-batch.aest.controller.getCASInvoiceBatchReport.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/cas-invoice-batch/_tests_/e2e/cas-invoice-batch.aest.controller.getCASInvoiceBatchReport.e2e-spec.ts
@@ -1,0 +1,280 @@
+import { HttpStatus, INestApplication } from "@nestjs/common";
+import * as request from "supertest";
+import {
+  AESTGroups,
+  BEARER_AUTH_TYPE,
+  createTestingAppModule,
+  getAESTToken,
+} from "../../../../testHelpers";
+import {
+  createE2EDataSources,
+  createFakeCASInvoiceBatch,
+  createFakeDisbursementValue,
+  E2EDataSources,
+  saveFakeInvoiceIntoBatchWithInvoiceDetails,
+} from "@sims/test-utils";
+import { SystemUsersService } from "@sims/services";
+import { parse } from "papaparse";
+import {
+  DisbursementValueType,
+  OfferingIntensity,
+  SupplierStatus,
+} from "@sims/sims-db";
+import { getPSTPDTDateTime } from "@sims/utilities";
+
+describe("CASInvoiceBatchAESTController(e2e)-getCASInvoiceBatchReport", () => {
+  let app: INestApplication;
+  let db: E2EDataSources;
+  let systemUsersService: SystemUsersService;
+
+  beforeAll(async () => {
+    const { nestApplication, dataSource } = await createTestingAppModule();
+    app = nestApplication;
+    systemUsersService = app.get(SystemUsersService);
+    db = createE2EDataSources(dataSource);
+  });
+
+  it("Should generate an invoice batch report when the batch exists.", async () => {
+    // Arrange
+    // Create invoice batch to generate the report.
+    const casInvoiceBatch = await db.casInvoiceBatch.save(
+      createFakeCASInvoiceBatch({
+        creator: systemUsersService.systemUser,
+      }),
+    );
+    const fullTimeInvoicePromise = saveFakeInvoiceIntoBatchWithInvoiceDetails(
+      db,
+      {
+        casInvoiceBatch,
+        creator: systemUsersService.systemUser,
+        // Full-time BC grants.
+        disbursementValues: [
+          createFakeDisbursementValue(
+            DisbursementValueType.BCGrant,
+            "BCAG",
+            10,
+            {
+              effectiveAmount: 5,
+            },
+          ),
+          createFakeDisbursementValue(
+            DisbursementValueType.BCGrant,
+            "BGPD",
+            20,
+            {
+              effectiveAmount: 15,
+            },
+          ),
+          createFakeDisbursementValue(
+            DisbursementValueType.BCGrant,
+            "SBSD",
+            30,
+            {
+              effectiveAmount: 25,
+            },
+          ),
+          createFakeDisbursementValue(
+            DisbursementValueType.BCTotalGrant,
+            "BCSG",
+            60,
+            { effectiveAmount: 45 },
+          ),
+        ],
+      },
+      {
+        offeringIntensity: OfferingIntensity.fullTime,
+        casSupplierInitialValues: {
+          supplierStatus: SupplierStatus.VerifiedManually,
+          supplierNumber: "111111",
+        },
+      },
+    );
+    const partTimeInvoicePromise = saveFakeInvoiceIntoBatchWithInvoiceDetails(
+      db,
+      {
+        casInvoiceBatch,
+        creator: systemUsersService.systemUser,
+        // Part-time BC grants.
+        disbursementValues: [
+          createFakeDisbursementValue(
+            DisbursementValueType.BCGrant,
+            "BCAG",
+            200,
+            {
+              effectiveAmount: 150,
+            },
+          ),
+          createFakeDisbursementValue(
+            DisbursementValueType.BCGrant,
+            "SBSD",
+            300,
+            {
+              effectiveAmount: 250,
+            },
+          ),
+          createFakeDisbursementValue(
+            DisbursementValueType.BCTotalGrant,
+            "BCSG",
+            500,
+            { effectiveAmount: 400 },
+          ),
+        ],
+      },
+      {
+        offeringIntensity: OfferingIntensity.partTime,
+        casSupplierInitialValues: {
+          supplierStatus: SupplierStatus.VerifiedManually,
+          supplierNumber: "222222",
+        },
+      },
+    );
+    const [fullTimeInvoice, partTimeInvoice] = await Promise.all([
+      fullTimeInvoicePromise,
+      partTimeInvoicePromise,
+    ]);
+    // Creating variables to provide easy access to some nested values.
+    // Full-time related variables.
+    const fullTimeStudent =
+      fullTimeInvoice.disbursementReceipt.disbursementSchedule.studentAssessment
+        .application.student;
+    const fullTimeDocumentNumber =
+      fullTimeInvoice.disbursementReceipt.disbursementSchedule.documentNumber.toString();
+    const partTimeStudent =
+      partTimeInvoice.disbursementReceipt.disbursementSchedule.studentAssessment
+        .application.student;
+    // Part-time related variables.
+    const partTimeDocumentNumber =
+      partTimeInvoice.disbursementReceipt.disbursementSchedule.documentNumber.toString();
+    const fullTimeGLDate = getPSTPDTDateTime(
+      fullTimeInvoice.disbursementReceipt.createdAt,
+    );
+    const partTimeGLDate = getPSTPDTDateTime(
+      partTimeInvoice.disbursementReceipt.createdAt.toISOString(),
+    );
+
+    const endpoint = `/aest/cas-invoice-batch/${casInvoiceBatch.id}/report`;
+    const token = await getAESTToken(AESTGroups.BusinessAdministrators);
+
+    // Act/Assert
+    await request(app.getHttpServer())
+      .get(endpoint)
+      .auth(token, BEARER_AUTH_TYPE)
+      .expect(HttpStatus.OK)
+      .then((response) => {
+        const fileContent = response.request.res["text"];
+        const parsedResult = parse(fileContent, {
+          header: true,
+        });
+        expect(parsedResult.data).toEqual([
+          {
+            "Invoice Number": fullTimeInvoice.invoiceNumber,
+            "Given Names": fullTimeStudent.user.firstName,
+            "Last Name": fullTimeStudent.user.lastName,
+            SIN: fullTimeStudent.sinValidation.sin,
+            "Supplier Number": "111111",
+            "Document Number": fullTimeDocumentNumber,
+            "GL Date": fullTimeGLDate,
+            "Award Type": "BCAG",
+            "CR Amount": "5",
+            "CR Account": "BCAG.CR.FULL-TIME.0000000000000000000000",
+            "DR Amount": "5",
+            "DR Account": "BCAG.DR.FULL-TIME.0000000000000000000000",
+          },
+          {
+            "Invoice Number": fullTimeInvoice.invoiceNumber,
+            "Given Names": fullTimeStudent.user.firstName,
+            "Last Name": fullTimeStudent.user.lastName,
+            SIN: fullTimeStudent.sinValidation.sin,
+            "Supplier Number": "111111",
+            "Document Number": fullTimeDocumentNumber,
+            "GL Date": fullTimeGLDate,
+            "Award Type": "BGPD",
+            "CR Amount": "15",
+            "CR Account": "BGPD.CR.FULL-TIME.0000000000000000000000",
+            "DR Amount": "15",
+            "DR Account": "BGPD.DR.FULL-TIME.0000000000000000000000",
+          },
+          {
+            "Invoice Number": fullTimeInvoice.invoiceNumber,
+            "Given Names": fullTimeStudent.user.firstName,
+            "Last Name": fullTimeStudent.user.lastName,
+            SIN: fullTimeStudent.sinValidation.sin,
+            "Supplier Number": "111111",
+            "Document Number": fullTimeDocumentNumber,
+            "GL Date": fullTimeGLDate,
+            "Award Type": "SBSD",
+            "CR Amount": "25",
+            "CR Account": "SBSD.CR.FULL-TIME.0000000000000000000000",
+            "DR Amount": "25",
+            "DR Account": "SBSD.DR.FULL-TIME.0000000000000000000000",
+          },
+          {
+            "Invoice Number": partTimeInvoice.invoiceNumber,
+            "Given Names": partTimeStudent.user.firstName,
+            "Last Name": partTimeStudent.user.lastName,
+            SIN: partTimeStudent.sinValidation.sin,
+            "Supplier Number": "222222",
+            "Document Number": partTimeDocumentNumber,
+            "GL Date": partTimeGLDate,
+            "Award Type": "BCAG",
+            "CR Amount": "150",
+            "CR Account": "BCAG.CR.PART-TIME.0000000000000000000000",
+            "DR Amount": "150",
+            "DR Account": "BCAG.DR.PART-TIME.0000000000000000000000",
+          },
+          {
+            "Invoice Number": partTimeInvoice.invoiceNumber,
+            "Given Names": partTimeStudent.user.firstName,
+            "Last Name": partTimeStudent.user.lastName,
+            SIN: partTimeStudent.sinValidation.sin,
+            "Supplier Number": "222222",
+            "Document Number": partTimeDocumentNumber,
+            "GL Date": partTimeGLDate,
+            "Award Type": "SBSD",
+            "CR Amount": "250",
+            "CR Account": "SBSD.CR.PART-TIME.0000000000000000000000",
+            "DR Amount": "250",
+            "DR Account": "SBSD.DR.PART-TIME.0000000000000000000000",
+          },
+        ]);
+      });
+  });
+
+  it("Should throw a HttpStatus Not Found (404) when the requested invoice batch does not exist.", async () => {
+    // Arrange
+    const endpoint = "/aest/cas-invoice-batch/999/report";
+    const token = await getAESTToken(AESTGroups.BusinessAdministrators);
+
+    // Act/Assert
+    await request(app.getHttpServer())
+      .get(endpoint)
+      .auth(token, BEARER_AUTH_TYPE)
+      .expect(HttpStatus.NOT_FOUND)
+      .expect({
+        statusCode: HttpStatus.NOT_FOUND,
+        message: "CAS invoice batch with ID 999 not found.",
+        error: "Not Found",
+      });
+  });
+
+  it("Should throw a HttpStatus Forbidden (403) error when an unauthorized Ministry user tries to get the invoice batch report.", async () => {
+    // Arrange
+    const endpoint = "/aest/cas-invoice-batch/999/report";
+    const token = await getAESTToken(AESTGroups.MOFOperations);
+
+    // Act/Assert
+    await request(app.getHttpServer())
+      .get(endpoint)
+      .auth(token, BEARER_AUTH_TYPE)
+      .expect(HttpStatus.FORBIDDEN)
+      .expect({
+        statusCode: HttpStatus.FORBIDDEN,
+        message: "Forbidden resource",
+        error: "Forbidden",
+      });
+  });
+
+  afterAll(async () => {
+    await app?.close();
+  });
+});

--- a/sources/packages/backend/apps/api/src/route-controllers/cas-invoice-batch/_tests_/e2e/cas-invoice-batch.aest.controller.getCASInvoiceBatchReport.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/cas-invoice-batch/_tests_/e2e/cas-invoice-batch.aest.controller.getCASInvoiceBatchReport.e2e-spec.ts
@@ -34,7 +34,7 @@ describe("CASInvoiceBatchAESTController(e2e)-getCASInvoiceBatchReport", () => {
     db = createE2EDataSources(dataSource);
   });
 
-  it("Should generate an invoice batch report when the batch exists.", async () => {
+  it("Should generate an invoice batch report with part-time and full-time invoices when the batch exists.", async () => {
     // Arrange
     // Create invoice batch to generate the report.
     const casInvoiceBatch = await db.casInvoiceBatch.save(
@@ -42,6 +42,7 @@ describe("CASInvoiceBatchAESTController(e2e)-getCASInvoiceBatchReport", () => {
         creator: systemUsersService.systemUser,
       }),
     );
+    // Creates full-time application with receipts, and invoices details.
     const fullTimeInvoicePromise = saveFakeInvoiceIntoBatchWithInvoiceDetails(
       db,
       {
@@ -89,6 +90,7 @@ describe("CASInvoiceBatchAESTController(e2e)-getCASInvoiceBatchReport", () => {
         },
       },
     );
+    // Creates part-time application with receipts, and invoices details.
     const partTimeInvoicePromise = saveFakeInvoiceIntoBatchWithInvoiceDetails(
       db,
       {
@@ -139,15 +141,15 @@ describe("CASInvoiceBatchAESTController(e2e)-getCASInvoiceBatchReport", () => {
         .application.student;
     const fullTimeDocumentNumber =
       fullTimeInvoice.disbursementReceipt.disbursementSchedule.documentNumber.toString();
-    const partTimeStudent =
-      partTimeInvoice.disbursementReceipt.disbursementSchedule.studentAssessment
-        .application.student;
-    // Part-time related variables.
-    const partTimeDocumentNumber =
-      partTimeInvoice.disbursementReceipt.disbursementSchedule.documentNumber.toString();
     const fullTimeGLDate = getPSTPDTDateTime(
       fullTimeInvoice.disbursementReceipt.createdAt,
     );
+    // Part-time related variables.
+    const partTimeStudent =
+      partTimeInvoice.disbursementReceipt.disbursementSchedule.studentAssessment
+        .application.student;
+    const partTimeDocumentNumber =
+      partTimeInvoice.disbursementReceipt.disbursementSchedule.documentNumber.toString();
     const partTimeGLDate = getPSTPDTDateTime(
       partTimeInvoice.disbursementReceipt.createdAt.toISOString(),
     );

--- a/sources/packages/backend/apps/api/src/route-controllers/cas-invoice-batch/_tests_/e2e/cas-invoice-batch.aest.controller.getInvoiceBatches.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/cas-invoice-batch/_tests_/e2e/cas-invoice-batch.aest.controller.getInvoiceBatches.e2e-spec.ts
@@ -75,7 +75,7 @@ describe("CASInvoiceBatchAESTController(e2e)-getInvoiceBatches", () => {
         .get(endpoint)
         .auth(token, BEARER_AUTH_TYPE)
         .expect(HttpStatus.OK);
-      // Assert only the two most recent invoice batches are returned.
+      // Assert only the two most recent invoices batches are returned.
       expect(response.body.count).toBeGreaterThanOrEqual(3);
       expect(response.body.results).toStrictEqual([
         {

--- a/sources/packages/backend/apps/api/src/route-controllers/cas-invoice-batch/_tests_/e2e/cas-invoice-batch.aest.controller.getInvoiceBatches.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/cas-invoice-batch/_tests_/e2e/cas-invoice-batch.aest.controller.getInvoiceBatches.e2e-spec.ts
@@ -1,0 +1,212 @@
+import { HttpStatus, INestApplication } from "@nestjs/common";
+import * as request from "supertest";
+import {
+  AESTGroups,
+  BEARER_AUTH_TYPE,
+  createTestingAppModule,
+  getAESTToken,
+} from "../../../../testHelpers";
+import { createE2EDataSources, E2EDataSources } from "@sims/test-utils";
+import { createFakeCASInvoiceBatch } from "../../../../../../../libs/test-utils/src";
+import { SystemUsersService } from "@sims/services";
+import { addDays } from "@sims/utilities";
+import { MoreThanOrEqual } from "typeorm";
+import { CASInvoiceBatchApprovalStatus } from "@sims/sims-db";
+import { CASInvoiceBatchAPIOutDTO } from "../../models/cas-invoice-batch.dto";
+
+/**
+ * Use a period that will never be reached to delete all existing invoice batches
+ * and allow the retrieval of invoice batches to be tested.
+ */
+const CAS_BATCHES_UNIQUE_START_PERIOD = new Date("2100-01-01");
+
+describe("CASInvoiceBatchAESTController(e2e)-getInvoiceBatches", () => {
+  let app: INestApplication;
+  let db: E2EDataSources;
+  let systemUsersService: SystemUsersService;
+
+  beforeAll(async () => {
+    const { nestApplication, dataSource } = await createTestingAppModule();
+    app = nestApplication;
+    systemUsersService = app.get(SystemUsersService);
+    db = createE2EDataSources(dataSource);
+  });
+
+  beforeEach(async () => {
+    // Delete all existing invoice batches that could impact the test results.
+    await db.casInvoiceBatch.delete({
+      batchDate: MoreThanOrEqual(CAS_BATCHES_UNIQUE_START_PERIOD),
+    });
+  });
+
+  it(
+    "Should be able to get invoice batches for the first page in a paginated result with a limit of two per page in the descending order " +
+      "when there are three invoice batches available.",
+    async () => {
+      // Arrange
+      // Create three invoice batches starting from from CAS_BATCHES_UNIQUE_START_PERIOD day.
+      const [
+        casInvoiceBatchFirst,
+        casInvoiceBatchSecond,
+        casInvoiceBatchThird,
+      ] = [0, 1, 2].map((addDaysValue) =>
+        createFakeCASInvoiceBatch(
+          {
+            creator: systemUsersService.systemUser,
+          },
+          {
+            initialValue: {
+              batchDate: addDays(addDaysValue, CAS_BATCHES_UNIQUE_START_PERIOD),
+            },
+          },
+        ),
+      );
+      await db.casInvoiceBatch.save([
+        casInvoiceBatchFirst,
+        casInvoiceBatchSecond,
+        casInvoiceBatchThird,
+      ]);
+      const endpoint =
+        "/aest/cas-invoice-batch?page=0&pageLimit=2&sortField=batchDate&sortOrder=DESC";
+      const token = await getAESTToken(AESTGroups.BusinessAdministrators);
+
+      // Act/Assert
+      const response = await request(app.getHttpServer())
+        .get(endpoint)
+        .auth(token, BEARER_AUTH_TYPE)
+        .expect(HttpStatus.OK);
+      // Assert only the two most recent invoice batches are returned.
+      expect(response.body.count).toBeGreaterThanOrEqual(3);
+      expect(response.body.results).toStrictEqual([
+        {
+          id: casInvoiceBatchThird.id,
+          batchName: casInvoiceBatchThird.batchName,
+          batchDate: casInvoiceBatchThird.batchDate.toISOString(),
+          approvalStatus: casInvoiceBatchThird.approvalStatus,
+          approvalStatusUpdatedOn:
+            casInvoiceBatchThird.approvalStatusUpdatedOn.toISOString(),
+          approvalStatusUpdatedBy: "system-user",
+        },
+        {
+          id: casInvoiceBatchSecond.id,
+          batchName: casInvoiceBatchSecond.batchName,
+          batchDate: casInvoiceBatchSecond.batchDate.toISOString(),
+          approvalStatus: casInvoiceBatchSecond.approvalStatus,
+          approvalStatusUpdatedOn:
+            casInvoiceBatchSecond.approvalStatusUpdatedOn.toISOString(),
+          approvalStatusUpdatedBy: "system-user",
+        },
+      ]);
+    },
+  );
+
+  it("Should be able to get only pending invoice batches when the filter for status is applied.", async () => {
+    // Arrange
+    // Create three invoice with different statuses expecting to return only the pending invoice batch.
+    const [
+      pendingCASInvoiceBatch,
+      approvedCASInvoiceBatch,
+      rejectedCASInvoiceBatch,
+    ] = [
+      CASInvoiceBatchApprovalStatus.Pending,
+      CASInvoiceBatchApprovalStatus.Approved,
+      CASInvoiceBatchApprovalStatus.Rejected,
+    ].map((approvalStatus) =>
+      createFakeCASInvoiceBatch(
+        {
+          creator: systemUsersService.systemUser,
+        },
+        {
+          initialValue: {
+            approvalStatus,
+            batchDate: CAS_BATCHES_UNIQUE_START_PERIOD,
+          },
+        },
+      ),
+    );
+    await db.casInvoiceBatch.save([
+      pendingCASInvoiceBatch,
+      approvedCASInvoiceBatch,
+      rejectedCASInvoiceBatch,
+    ]);
+    const endpoint =
+      "/aest/cas-invoice-batch?page=0&pageLimit=10&sortField=batchDate&sortOrder=DESC&approvalStatusSearch=Pending";
+    const token = await getAESTToken(AESTGroups.BusinessAdministrators);
+
+    // Act/Assert
+    const response = await request(app.getHttpServer())
+      .get(endpoint)
+      .auth(token, BEARER_AUTH_TYPE)
+      .expect(HttpStatus.OK);
+    // Assert only pending batches were returned.
+    const batches = response.body.results as CASInvoiceBatchAPIOutDTO[];
+    expect(
+      batches.every(
+        (batch) =>
+          batch.approvalStatus === CASInvoiceBatchApprovalStatus.Pending,
+      ),
+    ).toBe(true);
+    // Expected the pending batch created is part of the result.
+    expect(
+      batches.some((batch) => batch.id !== pendingCASInvoiceBatch.id),
+    ).toBe(true);
+  });
+
+  it("Should throw a HttpStatus Bad Request (400) error when the filter for status is invalid.", async () => {
+    // Arrange
+    const endpoint =
+      "/aest/cas-invoice-batch?page=0&pageLimit=10&sortField=batchDate&sortOrder=DESC&approvalStatusSearch=SomeInvalidStatus";
+    const token = await getAESTToken(AESTGroups.BusinessAdministrators);
+
+    // Act/Assert
+    await request(app.getHttpServer())
+      .get(endpoint)
+      .auth(token, BEARER_AUTH_TYPE)
+      .expect(HttpStatus.BAD_REQUEST)
+      .expect({
+        statusCode: HttpStatus.BAD_REQUEST,
+        message: [
+          "each value in approvalStatusSearch must be one of the following values: Pending, Approved, Rejected",
+        ],
+        error: "Bad Request",
+      });
+  });
+
+  it("Should throw a HttpStatus Bad Request (400) error when the sortField is invalid.", async () => {
+    // Arrange
+    const endpoint = `/aest/cas-invoice-batch?page=0&pageLimit=10&sortField=SomeInvalidField&sortOrder=DESC`;
+    const token = await getAESTToken(AESTGroups.BusinessAdministrators);
+
+    // Act/Assert
+    await request(app.getHttpServer())
+      .get(endpoint)
+      .auth(token, BEARER_AUTH_TYPE)
+      .expect(HttpStatus.BAD_REQUEST)
+      .expect({
+        statusCode: HttpStatus.BAD_REQUEST,
+        message: ["sortField must be one of the following values: batchDate"],
+        error: "Bad Request",
+      });
+  });
+
+  it("Should throw a HttpStatus Forbidden (403) error when an unauthorized Ministry user tries to get the invoice batches.", async () => {
+    // Arrange
+    const endpoint = "/aest/cas-invoice-batch";
+    const token = await getAESTToken(AESTGroups.Operations);
+
+    // Act/Assert
+    await request(app.getHttpServer())
+      .get(endpoint)
+      .auth(token, BEARER_AUTH_TYPE)
+      .expect(HttpStatus.FORBIDDEN)
+      .expect({
+        statusCode: HttpStatus.FORBIDDEN,
+        message: "Forbidden resource",
+        error: "Forbidden",
+      });
+  });
+
+  afterAll(async () => {
+    await app?.close();
+  });
+});

--- a/sources/packages/backend/apps/api/src/route-controllers/cas-invoice-batch/_tests_/e2e/cas-invoice-batch.aest.controller.getInvoiceBatches.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/cas-invoice-batch/_tests_/e2e/cas-invoice-batch.aest.controller.getInvoiceBatches.e2e-spec.ts
@@ -19,6 +19,7 @@ import { CASInvoiceBatchAPIOutDTO } from "../../models/cas-invoice-batch.dto";
  * and allow the retrieval of invoice batches to be tested.
  */
 const CAS_BATCHES_UNIQUE_START_PERIOD = new Date("2100-01-01");
+const SYSTEM_USER_NAME = "system-user";
 
 describe("CASInvoiceBatchAESTController(e2e)-getInvoiceBatches", () => {
   let app: INestApplication;
@@ -85,7 +86,7 @@ describe("CASInvoiceBatchAESTController(e2e)-getInvoiceBatches", () => {
           approvalStatus: casInvoiceBatchThird.approvalStatus,
           approvalStatusUpdatedOn:
             casInvoiceBatchThird.approvalStatusUpdatedOn.toISOString(),
-          approvalStatusUpdatedBy: "system-user",
+          approvalStatusUpdatedBy: SYSTEM_USER_NAME,
         },
         {
           id: casInvoiceBatchSecond.id,
@@ -94,7 +95,7 @@ describe("CASInvoiceBatchAESTController(e2e)-getInvoiceBatches", () => {
           approvalStatus: casInvoiceBatchSecond.approvalStatus,
           approvalStatusUpdatedOn:
             casInvoiceBatchSecond.approvalStatusUpdatedOn.toISOString(),
-          approvalStatusUpdatedBy: "system-user",
+          approvalStatusUpdatedBy: SYSTEM_USER_NAME,
         },
       ]);
     },

--- a/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/cas-integration/_tests_/cas-invoices-batches-creation.scheduler.e2e-spec.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/cas-integration/_tests_/cas-invoices-batches-creation.scheduler.e2e-spec.ts
@@ -427,7 +427,7 @@ describe(
         db,
         firstDisbursementSchedule,
       );
-      // Change BCAG account to be inactive.
+      // Change the distribution account to be inactive.
       await db.casDistributionAccount.update(
         {
           awardValueCode: BC_GRANT_WITHOUT_DISTRIBUTION_ACCOUNT,
@@ -444,7 +444,7 @@ describe(
         `No distribution accounts found for award ${BC_GRANT_WITHOUT_DISTRIBUTION_ACCOUNT} and offering intensity ${OfferingIntensity.fullTime}.`,
       );
 
-      // Revert back the BCSG distribution account to be active.
+      // Revert back the distribution account to be active.
       await db.casDistributionAccount.update(
         {
           awardValueCode: BC_GRANT_WITHOUT_DISTRIBUTION_ACCOUNT,

--- a/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/cas-integration/_tests_/cas-invoices-batches-creation.scheduler.e2e-spec.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/cas-integration/_tests_/cas-invoices-batches-creation.scheduler.e2e-spec.ts
@@ -284,7 +284,7 @@ describe(
       expect(currentInvoiceSequenceNumber.sequenceNumber).toEqual("2");
     });
 
-    it("Should create a new CAS invoice and avoid creating a second invoice when a receipt has already has an invoice associated with.", async () => {
+    it("Should create a new CAS invoice and avoid making a second invoice when a receipt already has an invoice associated with it.", async () => {
       // Arrange
       const casSupplier = await saveFakeCASSupplier(db, undefined, {
         initialValues: {

--- a/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/cas-integration/_tests_/cas-invoices-batches-creation.scheduler.e2e-spec.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/cas-integration/_tests_/cas-invoices-batches-creation.scheduler.e2e-spec.ts
@@ -394,7 +394,7 @@ describe(
 
     it("Should interrupt the process when an invoice is trying to be generated but there are no distribution accounts available to create the invoice details.", async () => {
       // Arrange
-      const BC_GRANT_WITHOUT_DISTRIBUTION_ACCOUNT = "BCAG";
+      const BC_GRANT_WITHOUT_DISTRIBUTION_ACCOUNT = "ABCD";
       const casSupplier = await saveFakeCASSupplier(db, undefined, {
         initialValues: {
           supplierStatus: SupplierStatus.VerifiedManually,
@@ -427,14 +427,6 @@ describe(
         db,
         firstDisbursementSchedule,
       );
-      // Change the distribution account to be inactive.
-      await db.casDistributionAccount.update(
-        {
-          awardValueCode: BC_GRANT_WITHOUT_DISTRIBUTION_ACCOUNT,
-          offeringIntensity: OfferingIntensity.fullTime,
-        },
-        { isActive: false },
-      );
 
       // Queued job.
       const mockedJob = mockBullJob<void>();
@@ -442,15 +434,6 @@ describe(
       // Act/Assert
       await expect(processor.processQueue(mockedJob.job)).rejects.toThrow(
         `No distribution accounts found for award ${BC_GRANT_WITHOUT_DISTRIBUTION_ACCOUNT} and offering intensity ${OfferingIntensity.fullTime}.`,
-      );
-
-      // Revert back the distribution account to be active.
-      await db.casDistributionAccount.update(
-        {
-          awardValueCode: BC_GRANT_WITHOUT_DISTRIBUTION_ACCOUNT,
-          offeringIntensity: OfferingIntensity.fullTime,
-        },
-        { isActive: true },
       );
     });
 

--- a/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/cas-integration/cas-invoices-batches-creation.scheduler.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/cas-integration/cas-invoices-batches-creation.scheduler.ts
@@ -17,7 +17,7 @@ import { DATABASE_TRANSACTION_CANCELLATION } from "@sims/services/constants";
 @Processor(QueueNames.CASInvoicesBatchesCreation)
 export class CASInvoicesBatchesCreationScheduler extends BaseScheduler<void> {
   constructor(
-    @InjectQueue(QueueNames.CASSupplierIntegration)
+    @InjectQueue(QueueNames.CASInvoicesBatchesCreation)
     schedulerQueue: Queue<void>,
     queueService: QueueService,
     private readonly casInvoiceBatchService: CASInvoiceBatchService,

--- a/sources/packages/backend/libs/services/src/constants/error-code.constants.ts
+++ b/sources/packages/backend/libs/services/src/constants/error-code.constants.ts
@@ -32,3 +32,14 @@ export const UNEXPECTED_ERROR_DOWNLOADING_FILE =
 export const ECE_DISBURSEMENT_DATA_NOT_VALID =
   "ECE_DISBURSEMENT_DATA_NOT_VALID";
 export const FILE_PARSING_ERROR = "FILE_PARSING_ERROR";
+
+/**
+ * Used to cancel a database transaction started using the method as below.
+ * @example
+ * await myDataSource.transaction(async (transactionalEntityManager) => {
+ *   // execute queries using transactionalEntityManager
+ * })
+ * @see https://typeorm.io/#/transactions
+ */
+export const DATABASE_TRANSACTION_CANCELLATION =
+  "DATABASE_TRANSACTION_CANCELLATION";

--- a/sources/packages/backend/libs/test-utils/src/factories/cas-invoice-batch.ts
+++ b/sources/packages/backend/libs/test-utils/src/factories/cas-invoice-batch.ts
@@ -1,0 +1,87 @@
+import {
+  ApplicationStatus,
+  CASInvoice,
+  CASInvoiceBatch,
+  CASInvoiceBatchApprovalStatus,
+  CASSupplier,
+  DisbursementValue,
+  OfferingIntensity,
+  SupplierStatus,
+  User,
+} from "@sims/sims-db";
+import * as faker from "faker";
+import { saveFakeCASSupplier } from "./cas-supplier";
+import {
+  E2EDataSources,
+  saveFakeApplicationDisbursements,
+  saveFakeDisbursementReceiptsFromDisbursementSchedule,
+  saveFakeInvoiceFromDisbursementReceipt,
+  saveFakeStudent,
+} from "..";
+
+export function createFakeCASInvoiceBatch(
+  relations: {
+    creator: User;
+  },
+  options?: { initialValue?: Partial<CASInvoiceBatch> },
+): CASInvoiceBatch {
+  const now = new Date();
+  const casInvoiceBatch = new CASInvoiceBatch();
+  casInvoiceBatch.batchName = `SIMS-BATCH-${faker.datatype.uuid()}}`;
+  casInvoiceBatch.batchDate = options?.initialValue?.batchDate ?? now;
+  casInvoiceBatch.approvalStatus =
+    options?.initialValue?.approvalStatus ??
+    CASInvoiceBatchApprovalStatus.Pending;
+  casInvoiceBatch.approvalStatusUpdatedOn =
+    options?.initialValue?.approvalStatusUpdatedOn ?? now;
+  casInvoiceBatch.approvalStatusUpdatedBy = relations.creator;
+  casInvoiceBatch.creator = relations.creator;
+  return casInvoiceBatch;
+}
+
+export async function saveFakeInvoiceIntoBatchWithInvoiceDetails(
+  db: E2EDataSources,
+  relations: {
+    casInvoiceBatch: CASInvoiceBatch;
+    creator: User;
+    disbursementValues?: DisbursementValue[];
+  },
+  options?: {
+    offeringIntensity?: OfferingIntensity;
+    casSupplierInitialValues?: Partial<CASSupplier>;
+  },
+): Promise<CASInvoice> {
+  const casSupplier = await saveFakeCASSupplier(db, undefined, {
+    initialValues: options?.casSupplierInitialValues ?? {
+      supplierStatus: SupplierStatus.VerifiedManually,
+    },
+  });
+  const student = await saveFakeStudent(db.dataSource, { casSupplier });
+  const application = await saveFakeApplicationDisbursements(
+    db.dataSource,
+    {
+      student,
+      disbursementValues: relations.disbursementValues,
+    },
+    {
+      offeringIntensity: options?.offeringIntensity,
+      applicationStatus: ApplicationStatus.Completed,
+    },
+  );
+  const [firstDisbursementSchedule] =
+    application.currentAssessment.disbursementSchedules;
+  const { provincial: provincialDisbursementReceipt } =
+    await saveFakeDisbursementReceiptsFromDisbursementSchedule(
+      db,
+      firstDisbursementSchedule,
+    );
+
+  // Create invoice and its details associated with th batch
+  const createdInvoice = await saveFakeInvoiceFromDisbursementReceipt(db, {
+    casInvoiceBatch: relations.casInvoiceBatch,
+    creator: relations.creator,
+    provincialDisbursementReceipt,
+    casSupplier,
+  });
+  return createdInvoice;
+}

--- a/sources/packages/backend/libs/test-utils/src/factories/cas-invoice-batch.ts
+++ b/sources/packages/backend/libs/test-utils/src/factories/cas-invoice-batch.ts
@@ -19,6 +19,14 @@ import {
   saveFakeStudent,
 } from "..";
 
+/**
+ * Creates a fake CAS invoice batch ready to be saved to the database.
+ * @param relations relations that will be used to create the batch.
+ * - `creator` user already saved to the database that will be the creator of the batch.
+ * @param options options to customize the created batch.
+ * - `initialValue` some fields that will be used to create the batch.
+ * @returns CAS invoice batch created from the provided relations and options.
+ */
 export function createFakeCASInvoiceBatch(
   relations: {
     creator: User;
@@ -39,6 +47,19 @@ export function createFakeCASInvoiceBatch(
   return casInvoiceBatch;
 }
 
+/**
+ * Creates and save a new invoice associated with the provided batch.
+ * Allow the creation of a back and the creation of many invoices associated with the same batch.
+ * @param db E2E data sources.
+ * @param relations relations used to create the invoice.
+ * - `casInvoiceBatch` invoice batch to associate with the invoice, already saved to the database.
+ * - `creator` user who creates the invoice and any other related records.
+ * - `disbursementValues` optional disbursement values for the invoice.
+ * @param options optional parameters to customize the invoice.
+ * - `offeringIntensity` offering intensity for the invoice.
+ * - `casSupplierInitialValues` initial values for the CAS supplier.
+ * @returns CAS invoice created and associated with the batch.
+ */
 export async function saveFakeInvoiceIntoBatchWithInvoiceDetails(
   db: E2EDataSources,
   relations: {
@@ -51,6 +72,7 @@ export async function saveFakeInvoiceIntoBatchWithInvoiceDetails(
     casSupplierInitialValues?: Partial<CASSupplier>;
   },
 ): Promise<CASInvoice> {
+  // Create a valid supplier. If not valid an invoice would not be created.
   const casSupplier = await saveFakeCASSupplier(db, undefined, {
     initialValues: options?.casSupplierInitialValues ?? {
       supplierStatus: SupplierStatus.VerifiedManually,

--- a/sources/packages/backend/libs/test-utils/src/factories/cas-invoice-detail.ts
+++ b/sources/packages/backend/libs/test-utils/src/factories/cas-invoice-detail.ts
@@ -1,0 +1,22 @@
+import {
+  CASDistributionAccount,
+  CASInvoice,
+  CASInvoiceDetail,
+  User,
+} from "@sims/sims-db";
+
+export function createFakeCASInvoiceDetail(
+  relations: {
+    casDistributionAccount: CASDistributionAccount;
+    creator: User;
+    casInvoice?: CASInvoice;
+  },
+  options?: { initialValues?: Partial<CASInvoiceDetail> },
+): CASInvoiceDetail {
+  const casInvoiceDetail = new CASInvoiceDetail();
+  casInvoiceDetail.casInvoice = relations.casInvoice;
+  casInvoiceDetail.casDistributionAccount = relations.casDistributionAccount;
+  casInvoiceDetail.valueAmount = options?.initialValues?.valueAmount ?? 0;
+  casInvoiceDetail.creator = relations.creator;
+  return casInvoiceDetail;
+}

--- a/sources/packages/backend/libs/test-utils/src/factories/cas-invoice-detail.ts
+++ b/sources/packages/backend/libs/test-utils/src/factories/cas-invoice-detail.ts
@@ -5,6 +5,18 @@ import {
   User,
 } from "@sims/sims-db";
 
+/**
+ * Creates a fake CAS invoice detail ready to be saved to the database.
+ * @param relations dependencies.
+ * - `casDistributionAccount` distribution account already saved to
+ * the database to be associated with the invoice detail.
+ * - `creator` user already saved to the database that will be the creator of the invoice detail.
+ * - `casInvoice` invoice already saved to the database to be associated with the
+ * invoice detail (optional).
+ * @param options options.
+ * - `initialValues` CAS invoice detail values.
+ * @returns a fake CAS invoice detail.
+ */
 export function createFakeCASInvoiceDetail(
   relations: {
     casDistributionAccount: CASDistributionAccount;

--- a/sources/packages/backend/libs/test-utils/src/factories/cas-invoice.ts
+++ b/sources/packages/backend/libs/test-utils/src/factories/cas-invoice.ts
@@ -18,7 +18,7 @@ import { E2EDataSources } from "..";
  * - `disbursementReceipt` disbursement receipt already saved to the database to be associated with the invoice.
  * - `casSupplier` CAS supplier already saved to the database to be associated with the invoice.
  * - `creator` user already saved to the database that will be the creator of the invoice.
- * @returns CAS invoice created from the provided {@see DisbursementReceipt}.
+ * @returns created CAS invoice.
  */
 export function createFakeCASInvoice(relations: {
   casInvoiceBatch: CASInvoiceBatch;
@@ -48,7 +48,8 @@ export function createFakeCASInvoice(relations: {
  * of the invoice and any other
  * related record.
  * - `provincialDisbursementReceipt` disbursement receipt created from the
- * E2E factory {@see saveFakeDisbursementReceiptsFromDisbursementSchedule}.
+ * E2E factory {@see saveFakeDisbursementReceiptsFromDisbursementSchedule} to ensure
+ * all nested records are created.
  * - `casSupplier` CAS supplier already saved to the database to be associated
  * with the invoice.
  * @returns invoice created from the provided {@see DisbursementReceipt}.

--- a/sources/packages/backend/libs/test-utils/src/factories/cas-invoice.ts
+++ b/sources/packages/backend/libs/test-utils/src/factories/cas-invoice.ts
@@ -1,0 +1,115 @@
+import {
+  CASInvoice,
+  CASInvoiceBatch,
+  CASInvoiceStatus,
+  CASSupplier,
+  DisbursementReceipt,
+  DisbursementValueType,
+  User,
+} from "@sims/sims-db";
+import * as faker from "faker";
+import { createFakeCASInvoiceDetail } from "./cas-invoice-detail";
+import { E2EDataSources } from "..";
+
+/**
+ * Creates a fake CAS invoice ready to be saved to the database.
+ * @param relations relations that will be used to create the invoice.
+ * - `casInvoiceBatch` invoice batch already saved to the database to be associated with the invoice.
+ * - `disbursementReceipt` disbursement receipt already saved to the database to be associated with the invoice.
+ * - `casSupplier` CAS supplier already saved to the database to be associated with the invoice.
+ * - `creator` user already saved to the database that will be the creator of the invoice.
+ * @returns CAS invoice created from the provided {@see DisbursementReceipt}.
+ */
+export function createFakeCASInvoice(relations: {
+  casInvoiceBatch: CASInvoiceBatch;
+  disbursementReceipt: DisbursementReceipt;
+  casSupplier: CASSupplier;
+  creator: User;
+}): CASInvoice {
+  const now = new Date();
+  const casInvoice = new CASInvoice();
+  casInvoice.casInvoiceBatch = relations.casInvoiceBatch;
+  casInvoice.disbursementReceipt = relations.disbursementReceipt;
+  casInvoice.casSupplier = relations.casSupplier;
+  casInvoice.invoiceNumber = faker.datatype.uuid();
+  casInvoice.invoiceStatus = CASInvoiceStatus.Pending;
+  casInvoice.invoiceStatusUpdatedOn = now;
+  casInvoice.creator = relations.creator;
+  return casInvoice;
+}
+
+/**
+ * Saves a fake CAS invoice from a given disbursement receipt.
+ * @param db The E2E data sources.
+ * @param relations relations that will be used to create the invoice.
+ * - `casInvoiceBatch` invoice batch already saved to the database to
+ * be associated with the invoice.
+ * - `creator` user already saved to the database that will be the creator
+ * of the invoice and any other
+ * related record.
+ * - `provincialDisbursementReceipt` disbursement receipt created from the
+ * E2E factory {@see saveFakeDisbursementReceiptsFromDisbursementSchedule}.
+ * - `casSupplier` CAS supplier already saved to the database to be associated
+ * with the invoice.
+ * @returns invoice created from the provided {@see DisbursementReceipt}.
+ */
+export async function saveFakeInvoiceFromDisbursementReceipt(
+  db: E2EDataSources,
+  relations: {
+    casInvoiceBatch: CASInvoiceBatch;
+    creator: User;
+    provincialDisbursementReceipt: DisbursementReceipt;
+    casSupplier: CASSupplier;
+  },
+): Promise<CASInvoice> {
+  const fakeCASInvoice = createFakeCASInvoice({
+    casInvoiceBatch: relations.casInvoiceBatch,
+    disbursementReceipt: relations.provincialDisbursementReceipt,
+    casSupplier: relations.casSupplier,
+    creator: relations.creator,
+  });
+  const offeringIntensity =
+    relations.provincialDisbursementReceipt.disbursementSchedule
+      .studentAssessment.offering.offeringIntensity;
+  // BC grants part of the award. BCSG (total grants) is not included.
+  const bcAwards =
+    relations.provincialDisbursementReceipt.disbursementSchedule.disbursementValues.filter(
+      (disbursementValue) =>
+        disbursementValue.valueType === DisbursementValueType.BCGrant,
+    );
+  // Get all active accounts that are supposed to be created by the DB seeding.
+  const allAccounts = await db.casDistributionAccount.find({
+    select: {
+      id: true,
+      distributionAccount: true,
+      awardValueCode: true,
+      offeringIntensity: true,
+    },
+    where: { isActive: true },
+  });
+  // Populate the CAS invoice details.
+  fakeCASInvoice.casInvoiceDetails = [];
+  bcAwards.forEach((award) => {
+    const awardAccounts = allAccounts.filter(
+      (account) =>
+        account.awardValueCode === award.valueCode &&
+        account.offeringIntensity === offeringIntensity,
+    );
+    const details = awardAccounts.map((account) =>
+      createFakeCASInvoiceDetail(
+        {
+          casDistributionAccount: account,
+          creator: relations.creator,
+        },
+        {
+          initialValues: {
+            valueAmount: award.effectiveAmount,
+          },
+        },
+      ),
+    );
+    fakeCASInvoice.casInvoiceDetails.push(...details);
+  });
+  // Save invoice and its details.
+  return db.casInvoice.save(fakeCASInvoice);
+}

--- a/sources/packages/backend/libs/test-utils/src/factories/cas-supplier.ts
+++ b/sources/packages/backend/libs/test-utils/src/factories/cas-supplier.ts
@@ -93,7 +93,7 @@ export function createFakeCASSupplier(
   }
   casSupplier.supplierName = `${faker.name.lastName()}, ${faker.name.firstName()}`;
   casSupplier.supplierNumber =
-    options.initialValues?.supplierNumber ??
+    options?.initialValues?.supplierNumber ??
     faker.datatype.number({ min: 100000, max: 9999999999 }).toString();
   casSupplier.supplierAddress.supplierSiteCode = faker.datatype
     .number({ min: 100, max: 999 })

--- a/sources/packages/backend/libs/test-utils/src/factories/cas-supplier.ts
+++ b/sources/packages/backend/libs/test-utils/src/factories/cas-supplier.ts
@@ -92,9 +92,9 @@ export function createFakeCASSupplier(
     casSupplier.isValid = options?.initialValues.isValid ?? false;
   }
   casSupplier.supplierName = `${faker.name.lastName()}, ${faker.name.firstName()}`;
-  casSupplier.supplierNumber = faker.datatype
-    .number({ min: 100000, max: 9999999999 })
-    .toString();
+  casSupplier.supplierNumber =
+    options.initialValues?.supplierNumber ??
+    faker.datatype.number({ min: 100000, max: 9999999999 }).toString();
   casSupplier.supplierAddress.supplierSiteCode = faker.datatype
     .number({ min: 100, max: 999 })
     .toString();

--- a/sources/packages/backend/libs/test-utils/src/factories/disbursement-receipt.ts
+++ b/sources/packages/backend/libs/test-utils/src/factories/disbursement-receipt.ts
@@ -87,7 +87,7 @@ export async function saveFakeDisbursementReceiptsFromDisbursementSchedule(
   federalDisbursementReceipt.totalDisbursedAmount =
     disbursementSchedule.disbursementValues.find(
       (award) => award.valueType === DisbursementValueType.CanadaLoan,
-    ).valueAmount;
+    )?.valueAmount ?? 0;
   // Provincial receipt.
   const provincialDisbursementReceipt = createFakeDisbursementReceipt({
     disbursementSchedule,

--- a/sources/packages/backend/libs/test-utils/src/index.ts
+++ b/sources/packages/backend/libs/test-utils/src/index.ts
@@ -39,3 +39,6 @@ export * from "./factories/cas-supplier";
 export * from "./factories/sfas-restriction-maps";
 export * from "./factories/restriction";
 export * from "./factories/cas-distribution-account";
+export * from "./factories/cas-invoice-batch";
+export * from "./factories/cas-invoice";
+export * from "./factories/cas-invoice-detail";

--- a/sources/packages/backend/package.json
+++ b/sources/packages/backend/package.json
@@ -25,7 +25,7 @@
     "test:watch": "jest --watch --config ./jest-unit-tests.json",
     "test:cov": "cross-env ENVIRONMENT=test jest --coverage --forceExit --config ./jest-unit-tests.json",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand --config ./jest-unit-tests.json",
-    "test:e2e:api": "npm run db:seed:test filter=CreateInstitutionsAndAuthenticationUsers,CreateAESTUsers,CreateStudentUsers,CreateRestrictions && cross-env ENVIRONMENT=test jest --collect-coverage --verbose --config ./apps/api/test/jest-e2e.json --forceExit",
+    "test:e2e:api": "npm run db:seed:test filter=CreateInstitutionsAndAuthenticationUsers,CreateAESTUsers,CreateStudentUsers,CreateRestrictions,CreateCASDistributionAccounts && cross-env ENVIRONMENT=test jest --collect-coverage --verbose --config ./apps/api/test/jest-e2e.json --forceExit",
     "test:e2e:api:local": "cross-env ENVIRONMENT=test TZ=UTC jest --config ./apps/api/test/jest-e2e.json --forceExit",
     "test:e2e:workers": "npm run migration:run && cross-env ENVIRONMENT=test jest --collect-coverage --verbose --config ./apps/workers/test/jest-e2e.json --forceExit",
     "test:e2e:workers:local": "cross-env ENVIRONMENT=test jest --collect-coverage --verbose --config ./apps/workers/test/jest-e2e.json --forceExit",


### PR DESCRIPTION
Created new E2E tests for the new endpoints and extended scheduler E2E tests previously added (only one).

## API Endpoints (CASInvoiceBatchAESTController)
- getCASInvoiceBatchReport
  - Should generate an invoice batch report with part-time and full-time invoices when the batch exists.
  - Should throw a HttpStatus Not Found (404) when the requested invoice batch does not exist.
  - Should throw a HttpStatus Forbidden (403) error when an unauthorized Ministry user tries to get the invoice batch report.
- getInvoiceBatches
  - Should be able to get invoice batches for the first page in a paginated result with a limit of two per page in descending order when there are three invoice batches available.
  - Should be able to get only pending invoice batches when the filter for status is applied.
  - Should throw a HttpStatus Bad Request (400) error when the filter for status is invalid.
  - Should throw a HttpStatus Bad Request (400) error when the sortField is invalid.
  - Should throw a HttpStatus Forbidden (403) error when an unauthorized Ministry user tries to get the invoice batches.

## Scheduler
- Should create a new CAS invoice and avoid making a second invoice when a receipt already has an invoice associated with it.
- Should interrupt the process when an invoice is trying to be generated but there are no distribution accounts available to create the invoice details ([addressing previous PR comment](https://github.com/bcgov/SIMS/pull/4297#discussion_r1934824195)).
- Should finalize the process nicely when there is no pending receipt to process ([addressing previous PR comment](https://github.com/bcgov/SIMS/pull/4297#discussion_r1934853466)).