### PR TITLE
#4014 - Institution Read-Only User Type PART 2 (UI) (Part 2)

### DIFF
--- a/sources/packages/backend/apps/api/src/route-controllers/institution-user/_tests_/e2e/institution-user.institutions.controller.createInstitutionUserWithAuth.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/institution-user/_tests_/e2e/institution-user.institutions.controller.createInstitutionUserWithAuth.e2e-spec.ts
@@ -1,0 +1,267 @@
+import { HttpStatus, INestApplication } from "@nestjs/common";
+import * as request from "supertest";
+import * as faker from "faker";
+import {
+  authorizeUserTokenForLocation,
+  BEARER_AUTH_TYPE,
+  createTestingAppModule,
+  getAuthRelatedEntities,
+  getInstitutionToken,
+  InstitutionTokenTypes,
+  mockBCeIDAccountDetails,
+} from "../../../../testHelpers";
+import {
+  E2EDataSources,
+  createE2EDataSources,
+  createFakeInstitutionLocation,
+  createFakeUser,
+} from "@sims/test-utils";
+import {
+  IdentityProviders,
+  Institution,
+  InstitutionLocation,
+  InstitutionUserTypes,
+} from "@sims/sims-db";
+import { TestingModule } from "@nestjs/testing";
+import {
+  BCEID_ACCOUNT_NOT_FOUND,
+  INSTITUTION_USER_ALREADY_EXISTS,
+} from "../../../../constants";
+
+describe("InstitutionUserInstitutionsController(e2e)-createInstitutionUserWithAuth", () => {
+  let app: INestApplication;
+  let db: E2EDataSources;
+  let appModule: TestingModule;
+  let collegeFLocationA: InstitutionLocation;
+  let collegeFLocationB: InstitutionLocation;
+  let collegeFInstitution: Institution;
+
+  beforeAll(async () => {
+    const { nestApplication, module, dataSource } =
+      await createTestingAppModule();
+    app = nestApplication;
+    db = createE2EDataSources(dataSource);
+    appModule = module;
+    // College F.
+    const { institution: collegeF } = await getAuthRelatedEntities(
+      db.dataSource,
+      InstitutionTokenTypes.CollegeFUser,
+    );
+    // Location A.
+    collegeFLocationA = createFakeInstitutionLocation({
+      institution: collegeF,
+    });
+    // Location B.
+    collegeFLocationB = createFakeInstitutionLocation({
+      institution: collegeF,
+    });
+    await authorizeUserTokenForLocation(
+      db.dataSource,
+      InstitutionTokenTypes.CollegeFUser,
+      collegeFLocationA,
+    );
+    await authorizeUserTokenForLocation(
+      db.dataSource,
+      InstitutionTokenTypes.CollegeFUser,
+      collegeFLocationB,
+    );
+    collegeFInstitution = collegeFLocationA.institution;
+  });
+
+  it("Should throw an UnprocessableEntityException error when the user passed in the payload is not found on BCeID.", async () => {
+    // Arrange
+    const user = createFakeUser();
+    const payload = {
+      bceidUserId: faker.random.alpha({ count: 5 }),
+      permissions: [{ locationId: collegeFLocationA.id, userType: "user" }],
+    };
+
+    // Mock BCeID account method to return null response.
+    await mockBCeIDAccountDetails(appModule, user, collegeFInstitution, true);
+
+    // Institution token.
+    const token = await getInstitutionToken(InstitutionTokenTypes.CollegeFUser);
+    const endpoint = "/institutions/institution-user";
+
+    // Act/Assert
+    await request(app.getHttpServer())
+      .post(endpoint)
+      .send(payload)
+      .auth(token, BEARER_AUTH_TYPE)
+      .expect(HttpStatus.UNPROCESSABLE_ENTITY)
+      .expect({
+        message: "User not found on BCeID.",
+        errorType: BCEID_ACCOUNT_NOT_FOUND,
+      });
+  });
+
+  it("Should throw an UnprocessableEntityException error when the user to be added is not found under the institution.", async () => {
+    // Arrange
+    const user = createFakeUser();
+    const payload = {
+      bceidUserId: faker.random.alpha({ count: 5 }),
+      permissions: [{ locationId: collegeFLocationA.id, userType: "user" }],
+    };
+    const { institution: collegeD } = await getAuthRelatedEntities(
+      db.dataSource,
+      InstitutionTokenTypes.CollegeDUser,
+    );
+    const collegeDLocation = createFakeInstitutionLocation({
+      institution: collegeD,
+    });
+
+    // Mock BCeID account details.
+    await mockBCeIDAccountDetails(
+      appModule,
+      user,
+      collegeDLocation.institution,
+    );
+    // Institution token.
+    const token = await getInstitutionToken(InstitutionTokenTypes.CollegeFUser);
+    const endpoint = "/institutions/institution-user";
+
+    // Act/Assert
+    await request(app.getHttpServer())
+      .post(endpoint)
+      .send(payload)
+      .auth(token, BEARER_AUTH_TYPE)
+      .expect(HttpStatus.UNPROCESSABLE_ENTITY)
+      .expect({
+        message: "User to be added not found under the institution.",
+        error: "Unprocessable Entity",
+        statusCode: HttpStatus.UNPROCESSABLE_ENTITY,
+      });
+  });
+
+  it("Should throw an UnprocessableEntityException error when the user to be added already exists.", async () => {
+    // Arrange
+    const user = createFakeUser();
+    // Copy the initial userName before adding @bceidboth.
+    const userGuid = user.userName;
+    user.userName =
+      `${user.userName}@${IdentityProviders.BCeIDBoth}`.toLowerCase();
+    await db.user.save(user);
+
+    const payload = {
+      bceidUserId: faker.random.alpha({ count: 5 }),
+      permissions: [{ locationId: collegeFLocationA.id, userType: "user" }],
+    };
+
+    // Mock get BCeID account details with the initial userName.
+    await mockBCeIDAccountDetails(
+      appModule,
+      { ...user, userName: userGuid },
+      collegeFInstitution,
+    );
+
+    // Institution token.
+    const token = await getInstitutionToken(InstitutionTokenTypes.CollegeFUser);
+    const endpoint = "/institutions/institution-user";
+
+    // Act/Assert
+    await request(app.getHttpServer())
+      .post(endpoint)
+      .send(payload)
+      .auth(token, BEARER_AUTH_TYPE)
+      .expect(HttpStatus.UNPROCESSABLE_ENTITY)
+      .expect({
+        message: "The user already exists.",
+        errorType: INSTITUTION_USER_ALREADY_EXISTS,
+      });
+  });
+
+  it("Should create an institution user with user and read-only auth types when valid data is passed.", async () => {
+    // Arrange
+    const user = createFakeUser();
+    const payload = {
+      bceidUserId: faker.random.alpha({ count: 5 }),
+      permissions: [
+        { locationId: collegeFLocationA.id, userType: "user" },
+        { locationId: collegeFLocationB.id, userType: "read-only-user" },
+      ],
+    };
+
+    // Mock get BCeID account details
+    await mockBCeIDAccountDetails(appModule, user, collegeFInstitution);
+    // Institution token.
+    const token = await getInstitutionToken(InstitutionTokenTypes.CollegeFUser);
+    const endpoint = "/institutions/institution-user";
+
+    // Act/Assert
+    let institutionUserId: number;
+    await request(app.getHttpServer())
+      .post(endpoint)
+      .send(payload)
+      .auth(token, BEARER_AUTH_TYPE)
+      .expect(HttpStatus.CREATED)
+      .then((response) => {
+        expect(response.body.id).toBeGreaterThan(0);
+        institutionUserId = response.body.id;
+      });
+    const savedInstitutionUser = await db.institutionUser.findOne({
+      select: {
+        user: {
+          userName: true,
+          email: true,
+          firstName: true,
+          lastName: true,
+        },
+        institution: {
+          id: true,
+          businessGuid: true,
+          legalOperatingName: true,
+        },
+      },
+      where: { id: institutionUserId },
+    });
+    expect(savedInstitutionUser.user).toEqual(
+      expect.objectContaining({
+        userName:
+          `${user.userName}@${IdentityProviders.BCeIDBoth}`.toLowerCase(),
+        email: user.email,
+        firstName: user.firstName,
+        lastName: user.lastName,
+      }),
+    );
+    expect(savedInstitutionUser.institution).toEqual(
+      expect.objectContaining({
+        id: collegeFInstitution.id,
+        businessGuid: collegeFInstitution.businessGuid,
+        legalOperatingName: collegeFInstitution.legalOperatingName,
+      }),
+    );
+    const savedInstitutionUserAuths = await db.institutionUserAuth.find({
+      select: {
+        location: {
+          id: true,
+        },
+        authType: { type: true },
+      },
+      relations: { institutionUser: true, location: true },
+      where: { institutionUser: { id: institutionUserId } },
+    });
+    expect(savedInstitutionUserAuths).toHaveLength(2);
+    expect(savedInstitutionUserAuths).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          authType: expect.objectContaining({
+            type: InstitutionUserTypes.user,
+            role: null,
+          }),
+          location: expect.objectContaining({ id: collegeFLocationA.id }),
+        }),
+        expect.objectContaining({
+          authType: expect.objectContaining({
+            type: InstitutionUserTypes.readOnlyUser,
+            role: null,
+          }),
+          location: expect.objectContaining({ id: collegeFLocationB.id }),
+        }),
+      ]),
+    );
+  });
+
+  afterAll(async () => {
+    await app?.close();
+  });
+});

--- a/sources/packages/backend/apps/api/src/route-controllers/institution-user/_tests_/e2e/institution-user.institutions.controller.createInstitutionUserWithAuth.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/institution-user/_tests_/e2e/institution-user.institutions.controller.createInstitutionUserWithAuth.e2e-spec.ts
@@ -65,7 +65,7 @@ describe("InstitutionUserInstitutionsController(e2e)-createInstitutionUserWithAu
       InstitutionTokenTypes.CollegeFUser,
       collegeFLocationB,
     );
-    collegeFInstitution = collegeFLocationA.institution;
+    collegeFInstitution = collegeF;
   });
 
   it("Should throw an UnprocessableEntityException error when the user passed in the payload is not found on BCeID.", async () => {
@@ -73,7 +73,12 @@ describe("InstitutionUserInstitutionsController(e2e)-createInstitutionUserWithAu
     const user = createFakeUser();
     const payload = {
       bceidUserId: faker.random.alpha({ count: 5 }),
-      permissions: [{ locationId: collegeFLocationA.id, userType: "user" }],
+      permissions: [
+        {
+          locationId: collegeFLocationA.id,
+          userType: InstitutionUserTypes.user,
+        },
+      ],
     };
 
     // Mock BCeID account method to return null response.
@@ -100,7 +105,12 @@ describe("InstitutionUserInstitutionsController(e2e)-createInstitutionUserWithAu
     const user = createFakeUser();
     const payload = {
       bceidUserId: faker.random.alpha({ count: 5 }),
-      permissions: [{ locationId: collegeFLocationA.id, userType: "user" }],
+      permissions: [
+        {
+          locationId: collegeFLocationA.id,
+          userType: InstitutionUserTypes.user,
+        },
+      ],
     };
     const { institution: collegeD } = await getAuthRelatedEntities(
       db.dataSource,
@@ -144,7 +154,12 @@ describe("InstitutionUserInstitutionsController(e2e)-createInstitutionUserWithAu
 
     const payload = {
       bceidUserId: faker.random.alpha({ count: 5 }),
-      permissions: [{ locationId: collegeFLocationA.id, userType: "user" }],
+      permissions: [
+        {
+          locationId: collegeFLocationA.id,
+          userType: InstitutionUserTypes.user,
+        },
+      ],
     };
 
     // Mock get BCeID account details with the initial userName.
@@ -176,8 +191,14 @@ describe("InstitutionUserInstitutionsController(e2e)-createInstitutionUserWithAu
     const payload = {
       bceidUserId: faker.random.alpha({ count: 5 }),
       permissions: [
-        { locationId: collegeFLocationA.id, userType: "user" },
-        { locationId: collegeFLocationB.id, userType: "read-only-user" },
+        {
+          locationId: collegeFLocationA.id,
+          userType: InstitutionUserTypes.user,
+        },
+        {
+          locationId: collegeFLocationB.id,
+          userType: InstitutionUserTypes.readOnlyUser,
+        },
       ],
     };
 
@@ -232,33 +253,35 @@ describe("InstitutionUserInstitutionsController(e2e)-createInstitutionUserWithAu
     );
     const savedInstitutionUserAuths = await db.institutionUserAuth.find({
       select: {
+        id: true,
         location: {
           id: true,
         },
-        authType: { type: true },
+        authType: { type: true, role: true },
       },
-      relations: { institutionUser: true, location: true },
+      relations: { location: true, authType: true },
       where: { institutionUser: { id: institutionUserId } },
+      loadEagerRelations: false,
     });
     expect(savedInstitutionUserAuths).toHaveLength(2);
-    expect(savedInstitutionUserAuths).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          authType: expect.objectContaining({
-            type: InstitutionUserTypes.user,
-            role: null,
-          }),
-          location: expect.objectContaining({ id: collegeFLocationA.id }),
-        }),
-        expect.objectContaining({
-          authType: expect.objectContaining({
-            type: InstitutionUserTypes.readOnlyUser,
-            role: null,
-          }),
-          location: expect.objectContaining({ id: collegeFLocationB.id }),
-        }),
-      ]),
-    );
+    expect(savedInstitutionUserAuths).toEqual([
+      {
+        id: expect.any(Number),
+        location: { id: collegeFLocationA.id },
+        authType: {
+          type: InstitutionUserTypes.user,
+          role: null,
+        },
+      },
+      {
+        id: expect.any(Number),
+        location: { id: collegeFLocationB.id },
+        authType: {
+          type: InstitutionUserTypes.readOnlyUser,
+          role: null,
+        },
+      },
+    ]);
   });
 
   afterAll(async () => {

--- a/sources/packages/backend/apps/api/src/route-controllers/institution-user/_tests_/e2e/institution-user.institutions.controller.createInstitutionUserWithAuth.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/institution-user/_tests_/e2e/institution-user.institutions.controller.createInstitutionUserWithAuth.e2e-spec.ts
@@ -8,7 +8,8 @@ import {
   getAuthRelatedEntities,
   getInstitutionToken,
   InstitutionTokenTypes,
-  mockBCeIDAccountDetails,
+  mockBCeIDAccountUserFound,
+  mockBCeIDAccountUserNotFound,
 } from "../../../../testHelpers";
 import {
   E2EDataSources,
@@ -70,7 +71,6 @@ describe("InstitutionUserInstitutionsController(e2e)-createInstitutionUserWithAu
 
   it("Should throw an UnprocessableEntityException error when the user passed in the payload is not found on BCeID.", async () => {
     // Arrange
-    const user = createFakeUser();
     const payload = {
       bceidUserId: faker.random.alpha({ count: 5 }),
       permissions: [
@@ -82,7 +82,7 @@ describe("InstitutionUserInstitutionsController(e2e)-createInstitutionUserWithAu
     };
 
     // Mock BCeID account method to return null response.
-    await mockBCeIDAccountDetails(appModule, user, collegeFInstitution, true);
+    await mockBCeIDAccountUserNotFound(appModule);
 
     // Institution token.
     const token = await getInstitutionToken(InstitutionTokenTypes.CollegeFUser);
@@ -121,7 +121,7 @@ describe("InstitutionUserInstitutionsController(e2e)-createInstitutionUserWithAu
     });
 
     // Mock BCeID account details.
-    await mockBCeIDAccountDetails(
+    await mockBCeIDAccountUserFound(
       appModule,
       user,
       collegeDLocation.institution,
@@ -163,7 +163,7 @@ describe("InstitutionUserInstitutionsController(e2e)-createInstitutionUserWithAu
     };
 
     // Mock get BCeID account details with the initial userName.
-    await mockBCeIDAccountDetails(
+    await mockBCeIDAccountUserFound(
       appModule,
       { ...user, userName: userGuid },
       collegeFInstitution,
@@ -203,7 +203,7 @@ describe("InstitutionUserInstitutionsController(e2e)-createInstitutionUserWithAu
     };
 
     // Mock get BCeID account details
-    await mockBCeIDAccountDetails(appModule, user, collegeFInstitution);
+    await mockBCeIDAccountUserFound(appModule, user, collegeFInstitution);
     // Institution token.
     const token = await getInstitutionToken(InstitutionTokenTypes.CollegeFUser);
     const endpoint = "/institutions/institution-user";

--- a/sources/packages/backend/apps/api/src/route-controllers/institution-user/_tests_/e2e/institution-user.institutions.controller.updateInstitutionUserWithAuth.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/institution-user/_tests_/e2e/institution-user.institutions.controller.updateInstitutionUserWithAuth.e2e-spec.ts
@@ -67,7 +67,12 @@ describe("InstitutionUserInstitutionsController(e2e)-updateInstitutionUserWithAu
   it("Should throw a HttpStatus Not Found (404) error when the user to be updated not found.", async () => {
     // Arrange
     const payload = {
-      permissions: [{ locationId: collegeFLocationA.id, userType: "user" }],
+      permissions: [
+        {
+          locationId: collegeFLocationA.id,
+          userType: InstitutionUserTypes.user,
+        },
+      ],
     };
 
     // Institution token.
@@ -104,7 +109,12 @@ describe("InstitutionUserInstitutionsController(e2e)-updateInstitutionUserWithAu
     await db.institutionUserAuth.save(institutionUserAuth);
 
     const payload = {
-      permissions: [{ locationId: collegeFLocationA.id, userType: "user" }],
+      permissions: [
+        {
+          locationId: collegeFLocationA.id,
+          userType: InstitutionUserTypes.user,
+        },
+      ],
     };
 
     // Institution token.
@@ -136,7 +146,12 @@ describe("InstitutionUserInstitutionsController(e2e)-updateInstitutionUserWithAu
     await db.institutionUserAuth.save(institutionUserAuth);
 
     const payload = {
-      permissions: [{ locationId: collegeFLocationA.id, userType: "user" }],
+      permissions: [
+        {
+          locationId: collegeFLocationA.id,
+          userType: InstitutionUserTypes.user,
+        },
+      ],
     };
 
     // Institution token.
@@ -172,8 +187,14 @@ describe("InstitutionUserInstitutionsController(e2e)-updateInstitutionUserWithAu
     const user = institutionUser.user;
     const payload = {
       permissions: [
-        { locationId: collegeFLocationA.id, userType: "read-only-user" },
-        { locationId: collegeFLocationB.id, userType: "user" },
+        {
+          locationId: collegeFLocationA.id,
+          userType: InstitutionUserTypes.readOnlyUser,
+        },
+        {
+          locationId: collegeFLocationB.id,
+          userType: InstitutionUserTypes.user,
+        },
       ],
     };
 
@@ -220,33 +241,35 @@ describe("InstitutionUserInstitutionsController(e2e)-updateInstitutionUserWithAu
     );
     const savedInstitutionUserAuths = await db.institutionUserAuth.find({
       select: {
+        id: true,
         location: {
           id: true,
         },
-        authType: { type: true },
+        authType: { type: true, role: true },
       },
-      relations: { institutionUser: true, location: true },
+      relations: { location: true, authType: true },
       where: { institutionUser: { id: institutionUser.id } },
+      loadEagerRelations: false,
     });
     expect(savedInstitutionUserAuths).toHaveLength(2);
-    expect(savedInstitutionUserAuths).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          authType: expect.objectContaining({
-            type: InstitutionUserTypes.readOnlyUser,
-            role: null,
-          }),
-          location: expect.objectContaining({ id: collegeFLocationA.id }),
-        }),
-        expect.objectContaining({
-          authType: expect.objectContaining({
-            type: InstitutionUserTypes.user,
-            role: null,
-          }),
-          location: expect.objectContaining({ id: collegeFLocationB.id }),
-        }),
-      ]),
-    );
+    expect(savedInstitutionUserAuths).toEqual([
+      {
+        id: expect.any(Number),
+        location: { id: collegeFLocationA.id },
+        authType: {
+          type: InstitutionUserTypes.readOnlyUser,
+          role: null,
+        },
+      },
+      {
+        id: expect.any(Number),
+        location: { id: collegeFLocationB.id },
+        authType: {
+          type: InstitutionUserTypes.user,
+          role: null,
+        },
+      },
+    ]);
   });
 
   afterAll(async () => {

--- a/sources/packages/backend/apps/api/src/route-controllers/institution-user/_tests_/e2e/institution-user.institutions.controller.updateInstitutionUserWithAuth.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/institution-user/_tests_/e2e/institution-user.institutions.controller.updateInstitutionUserWithAuth.e2e-spec.ts
@@ -1,0 +1,255 @@
+import { HttpStatus, INestApplication } from "@nestjs/common";
+import * as request from "supertest";
+import {
+  authorizeUserTokenForLocation,
+  BEARER_AUTH_TYPE,
+  createTestingAppModule,
+  getAuthRelatedEntities,
+  getInstitutionToken,
+  InstitutionTokenTypes,
+} from "../../../../testHelpers";
+import {
+  E2EDataSources,
+  createE2EDataSources,
+  createFakeInstitutionLocation,
+  createFakeInstitutionUser,
+  createFakeInstitutionUserAuth,
+  createFakeUser,
+} from "@sims/test-utils";
+import {
+  Institution,
+  InstitutionLocation,
+  InstitutionUserTypeAndRole,
+  InstitutionUserTypes,
+} from "@sims/sims-db";
+
+describe("InstitutionUserInstitutionsController(e2e)-updateInstitutionUserWithAuth", () => {
+  let app: INestApplication;
+  let db: E2EDataSources;
+  let collegeFLocationA: InstitutionLocation;
+  let collegeFLocationB: InstitutionLocation;
+  let collegeFInstitution: Institution;
+  let institutionUserRole: InstitutionUserTypeAndRole;
+
+  beforeAll(async () => {
+    const { nestApplication, dataSource } = await createTestingAppModule();
+    app = nestApplication;
+    db = createE2EDataSources(dataSource);
+    // College F.
+    const { institution: collegeF } = await getAuthRelatedEntities(
+      db.dataSource,
+      InstitutionTokenTypes.CollegeFUser,
+    );
+    // Location A.
+    collegeFLocationA = createFakeInstitutionLocation({
+      institution: collegeF,
+    });
+    // Location B.
+    collegeFLocationB = createFakeInstitutionLocation({
+      institution: collegeF,
+    });
+    await authorizeUserTokenForLocation(
+      db.dataSource,
+      InstitutionTokenTypes.CollegeFUser,
+      collegeFLocationA,
+    );
+    await authorizeUserTokenForLocation(
+      db.dataSource,
+      InstitutionTokenTypes.CollegeFUser,
+      collegeFLocationB,
+    );
+    collegeFInstitution = collegeFLocationA.institution;
+    institutionUserRole = await db.institutionUserTypeAndRole.findOne({
+      where: { type: InstitutionUserTypes.user },
+    });
+  });
+
+  it("Should throw a HttpStatus Not Found (404) error when the user to be updated not found.", async () => {
+    // Arrange
+    const payload = {
+      permissions: [{ locationId: collegeFLocationA.id, userType: "user" }],
+    };
+
+    // Institution token.
+    const token = await getInstitutionToken(InstitutionTokenTypes.CollegeFUser);
+    const endpoint = "/institutions/institution-user/99999";
+
+    // Act/Assert
+    await request(app.getHttpServer())
+      .patch(endpoint)
+      .send(payload)
+      .auth(token, BEARER_AUTH_TYPE)
+      .expect(HttpStatus.NOT_FOUND)
+      .expect({
+        message: "User to be updated not found.",
+        error: "Not Found",
+        statusCode: HttpStatus.NOT_FOUND,
+      });
+  });
+
+  it("Should throw a UnprocessableEntityException error when the user to be updated is an inactive user.", async () => {
+    // Arrange
+    const user = createFakeUser();
+    user.isActive = false;
+    const institutionUser = createFakeInstitutionUser(
+      user,
+      collegeFInstitution,
+    );
+    await db.institutionUser.save(institutionUser);
+    const institutionUserAuth = createFakeInstitutionUserAuth(
+      institutionUser,
+      institutionUserRole,
+      collegeFLocationA,
+    );
+    await db.institutionUserAuth.save(institutionUserAuth);
+
+    const payload = {
+      permissions: [{ locationId: collegeFLocationA.id, userType: "user" }],
+    };
+
+    // Institution token.
+    const token = await getInstitutionToken(InstitutionTokenTypes.CollegeFUser);
+    const endpoint = `/institutions/institution-user/${institutionUser.id}`;
+
+    // Act/Assert
+    await request(app.getHttpServer())
+      .patch(endpoint)
+      .send(payload)
+      .auth(token, BEARER_AUTH_TYPE)
+      .expect(HttpStatus.UNPROCESSABLE_ENTITY)
+      .expect({
+        message: "Not able to edit an inactive user.",
+        error: "Unprocessable Entity",
+        statusCode: HttpStatus.UNPROCESSABLE_ENTITY,
+      });
+  });
+
+  it("Should throw a HttpStatus Forbidden error when the user to be updated does not belong to the institution.", async () => {
+    // Arrange
+    const institutionUser = createFakeInstitutionUser();
+    await db.institutionUser.save(institutionUser);
+    const institutionUserAuth = createFakeInstitutionUserAuth(
+      institutionUser,
+      institutionUserRole,
+      collegeFLocationA,
+    );
+    await db.institutionUserAuth.save(institutionUserAuth);
+
+    const payload = {
+      permissions: [{ locationId: collegeFLocationA.id, userType: "user" }],
+    };
+
+    // Institution token.
+    const token = await getInstitutionToken(InstitutionTokenTypes.CollegeFUser);
+    const endpoint = `/institutions/institution-user/${institutionUser.id}`;
+
+    // Act/Assert
+    await request(app.getHttpServer())
+      .patch(endpoint)
+      .send(payload)
+      .auth(token, BEARER_AUTH_TYPE)
+      .expect(HttpStatus.FORBIDDEN)
+      .expect({
+        message: "User to be updated does not belong to the institution.",
+        error: "Forbidden",
+        statusCode: HttpStatus.FORBIDDEN,
+      });
+  });
+
+  it("Should update an institution user with user and read-only auth types when valid data is passed.", async () => {
+    // Arrange
+    const institutionUser = createFakeInstitutionUser(
+      createFakeUser(),
+      collegeFInstitution,
+    );
+    await db.institutionUser.save(institutionUser);
+    const institutionUserAuth = createFakeInstitutionUserAuth(
+      institutionUser,
+      institutionUserRole,
+      collegeFLocationA,
+    );
+    await db.institutionUserAuth.save(institutionUserAuth);
+    const user = institutionUser.user;
+    const payload = {
+      permissions: [
+        { locationId: collegeFLocationA.id, userType: "read-only-user" },
+        { locationId: collegeFLocationB.id, userType: "user" },
+      ],
+    };
+
+    // Institution token.
+    const token = await getInstitutionToken(InstitutionTokenTypes.CollegeFUser);
+    const endpoint = `/institutions/institution-user/${institutionUser.id}`;
+
+    // Act/Assert
+    await request(app.getHttpServer())
+      .patch(endpoint)
+      .send(payload)
+      .auth(token, BEARER_AUTH_TYPE)
+      .expect(HttpStatus.OK);
+    const savedInstitutionUser = await db.institutionUser.findOne({
+      select: {
+        user: {
+          userName: true,
+          email: true,
+          firstName: true,
+          lastName: true,
+        },
+        institution: {
+          id: true,
+          businessGuid: true,
+          legalOperatingName: true,
+        },
+      },
+      where: { id: institutionUser.id },
+    });
+    expect(savedInstitutionUser.user).toEqual(
+      expect.objectContaining({
+        userName: user.userName,
+        email: user.email,
+        firstName: user.firstName,
+        lastName: user.lastName,
+      }),
+    );
+    expect(savedInstitutionUser.institution).toEqual(
+      expect.objectContaining({
+        id: collegeFInstitution.id,
+        businessGuid: collegeFInstitution.businessGuid,
+        legalOperatingName: collegeFInstitution.legalOperatingName,
+      }),
+    );
+    const savedInstitutionUserAuths = await db.institutionUserAuth.find({
+      select: {
+        location: {
+          id: true,
+        },
+        authType: { type: true },
+      },
+      relations: { institutionUser: true, location: true },
+      where: { institutionUser: { id: institutionUser.id } },
+    });
+    expect(savedInstitutionUserAuths).toHaveLength(2);
+    expect(savedInstitutionUserAuths).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          authType: expect.objectContaining({
+            type: InstitutionUserTypes.readOnlyUser,
+            role: null,
+          }),
+          location: expect.objectContaining({ id: collegeFLocationA.id }),
+        }),
+        expect.objectContaining({
+          authType: expect.objectContaining({
+            type: InstitutionUserTypes.user,
+            role: null,
+          }),
+          location: expect.objectContaining({ id: collegeFLocationB.id }),
+        }),
+      ]),
+    );
+  });
+
+  afterAll(async () => {
+    await app?.close();
+  });
+});

--- a/sources/packages/backend/apps/api/src/testHelpers/auth/bceid-helpers.ts
+++ b/sources/packages/backend/apps/api/src/testHelpers/auth/bceid-helpers.ts
@@ -10,14 +10,12 @@ import { BCeIDService } from "../../services";
  * @param user a persisted user object.
  * @param displayName a persisted display name for user login.
  * @param institution a persisted institution object.
- * @param returnsNull indicates whether mocks a null response.
  * @returns a persisted BCeID account object.
  */
-export async function mockBCeIDAccountDetails(
+export async function mockBCeIDAccountUserFound(
   testingModule: TestingModule,
   user: User,
   institution: Institution,
-  returnsNull?: boolean,
 ): Promise<jest.SpyInstance> {
   const bceIDService = await getProviderInstanceForModule(
     testingModule,
@@ -27,21 +25,43 @@ export async function mockBCeIDAccountDetails(
   return jest
     .spyOn(bceIDService, "getAccountDetails")
     .mockImplementation(() => {
-      const response = returnsNull
-        ? null
-        : {
-            user: {
-              guid: user.userName,
-              displayName: `${user.firstName}_${user.lastName}`,
-              firstname: user.firstName,
-              surname: user.lastName,
-              email: user.email,
-            },
-            institution: {
-              guid: institution.businessGuid,
-              legalName: institution.legalOperatingName,
-            },
-          };
+      const response = {
+        user: {
+          guid: user.userName,
+          displayName: `${user.firstName}_${user.lastName}`,
+          firstname: user.firstName,
+          surname: user.lastName,
+          email: user.email,
+        },
+        institution: {
+          guid: institution.businessGuid,
+          legalName: institution.legalOperatingName,
+        },
+      };
+      return Promise.resolve(response);
+    });
+}
+
+/**
+ * Mocks BCeID account info from BCeID service to return null.
+ * @param testingModule nest testing module.
+ * @param user a persisted user object.
+ * @param displayName a persisted display name for user login.
+ * @param institution a persisted institution object.
+ * @returns a persisted BCeID account object.
+ */
+export async function mockBCeIDAccountUserNotFound(
+  testingModule: TestingModule,
+): Promise<jest.SpyInstance> {
+  const bceIDService = await getProviderInstanceForModule(
+    testingModule,
+    AppInstitutionsModule,
+    BCeIDService,
+  );
+  return jest
+    .spyOn(bceIDService, "getAccountDetails")
+    .mockImplementation(() => {
+      const response = null;
       return Promise.resolve(response);
     });
 }

--- a/sources/packages/backend/apps/api/src/testHelpers/auth/bceid-helpers.ts
+++ b/sources/packages/backend/apps/api/src/testHelpers/auth/bceid-helpers.ts
@@ -1,0 +1,47 @@
+import { TestingModule } from "@nestjs/testing";
+import { Institution, User } from "@sims/sims-db";
+import { getProviderInstanceForModule } from "@sims/test-utils";
+import { AppInstitutionsModule } from "../../app.institutions.module";
+import { BCeIDService } from "../../services";
+
+/**
+ * Mocks BCeID account info from BCeID service to return the passed BCeID account.
+ * @param testingModule nest testing module.
+ * @param user a persisted user object.
+ * @param displayName a persisted display name for user login.
+ * @param institution a persisted institution object.
+ * @param returnsNull indicates whether mocks a null response.
+ * @returns a persisted BCeID account object.
+ */
+export async function mockBCeIDAccountDetails(
+  testingModule: TestingModule,
+  user: User,
+  institution: Institution,
+  returnsNull?: boolean,
+): Promise<jest.SpyInstance> {
+  const bceIDService = await getProviderInstanceForModule(
+    testingModule,
+    AppInstitutionsModule,
+    BCeIDService,
+  );
+  return jest
+    .spyOn(bceIDService, "getAccountDetails")
+    .mockImplementation(() => {
+      const response = returnsNull
+        ? null
+        : {
+            user: {
+              guid: user.userName,
+              displayName: `${user.firstName}_${user.lastName}`,
+              firstname: user.firstName,
+              surname: user.lastName,
+              email: user.email,
+            },
+            institution: {
+              guid: institution.businessGuid,
+              legalName: institution.legalOperatingName,
+            },
+          };
+      return Promise.resolve(response);
+    });
+}

--- a/sources/packages/backend/apps/api/src/testHelpers/auth/bceid-helpers.ts
+++ b/sources/packages/backend/apps/api/src/testHelpers/auth/bceid-helpers.ts
@@ -8,7 +8,6 @@ import { BCeIDService } from "../../services";
  * Mocks BCeID account info from BCeID service to return the passed BCeID account.
  * @param testingModule nest testing module.
  * @param user a persisted user object.
- * @param displayName a persisted display name for user login.
  * @param institution a persisted institution object.
  * @returns a persisted BCeID account object.
  */
@@ -45,9 +44,6 @@ export async function mockBCeIDAccountUserFound(
 /**
  * Mocks BCeID account info from BCeID service to return null.
  * @param testingModule nest testing module.
- * @param user a persisted user object.
- * @param displayName a persisted display name for user login.
- * @param institution a persisted institution object.
  * @returns a persisted BCeID account object.
  */
 export async function mockBCeIDAccountUserNotFound(

--- a/sources/packages/backend/apps/api/src/testHelpers/auth/index.ts
+++ b/sources/packages/backend/apps/api/src/testHelpers/auth/index.ts
@@ -1,6 +1,7 @@
 export * from "./token-helpers";
 export * from "./aest-token-helpers";
 export * from "./aest-auth-helpers";
+export * from "./bceid-helpers";
 export * from "./institution-token-helpers";
 export * from "./institution-auth-helpers";
 export * from "./student-token-helpers";

--- a/sources/packages/backend/libs/test-utils/src/data-source/e2e-data-source.ts
+++ b/sources/packages/backend/libs/test-utils/src/data-source/e2e-data-source.ts
@@ -62,6 +62,7 @@ import {
   CASDistributionAccount,
   SFASApplicationDependant,
   SFASApplicationDisbursement,
+  InstitutionUser,
 } from "@sims/sims-db";
 import { DataSource, Repository } from "typeorm";
 
@@ -114,6 +115,7 @@ export function createE2EDataSources(dataSource: DataSource): E2EDataSources {
     institutionLocation: dataSource.getRepository(InstitutionLocation),
     institutionType: dataSource.getRepository(InstitutionType),
     institutionRestriction: dataSource.getRepository(InstitutionRestriction),
+    institutionUser: dataSource.getRepository(InstitutionUser),
     institutionUserAuth: dataSource.getRepository(InstitutionUserAuth),
     institutionUserTypeAndRole: dataSource.getRepository(
       InstitutionUserTypeAndRole,
@@ -199,6 +201,7 @@ export interface E2EDataSources {
   institutionLocation: Repository<InstitutionLocation>;
   institutionType: Repository<InstitutionType>;
   institutionRestriction: Repository<InstitutionRestriction>;
+  institutionUser: Repository<InstitutionUser>;
   institutionUserAuth: Repository<InstitutionUserAuth>;
   institutionUserTypeAndRole: Repository<InstitutionUserTypeAndRole>;
   msfaaNumber: Repository<MSFAANumber>;


### PR DESCRIPTION
As the second part of this story, this PR has the following changes:
- Added E2E tests for the following endpoint methods:
  - createInstitutionUserWithAuth
  - updateInstitutionUserWithAuth
- Added method `mockBCeIDAccountDetails` to mock the response from method `bceIDService.getAccountDetails` to assist the endpoint method `createInstitutionUserWithAuth`.

Screenshots of E2E tests
![image](https://github.com/user-attachments/assets/b759d4f1-4dbe-45bc-b88e-9d7381cdcd50)

![image](https://github.com/user-attachments/assets/d3cfbda2-a9dd-4242-8f22-68cffb7a44c8)


