### PR TITLE
#2380 - Updated the criteria to get disbursements for ECE request

### DIFF
--- a/sims.code-workspace
+++ b/sims.code-workspace
@@ -141,7 +141,9 @@
       "Zeebe",
       "lmpt",
       "lmpu",
-      "dependants"
+      "dependants",
+      "enrolment",
+      "enrolments"
     ],
     "[json]": {
       "editor.defaultFormatter": "vscode.json-language-features"

--- a/sources/packages/backend/apps/api/src/route-controllers/confirmation-of-enrollment/_tests_/e2e/confirmation-of-enrollment.institutions.getCOESummary.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/confirmation-of-enrollment/_tests_/e2e/confirmation-of-enrollment.institutions.getCOESummary.e2e-spec.ts
@@ -22,11 +22,12 @@ import {
   Institution,
   Student,
 } from "@sims/sims-db";
-import { EnrollmentPeriod } from "../../../../services";
+
 import { addDays, getISODateOnlyString } from "@sims/utilities";
 import { PaginatedResultsAPIOutDTO } from "../../../models/pagination.dto";
 import { COESummaryAPIOutDTO } from "../../models/confirmation-of-enrollment.dto";
 import { getUserFullName } from "../../../../utilities";
+import { EnrollmentPeriod } from "@sims/services";
 
 describe("ConfirmationOfEnrollmentInstitutionsController(e2e)-getCOESummary", () => {
   let app: INestApplication;

--- a/sources/packages/backend/apps/api/src/route-controllers/confirmation-of-enrollment/confirmation-of-enrollment.institutions.controller.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/confirmation-of-enrollment/confirmation-of-enrollment.institutions.controller.ts
@@ -40,7 +40,6 @@ import {
   ConfirmationOfEnrollmentAPIInDTO,
   COESummaryAPIOutDTO,
 } from "./models/confirmation-of-enrollment.dto";
-import { EnrollmentPeriod } from "../../services/disbursement-schedule/disbursement-schedule.models";
 import { ClientTypeBaseRoute } from "../../types";
 import {
   ApiNotFoundResponse,
@@ -56,6 +55,7 @@ import { ConfirmationOfEnrollmentControllerService } from "./confirmation-of-enr
 import {
   ConfirmationOfEnrollmentService,
   DisbursementOverawardService,
+  EnrollmentPeriod,
 } from "@sims/services";
 import {
   ENROLMENT_ALREADY_COMPLETED,

--- a/sources/packages/backend/apps/api/src/route-controllers/confirmation-of-enrollment/confirmation-of-enrollment.institutions.controller.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/confirmation-of-enrollment/confirmation-of-enrollment.institutions.controller.ts
@@ -108,9 +108,7 @@ export class ConfirmationOfEnrollmentInstitutionsController extends BaseControll
     return {
       results: disbursementPaginatedResult.results.map(
         (disbursement: DisbursementSchedule) => {
-          const offering =
-            disbursement.studentAssessment.application.currentAssessment
-              .offering;
+          const offering = disbursement.studentAssessment.offering;
           return {
             applicationNumber:
               disbursement.studentAssessment.application.applicationNumber,

--- a/sources/packages/backend/apps/api/src/services/disbursement-schedule/disbursement-schedule-service.ts
+++ b/sources/packages/backend/apps/api/src/services/disbursement-schedule/disbursement-schedule-service.ts
@@ -12,8 +12,10 @@ import {
   DisbursementSchedule,
   getUserFullNameLikeSearch,
 } from "@sims/sims-db";
-import { EnrollmentPeriod } from "./disbursement-schedule.models";
-import { ConfirmationOfEnrollmentService } from "@sims/services";
+import {
+  ConfirmationOfEnrollmentService,
+  EnrollmentPeriod,
+} from "@sims/services";
 
 /**
  * Service layer for Student Application disbursement schedules.
@@ -32,20 +34,20 @@ export class DisbursementScheduleService extends RecordDataModelService<Disburse
    ** COE values are retrieved only when an application reaches enrollment status.
    ** When the first COE is approved, application moves to complete status as per workflow but second COE is still
    ** waiting to be approved by institution.
-   * @param locationId
-   * @param enrollmentPeriod
-   * @param paginationOptions
+   * @param locationId location id.
+   * @param enrolmentPeriod enrolment period.
+   * @param paginationOptions pagination options.
    * @returns List of COE for given location.
    */
   async getCOEByLocation(
     locationId: number,
-    enrollmentPeriod: EnrollmentPeriod,
+    enrolmentPeriod: EnrollmentPeriod,
     paginationOptions: PaginationOptions,
   ): Promise<PaginatedResults<DisbursementSchedule>> {
     const disbursementCOEQuery =
       this.confirmationOfEnrollmentService.getDisbursementForCOEQuery(
         this.repo,
-        enrollmentPeriod === EnrollmentPeriod.Current,
+        enrolmentPeriod,
       );
     disbursementCOEQuery.andWhere("location.id = :locationId", { locationId });
     // Add pagination, sort and search criteria.

--- a/sources/packages/backend/apps/api/src/services/disbursement-schedule/disbursement-schedule-service.ts
+++ b/sources/packages/backend/apps/api/src/services/disbursement-schedule/disbursement-schedule-service.ts
@@ -4,23 +4,26 @@ import {
   PaginatedResults,
   OrderByCondition,
 } from "../../utilities";
-import { addDays, FieldSortOrder, COE_WINDOW } from "@sims/utilities";
+import { FieldSortOrder } from "@sims/utilities";
 import { DataSource, Brackets } from "typeorm";
 import {
   RecordDataModelService,
   ApplicationStatus,
-  COEStatus,
   DisbursementSchedule,
   getUserFullNameLikeSearch,
 } from "@sims/sims-db";
 import { EnrollmentPeriod } from "./disbursement-schedule.models";
+import { ConfirmationOfEnrollmentService } from "@sims/services";
 
 /**
  * Service layer for Student Application disbursement schedules.
  */
 @Injectable()
 export class DisbursementScheduleService extends RecordDataModelService<DisbursementSchedule> {
-  constructor(dataSource: DataSource) {
+  constructor(
+    dataSource: DataSource,
+    private readonly confirmationOfEnrollmentService: ConfirmationOfEnrollmentService,
+  ) {
     super(dataSource.getRepository(DisbursementSchedule));
   }
 
@@ -39,56 +42,15 @@ export class DisbursementScheduleService extends RecordDataModelService<Disburse
     enrollmentPeriod: EnrollmentPeriod,
     paginationOptions: PaginationOptions,
   ): Promise<PaginatedResults<DisbursementSchedule>> {
-    const coeThresholdDate = addDays(COE_WINDOW);
-    const coeQuery = this.repo
-      .createQueryBuilder("disbursementSchedule")
-      .select([
-        "disbursementSchedule.id",
-        "disbursementSchedule.disbursementDate",
-        "disbursementSchedule.coeStatus",
-        "application.applicationNumber",
-        "application.id",
-        "studentAssessment.id",
-        "currentAssessment.id",
-        "offering.studyStartDate",
-        "offering.studyEndDate",
-        "student.id",
-        "user.firstName",
-        "user.lastName",
-      ])
-      .innerJoin("disbursementSchedule.studentAssessment", "studentAssessment")
-      .innerJoin("studentAssessment.application", "application")
-      .innerJoin("application.currentAssessment", "currentAssessment")
-      .innerJoin("currentAssessment.offering", "offering")
-      .innerJoin("offering.institutionLocation", "location")
-      .innerJoin("application.student", "student")
-      .innerJoin("student.user", "user")
-      .where("studentAssessment.id = currentAssessment.id")
-      .andWhere("location.id = :locationId", { locationId })
-      .andWhere("application.applicationStatus IN (:...status)", {
-        status: [ApplicationStatus.Enrolment, ApplicationStatus.Completed],
-      })
-      .andWhere("disbursementSchedule.hasEstimatedAwards = true");
-    if (enrollmentPeriod === EnrollmentPeriod.Upcoming) {
-      coeQuery.andWhere(
-        new Brackets((qb) => {
-          qb.where(
-            "disbursementSchedule.disbursementDate > :coeThresholdDate",
-          ).orWhere("disbursementSchedule.coeStatus != :required", {
-            required: COEStatus.required,
-          });
-        }),
+    const disbursementCOEQuery =
+      this.confirmationOfEnrollmentService.getDisbursementForCOEQuery(
+        this.repo,
+        enrollmentPeriod === EnrollmentPeriod.Current,
       );
-    } else {
-      coeQuery
-        .andWhere("disbursementSchedule.disbursementDate <= :coeThresholdDate")
-        .andWhere("disbursementSchedule.coeStatus = :required", {
-          required: COEStatus.required,
-        });
-    }
-    coeQuery.setParameter("coeThresholdDate", coeThresholdDate);
+    disbursementCOEQuery.andWhere("location.id = :locationId", { locationId });
+    // Add pagination, sort and search criteria.
     if (paginationOptions.searchCriteria) {
-      coeQuery
+      disbursementCOEQuery
         .andWhere(
           new Brackets((qb) => {
             qb.where(getUserFullNameLikeSearch()).orWhere(
@@ -101,7 +63,7 @@ export class DisbursementScheduleService extends RecordDataModelService<Disburse
           `%${paginationOptions.searchCriteria.trim()}%`,
         );
     }
-    coeQuery
+    disbursementCOEQuery
       .orderBy(
         this.transformToEntitySortField(
           paginationOptions.sortField,
@@ -110,7 +72,7 @@ export class DisbursementScheduleService extends RecordDataModelService<Disburse
       )
       .offset(paginationOptions.page * paginationOptions.pageLimit)
       .limit(paginationOptions.pageLimit);
-    const [result, count] = await coeQuery.getManyAndCount();
+    const [result, count] = await disbursementCOEQuery.getManyAndCount();
     return {
       results: result,
       count: count,

--- a/sources/packages/backend/apps/api/src/services/disbursement-schedule/disbursement-schedule.models.ts
+++ b/sources/packages/backend/apps/api/src/services/disbursement-schedule/disbursement-schedule.models.ts
@@ -12,24 +12,6 @@ export interface Disbursement {
   disbursements: DisbursementValue[];
 }
 
-/**
- * Enum for COE enrollment period.
- */
-export enum EnrollmentPeriod {
-  /**
-   * The ones considered inside a 21 days period
-   * prior to the offering start date, that allow
-   * them to be approved.
-   */
-  Current = "current",
-  /**
-   * The ones not yet inside a 21 days period
-   * prior to the offering start date, that allow
-   * them to be approved.
-   */
-  Upcoming = "upcoming",
-}
-
 export interface ECertDisbursementSchedule extends DisbursementSchedule {
   stopFullTimeBCFunding: boolean;
 }

--- a/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/institution-integration/ece-request/_tests_/ece-process-integration.scheduler.e2e-spec.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/institution-integration/ece-request/_tests_/ece-process-integration.scheduler.e2e-spec.ts
@@ -69,7 +69,7 @@ describe(describeProcessorRootTest(QueueNames.ECEProcessIntegration), () => {
   });
 
   it(
-    "Should process an ECE request file and when there are valid disbursements and applications" +
+    "Should process an ECE request file when there are valid disbursements for applications" +
       " ignoring the disbursements outside COE window.",
     async () => {
       // Arrange

--- a/sources/packages/backend/libs/integrations/src/esdc-integration/disbursement-receipt-integration/disbursement-receipt-integration.module.ts
+++ b/sources/packages/backend/libs/integrations/src/esdc-integration/disbursement-receipt-integration/disbursement-receipt-integration.module.ts
@@ -1,5 +1,7 @@
 import { Module } from "@nestjs/common";
 import {
+  AssessmentSequentialProcessingService,
+  ConfirmationOfEnrollmentService,
   ReportService,
   RestrictionSharedService,
   SequenceControlService,
@@ -27,6 +29,8 @@ import {
     ReportService,
     StudentRestrictionSharedService,
     RestrictionSharedService,
+    ConfirmationOfEnrollmentService,
+    AssessmentSequentialProcessingService,
   ],
   exports: [DisbursementReceiptProcessingService],
 })

--- a/sources/packages/backend/libs/integrations/src/institution-integration/ece-integration/ece.processing.service.ts
+++ b/sources/packages/backend/libs/integrations/src/institution-integration/ece-integration/ece.processing.service.ts
@@ -41,16 +41,15 @@ export class ECEProcessingService {
   ): Promise<ECEUploadResult[]> {
     processSummary.info(`Retrieving eligible COEs for ECE request.`);
     const eligibleCOEs =
-      await this.disbursementScheduleService.getPendingCOEs();
+      await this.disbursementScheduleService.getInstitutionEligiblePendingEnrolments();
     if (!eligibleCOEs.length) {
       return [];
     }
     processSummary.info(`Found ${eligibleCOEs.length} COEs.`);
     const fileRecords: Record<string, ECERecord[]> = {};
     eligibleCOEs.forEach((eligibleCOE) => {
-      const institutionCode =
-        eligibleCOE.studentAssessment.application.currentAssessment.offering
-          .institutionLocation.institutionCode;
+      const offering = eligibleCOE.studentAssessment.offering;
+      const institutionCode = offering.institutionLocation.institutionCode;
       if (!fileRecords[institutionCode]) {
         fileRecords[institutionCode] = [];
       }
@@ -149,12 +148,11 @@ export class ECEProcessingService {
    */
   private createECERecord(eligibleCOE: DisbursementSchedule): ECERecord {
     const studentAssessment = eligibleCOE.studentAssessment;
+    const offering = studentAssessment.offering;
     const application = studentAssessment.application;
-    const currentAssessment = application.currentAssessment;
     const student = application.student;
     const user = student.user;
     const sinValidation = student.sinValidation;
-    const offering = currentAssessment.offering;
     const institutionLocation = offering.institutionLocation;
     return {
       institutionCode: institutionLocation.institutionCode,

--- a/sources/packages/backend/libs/integrations/src/services/disbursement-schedule/disbursement-schedule.service.ts
+++ b/sources/packages/backend/libs/integrations/src/services/disbursement-schedule/disbursement-schedule.service.ts
@@ -71,7 +71,7 @@ export class DisbursementScheduleService extends RecordDataModelService<Disburse
   }
   /**
    * Fetch the COEs which are eligible to confirm enrolment by the institutions.
-   * @returns eligible COE .
+   * @returns eligible COE.
    */
   async getInstitutionEligiblePendingEnrolments(): Promise<
     DisbursementSchedule[]
@@ -79,13 +79,12 @@ export class DisbursementScheduleService extends RecordDataModelService<Disburse
     const eligibleCOEQuery =
       this.confirmationOfEnrollmentService.getDisbursementForCOEQuery(
         this.repo,
-        true,
       );
     return eligibleCOEQuery
       .andWhere("offering.offeringIntensity = :fullTime", {
         fullTime: OfferingIntensity.fullTime,
       })
-      .andWhere("location.hasIntegration = TRUE")
+      .andWhere("location.hasIntegration = true")
       .orderBy("disbursementSchedule.id", "ASC")
       .getMany();
   }

--- a/sources/packages/backend/libs/integrations/src/services/disbursement-schedule/disbursement-schedule.service.ts
+++ b/sources/packages/backend/libs/integrations/src/services/disbursement-schedule/disbursement-schedule.service.ts
@@ -2,11 +2,12 @@ import { Injectable } from "@nestjs/common";
 import {
   RecordDataModelService,
   DisbursementSchedule,
-  OfferingIntensity,
   ApplicationStatus,
   COEStatus,
+  OfferingIntensity,
 } from "@sims/sims-db";
-import { DataSource, In } from "typeorm";
+import { addDays, COE_WINDOW } from "@sims/utilities";
+import { DataSource } from "typeorm";
 
 /**
  * Service layer for Student Application disbursement schedules.
@@ -68,71 +69,64 @@ export class DisbursementScheduleService extends RecordDataModelService<Disburse
       .getMany();
   }
   /**
-   * Fetch the COEs which are pending for the institution.
-   * @returns eligible COEs.
+   * Fetch the COEs which are eligible to confirm enrolment by the institutions.
+   * @returns eligible COE .
    */
-  async getPendingCOEs(): Promise<DisbursementSchedule[]> {
-    return this.repo.find({
-      select: {
-        id: true,
-        disbursementDate: true,
-        disbursementValues: { id: true, valueCode: true, valueAmount: true },
-        studentAssessment: {
-          id: true,
-          application: {
-            id: true,
-            applicationNumber: true,
-            studentNumber: true,
-            currentAssessment: {
-              id: true,
-              offering: {
-                id: true,
-                studyStartDate: true,
-                studyEndDate: true,
-                institutionLocation: {
-                  institutionCode: true,
-                },
-              },
-            },
-            student: {
-              id: true,
-              birthDate: true,
-              sinValidation: { id: true, sin: true },
-              user: { id: true, lastName: true, firstName: true },
-            },
-          },
-        },
-      },
-      relations: {
-        disbursementValues: true,
-        studentAssessment: {
-          application: {
-            currentAssessment: { offering: { institutionLocation: true } },
-            student: {
-              sinValidation: true,
-              user: true,
-            },
-          },
-        },
-      },
-      where: {
-        coeStatus: COEStatus.required,
-        studentAssessment: {
-          application: {
-            applicationStatus: In([
-              ApplicationStatus.Enrolment,
-              ApplicationStatus.Completed,
-            ]),
-            currentAssessment: {
-              offering: {
-                institutionLocation: { hasIntegration: true },
-                offeringIntensity: OfferingIntensity.fullTime,
-              },
-            },
-          },
-        },
-        hasEstimatedAwards: true,
-      },
-    });
+  async getInstitutionEligiblePendingEnrolments(): Promise<
+    DisbursementSchedule[]
+  > {
+    const coeThresholdDate = addDays(COE_WINDOW);
+    return this.repo
+      .createQueryBuilder("disbursementSchedule")
+      .select([
+        "disbursementSchedule.id",
+        "disbursementSchedule.disbursementDate",
+        "disbursementValues.id",
+        "disbursementValues.valueAmount",
+        "disbursementValues.valueCode",
+        "studentAssessment.id",
+        "offering.id",
+        "offering.studyStartDate",
+        "offering.studyEndDate",
+        "location.id",
+        "location.institutionCode",
+        "application.id",
+        "application.applicationNumber",
+        "application.studentNumber",
+        "student.id",
+        "student.birthDate",
+        "sinValidation.id",
+        "sinValidation.sin",
+        "user.id",
+        "user.firstName",
+        "user.lastName",
+      ])
+      .innerJoin(
+        "disbursementSchedule.disbursementValues",
+        "disbursementValues",
+      )
+      .innerJoin("disbursementSchedule.studentAssessment", "studentAssessment")
+      .innerJoin("studentAssessment.offering", "offering")
+      .innerJoin("studentAssessment.application", "application")
+      .innerJoin("offering.institutionLocation", "location")
+      .innerJoin("application.student", "student")
+      .innerJoin("student.sinValidation", "sinValidation")
+      .innerJoin("student.user", "user")
+      .where("studentAssessment.id = application.currentAssessment.id")
+      .andWhere("application.applicationStatus IN (:...status)", {
+        status: [ApplicationStatus.Enrolment, ApplicationStatus.Completed],
+      })
+      .andWhere("disbursementSchedule.hasEstimatedAwards = true")
+      .andWhere("disbursementSchedule.disbursementDate <= :coeThresholdDate", {
+        coeThresholdDate,
+      })
+      .andWhere("disbursementSchedule.coeStatus = :required", {
+        required: COEStatus.required,
+      })
+      .andWhere("offering.offeringIntensity = :fullTime", {
+        fullTime: OfferingIntensity.fullTime,
+      })
+      .andWhere("location.hasIntegration = TRUE")
+      .getMany();
   }
 }

--- a/sources/packages/backend/libs/services/src/confirmation-of-enrollment/confirmation-of-enrollment.service.ts
+++ b/sources/packages/backend/libs/services/src/confirmation-of-enrollment/confirmation-of-enrollment.service.ts
@@ -736,8 +736,10 @@ export class ConfirmationOfEnrollmentService {
   /**
    * Get disbursement(s) for COE Query.
    **Note: Please ensure that alias from this query is used correctly at the consumer side.
+   * @param disbursementScheduleRepo disbursement schedule repository.
    * @param isEligibleToConfirm whether the disbursement(s) is/are eligible to be confirmed by institution.
-   * @param addConditionsAndOrderAndSelect add conditions and order to the query builder.
+   * If the value is false, then the query returns disbursements that are either not eligible to be confirmed
+   * or already confirmed.
    * @returns disbursements query.
    */
   getDisbursementForCOEQuery(
@@ -787,6 +789,7 @@ export class ConfirmationOfEnrollmentService {
         status: [ApplicationStatus.Enrolment, ApplicationStatus.Completed],
       })
       .andWhere("disbursementSchedule.hasEstimatedAwards = true");
+    // Get only COE(s) that are eligible to be confirmed by institution.
     if (isEligibleToConfirm) {
       disbursementCOEQuery
         .andWhere(
@@ -796,7 +799,9 @@ export class ConfirmationOfEnrollmentService {
         .andWhere("disbursementSchedule.coeStatus = :required", {
           required: COEStatus.required,
         });
-    } else {
+    }
+    // Get only COE(s) that are either already confirmed or not eligible to be confirmed by institution.
+    else {
       disbursementCOEQuery.andWhere(
         new Brackets((qb) => {
           qb.where(

--- a/sources/packages/backend/libs/services/src/confirmation-of-enrollment/confirmation-of-enrollment.service.ts
+++ b/sources/packages/backend/libs/services/src/confirmation-of-enrollment/confirmation-of-enrollment.service.ts
@@ -22,6 +22,7 @@ import {
 import {
   Award,
   COEApprovalPeriodStatus,
+  EnrollmentPeriod,
   MaxTuitionRemittanceTypes,
   OfferingCosts,
 } from "./models/confirmation-of-enrollment.models";
@@ -737,14 +738,14 @@ export class ConfirmationOfEnrollmentService {
    * Get disbursement(s) for COE Query.
    **Note: Please ensure that alias from this query is used correctly at the consumer side.
    * @param disbursementScheduleRepo disbursement schedule repository.
-   * @param isEligibleToConfirm whether the disbursement(s) is/are eligible to be confirmed by institution.
-   * If the value is false, then the query returns disbursements that are either not eligible to be confirmed
+   * @param enrolmentPeriod if the value is 'Current' then the query returns disbursement(s) is/are eligible to be confirmed by institution.
+   * If the value is 'Upcoming', then the query returns disbursements that are either not eligible to be confirmed
    * or already confirmed.
    * @returns disbursements query.
    */
   getDisbursementForCOEQuery(
     disbursementScheduleRepo: Repository<DisbursementSchedule>,
-    isEligibleToConfirm: boolean,
+    enrolmentPeriod = EnrollmentPeriod.Current,
   ): SelectQueryBuilder<DisbursementSchedule> {
     const coeThresholdDate = addDays(COE_WINDOW);
     const disbursementCOEQuery = disbursementScheduleRepo
@@ -790,7 +791,7 @@ export class ConfirmationOfEnrollmentService {
       })
       .andWhere("disbursementSchedule.hasEstimatedAwards = true");
     // Get only COE(s) that are eligible to be confirmed by institution.
-    if (isEligibleToConfirm) {
+    if (enrolmentPeriod === EnrollmentPeriod.Current) {
       disbursementCOEQuery
         .andWhere(
           "disbursementSchedule.disbursementDate <= :coeThresholdDate",

--- a/sources/packages/backend/libs/services/src/confirmation-of-enrollment/confirmation-of-enrollment.service.ts
+++ b/sources/packages/backend/libs/services/src/confirmation-of-enrollment/confirmation-of-enrollment.service.ts
@@ -801,6 +801,7 @@ export class ConfirmationOfEnrollmentService {
         new Brackets((qb) => {
           qb.where(
             "disbursementSchedule.disbursementDate > :coeThresholdDate",
+            { coeThresholdDate },
           ).orWhere("disbursementSchedule.coeStatus != :required", {
             required: COEStatus.required,
           });

--- a/sources/packages/backend/libs/services/src/confirmation-of-enrollment/models/confirmation-of-enrollment.models.ts
+++ b/sources/packages/backend/libs/services/src/confirmation-of-enrollment/models/confirmation-of-enrollment.models.ts
@@ -52,3 +52,21 @@ export enum COEApprovalPeriodStatus {
    */
   AfterApprovalPeriod = "After approval period",
 }
+
+/**
+ * Enum for COE enrollment period.
+ */
+export enum EnrollmentPeriod {
+  /**
+   * The ones considered inside a 21 days period
+   * prior to the offering start date, that allow
+   * them to be approved.
+   */
+  Current = "current",
+  /**
+   * The ones not yet inside a 21 days period
+   * prior to the offering start date, that allow
+   * them to be approved.
+   */
+  Upcoming = "upcoming",
+}


### PR DESCRIPTION
# Fix ECE Request COE conditions

## Logic Centralization

- [x] Centralized the logic which displays the COE Requests for `Current Period` and ECE Requests sent on integration.

## Added default order to pull ECE records

- [x] Currently when fetching `disbursement` records for ECE there is no ordering. Hence added ordering by `disbursement schedule id`.

## E2E Tests

- [x] Added E2E Tests for ECE Request processor for `COE_Window` and to get records only from `Current Assessment`.
![image](https://github.com/user-attachments/assets/fe475f48-0d62-4b33-ad24-daf9695a7bce)

- [x] Added API E2E Tests for COE Summary for application status, COE Status criteria and location criteria.
![image](https://github.com/user-attachments/assets/da01241e-46a3-49a1-a43e-c34f98835f75)

