### PR TITLE
#4235 - Student File Upload - Reset after submit

### DIFF
--- a/sources/packages/web/src/types/formio.ts
+++ b/sources/packages/web/src/types/formio.ts
@@ -19,6 +19,10 @@ export interface FormIOForm<T = unknown> extends FormIOComponent {
   prevPage: () => WizardNavigationEvent;
   nextPage: () => WizardNavigationEvent;
   redraw: () => void;
+  /**
+   * Force a reset value on the form.
+   */
+  resetValue: () => Promise<void>;
   page: WizardNavigationEvent;
 }
 

--- a/sources/packages/web/src/views/student/StudentFileUploader.vue
+++ b/sources/packages/web/src/views/student/StudentFileUploader.vue
@@ -68,7 +68,8 @@ export default defineComponent({
         };
         await StudentService.shared.saveStudentFiles(payload);
         // Form reset and document list reload.
-        form.submission = {};
+        await form.resetValue();
+        form.redraw();
         reloadDocuments.value = !reloadDocuments.value;
         snackBar.success("Your documents have been submitted!");
       } catch (error: unknown) {


### PR DESCRIPTION
## Student File Upload - Reset after submit

- [x] Updated the formio object typed with `resetValue` from the formio SDK library. `resetValue()` is expected to do more than just resetting the values like setting the form to pristine .etc. 
- [x] Using reset and redraw to mitigate the error shown in student uploader after submit.

![image](https://github.com/user-attachments/assets/f03391b4-7669-451e-8f07-897f5a7f46ba)

![image](https://github.com/user-attachments/assets/7234edf7-46d7-473f-8c23-eb3e874ca42c)
