### PR TITLE
#4427 - Update ECE Request fields

### DIFF
--- a/sims.code-workspace
+++ b/sims.code-workspace
@@ -143,7 +143,11 @@
       "lmpu",
       "dependants",
       "enrolment",
-      "enrolments"
+      "enrolments",
+      "PDRQ",
+      "PDAP",
+      "PPDA",
+      "PDDC"
     ],
     "[json]": {
       "editor.defaultFormatter": "vscode.json-language-features"

--- a/sources/packages/backend/apps/api/src/services/disbursement-schedule/disbursement-schedule-service.ts
+++ b/sources/packages/backend/apps/api/src/services/disbursement-schedule/disbursement-schedule-service.ts
@@ -47,7 +47,7 @@ export class DisbursementScheduleService extends RecordDataModelService<Disburse
     const disbursementCOEQuery =
       this.confirmationOfEnrollmentService.getDisbursementForCOEQuery(
         this.repo,
-        enrolmentPeriod,
+        { enrolmentPeriod },
       );
     disbursementCOEQuery.andWhere("location.id = :locationId", { locationId });
     // Add pagination, sort and search criteria.

--- a/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/institution-integration/ece-request/_tests_/ece-process-integration.scheduler.e2e-spec.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/institution-integration/ece-request/_tests_/ece-process-integration.scheduler.e2e-spec.ts
@@ -7,6 +7,7 @@ import {
   DisbursementValueType,
   OfferingIntensity,
   Student,
+  WorkflowData,
 } from "@sims/sims-db";
 import {
   E2EDataSources,
@@ -37,6 +38,7 @@ import { getUploadedFile } from "@sims/test-utils/mocks";
 import { RecordTypeCodes } from "@sims/integrations/institution-integration/ece-integration";
 import * as Client from "ssh2-sftp-client";
 import * as dayjs from "dayjs";
+import { YNFlag } from "@sims/integrations/models";
 
 describe(describeProcessorRootTest(QueueNames.ECEProcessIntegration), () => {
   let app: INestApplication;
@@ -109,6 +111,11 @@ describe(describeProcessorRootTest(QueueNames.ECEProcessIntegration), () => {
             coeStatus: COEStatus.required,
             disbursementDate: getISODateOnlyString(addDays(COE_WINDOW + 10)),
           },
+          currentAssessmentInitialValues: {
+            workflowData: {
+              calculatedData: { pdppdStatus: false },
+            } as WorkflowData,
+          },
         },
       );
       application.studentNumber = "1234567789";
@@ -149,6 +156,8 @@ describe(describeProcessorRootTest(QueueNames.ECEProcessIntegration), () => {
         application,
         disbursementValue,
         disbursement.disbursementDate,
+        "NONE",
+        YNFlag.N,
       );
       expect(fileDetail).toBe(expectedDetailRecord);
       // Expect the file footer.
@@ -207,6 +216,11 @@ describe(describeProcessorRootTest(QueueNames.ECEProcessIntegration), () => {
           firstDisbursementInitialValues: {
             coeStatus: COEStatus.required,
           },
+          currentAssessmentInitialValues: {
+            workflowData: {
+              calculatedData: { pdppdStatus: false },
+            } as WorkflowData,
+          },
         },
       );
       application.studentNumber = "1234567789";
@@ -225,6 +239,9 @@ describe(describeProcessorRootTest(QueueNames.ECEProcessIntegration), () => {
         {
           initialValue: {
             triggerType: AssessmentTriggerType.ManualReassessment,
+            workflowData: {
+              calculatedData: { pdppdStatus: false },
+            } as WorkflowData,
           },
         },
       );
@@ -276,6 +293,8 @@ describe(describeProcessorRootTest(QueueNames.ECEProcessIntegration), () => {
         application,
         newDisbursementValue,
         newDisbursement.disbursementDate,
+        "NONE",
+        YNFlag.N,
       );
       expect(fileDetail).toBe(expectedDetailRecord);
       // Expect the file footer.
@@ -287,6 +306,8 @@ describe(describeProcessorRootTest(QueueNames.ECEProcessIntegration), () => {
     application: Application,
     disbursementValue: DisbursementValue,
     disbursementDate: string,
+    studentPDStatusCode: string,
+    applicationPDStatusFlag: YNFlag,
   ): string {
     const DATE_FORMAT = "YYYYMMDD";
     const offering = application.currentAssessment.offering;
@@ -313,6 +334,6 @@ describe(describeProcessorRootTest(QueueNames.ECEProcessIntegration), () => {
     }${institutionStudentNumber.padEnd(
       12,
       " ",
-    )}100${studyStartDate}${studyEndDate}${disbursementDateFormatted}`;
+    )}100${studyStartDate}${studyEndDate}${disbursementDateFormatted}${studentPDStatusCode}${applicationPDStatusFlag}`;
   }
 });

--- a/sources/packages/backend/libs/integrations/src/institution-integration/ece-integration/ece-files/ece-file-detail.ts
+++ b/sources/packages/backend/libs/integrations/src/institution-integration/ece-integration/ece-files/ece-file-detail.ts
@@ -7,6 +7,7 @@ import {
   SPACE_FILLER,
 } from "../models/ece-integration.model";
 import { ECERequestFileLine } from "./ece-file-line";
+import { YNFlag } from "@sims/integrations/models";
 
 /**
  * Record of a ECE request file.
@@ -21,7 +22,9 @@ export class ECERequestFileDetail implements ECERequestFileLine {
   studentLastName: string;
   studentGivenName: string;
   birthDate: string;
+  studentPDStatusCode: string;
   applicationNumber: string;
+  applicationPDStatusFlag: YNFlag;
   institutionStudentNumber: string;
   courseLoad: string;
   studyStartDate: string;
@@ -58,6 +61,8 @@ export class ECERequestFileDetail implements ECERequestFileLine {
       record.appendDate(this.studyStartDate, DATE_FORMAT);
       record.appendDate(this.studyEndDate, DATE_FORMAT);
       record.appendDate(this.disbursementDate, DATE_FORMAT);
+      record.append(this.studentPDStatusCode);
+      record.append(this.applicationPDStatusFlag);
       return record.toString();
     });
     return records.join(END_OF_LINE);

--- a/sources/packages/backend/libs/integrations/src/institution-integration/ece-integration/ece.integration.service.ts
+++ b/sources/packages/backend/libs/integrations/src/institution-integration/ece-integration/ece.integration.service.ts
@@ -6,6 +6,8 @@ import { ECEFileFooter } from "./ece-files/ece-file-footer";
 import { ECEFileHeader } from "./ece-files/ece-file-header";
 import { ECERequestFileLine } from "./ece-files/ece-file-line";
 import { ECERecord, RecordTypeCodes } from "./models/ece-integration.model";
+import { getStudentDisabilityStatusCode } from "@sims/utilities";
+import { YNFlag } from "@sims/integrations/models";
 
 /**
  * Manages the creation of the content files that needs to be sent
@@ -50,6 +52,11 @@ export class ECEIntegrationService extends SFTPIntegrationBase<void> {
       eceRequestFileDetail.studyStartDate = eceRecord.studyStartDate;
       eceRequestFileDetail.studyEndDate = eceRecord.studyEndDate;
       eceRequestFileDetail.disbursementDate = eceRecord.disbursementDate;
+      eceRequestFileDetail.studentPDStatusCode = getStudentDisabilityStatusCode(
+        eceRecord.studentDisabilityStatus,
+      );
+      eceRequestFileDetail.applicationPDStatusFlag =
+        eceRecord.applicationStudentDisabilityStatus ? YNFlag.Y : YNFlag.N;
       return eceRequestFileDetail;
     });
     eceRequestFileLines.push(...fileRecords);

--- a/sources/packages/backend/libs/integrations/src/institution-integration/ece-integration/ece.processing.service.ts
+++ b/sources/packages/backend/libs/integrations/src/institution-integration/ece-integration/ece.processing.service.ts
@@ -166,6 +166,9 @@ export class ECEProcessingService {
       studyStartDate: offering.studyStartDate,
       studyEndDate: offering.studyEndDate,
       disbursementDate: eligibleCOE.disbursementDate,
+      studentDisabilityStatus: student.disabilityStatus,
+      applicationStudentDisabilityStatus:
+        studentAssessment.workflowData.calculatedData.pdppdStatus,
     };
   }
 

--- a/sources/packages/backend/libs/integrations/src/institution-integration/ece-integration/models/ece-integration.model.ts
+++ b/sources/packages/backend/libs/integrations/src/institution-integration/ece-integration/models/ece-integration.model.ts
@@ -1,4 +1,4 @@
-import { DisbursementValue } from "@sims/sims-db";
+import { DisabilityStatus, DisbursementValue } from "@sims/sims-db";
 
 export const ECE_SENT_TITLE = "CONFIRMATION REQUEST";
 
@@ -17,7 +17,9 @@ export interface ECERecord {
   studentLastName: string;
   studentGivenName: string;
   birthDate: string;
+  studentDisabilityStatus: DisabilityStatus;
   applicationNumber: string;
+  applicationStudentDisabilityStatus: boolean;
   institutionStudentNumber: string;
   studyStartDate: string;
   studyEndDate: string;

--- a/sources/packages/backend/libs/integrations/src/services/disbursement-schedule/disbursement-schedule.service.ts
+++ b/sources/packages/backend/libs/integrations/src/services/disbursement-schedule/disbursement-schedule.service.ts
@@ -79,6 +79,9 @@ export class DisbursementScheduleService extends RecordDataModelService<Disburse
     const eligibleCOEQuery =
       this.confirmationOfEnrollmentService.getDisbursementForCOEQuery(
         this.repo,
+        {
+          loadWorkflowData: true,
+        },
       );
     return eligibleCOEQuery
       .andWhere("offering.offeringIntensity = :fullTime", {

--- a/sources/packages/backend/libs/services/src/confirmation-of-enrollment/confirmation-of-enrollment.service.ts
+++ b/sources/packages/backend/libs/services/src/confirmation-of-enrollment/confirmation-of-enrollment.service.ts
@@ -748,7 +748,7 @@ export class ConfirmationOfEnrollmentService {
   getDisbursementForCOEQuery(
     disbursementScheduleRepo: Repository<DisbursementSchedule>,
     options?: {
-      enrolmentPeriod: EnrollmentPeriod;
+      enrolmentPeriod?: EnrollmentPeriod;
       loadWorkflowData?: boolean;
     },
   ): SelectQueryBuilder<DisbursementSchedule> {

--- a/sources/packages/backend/libs/services/src/confirmation-of-enrollment/confirmation-of-enrollment.service.ts
+++ b/sources/packages/backend/libs/services/src/confirmation-of-enrollment/confirmation-of-enrollment.service.ts
@@ -740,9 +740,8 @@ export class ConfirmationOfEnrollmentService {
    * @param disbursementScheduleRepo disbursement schedule repository.
    * @param options options.
    * - `enrolmentPeriod` if the value is 'Current' then the query returns disbursement(s) is/are eligible to be confirmed by institution.
-   * If the value is 'Upcoming', then the query returns disbursements that are either not eligible to be confirmed.
+   * If the value is 'Upcoming', then the query returns disbursements that are either not eligible to be confirmed or are already confirmed.
    * - `loadWorkflowData` load workflow data for the associated assessment.
-   * or already confirmed.
    * @returns disbursements query.
    */
   getDisbursementForCOEQuery(

--- a/sources/packages/backend/libs/services/src/confirmation-of-enrollment/confirmation-of-enrollment.service.ts
+++ b/sources/packages/backend/libs/services/src/confirmation-of-enrollment/confirmation-of-enrollment.service.ts
@@ -738,16 +738,24 @@ export class ConfirmationOfEnrollmentService {
    * Get disbursement(s) for COE Query.
    **Note: Please ensure that alias from this query is used correctly at the consumer side.
    * @param disbursementScheduleRepo disbursement schedule repository.
-   * @param enrolmentPeriod if the value is 'Current' then the query returns disbursement(s) is/are eligible to be confirmed by institution.
-   * If the value is 'Upcoming', then the query returns disbursements that are either not eligible to be confirmed
+   * @param options options.
+   * - `enrolmentPeriod` if the value is 'Current' then the query returns disbursement(s) is/are eligible to be confirmed by institution.
+   * If the value is 'Upcoming', then the query returns disbursements that are either not eligible to be confirmed.
+   * - `loadWorkflowData` load workflow data for the associated assessment.
    * or already confirmed.
    * @returns disbursements query.
    */
   getDisbursementForCOEQuery(
     disbursementScheduleRepo: Repository<DisbursementSchedule>,
-    enrolmentPeriod = EnrollmentPeriod.Current,
+    options?: {
+      enrolmentPeriod: EnrollmentPeriod;
+      loadWorkflowData?: boolean;
+    },
   ): SelectQueryBuilder<DisbursementSchedule> {
+    const enrolmentPeriod =
+      options?.enrolmentPeriod ?? EnrollmentPeriod.Current;
     const coeThresholdDate = addDays(COE_WINDOW);
+    // Basic select query.
     const disbursementCOEQuery = disbursementScheduleRepo
       .createQueryBuilder("disbursementSchedule")
       .select([
@@ -768,12 +776,18 @@ export class ConfirmationOfEnrollmentService {
         "application.studentNumber",
         "student.id",
         "student.birthDate",
+        "student.disabilityStatus",
         "sinValidation.id",
         "sinValidation.sin",
         "user.id",
         "user.firstName",
         "user.lastName",
-      ])
+      ]);
+    // Load workflow data for the assessment.
+    if (options?.loadWorkflowData) {
+      disbursementCOEQuery.addSelect("studentAssessment.workflowData");
+    }
+    disbursementCOEQuery
       .innerJoin(
         "disbursementSchedule.disbursementValues",
         "disbursementValues",

--- a/sources/packages/backend/libs/utilities/src/integration-utils.ts
+++ b/sources/packages/backend/libs/utilities/src/integration-utils.ts
@@ -1,3 +1,5 @@
+import { DisabilityStatus } from "@sims/sims-db";
+
 /**
  * Express the completion years data present on educational programs as
  * an amount of years.
@@ -21,5 +23,20 @@ export function getTotalYearsOfStudy(completionYears: string): number {
       return 6;
     default:
       return 1;
+  }
+}
+
+export function getStudentDisabilityStatusCode(
+  disabilityStatus: DisabilityStatus,
+) {
+  switch (disabilityStatus) {
+    case DisabilityStatus.NotRequested:
+      return "NONE";
+    case DisabilityStatus.Requested:
+      return "PDRQ";
+    case DisabilityStatus.PD:
+      return "Approved for Permanent Disability";
+    case DisabilityStatus.PPD:
+      return "Approved for Persistent or Prolonged Disability";
   }
 }

--- a/sources/packages/backend/libs/utilities/src/integration-utils.ts
+++ b/sources/packages/backend/libs/utilities/src/integration-utils.ts
@@ -26,17 +26,29 @@ export function getTotalYearsOfStudy(completionYears: string): number {
   }
 }
 
+/**
+ * Get the student disability status code.
+ * @param disabilityStatus disability status.
+ * @throws error if the disability status cannot be translated.
+ * @returns disability status code.
+ */
 export function getStudentDisabilityStatusCode(
   disabilityStatus: DisabilityStatus,
-) {
+): string {
   switch (disabilityStatus) {
     case DisabilityStatus.NotRequested:
       return "NONE";
     case DisabilityStatus.Requested:
       return "PDRQ";
     case DisabilityStatus.PD:
-      return "Approved for Permanent Disability";
+      return "PDAP";
     case DisabilityStatus.PPD:
-      return "Approved for Persistent or Prolonged Disability";
+      return "PPDA";
+    case DisabilityStatus.Declined:
+      return "PDDC";
+    default:
+      throw new Error(
+        `Unknown disability status to get code: ${disabilityStatus}`,
+      );
   }
 }


### PR DESCRIPTION
## Add new fields to the ECE request file
- [x] Added new field `studentPDStatusCode` based on the student disability status translated as per the requirement.
- [x] Added new field `applicationPDStatusFlag` based on application PD status i.e `calculatedPDPPDStatus`.

![image](https://github.com/user-attachments/assets/57437a18-cf74-4ab5-a3ad-44b6f08acc02)



## E2E Tests

- [x] Updated the existing E2E Tests assert the new fields.
- [x] Added 2 scenarios with student disability status as `PD` and `PPD` respectively and application PD status as `Y` in both the cases.
![image](https://github.com/user-attachments/assets/4a22045d-30b2-474e-b88b-1fa99632a391)

