### PR TITLE
#3739 - Release DB Migrations Rollback - Allow migration to fail on CI/CD

### DIFF
--- a/sources/packages/backend/apps/db-migrations/src/db-migrations.service.ts
+++ b/sources/packages/backend/apps/db-migrations/src/db-migrations.service.ts
@@ -4,6 +4,27 @@ import { ormConfig } from "./data-source";
 import { inspect } from "util";
 
 /**
+ * Default limit to use when listing migrations.
+ */
+export const DEFAULT_LIST_LIMIT = 5;
+
+/**
+ * Behavior to use when a failure occurs.
+ * Useful to control the behavior when the migration is executed
+ * in the CI/CD pipeline or using the REPL mode.
+ */
+export enum FailureBehavior {
+  /**
+   * Only log the error and continue.
+   */
+  LogOnly = "log-only",
+  /**
+   * Rethrow the error.
+   */
+  Rethrow = "rethrow",
+}
+
+/**
  * DB migrations options available.
  * Each operation is executed in an isolated data source.
  */
@@ -13,8 +34,10 @@ export class DBMigrationsService {
 
   /**
    * Run all pending migrations.
+   * @param failureBehavior the behavior to use when a failure occurs.
+   * Defaults to log only.
    */
-  async run(): Promise<void> {
+  async run(failureBehavior = FailureBehavior.LogOnly): Promise<void> {
     await this.executeDBOperation(async (dataSource) => {
       this.logger.log("Setting up data source to execute migrations.");
       await dataSource.query(
@@ -25,13 +48,15 @@ export class DBMigrationsService {
       this.logger.log("Running migrations.");
       await dataSource.runMigrations();
       this.logger.log("All migrations executed.");
-    });
+    }, failureBehavior);
   }
 
   /**
    * Revert the last migration.
+   * @param failureBehavior the behavior to use when a failure occurs.
+   * Defaults to log only.
    */
-  async revert(): Promise<void> {
+  async revert(failureBehavior = FailureBehavior.LogOnly): Promise<void> {
     await this.executeDBOperation(async (dataSource) => {
       this.logger.log("Running rollback.");
       this.logger.warn("The below is the migration being reverted.");
@@ -41,36 +66,51 @@ export class DBMigrationsService {
       this.logger.log("Migration reverted.");
       this.logger.warn("The below is the latest migration now.");
       await this.list(1);
-    });
+    }, failureBehavior);
   }
 
   /**
    * List the latest migrations.
    * @param limit number of latest migrations to list.
+   * @param failureBehavior the behavior to use when a failure occurs.
+   * Defaults to log only.
    */
-  async list(limit = 5): Promise<void> {
+  async list(
+    limit = DEFAULT_LIST_LIMIT,
+    failureBehavior = FailureBehavior.LogOnly,
+  ): Promise<void> {
     await this.executeDBOperation(async (dataSource) => {
       const mostRecentMigrations = await this.getRecentMigrationRecords(
         dataSource,
         limit,
       );
       console.table(mostRecentMigrations);
-    });
+    }, failureBehavior);
   }
 
   /**
    * Executes a database operation within a data source context.
    * @param operation the operation to execute.
+   * @param failureBehavior the behavior to use when a failure occurs.
+   * Defaults to log only.
    */
   private async executeDBOperation(
-    operation: (sataSource: DataSource) => Promise<void>,
+    operation: (dataSource: DataSource) => Promise<void>,
+    failureBehavior = FailureBehavior.LogOnly,
   ): Promise<void> {
     const migrationDataSource = new DataSource(ormConfig);
     const dataSource = await migrationDataSource.initialize();
     try {
       await operation(dataSource);
     } catch (error: unknown) {
-      this.logger.error("Error listing migrations.", inspect(error));
+      if (failureBehavior === FailureBehavior.LogOnly) {
+        this.logger.error(
+          "Error executing migration operation.",
+          inspect(error),
+        );
+        return;
+      }
+      throw error;
     } finally {
       await dataSource.destroy();
     }

--- a/sources/packages/backend/apps/db-migrations/src/main.ts
+++ b/sources/packages/backend/apps/db-migrations/src/main.ts
@@ -1,7 +1,11 @@
 import { NestFactory, repl } from "@nestjs/core";
 import { REPLModule } from "./repl.module";
 import { DBMigrationsModule } from "./db-migrations.module";
-import { DBMigrationsService } from "./db-migrations.service";
+import {
+  DBMigrationsService,
+  DEFAULT_LIST_LIMIT,
+  FailureBehavior,
+} from "./db-migrations.service";
 import { Logger } from "@nestjs/common";
 
 /**
@@ -41,13 +45,13 @@ enum InitArguments {
   const migrationsService = app.get(DBMigrationsService);
   switch (initArg) {
     case InitArguments.Run:
-      await migrationsService.run();
+      await migrationsService.run(FailureBehavior.Rethrow);
       break;
     case InitArguments.Revert:
-      await migrationsService.revert();
+      await migrationsService.revert(FailureBehavior.Rethrow);
       break;
     case InitArguments.List:
-      await migrationsService.list();
+      await migrationsService.list(DEFAULT_LIST_LIMIT, FailureBehavior.Rethrow);
       break;
     default:
       logger.warn(


### PR DESCRIPTION
When CI/CD is executing the migrations, the job was considered successful even if a migration failed to be executed.
Changed the behavior of the exceptions handling when they are executed in the CI/CD pipeline or using the REPL mode.