### PR TITLE
#4390 - CAS Manual Intervention (API)

### DIFF
--- a/sources/packages/backend/apps/api/src/app.aest.module.ts
+++ b/sources/packages/backend/apps/api/src/app.aest.module.ts
@@ -36,6 +36,7 @@ import {
   CRAIncomeVerificationService,
   CASInvoiceBatchService,
   CASInvoiceBatchReportService,
+  CASInvoiceService,
 } from "./services";
 import {
   SupportingUserAESTController,
@@ -81,6 +82,7 @@ import {
   CASSupplierAESTController,
   ApplicationRestrictionBypassAESTController,
   CASInvoiceBatchAESTController,
+  CASInvoiceAESTController,
 } from "./route-controllers";
 import { AuthModule } from "./auth/auth.module";
 import {
@@ -130,6 +132,7 @@ import { ECertIntegrationModule } from "@sims/integrations/esdc-integration";
     StudentLoanBalanceAESTController,
     CASSupplierAESTController,
     CASInvoiceBatchAESTController,
+    CASInvoiceAESTController,
     ApplicationRestrictionBypassAESTController,
   ],
   providers: [
@@ -201,6 +204,7 @@ import { ECertIntegrationModule } from "@sims/integrations/esdc-integration";
     SupportingUserService,
     CASSupplierSharedService,
     CASInvoiceBatchService,
+    CASInvoiceService,
     CASInvoiceBatchReportService,
   ],
 })

--- a/sources/packages/backend/apps/api/src/route-controllers/cas-invoice/cas-invoice.aest.controller.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/cas-invoice/cas-invoice.aest.controller.ts
@@ -3,6 +3,7 @@ import {
   Get,
   NotFoundException,
   Param,
+  ParseIntPipe,
   Patch,
   Query,
 } from "@nestjs/common";
@@ -62,19 +63,20 @@ export class CASInvoiceAESTController extends BaseController {
   }
 
   /**
-   * Updates CAS invoice status.
+   * Updates CAS invoice status to Resolved.
    * @param invoiceId invoice id.
    */
   @ApiNotFoundResponse({
     description: `CAS invoice not found.`,
   })
-  @Patch(":invoiceId")
-  async updateInvoiceStatus(
-    @Param("invoiceId") invoiceId: number,
+  @Patch(":invoiceId/resolve")
+  async updateInvoiceToResolved(
+    @Param("invoiceId", ParseIntPipe) invoiceId: number,
     @UserToken() userToken: IUserToken,
   ): Promise<void> {
     const invoiceExists = await this.casInvoiceService.checkCASInvoiceExists(
       invoiceId,
+      { invoiceStatus: CASInvoiceStatus.ManualIntervention },
     );
     if (!invoiceExists) {
       throw new NotFoundException("CAS invoice not found.");

--- a/sources/packages/backend/apps/api/src/route-controllers/cas-invoice/cas-invoice.aest.controller.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/cas-invoice/cas-invoice.aest.controller.ts
@@ -1,0 +1,88 @@
+import {
+  Controller,
+  Get,
+  NotFoundException,
+  Param,
+  Patch,
+  Query,
+} from "@nestjs/common";
+import { ApiNotFoundResponse, ApiTags } from "@nestjs/swagger";
+import { AuthorizedParties, IUserToken, Role, UserGroups } from "../../auth";
+import {
+  AllowAuthorizedParty,
+  Groups,
+  Roles,
+  UserToken,
+} from "../../auth/decorators";
+import BaseController from "../BaseController";
+import { ClientTypeBaseRoute } from "../../types";
+import {
+  CASInvoicePaginationOptionsAPIInDTO,
+  PaginatedResultsAPIOutDTO,
+} from "../models/pagination.dto";
+import { CASInvoiceService } from "../../services";
+import { CASInvoiceAPIOutDTO } from "./models/cas-invoice.dto";
+import { CASInvoiceStatus } from "@sims/sims-db";
+
+@AllowAuthorizedParty(AuthorizedParties.aest)
+@Roles(Role.AESTCASInvoicing)
+@Groups(UserGroups.AESTUser)
+@Controller("cas-invoice")
+@ApiTags(`${ClientTypeBaseRoute.AEST}-cas-invoice`)
+export class CASInvoiceAESTController extends BaseController {
+  constructor(private readonly casInvoiceService: CASInvoiceService) {
+    super();
+  }
+
+  /**
+   * Retrieves all CAS invoices.
+   * @param paginationOptions pagination options.
+   * @returns list of all invoices.
+   */
+  @Get()
+  async getInvoices(
+    @Query() paginationOptions: CASInvoicePaginationOptionsAPIInDTO,
+  ): Promise<PaginatedResultsAPIOutDTO<CASInvoiceAPIOutDTO>> {
+    const pagination = await this.casInvoiceService.getCASInvoices(
+      paginationOptions,
+    );
+    const invoices = pagination.results.map((invoice) => ({
+      id: invoice.id,
+      invoiceNumber: invoice.invoiceNumber,
+      invoiceStatus: invoice.invoiceStatus,
+      invoiceStatusUpdatedOn: invoice.invoiceStatusUpdatedOn,
+      invoiceBatchName: invoice.casInvoiceBatch.batchName,
+      supplierNumber: invoice.casSupplier.supplierNumber,
+      errors: invoice.errors,
+    }));
+    return {
+      results: invoices,
+      count: pagination.count,
+    };
+  }
+
+  /**
+   * Updates CAS invoice status.
+   * @param invoiceId invoice id.
+   */
+  @ApiNotFoundResponse({
+    description: `CAS invoice not found.`,
+  })
+  @Patch(":invoiceId")
+  async updateInvoiceStatus(
+    @Param("invoiceId") invoiceId: number,
+    @UserToken() userToken: IUserToken,
+  ): Promise<void> {
+    const invoiceExists = await this.casInvoiceService.checkCASInvoiceExists(
+      invoiceId,
+    );
+    if (!invoiceExists) {
+      throw new NotFoundException("CAS invoice not found.");
+    }
+    await this.casInvoiceService.updateCASInvoiceStatus(
+      invoiceId,
+      CASInvoiceStatus.Resolved,
+      userToken.userId,
+    );
+  }
+}

--- a/sources/packages/backend/apps/api/src/route-controllers/cas-invoice/models/cas-invoice.dto.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/cas-invoice/models/cas-invoice.dto.ts
@@ -1,0 +1,8 @@
+export class CASInvoiceAPIOutDTO {
+  id: number;
+  invoiceNumber: string;
+  invoiceStatusUpdatedOn: Date;
+  invoiceBatchName: string;
+  supplierNumber: string;
+  errors: string[];
+}

--- a/sources/packages/backend/apps/api/src/route-controllers/index.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/index.ts
@@ -85,6 +85,8 @@ export * from "./audit/audit.controller";
 export * from "./student/student.external.controller.service";
 export * from "./student/student.external.controller";
 export * from "./cas-invoice-batch/cas-invoice-batch.aest.controller";
+export * from "./cas-invoice/cas-invoice.aest.controller";
+export * from "./cas-invoice/models/cas-invoice.dto";
 export * from "./models/primary.identifier.dto";
 export * from "./models/common.dto";
 export * from "./health-check/health.controller";

--- a/sources/packages/backend/apps/api/src/route-controllers/models/pagination.dto.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/models/pagination.dto.ts
@@ -128,7 +128,7 @@ export class CASInvoicePaginationOptionsAPIInDTO extends PaginationOptionsAPIInD
   sortField?: string;
   @IsArray()
   @Transform(({ value }) => value.split(","))
-  @IsEnum(CASInvoiceStatus, { each: true })
+  @IsIn([CASInvoiceStatus.ManualIntervention])
   invoiceStatusSearch: CASInvoiceStatus[];
 }
 

--- a/sources/packages/backend/apps/api/src/route-controllers/models/pagination.dto.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/models/pagination.dto.ts
@@ -1,5 +1,4 @@
 import {
-  Equals,
   IsArray,
   IsBoolean,
   IsEnum,
@@ -127,7 +126,7 @@ export class CASInvoicePaginationOptionsAPIInDTO extends PaginationOptionsAPIInD
   @IsOptional()
   @IsIn(["invoiceStatusUpdatedOn"])
   sortField?: string;
-  @Equals(CASInvoiceStatus.ManualIntervention)
+  @IsEnum(CASInvoiceStatus)
   invoiceStatusSearch: CASInvoiceStatus;
 }
 

--- a/sources/packages/backend/apps/api/src/route-controllers/models/pagination.dto.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/models/pagination.dto.ts
@@ -1,4 +1,5 @@
 import {
+  Equals,
   IsArray,
   IsBoolean,
   IsEnum,
@@ -126,10 +127,8 @@ export class CASInvoicePaginationOptionsAPIInDTO extends PaginationOptionsAPIInD
   @IsOptional()
   @IsIn(["invoiceStatusUpdatedOn"])
   sortField?: string;
-  @IsArray()
-  @Transform(({ value }) => value.split(","))
-  @IsIn([CASInvoiceStatus.ManualIntervention])
-  invoiceStatusSearch: CASInvoiceStatus[];
+  @Equals(CASInvoiceStatus.ManualIntervention)
+  invoiceStatusSearch: CASInvoiceStatus;
 }
 
 export class CASInvoiceBatchesPaginationOptionsAPIInDTO extends PaginationOptionsAPIInDTO {

--- a/sources/packages/backend/apps/api/src/route-controllers/models/pagination.dto.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/models/pagination.dto.ts
@@ -10,7 +10,11 @@ import {
 } from "class-validator";
 import { PAGINATION_SEARCH_MAX_LENGTH } from "../../constants";
 import { FieldSortOrder } from "@sims/utilities";
-import { CASInvoiceBatchApprovalStatus, ProgramStatus } from "@sims/sims-db";
+import {
+  CASInvoiceBatchApprovalStatus,
+  CASInvoiceStatus,
+  ProgramStatus,
+} from "@sims/sims-db";
 import { Transform } from "class-transformer";
 import { ToBoolean } from "../../utilities/class-transform";
 
@@ -116,6 +120,16 @@ export class OfferingsPaginationOptionsAPIInDTO extends PaginationOptionsAPIInDT
   @IsOptional()
   @IsIn(["name"])
   sortField?: string;
+}
+
+export class CASInvoicePaginationOptionsAPIInDTO extends PaginationOptionsAPIInDTO {
+  @IsOptional()
+  @IsIn(["invoiceStatusUpdatedOn"])
+  sortField?: string;
+  @IsArray()
+  @Transform(({ value }) => value.split(","))
+  @IsEnum(CASInvoiceStatus, { each: true })
+  invoiceStatusSearch: CASInvoiceStatus[];
 }
 
 export class CASInvoiceBatchesPaginationOptionsAPIInDTO extends PaginationOptionsAPIInDTO {

--- a/sources/packages/backend/apps/api/src/services/cas-invoice/cas-invoice.service.ts
+++ b/sources/packages/backend/apps/api/src/services/cas-invoice/cas-invoice.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from "@nestjs/common";
 import { InjectRepository } from "@nestjs/typeorm";
 import { CASInvoice, CASInvoiceStatus, User } from "@sims/sims-db";
-import { In, Repository, UpdateResult } from "typeorm";
+import { Repository, UpdateResult } from "typeorm";
 import { CASInvoicePaginationOptions, PaginatedResults } from "../../utilities";
 
 @Injectable()
@@ -39,9 +39,7 @@ export class CASInvoiceService {
         casInvoiceBatch: true,
       },
       where: {
-        invoiceStatus: paginationOptions.invoiceStatusSearch?.length
-          ? In(paginationOptions.invoiceStatusSearch)
-          : undefined,
+        invoiceStatus: paginationOptions.invoiceStatusSearch,
       },
       skip: paginationOptions.pageLimit * paginationOptions.page,
       take: paginationOptions.pageLimit,

--- a/sources/packages/backend/apps/api/src/services/cas-invoice/cas-invoice.service.ts
+++ b/sources/packages/backend/apps/api/src/services/cas-invoice/cas-invoice.service.ts
@@ -87,6 +87,7 @@ export class CASInvoiceService {
       { id: invoiceId },
       {
         invoiceStatus,
+        invoiceStatusUpdatedOn: now,
         invoiceStatusUpdatedBy: auditUser,
         modifier: auditUser,
         updatedAt: now,

--- a/sources/packages/backend/apps/api/src/services/cas-invoice/cas-invoice.service.ts
+++ b/sources/packages/backend/apps/api/src/services/cas-invoice/cas-invoice.service.ts
@@ -1,0 +1,93 @@
+import { Injectable } from "@nestjs/common";
+import { InjectRepository } from "@nestjs/typeorm";
+import { CASInvoice, CASInvoiceStatus, User } from "@sims/sims-db";
+import { In, Repository, UpdateResult } from "typeorm";
+import {
+  CASInvoicePaginationOptionsAPIInDTO,
+  PaginatedResults,
+} from "../../utilities";
+
+@Injectable()
+export class CASInvoiceService {
+  constructor(
+    @InjectRepository(CASInvoice)
+    private readonly repo: Repository<CASInvoice>,
+  ) {}
+
+  /**
+   * Retrieve all CAS invoices.
+   * @param paginationOptions pagination options.
+   * @returns paginated CAS invoices.
+   */
+  async getCASInvoices(
+    paginationOptions: CASInvoicePaginationOptionsAPIInDTO,
+  ): Promise<PaginatedResults<CASInvoice>> {
+    const [results, count] = await this.repo.findAndCount({
+      select: {
+        id: true,
+        invoiceStatusUpdatedOn: true,
+        invoiceNumber: true,
+        casInvoiceBatch: {
+          id: true,
+          batchName: true,
+        },
+        casSupplier: {
+          id: true,
+          supplierNumber: true,
+        },
+        errors: true,
+      },
+      relations: {
+        casSupplier: true,
+        casInvoiceBatch: true,
+      },
+      where: {
+        invoiceStatus: paginationOptions.invoiceStatusSearch?.length
+          ? In(paginationOptions.invoiceStatusSearch)
+          : undefined,
+      },
+      skip: paginationOptions.pageLimit * paginationOptions.page,
+      take: paginationOptions.pageLimit,
+      order: {
+        [paginationOptions.sortField]: paginationOptions.sortOrder,
+      },
+    });
+    return { results, count };
+  }
+
+  /**
+   * Checks if CAS invoice exists.
+   * @param invoiceId invoice id.
+   * @returns true if invoice exists, false otherwise.
+   */
+  async checkCASInvoiceExists(invoiceId: number): Promise<boolean> {
+    return this.repo.exists({
+      where: {
+        id: invoiceId,
+        invoiceStatus: CASInvoiceStatus.ManualIntervention,
+      },
+    });
+  }
+
+  /**
+   * Update CAS invoice status.
+   * @param invoiceId invoice id for which status has to be updated.
+   * @param invoiceStatus invoice status to update to.
+   * @param auditUserId audit user id.
+   * @returns update result.
+   */
+  async updateCASInvoiceStatus(
+    invoiceId: number,
+    invoiceStatus: CASInvoiceStatus,
+    auditUserId: number,
+  ): Promise<UpdateResult> {
+    const auditUser = { id: auditUserId } as User;
+    return this.repo.update(
+      { id: invoiceId },
+      {
+        invoiceStatus,
+        invoiceStatusUpdatedBy: auditUser,
+      },
+    );
+  }
+}

--- a/sources/packages/backend/apps/api/src/services/index.ts
+++ b/sources/packages/backend/apps/api/src/services/index.ts
@@ -53,4 +53,5 @@ export * from "./audit/audit-event.enum";
 export * from "./application-restriction-bypass/application-restriction-bypass.models";
 export * from "./cas-invoice-batch/cas-invoice-batch.service";
 export * from "./cas-invoice-batch/cas-invoice-batch-report.service";
+export * from "./cas-invoice/cas-invoice.service";
 export * from "./student/student-information.service";

--- a/sources/packages/backend/apps/api/src/utilities/datatable-config.ts
+++ b/sources/packages/backend/apps/api/src/utilities/datatable-config.ts
@@ -36,7 +36,7 @@ export interface ProgramPaginationOptions extends BasePaginationOptions {
  * CAS invoices specific parameters.
  */
 export interface CASInvoicePaginationOptions extends BasePaginationOptions {
-  invoiceStatusSearch: CASInvoiceStatus[];
+  invoiceStatusSearch: CASInvoiceStatus;
 }
 
 /**

--- a/sources/packages/backend/apps/api/src/utilities/datatable-config.ts
+++ b/sources/packages/backend/apps/api/src/utilities/datatable-config.ts
@@ -1,4 +1,8 @@
-import { CASInvoiceBatchApprovalStatus, ProgramStatus } from "@sims/sims-db";
+import {
+  CASInvoiceBatchApprovalStatus,
+  CASInvoiceStatus,
+  ProgramStatus,
+} from "@sims/sims-db";
 import { FieldSortOrder } from "@sims/utilities";
 
 /**
@@ -26,6 +30,14 @@ export interface ProgramPaginationOptions extends BasePaginationOptions {
   locationNameSearch?: string;
   statusSearch?: ProgramStatus[];
   inactiveProgramSearch?: boolean;
+}
+
+/**
+ * CAS invoices specific parameters.
+ */
+export interface CASInvoicePaginationOptionsAPIInDTO
+  extends BasePaginationOptions {
+  invoiceStatusSearch: CASInvoiceStatus[];
 }
 
 /**

--- a/sources/packages/backend/apps/api/src/utilities/datatable-config.ts
+++ b/sources/packages/backend/apps/api/src/utilities/datatable-config.ts
@@ -35,8 +35,7 @@ export interface ProgramPaginationOptions extends BasePaginationOptions {
 /**
  * CAS invoices specific parameters.
  */
-export interface CASInvoicePaginationOptionsAPIInDTO
-  extends BasePaginationOptions {
+export interface CASInvoicePaginationOptions extends BasePaginationOptions {
   invoiceStatusSearch: CASInvoiceStatus[];
 }
 


### PR DESCRIPTION
### As a part of this PR, the following were completed:

- Created a new controller named `cas-invoice` with the two below endpoints:
   1) Create new endpoint to get list of manual intervention invoices from `cas-invoices` table, with lazy pagination enabled.
   2) Created new endpoint to update the status of the `cas-invoices`.
