### PR TITLE
#4247 - Revert route changes and parent application (Vue only)

### DIFF
--- a/sources/packages/web/src/components/aest/students/ApplicationHeaderTitle.vue
+++ b/sources/packages/web/src/components/aest/students/ApplicationHeaderTitle.vue
@@ -15,8 +15,6 @@ export default defineComponent({
     applicationId: {
       type: Number,
       required: true,
-      // The value could be null on load of the component and updated later.
-      default: null,
     },
   },
   setup(props) {

--- a/sources/packages/web/src/components/aest/students/assessment/ManualReassessment.vue
+++ b/sources/packages/web/src/components/aest/students/assessment/ManualReassessment.vue
@@ -46,8 +46,6 @@ export default defineComponent({
     applicationId: {
       type: Number,
       required: true,
-      // The value could be null on load of the component and updated later.
-      default: null,
     },
   },
   setup(props, { emit }) {

--- a/sources/packages/web/src/components/aest/students/bypassedRestrictions/HistoryBypassedRestrictions.vue
+++ b/sources/packages/web/src/components/aest/students/bypassedRestrictions/HistoryBypassedRestrictions.vue
@@ -122,8 +122,6 @@ export default defineComponent({
     applicationId: {
       type: Number,
       required: true,
-      // The value could be null on load of the component and updated later.
-      default: null,
     },
   },
   setup(props) {

--- a/sources/packages/web/src/components/common/NoticeOfAssessmentFormView.vue
+++ b/sources/packages/web/src/components/common/NoticeOfAssessmentFormView.vue
@@ -23,7 +23,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, ref, watchEffect } from "vue";
+import { defineComponent, ref, onMounted } from "vue";
 import { StudentAssessmentsService } from "@/services/StudentAssessmentsService";
 import { AssessmentNOAAPIOutDTO } from "@/services/http/dto";
 import { ModalDialog, useFormatters } from "@/composables";
@@ -205,7 +205,7 @@ export default defineComponent({
       );
     };
 
-    watchEffect(loadNOA);
+    onMounted(loadNOA);
 
     const setMSFAAReissueProcessing = (processing: boolean) => {
       msfaaReissueProcessing.value = processing;

--- a/sources/packages/web/src/components/common/NoticeOfAssessmentFormView.vue
+++ b/sources/packages/web/src/components/common/NoticeOfAssessmentFormView.vue
@@ -150,9 +150,6 @@ export default defineComponent({
     };
 
     const loadNOA = async () => {
-      if (!props.studentId || !props.applicationId || !props.assessmentId) {
-        return;
-      }
       const assessment =
         await StudentAssessmentsService.shared.getAssessmentNOA(
           props.assessmentId,

--- a/sources/packages/web/src/components/common/applicationTracker/ApplicationProgressBar.vue
+++ b/sources/packages/web/src/components/common/applicationTracker/ApplicationProgressBar.vue
@@ -132,8 +132,6 @@ export default defineComponent({
     applicationId: {
       type: Number,
       required: true,
-      // The value could be null on load of the component and updated later.
-      default: null,
     },
     areApplicationActionsAllowed: {
       type: Boolean,

--- a/sources/packages/web/src/components/common/students/StudentApplications.vue
+++ b/sources/packages/web/src/components/common/students/StudentApplications.vue
@@ -87,7 +87,7 @@
             <span v-if="enableViewApplication">
               <v-btn
                 variant="outlined"
-                @click="$emit('goToApplication', item.parentApplicationId)"
+                @click="$emit('goToApplication', item.id)"
                 >View</v-btn
               >
             </span>

--- a/sources/packages/web/src/components/common/students/assessment/History.vue
+++ b/sources/packages/web/src/components/common/students/assessment/History.vue
@@ -122,11 +122,13 @@ export default defineComponent({
     // Adding watch effect instead of onMounted because
     // applicationId may not be not available on load.
     watchEffect(async () => {
-      assessmentHistory.value =
-        await StudentAssessmentsService.shared.getAssessmentHistory(
-          props.applicationId,
-          props.studentId,
-        );
+      if (props.applicationId) {
+        assessmentHistory.value =
+          await StudentAssessmentsService.shared.getAssessmentHistory(
+            props.applicationId,
+            props.studentId,
+          );
+      }
     });
 
     const viewRequest = (data: AssessmentHistorySummaryAPIOutDTO) => {

--- a/sources/packages/web/src/components/common/students/assessment/History.vue
+++ b/sources/packages/web/src/components/common/students/assessment/History.vue
@@ -104,8 +104,6 @@ export default defineComponent({
     applicationId: {
       type: Number,
       required: true,
-      // The value could be null on load of the component and updated later.
-      default: null,
     },
     // Assessment trigger types for which request form is available to view.
     viewRequestTypes: {
@@ -124,13 +122,11 @@ export default defineComponent({
     // Adding watch effect instead of onMounted because
     // applicationId may not be not available on load.
     watchEffect(async () => {
-      if (props.applicationId) {
-        assessmentHistory.value =
-          await StudentAssessmentsService.shared.getAssessmentHistory(
-            props.applicationId,
-            props.studentId,
-          );
-      }
+      assessmentHistory.value =
+        await StudentAssessmentsService.shared.getAssessmentHistory(
+          props.applicationId,
+          props.studentId,
+        );
     });
 
     const viewRequest = (data: AssessmentHistorySummaryAPIOutDTO) => {

--- a/sources/packages/web/src/components/common/students/assessment/Request.vue
+++ b/sources/packages/web/src/components/common/students/assessment/Request.vue
@@ -78,8 +78,6 @@ export default defineComponent({
     applicationId: {
       type: Number,
       required: true,
-      // The value could be null on load of the component and updated later.
-      default: null,
     },
     showWhenEmpty: {
       type: Boolean,

--- a/sources/packages/web/src/components/layouts/aest/AESTApplicationSideBar.vue
+++ b/sources/packages/web/src/components/layouts/aest/AESTApplicationSideBar.vue
@@ -165,15 +165,9 @@ export default defineComponent({
     };
 
     onMounted(async () => {
-      // Get current application for the parent application.
-      const currentApplication =
-        await ApplicationService.shared.getCurrentApplicationFromParent(
-          props.applicationId,
-        );
-      const currentApplicationId = currentApplication.id;
       const supportingUsers =
         await SupportingUsersService.shared.getSupportingUsersForSideBar(
-          currentApplicationId,
+          props.applicationId,
         );
       supportingUsers.forEach((supportingUser, index) => {
         if (supportingUser.supportingUserType === SupportingUserType.Parent) {

--- a/sources/packages/web/src/views/aest/StudentApplicationView.vue
+++ b/sources/packages/web/src/views/aest/StudentApplicationView.vue
@@ -92,7 +92,6 @@ export default defineComponent({
       if (!props.versionApplicationId) {
         application = await ApplicationService.shared.getApplicationDetail(
           applicationId,
-          { isParentApplication: true },
         );
       } else {
         application = await ApplicationService.shared.getApplicationDetail(

--- a/sources/packages/web/src/views/aest/StudentApplicationView.vue
+++ b/sources/packages/web/src/views/aest/StudentApplicationView.vue
@@ -87,17 +87,9 @@ export default defineComponent({
       // When the application version is present load the given application version instead of the current application version.
       const applicationId = props.versionApplicationId ?? props.applicationId;
       let application: ApplicationBaseAPIOutDTO;
-      // When the application version is not present, load the current application from the parent application.
-      // Otherwise, load the given application version details.
-      if (!props.versionApplicationId) {
-        application = await ApplicationService.shared.getApplicationDetail(
-          applicationId,
-        );
-      } else {
-        application = await ApplicationService.shared.getApplicationDetail(
-          applicationId,
-        );
-      }
+      application = await ApplicationService.shared.getApplicationDetail(
+        applicationId,
+      );
       applicationDetail.value =
         application as ApplicationSupplementalDataAPIOutDTO;
       selectedForm.value = applicationDetail.value.applicationFormName;

--- a/sources/packages/web/src/views/aest/student/applicationDetails/ApplicationRestrictionsManagement.vue
+++ b/sources/packages/web/src/views/aest/student/applicationDetails/ApplicationRestrictionsManagement.vue
@@ -9,19 +9,18 @@
         }"
         subTitle="Application Restriction Management"
       />
-      <application-header-title :application-id="currentApplicationId" />
+      <application-header-title :application-id="applicationId" />
     </template>
-    <history-bypassed-restrictions :applicationId="currentApplicationId" />
+    <history-bypassed-restrictions :applicationId="applicationId" />
   </full-page-container>
 </template>
 
 <script lang="ts">
 import { AESTRoutesConst } from "@/constants/routes/RouteConstants";
-import { defineComponent, onMounted, ref } from "vue";
+import { defineComponent } from "vue";
 import { useFormatters } from "@/composables";
 import ApplicationHeaderTitle from "@/components/aest/students/ApplicationHeaderTitle.vue";
 import HistoryBypassedRestrictions from "@/components/aest/students/bypassedRestrictions/HistoryBypassedRestrictions.vue";
-import { ApplicationService } from "@/services/ApplicationService";
 
 export default defineComponent({
   components: {
@@ -38,23 +37,11 @@ export default defineComponent({
       required: true,
     },
   },
-  setup(props) {
+  setup() {
     const { emptyStringFiller } = useFormatters();
-    const currentApplicationId = ref<number>();
-
-    onMounted(async () => {
-      // Get current application for the parent application.
-      const currentApplication =
-        await ApplicationService.shared.getCurrentApplicationFromParent(
-          props.applicationId,
-        );
-      currentApplicationId.value = currentApplication.id;
-    });
-
     return {
       AESTRoutesConst,
       emptyStringFiller,
-      currentApplicationId,
     };
   },
 });

--- a/sources/packages/web/src/views/aest/student/applicationDetails/ApplicationStatusTracker.vue
+++ b/sources/packages/web/src/views/aest/student/applicationDetails/ApplicationStatusTracker.vue
@@ -9,20 +9,19 @@
         }"
         subTitle="Application Status"
       />
-      <application-header-title :application-id="currentApplicationId" />
+      <application-header-title :application-id="applicationId" />
     </template>
     <application-progress-bar
-      :application-id="currentApplicationId"
+      :application-id="applicationId"
     ></application-progress-bar>
   </full-page-container>
 </template>
 
 <script lang="ts">
 import { AESTRoutesConst } from "@/constants/routes/RouteConstants";
-import { defineComponent, onMounted, ref } from "vue";
+import { defineComponent } from "vue";
 import ApplicationHeaderTitle from "@/components/aest/students/ApplicationHeaderTitle.vue";
 import ApplicationProgressBar from "@/components/common/applicationTracker/ApplicationProgressBar.vue";
-import { ApplicationService } from "@/services/ApplicationService";
 
 export default defineComponent({
   components: {
@@ -39,20 +38,9 @@ export default defineComponent({
       required: true,
     },
   },
-  setup(props) {
-    const currentApplicationId = ref<number>();
-
-    onMounted(async () => {
-      // Get current application for the parent application.
-      const currentApplication =
-        await ApplicationService.shared.getCurrentApplicationFromParent(
-          props.applicationId,
-        );
-      currentApplicationId.value = currentApplication.id;
-    });
+  setup() {
     return {
       AESTRoutesConst,
-      currentApplicationId,
     };
   },
 });

--- a/sources/packages/web/src/views/aest/student/applicationDetails/AssessmentAward.vue
+++ b/sources/packages/web/src/views/aest/student/applicationDetails/AssessmentAward.vue
@@ -9,7 +9,7 @@
           params: { applicationId, studentId },
         }"
       />
-      <application-header-title :application-id="currentApplicationId" />
+      <application-header-title :application-id="applicationId" />
     </template>
     <assessment-award
       :assessment-award-data="assessmentAwardData"
@@ -31,7 +31,6 @@ import { FIRST_COE_NOT_COMPLETE } from "@/constants";
 import { ApiProcessError } from "@/types";
 import AssessmentAward from "@/components/common/students/applicationDetails/AssessmentAward.vue";
 import ApplicationHeaderTitle from "@/components/aest/students/ApplicationHeaderTitle.vue";
-import { ApplicationService } from "@/services/ApplicationService";
 
 export default defineComponent({
   components: { AssessmentAward, ApplicationHeaderTitle },
@@ -52,16 +51,6 @@ export default defineComponent({
   setup(props) {
     const assessmentAwardData = ref<AwardDetailsAPIOutDTO>();
     const snackBar = useSnackBar();
-    const currentApplicationId = ref<number>();
-
-    onMounted(async () => {
-      // Get current application for the parent application.
-      const currentApplication =
-        await ApplicationService.shared.getCurrentApplicationFromParent(
-          props.applicationId,
-        );
-      currentApplicationId.value = currentApplication.id;
-    });
 
     const loadAssessmentAwardValues = async () => {
       assessmentAwardData.value =
@@ -105,7 +94,6 @@ export default defineComponent({
       noticeOfAssessmentRoute,
       assessmentAwardData,
       confirmEnrolment,
-      currentApplicationId,
     };
   },
 });

--- a/sources/packages/web/src/views/aest/student/applicationDetails/AssessmentsSummary.vue
+++ b/sources/packages/web/src/views/aest/student/applicationDetails/AssessmentsSummary.vue
@@ -9,11 +9,11 @@
         }"
         subTitle="Assessments"
       />
-      <application-header-title :application-id="currentApplicationId" />
+      <application-header-title :application-id="applicationId" />
     </template>
     <request-assessment
       class="mb-5"
-      :applicationId="currentApplicationId"
+      :applicationId="applicationId"
       @viewStudentAppeal="goToStudentAppeal"
       @viewStudentApplicationOfferingChange="
         goToStudentApplicationOfferingChangeRequest
@@ -23,12 +23,12 @@
     />
     <manual-reassessment
       class="mb-5"
-      :applicationId="currentApplicationId"
+      :applicationId="applicationId"
       @reassessmentTriggered="reloadHistory"
     />
     <history-assessment
       class="mb-5"
-      :applicationId="currentApplicationId"
+      :applicationId="applicationId"
       :viewRequestTypes="assessmentRequestTypes"
       @viewStudentAppeal="goToStudentAppeal"
       @viewStudentApplicationOfferingChange="
@@ -46,13 +46,12 @@
 <script lang="ts">
 import { AESTRoutesConst } from "@/constants/routes/RouteConstants";
 import { useRouter } from "vue-router";
-import { defineComponent, onMounted, ref } from "vue";
+import { defineComponent, ref } from "vue";
 import { AssessmentTriggerType } from "@/types";
 import RequestAssessment from "@/components/common/students/assessment/Request.vue";
 import HistoryAssessment from "@/components/common/students/assessment/History.vue";
 import ManualReassessment from "@/components/aest/students/assessment/ManualReassessment.vue";
 import ApplicationHeaderTitle from "@/components/aest/students/ApplicationHeaderTitle.vue";
-import { ApplicationService } from "@/services/ApplicationService";
 
 export default defineComponent({
   components: {
@@ -74,16 +73,6 @@ export default defineComponent({
   setup(props) {
     const router = useRouter();
     const historyKey = ref(0);
-    const currentApplicationId = ref<number>();
-
-    onMounted(async () => {
-      // Get current application for the parent application.
-      const currentApplication =
-        await ApplicationService.shared.getCurrentApplicationFromParent(
-          props.applicationId,
-        );
-      currentApplicationId.value = currentApplication.id;
-    });
 
     // The assessment trigger types for which the request form must be visible by default.
     const assessmentRequestTypes = [
@@ -175,7 +164,6 @@ export default defineComponent({
       goToStudentApplicationOfferingChangeRequest,
       historyKey,
       reloadHistory,
-      currentApplicationId,
     };
   },
 });

--- a/sources/packages/web/src/views/aest/student/applicationDetails/NoticeOfAssessment.vue
+++ b/sources/packages/web/src/views/aest/student/applicationDetails/NoticeOfAssessment.vue
@@ -9,7 +9,7 @@
           params: { applicationId, studentId, assessmentId },
         }"
       />
-      <application-header-title :application-id="currentApplicationId" />
+      <application-header-title :application-id="applicationId" />
     </template>
     <notice-of-assessment-form-view
       :assessment-id="assessmentId"
@@ -20,7 +20,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, onMounted, ref } from "vue";
+import { defineComponent } from "vue";
 import NoticeOfAssessmentFormView from "@/components/common/NoticeOfAssessmentFormView.vue";
 import { AESTRoutesConst } from "@/constants/routes/RouteConstants";
 import { ApplicationService } from "@/services/ApplicationService";
@@ -47,20 +47,11 @@ export default defineComponent({
       required: true,
     },
   },
-  setup(props) {
+  setup() {
     const snackBar = useSnackBar();
     const { hasRole } = useAuth();
     const hasStudentReissueMSFAARole = hasRole(Role.StudentReissueMSFAA);
-    const currentApplicationId = ref<number>();
 
-    onMounted(async () => {
-      // Get current application for the parent application.
-      const currentApplication =
-        await ApplicationService.shared.getCurrentApplicationFromParent(
-          props.applicationId,
-        );
-      currentApplicationId.value = currentApplication.id;
-    });
     const reissueMSFAA = async (
       applicationId: number,
       reloadNOA: () => Promise<void>,
@@ -82,7 +73,6 @@ export default defineComponent({
       reissueMSFAA,
       AESTRoutesConst,
       hasStudentReissueMSFAARole,
-      currentApplicationId,
     };
   },
 });

--- a/sources/packages/web/src/views/institution/student/InstitutionStudentApplicationView.vue
+++ b/sources/packages/web/src/views/institution/student/InstitutionStudentApplicationView.vue
@@ -56,7 +56,6 @@ export default defineComponent({
           props.applicationId,
           {
             studentId: props.studentId,
-            isParentApplication: true,
           },
         );
       selectedForm.value = applicationDetail.value.applicationFormName;

--- a/sources/packages/web/src/views/institution/student/applicationDetails/ApplicationExceptions.vue
+++ b/sources/packages/web/src/views/institution/student/applicationDetails/ApplicationExceptions.vue
@@ -4,14 +4,13 @@
     :exceptionId="exceptionId"
     :backRouteLocation="assessmentsSummaryRoute"
     :readOnlyForm="true"
-    :application-id="currentApplicationId"
+    :application-id="applicationId"
   />
 </template>
 <script lang="ts">
-import { defineComponent, onMounted, ref } from "vue";
+import { defineComponent } from "vue";
 import { InstitutionRoutesConst } from "@/constants/routes/RouteConstants";
 import ApplicationExceptionsApproval from "@/components/common/students/applicationDetails/ApplicationExceptionsApproval.vue";
-import { ApplicationService } from "@/services/ApplicationService";
 
 export default defineComponent({
   components: {
@@ -32,20 +31,6 @@ export default defineComponent({
     },
   },
   setup(props) {
-    const currentApplicationId = ref<number>();
-
-    onMounted(async () => {
-      // Get current application for the parent application.
-      const currentApplication =
-        await ApplicationService.shared.getCurrentApplicationFromParent(
-          props.applicationId,
-          {
-            studentId: props.studentId,
-          },
-        );
-      currentApplicationId.value = currentApplication.id;
-    });
-
     const assessmentsSummaryRoute = {
       name: InstitutionRoutesConst.ASSESSMENTS_SUMMARY,
       params: {
@@ -56,7 +41,6 @@ export default defineComponent({
 
     return {
       assessmentsSummaryRoute,
-      currentApplicationId,
     };
   },
 });

--- a/sources/packages/web/src/views/institution/student/applicationDetails/AssessmentAward.vue
+++ b/sources/packages/web/src/views/institution/student/applicationDetails/AssessmentAward.vue
@@ -44,27 +44,17 @@ export default defineComponent({
     const assessmentAwardData = ref<AwardDetailsAPIOutDTO>();
     const { mapAssessmentDetailHeader } = useAssessment();
     const headerMap = ref<Record<string, string>>({});
-    const currentApplicationId = ref<number>();
 
     onMounted(async () => {
-      // Get current application for the parent application.
-      const currentApplication =
-        await ApplicationService.shared.getCurrentApplicationFromParent(
-          props.applicationId,
-          {
-            studentId: props.studentId,
-          },
-        );
-      currentApplicationId.value = currentApplication.id;
-      loadAssessmentAwardValues(currentApplicationId.value);
+      await loadAssessmentAwardValues();
     });
 
-    const loadAssessmentAwardValues = async (applicationId: number) => {
+    const loadAssessmentAwardValues = async () => {
       assessmentAwardData.value =
         await StudentAssessmentsService.shared.getAssessmentAwardDetails(
           props.assessmentId,
           props.studentId,
-          applicationId,
+          props.applicationId,
         );
       headerMap.value = mapAssessmentDetailHeader(assessmentAwardData.value);
     };

--- a/sources/packages/web/src/views/institution/student/applicationDetails/AssessmentAward.vue
+++ b/sources/packages/web/src/views/institution/student/applicationDetails/AssessmentAward.vue
@@ -22,7 +22,6 @@ import { StudentAssessmentsService } from "@/services/StudentAssessmentsService"
 import { AwardDetailsAPIOutDTO } from "@/services/http/dto";
 import DetailHeader from "@/components/generic/DetailHeader.vue";
 import AssessmentAward from "@/components/common/students/applicationDetails/AssessmentAward.vue";
-import { ApplicationService } from "@/services/ApplicationService";
 
 export default defineComponent({
   components: { AssessmentAward, DetailHeader },

--- a/sources/packages/web/src/views/institution/student/applicationDetails/InstitutionAssessmentsSummary.vue
+++ b/sources/packages/web/src/views/institution/student/applicationDetails/InstitutionAssessmentsSummary.vue
@@ -9,13 +9,13 @@
     </template>
     <request-assessment
       class="mb-5"
-      :applicationId="currentApplicationId"
+      :applicationId="applicationId"
       :studentId="studentId"
       @viewStudentAppeal="goToStudentAppeal"
       @viewApplicationException="goToApplicationException"
     />
     <history-assessment
-      :applicationId="currentApplicationId"
+      :applicationId="applicationId"
       :studentId="studentId"
       :viewRequestTypes="assessmentRequestViewTypes"
       @viewStudentAppeal="goToStudentAppeal"
@@ -28,11 +28,10 @@
 <script lang="ts">
 import { InstitutionRoutesConst } from "@/constants/routes/RouteConstants";
 import { useRouter } from "vue-router";
-import { defineComponent, computed, onMounted, ref } from "vue";
+import { defineComponent, computed } from "vue";
 import { AssessmentTriggerType } from "@/types";
 import RequestAssessment from "@/components/common/students/assessment/Request.vue";
 import HistoryAssessment from "@/components/common/students/assessment/History.vue";
-import { ApplicationService } from "@/services/ApplicationService";
 
 export default defineComponent({
   components: {
@@ -51,19 +50,6 @@ export default defineComponent({
   },
   setup(props) {
     const router = useRouter();
-    const currentApplicationId = ref<number>();
-
-    onMounted(async () => {
-      // Get current application for the parent application.
-      const currentApplication =
-        await ApplicationService.shared.getCurrentApplicationFromParent(
-          props.applicationId,
-          {
-            studentId: props.studentId,
-          },
-        );
-      currentApplicationId.value = currentApplication.id;
-    });
 
     // The assessment trigger types for which the request form must be visible by default.
     const assessmentRequestViewTypes = [
@@ -118,7 +104,6 @@ export default defineComponent({
       goToApplicationException,
       assessmentRequestViewTypes,
       backRoute,
-      currentApplicationId,
     };
   },
 });

--- a/sources/packages/web/src/views/institution/student/applicationDetails/NoticeOfAssessment.vue
+++ b/sources/packages/web/src/views/institution/student/applicationDetails/NoticeOfAssessment.vue
@@ -10,16 +10,15 @@
     <notice-of-assessment-form-view
       :assessment-id="assessmentId"
       :student-id="studentId"
-      :application-id="currentApplicationId"
+      :application-id="applicationId"
     />
   </full-page-container>
 </template>
 
 <script lang="ts">
-import { defineComponent, computed, onMounted, ref } from "vue";
+import { defineComponent, computed } from "vue";
 import NoticeOfAssessmentFormView from "@/components/common/NoticeOfAssessmentFormView.vue";
 import { InstitutionRoutesConst } from "@/constants/routes/RouteConstants";
-import { ApplicationService } from "@/services/ApplicationService";
 
 export default defineComponent({
   components: {
@@ -40,20 +39,6 @@ export default defineComponent({
     },
   },
   setup(props) {
-    const currentApplicationId = ref<number>();
-
-    onMounted(async () => {
-      // Get current application for the parent application.
-      const currentApplication =
-        await ApplicationService.shared.getCurrentApplicationFromParent(
-          props.applicationId,
-          {
-            studentId: props.studentId,
-          },
-        );
-      currentApplicationId.value = currentApplication.id;
-    });
-
     const routeLocation = computed(() => ({
       name: InstitutionRoutesConst.ASSESSMENT_AWARD_VIEW,
       params: {
@@ -63,7 +48,7 @@ export default defineComponent({
       },
     }));
 
-    return { routeLocation, currentApplicationId };
+    return { routeLocation };
   },
 });
 </script>

--- a/sources/packages/web/src/views/institution/student/applicationDetails/StudentAppealRequest.vue
+++ b/sources/packages/web/src/views/institution/student/applicationDetails/StudentAppealRequest.vue
@@ -11,16 +11,15 @@
       :studentId="studentId"
       :appealId="appealId"
       :readOnlyForm="true"
-      :application-id="currentApplicationId"
+      :application-id="applicationId"
     />
   </full-page-container>
 </template>
 
 <script lang="ts">
-import { defineComponent, onMounted, ref } from "vue";
+import { defineComponent } from "vue";
 import { InstitutionRoutesConst } from "@/constants/routes/RouteConstants";
 import StudentAppealRequestsApproval from "@/components/common/students/applicationDetails/StudentAppealRequestsApproval.vue";
-import { ApplicationService } from "@/services/ApplicationService";
 
 export default defineComponent({
   components: { StudentAppealRequestsApproval },
@@ -39,20 +38,6 @@ export default defineComponent({
     },
   },
   setup(props) {
-    const currentApplicationId = ref<number>();
-
-    onMounted(async () => {
-      // Get current application for the parent application.
-      const currentApplication =
-        await ApplicationService.shared.getCurrentApplicationFromParent(
-          props.applicationId,
-          {
-            studentId: props.studentId,
-          },
-        );
-      currentApplicationId.value = currentApplication.id;
-    });
-
     const assessmentsSummaryRoute = {
       name: InstitutionRoutesConst.ASSESSMENTS_SUMMARY,
       params: {
@@ -62,7 +47,6 @@ export default defineComponent({
     };
     return {
       assessmentsSummaryRoute,
-      currentApplicationId,
     };
   },
 });


### PR DESCRIPTION
Reverting changes related to the route with the parent application ID instead of the application ID itself, due to complexities moving forward with the changes that affected more areas than what was foreseen by the Team.