### PR TITLE
#4510 - Sequential assessment and PY totals bug fix

### DIFF
--- a/sources/packages/backend/apps/queue-consumers/src/processors/assessment/_tests_/cancel-application-assessment.processor.e2e-spec.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/processors/assessment/_tests_/cancel-application-assessment.processor.e2e-spec.ts
@@ -490,6 +490,7 @@ describe(
           },
           firstDisbursementInitialValues: {
             coeStatus: COEStatus.declined,
+            disbursementScheduleStatus: DisbursementScheduleStatus.Cancelled,
           },
         },
       );

--- a/sources/packages/backend/apps/workers/src/controllers/assessment/_tests_/e2e/assessment.controller-verifyAssessmentCalculationOrder.e2e-spec.ts
+++ b/sources/packages/backend/apps/workers/src/controllers/assessment/_tests_/e2e/assessment.controller-verifyAssessmentCalculationOrder.e2e-spec.ts
@@ -1410,6 +1410,7 @@ describe("AssessmentController(e2e)-verifyAssessmentCalculationOrder", () => {
       pastApplication.currentAssessment = currentAssessment;
       await db.application.save(pastApplication);
 
+      // COE declined for current assessment disbursement.
       const currentAssessmentDisbursement = createFakeDisbursementSchedule(
         {
           studentAssessment: currentAssessment,

--- a/sources/packages/backend/apps/workers/src/controllers/assessment/_tests_/e2e/assessment.controller-verifyAssessmentCalculationOrder.e2e-spec.ts
+++ b/sources/packages/backend/apps/workers/src/controllers/assessment/_tests_/e2e/assessment.controller-verifyAssessmentCalculationOrder.e2e-spec.ts
@@ -1,5 +1,6 @@
 import {
   createE2EDataSources,
+  createFakeDisbursementSchedule,
   createFakeDisbursementValue,
   createFakeStudentAssessment,
   createFakeStudentLoanBalance,
@@ -17,6 +18,7 @@ import { createTestingAppModule } from "../../../../../test/helpers";
 import { AssessmentController } from "../../assessment.controller";
 import {
   ApplicationStatus,
+  AssessmentTriggerType,
   COEStatus,
   DisbursementScheduleStatus,
   DisbursementValueType,
@@ -1220,4 +1222,256 @@ describe("AssessmentController(e2e)-verifyAssessmentCalculationOrder", () => {
       programYearTotalBookCost: 1200,
     });
   });
+
+  it(
+    "Should calculate the sum of grants from effective amount for sent disbursements and from the difference between value amount and disbursement amount subtracted" +
+      " for the pending disbursements when a past application has one disbursement sent and the other in pending status.",
+    async () => {
+      // Arrange
+
+      // Create the student to be shared across the applications.
+      const student = await saveFakeStudent(db.dataSource);
+      // Past part-time application with two assessments where the first assessment disbursement is sent
+      // and current assessment disbursement is pending to be sent.
+      const pastApplication = await saveFakeApplicationDisbursements(
+        db.dataSource,
+        {
+          student,
+          firstDisbursementValues: [
+            createFakeDisbursementValue(
+              DisbursementValueType.CanadaGrant,
+              "CSPT",
+              1000,
+              { effectiveAmount: 1000 },
+            ),
+            createFakeDisbursementValue(
+              DisbursementValueType.CanadaGrant,
+              "CSGD",
+              500,
+              { effectiveAmount: 500 },
+            ),
+          ],
+        },
+        {
+          offeringIntensity: OfferingIntensity.partTime,
+          applicationStatus: ApplicationStatus.Completed,
+          firstDisbursementInitialValues: {
+            coeStatus: COEStatus.completed,
+            disbursementScheduleStatus: DisbursementScheduleStatus.Sent,
+          },
+          currentAssessmentInitialValues: {
+            assessmentWorkflowId: "some fake id",
+            assessmentDate: addDays(-2),
+            studentAssessmentStatus: StudentAssessmentStatus.Completed,
+          },
+        },
+      );
+      const currentAssessment = createFakeStudentAssessment(
+        {
+          auditUser: student.user,
+          application: pastApplication,
+          offering: pastApplication.currentAssessment.offering,
+        },
+        {
+          initialValue: {
+            assessmentWorkflowId: "some fake id",
+            triggerType: AssessmentTriggerType.ManualReassessment,
+            studentAssessmentStatus: StudentAssessmentStatus.Completed,
+            assessmentDate: addDays(-1),
+          },
+        },
+      );
+      pastApplication.currentAssessment = currentAssessment;
+      await db.application.save(pastApplication);
+
+      const currentAssessmentDisbursement = createFakeDisbursementSchedule(
+        {
+          studentAssessment: currentAssessment,
+          disbursementValues: [
+            createFakeDisbursementValue(
+              DisbursementValueType.CanadaGrant,
+              "CSPT",
+              1150,
+              { disbursedAmountSubtracted: 1000 },
+            ),
+            createFakeDisbursementValue(
+              DisbursementValueType.CanadaGrant,
+              "CSGD",
+              500,
+              { disbursedAmountSubtracted: 500 },
+            ),
+          ],
+        },
+        {
+          initialValues: {
+            coeStatus: COEStatus.required,
+            disbursementScheduleStatus: DisbursementScheduleStatus.Pending,
+          },
+        },
+      );
+      currentAssessment.disbursementSchedules = [currentAssessmentDisbursement];
+      await db.studentAssessment.save(currentAssessment);
+
+      // Application currently being processed.
+      const currentApplication = await saveFakeApplicationDisbursements(
+        db.dataSource,
+        { student },
+        {
+          offeringIntensity: OfferingIntensity.partTime,
+          applicationStatus: ApplicationStatus.InProgress,
+          currentAssessmentInitialValues: {
+            assessmentWorkflowId: "some fake id",
+            studentAssessmentStatus: StudentAssessmentStatus.InProgress,
+          },
+        },
+      );
+
+      // Act
+      const result =
+        await assessmentController.verifyAssessmentCalculationOrder(
+          createFakeVerifyAssessmentCalculationOrderPayload(
+            currentApplication.currentAssessment.id,
+          ),
+        );
+
+      // Asserts
+      expect(FakeWorkerJobResult.getResultType(result)).toBe(
+        MockedZeebeJobResult.Complete,
+      );
+      // Expect to consider only the CSGP from the first disbursement
+      // and ignore the second disbursement with the declined COE.
+      expect(FakeWorkerJobResult.getOutputVariables(result)).toStrictEqual({
+        isReadyForCalculation: true,
+        latestCSLPBalance: 0,
+        programYearTotalPartTimeCSPT: 1150,
+        programYearTotalPartTimeCSGD: 500,
+      });
+    },
+  );
+
+  it(
+    "Should consider the sum of grants only from the sent disbursement when a past application has COE declined for current assessment disbursement" +
+      " but has a disbursement sent from previous assessment.",
+    async () => {
+      // Arrange
+
+      // Create the student to be shared across the applications.
+      const student = await saveFakeStudent(db.dataSource);
+      // Past part-time application with two assessments where the first assessment disbursement is sent
+      // and current assessment disbursement COE is declined and the disbursement is cancelled.
+      const pastApplication = await saveFakeApplicationDisbursements(
+        db.dataSource,
+        {
+          student,
+          firstDisbursementValues: [
+            createFakeDisbursementValue(
+              DisbursementValueType.CanadaGrant,
+              "CSPT",
+              1000,
+              { effectiveAmount: 1000 },
+            ),
+            createFakeDisbursementValue(
+              DisbursementValueType.CanadaGrant,
+              "CSGD",
+              500,
+              { effectiveAmount: 500 },
+            ),
+          ],
+        },
+        {
+          offeringIntensity: OfferingIntensity.partTime,
+          applicationStatus: ApplicationStatus.Completed,
+          firstDisbursementInitialValues: {
+            coeStatus: COEStatus.completed,
+            disbursementScheduleStatus: DisbursementScheduleStatus.Sent,
+          },
+          currentAssessmentInitialValues: {
+            assessmentWorkflowId: "some fake id",
+            assessmentDate: addDays(-2),
+            studentAssessmentStatus: StudentAssessmentStatus.Completed,
+          },
+        },
+      );
+      const currentAssessment = createFakeStudentAssessment(
+        {
+          auditUser: student.user,
+          application: pastApplication,
+          offering: pastApplication.currentAssessment.offering,
+        },
+        {
+          initialValue: {
+            assessmentWorkflowId: "some fake id",
+            triggerType: AssessmentTriggerType.ManualReassessment,
+            studentAssessmentStatus: StudentAssessmentStatus.Completed,
+            assessmentDate: addDays(-1),
+          },
+        },
+      );
+      pastApplication.currentAssessment = currentAssessment;
+      await db.application.save(pastApplication);
+
+      const currentAssessmentDisbursement = createFakeDisbursementSchedule(
+        {
+          studentAssessment: currentAssessment,
+          disbursementValues: [
+            createFakeDisbursementValue(
+              DisbursementValueType.CanadaGrant,
+              "CSPT",
+              1150,
+              { disbursedAmountSubtracted: 1000 },
+            ),
+            createFakeDisbursementValue(
+              DisbursementValueType.CanadaGrant,
+              "CSGD",
+              500,
+              { disbursedAmountSubtracted: 500 },
+            ),
+          ],
+        },
+        {
+          initialValues: {
+            coeStatus: COEStatus.declined,
+            disbursementScheduleStatus: DisbursementScheduleStatus.Cancelled,
+          },
+        },
+      );
+      currentAssessment.disbursementSchedules = [currentAssessmentDisbursement];
+      await db.studentAssessment.save(currentAssessment);
+
+      // Application currently being processed.
+      const currentApplication = await saveFakeApplicationDisbursements(
+        db.dataSource,
+        { student },
+        {
+          offeringIntensity: OfferingIntensity.partTime,
+          applicationStatus: ApplicationStatus.InProgress,
+          currentAssessmentInitialValues: {
+            assessmentWorkflowId: "some fake id",
+            studentAssessmentStatus: StudentAssessmentStatus.InProgress,
+          },
+        },
+      );
+
+      // Act
+      const result =
+        await assessmentController.verifyAssessmentCalculationOrder(
+          createFakeVerifyAssessmentCalculationOrderPayload(
+            currentApplication.currentAssessment.id,
+          ),
+        );
+
+      // Asserts
+      expect(FakeWorkerJobResult.getResultType(result)).toBe(
+        MockedZeebeJobResult.Complete,
+      );
+      // Expect to consider only the CSGP from the first disbursement
+      // and ignore the second disbursement with the declined COE.
+      expect(FakeWorkerJobResult.getOutputVariables(result)).toStrictEqual({
+        isReadyForCalculation: true,
+        latestCSLPBalance: 0,
+        programYearTotalPartTimeCSPT: 1000,
+        programYearTotalPartTimeCSGD: 500,
+      });
+    },
+  );
 });

--- a/sources/packages/backend/apps/workers/src/controllers/assessment/_tests_/e2e/assessment.controller-verifyAssessmentCalculationOrder.e2e-spec.ts
+++ b/sources/packages/backend/apps/workers/src/controllers/assessment/_tests_/e2e/assessment.controller-verifyAssessmentCalculationOrder.e2e-spec.ts
@@ -18,6 +18,7 @@ import { AssessmentController } from "../../assessment.controller";
 import {
   ApplicationStatus,
   COEStatus,
+  DisbursementScheduleStatus,
   DisbursementValueType,
   OfferingIntensity,
   StudentAssessmentStatus,
@@ -202,6 +203,7 @@ describe("AssessmentController(e2e)-verifyAssessmentCalculationOrder", () => {
         ],
       },
       {
+        createSecondDisbursement: true,
         offeringIntensity: OfferingIntensity.partTime,
         applicationStatus: ApplicationStatus.Completed,
         currentAssessmentInitialValues: {
@@ -211,6 +213,7 @@ describe("AssessmentController(e2e)-verifyAssessmentCalculationOrder", () => {
         },
         secondDisbursementInitialValues: {
           coeStatus: COEStatus.declined,
+          disbursementScheduleStatus: DisbursementScheduleStatus.Cancelled,
         },
       },
     );

--- a/sources/packages/backend/apps/workers/src/controllers/assessment/_tests_/e2e/assessment.controller-verifyAssessmentCalculationOrder.e2e-spec.ts
+++ b/sources/packages/backend/apps/workers/src/controllers/assessment/_tests_/e2e/assessment.controller-verifyAssessmentCalculationOrder.e2e-spec.ts
@@ -1248,7 +1248,7 @@ describe("AssessmentController(e2e)-verifyAssessmentCalculationOrder", () => {
               DisbursementValueType.CanadaGrant,
               "CSGD",
               500,
-              { effectiveAmount: 500 },
+              { effectiveAmount: 450 },
             ),
           ],
         },
@@ -1297,8 +1297,8 @@ describe("AssessmentController(e2e)-verifyAssessmentCalculationOrder", () => {
             createFakeDisbursementValue(
               DisbursementValueType.CanadaGrant,
               "CSGD",
-              500,
-              { disbursedAmountSubtracted: 500 },
+              460,
+              { disbursedAmountSubtracted: 450 },
             ),
           ],
         },
@@ -1334,17 +1334,17 @@ describe("AssessmentController(e2e)-verifyAssessmentCalculationOrder", () => {
           ),
         );
 
-      // Asserts
+      // Assert
       expect(FakeWorkerJobResult.getResultType(result)).toBe(
         MockedZeebeJobResult.Complete,
       );
-      // Expect to consider only the CSGP from the first disbursement
-      // and ignore the second disbursement with the declined COE.
+      // Expect to consider the CSGP and CSGD effective amount from the first assessment disbursement
+      // and CSGP and CSGD value amount and disbursement amount subtracted difference from the second disbursement.
       expect(FakeWorkerJobResult.getOutputVariables(result)).toStrictEqual({
         isReadyForCalculation: true,
         latestCSLPBalance: 0,
         programYearTotalPartTimeCSPT: 1150,
-        programYearTotalPartTimeCSGD: 500,
+        programYearTotalPartTimeCSGD: 460,
       });
     },
   );
@@ -1374,7 +1374,7 @@ describe("AssessmentController(e2e)-verifyAssessmentCalculationOrder", () => {
               DisbursementValueType.CanadaGrant,
               "CSGD",
               500,
-              { effectiveAmount: 500 },
+              { effectiveAmount: 420 },
             ),
           ],
         },
@@ -1424,8 +1424,8 @@ describe("AssessmentController(e2e)-verifyAssessmentCalculationOrder", () => {
             createFakeDisbursementValue(
               DisbursementValueType.CanadaGrant,
               "CSGD",
-              500,
-              { disbursedAmountSubtracted: 500 },
+              450,
+              { disbursedAmountSubtracted: 420 },
             ),
           ],
         },
@@ -1461,17 +1461,16 @@ describe("AssessmentController(e2e)-verifyAssessmentCalculationOrder", () => {
           ),
         );
 
-      // Asserts
+      // Assert
       expect(FakeWorkerJobResult.getResultType(result)).toBe(
         MockedZeebeJobResult.Complete,
       );
-      // Expect to consider only the CSGP from the first disbursement
-      // and ignore the second disbursement with the declined COE.
+      // Expect to consider the CSGP and CSGD effective amount from the first assessment disbursement.
       expect(FakeWorkerJobResult.getOutputVariables(result)).toStrictEqual({
         isReadyForCalculation: true,
         latestCSLPBalance: 0,
         programYearTotalPartTimeCSPT: 1000,
-        programYearTotalPartTimeCSGD: 500,
+        programYearTotalPartTimeCSGD: 420,
       });
     },
   );

--- a/sources/packages/backend/apps/workers/src/controllers/assessment/_tests_/e2e/assessment.controller-workflowWrapUp.e2e-spec.ts
+++ b/sources/packages/backend/apps/workers/src/controllers/assessment/_tests_/e2e/assessment.controller-workflowWrapUp.e2e-spec.ts
@@ -290,7 +290,7 @@ describe("AssessmentController(e2e)-workflowWrapUp", () => {
         ),
       );
 
-      // Asserts
+      // Assert
       expect(FakeWorkerJobResult.getResultType(result)).toBe(
         MockedZeebeJobResult.Complete,
       );
@@ -376,7 +376,7 @@ describe("AssessmentController(e2e)-workflowWrapUp", () => {
         ),
       );
 
-      // Asserts
+      // Assert
       expect(FakeWorkerJobResult.getResultType(result)).toBe(
         MockedZeebeJobResult.Complete,
       );

--- a/sources/packages/backend/apps/workers/src/controllers/assessment/_tests_/e2e/assessment.controller-workflowWrapUp.e2e-spec.ts
+++ b/sources/packages/backend/apps/workers/src/controllers/assessment/_tests_/e2e/assessment.controller-workflowWrapUp.e2e-spec.ts
@@ -294,7 +294,7 @@ describe("AssessmentController(e2e)-workflowWrapUp", () => {
       expect(FakeWorkerJobResult.getResultType(result)).toBe(
         MockedZeebeJobResult.Complete,
       );
-      // Asserts that the student assessment status has changed to completed.
+      // Asserts that the current student assessment is 'Related application changed' trigger type.
       const expectedAssessment = await db.application.findOne({
         select: {
           id: true,

--- a/sources/packages/backend/apps/workers/src/controllers/assessment/_tests_/e2e/assessment.controller-workflowWrapUp.e2e-spec.ts
+++ b/sources/packages/backend/apps/workers/src/controllers/assessment/_tests_/e2e/assessment.controller-workflowWrapUp.e2e-spec.ts
@@ -199,7 +199,7 @@ describe("AssessmentController(e2e)-workflowWrapUp", () => {
 
   it(
     "Should find the next impacted assessment and create a reassessment when there is an application for the same student and program year in the future" +
-      " when the future application has COE declined for all current assessment disbursements but has a disbursement sent from previous assessment.",
+      " and the future application has COE declined for all current assessment disbursements but has a disbursement sent from previous assessment.",
     async () => {
       // Arrange
 
@@ -301,11 +301,10 @@ describe("AssessmentController(e2e)-workflowWrapUp", () => {
           currentAssessment: {
             id: true,
             triggerType: true,
-            studentAppeal: { id: true },
           },
         },
         relations: {
-          currentAssessment: { studentAppeal: true },
+          currentAssessment: true,
         },
         where: {
           id: impactedApplication.id,
@@ -314,6 +313,96 @@ describe("AssessmentController(e2e)-workflowWrapUp", () => {
       expect(expectedAssessment.currentAssessment.triggerType).toBe(
         AssessmentTriggerType.RelatedApplicationChanged,
       );
+    },
+  );
+
+  it(
+    "Should not find any next impacted assessment when there is an application for the same student and program year in the future" +
+      " and the future application has COE declined for all assessment disbursements.",
+    async () => {
+      // Arrange
+
+      // Create the student to be shared across the applications.
+      const student = await saveFakeStudent(db.dataSource);
+      // Current application to have the workflow wrapped up.
+      const currentApplicationToWrapUp = await saveFakeApplicationDisbursements(
+        db.dataSource,
+        { student },
+        {
+          offeringIntensity: OfferingIntensity.partTime,
+          applicationStatus: ApplicationStatus.Assessment,
+          currentAssessmentInitialValues: {
+            assessmentWorkflowId: "some fake id",
+            assessmentDate: new Date(),
+            studentAssessmentStatus: StudentAssessmentStatus.InProgress,
+          },
+        },
+      );
+      // Resets the workflow data to allow the wrap up worker to be executed.
+      await db.studentAssessment.update(
+        currentApplicationToWrapUp.currentAssessment.id,
+        { workflowData: null },
+      );
+      // Application in the future and COE declined.
+      const futureApplication = await saveFakeApplicationDisbursements(
+        db.dataSource,
+        { student },
+        {
+          offeringIntensity: OfferingIntensity.partTime,
+          applicationStatus: ApplicationStatus.Completed,
+          currentAssessmentInitialValues: {
+            assessmentWorkflowId: "some fake id",
+            assessmentDate: addDays(1),
+            studentAssessmentStatus: StudentAssessmentStatus.Completed,
+          },
+          firstDisbursementInitialValues: {
+            coeStatus: COEStatus.declined,
+            disbursementScheduleStatus: DisbursementScheduleStatus.Cancelled,
+          },
+        },
+      );
+      // Dummy workflowData to be saved during workflow wrap up.
+      const workflowData = {
+        studentData: {
+          dependantStatus: "independant",
+        },
+      } as WorkflowData;
+
+      // Act
+      const result = await assessmentController.workflowWrapUp(
+        createFakeWorkflowWrapUpPayload(
+          currentApplicationToWrapUp.currentAssessment.id,
+          workflowData,
+        ),
+      );
+
+      // Asserts
+      expect(FakeWorkerJobResult.getResultType(result)).toBe(
+        MockedZeebeJobResult.Complete,
+      );
+      // Asserts that the current assessment status has not changed.
+      const expectedAssessmentApplication = await db.application.findOne({
+        select: {
+          id: true,
+          currentAssessment: {
+            id: true,
+            triggerType: true,
+          },
+        },
+        relations: {
+          currentAssessment: true,
+        },
+        where: {
+          id: futureApplication.id,
+        },
+      });
+      expect(expectedAssessmentApplication).toEqual({
+        id: futureApplication.id,
+        currentAssessment: {
+          id: futureApplication.currentAssessment.id,
+          triggerType: AssessmentTriggerType.OriginalAssessment,
+        },
+      });
     },
   );
 

--- a/sources/packages/backend/libs/services/src/students-assessments/assessment-sequential-processing.service.ts
+++ b/sources/packages/backend/libs/services/src/students-assessments/assessment-sequential-processing.service.ts
@@ -242,6 +242,13 @@ export class AssessmentSequentialProcessingService {
       .createQueryBuilder("disbursementValue")
       .select("disbursementValue.valueCode", "valueCode")
       .addSelect("offering.offeringIntensity", "offeringIntensity")
+      // When obtaining the SUM of a given grant, calculate the value from effective_amount of disbursement_values when effective_amount is present
+      // or in other words disbursement is Sent
+      // and if the value is not present in effective_amount which means the disbursement has not been calculated for e-cert
+      // then use a forecast value which is (value_amount - disbursed_amount_subtracted) which could potentially be sent to the student.
+
+      // The consideration of overawards has been excluded while calculating the PY SUM value for any grant
+      // as the overawards are applicable only for the loans and NOT for the grants.
       .addSelect(
         "SUM(COALESCE(disbursementValue.effectiveAmount, disbursementValue.valueAmount - COALESCE(disbursementValue.disbursedAmountSubtracted, 0)))",
         "total",

--- a/sources/packages/backend/libs/services/src/students-assessments/assessment-sequential-processing.service.ts
+++ b/sources/packages/backend/libs/services/src/students-assessments/assessment-sequential-processing.service.ts
@@ -4,9 +4,9 @@ import {
   Application,
   ApplicationStatus,
   AssessmentTriggerType,
-  COEStatus,
   DisbursementSchedule,
   DisbursementScheduleStatus,
+  DisbursementValue,
   DisbursementValueType,
   OfferingIntensity,
   SFASApplication,
@@ -42,6 +42,8 @@ export class AssessmentSequentialProcessingService {
     private readonly sfasApplicationsRepo: Repository<SFASApplication>,
     @InjectRepository(SFASPartTimeApplications)
     private readonly sfasPartTimeApplicationsRepo: Repository<SFASPartTimeApplications>,
+    @InjectRepository(DisbursementValue)
+    private readonly disbursementValueRepo: Repository<DisbursementValue>,
   ) {}
 
   /**
@@ -236,18 +238,21 @@ export class AssessmentSequentialProcessingService {
     const applicationNumbers = sequencedApplications.previous.map(
       (application) => application.applicationNumber,
     );
-    const totals = await this.applicationRepo
-      .createQueryBuilder("application")
+    const totals = await this.disbursementValueRepo
+      .createQueryBuilder("disbursementValue")
       .select("disbursementValue.valueCode", "valueCode")
       .addSelect("offering.offeringIntensity", "offeringIntensity")
-      .addSelect("SUM(disbursementValue.valueAmount)", "total")
-      .innerJoin("application.currentAssessment", "currentAssessment")
+      .addSelect(
+        "SUM(COALESCE(disbursementValue.effectiveAmount, disbursementValue.valueAmount - disbursementValue.overawardAmountSubtracted))",
+        "total",
+      )
       .innerJoin(
-        "currentAssessment.disbursementSchedules",
+        "disbursementValue.disbursementSchedule",
         "disbursementSchedule",
       )
-      .innerJoin("disbursementSchedule.disbursementValues", "disbursementValue")
-      .innerJoin("currentAssessment.offering", "offering")
+      .innerJoin("disbursementSchedule.studentAssessment", "studentAssessment")
+      .innerJoin("studentAssessment.offering", "offering")
+      .innerJoin("studentAssessment.application", "application")
       .where("application.applicationNumber IN (:...applicationNumbers)", {
         applicationNumbers,
       })
@@ -255,26 +260,17 @@ export class AssessmentSequentialProcessingService {
       .andWhere("application.applicationStatus != :overwrittenStatus", {
         overwrittenStatus: ApplicationStatus.Overwritten,
       })
-      // Check for assessment completed status to avoid retrieving any cancelation status.
-      .andWhere(
-        "currentAssessment.studentAssessmentStatus = :completedStudentAssessmentStatus",
-        {
-          completedStudentAssessmentStatus: StudentAssessmentStatus.Completed,
-        },
-      )
       // Only consider disbursements in Pending, ReadyToSend, or Sent.
       .andWhere(
-        "disbursementSchedule.disbursementScheduleStatus != :cancelledDisbursementScheduleStatus",
+        "disbursementSchedule.disbursementScheduleStatus IN (:...payableDisbursementScheduleStatus)",
         {
-          cancelledDisbursementScheduleStatus:
-            DisbursementScheduleStatus.Cancelled,
+          payableDisbursementScheduleStatus: [
+            DisbursementScheduleStatus.Pending,
+            DisbursementScheduleStatus.ReadyToSend,
+            DisbursementScheduleStatus.Sent,
+          ],
         },
       )
-      // Sequenced applications need at least one valid COE, which means that one can be cancelled
-      // and the other still valid. This ensures that only the valid one will be considered.
-      .andWhere("disbursementSchedule.coeStatus != :declinedCOEStatus", {
-        declinedCOEStatus: COEStatus.declined,
-      })
       // Ensures that only grants will be returned since loans and not needed.
       .andWhere("disbursementValue.valueType IN (:...grantsValueTypes)", {
         grantsValueTypes: [
@@ -282,8 +278,8 @@ export class AssessmentSequentialProcessingService {
           DisbursementValueType.BCGrant,
         ],
       })
-      .groupBy("offering.offeringIntensity")
-      .addGroupBy("disbursementValue.valueCode")
+      .groupBy("disbursementValue.valueCode")
+      .addGroupBy("offering.offeringIntensity")
       .getRawMany<{
         offeringIntensity: OfferingIntensity;
         valueCode: string;
@@ -458,15 +454,24 @@ export class AssessmentSequentialProcessingService {
       .orderBy("assessment.assessmentDate")
       .limit(1)
       .getQuery();
-    // Sub query to determined if the assessment has at least one non-declined COE (Required or Completed).
-    // If all the COEs from the assessment are declined some user action will be needed in the application
-    // and this application will not be considered for sequential processing.
-    const existsValidCOE = entityManager
+    // Sub query to determine if the application has at least one payable disbursement.
+    // If all the disbursements from the application are NOT payable then the application will not be considered for sequential processing.
+    const existsValidDisbursement = entityManager
       .getRepository(DisbursementSchedule)
       .createQueryBuilder("disbursementSchedule")
       .select("1")
-      .where("disbursementSchedule.studentAssessment.id = currentAssessment.id")
-      .andWhere("disbursementSchedule.coeStatus != :declinedCOEStatus")
+      .innerJoin(
+        "disbursementSchedule.studentAssessment",
+        "disbursementAssessment",
+      )
+      .innerJoin(
+        "disbursementAssessment.application",
+        "disbursementApplication",
+      )
+      .where("disbursementApplication.id = application.id")
+      .andWhere(
+        "disbursementSchedule.disbursementScheduleStatus IN (:...payableDisbursementStatuses)",
+      )
       .limit(1)
       .getSql();
     // Returns past, current, and future applications ordered by the first ever executed assessment calculation.
@@ -503,7 +508,7 @@ export class AssessmentSequentialProcessingService {
                   cancelledStatus: ApplicationStatus.Cancelled,
                 })
                 .andWhere("currentAssessment.assessmentDate IS NOT NULL")
-                .andWhere(`EXISTS (${existsValidCOE})`),
+                .andWhere(`EXISTS (${existsValidDisbursement})`),
             ),
             // The 'or' condition forces the current application to be returned since its data matters for decisions,
             // for instance, if the current application has no calculation date no future application should be impacted.
@@ -512,7 +517,13 @@ export class AssessmentSequentialProcessingService {
           });
         }),
       )
-      .setParameters({ declinedCOEStatus: COEStatus.declined })
+      .setParameters({
+        payableDisbursementStatuses: [
+          DisbursementScheduleStatus.Pending,
+          DisbursementScheduleStatus.ReadyToSend,
+          DisbursementScheduleStatus.Sent,
+        ],
+      })
       .orderBy(`"${referenceAssessmentDateColumn}"`)
       .getRawMany<SequentialApplication>();
     return new SequencedApplications(

--- a/sources/packages/backend/libs/services/src/students-assessments/assessment-sequential-processing.service.ts
+++ b/sources/packages/backend/libs/services/src/students-assessments/assessment-sequential-processing.service.ts
@@ -243,7 +243,7 @@ export class AssessmentSequentialProcessingService {
       .select("disbursementValue.valueCode", "valueCode")
       .addSelect("offering.offeringIntensity", "offeringIntensity")
       .addSelect(
-        "SUM(COALESCE(disbursementValue.effectiveAmount, disbursementValue.valueAmount - disbursementValue.overawardAmountSubtracted))",
+        "SUM(COALESCE(disbursementValue.effectiveAmount, disbursementValue.valueAmount - COALESCE(disbursementValue.disbursedAmountSubtracted, 0)))",
         "total",
       )
       .innerJoin(


### PR DESCRIPTION
# Sequential assessment and PY totals bug fix

## Root Cause

Currently there is an issue with sequential assessment processing and PY totals in production, when an application has all it's current assessment disbursement(s) have `Declined` COE.

Issue Description: As explained above, the sequential assessment processing logic considers only the current assessment of any application to see if the given application must be considered with the sequential applications 
FOR 
both `Calculation of PY totals from past applications` and `Consider the impacted applications to re-assess` 

WHEN 
the application has all it's current assessment disbursement(s) have `Declined` COE.


## Solution
**_Update to Sequential Applications Logic(In addition to the existing ones):_** 

 - Applications that have at-least one disbursement which are in following `disbursementScheduleStatus` - `Pending | Ready to send | Sent` are considered to be part of sequential applications.

**_Calculation of program year totals:_** 
- Calculate the program year totals from past application disbursements which are only in following payable statuses - `Pending | Ready to send | Sent`
- When obtaining the SUM of a given grant, calculate the value from `effective_amount` of `disbursement_values` when `effective_amount` is present or in other words disbursement is `Sent` and if the value is not present in `effective_amount` which means the disbursement has not been calculated for `e-cert`, then use a forecast value which is `value_amount - disbursed_amount_subtracted`  which could potentially be sent to the student. 

**Note**: The consideration of over-awards has been excluded while calculating the PY SUM value for any grants as the over-awards are applicable only for the loans and NOT for the grants.


## Manual Test

- [x] Student with application A, which has the original assessment awards SENT and then is reported for withdrawal by the institution and `COE` is declined for the `Scholastic Standing` re-assessment.

Original Assessment
![image](https://github.com/user-attachments/assets/dfc02186-5a22-497e-b58c-cbaa3408d9b0)

COE Declined for SSR re-assessment
![image](https://github.com/user-attachments/assets/1ddab407-d35b-4f7a-818f-b5744e1f3c64)

- [x]  Student submitted Application B, and award was reduced based on what was SENT on Application A.

![image](https://github.com/user-attachments/assets/8dc717fc-a837-4f93-a347-3f115d257576)

![image](https://github.com/user-attachments/assets/bef297ca-270a-4c60-b07e-b6694922ee46)





## E2E Tests

- [x] Added E2E tests to assert that PY Totals are calculated as per the updated logic.
- [x] Added E2E test assert that any application with all current assessment disbursement(s) having `Declined` COE but any of the previous assessment(s) having a sent disbursement is considered for sequential applications.

![image](https://github.com/user-attachments/assets/f011676a-b737-4007-86da-f0e53c32145e)

![image](https://github.com/user-attachments/assets/ea77cb8a-1d11-4376-a4c2-a9311a881b39)

