### PR TITLE
#4291 - Date COE Confirmed on Funding Summary

### DIFF
--- a/sources/packages/backend/apps/api/src/route-controllers/assessment/_tests_/e2e/assessment.aest.controller.getAssessmentAwardDetails.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/assessment/_tests_/e2e/assessment.aest.controller.getAssessmentAwardDetails.e2e-spec.ts
@@ -55,6 +55,7 @@ describe("AssessmentAESTController(e2e)-getAssessmentAwardDetails", () => {
   it("Should get the student assessment award summary containing all federal and provincial estimated and final awards for a full-time application with two disbursements when the receipts are available.", async () => {
     // Arrange
     const [dateSent1, dateSent2] = [addDays(-30), addDays(-1)];
+    const [enrolmentDate1, enrolmentDate2] = [addDays(1), addDays(30)];
     // First disbursement values.
     const firstDisbursementValues = [
       createFakeDisbursementValue(DisbursementValueType.CanadaLoan, "CSLF", 1),
@@ -126,11 +127,13 @@ describe("AssessmentAESTController(e2e)-getAssessmentAwardDetails", () => {
           disbursementScheduleStatus: DisbursementScheduleStatus.Sent,
           dateSent: dateSent1,
           tuitionRemittanceRequestedAmount: 1099,
+          coeUpdatedAt: enrolmentDate1,
         },
         secondDisbursementInitialValues: {
           disbursementScheduleStatus: DisbursementScheduleStatus.Sent,
           coeStatus: COEStatus.completed,
           dateSent: dateSent2,
+          coeUpdatedAt: enrolmentDate2,
         },
       },
     );
@@ -183,6 +186,7 @@ describe("AssessmentAESTController(e2e)-getAssessmentAwardDetails", () => {
           disbursement1bcag: 7,
           disbursement1bgpd: 8,
           disbursement1sbsd: 9,
+          disbursement1EnrolmentDate: enrolmentDate1.toISOString(),
           // Second disbursement schedule dynamic properties.
           disbursement2Date: getDateOnlyFullMonthFormat(
             secondSchedule.disbursementDate,
@@ -206,6 +210,7 @@ describe("AssessmentAESTController(e2e)-getAssessmentAwardDetails", () => {
           disbursement2bcag: 700,
           disbursement2bgpd: 800,
           disbursement2sbsd: 900,
+          disbursement2EnrolmentDate: enrolmentDate2.toISOString(),
         },
         finalAward: {
           // First disbursement schedule receipt dynamic properties.
@@ -235,6 +240,7 @@ describe("AssessmentAESTController(e2e)-getAssessmentAwardDetails", () => {
   it("Should get the student assessment award summary containing estimated and final awards for a part-time application with two disbursements when e-Cert was sent.", async () => {
     // Arrange
     const [dateSent1, dateSent2] = [addDays(-60), addDays(-5)];
+    const [enrolmentDate1, enrolmentDate2] = [addDays(1), addDays(30)];
     // First disbursement values.
     const firstDisbursementValues = [
       createFakeDisbursementValue(
@@ -331,12 +337,14 @@ describe("AssessmentAESTController(e2e)-getAssessmentAwardDetails", () => {
         firstDisbursementInitialValues: {
           disbursementScheduleStatus: DisbursementScheduleStatus.Sent,
           dateSent: dateSent1,
+          coeUpdatedAt: enrolmentDate1,
         },
         secondDisbursementInitialValues: {
           disbursementScheduleStatus: DisbursementScheduleStatus.Sent,
           coeStatus: COEStatus.completed,
           tuitionRemittanceRequestedAmount: 9876,
           dateSent: dateSent2,
+          coeUpdatedAt: enrolmentDate2,
         },
       },
     );
@@ -386,6 +394,7 @@ describe("AssessmentAESTController(e2e)-getAssessmentAwardDetails", () => {
           disbursement1csgd: 444,
           disbursement1bcag: 555,
           disbursement1sbsd: 666,
+          disbursement1EnrolmentDate: enrolmentDate1.toISOString(),
           // Second disbursement schedule dynamic properties.
           disbursement2Date: getDateOnlyFullMonthFormat(
             secondSchedule.disbursementDate,
@@ -406,6 +415,7 @@ describe("AssessmentAESTController(e2e)-getAssessmentAwardDetails", () => {
           disbursement2csgd: 1212,
           disbursement2bcag: 1313,
           disbursement2sbsd: 1414,
+          disbursement2EnrolmentDate: enrolmentDate2.toISOString(),
         },
         finalAward: {
           // First disbursement schedule receipt dynamic properties.

--- a/sources/packages/backend/apps/api/src/route-controllers/assessment/_tests_/e2e/assessment.institutions.controller.getAssessmentAwardDetails.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/assessment/_tests_/e2e/assessment.institutions.controller.getAssessmentAwardDetails.e2e-spec.ts
@@ -28,7 +28,11 @@ import {
   Institution,
   InstitutionLocation,
 } from "@sims/sims-db";
-import { getDateOnlyFormat, getDateOnlyFullMonthFormat } from "@sims/utilities";
+import {
+  addDays,
+  getDateOnlyFormat,
+  getDateOnlyFullMonthFormat,
+} from "@sims/utilities";
 import { saveStudentApplicationForCollegeC } from "../../../student/_tests_/e2e/student.institutions.utils";
 import { MASKED_MSFAA_NUMBER } from "../../../../../src/services";
 
@@ -57,7 +61,7 @@ describe("AssessmentInstitutionsController(e2e)-getAssessmentAwardDetails", () =
 
   it("Should get the student award details for an eligible application when an eligible public institution user tries to access it.", async () => {
     // Arrange
-
+    const enrolmentDate1 = addDays(1);
     // Student has an application to the institution with award details.
     const student = await saveFakeStudent(db.dataSource);
 
@@ -80,6 +84,7 @@ describe("AssessmentInstitutionsController(e2e)-getAssessmentAwardDetails", () =
         applicationStatus: ApplicationStatus.Completed,
         firstDisbursementInitialValues: {
           disbursementScheduleStatus: DisbursementScheduleStatus.Sent,
+          coeUpdatedAt: enrolmentDate1,
         },
       },
     );
@@ -157,6 +162,7 @@ describe("AssessmentInstitutionsController(e2e)-getAssessmentAwardDetails", () =
             firstDisbursementSchedule.tuitionRemittanceRequestedAmount,
           disbursement1Id: firstDisbursementSchedule.id,
           disbursement1DocumentNumber: firstDisbursementSchedule.documentNumber,
+          disbursement1EnrolmentDate: enrolmentDate1.toISOString(),
           ...awards,
         },
         finalAward: finalAwards,

--- a/sources/packages/backend/apps/api/src/route-controllers/assessment/_tests_/e2e/assessment.institutions.controller.getAssessmentNOA.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/assessment/_tests_/e2e/assessment.institutions.controller.getAssessmentNOA.e2e-spec.ts
@@ -29,7 +29,7 @@ import {
 import { MASKED_MSFAA_NUMBER } from "../../../../../src/services";
 import { saveStudentApplicationForCollegeC } from "../../../student/_tests_/e2e/student.institutions.utils";
 import { getUserFullName } from "../../../../utilities";
-import { getDateOnlyFullMonthFormat } from "@sims/utilities";
+import { addDays, getDateOnlyFullMonthFormat } from "@sims/utilities";
 
 describe("AssessmentInstitutionsController(e2e)-getAssessmentNOA", () => {
   let app: INestApplication;
@@ -56,7 +56,7 @@ describe("AssessmentInstitutionsController(e2e)-getAssessmentNOA", () => {
 
   it("Should get the student noa details for an eligible full time application when an eligible public institution user tries to access it.", async () => {
     // Arrange
-
+    const [enrolmentDate1, enrolmentDate2] = [addDays(1), addDays(30)];
     // Student has an application to the institution eligible for NOA.
     const student = await saveFakeStudent(db.dataSource);
 
@@ -78,6 +78,8 @@ describe("AssessmentInstitutionsController(e2e)-getAssessmentNOA", () => {
       {
         offeringIntensity: OfferingIntensity.fullTime,
         createSecondDisbursement: true,
+        firstDisbursementInitialValues: { coeUpdatedAt: enrolmentDate1 },
+        secondDisbursementInitialValues: { coeUpdatedAt: enrolmentDate2 },
       },
     );
     const assessment = application.currentAssessment;
@@ -127,6 +129,7 @@ describe("AssessmentInstitutionsController(e2e)-getAssessmentNOA", () => {
           disbursement1TuitionRemittance:
             firstDisbursementSchedule.tuitionRemittanceRequestedAmount,
           ...firstDisbursementScheduleAwards,
+          disbursement1EnrolmentDate: enrolmentDate1.toISOString(),
           disbursement2COEStatus: secondDisbursementSchedule.coeStatus,
           disbursement2Date: getDateOnlyFullMonthFormat(
             secondDisbursementSchedule.disbursementDate,
@@ -143,6 +146,7 @@ describe("AssessmentInstitutionsController(e2e)-getAssessmentNOA", () => {
           disbursement2TuitionRemittance:
             secondDisbursementSchedule.tuitionRemittanceRequestedAmount,
           ...secondDisbursementScheduleAwards,
+          disbursement2EnrolmentDate: enrolmentDate2.toISOString(),
         },
         eligibleAmount: 2,
         fullName: getUserFullName(application.student.user),
@@ -163,7 +167,7 @@ describe("AssessmentInstitutionsController(e2e)-getAssessmentNOA", () => {
 
   it("Should get the student noa details for an eligible part time application when an eligible public institution user tries to access it.", async () => {
     // Arrange
-
+    const [enrolmentDate1, enrolmentDate2] = [addDays(1), addDays(30)];
     // Student has an application to the institution eligible for NOA.
     const student = await saveFakeStudent(db.dataSource);
 
@@ -185,6 +189,8 @@ describe("AssessmentInstitutionsController(e2e)-getAssessmentNOA", () => {
       {
         offeringIntensity: OfferingIntensity.partTime,
         createSecondDisbursement: true,
+        firstDisbursementInitialValues: { coeUpdatedAt: enrolmentDate1 },
+        secondDisbursementInitialValues: { coeUpdatedAt: enrolmentDate2 },
       },
     );
     const assessment = application.currentAssessment;
@@ -234,6 +240,7 @@ describe("AssessmentInstitutionsController(e2e)-getAssessmentNOA", () => {
           disbursement1TuitionRemittance:
             firstDisbursementSchedule.tuitionRemittanceRequestedAmount,
           ...firstDisbursementScheduleAwards,
+          disbursement1EnrolmentDate: enrolmentDate1.toISOString(),
           disbursement2COEStatus: secondDisbursementSchedule.coeStatus,
           disbursement2Date: getDateOnlyFullMonthFormat(
             secondDisbursementSchedule.disbursementDate,
@@ -250,6 +257,7 @@ describe("AssessmentInstitutionsController(e2e)-getAssessmentNOA", () => {
           disbursement2TuitionRemittance:
             secondDisbursementSchedule.tuitionRemittanceRequestedAmount,
           ...secondDisbursementScheduleAwards,
+          disbursement2EnrolmentDate: enrolmentDate2.toISOString(),
         },
         eligibleAmount: 2,
         fullName: getUserFullName(application.student.user),

--- a/sources/packages/backend/apps/api/src/route-controllers/assessment/_tests_/e2e/assessment.students.controller.getAssessmentAwardDetails.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/assessment/_tests_/e2e/assessment.students.controller.getAssessmentAwardDetails.e2e-spec.ts
@@ -27,7 +27,11 @@ import {
   Student,
 } from "@sims/sims-db";
 import { BC_TOTAL_GRANT_AWARD_CODE } from "@sims/services/constants";
-import { getDateOnlyFormat, getDateOnlyFullMonthFormat } from "@sims/utilities";
+import {
+  addDays,
+  getDateOnlyFormat,
+  getDateOnlyFullMonthFormat,
+} from "@sims/utilities";
 
 describe("AssessmentStudentsController(e2e)-getAssessmentAwardDetails", () => {
   let app: INestApplication;
@@ -53,6 +57,7 @@ describe("AssessmentStudentsController(e2e)-getAssessmentAwardDetails", () => {
   });
 
   it("Should get the student assessment summary containing loan and all grants values from e-Cert effective amount for a part-time application with a single disbursement.", async () => {
+    const enrolmentDate1 = addDays(1);
     // First disbursement values.
     const firstDisbursementValues = [
       createFakeDisbursementValue(
@@ -108,6 +113,7 @@ describe("AssessmentStudentsController(e2e)-getAssessmentAwardDetails", () => {
           disbursementScheduleStatus: DisbursementScheduleStatus.Sent,
           // Adding date sent to ensure that will not be returned by the API (students should not receive it).
           dateSent: new Date(),
+          coeUpdatedAt: enrolmentDate1,
         },
         secondDisbursementInitialValues: {
           disbursementScheduleStatus: DisbursementScheduleStatus.Sent,
@@ -146,6 +152,7 @@ describe("AssessmentStudentsController(e2e)-getAssessmentAwardDetails", () => {
           disbursement1MSFAAId: sharedMSFAANumber.id,
           disbursement1MSFAACancelledDate: null,
           disbursement1MSFAADateSigned: sharedMSFAANumber.dateSigned,
+          disbursement1EnrolmentDate: enrolmentDate1.toISOString(),
           disbursement1TuitionRemittance: 0,
           disbursement1Id: firstSchedule.id,
           disbursement1cslp: 111,
@@ -167,6 +174,7 @@ describe("AssessmentStudentsController(e2e)-getAssessmentAwardDetails", () => {
   });
 
   it("Should get the student assessment summary containing loan and all grants values from e-Cert effective amount for a part-time application with two disbursements.", async () => {
+    const [enrolmentDate1, enrolmentDate2] = [addDays(1), addDays(30)];
     // First disbursement values.
     const firstDisbursementValues = [
       createFakeDisbursementValue(
@@ -262,11 +270,13 @@ describe("AssessmentStudentsController(e2e)-getAssessmentAwardDetails", () => {
         createSecondDisbursement: true,
         firstDisbursementInitialValues: {
           disbursementScheduleStatus: DisbursementScheduleStatus.Sent,
+          coeUpdatedAt: enrolmentDate1,
         },
         secondDisbursementInitialValues: {
           disbursementScheduleStatus: DisbursementScheduleStatus.Sent,
           coeStatus: COEStatus.completed,
           tuitionRemittanceRequestedAmount: 9876,
+          coeUpdatedAt: enrolmentDate2,
         },
       },
     );
@@ -320,6 +330,7 @@ describe("AssessmentStudentsController(e2e)-getAssessmentAwardDetails", () => {
           disbursement2Date: getDateOnlyFullMonthFormat(
             secondSchedule.disbursementDate,
           ),
+          disbursement1EnrolmentDate: enrolmentDate1.toISOString(),
           disbursement2Status: secondSchedule.disbursementScheduleStatus,
           disbursement2COEStatus: COEStatus.completed,
           disbursement2MSFAANumber: "XXXXXXXXXX",
@@ -334,6 +345,7 @@ describe("AssessmentStudentsController(e2e)-getAssessmentAwardDetails", () => {
           disbursement2csgd: 1212,
           disbursement2bcag: 1313,
           disbursement2sbsd: 1414,
+          disbursement2EnrolmentDate: enrolmentDate2.toISOString(),
         },
         finalAward: {
           // First disbursement schedule receipt dynamic properties.
@@ -355,6 +367,7 @@ describe("AssessmentStudentsController(e2e)-getAssessmentAwardDetails", () => {
   });
 
   it("Should not generate final award values for a part-time application when the disbursement has not been sent yet.", async () => {
+    const enrolmentDate1 = addDays(1);
     const firstDisbursementValues = [
       createFakeDisbursementValue(
         DisbursementValueType.CanadaLoan,
@@ -375,6 +388,7 @@ describe("AssessmentStudentsController(e2e)-getAssessmentAwardDetails", () => {
         applicationStatus: ApplicationStatus.Completed,
         firstDisbursementInitialValues: {
           disbursementScheduleStatus: DisbursementScheduleStatus.Pending,
+          coeUpdatedAt: enrolmentDate1,
         },
       },
     );
@@ -411,11 +425,13 @@ describe("AssessmentStudentsController(e2e)-getAssessmentAwardDetails", () => {
           disbursement1TuitionRemittance: 0,
           disbursement1Id: firstSchedule.id,
           disbursement1cslp: 111,
+          disbursement1EnrolmentDate: enrolmentDate1.toISOString(),
         },
       });
   });
 
   it("Should get the student assessment summary containing federal and provincial loans and all grants for a full-time application with two disbursements.", async () => {
+    const [enrolmentDate1, enrolmentDate2] = [addDays(1), addDays(30)];
     // First disbursement values.
     const firstDisbursementValues = [
       createFakeDisbursementValue(
@@ -508,10 +524,12 @@ describe("AssessmentStudentsController(e2e)-getAssessmentAwardDetails", () => {
           tuitionRemittanceRequestedAmount: 1099,
           // Adding date sent to ensure that will not be returned by the API (students should not receive it).
           dateSent: new Date(),
+          coeUpdatedAt: enrolmentDate1,
         },
         secondDisbursementInitialValues: {
           disbursementScheduleStatus: DisbursementScheduleStatus.Sent,
           coeStatus: COEStatus.completed,
+          coeUpdatedAt: enrolmentDate2,
         },
       },
     );
@@ -564,6 +582,7 @@ describe("AssessmentStudentsController(e2e)-getAssessmentAwardDetails", () => {
           disbursement1bcag: 1006,
           disbursement1bgpd: 1007,
           disbursement1sbsd: 1008,
+          disbursement1EnrolmentDate: enrolmentDate1.toISOString(),
           // Second disbursement schedule dynamic properties.
           disbursement2Date: getDateOnlyFullMonthFormat(
             secondSchedule.disbursementDate,
@@ -585,6 +604,7 @@ describe("AssessmentStudentsController(e2e)-getAssessmentAwardDetails", () => {
           disbursement2bcag: 10016,
           disbursement2bgpd: 10017,
           disbursement2sbsd: 10018,
+          disbursement2EnrolmentDate: enrolmentDate2.toISOString(),
         },
         finalAward: {
           // First disbursement schedule receipt dynamic properties.
@@ -612,6 +632,7 @@ describe("AssessmentStudentsController(e2e)-getAssessmentAwardDetails", () => {
   });
 
   it("Should get the student assessment summary containing federal, provincial loan, all federal grants and no provincial grants values for a full-time application when the BCSG does not match.", async () => {
+    const enrolmentDate1 = addDays(1);
     // First disbursement values.
     const firstDisbursementValues = [
       createFakeDisbursementValue(DisbursementValueType.CanadaLoan, "CSLF", 1),
@@ -638,6 +659,7 @@ describe("AssessmentStudentsController(e2e)-getAssessmentAwardDetails", () => {
         applicationStatus: ApplicationStatus.Completed,
         firstDisbursementInitialValues: {
           disbursementScheduleStatus: DisbursementScheduleStatus.Sent,
+          coeUpdatedAt: enrolmentDate1,
         },
       },
     );
@@ -690,6 +712,7 @@ describe("AssessmentStudentsController(e2e)-getAssessmentAwardDetails", () => {
           disbursement1bcsl: 3,
           disbursement1bcag: 4,
           disbursement1sbsd: 5,
+          disbursement1EnrolmentDate: enrolmentDate1.toISOString(),
         },
         finalAward: {
           disbursementReceipt1cslf: 1,

--- a/sources/packages/backend/apps/api/src/route-controllers/assessment/assessment.controller.service.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/assessment/assessment.controller.service.ts
@@ -170,6 +170,8 @@ export class AssessmentControllerService {
         schedule.msfaaNumber.dateSigned;
       disbursementDetails[`${disbursementIdentifier}TuitionRemittance`] =
         schedule.tuitionRemittanceRequestedAmount;
+      disbursementDetails[`${disbursementIdentifier}EnrolmentDate`] =
+        schedule.coeUpdatedAt;
       disbursementDetails[`${disbursementIdentifier}Id`] = schedule.id;
       if (includeDateSent) {
         disbursementDetails[`${disbursementIdentifier}DateSent`] =

--- a/sources/packages/backend/apps/api/src/services/student-assessment/student-assessment.service.ts
+++ b/sources/packages/backend/apps/api/src/services/student-assessment/student-assessment.service.ts
@@ -83,6 +83,7 @@ export class StudentAssessmentService extends RecordDataModelService<StudentAsse
         "disbursementSchedule.coeStatus",
         "disbursementSchedule.tuitionRemittanceRequestedAmount",
         "disbursementSchedule.dateSent",
+        "disbursementSchedule.coeUpdatedAt",
         "msfaaNumber.id",
         "msfaaNumber.msfaaNumber",
         "msfaaNumber.dateSigned",

--- a/sources/packages/web/src/components/common/AssessmentAwardDetails.vue
+++ b/sources/packages/web/src/components/common/AssessmentAwardDetails.vue
@@ -44,9 +44,7 @@
                 assessmentAwardData.estimatedAward.disbursement1COEStatus as COEStatus
               "
               :enrolmentDate="
-                dateOnlyLongString(
-                  assessmentAwardData.estimatedAward.disbursement1EnrolmentDate as Date,
-                )
+                assessmentAwardData.estimatedAward.disbursement1EnrolmentDate as Date
               "
             />
             <confirm-enrolment
@@ -186,9 +184,7 @@
                 assessmentAwardData.estimatedAward.disbursement2COEStatus as COEStatus
               "
               :enrolmentDate="
-                dateOnlyLongString(
-                  assessmentAwardData.estimatedAward.disbursement2EnrolmentDate as Date,
-                )
+                assessmentAwardData.estimatedAward.disbursement2EnrolmentDate as Date
               "
             />
             <confirm-enrolment

--- a/sources/packages/web/src/components/common/AssessmentAwardDetails.vue
+++ b/sources/packages/web/src/components/common/AssessmentAwardDetails.vue
@@ -43,6 +43,11 @@
               :coeStatus="
                 assessmentAwardData.estimatedAward.disbursement1COEStatus as COEStatus
               "
+              :enrolmentDate="
+                dateOnlyLongString(
+                  assessmentAwardData.estimatedAward.disbursement1EnrolmentDate as Date,
+                )
+              "
             />
             <confirm-enrolment
               v-if="allowConfirmEnrolment"
@@ -179,6 +184,11 @@
             <status-info-enrolment
               :coeStatus="
                 assessmentAwardData.estimatedAward.disbursement2COEStatus as COEStatus
+              "
+              :enrolmentDate="
+                dateOnlyLongString(
+                  assessmentAwardData.estimatedAward.disbursement2EnrolmentDate as Date,
+                )
               "
             />
             <confirm-enrolment

--- a/sources/packages/web/src/components/common/StatusInfoEnrolment.vue
+++ b/sources/packages/web/src/components/common/StatusInfoEnrolment.vue
@@ -19,6 +19,10 @@ export default defineComponent({
       type: Object as PropType<COEStatus>,
       required: true,
     },
+    enrolmentDate: {
+      type: String,
+      required: false,
+    },
   },
   setup(props) {
     const enrollmentStatus = computed<EnrollmentStatusInfo>(() => {
@@ -26,7 +30,7 @@ export default defineComponent({
         case COEStatus.completed:
           return {
             status: StatusInfo.Completed,
-            header: "Enrolment confirmed",
+            header: `Enrolment confirmed on ${props.enrolmentDate}`,
           };
         case COEStatus.required:
           return {

--- a/sources/packages/web/src/components/common/StatusInfoEnrolment.vue
+++ b/sources/packages/web/src/components/common/StatusInfoEnrolment.vue
@@ -7,6 +7,7 @@
 <script lang="ts">
 import { PropType, computed, defineComponent } from "vue";
 import { StatusInfo, COEStatus } from "@/types";
+import { useFormatters } from "@/composables";
 
 export interface EnrollmentStatusInfo {
   status: StatusInfo;
@@ -20,17 +21,20 @@ export default defineComponent({
       required: true,
     },
     enrolmentDate: {
-      type: String,
+      type: Date,
       required: false,
     },
   },
   setup(props) {
+    const { dateOnlyLongString } = useFormatters();
     const enrollmentStatus = computed<EnrollmentStatusInfo>(() => {
       switch (props.coeStatus) {
         case COEStatus.completed:
           return {
             status: StatusInfo.Completed,
-            header: `Enrolment confirmed on ${props.enrolmentDate}`,
+            header: `Enrolment confirmed on ${dateOnlyLongString(
+              props.enrolmentDate,
+            )}`,
           };
         case COEStatus.required:
           return {


### PR DESCRIPTION
- Added the date COE was actioned beside Enrolment confirmed/declined in the screenshot below:
- Format: "Enrolment confirmed on DATE"
- Ensured the date is available for the Ministry, Student, and Institution.
- Used column `coe_updated_at`.
- Append "on DATE" to the current "status label".
- Adjusted E2E tests to ensure the API sends the date.

Screenshot
![image](https://github.com/user-attachments/assets/b097c65c-6f50-4b3b-b7c6-18a7ba80fc77)
