### PR TITLE
#3249 - Bridge Matching - Re-matching and persisting the match

### DIFF
--- a/sources/packages/backend/apps/api/src/route-controllers/application/_tests_/application.students.controller.submitApplication.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/application/_tests_/application.students.controller.submitApplication.e2e-spec.ts
@@ -149,9 +149,7 @@ describe("ApplicationStudentsController(e2e)-submitApplication", () => {
     const student = await saveFakeStudent(db.dataSource);
     const sfasIndividual = await saveFakeSFASIndividual(db.dataSource, {
       initialValues: {
-        lastName: student.user.lastName,
-        birthDate: student.birthDate,
-        sin: student.sinValidation.sin,
+        student,
       },
     });
     // First offering created with start date 30 days after the
@@ -203,6 +201,7 @@ describe("ApplicationStudentsController(e2e)-submitApplication", () => {
         secondApplicationOfferingInitialValues.offeringIntensity,
       selectedProgram: savedOffering.educationProgram.id,
       selectedOffering: savedOffering.id,
+      selectedLocation: savedOffering.institutionLocation.id,
     };
     const payload = {
       associatedFiles: [],
@@ -238,9 +237,7 @@ describe("ApplicationStudentsController(e2e)-submitApplication", () => {
     const student = await saveFakeStudent(db.dataSource);
     const sfasIndividual = await saveFakeSFASIndividual(db.dataSource, {
       initialValues: {
-        lastName: student.user.lastName,
-        birthDate: student.birthDate,
-        sin: student.sinValidation.sin,
+        student,
       },
     });
 
@@ -288,6 +285,7 @@ describe("ApplicationStudentsController(e2e)-submitApplication", () => {
         simsApplicationOfferingInitialValues.offeringIntensity,
       selectedProgram: savedOffering.educationProgram.id,
       selectedOffering: savedOffering.id,
+      selectedLocation: savedOffering.institutionLocation.id,
     };
     const payload = {
       associatedFiles: [],
@@ -408,11 +406,7 @@ describe("ApplicationStudentsController(e2e)-submitApplication", () => {
       // Arrange
       const student = await saveFakeStudent(db.dataSource);
       const sfasIndividual = await saveFakeSFASIndividual(db.dataSource, {
-        initialValues: {
-          lastName: student.user.lastName,
-          birthDate: student.birthDate,
-          sin: student.sinValidation.sin,
-        },
+        initialValues: { student },
       });
       // Cancelled SFAS full time application with overlapping study dates.
       const sfasFullTimeApplication = createFakeSFASApplication(
@@ -499,11 +493,7 @@ describe("ApplicationStudentsController(e2e)-submitApplication", () => {
       // Arrange
       const student = await saveFakeStudent(db.dataSource);
       const sfasIndividual = await saveFakeSFASIndividual(db.dataSource, {
-        initialValues: {
-          lastName: student.user.lastName,
-          birthDate: student.birthDate,
-          sin: student.sinValidation.sin,
-        },
+        initialValues: { student },
       });
       // Cancelled SFAS full time application with overlapping study dates.
       const sfasPartTimeApplication = createFakeSFASPartTimeApplication(

--- a/sources/packages/backend/apps/api/src/route-controllers/application/application.students.controller.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/application/application.students.controller.ts
@@ -316,10 +316,8 @@ export class ApplicationStudentsController extends BaseController {
     try {
       await this.applicationService.validateOverlappingDates(
         applicationId,
-        student.user.lastName,
         studentToken.userId,
-        student.sinValidation.sin,
-        student.birthDate,
+        student.id,
         referenceStudyStartDate,
         referencedStudyEndDate,
       );

--- a/sources/packages/backend/apps/api/src/route-controllers/application/application.students.controller.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/application/application.students.controller.ts
@@ -300,9 +300,6 @@ export class ApplicationStudentsController extends BaseController {
       submissionResult.data.data.howWillYouBeAttendingTheProgram,
     );
 
-    const student = await this.studentService.getStudentById(
-      studentToken.studentId,
-    );
     // If offering is present, the selected offering's start and end dates will be used.
     let referenceStudyStartDate =
       submissionResult.data.data.selectedOfferingDate;
@@ -317,14 +314,14 @@ export class ApplicationStudentsController extends BaseController {
       await this.applicationService.validateOverlappingDates(
         applicationId,
         studentToken.userId,
-        student.id,
+        studentToken.studentId,
         referenceStudyStartDate,
         referencedStudyEndDate,
       );
       await this.applicationService.submitApplication(
         applicationId,
         studentToken.userId,
-        student.id,
+        studentToken.studentId,
         programYear.id,
         submissionResult.data.data,
         payload.associatedFiles,

--- a/sources/packages/backend/apps/api/src/route-controllers/student-account-applications/_test_/e2e/student-account-application.aest.controller.approveStudentAccountApplication.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/student-account-applications/_test_/e2e/student-account-application.aest.controller.approveStudentAccountApplication.e2e-spec.ts
@@ -13,6 +13,7 @@ import {
   createFakeUser,
   getProviderInstanceForModule,
   saveFakeSFASIndividual,
+  saveFakeStudent,
 } from "@sims/test-utils";
 import { AppAESTModule } from "../../../../app.aest.module";
 import { FormNames, FormService } from "../../../../services";
@@ -249,6 +250,7 @@ describe("StudentAccountApplicationAESTController(e2e)-approveStudentAccountAppl
     // Arrange
     const user = await db.user.save(createFakeUser());
     const submittedData = createFakeSubmittedData(user);
+    const student = await saveFakeStudent(db.dataSource, { user });
 
     // Save the fake student account application to be later approved by the Ministry
     // and create the Student Account.
@@ -264,6 +266,7 @@ describe("StudentAccountApplicationAESTController(e2e)-approveStudentAccountAppl
         lastName: user.lastName,
         birthDate: submittedData.dateOfBirth,
         sin: submittedData.sinNumber,
+        student,
         cslOveraward: 1000,
         bcslOveraward: 2000,
       },

--- a/sources/packages/backend/apps/api/src/route-controllers/student-account-applications/_test_/e2e/student-account-application.aest.controller.approveStudentAccountApplication.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/student-account-applications/_test_/e2e/student-account-application.aest.controller.approveStudentAccountApplication.e2e-spec.ts
@@ -13,7 +13,6 @@ import {
   createFakeUser,
   getProviderInstanceForModule,
   saveFakeSFASIndividual,
-  saveFakeStudent,
 } from "@sims/test-utils";
 import { AppAESTModule } from "../../../../app.aest.module";
 import { FormNames, FormService } from "../../../../services";
@@ -244,75 +243,6 @@ describe("StudentAccountApplicationAESTController(e2e)-approveStudentAccountAppl
         matchTime: expect.any(String),
       },
     });
-  });
-
-  it("Should create disbursement overawards when an exact match is found with matching last name, birth dates and SIN for importing a student record with disbursement overawards from SFAS.", async () => {
-    // Arrange
-    const user = await db.user.save(createFakeUser());
-    const submittedData = createFakeSubmittedData(user);
-    const student = await saveFakeStudent(db.dataSource, { user });
-
-    // Save the fake student account application to be later approved by the Ministry
-    // and create the Student Account.
-    const studentAccountApplication = await db.studentAccountApplication.save(
-      createFakeStudentAccountApplication(
-        { user },
-        { initialValues: { submittedData } },
-      ),
-    );
-
-    const sfasIndividual = await saveFakeSFASIndividual(db.dataSource, {
-      initialValues: {
-        lastName: user.lastName,
-        birthDate: submittedData.dateOfBirth,
-        sin: submittedData.sinNumber,
-        student,
-        cslOveraward: 1000,
-        bcslOveraward: 2000,
-      },
-    });
-
-    const endpoint = `/aest/student-account-application/${studentAccountApplication.id}/approve`;
-    const token = await getAESTToken(AESTGroups.BusinessAdministrators);
-    // Mock the form.io response.
-    sharedFormService.dryRunSubmission = jest.fn().mockResolvedValue({
-      valid: true,
-      formName: FormNames.StudentProfile,
-      data: { data: submittedData },
-    });
-
-    // Act/Assert
-    await request(app.getHttpServer())
-      .post(endpoint)
-      .send(submittedData)
-      .auth(token, BEARER_AUTH_TYPE)
-      .expect(HttpStatus.CREATED)
-      .then((response) => {
-        expect(response.body.id).toBeGreaterThan(0);
-      });
-
-    // Check that the disbursement overawards are created.
-    const disbursementOverawards = await db.disbursementOveraward.find({
-      select: {
-        overawardValue: true,
-        originType: true,
-      },
-      where: {
-        student: { id: sfasIndividual.student.id },
-      },
-    });
-    expect(disbursementOverawards).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          overawardValue: 1000,
-          originType: "Legacy overaward",
-        }),
-        expect.objectContaining({
-          overawardValue: 2000,
-          originType: "Legacy overaward",
-        }),
-      ]),
-    );
   });
 
   afterAll(async () => {

--- a/sources/packages/backend/apps/api/src/route-controllers/student-scholastic-standings/_tests_/e2e/student-scholastic-standings.aest.controller.getScholasticStandingSummary.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/student-scholastic-standings/_tests_/e2e/student-scholastic-standings.aest.controller.getScholasticStandingSummary.e2e-spec.ts
@@ -43,6 +43,7 @@ describe("StudentScholasticStandingsAESTController(e2e)-getScholasticStandingSum
         lastName: student.user.lastName,
         birthDate: student.birthDate,
         sin: student.sinValidation.sin,
+        student,
         unsuccessfulCompletion: 12,
       },
     });

--- a/sources/packages/backend/apps/api/src/route-controllers/student-scholastic-standings/_tests_/e2e/student-scholastic-standings.institutions.controller.getScholasticStandingSummary.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/student-scholastic-standings/_tests_/e2e/student-scholastic-standings.institutions.controller.getScholasticStandingSummary.e2e-spec.ts
@@ -114,6 +114,7 @@ describe("StudentScholasticStandingsInstitutionsController(e2e)-getScholasticSta
         lastName: student.user.lastName,
         birthDate: student.birthDate,
         sin: student.sinValidation.sin,
+        student,
         unsuccessfulCompletion: 12,
       },
     });

--- a/sources/packages/backend/apps/api/src/route-controllers/student-scholastic-standings/_tests_/e2e/student-scholastic-standings.students.controller.getScholasticStandingSummary.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/student-scholastic-standings/_tests_/e2e/student-scholastic-standings.students.controller.getScholasticStandingSummary.e2e-spec.ts
@@ -50,6 +50,7 @@ describe("StudentScholasticStandingsStudentsController(e2e)-getScholasticStandin
         lastName: student.user.lastName,
         birthDate: student.birthDate,
         sin: student.sinValidation.sin,
+        student,
         unsuccessfulCompletion: 12,
       },
     });

--- a/sources/packages/backend/apps/api/src/services/application/application.service.ts
+++ b/sources/packages/backend/apps/api/src/services/application/application.service.ts
@@ -1456,20 +1456,16 @@ export class ApplicationService extends RecordDataModelService<Application> {
   /**
    * Validation for application overlapping dates or Pending PIR.
    * This validation can be disabled by setting BYPASS_APPLICATION_SUBMIT_VALIDATIONS to true in .env file.
-   * @param applicationId
-   * @param lastName
-   * @param userId
-   * @param sin
-   * @param birthDate
-   * @param studyStartDate
-   * @param studyEndDate
+   * @param applicationId application id.
+   * @param userId user id.
+   * @param studentId student id.
+   * @param studyStartDate study start date.
+   * @param studyEndDate study end date.
    */
   async validateOverlappingDates(
     applicationId: number,
-    lastName: string,
     userId: number,
-    sin: string,
-    birthDate: string,
+    studentId: number,
     studyStartDate: string,
     studyEndDate: string,
   ): Promise<void> {
@@ -1483,18 +1479,14 @@ export class ApplicationService extends RecordDataModelService<Application> {
 
       const existingSFASFTApplication =
         this.sfasApplicationService.validateDateOverlap(
-          sin,
-          birthDate,
-          lastName,
+          studentId,
           studyStartDate,
           studyEndDate,
         );
 
       const existingSFASPTApplication =
         this.sfasPartTimeApplicationsService.validateDateOverlap(
-          sin,
-          birthDate,
-          lastName,
+          studentId,
           studyStartDate,
           studyEndDate,
         );
@@ -1779,10 +1771,8 @@ export class ApplicationService extends RecordDataModelService<Application> {
     // Validate possible overlaps with exists applications.
     await this.validateOverlappingDates(
       application.id,
-      application.student.user.lastName,
       application.student.user.id,
-      application.student.sinValidation.sin,
-      application.student.birthDate,
+      application.student.id,
       offering.studyStartDate,
       offering.studyEndDate,
     );

--- a/sources/packages/backend/apps/api/src/services/student/student.service.ts
+++ b/sources/packages/backend/apps/api/src/services/student/student.service.ts
@@ -749,9 +749,7 @@ export class StudentService extends RecordDataModelService<Student> {
   /**
    * Search for the student's SFAS data and update overaward values in
    * disbursement overawards table if any overaward values for BCSL or CSLF exist.
-   * @param studentId student id for the disbursement overaward record.
-   * @param lastName last name for sfas individuals.
-   * @param sinNumber student's sin number.
+   * @param studentId student id for finding a SFAS individual.
    * @param auditUserId user that should be considered the one that is causing the changes.
    * @param entityManager entityManager to be used to perform the query.
    */

--- a/sources/packages/backend/apps/api/src/services/student/student.service.ts
+++ b/sources/packages/backend/apps/api/src/services/student/student.service.ts
@@ -232,10 +232,7 @@ export class StudentService extends RecordDataModelService<Student> {
 
       if (sfasIndividual) {
         await this.importSFASOverawards(
-          student.id,
-          student.user.lastName,
-          student.birthDate,
-          studentSIN,
+          sfasIndividual.student.id,
           auditUserId,
           entityManager,
         );
@@ -760,16 +757,11 @@ export class StudentService extends RecordDataModelService<Student> {
    */
   async importSFASOverawards(
     studentId: number,
-    lastName: string,
-    birthDate: string,
-    sinNumber: string,
     auditUserId: number,
     entityManager: EntityManager,
   ): Promise<void> {
     const sfasIndividual = await this.sfasIndividualService.getSFASOverawards(
-      lastName,
-      birthDate,
-      sinNumber,
+      studentId,
     );
     if (!sfasIndividual) {
       return;

--- a/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/sfas-integration/_tests_/sfas-integration.scheduler.e2e-spec.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/sfas-integration/_tests_/sfas-integration.scheduler.e2e-spec.ts
@@ -529,30 +529,21 @@ describe(describeProcessorRootTest(QueueNames.SFASIntegration), () => {
       "where the record type is the individual data record.",
     async () => {
       // Arrange
-      let student = await db.student.findOne({
-        where: {
-          birthDate: getISODateOnlyString(new Date("1966-07-21")),
-          user: { lastName: "INNAVOIG" },
-          sinValidation: { sin: "121380175" },
+      const user = createFakeUser();
+      user.lastName = "INNAVOIG";
+      const student = await saveFakeStudent(
+        db.dataSource,
+        { user },
+        { initialValue: { birthDate: "1966-07-21" } },
+      );
+      const sinValidation = createFakeSINValidation(
+        {
+          student,
         },
-      });
-      if (!student) {
-        const user = createFakeUser();
-        user.lastName = "INNAVOIG";
-        student = await saveFakeStudent(
-          db.dataSource,
-          { user },
-          { initialValue: { birthDate: "1966-07-21" } },
-        );
-        const sinValidation = createFakeSINValidation(
-          {
-            student,
-          },
-          { initialValue: { sin: "121380175" } },
-        );
-        student.sinValidation = sinValidation;
-        await db.student.save(student);
-      }
+        { initialValue: { sin: "121380175" } },
+      );
+      student.sinValidation = sinValidation;
+      await db.student.save(student);
       // Queued job.
       const mockedJob = mockBullJob<void>();
       mockDownloadFiles(sftpClientMock, [

--- a/sources/packages/backend/apps/workers/src/controllers/assessment/_tests_/e2e/assessment.controller-verifyAssessmentCalculationOrder.e2e-spec.ts
+++ b/sources/packages/backend/apps/workers/src/controllers/assessment/_tests_/e2e/assessment.controller-verifyAssessmentCalculationOrder.e2e-spec.ts
@@ -433,6 +433,7 @@ describe("AssessmentController(e2e)-verifyAssessmentCalculationOrder", () => {
         lastName: student.user.lastName,
         birthDate: student.birthDate,
         sin: student.sinValidation.sin,
+        student,
       },
     });
     // First SFAS application with the start date before the first assessment date of the current application.
@@ -586,6 +587,7 @@ describe("AssessmentController(e2e)-verifyAssessmentCalculationOrder", () => {
           lastName: student.user.lastName,
           birthDate: student.birthDate,
           sin: student.sinValidation.sin,
+          student,
         },
       });
       // Past SFAS application with the start date before the first assessment date of the current application and cancelled.
@@ -729,6 +731,7 @@ describe("AssessmentController(e2e)-verifyAssessmentCalculationOrder", () => {
         lastName: student.user.lastName,
         birthDate: student.birthDate,
         sin: student.sinValidation.sin,
+        student,
       },
     });
     // First SFAS application with the start date before the first assessment date of the current application.
@@ -879,6 +882,7 @@ describe("AssessmentController(e2e)-verifyAssessmentCalculationOrder", () => {
         lastName: student.user.lastName,
         birthDate: student.birthDate,
         sin: student.sinValidation.sin,
+        student,
       },
     });
 

--- a/sources/packages/backend/libs/integrations/src/sfas-integration/sfas-integration.processing.service.ts
+++ b/sources/packages/backend/libs/integrations/src/sfas-integration/sfas-integration.processing.service.ts
@@ -58,7 +58,7 @@ export class SFASIntegrationProcessingService {
         "There are no files to be processed, but post-file import operations will be executed.",
       );
     }
-    await this.postFileImportOperations(!!filePaths.length, processSummary);
+    await this.postFileImportOperations(processSummary);
   }
 
   /**
@@ -158,12 +158,10 @@ export class SFASIntegrationProcessingService {
    * Responsible for completing the post file import operations.
    * These include updating the student ids, disbursement overawards
    * and inserting student restrictions.
-   * @param executeDisbursementOverawardsUpdate boolean indicating if the disbursement overawards update should execute or not.
    * @param processSummary process summary for logging.
    * @returns postFileImportResult process sftp response result object.
    */
   private async postFileImportOperations(
-    executeDisbursementOverawardsUpdate: boolean,
     processSummary: ProcessSummary,
   ): Promise<void> {
     // The following sequence of actions take place after the files have been imported and processed.
@@ -178,15 +176,13 @@ export class SFASIntegrationProcessingService {
       await this.sfasIndividualImportService.updateStudentId();
       processSummary.info("Student ids updated.");
       // Update the disbursement overawards if there is at least one file to process.
-      if (executeDisbursementOverawardsUpdate) {
-        processSummary.info(
-          "Updating and inserting new disbursement overaward balances from sfas to disbursement overawards table.",
-        );
-        await this.sfasIndividualImportService.updateDisbursementOverawards();
-        processSummary.info(
-          "New disbursement overaward balances inserted to disbursement overawards table.",
-        );
-      }
+      processSummary.info(
+        "Updating and inserting new disbursement overaward balances from sfas to disbursement overawards table.",
+      );
+      await this.sfasIndividualImportService.updateDisbursementOverawards();
+      processSummary.info(
+        "New disbursement overaward balances inserted to disbursement overawards table.",
+      );
       processSummary.info(
         "Inserting student restrictions from SFAS restrictions data.",
       );

--- a/sources/packages/backend/libs/services/src/sfas/sfas-application.service.ts
+++ b/sources/packages/backend/libs/services/src/sfas/sfas-application.service.ts
@@ -34,9 +34,8 @@ export class SFASApplicationService extends DataModelService<SFASApplication> {
       .createQueryBuilder("sfasApplication")
       .select(["sfasApplication.id"])
       .innerJoin("sfasApplication.individual", "sfasIndividual")
-      .innerJoin("sfasIndividual.student", "student")
       .where("sfasApplication.applicationCancelDate IS NULL")
-      .andWhere("student.id = :studentId", { studentId })
+      .andWhere("sfasIndividual.student.id = :studentId", { studentId })
       .andWhere(
         new Brackets((qb) => {
           qb.where(

--- a/sources/packages/backend/libs/services/src/sfas/sfas-application.service.ts
+++ b/sources/packages/backend/libs/services/src/sfas/sfas-application.service.ts
@@ -20,30 +20,23 @@ export class SFASApplicationService extends DataModelService<SFASApplication> {
 
   /**
    * Validates before an application submission to see if there is an overlapping SFAS fulltime application existing.
-   * @param sin
-   * @param birthDate
-   * @param lastName
-   * @param studyStartDate
-   * @param studyEndDate
+   * @param studentId student id.
+   * @param studyStartDate study start date.
+   * @param studyEndDate study end date.
    * @returns SFAS fulltime application.
    */
   async validateDateOverlap(
-    sin: string,
-    birthDate: string,
-    lastName: string,
+    studentId: number,
     studyStartDate: string,
     studyEndDate: string,
   ): Promise<SFASApplication> {
     return this.repo
       .createQueryBuilder("sfasApplication")
       .select(["sfasApplication.id"])
-      .innerJoin("sfasApplication.individual", "sfasFTstudent")
+      .innerJoin("sfasApplication.individual", "sfasIndividual")
+      .innerJoin("sfasIndividual.student", "student")
       .where("sfasApplication.applicationCancelDate IS NULL")
-      .andWhere("lower(sfasFTstudent.lastName) = lower(:lastName)", {
-        lastName,
-      })
-      .andWhere("sfasFTstudent.sin = :sin", { sin })
-      .andWhere("sfasFTstudent.birthDate = :birthDate", { birthDate })
+      .andWhere("student.id = :studentId", { studentId })
       .andWhere(
         new Brackets((qb) => {
           qb.where(

--- a/sources/packages/backend/libs/services/src/sfas/sfas-individual.service.ts
+++ b/sources/packages/backend/libs/services/src/sfas/sfas-individual.service.ts
@@ -35,9 +35,7 @@ export class SFASIndividualService {
         "individual.pdStatus",
         "individual.ppdStatus",
         "individual.ppdStatusDate",
-        "student.id",
       ])
-      .innerJoin("individual.student", "student")
       .where("lower(individual.lastName) = :lastName", {
         lastName: lastName.toLowerCase(),
       })
@@ -92,24 +90,6 @@ export class SFASIndividualService {
         }),
       )
       .getOne();
-  }
-
-  /**
-   * Search for a record in SFAS table using student details.
-   * @param studentId Student id.
-   * @returns SFAS individual details.
-   */
-  async getSFASOverawards(studentId: number): Promise<SFASIndividual> {
-    return await this.sfasIndividualRepo.findOne({
-      select: {
-        id: true,
-        cslOveraward: true,
-        bcslOveraward: true,
-      },
-      where: {
-        student: { id: studentId },
-      },
-    });
   }
 
   /**

--- a/sources/packages/backend/libs/services/src/sfas/sfas-individual.service.ts
+++ b/sources/packages/backend/libs/services/src/sfas/sfas-individual.service.ts
@@ -106,8 +106,7 @@ export class SFASIndividualService {
         "SUM(sfasIndividual.unsuccessfulCompletion)::int",
         "totalUnsuccessfulWeeks",
       )
-      .innerJoin("sfasIndividual.student", "student")
-      .where("student.id = :studentId", { studentId })
+      .where("sfasIndividual.student.id = :studentId", { studentId })
       .getRawOne<SFASIndividualDataSummary>();
     return sfasIndividualData?.totalUnsuccessfulWeeks;
   }

--- a/sources/packages/backend/libs/services/src/sfas/sfas-individual.service.ts
+++ b/sources/packages/backend/libs/services/src/sfas/sfas-individual.service.ts
@@ -120,33 +120,14 @@ export class SFASIndividualService {
   async getSFASTotalUnsuccessfulCompletionWeeks(
     studentId: number,
   ): Promise<number | null> {
-    const studentData = await this.studentRepo.findOne({
-      select: {
-        id: true,
-        birthDate: true,
-        sinValidation: { sin: true },
-        user: { lastName: true },
-      },
-      relations: {
-        sinValidation: true,
-        user: true,
-      },
-      where: {
-        id: studentId,
-      },
-    });
-    const sin = studentData.sinValidation.sin;
-    const birthDate = studentData.birthDate;
-    const lastName = studentData.user.lastName;
     const sfasIndividualData = await this.sfasIndividualRepo
       .createQueryBuilder("sfasIndividual")
       .select(
         "SUM(sfasIndividual.unsuccessfulCompletion)::int",
         "totalUnsuccessfulWeeks",
       )
-      .where("sin = :sin", { sin })
-      .andWhere("birth_date = :birthDate", { birthDate })
-      .andWhere("LOWER(last_name) = LOWER(:lastName)", { lastName })
+      .innerJoin("sfasIndividual.student", "student")
+      .where("student.id = :studentId", { studentId })
       .getRawOne<SFASIndividualDataSummary>();
     return sfasIndividualData?.totalUnsuccessfulWeeks;
   }

--- a/sources/packages/backend/libs/services/src/sfas/sfas-individual.service.ts
+++ b/sources/packages/backend/libs/services/src/sfas/sfas-individual.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from "@nestjs/common";
-import { Brackets, Raw, Repository } from "typeorm";
+import { Brackets, Repository } from "typeorm";
 import { SFASIndividual, Student } from "@sims/sims-db";
 import { SFASIndividualDataSummary } from "./sfas-individual.model";
 import { InjectRepository } from "@nestjs/typeorm";
@@ -35,7 +35,9 @@ export class SFASIndividualService {
         "individual.pdStatus",
         "individual.ppdStatus",
         "individual.ppdStatusDate",
+        "student.id",
       ])
+      .innerJoin("individual.student", "student")
       .where("lower(individual.lastName) = :lastName", {
         lastName: lastName.toLowerCase(),
       })
@@ -94,16 +96,10 @@ export class SFASIndividualService {
 
   /**
    * Search for a record in SFAS table using student details.
-   * @param lastName student's last name.
-   * @param birthDate student's birth date.
-   * @param sin student's sin.
+   * @param studentId Student id.
    * @returns SFAS individual details.
    */
-  async getSFASOverawards(
-    lastName: string,
-    birthDate: string,
-    sin: string,
-  ): Promise<SFASIndividual> {
+  async getSFASOverawards(studentId: number): Promise<SFASIndividual> {
     return await this.sfasIndividualRepo.findOne({
       select: {
         id: true,
@@ -111,11 +107,7 @@ export class SFASIndividualService {
         bcslOveraward: true,
       },
       where: {
-        lastName: Raw((alias) => `LOWER(${alias}) = LOWER(:lastName)`, {
-          lastName,
-        }),
-        sin: sin,
-        birthDate: birthDate,
+        student: { id: studentId },
       },
     });
   }

--- a/sources/packages/backend/libs/services/src/sfas/sfas-part-time-application.service.ts
+++ b/sources/packages/backend/libs/services/src/sfas/sfas-part-time-application.service.ts
@@ -34,9 +34,8 @@ export class SFASPartTimeApplicationsService extends DataModelService<SFASPartTi
       .createQueryBuilder("sfasPTApplication")
       .select(["sfasPTApplication.id"])
       .innerJoin("sfasPTApplication.individual", "sfasIndividual")
-      .innerJoin("sfasIndividual.student", "student")
       .where("sfasPTApplication.applicationCancelDate IS NULL")
-      .andWhere("student.id = :studentId", { studentId })
+      .andWhere("sfasIndividual.student.id = :studentId", { studentId })
       .andWhere(
         new Brackets((qb) => {
           qb.where(

--- a/sources/packages/backend/libs/services/src/sfas/sfas-part-time-application.service.ts
+++ b/sources/packages/backend/libs/services/src/sfas/sfas-part-time-application.service.ts
@@ -20,30 +20,23 @@ export class SFASPartTimeApplicationsService extends DataModelService<SFASPartTi
 
   /**
    * Validates before an application submission to see if there is an overlapping SFAS part-time application existing.
-   * @param sin Student SIN number.
-   * @param birthDate Student date of birth.
-   * @param lastName Student last name.
+   * @param studentId Student id.
    * @param studyStartDate Study period start date.
    * @param studyEndDate Study period end date.
    * @returns SFAS part-time application.
    */
   async validateDateOverlap(
-    sin: string,
-    birthDate: string,
-    lastName: string,
+    studentId: number,
     studyStartDate: string,
     studyEndDate: string,
   ): Promise<SFASPartTimeApplications> {
     return this.repo
       .createQueryBuilder("sfasPTApplication")
       .select(["sfasPTApplication.id"])
-      .innerJoin("sfasPTApplication.individual", "sfasPTstudent")
+      .innerJoin("sfasPTApplication.individual", "sfasIndividual")
+      .innerJoin("sfasIndividual.student", "student")
       .where("sfasPTApplication.applicationCancelDate IS NULL")
-      .andWhere("lower(sfasPTstudent.lastName) = lower(:lastName)", {
-        lastName,
-      })
-      .andWhere("sfasPTstudent.sin = :sin", { sin })
-      .andWhere("sfasPTstudent.birthDate = :birthDate", { birthDate })
+      .andWhere("student.id = :studentId", { studentId })
       .andWhere(
         new Brackets((qb) => {
           qb.where(

--- a/sources/packages/backend/libs/services/src/students-assessments/assessment-sequential-processing.service.ts
+++ b/sources/packages/backend/libs/services/src/students-assessments/assessment-sequential-processing.service.ts
@@ -532,9 +532,8 @@ export class AssessmentSequentialProcessingService {
       .addSelect("SUM(sfasApplication.csgdAward)", "CSGD")
       .addSelect("SUM(sfasApplication.bcagAward)", "BCAG")
       .innerJoin("sfasApplication.individual", "sfasIndividual")
-      .innerJoin("sfasIndividual.student", "student")
       .where("sfasApplication.applicationCancelDate IS NULL")
-      .andWhere("student.id = :studentId", { studentId })
+      .andWhere("sfasIndividual.student.id = :studentId", { studentId })
       .andWhere("sfasApplication.startDate >= :startDate", {
         startDate: programYearStartDate,
       })
@@ -577,9 +576,8 @@ export class AssessmentSequentialProcessingService {
       .addSelect("SUM(sfasPTApplication.bcagAward)", "BCAG")
       .addSelect("SUM(sfasPTApplication.csptAward)", "CSPT")
       .innerJoin("sfasPTApplication.individual", "sfasIndividual")
-      .innerJoin("sfasIndividual.student", "student")
       .where("sfasPTApplication.applicationCancelDate IS NULL")
-      .andWhere("student.id = :studentId", { studentId })
+      .andWhere("sfasIndividual.student.id = :studentId", { studentId })
       .andWhere("sfasPTApplication.startDate >= :startDate", {
         startDate: programYearStartDate,
       })

--- a/sources/packages/backend/libs/services/src/students-assessments/assessment-sequential-processing.service.ts
+++ b/sources/packages/backend/libs/services/src/students-assessments/assessment-sequential-processing.service.ts
@@ -10,7 +10,6 @@ import {
   DisbursementValueType,
   OfferingIntensity,
   SFASApplication,
-  SFASIndividual,
   SFASPartTimeApplications,
   StudentAppeal,
   StudentAssessment,
@@ -43,8 +42,6 @@ export class AssessmentSequentialProcessingService {
     private readonly sfasApplicationsRepo: Repository<SFASApplication>,
     @InjectRepository(SFASPartTimeApplications)
     private readonly sfasPartTimeApplicationsRepo: Repository<SFASPartTimeApplications>,
-    @InjectRepository(SFASIndividual)
-    private readonly sfasIndividualRepo: Repository<SFASIndividual>,
   ) {}
 
   /**

--- a/sources/packages/backend/libs/services/src/students-assessments/assessment-sequential-processing.service.ts
+++ b/sources/packages/backend/libs/services/src/students-assessments/assessment-sequential-processing.service.ts
@@ -10,6 +10,7 @@ import {
   DisbursementValueType,
   OfferingIntensity,
   SFASApplication,
+  SFASIndividual,
   SFASPartTimeApplications,
   StudentAppeal,
   StudentAssessment,
@@ -42,6 +43,8 @@ export class AssessmentSequentialProcessingService {
     private readonly sfasApplicationsRepo: Repository<SFASApplication>,
     @InjectRepository(SFASPartTimeApplications)
     private readonly sfasPartTimeApplicationsRepo: Repository<SFASPartTimeApplications>,
+    @InjectRepository(SFASIndividual)
+    private readonly sfasIndividualRepo: Repository<SFASIndividual>,
   ) {}
 
   /**
@@ -217,22 +220,15 @@ export class AssessmentSequentialProcessingService {
     const formattedReferenceAssessmentDate = getISODateOnlyString(
       referenceAssessmentDate,
     );
-    const lastName = assessment.application.student.user.lastName;
-    const sin = assessment.application.student.sinValidation.sin;
-    const birthDate = assessment.application.student.birthDate;
     const programYearStartDate = assessment.application.programYear.startDate;
     const [sfasAwardsTotals, sfasPartTimeAwardsTotals] = await Promise.all([
       this.getProgramYearSFASAwardsTotals(
-        lastName,
-        birthDate,
-        sin,
+        assessment.application.student.id,
         programYearStartDate,
         formattedReferenceAssessmentDate,
       ),
       this.getProgramYearSFASPartTimeAwardsTotals(
-        lastName,
-        birthDate,
-        sin,
+        assessment.application.student.id,
         programYearStartDate,
         formattedReferenceAssessmentDate,
       ),
@@ -522,17 +518,13 @@ export class AssessmentSequentialProcessingService {
 
   /**
    * Get SFAS application awards totals.
-   * @param lastName last name of the student.
-   * @param birthDate birth date of the student.
-   * @param sin: SIN number of the student.
+   * @param studentId student id.
    * @param programYearStartDate: the start date of the program year.
    * @param referenceAssessmentDate  date of the first assessment date of the current application.
    * @returns SFAS application awards totals.
    */
   private async getProgramYearSFASAwardsTotals(
-    lastName: string,
-    birthDate: string,
-    sin: string,
+    studentId: number,
     programYearStartDate: string,
     referenceAssessmentDate: string,
   ): Promise<AwardTotal[]> {
@@ -542,11 +534,10 @@ export class AssessmentSequentialProcessingService {
       .addSelect("SUM(sfasApplication.sbsdAward)", "SBSD")
       .addSelect("SUM(sfasApplication.csgdAward)", "CSGD")
       .addSelect("SUM(sfasApplication.bcagAward)", "BCAG")
-      .innerJoin("sfasApplication.individual", "sfasStudent")
+      .innerJoin("sfasApplication.individual", "sfasIndividual")
+      .innerJoin("sfasIndividual.student", "student")
       .where("sfasApplication.applicationCancelDate IS NULL")
-      .andWhere("lower(sfasStudent.lastName) = lower(:lastName)", { lastName })
-      .andWhere("sfasStudent.sin = :sin", { sin })
-      .andWhere("sfasStudent.birthDate = :birthDate", { birthDate })
+      .andWhere("student.id = :studentId", { studentId })
       .andWhere("sfasApplication.startDate >= :startDate", {
         startDate: programYearStartDate,
       })
@@ -571,17 +562,13 @@ export class AssessmentSequentialProcessingService {
 
   /**
    * Get SFAS part-time application awards totals.
-   * @param lastName last name of the student.
-   * @param birthDate birth date of the student.
-   * @param sin: SIN number of the student.
+   * @param studentId student id.
    * @param programYearStartDate: the start date of the program year.
    * @param referenceAssessmentDate  date of the first assessment date of the current application.
    * @returns SFAS application part-time awards totals.
    */
   private async getProgramYearSFASPartTimeAwardsTotals(
-    lastName: string,
-    birthDate: string,
-    sin: string,
+    studentId: number,
     programYearStartDate: string,
     referenceAssessmentDate: string,
   ): Promise<AwardTotal[]> {
@@ -592,11 +579,10 @@ export class AssessmentSequentialProcessingService {
       .addSelect("SUM(sfasPTApplication.csgdAward)", "CSGD")
       .addSelect("SUM(sfasPTApplication.bcagAward)", "BCAG")
       .addSelect("SUM(sfasPTApplication.csptAward)", "CSPT")
-      .innerJoin("sfasPTApplication.individual", "sfasStudent")
+      .innerJoin("sfasPTApplication.individual", "sfasIndividual")
+      .innerJoin("sfasIndividual.student", "student")
       .where("sfasPTApplication.applicationCancelDate IS NULL")
-      .andWhere("lower(sfasStudent.lastName) = lower(:lastName)", { lastName })
-      .andWhere("sfasStudent.sin = :sin", { sin })
-      .andWhere("sfasStudent.birthDate = :birthDate", { birthDate })
+      .andWhere("student.id = :studentId", { studentId })
       .andWhere("sfasPTApplication.startDate >= :startDate", {
         startDate: programYearStartDate,
       })

--- a/sources/packages/backend/libs/src-sql/sfas-individuals/Bulk-update-students-foreign-key.sql
+++ b/sources/packages/backend/libs/src-sql/sfas-individuals/Bulk-update-students-foreign-key.sql
@@ -1,8 +1,7 @@
 /*
  * After all the SFAS individuals are imported, this update
  * associates all the students ids that matches with the students
- * currently on the database. This will be used for all subsequent
- * bulk operations to update the data on the table sims.disbursement-overawards.
+ * currently on the database.
  */
 UPDATE
     sims.sfas_individuals

--- a/sources/packages/backend/libs/src-sql/sfas-individuals/Bulk-update-students-foreign-key.sql
+++ b/sources/packages/backend/libs/src-sql/sfas-individuals/Bulk-update-students-foreign-key.sql
@@ -15,4 +15,5 @@ FROM
 WHERE
     students.birth_date = sims.sfas_individuals.birth_date
     AND sin_validations.sin = sims.sfas_individuals.sin
-    AND lower(users.last_name) = lower(sims.sfas_individuals.last_name);
+    AND lower(users.last_name) = lower(sims.sfas_individuals.last_name)
+    AND sims.sfas_individuals.student_id IS NULL;


### PR DESCRIPTION
- Updated the SQL script [Bulk-update-students-foreign-key.sql](https://github.com/bcgov/SIMS/blob/32674e65bdb026d42967835c0aa20114ae17fb55/sources/packages/backend/libs/src-sql/sfas-individuals/Bulk-update-students-foreign-key.sql) to avoid updating the student ID on the sfas_individuals table if already populated.
- Checked the below areas (and other possible features) to ensure the student ID from sfas_individuals table will be used instead of the 3 matching fields.
  - Overawards
  - Application Overlaps
  - Program year totals (workers)
- Adapted existing E2E tests.