### PR TITLE
#4014 - Institution Read-Only User Type PART 2 (UI) (Part 3)

### DIFF
--- a/sources/packages/forms/src/form-definitions/programinformationrequest.json
+++ b/sources/packages/forms/src/form-definitions/programinformationrequest.json
@@ -2358,7 +2358,7 @@
             "eq": "",
             "json": ""
           },
-          "customConditional": "show = data['isReadOnlyUser'] !== true;",
+          "customConditional": "show = data.isReadOnlyUser !== true;",
           "logic": [],
           "attributes": {},
           "overlay": {

--- a/sources/packages/forms/src/form-definitions/programinformationrequest.json
+++ b/sources/packages/forms/src/form-definitions/programinformationrequest.json
@@ -2353,12 +2353,12 @@
           "tags": [],
           "properties": {},
           "conditional": {
-            "show": null,
+            "show": "",
             "when": null,
             "eq": "",
             "json": ""
           },
-          "customConditional": "",
+          "customConditional": "show = data['isReadOnlyUser'] !== true;",
           "logic": [],
           "attributes": {},
           "overlay": {

--- a/sources/packages/web/src/services/http/dto/ProgramInfoRequest.dto.ts
+++ b/sources/packages/web/src/services/http/dto/ProgramInfoRequest.dto.ts
@@ -35,6 +35,7 @@ export interface ProgramInfoRequestAPIOutDTO {
   courseDetails?: CourseDetails[];
   pirDenyReasonId?: number;
   otherReasonDesc?: string;
+  isReadOnlyUser?: boolean;
 }
 
 export interface PIRDeniedReasonAPIOutDTO {

--- a/sources/packages/web/src/views/institution/locations/offerings/OfferingEdit.vue
+++ b/sources/packages/web/src/views/institution/locations/offerings/OfferingEdit.vue
@@ -8,7 +8,9 @@
       >
         <template #buttons>
           <v-row class="p-0 m-0">
-            <v-menu v-if="hasExistingApplication">
+            <v-menu
+              v-if="hasExistingApplication && !isReadOnlyUser(locationId)"
+            >
               <template v-slot:activator="{ props }">
                 <v-btn
                   class="ml-2"
@@ -259,6 +261,7 @@ export default defineComponent({
       processing,
       submit,
       goBack,
+      isReadOnlyUser,
     };
   },
 });

--- a/sources/packages/web/src/views/institution/locations/program-info-request/LocationEditProgramInfoRequest.vue
+++ b/sources/packages/web/src/views/institution/locations/program-info-request/LocationEditProgramInfoRequest.vue
@@ -155,6 +155,8 @@ export default defineComponent({
             programRequestData.value.isExpiredProgram)
             ? null
             : programRequestData.value.selectedProgram,
+        // Hide the create program button for read-only user.
+        isReadOnlyUser: isReadOnlyUser(props.locationId),
       };
 
       // While loading a PIR that is in the some readonly status


### PR DESCRIPTION
This PR removes the two buttons related to program and offering executions for read-only users:
- Removed button "+ Create program" on the PIR page.
- Removed dropdown button "Edit offering" on the offering edit page.

Screenshots
![image](https://github.com/user-attachments/assets/55344aaa-5674-4135-8ed6-eb65c386c416)

![image](https://github.com/user-attachments/assets/f4a3e3b4-b3e1-49f5-9f33-c769b1cde94b)
