### PR TITLE
#3961 - NOA Layout: Dependents spelling with e

### DIFF
--- a/sources/packages/forms/src/form-definitions/noticeofassessment.json
+++ b/sources/packages/forms/src/form-definitions/noticeofassessment.json
@@ -8400,7 +8400,7 @@
                       {
                         "components": [
                           {
-                            "label": "Canada Student Grant for Persons with Dependants (CSG-FTDEP)",
+                            "label": "Canada Student Grant for Persons with Dependents (CSG-FTDEP)",
                             "labelWidth": "",
                             "labelMargin": "",
                             "tag": "p",
@@ -8411,7 +8411,7 @@
                                 "value": ""
                               }
                             ],
-                            "content": "Canada Student Grant for Persons with Dependants (CSG-FTDEP)",
+                            "content": "Canada Student Grant for Persons with Dependents (CSG-FTDEP)",
                             "refreshOnChange": false,
                             "customClass": "",
                             "hidden": false,


### PR DESCRIPTION
-  "Dependents" on this page should be spelled with "e".