### PR TITLE
#4343 - Updates to KeyCloak - start after Feb25

### DIFF
--- a/sources/packages/web/package-lock.json
+++ b/sources/packages/web/package-lock.json
@@ -18,7 +18,7 @@
         "class-validator": "^0.14.1",
         "dayjs": "^1.11.10",
         "http-status-codes": "^2.3.0",
-        "keycloak-js": "^24.0.3",
+        "keycloak-js": "^26.2.0",
         "mitt": "^2.1.0",
         "primeflex": "^2.0.0",
         "primeicons": "^5.0.0",
@@ -3967,23 +3967,10 @@
       "license": "MIT"
     },
     "node_modules/keycloak-js": {
-      "version": "24.0.5",
-      "resolved": "https://registry.npmjs.org/keycloak-js/-/keycloak-js-24.0.5.tgz",
-      "integrity": "sha512-VQOSn3j13DPB6OuavKAq+sRjDERhIKrXgBzekoHRstifPuyULILguugX6yxRUYFSpn3OMYUXmSX++tkdCupOjA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "js-sha256": "^0.11.0",
-        "jwt-decode": "^4.0.0"
-      }
-    },
-    "node_modules/keycloak-js/node_modules/jwt-decode": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-4.0.0.tgz",
-      "integrity": "sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      }
+      "version": "26.2.0",
+      "resolved": "https://registry.npmjs.org/keycloak-js/-/keycloak-js-26.2.0.tgz",
+      "integrity": "sha512-CrFcXTN+d6J0V/1v3Zpioys6qHNWE6yUzVVIsCUAmFn9H14GZ0vuYod+lt+SSpMgWGPuneDZBSGBAeLBFuqjsw==",
+      "license": "Apache-2.0"
     },
     "node_modules/keyv": {
       "version": "4.5.4",

--- a/sources/packages/web/package-lock.json
+++ b/sources/packages/web/package-lock.json
@@ -3909,12 +3909,6 @@
         "node": ">=14"
       }
     },
-    "node_modules/js-sha256": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/js-sha256/-/js-sha256-0.11.0.tgz",
-      "integrity": "sha512-6xNlKayMZvds9h1Y1VWc0fQHQ82BxTXizWPEtEeGvmOUYpBRy4gbWroHLpzowe6xiQhHpelCQiE7HEdznyBL9Q==",
-      "license": "MIT"
-    },
     "node_modules/js-yaml": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",

--- a/sources/packages/web/package.json
+++ b/sources/packages/web/package.json
@@ -22,7 +22,7 @@
     "class-validator": "^0.14.1",
     "dayjs": "^1.11.10",
     "http-status-codes": "^2.3.0",
-    "keycloak-js": "^24.0.3",
+    "keycloak-js": "^26.2.0",
     "mitt": "^2.1.0",
     "primeflex": "^2.0.0",
     "primeicons": "^5.0.0",


### PR DESCRIPTION
**Technical**
- [x] Review the comments added by @ninosamson below to check any possible impact.
- [x] Update keycloakjs lib can be done without any breaks. If the login is happening for all portals it should be good enough to proceed.
- [x] To be executed after Feb 25 (Dev/TEST) to check possible impacts.