### PR TITLE
#4352 - CAS - Status on Approve / Reject Batch Action

### DIFF
--- a/sources/packages/backend/apps/api/src/auth/roles.enum.ts
+++ b/sources/packages/backend/apps/api/src/auth/roles.enum.ts
@@ -10,7 +10,7 @@ export enum Role {
   AESTCreateInstitution = "aest-create-institution",
   AESTEditCASSupplierInfo = "aest-edit-cas-supplier-info",
   AESTCASInvoicing = "aest-cas-invoicing",
-  AESTCASInvoiceBatchExpense = "aest-cas-expense-authority",
+  AESTCCASExpenseAuthority = "aest-cas-expense-authority",
   AESTBypassStudentRestriction = "aest-bypass-student-restriction",
   AESTQueueDashboardAdmin = "aest-queue-dashboard-admin",
   StudentAddRestriction = "student-add-restriction",

--- a/sources/packages/backend/apps/api/src/auth/roles.enum.ts
+++ b/sources/packages/backend/apps/api/src/auth/roles.enum.ts
@@ -10,7 +10,7 @@ export enum Role {
   AESTCreateInstitution = "aest-create-institution",
   AESTEditCASSupplierInfo = "aest-edit-cas-supplier-info",
   AESTCASInvoicing = "aest-cas-invoicing",
-  AESTCCASExpenseAuthority = "aest-cas-expense-authority",
+  AESTCASExpenseAuthority = "aest-cas-expense-authority",
   AESTBypassStudentRestriction = "aest-bypass-student-restriction",
   AESTQueueDashboardAdmin = "aest-queue-dashboard-admin",
   StudentAddRestriction = "student-add-restriction",

--- a/sources/packages/backend/apps/api/src/auth/roles.enum.ts
+++ b/sources/packages/backend/apps/api/src/auth/roles.enum.ts
@@ -10,6 +10,7 @@ export enum Role {
   AESTCreateInstitution = "aest-create-institution",
   AESTEditCASSupplierInfo = "aest-edit-cas-supplier-info",
   AESTCASInvoicing = "aest-cas-invoicing",
+  AESTCASInvoiceBatchExpense = "aest-cas-expense-authority",
   AESTBypassStudentRestriction = "aest-bypass-student-restriction",
   AESTQueueDashboardAdmin = "aest-queue-dashboard-admin",
   StudentAddRestriction = "student-add-restriction",

--- a/sources/packages/backend/apps/api/src/constants/error-code.constants.ts
+++ b/sources/packages/backend/apps/api/src/constants/error-code.constants.ts
@@ -249,3 +249,8 @@ export const STUDENT_NOT_FOUND = "STUDENT_NOT_FOUND";
  * CAS invoice batch not found error code.
  */
 export const CAS_INVOICE_BATCH_NOT_FOUND = "CAS_INVOICE_BATCH_NOT_FOUND";
+
+/**
+ * CAS invoice batch not pending error code.
+ */
+export const CAS_INVOICE_BATCH_NOT_PENDING = "CAS_INVOICE_BATCH_NOT_PENDING";

--- a/sources/packages/backend/apps/api/src/route-controllers/cas-invoice-batch/_tests_/e2e/cas-invoice-batch.aest.controller.updateCASInvoiceBatch.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/cas-invoice-batch/_tests_/e2e/cas-invoice-batch.aest.controller.updateCASInvoiceBatch.e2e-spec.ts
@@ -1,0 +1,142 @@
+import { HttpStatus, INestApplication } from "@nestjs/common";
+import * as request from "supertest";
+import {
+  AESTGroups,
+  BEARER_AUTH_TYPE,
+  createTestingAppModule,
+  getAESTToken,
+  getAESTUser,
+} from "../../../../testHelpers";
+import { createE2EDataSources, E2EDataSources } from "@sims/test-utils";
+import { createFakeCASInvoiceBatch } from "../../../../../../../libs/test-utils/src";
+import { SystemUsersService } from "@sims/services";
+import { CASInvoiceBatchApprovalStatus, User } from "@sims/sims-db";
+
+describe("CASInvoiceBatchAESTController(e2e)-updateCASInvoiceBatch", () => {
+  let app: INestApplication;
+  let db: E2EDataSources;
+  let systemUsersService: SystemUsersService;
+
+  beforeAll(async () => {
+    const { nestApplication, dataSource } = await createTestingAppModule();
+    app = nestApplication;
+    systemUsersService = app.get(SystemUsersService);
+    db = createE2EDataSources(dataSource);
+  });
+
+  it("Should be able to approve an invoice batch when the batch is pending.", async () => {
+    // Arrange
+    const casInvoiceBatch = createFakeCASInvoiceBatch({
+      creator: systemUsersService.systemUser,
+    });
+    await db.casInvoiceBatch.save(casInvoiceBatch);
+    const payload = {
+      approvalStatus: CASInvoiceBatchApprovalStatus.Approved,
+    };
+    const endpoint = `/aest/cas-invoice-batch/${casInvoiceBatch.id}`;
+    const token = await getAESTToken(AESTGroups.BusinessAdministrators);
+
+    // Act/Assert
+    await request(app.getHttpServer())
+      .patch(endpoint)
+      .send(payload)
+      .auth(token, BEARER_AUTH_TYPE)
+      .expect(HttpStatus.OK);
+    const updatedCASInvoiceBatch = await db.casInvoiceBatch.findOne({
+      select: {
+        id: true,
+        approvalStatus: true,
+        approvalStatusUpdatedBy: { id: true },
+      },
+      relations: { approvalStatusUpdatedBy: true },
+      where: { id: casInvoiceBatch.id },
+      loadEagerRelations: false,
+    });
+    const approvalStatusUpdatedBy = await getAESTUser(
+      db.dataSource,
+      AESTGroups.BusinessAdministrators,
+    );
+    expect(updatedCASInvoiceBatch).toEqual({
+      id: casInvoiceBatch.id,
+      approvalStatus: CASInvoiceBatchApprovalStatus.Approved,
+      approvalStatusUpdatedBy: { id: approvalStatusUpdatedBy.id } as User,
+    });
+  });
+
+  it("Should throw a HttpStatus UnprocessableEntityException (422) error when the batch is approved.", async () => {
+    // Arrange
+    const casInvoiceBatch = createFakeCASInvoiceBatch(
+      {
+        creator: systemUsersService.systemUser,
+      },
+      {
+        initialValue: {
+          approvalStatus: CASInvoiceBatchApprovalStatus.Approved,
+        },
+      },
+    );
+    await db.casInvoiceBatch.save(casInvoiceBatch);
+    const payload = {
+      approvalStatus: CASInvoiceBatchApprovalStatus.Approved,
+    };
+    const endpoint = `/aest/cas-invoice-batch/${casInvoiceBatch.id}`;
+    const token = await getAESTToken(AESTGroups.BusinessAdministrators);
+
+    // Act/Assert
+    await request(app.getHttpServer())
+      .patch(endpoint)
+      .send(payload)
+      .auth(token, BEARER_AUTH_TYPE)
+      .expect(HttpStatus.UNPROCESSABLE_ENTITY)
+      .expect({
+        statusCode: HttpStatus.UNPROCESSABLE_ENTITY,
+        message: `Cannot update CAS invoice batch with ID ${casInvoiceBatch.id} that is approved or rejected.`,
+        error: "Unprocessable Entity",
+      });
+  });
+
+  it("Should throw a HttpStatus Not Found (404) error when the CAS invoice batch doesn't exist.", async () => {
+    // Arrange
+    const endpoint = "/aest/cas-invoice-batch/99999999";
+    const token = await getAESTToken(AESTGroups.BusinessAdministrators);
+    const payload = {
+      approvalStatus: CASInvoiceBatchApprovalStatus.Approved,
+    };
+
+    // Act/Assert
+    await request(app.getHttpServer())
+      .patch(endpoint)
+      .send(payload)
+      .auth(token, BEARER_AUTH_TYPE)
+      .expect(HttpStatus.NOT_FOUND)
+      .expect({
+        statusCode: HttpStatus.NOT_FOUND,
+        message: "CAS invoice batch with ID 99999999 not found.",
+        error: "Not Found",
+      });
+  });
+
+  it("Should throw a HttpStatus Forbidden (403) error when an unauthorized Ministry user tries to update the invoice batch.", async () => {
+    // Arrange
+    const endpoint = "/aest/cas-invoice-batch/99999999";
+    const token = await getAESTToken(AESTGroups.MOFOperations);
+    const payload = {
+      approvalStatus: CASInvoiceBatchApprovalStatus.Approved,
+    };
+    // Act/Assert
+    await request(app.getHttpServer())
+      .patch(endpoint)
+      .send(payload)
+      .auth(token, BEARER_AUTH_TYPE)
+      .expect(HttpStatus.FORBIDDEN)
+      .expect({
+        statusCode: HttpStatus.FORBIDDEN,
+        message: "Forbidden resource",
+        error: "Forbidden",
+      });
+  });
+
+  afterAll(async () => {
+    await app?.close();
+  });
+});

--- a/sources/packages/backend/apps/api/src/route-controllers/cas-invoice-batch/cas-invoice-batch.aest.controller.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/cas-invoice-batch/cas-invoice-batch.aest.controller.ts
@@ -1,22 +1,37 @@
 import {
+  Body,
   Controller,
   Get,
   NotFoundException,
   Param,
   ParseIntPipe,
+  Patch,
   Query,
   Res,
+  UnprocessableEntityException,
 } from "@nestjs/common";
-import { ApiNotFoundResponse, ApiTags } from "@nestjs/swagger";
-import { AuthorizedParties, Role, UserGroups } from "../../auth";
-import { AllowAuthorizedParty, Groups, Roles } from "../../auth/decorators";
+import {
+  ApiForbiddenResponse,
+  ApiNotFoundResponse,
+  ApiTags,
+} from "@nestjs/swagger";
+import { AuthorizedParties, IUserToken, Role, UserGroups } from "../../auth";
+import {
+  AllowAuthorizedParty,
+  Groups,
+  Roles,
+  UserToken,
+} from "../../auth/decorators";
 import BaseController from "../BaseController";
 import { ClientTypeBaseRoute } from "../../types";
 import {
   CASInvoiceBatchReportService,
   CASInvoiceBatchService,
 } from "../../services";
-import { CASInvoiceBatchAPIOutDTO } from "./models/cas-invoice-batch.dto";
+import {
+  CASInvoiceBatchAPIOutDTO,
+  UpdateCASInvoiceBatchAPIInDTO,
+} from "./models/cas-invoice-batch.dto";
 import { getUserFullName } from "../../utilities";
 import {
   CASInvoiceBatchesPaginationOptionsAPIInDTO,
@@ -28,10 +43,13 @@ import {
 } from "@sims/utilities";
 import { Response } from "express";
 import { streamFile } from "../utils";
-import { CAS_INVOICE_BATCH_NOT_FOUND } from "../../constants";
+import {
+  CAS_INVOICE_BATCH_NOT_FOUND,
+  CAS_INVOICE_BATCH_NOT_PENDING,
+} from "../../constants";
 
 @AllowAuthorizedParty(AuthorizedParties.aest)
-@Roles(Role.AESTCASInvoicing)
+@Roles(Role.AESTCASInvoicing, Role.AESTCASInvoiceBatchExpense)
 @Groups(UserGroups.AESTUser)
 @Controller("cas-invoice-batch")
 @ApiTags(`${ClientTypeBaseRoute.AEST}-cas-invoice-batch`)
@@ -97,6 +115,43 @@ export class CASInvoiceBatchAESTController extends BaseController {
         error.name === CAS_INVOICE_BATCH_NOT_FOUND
       ) {
         throw new NotFoundException(error.message);
+      }
+      throw error;
+    }
+  }
+
+  /**
+   * Update the approval status for a CAS invoice batch record.
+   * @param payload CAS invoice batch payload.
+   * @param casInvoiceBatchId ID of the CAS invoice batch to be updated.
+   */
+  @Roles(Role.AESTCASInvoiceBatchExpense)
+  @Patch("/:casInvoiceBatchId")
+  @ApiNotFoundResponse({
+    description: "CAS invoice batch not found.",
+  })
+  @ApiForbiddenResponse({
+    description: "You are not authorized to update a CAS invoice batch.",
+  })
+  async updateCASInvoiceBatch(
+    @Body() payload: UpdateCASInvoiceBatchAPIInDTO,
+    @Param("casInvoiceBatchId", ParseIntPipe) casInvoiceBatchId: number,
+    @UserToken() userToken: IUserToken,
+  ): Promise<void> {
+    try {
+      await this.casInvoiceBatchService.updateCASInvoiceBatch(
+        casInvoiceBatchId,
+        payload.approvalStatus,
+        userToken.userId,
+      );
+    } catch (error: unknown) {
+      if (error instanceof CustomNamedError) {
+        if (error.name === CAS_INVOICE_BATCH_NOT_FOUND) {
+          throw new NotFoundException(error.message);
+        }
+        if (error.name === CAS_INVOICE_BATCH_NOT_PENDING) {
+          throw new UnprocessableEntityException(error.message);
+        }
       }
       throw error;
     }

--- a/sources/packages/backend/apps/api/src/route-controllers/cas-invoice-batch/cas-invoice-batch.aest.controller.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/cas-invoice-batch/cas-invoice-batch.aest.controller.ts
@@ -126,7 +126,7 @@ export class CASInvoiceBatchAESTController extends BaseController {
    * @param payload CAS invoice batch payload.
    * @param casInvoiceBatchId ID of the CAS invoice batch to be updated.
    */
-  @Roles(Role.AESTCCASExpenseAuthority)
+  @Roles(Role.AESTCASExpenseAuthority)
   @Patch(":casInvoiceBatchId")
   @ApiNotFoundResponse({
     description: "CAS invoice batch not found.",

--- a/sources/packages/backend/apps/api/src/route-controllers/cas-invoice-batch/cas-invoice-batch.aest.controller.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/cas-invoice-batch/cas-invoice-batch.aest.controller.ts
@@ -49,7 +49,6 @@ import {
 } from "../../constants";
 
 @AllowAuthorizedParty(AuthorizedParties.aest)
-@Roles(Role.AESTCASInvoicing, Role.AESTCASInvoiceBatchExpense)
 @Groups(UserGroups.AESTUser)
 @Controller("cas-invoice-batch")
 @ApiTags(`${ClientTypeBaseRoute.AEST}-cas-invoice-batch`)
@@ -66,6 +65,7 @@ export class CASInvoiceBatchAESTController extends BaseController {
    * @param paginationOptions pagination options.
    * @returns list of all invoice batches.
    */
+  @Roles(Role.AESTCASInvoicing)
   @Get()
   async getInvoiceBatches(
     @Query() paginationOptions: CASInvoiceBatchesPaginationOptionsAPIInDTO,
@@ -93,6 +93,7 @@ export class CASInvoiceBatchAESTController extends BaseController {
    * @param casInvoiceBatchId batch ID to have the report generated for.
    * @returns list of all invoices in the batch.
    */
+  @Roles(Role.AESTCASInvoicing)
   @Get(":casInvoiceBatchId/report")
   @ApiNotFoundResponse({ description: "CAS invoice batch not found." })
   async getCASInvoiceBatchReport(
@@ -125,8 +126,8 @@ export class CASInvoiceBatchAESTController extends BaseController {
    * @param payload CAS invoice batch payload.
    * @param casInvoiceBatchId ID of the CAS invoice batch to be updated.
    */
-  @Roles(Role.AESTCASInvoiceBatchExpense)
-  @Patch("/:casInvoiceBatchId")
+  @Roles(Role.AESTCCASExpenseAuthority)
+  @Patch(":casInvoiceBatchId")
   @ApiNotFoundResponse({
     description: "CAS invoice batch not found.",
   })

--- a/sources/packages/backend/apps/api/src/route-controllers/cas-invoice-batch/cas-invoice-batch.aest.controller.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/cas-invoice-batch/cas-invoice-batch.aest.controller.ts
@@ -14,6 +14,7 @@ import {
   ApiForbiddenResponse,
   ApiNotFoundResponse,
   ApiTags,
+  ApiUnprocessableEntityResponse,
 } from "@nestjs/swagger";
 import { AuthorizedParties, IUserToken, Role, UserGroups } from "../../auth";
 import {
@@ -133,6 +134,10 @@ export class CASInvoiceBatchAESTController extends BaseController {
   })
   @ApiForbiddenResponse({
     description: "You are not authorized to update a CAS invoice batch.",
+  })
+  @ApiUnprocessableEntityResponse({
+    description:
+      "Cannot update CAS invoice batch that is approved or rejected.",
   })
   async updateCASInvoiceBatch(
     @Body() payload: UpdateCASInvoiceBatchAPIInDTO,

--- a/sources/packages/backend/apps/api/src/route-controllers/cas-invoice-batch/models/cas-invoice-batch.dto.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/cas-invoice-batch/models/cas-invoice-batch.dto.ts
@@ -1,5 +1,5 @@
 import { CASInvoiceBatchApprovalStatus } from "@sims/sims-db";
-import { IsNotEmpty } from "class-validator";
+import { IsIn } from "class-validator";
 
 export class CASInvoiceBatchAPIOutDTO {
   id: number;
@@ -11,6 +11,11 @@ export class CASInvoiceBatchAPIOutDTO {
 }
 
 export class UpdateCASInvoiceBatchAPIInDTO {
-  @IsNotEmpty()
-  approvalStatus: CASInvoiceBatchApprovalStatus;
+  @IsIn([
+    CASInvoiceBatchApprovalStatus.Approved,
+    CASInvoiceBatchApprovalStatus.Rejected,
+  ])
+  approvalStatus:
+    | CASInvoiceBatchApprovalStatus.Approved
+    | CASInvoiceBatchApprovalStatus.Rejected;
 }

--- a/sources/packages/backend/apps/api/src/route-controllers/cas-invoice-batch/models/cas-invoice-batch.dto.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/cas-invoice-batch/models/cas-invoice-batch.dto.ts
@@ -1,4 +1,5 @@
 import { CASInvoiceBatchApprovalStatus } from "@sims/sims-db";
+import { IsNotEmpty } from "class-validator";
 
 export class CASInvoiceBatchAPIOutDTO {
   id: number;
@@ -7,4 +8,9 @@ export class CASInvoiceBatchAPIOutDTO {
   approvalStatus: CASInvoiceBatchApprovalStatus;
   approvalStatusUpdatedOn: Date;
   approvalStatusUpdatedBy: string;
+}
+
+export class UpdateCASInvoiceBatchAPIInDTO {
+  @IsNotEmpty()
+  approvalStatus: CASInvoiceBatchApprovalStatus;
 }

--- a/sources/packages/backend/apps/api/src/services/cas-invoice-batch/cas-invoice-batch.service.ts
+++ b/sources/packages/backend/apps/api/src/services/cas-invoice-batch/cas-invoice-batch.service.ts
@@ -1,11 +1,20 @@
 import { Injectable } from "@nestjs/common";
 import { InjectRepository } from "@nestjs/typeorm";
-import { CASInvoiceBatch } from "@sims/sims-db";
+import {
+  CASInvoiceBatch,
+  CASInvoiceBatchApprovalStatus,
+  User,
+} from "@sims/sims-db";
 import { In, Repository } from "typeorm";
 import {
   CASInvoiceBatchesPaginationOptions,
   PaginatedResults,
 } from "../../utilities";
+import { CustomNamedError } from "@sims/utilities";
+import {
+  CAS_INVOICE_BATCH_NOT_FOUND,
+  CAS_INVOICE_BATCH_NOT_PENDING,
+} from "../../constants";
 
 @Injectable()
 export class CASInvoiceBatchService {
@@ -46,5 +55,65 @@ export class CASInvoiceBatchService {
       },
     });
     return { results, count };
+  }
+
+  /**
+   * Update the approval status for a CAS invoice batch record.
+   * @param casInvoiceBatchId ID of the CAS invoice batch to be updated.
+   * @param approvalStatus approval status.
+   * @param auditUserId user to update the record.
+   */
+  async updateCASInvoiceBatch(
+    casInvoiceBatchId: number,
+    approvalStatus: CASInvoiceBatchApprovalStatus,
+    auditUserId: number,
+  ): Promise<void> {
+    const casInvoiceBatch = await this.getCASInvoiceBatchRecord(
+      casInvoiceBatchId,
+    );
+    if (!casInvoiceBatch) {
+      throw new CustomNamedError(
+        `CAS invoice batch with ID ${casInvoiceBatchId} not found.`,
+        CAS_INVOICE_BATCH_NOT_FOUND,
+      );
+    }
+    if (
+      casInvoiceBatch.approvalStatus !== CASInvoiceBatchApprovalStatus.Pending
+    ) {
+      throw new CustomNamedError(
+        `Cannot update CAS invoice batch with ID ${casInvoiceBatchId} that is approved or rejected.`,
+        CAS_INVOICE_BATCH_NOT_PENDING,
+      );
+    }
+    const auditUser = { id: auditUserId } as User;
+    try {
+      await this.casInvoiceBatchRepo.update(
+        { id: casInvoiceBatchId },
+        {
+          approvalStatus,
+          approvalStatusUpdatedBy: auditUser,
+          approvalStatusUpdatedOn: new Date(),
+        },
+      );
+    } catch (error: unknown) {
+      throw error;
+    }
+  }
+
+  /**
+   * Retrieve a CAS invoice batch record.
+   * @param casInvoiceBatchId ID of the CAS invoice batch to be retrieved.
+   * @returns the CAS invoice batch with all its invoices and related data.
+   */
+  private async getCASInvoiceBatchRecord(
+    casInvoiceBatchId: number,
+  ): Promise<CASInvoiceBatch> {
+    return this.casInvoiceBatchRepo.findOne({
+      select: {
+        id: true,
+        approvalStatus: true,
+      },
+      where: { id: casInvoiceBatchId },
+    });
   }
 }

--- a/sources/packages/backend/apps/api/src/services/cas-invoice-batch/cas-invoice-batch.service.ts
+++ b/sources/packages/backend/apps/api/src/services/cas-invoice-batch/cas-invoice-batch.service.ts
@@ -86,18 +86,14 @@ export class CASInvoiceBatchService {
       );
     }
     const auditUser = { id: auditUserId } as User;
-    try {
-      await this.casInvoiceBatchRepo.update(
-        { id: casInvoiceBatchId },
-        {
-          approvalStatus,
-          approvalStatusUpdatedBy: auditUser,
-          approvalStatusUpdatedOn: new Date(),
-        },
-      );
-    } catch (error: unknown) {
-      throw error;
-    }
+    await this.casInvoiceBatchRepo.update(
+      { id: casInvoiceBatchId },
+      {
+        approvalStatus,
+        approvalStatusUpdatedBy: auditUser,
+        approvalStatusUpdatedOn: new Date(),
+      },
+    );
   }
 
   /**

--- a/sources/packages/web/src/services/CASInvoiceBatchService.ts
+++ b/sources/packages/web/src/services/CASInvoiceBatchService.ts
@@ -3,6 +3,7 @@ import ApiClient from "@/services/http/ApiClient";
 import {
   CASInvoiceBatchAPIOutDTO,
   PaginatedResultsAPIOutDTO,
+  UpdateCASInvoiceBatchAPIInDTO,
 } from "@/services/http/dto";
 import { PaginationOptions } from "@/types";
 
@@ -40,5 +41,20 @@ export class CASInvoiceBatchService {
     );
     const { downloadFileAsBlob } = useFileUtils();
     downloadFileAsBlob(file);
+  }
+
+  /**
+   * Update the approval status for a CAS invoice batch record.
+   * @param casInvoiceBatchId ID of the CAS invoice batch to be updated.
+   * @param payload approval status to be updated for the record.
+   */
+  async updateCASInvoiceBatch(
+    casInvoiceBatchId: number,
+    payload: UpdateCASInvoiceBatchAPIInDTO,
+  ): Promise<void> {
+    await ApiClient.CASInvoiceBatchApi.updateCASInvoiceBatch(
+      casInvoiceBatchId,
+      payload,
+    );
   }
 }

--- a/sources/packages/web/src/services/http/CASInvoiceBatchApi.ts
+++ b/sources/packages/web/src/services/http/CASInvoiceBatchApi.ts
@@ -3,6 +3,7 @@ import HttpBaseClient from "./common/HttpBaseClient";
 import {
   CASInvoiceBatchAPIOutDTO,
   PaginatedResultsAPIOutDTO,
+  UpdateCASInvoiceBatchAPIInDTO,
 } from "@/services/http/dto";
 import { getPaginationQueryString } from "@/helpers";
 import { AxiosResponse } from "axios";
@@ -36,5 +37,18 @@ export class CASInvoiceBatchApi extends HttpBaseClient {
     casInvoiceBatchId: number,
   ): Promise<AxiosResponse<unknown>> {
     return this.downloadFile(`cas-invoice-batch/${casInvoiceBatchId}/report`);
+  }
+
+  /**
+   * Update the approval status for a CAS invoice batch record.
+   * @param casInvoiceBatchId ID of the CAS invoice batch to be updated.
+   * @param payload approval status to be updated for the record.
+   */
+  async updateCASInvoiceBatch(
+    casInvoiceBatchId: number,
+    payload: UpdateCASInvoiceBatchAPIInDTO,
+  ): Promise<void> {
+    const url = `cas-invoice-batch/${casInvoiceBatchId}`;
+    return this.patchCall(this.addClientRoot(url), payload);
   }
 }

--- a/sources/packages/web/src/services/http/dto/CASInvoiceBatch.dto.ts
+++ b/sources/packages/web/src/services/http/dto/CASInvoiceBatch.dto.ts
@@ -8,3 +8,7 @@ export interface CASInvoiceBatchAPIOutDTO {
   approvalStatusUpdatedOn: Date;
   approvalStatusUpdatedBy: string;
 }
+
+export interface UpdateCASInvoiceBatchAPIInDTO {
+  approvalStatus: CASInvoiceBatchApprovalStatus;
+}

--- a/sources/packages/web/src/types/contracts/aest/roles.ts
+++ b/sources/packages/web/src/types/contracts/aest/roles.ts
@@ -10,7 +10,7 @@ export enum Role {
   AESTCreateInstitution = "aest-create-institution",
   AESTEditCASSupplierInfo = "aest-edit-cas-supplier-info",
   AESTCASInvoicing = "aest-cas-invoicing",
-  AESTCASInvoiceBatchExpense = "aest-cas-expense-authority",
+  AESTCCASExpenseAuthority = "aest-cas-expense-authority",
   AESTBypassStudentRestriction = "aest-bypass-student-restriction",
   AESTQueueDashboardAdmin = "aest-queue-dashboard-admin",
   StudentAddRestriction = "student-add-restriction",

--- a/sources/packages/web/src/types/contracts/aest/roles.ts
+++ b/sources/packages/web/src/types/contracts/aest/roles.ts
@@ -10,7 +10,7 @@ export enum Role {
   AESTCreateInstitution = "aest-create-institution",
   AESTEditCASSupplierInfo = "aest-edit-cas-supplier-info",
   AESTCASInvoicing = "aest-cas-invoicing",
-  AESTCCASExpenseAuthority = "aest-cas-expense-authority",
+  AESTCASExpenseAuthority = "aest-cas-expense-authority",
   AESTBypassStudentRestriction = "aest-bypass-student-restriction",
   AESTQueueDashboardAdmin = "aest-queue-dashboard-admin",
   StudentAddRestriction = "student-add-restriction",

--- a/sources/packages/web/src/types/contracts/aest/roles.ts
+++ b/sources/packages/web/src/types/contracts/aest/roles.ts
@@ -10,6 +10,7 @@ export enum Role {
   AESTCreateInstitution = "aest-create-institution",
   AESTEditCASSupplierInfo = "aest-edit-cas-supplier-info",
   AESTCASInvoicing = "aest-cas-invoicing",
+  AESTCASInvoiceBatchExpense = "aest-cas-expense-authority",
   AESTBypassStudentRestriction = "aest-bypass-student-restriction",
   AESTQueueDashboardAdmin = "aest-queue-dashboard-admin",
   StudentAddRestriction = "student-add-restriction",

--- a/sources/packages/web/src/views/aest/CASInvoices.vue
+++ b/sources/packages/web/src/views/aest/CASInvoices.vue
@@ -253,7 +253,7 @@ export default defineComponent({
     };
 
     const rejectBatch = async (batch: CASInvoiceBatchModel) => {
-      if (await approveBatchModal.value.showModal()) {
+      if (await rejectBatchModal.value.showModal()) {
         try {
           batch.approvalInProgress = true;
           await CASInvoiceBatchService.shared.updateCASInvoiceBatch(batch.id, {

--- a/sources/packages/web/src/views/aest/CASInvoices.vue
+++ b/sources/packages/web/src/views/aest/CASInvoices.vue
@@ -83,7 +83,7 @@
                   </v-btn>
                 </template>
               </check-permission-role>
-              <check-permission-role :role="Role.AESTCCASExpenseAuthority">
+              <check-permission-role :role="Role.AESTCASExpenseAuthority">
                 <template #="{ notAllowed }">
                   <v-btn
                     :disabled="

--- a/sources/packages/web/src/views/aest/CASInvoices.vue
+++ b/sources/packages/web/src/views/aest/CASInvoices.vue
@@ -81,8 +81,16 @@
                       ><strong>Download</strong></span
                     >
                   </v-btn>
+                </template>
+              </check-permission-role>
+              <check-permission-role :role="Role.AESTCASInvoiceBatchExpense">
+                <template #="{ notAllowed }">
                   <v-btn
-                    :disabled="notAllowed"
+                    :disabled="
+                      notAllowed ||
+                      item.approvalStatus !==
+                        CASInvoiceBatchApprovalStatus.Pending
+                    "
                     variant="text"
                     color="primary"
                     @click="approveBatch(item.id)"
@@ -92,7 +100,11 @@
                     >
                   </v-btn>
                   <v-btn
-                    :disabled="notAllowed"
+                    :disabled="
+                      notAllowed ||
+                      item.approvalStatus !==
+                        CASInvoiceBatchApprovalStatus.Pending
+                    "
                     variant="text"
                     color="primary"
                     @click="rejectBatch(item.id)"
@@ -220,13 +232,31 @@ export default defineComponent({
 
     const approveBatch = async (batchId: number) => {
       if (await approveBatchModal.value.showModal()) {
-        snackBar.warn(`Approve batch to be implemented (Batch ID ${batchId}).`);
+        try {
+          await CASInvoiceBatchService.shared.updateCASInvoiceBatch(batchId, {
+            approvalStatus: CASInvoiceBatchApprovalStatus.Approved,
+          });
+          snackBar.success(
+            `Batch ${batchId} has been approved and added to the queue.`,
+          );
+          loadInvoiceBatches();
+        } catch (error: unknown) {
+          snackBar.error(`Unexpected error updating batch ${batchId}.`);
+        }
       }
     };
 
     const rejectBatch = async (batchId: number) => {
       if (await rejectBatchModal.value.showModal()) {
-        snackBar.warn(`Reject batch to be implemented (Batch ID ${batchId}).`);
+        try {
+          await CASInvoiceBatchService.shared.updateCASInvoiceBatch(batchId, {
+            approvalStatus: CASInvoiceBatchApprovalStatus.Rejected,
+          });
+          snackBar.success(`Batch ${batchId} has been has been rejected.`);
+          loadInvoiceBatches();
+        } catch (error: unknown) {
+          snackBar.error(`Unexpected error updating batch ${batchId}.`);
+        }
       }
     };
 


### PR DESCRIPTION
- Created API to approve/reject batch and API validations
- Updated the column `approval_status`, `approval_status_updated_on` and `approval_status_updated_by` for table `cas_invoice_batch` once a record is approved or rejected.
- Created new role for ministry `aest-cas-expense-authority` on Keycloak DEV.
- Created E2E tests for the endpoint.

Screenshot of the table with two records viewed from ministry user without role `cas-expense-authority`
![Screenshot 2025-03-07 150934](https://github.com/user-attachments/assets/0c08d90d-ad21-4d1a-8501-d432c8be773d)

Screenshot of the table with two records viewed from ministry user with role `cas-expense-authority`
![Screenshot 2025-03-07 150000](https://github.com/user-attachments/assets/0554b437-1ea3-4c4b-9e9a-9a551e62c025)

Screenshot when a CAS invoice batch is approved
![Screenshot 2025-03-07 151420](https://github.com/user-attachments/assets/7110478f-6da8-4e9d-9d28-a96a15058f71)

Screenshot when a CAS invoice batch is rejected
![Screenshot 2025-03-07 153121](https://github.com/user-attachments/assets/b261c384-3c3a-417f-aa0d-4ed4cd3c8d97)

Screenshot of the E2E tests
![image](https://github.com/user-attachments/assets/8b3108a4-0d97-4579-a6ef-74daece87c3a)

### Reminder
Create ministry role `aest-cas-expense-authority` on Keycloak TEST and PROD for the current release.