### PR TITLE
#4253 - Upgrade Redis - metrics

### DIFF
--- a/devops/helm/redis-cluster/templates/metrics-prometheus.yaml
+++ b/devops/helm/redis-cluster/templates/metrics-prometheus.yaml
@@ -1,0 +1,45 @@
+{{- /*
+Copyright Broadcom, Inc. All Rights Reserved.
+SPDX-License-Identifier: APACHE-2.0
+*/}}
+
+{{- if and (.Values.metrics.enabled) (.Values.metrics.serviceMonitor.enabled) }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ template "common.names.fullname" . }}
+  namespace: {{ default (include "common.names.namespace" .) .Values.metrics.serviceMonitor.namespace | quote }}
+  {{- $labels := include "common.tplvalues.merge" ( dict "values" ( list .Values.metrics.serviceMonitor.labels .Values.commonLabels ) "context" . ) }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}
+  {{- if or .Values.commonAnnotations .Values.metrics.serviceMonitor.annotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.metrics.serviceMonitor.annotations .Values.commonAnnotations ) "context" . ) }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.metrics.serviceMonitor.jobLabel }}
+  jobLabel: {{ .Values.metrics.serviceMonitor.jobLabel }}
+  {{- end }}
+  endpoints:
+  - port: metrics
+    {{- if .Values.metrics.serviceMonitor.interval }}
+    interval: {{ .Values.metrics.serviceMonitor.interval }}
+    {{- end }}
+    {{- if .Values.metrics.serviceMonitor.scrapeTimeout }}
+    scrapeTimeout: {{ .Values.metrics.serviceMonitor.scrapeTimeout }}
+    {{- end }}
+    {{- if .Values.metrics.serviceMonitor.relabelings }}
+    relabelings: {{- include "common.tplvalues.render" ( dict "value" .Values.metrics.serviceMonitor.relabelings "context" $) | nindent 8 }}
+    {{- end }}
+    {{- if .Values.metrics.serviceMonitor.metricRelabelings }}
+    metricRelabelings: {{- include "common.tplvalues.render" ( dict "value" .Values.metrics.serviceMonitor.metricRelabelings "context" $) | nindent 8 }}
+    {{- end }}
+  selector:
+    matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 6 }}
+      {{- if .Values.metrics.serviceMonitor.selector }}
+      {{- include "common.tplvalues.render" (dict "value" .Values.metrics.serviceMonitor.selector "context" $) | nindent 6 }}
+      {{- end }}
+      app.kubernetes.io/component: "metrics"
+  namespaceSelector:
+    matchNames:
+    - {{ include "common.names.namespace" . }}
+{{- end -}}

--- a/devops/helm/redis-cluster/templates/metrics-svc.yaml
+++ b/devops/helm/redis-cluster/templates/metrics-svc.yaml
@@ -1,0 +1,39 @@
+{{- /*
+Copyright Broadcom, Inc. All Rights Reserved.
+SPDX-License-Identifier: APACHE-2.0
+*/}}
+
+{{- if .Values.metrics.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "common.names.fullname" . }}-metrics
+  namespace: {{ include "common.names.namespace" . | quote }}
+  {{- $labels := include "common.tplvalues.merge" ( dict "values" ( list .Values.metrics.service.labels .Values.commonLabels ) "context" . ) }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}
+    app.kubernetes.io/component: "metrics"
+  {{- if or .Values.metrics.service.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.metrics.service.annotations .Values.commonAnnotations ) "context" . ) }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.metrics.service.type }}
+  {{- if and .Values.metrics.service.clusterIP (eq .Values.metrics.service.type "ClusterIP") }}
+  clusterIP: {{ .Values.metrics.service.clusterIP }}
+  {{- end }}
+  {{- if and (eq .Values.metrics.service.type "LoadBalancer") .Values.metrics.service.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.metrics.service.loadBalancerIP }}
+  {{- end }}
+  {{- if and (eq .Values.metrics.service.type "LoadBalancer")  .Values.metrics.service.loadBalancerClass }}
+  loadBalancerClass: {{ .Values.metrics.service.loadBalancerClass }}
+  {{- end }}
+  ports:
+    - name: metrics
+      port: {{ .Values.metrics.service.ports.http }}
+      {{- if .Values.metrics.service.ports.appProtocol }}
+      appProtocol: {{ .Values.metrics.service.ports.appProtocol }}
+      {{- end }}
+      targetPort: http-metrics
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.redis.podLabels .Values.commonLabels ) "context" . ) }}
+  selector: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 4 }}
+{{- end }}

--- a/devops/helm/redis-cluster/templates/prometheusrule.yaml
+++ b/devops/helm/redis-cluster/templates/prometheusrule.yaml
@@ -1,0 +1,25 @@
+{{- /*
+Copyright Broadcom, Inc. All Rights Reserved.
+SPDX-License-Identifier: APACHE-2.0
+*/}}
+
+{{- if and .Values.metrics.enabled .Values.metrics.prometheusRule.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: {{ template "common.names.fullname" . }}
+  namespace: {{ default (include "common.names.namespace" .) .Values.metrics.prometheusRule.namespace | quote }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- if .Values.metrics.prometheusRule.additionalLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.metrics.prometheusRule.additionalLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.metrics.prometheusRule.rules }}
+  groups:
+    - name: {{ template "common.names.name" $ }}
+      rules: {{- include "common.tplvalues.render" ( dict "value" . "context" $ ) | nindent 8 }}
+  {{- end }}
+{{- end }}

--- a/devops/helm/redis-cluster/values-0c27fb-dev.yaml
+++ b/devops/helm/redis-cluster/values-0c27fb-dev.yaml
@@ -41,3 +41,16 @@ updateJob:
       memory: 1024Mi
 
   # resources: {}
+
+## Prometheus Exporter / Metrics
+##
+metrics:
+  ## @param metrics.enabled Start a side-car prometheus exporter
+  ##
+  enabled: true
+  ## Enable this if you're using https://github.com/coreos/prometheus-operator
+  ##
+  serviceMonitor:
+    ## @param metrics.serviceMonitor.enabled If `true`, creates a Prometheus Operator ServiceMonitor (also requires `metrics.enabled` to be `true`)
+    ##
+    enabled: true

--- a/devops/helm/redis-cluster/values-0c27fb-dev.yaml
+++ b/devops/helm/redis-cluster/values-0c27fb-dev.yaml
@@ -48,9 +48,3 @@ metrics:
   ## @param metrics.enabled Start a side-car prometheus exporter
   ##
   enabled: true
-  ## Enable this if you're using https://github.com/coreos/prometheus-operator
-  ##
-  serviceMonitor:
-    ## @param metrics.serviceMonitor.enabled If `true`, creates a Prometheus Operator ServiceMonitor (also requires `metrics.enabled` to be `true`)
-    ##
-    enabled: true

--- a/devops/helm/redis-cluster/values-0c27fb-prod.yaml
+++ b/devops/helm/redis-cluster/values-0c27fb-prod.yaml
@@ -48,9 +48,3 @@ metrics:
   ## @param metrics.enabled Start a side-car prometheus exporter
   ##
   enabled: false
-  ## Enable this if you're using https://github.com/coreos/prometheus-operator
-  ##
-  serviceMonitor:
-    ## @param metrics.serviceMonitor.enabled If `true`, creates a Prometheus Operator ServiceMonitor (also requires `metrics.enabled` to be `true`)
-    ##
-    enabled: false

--- a/devops/helm/redis-cluster/values-0c27fb-prod.yaml
+++ b/devops/helm/redis-cluster/values-0c27fb-prod.yaml
@@ -41,3 +41,16 @@ updateJob:
       memory: 1024Mi
 
   # resources: {}
+
+## Prometheus Exporter / Metrics
+##
+metrics:
+  ## @param metrics.enabled Start a side-car prometheus exporter
+  ##
+  enabled: false
+  ## Enable this if you're using https://github.com/coreos/prometheus-operator
+  ##
+  serviceMonitor:
+    ## @param metrics.serviceMonitor.enabled If `true`, creates a Prometheus Operator ServiceMonitor (also requires `metrics.enabled` to be `true`)
+    ##
+    enabled: false

--- a/devops/helm/redis-cluster/values-0c27fb-test.yaml
+++ b/devops/helm/redis-cluster/values-0c27fb-test.yaml
@@ -48,9 +48,3 @@ metrics:
   ## @param metrics.enabled Start a side-car prometheus exporter
   ##
   enabled: false
-  ## Enable this if you're using https://github.com/coreos/prometheus-operator
-  ##
-  serviceMonitor:
-    ## @param metrics.serviceMonitor.enabled If `true`, creates a Prometheus Operator ServiceMonitor (also requires `metrics.enabled` to be `true`)
-    ##
-    enabled: false

--- a/devops/helm/redis-cluster/values-0c27fb-test.yaml
+++ b/devops/helm/redis-cluster/values-0c27fb-test.yaml
@@ -41,3 +41,16 @@ updateJob:
       memory: 1024Mi
 
   # resources: {}
+
+## Prometheus Exporter / Metrics
+##
+metrics:
+  ## @param metrics.enabled Start a side-car prometheus exporter
+  ##
+  enabled: false
+  ## Enable this if you're using https://github.com/coreos/prometheus-operator
+  ##
+  serviceMonitor:
+    ## @param metrics.serviceMonitor.enabled If `true`, creates a Prometheus Operator ServiceMonitor (also requires `metrics.enabled` to be `true`)
+    ##
+    enabled: false

--- a/devops/helm/redis-cluster/values-a6ef19-dev.yaml
+++ b/devops/helm/redis-cluster/values-a6ef19-dev.yaml
@@ -47,10 +47,4 @@ updateJob:
 metrics:
   ## @param metrics.enabled Start a side-car prometheus exporter
   ##
-  enabled: true
-  ## Enable this if you're using https://github.com/coreos/prometheus-operator
-  ##
-  serviceMonitor:
-    ## @param metrics.serviceMonitor.enabled If `true`, creates a Prometheus Operator ServiceMonitor (also requires `metrics.enabled` to be `true`)
-    ##
-    enabled: true
+  enabled: false

--- a/devops/helm/redis-cluster/values-a6ef19-dev.yaml
+++ b/devops/helm/redis-cluster/values-a6ef19-dev.yaml
@@ -41,3 +41,16 @@ updateJob:
       memory: 1024Mi
 
   # resources: {}
+
+## Prometheus Exporter / Metrics
+##
+metrics:
+  ## @param metrics.enabled Start a side-car prometheus exporter
+  ##
+  enabled: true
+  ## Enable this if you're using https://github.com/coreos/prometheus-operator
+  ##
+  serviceMonitor:
+    ## @param metrics.serviceMonitor.enabled If `true`, creates a Prometheus Operator ServiceMonitor (also requires `metrics.enabled` to be `true`)
+    ##
+    enabled: true

--- a/devops/helm/redis-cluster/values-a6ef19-prod.yaml
+++ b/devops/helm/redis-cluster/values-a6ef19-prod.yaml
@@ -48,9 +48,3 @@ metrics:
   ## @param metrics.enabled Start a side-car prometheus exporter
   ##
   enabled: false
-  ## Enable this if you're using https://github.com/coreos/prometheus-operator
-  ##
-  serviceMonitor:
-    ## @param metrics.serviceMonitor.enabled If `true`, creates a Prometheus Operator ServiceMonitor (also requires `metrics.enabled` to be `true`)
-    ##
-    enabled: false

--- a/devops/helm/redis-cluster/values-a6ef19-prod.yaml
+++ b/devops/helm/redis-cluster/values-a6ef19-prod.yaml
@@ -41,3 +41,16 @@ updateJob:
       memory: 1024Mi
 
   # resources: {}
+
+## Prometheus Exporter / Metrics
+##
+metrics:
+  ## @param metrics.enabled Start a side-car prometheus exporter
+  ##
+  enabled: false
+  ## Enable this if you're using https://github.com/coreos/prometheus-operator
+  ##
+  serviceMonitor:
+    ## @param metrics.serviceMonitor.enabled If `true`, creates a Prometheus Operator ServiceMonitor (also requires `metrics.enabled` to be `true`)
+    ##
+    enabled: false

--- a/devops/helm/redis-cluster/values-a6ef19-test.yaml
+++ b/devops/helm/redis-cluster/values-a6ef19-test.yaml
@@ -48,9 +48,3 @@ metrics:
   ## @param metrics.enabled Start a side-car prometheus exporter
   ##
   enabled: false
-  ## Enable this if you're using https://github.com/coreos/prometheus-operator
-  ##
-  serviceMonitor:
-    ## @param metrics.serviceMonitor.enabled If `true`, creates a Prometheus Operator ServiceMonitor (also requires `metrics.enabled` to be `true`)
-    ##
-    enabled: false

--- a/devops/helm/redis-cluster/values-a6ef19-test.yaml
+++ b/devops/helm/redis-cluster/values-a6ef19-test.yaml
@@ -41,3 +41,16 @@ updateJob:
       memory: 1024Mi
 
   # resources: {}
+
+## Prometheus Exporter / Metrics
+##
+metrics:
+  ## @param metrics.enabled Start a side-car prometheus exporter
+  ##
+  enabled: false
+  ## Enable this if you're using https://github.com/coreos/prometheus-operator
+  ##
+  serviceMonitor:
+    ## @param metrics.serviceMonitor.enabled If `true`, creates a Prometheus Operator ServiceMonitor (also requires `metrics.enabled` to be `true`)
+    ##
+    enabled: false

--- a/devops/helm/redis-cluster/values.yaml
+++ b/devops/helm/redis-cluster/values.yaml
@@ -936,7 +936,7 @@ cluster:
 metrics:
   ## @param metrics.enabled Start a side-car prometheus exporter
   ##
-  enabled: true
+  enabled: false
   ## @param metrics.image.registry [default: REGISTRY_NAME] Redis&reg; exporter image registry
   ## @param metrics.image.repository [default: REPOSITORY_NAME/redis-exporter] Redis&reg; exporter image name
   ## @skip metrics.image.tag Redis&reg; exporter image tag
@@ -1028,7 +1028,7 @@ metrics:
   serviceMonitor:
     ## @param metrics.serviceMonitor.enabled If `true`, creates a Prometheus Operator ServiceMonitor (also requires `metrics.enabled` to be `true`)
     ##
-    enabled: true
+    enabled: false
     ## @param metrics.serviceMonitor.namespace Optional namespace which Prometheus is running in
     ##
     namespace: ""

--- a/devops/helm/redis-cluster/values.yaml
+++ b/devops/helm/redis-cluster/values.yaml
@@ -936,7 +936,7 @@ cluster:
 metrics:
   ## @param metrics.enabled Start a side-car prometheus exporter
   ##
-  enabled: false
+  enabled: true
   ## @param metrics.image.registry [default: REGISTRY_NAME] Redis&reg; exporter image registry
   ## @param metrics.image.repository [default: REPOSITORY_NAME/redis-exporter] Redis&reg; exporter image name
   ## @skip metrics.image.tag Redis&reg; exporter image tag
@@ -1028,7 +1028,7 @@ metrics:
   serviceMonitor:
     ## @param metrics.serviceMonitor.enabled If `true`, creates a Prometheus Operator ServiceMonitor (also requires `metrics.enabled` to be `true`)
     ##
-    enabled: false
+    enabled: true
     ## @param metrics.serviceMonitor.namespace Optional namespace which Prometheus is running in
     ##
     namespace: ""


### PR DESCRIPTION
Enable Metrics to check alerts in sysdig.
Currently only dev namespaces enabled, to test the metrics.

<img width="851" alt="image" src="https://github.com/user-attachments/assets/7cbbeb77-bf2c-4f3a-a6de-8deb2c0120b5" />

Ignore the below files, as they are copied from bitnami to enable metrics
<img width="319" alt="image" src="https://github.com/user-attachments/assets/46dbd7d0-19cd-45a5-a56c-870e001a5459" />
