### PR TITLE
#4390 - CAS Manual Intervention: Add `CASInvoiceStatusUpdatedBy` Column

### DIFF
--- a/sources/packages/backend/apps/db-migrations/src/migrations/1741646122852-AddCASInvoiceStatusUpdatedByColumn.ts
+++ b/sources/packages/backend/apps/db-migrations/src/migrations/1741646122852-AddCASInvoiceStatusUpdatedByColumn.ts
@@ -1,0 +1,24 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+import { getSQLFileData } from "../utilities/sqlLoader";
+
+export class AddCASInvoiceStatusUpdatedByColumn1741646122852
+  implements MigrationInterface
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      getSQLFileData(
+        "Add-cas-invoice-status-updated-by-column.sql",
+        "CASInvoices",
+      ),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      getSQLFileData(
+        "Rollback-add-cas-invoice-status-updated-by-column.sql",
+        "CASInvoices",
+      ),
+    );
+  }
+}

--- a/sources/packages/backend/apps/db-migrations/src/sql/CASInvoices/Add-cas-invoice-status-updated-by-column.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/CASInvoices/Add-cas-invoice-status-updated-by-column.sql
@@ -1,0 +1,27 @@
+ALTER TABLE
+  sims.cas_invoices
+ADD
+  COLUMN invoice_status_updated_by INT REFERENCES sims.users(id);
+
+COMMENT ON COLUMN sims.cas_invoices.invoice_status_updated_by IS 'User who updated the invoice status.';
+
+-- Update the existing records with the system user.
+UPDATE
+  sims.cas_invoices
+SET
+  invoice_status_updated_by = (
+    SELECT
+      id
+    FROM
+      sims.users
+    WHERE
+      last_name = 'system-user'
+  );
+
+-- Update the column to NOT NULL.
+ALTER TABLE
+  sims.cas_invoices
+ALTER COLUMN
+  invoice_status_updated_by
+SET
+  NOT NULL;

--- a/sources/packages/backend/apps/db-migrations/src/sql/CASInvoices/Add-cas-invoice-status-updated-by-column.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/CASInvoices/Add-cas-invoice-status-updated-by-column.sql
@@ -5,7 +5,7 @@ ADD
 
 COMMENT ON COLUMN sims.cas_invoices.invoice_status_updated_by IS 'User who updated the invoice status.';
 
--- Update the existing records with the system user.
+-- Update the existing records with the creator.
 UPDATE
   sims.cas_invoices
 SET

--- a/sources/packages/backend/apps/db-migrations/src/sql/CASInvoices/Add-cas-invoice-status-updated-by-column.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/CASInvoices/Add-cas-invoice-status-updated-by-column.sql
@@ -9,14 +9,7 @@ COMMENT ON COLUMN sims.cas_invoices.invoice_status_updated_by IS 'User who updat
 UPDATE
   sims.cas_invoices
 SET
-  invoice_status_updated_by = (
-    SELECT
-      id
-    FROM
-      sims.users
-    WHERE
-      last_name = 'system-user'
-  );
+  invoice_status_updated_by = creator;
 
 -- Update the column to NOT NULL.
 ALTER TABLE

--- a/sources/packages/backend/apps/db-migrations/src/sql/CASInvoices/Rollback-add-cas-invoice-status-updated-by-column.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/CASInvoices/Rollback-add-cas-invoice-status-updated-by-column.sql
@@ -1,0 +1,2 @@
+ALTER TABLE
+  sims.cas_invoices DROP COLUMN invoice_status_updated_by;

--- a/sources/packages/backend/apps/queue-consumers/src/services/cas-invoice-batch/cas-invoice-batch.service.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/services/cas-invoice-batch/cas-invoice-batch.service.ts
@@ -153,6 +153,7 @@ export class CASInvoiceBatchService {
       newInvoice.invoiceStatus = CASInvoiceStatus.Pending;
       newInvoice.invoiceStatusUpdatedOn = referenceDate;
       newInvoice.creator = this.systemUsersService.systemUser;
+      newInvoice.invoiceStatusUpdatedBy = this.systemUsersService.systemUser;
       newInvoice.createdAt = referenceDate;
       newInvoice.updatedAt = referenceDate;
       // Create invoice details.

--- a/sources/packages/backend/apps/queue-consumers/src/services/cas-invoice-batch/cas-invoice-batch.service.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/services/cas-invoice-batch/cas-invoice-batch.service.ts
@@ -133,6 +133,7 @@ export class CASInvoiceBatchService {
   ): CASInvoice[] {
     const casInvoices: CASInvoice[] = [];
     const invoicesSummary = new ProcessSummary();
+    const systemUser = this.systemUsersService.systemUser;
     parentProcessSummary.children(invoicesSummary);
     // Start processing the invoices for each pending receipt.
     for (const receipt of pendingReceipts) {
@@ -152,8 +153,8 @@ export class CASInvoiceBatchService {
       }`;
       newInvoice.invoiceStatus = CASInvoiceStatus.Pending;
       newInvoice.invoiceStatusUpdatedOn = referenceDate;
-      newInvoice.creator = this.systemUsersService.systemUser;
-      newInvoice.invoiceStatusUpdatedBy = this.systemUsersService.systemUser;
+      newInvoice.creator = systemUser;
+      newInvoice.invoiceStatusUpdatedBy = systemUser;
       newInvoice.createdAt = referenceDate;
       newInvoice.updatedAt = referenceDate;
       // Create invoice details.

--- a/sources/packages/backend/libs/sims-db/src/entities/cas-invoice.model.ts
+++ b/sources/packages/backend/libs/sims-db/src/entities/cas-invoice.model.ts
@@ -14,6 +14,7 @@ import {
   CASSupplier,
   CASInvoiceStatus,
   CASInvoiceDetail,
+  User,
 } from ".";
 
 /**
@@ -79,6 +80,15 @@ export class CASInvoice extends RecordDataModel {
     type: "timestamptz",
   })
   invoiceStatusUpdatedOn: Date;
+  /**
+   * User that changed the status last time.
+   */
+  @ManyToOne(() => User, { nullable: false })
+  @JoinColumn({
+    name: "invoice_status_updated_by",
+    referencedColumnName: ColumnNames.ID,
+  })
+  invoiceStatusUpdatedBy: User;
   /**
    * Invoice details.
    */

--- a/sources/packages/backend/libs/test-utils/src/factories/cas-invoice.ts
+++ b/sources/packages/backend/libs/test-utils/src/factories/cas-invoice.ts
@@ -35,6 +35,7 @@ export function createFakeCASInvoice(relations: {
   casInvoice.invoiceStatus = CASInvoiceStatus.Pending;
   casInvoice.invoiceStatusUpdatedOn = now;
   casInvoice.creator = relations.creator;
+  casInvoice.invoiceStatusUpdatedBy = relations.creator;
   return casInvoice;
 }
 


### PR DESCRIPTION
### As a part of this PR, the following have been completed:

- Added the migration for the `CASInvoiceStatusUpdatedBy` column.

**Rollback Screenshot:**

<img width="815" alt="image" src="https://github.com/user-attachments/assets/43a2d311-ab3e-43b1-9c65-0124a6e0dff7" />
