### PR TITLE
#4459 - Set max documents for application uploaders to 25

### DIFF
--- a/sources/packages/forms/src/form-definitions/partnerinformationandincomeappeal.json
+++ b/sources/packages/forms/src/form-definitions/partnerinformationandincomeappeal.json
@@ -141,6 +141,27 @@
       "lockKey": true
     },
     {
+      "input": true,
+      "tableView": true,
+      "key": "maxUploadedFiles",
+      "label": "maxUploadedFiles",
+      "protected": false,
+      "unique": false,
+      "persistent": false,
+      "type": "hidden",
+      "tags": [],
+      "conditional": {
+        "show": "",
+        "when": null,
+        "eq": ""
+      },
+      "properties": {},
+      "defaultValue": "",
+      "lockKey": true,
+      "calculateValue": "value = 25;",
+      "calculateServer": true
+    },
+    {
       "label": "HTML",
       "labelWidth": "",
       "labelMargin": "",
@@ -1689,8 +1710,8 @@
               "dir": "Current Year Income - Supporting Documents",
               "customClass": "font-weight-bold",
               "validate": {
-                "required": false,
-                "custom": "const maxUploadedFiles = 25; const files = data[instance.key] || []; valid = !files.length ? 'At least one file is required' : files.length > maxUploadedFiles ? `Maximum ${maxUploadedFiles} files allowed` : true;"
+                "required": true,
+                "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? `Maximum ${data.maxUploadedFiles} files allowed` : true;"
               },
               "lockKey": true
             },

--- a/sources/packages/forms/src/form-definitions/partnerinformationandincomeappeal.json
+++ b/sources/packages/forms/src/form-definitions/partnerinformationandincomeappeal.json
@@ -1711,7 +1711,8 @@
               "customClass": "font-weight-bold",
               "validate": {
                 "required": true,
-                "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? `Maximum ${data.maxUploadedFiles} files allowed` : true;"
+                "customMessage": "You must upload at least one file, and the total number of uploaded files cannot exceed {{data.maxUploadedFiles}}.",
+                "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? false : true;"
               },
               "lockKey": true
             },

--- a/sources/packages/forms/src/form-definitions/partnerinformationandincomeappeal.json
+++ b/sources/packages/forms/src/form-definitions/partnerinformationandincomeappeal.json
@@ -1689,7 +1689,8 @@
               "dir": "Current Year Income - Supporting Documents",
               "customClass": "font-weight-bold",
               "validate": {
-                "required": true
+                "required": false,
+                "custom": "const maxUploadedFiles = 25; const files = data[instance.key] || []; valid = !files.length ? 'At least one file is required' : files.length > maxUploadedFiles ? `Maximum ${maxUploadedFiles} files allowed` : true;"
               },
               "lockKey": true
             },

--- a/sources/packages/forms/src/form-definitions/sfaa2022-23.json
+++ b/sources/packages/forms/src/form-definitions/sfaa2022-23.json
@@ -7899,9 +7899,8 @@
                   "calculateServer": false,
                   "allowCalculateOverride": false,
                   "validate": {
-                    "required": true,
-                    "customMessage": "",
-                    "custom": "",
+                    "required": false,
+                    "custom": "const maxUploadedFiles = 25; const files = data[instance.key] || []; valid = !files.length ? 'At least one file is required' : files.length > maxUploadedFiles ? `Maximum ${maxUploadedFiles} files allowed` : true;",
                     "customPrivate": false,
                     "json": "",
                     "strictDateValidation": false,
@@ -9257,7 +9256,7 @@
                       "id": "ekl3d6"
                     },
                     {
-                      "label": "Upload supporting documents (optional):",
+                      "label": "Upload supporting documents",
                       "customClass": "font-weight-bold",
                       "hideLabel": true,
                       "tableView": false,
@@ -9305,8 +9304,8 @@
                       "attributes": {},
                       "validateOn": "change",
                       "validate": {
-                        "required": true,
-                        "custom": "",
+                        "required": false,
+                        "custom": "const maxUploadedFiles = 25; const files = data[instance.key] || []; valid = !files.length ? 'At least one file is required' : files.length > maxUploadedFiles ? `Maximum ${maxUploadedFiles} files allowed` : true;",
                         "customPrivate": false,
                         "strictDateValidation": false,
                         "multiple": false,
@@ -13867,8 +13866,8 @@
                               "multiple": true,
                               "redrawOn": "dependants.declaredOnTaxes",
                               "validate": {
-                                "required": true,
-                                "custom": "",
+                                "required": false,
+                                "custom": "const maxUploadedFiles = 25; const files = data[instance.key] || []; valid = !files.length ? 'At least one file is required' : files.length > maxUploadedFiles ? `Maximum ${maxUploadedFiles} files allowed` : true;",
                                 "customPrivate": false,
                                 "strictDateValidation": false,
                                 "multiple": false,
@@ -14928,9 +14927,8 @@
                   "calculateServer": false,
                   "allowCalculateOverride": false,
                   "validate": {
-                    "required": true,
-                    "customMessage": "",
-                    "custom": "",
+                    "required": false,
+                    "custom": "const maxUploadedFiles = 25; const files = data[instance.key] || []; valid = !files.length ? 'At least one file is required' : files.length > maxUploadedFiles ? `Maximum ${maxUploadedFiles} files allowed` : true;",
                     "customPrivate": false,
                     "json": "",
                     "strictDateValidation": false,
@@ -16833,7 +16831,8 @@
                   "url": "student/files",
                   "lockKey": true,
                   "validate": {
-                    "required": true
+                    "required": false,
+                    "custom": "const maxUploadedFiles = 25; const files = data[instance.key] || []; valid = !files.length ? 'At least one file is required' : files.length > maxUploadedFiles ? `Maximum ${maxUploadedFiles} files allowed` : true;"
                   }
                 },
                 {
@@ -21091,7 +21090,7 @@
               "id": "ecfi9yd"
             },
             {
-              "label": "Upload supporting documents (optional):",
+              "label": "Upload supporting documents",
               "labelPosition": "top",
               "labelWidth": "",
               "labelMargin": "",
@@ -21133,8 +21132,7 @@
               "allowCalculateOverride": false,
               "validate": {
                 "required": false,
-                "customMessage": "",
-                "custom": "",
+                "custom": "const maxUploadedFiles = 25; const files = data[instance.key] || []; valid = !files.length ? 'At least one file is required' : files.length > maxUploadedFiles ? `Maximum ${maxUploadedFiles} files allowed` : true;",
                 "customPrivate": false,
                 "json": "",
                 "strictDateValidation": false,
@@ -22167,7 +22165,7 @@
                   "validateOn": "change",
                   "validate": {
                     "required": false,
-                    "custom": "",
+                    "custom": "const maxUploadedFiles = 25; const files = data[instance.key] || []; valid = !files.length ? 'At least one file is required' : files.length > maxUploadedFiles ? `Maximum ${maxUploadedFiles} files allowed` : true;",
                     "customPrivate": false,
                     "strictDateValidation": false,
                     "multiple": false,
@@ -24710,7 +24708,8 @@
                   "dir": "Current Year Income - Supporting Documents",
                   "customClass": "font-weight-bold",
                   "validate": {
-                    "required": true
+                    "required": false,
+                    "custom": "const maxUploadedFiles = 25; const files = data[instance.key] || []; valid = !files.length ? 'At least one file is required' : files.length > maxUploadedFiles ? `Maximum ${maxUploadedFiles} files allowed` : true;"
                   },
                   "lockKey": true
                 },
@@ -25919,7 +25918,7 @@
                   "validateOn": "change",
                   "validate": {
                     "required": false,
-                    "custom": "",
+                    "custom": "const maxUploadedFiles = 25; const files = data[instance.key] || []; valid = !files.length ? 'At least one file is required' : files.length > maxUploadedFiles ? `Maximum ${maxUploadedFiles} files allowed` : true;",
                     "customPrivate": false,
                     "strictDateValidation": false,
                     "multiple": false,
@@ -29653,7 +29652,7 @@
                       "className": ""
                     },
                     {
-                      "label": "Upload supporting documents (optional):",
+                      "label": "Upload supporting documents",
                       "hideLabel": true,
                       "tableView": false,
                       "storage": "url",
@@ -29702,7 +29701,7 @@
                       "validateOn": "change",
                       "validate": {
                         "required": false,
-                        "custom": "",
+                        "custom": "const maxUploadedFiles = 25; const files = data[instance.key] || []; valid = !files.length ? 'At least one file is required' : files.length > maxUploadedFiles ? `Maximum ${maxUploadedFiles} files allowed` : true;",
                         "customPrivate": false,
                         "strictDateValidation": false,
                         "multiple": false,
@@ -31738,7 +31737,7 @@
                       "tags": []
                     },
                     {
-                      "label": "Upload supporting documents (optional):",
+                      "label": "Upload supporting documents",
                       "customClass": "font-weight-bold",
                       "hideLabel": true,
                       "tableView": false,
@@ -31787,8 +31786,8 @@
                       "attributes": {},
                       "validateOn": "change",
                       "validate": {
-                        "required": true,
-                        "custom": "",
+                        "required": false,
+                        "custom": "const maxUploadedFiles = 25; const files = data[instance.key] || []; valid = !files.length ? 'At least one file is required' : files.length > maxUploadedFiles ? `Maximum ${maxUploadedFiles} files allowed` : true;",
                         "customPrivate": false,
                         "strictDateValidation": false,
                         "multiple": false,

--- a/sources/packages/forms/src/form-definitions/sfaa2022-23.json
+++ b/sources/packages/forms/src/form-definitions/sfaa2022-23.json
@@ -7900,7 +7900,8 @@
                   "allowCalculateOverride": false,
                   "validate": {
                     "required": true,
-                    "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? `Maximum ${data.maxUploadedFiles} files allowed` : true;",
+                    "customMessage": "You must upload at least one file, and the total number of uploaded files cannot exceed {{data.maxUploadedFiles}}.",
+                    "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? false : true;",
                     "customPrivate": false,
                     "json": "",
                     "strictDateValidation": false,
@@ -9305,7 +9306,8 @@
                       "validateOn": "change",
                       "validate": {
                         "required": true,
-                        "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? `Maximum ${data.maxUploadedFiles} files allowed` : true;",
+                        "customMessage": "You must upload at least one file, and the total number of uploaded files cannot exceed {{data.maxUploadedFiles}}.",
+                        "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? false : true;",
                         "customPrivate": false,
                         "strictDateValidation": false,
                         "multiple": false,
@@ -13888,7 +13890,8 @@
                               "redrawOn": "dependants.declaredOnTaxes",
                               "validate": {
                                 "required": true,
-                                "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? `Maximum ${data.maxUploadedFiles} files allowed` : true;",
+                                "customMessage": "You must upload at least one file, and the total number of uploaded files cannot exceed {{data.maxUploadedFiles}}.",
+                                "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? false : true;",
                                 "customPrivate": false,
                                 "strictDateValidation": false,
                                 "multiple": false,
@@ -14949,7 +14952,8 @@
                   "allowCalculateOverride": false,
                   "validate": {
                     "required": true,
-                    "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? `Maximum ${data.maxUploadedFiles} files allowed` : true;",
+                    "customMessage": "You must upload at least one file, and the total number of uploaded files cannot exceed {{data.maxUploadedFiles}}.",
+                    "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? false : true;",
                     "customPrivate": false,
                     "json": "",
                     "strictDateValidation": false,
@@ -16853,7 +16857,8 @@
                   "lockKey": true,
                   "validate": {
                     "required": true,
-                    "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? `Maximum ${data.maxUploadedFiles} files allowed` : true;"
+                    "customMessage": "You must upload at least one file, and the total number of uploaded files cannot exceed {{data.maxUploadedFiles}}.",
+                    "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? false : true;"
                   }
                 },
                 {
@@ -21153,7 +21158,8 @@
               "allowCalculateOverride": false,
               "validate": {
                 "required": true,
-                "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? `Maximum ${data.maxUploadedFiles} files allowed` : true;",
+                "customMessage": "You must upload at least one file, and the total number of uploaded files cannot exceed {{data.maxUploadedFiles}}.",
+                "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? false : true;",
                 "customPrivate": false,
                 "json": "",
                 "strictDateValidation": false,
@@ -22186,7 +22192,8 @@
                   "validateOn": "change",
                   "validate": {
                     "required": true,
-                    "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? `Maximum ${data.maxUploadedFiles} files allowed` : true;",
+                    "customMessage": "You must upload at least one file, and the total number of uploaded files cannot exceed {{data.maxUploadedFiles}}.",
+                    "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? false : true;",
                     "customPrivate": false,
                     "strictDateValidation": false,
                     "multiple": false,
@@ -24730,7 +24737,8 @@
                   "customClass": "font-weight-bold",
                   "validate": {
                     "required": true,
-                    "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? `Maximum ${data.maxUploadedFiles} files allowed` : true;"
+                    "customMessage": "You must upload at least one file, and the total number of uploaded files cannot exceed {{data.maxUploadedFiles}}.",
+                    "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? false : true;"
                   },
                   "lockKey": true
                 },
@@ -25939,7 +25947,8 @@
                   "validateOn": "change",
                   "validate": {
                     "required": true,
-                    "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? `Maximum ${data.maxUploadedFiles} files allowed` : true;",
+                    "customMessage": "You must upload at least one file, and the total number of uploaded files cannot exceed {{data.maxUploadedFiles}}.",
+                    "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? false : true;",
                     "customPrivate": false,
                     "strictDateValidation": false,
                     "multiple": false,
@@ -29722,7 +29731,8 @@
                       "validateOn": "change",
                       "validate": {
                         "required": true,
-                        "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? `Maximum ${data.maxUploadedFiles} files allowed` : true;",
+                        "customMessage": "You must upload at least one file, and the total number of uploaded files cannot exceed {{data.maxUploadedFiles}}.",
+                        "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? false : true;",
                         "customPrivate": false,
                         "strictDateValidation": false,
                         "multiple": false,
@@ -31808,7 +31818,8 @@
                       "validateOn": "change",
                       "validate": {
                         "required": true,
-                        "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? `Maximum ${data.maxUploadedFiles} files allowed` : true;",
+                        "customMessage": "You must upload at least one file, and the total number of uploaded files cannot exceed {{data.maxUploadedFiles}}.",
+                        "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? false : true;",
                         "customPrivate": false,
                         "strictDateValidation": false,
                         "multiple": false,

--- a/sources/packages/forms/src/form-definitions/sfaa2022-23.json
+++ b/sources/packages/forms/src/form-definitions/sfaa2022-23.json
@@ -7899,8 +7899,8 @@
                   "calculateServer": false,
                   "allowCalculateOverride": false,
                   "validate": {
-                    "required": false,
-                    "custom": "const maxUploadedFiles = 25; const files = data[instance.key] || []; valid = !files.length ? 'At least one file is required' : files.length > maxUploadedFiles ? `Maximum ${maxUploadedFiles} files allowed` : true;",
+                    "required": true,
+                    "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? `Maximum ${data.maxUploadedFiles} files allowed` : true;",
                     "customPrivate": false,
                     "json": "",
                     "strictDateValidation": false,
@@ -9304,8 +9304,8 @@
                       "attributes": {},
                       "validateOn": "change",
                       "validate": {
-                        "required": false,
-                        "custom": "const maxUploadedFiles = 25; const files = data[instance.key] || []; valid = !files.length ? 'At least one file is required' : files.length > maxUploadedFiles ? `Maximum ${maxUploadedFiles} files allowed` : true;",
+                        "required": true,
+                        "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? `Maximum ${data.maxUploadedFiles} files allowed` : true;",
                         "customPrivate": false,
                         "strictDateValidation": false,
                         "multiple": false,
@@ -12288,6 +12288,27 @@
           },
           "properties": {},
           "lockKey": true
+        },
+        {
+          "input": true,
+          "tableView": true,
+          "key": "maxUploadedFiles",
+          "label": "maxUploadedFiles",
+          "protected": false,
+          "unique": false,
+          "persistent": false,
+          "type": "hidden",
+          "tags": [],
+          "conditional": {
+            "show": "",
+            "when": null,
+            "eq": ""
+          },
+          "properties": {},
+          "defaultValue": "",
+          "lockKey": true,
+          "calculateValue": "value = 25;",
+          "calculateServer": true
         }
       ],
       "input": false,
@@ -13866,8 +13887,8 @@
                               "multiple": true,
                               "redrawOn": "dependants.declaredOnTaxes",
                               "validate": {
-                                "required": false,
-                                "custom": "const maxUploadedFiles = 25; const files = data[instance.key] || []; valid = !files.length ? 'At least one file is required' : files.length > maxUploadedFiles ? `Maximum ${maxUploadedFiles} files allowed` : true;",
+                                "required": true,
+                                "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? `Maximum ${data.maxUploadedFiles} files allowed` : true;",
                                 "customPrivate": false,
                                 "strictDateValidation": false,
                                 "multiple": false,
@@ -14927,8 +14948,8 @@
                   "calculateServer": false,
                   "allowCalculateOverride": false,
                   "validate": {
-                    "required": false,
-                    "custom": "const maxUploadedFiles = 25; const files = data[instance.key] || []; valid = !files.length ? 'At least one file is required' : files.length > maxUploadedFiles ? `Maximum ${maxUploadedFiles} files allowed` : true;",
+                    "required": true,
+                    "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? `Maximum ${data.maxUploadedFiles} files allowed` : true;",
                     "customPrivate": false,
                     "json": "",
                     "strictDateValidation": false,
@@ -16809,7 +16830,7 @@
                   "image": false,
                   "imageSize": "200",
                   "placeholder": "",
-                  "multiple": false,
+                  "multiple": true,
                   "defaultValue": "",
                   "protected": false,
                   "persistent": true,
@@ -16831,8 +16852,8 @@
                   "url": "student/files",
                   "lockKey": true,
                   "validate": {
-                    "required": false,
-                    "custom": "const maxUploadedFiles = 25; const files = data[instance.key] || []; valid = !files.length ? 'At least one file is required' : files.length > maxUploadedFiles ? `Maximum ${maxUploadedFiles} files allowed` : true;"
+                    "required": true,
+                    "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? `Maximum ${data.maxUploadedFiles} files allowed` : true;"
                   }
                 },
                 {
@@ -21131,8 +21152,8 @@
               "calculateServer": false,
               "allowCalculateOverride": false,
               "validate": {
-                "required": false,
-                "custom": "const maxUploadedFiles = 25; const files = data[instance.key] || []; valid = !files.length ? 'At least one file is required' : files.length > maxUploadedFiles ? `Maximum ${maxUploadedFiles} files allowed` : true;",
+                "required": true,
+                "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? `Maximum ${data.maxUploadedFiles} files allowed` : true;",
                 "customPrivate": false,
                 "json": "",
                 "strictDateValidation": false,
@@ -22138,7 +22159,7 @@
                   "prefix": "",
                   "customClass": "",
                   "suffix": "",
-                  "multiple": false,
+                  "multiple": true,
                   "defaultValue": null,
                   "protected": false,
                   "unique": false,
@@ -22164,8 +22185,8 @@
                   "attributes": {},
                   "validateOn": "change",
                   "validate": {
-                    "required": false,
-                    "custom": "const maxUploadedFiles = 25; const files = data[instance.key] || []; valid = !files.length ? 'At least one file is required' : files.length > maxUploadedFiles ? `Maximum ${maxUploadedFiles} files allowed` : true;",
+                    "required": true,
+                    "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? `Maximum ${data.maxUploadedFiles} files allowed` : true;",
                     "customPrivate": false,
                     "strictDateValidation": false,
                     "multiple": false,
@@ -24708,8 +24729,8 @@
                   "dir": "Current Year Income - Supporting Documents",
                   "customClass": "font-weight-bold",
                   "validate": {
-                    "required": false,
-                    "custom": "const maxUploadedFiles = 25; const files = data[instance.key] || []; valid = !files.length ? 'At least one file is required' : files.length > maxUploadedFiles ? `Maximum ${maxUploadedFiles} files allowed` : true;"
+                    "required": true,
+                    "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? `Maximum ${data.maxUploadedFiles} files allowed` : true;"
                   },
                   "lockKey": true
                 },
@@ -25917,8 +25938,8 @@
                   "attributes": {},
                   "validateOn": "change",
                   "validate": {
-                    "required": false,
-                    "custom": "const maxUploadedFiles = 25; const files = data[instance.key] || []; valid = !files.length ? 'At least one file is required' : files.length > maxUploadedFiles ? `Maximum ${maxUploadedFiles} files allowed` : true;",
+                    "required": true,
+                    "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? `Maximum ${data.maxUploadedFiles} files allowed` : true;",
                     "customPrivate": false,
                     "strictDateValidation": false,
                     "multiple": false,
@@ -29700,8 +29721,8 @@
                       "attributes": {},
                       "validateOn": "change",
                       "validate": {
-                        "required": false,
-                        "custom": "const maxUploadedFiles = 25; const files = data[instance.key] || []; valid = !files.length ? 'At least one file is required' : files.length > maxUploadedFiles ? `Maximum ${maxUploadedFiles} files allowed` : true;",
+                        "required": true,
+                        "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? `Maximum ${data.maxUploadedFiles} files allowed` : true;",
                         "customPrivate": false,
                         "strictDateValidation": false,
                         "multiple": false,
@@ -31786,8 +31807,8 @@
                       "attributes": {},
                       "validateOn": "change",
                       "validate": {
-                        "required": false,
-                        "custom": "const maxUploadedFiles = 25; const files = data[instance.key] || []; valid = !files.length ? 'At least one file is required' : files.length > maxUploadedFiles ? `Maximum ${maxUploadedFiles} files allowed` : true;",
+                        "required": true,
+                        "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? `Maximum ${data.maxUploadedFiles} files allowed` : true;",
                         "customPrivate": false,
                         "strictDateValidation": false,
                         "multiple": false,

--- a/sources/packages/forms/src/form-definitions/sfaa2023-24.json
+++ b/sources/packages/forms/src/form-definitions/sfaa2023-24.json
@@ -7899,9 +7899,8 @@
                   "calculateServer": false,
                   "allowCalculateOverride": false,
                   "validate": {
-                    "required": true,
-                    "customMessage": "",
-                    "custom": "",
+                    "required": false,
+                    "custom": "const maxUploadedFiles = 25; const files = data[instance.key] || []; valid = !files.length ? 'At least one file is required' : files.length > maxUploadedFiles ? `Maximum ${maxUploadedFiles} files allowed` : true;",
                     "customPrivate": false,
                     "json": "",
                     "strictDateValidation": false,
@@ -9257,7 +9256,7 @@
                       "id": "ekl3d6"
                     },
                     {
-                      "label": "Upload supporting documents (optional):",
+                      "label": "Upload supporting documents",
                       "customClass": "font-weight-bold",
                       "hideLabel": true,
                       "tableView": false,
@@ -9305,8 +9304,8 @@
                       "attributes": {},
                       "validateOn": "change",
                       "validate": {
-                        "required": true,
-                        "custom": "",
+                        "required": false,
+                        "custom": "const maxUploadedFiles = 25; const files = data[instance.key] || []; valid = !files.length ? 'At least one file is required' : files.length > maxUploadedFiles ? `Maximum ${maxUploadedFiles} files allowed` : true;",
                         "customPrivate": false,
                         "strictDateValidation": false,
                         "multiple": false,
@@ -13867,8 +13866,8 @@
                               "multiple": true,
                               "redrawOn": "dependants.declaredOnTaxes",
                               "validate": {
-                                "required": true,
-                                "custom": "",
+                                "required": false,
+                                "custom": "const maxUploadedFiles = 25; const files = data[instance.key] || []; valid = !files.length ? 'At least one file is required' : files.length > maxUploadedFiles ? `Maximum ${maxUploadedFiles} files allowed` : true;",
                                 "customPrivate": false,
                                 "strictDateValidation": false,
                                 "multiple": false,
@@ -14928,9 +14927,8 @@
                   "calculateServer": false,
                   "allowCalculateOverride": false,
                   "validate": {
-                    "required": true,
-                    "customMessage": "",
-                    "custom": "",
+                    "required": false,
+                    "custom": "const maxUploadedFiles = 25; const files = data[instance.key] || []; valid = !files.length ? 'At least one file is required' : files.length > maxUploadedFiles ? `Maximum ${maxUploadedFiles} files allowed` : true;",
                     "customPrivate": false,
                     "json": "",
                     "strictDateValidation": false,
@@ -16833,7 +16831,8 @@
                   "url": "student/files",
                   "lockKey": true,
                   "validate": {
-                    "required": true
+                    "required": false,
+                    "custom": "const maxUploadedFiles = 25; const files = data[instance.key] || []; valid = !files.length ? 'At least one file is required' : files.length > maxUploadedFiles ? `Maximum ${maxUploadedFiles} files allowed` : true;"
                   }
                 },
                 {
@@ -21091,7 +21090,7 @@
               "id": "ecfi9yd"
             },
             {
-              "label": "Upload supporting documents (optional):",
+              "label": "Upload supporting documents",
               "labelPosition": "top",
               "labelWidth": "",
               "labelMargin": "",
@@ -21133,8 +21132,7 @@
               "allowCalculateOverride": false,
               "validate": {
                 "required": false,
-                "customMessage": "",
-                "custom": "",
+                "custom": "const maxUploadedFiles = 25; const files = data[instance.key] || []; valid = !files.length ? 'At least one file is required' : files.length > maxUploadedFiles ? `Maximum ${maxUploadedFiles} files allowed` : true;",
                 "customPrivate": false,
                 "json": "",
                 "strictDateValidation": false,
@@ -22167,7 +22165,7 @@
                   "validateOn": "change",
                   "validate": {
                     "required": false,
-                    "custom": "",
+                    "custom": "const maxUploadedFiles = 25; const files = data[instance.key] || []; valid = !files.length ? 'At least one file is required' : files.length > maxUploadedFiles ? `Maximum ${maxUploadedFiles} files allowed` : true;",
                     "customPrivate": false,
                     "strictDateValidation": false,
                     "multiple": false,
@@ -24710,7 +24708,8 @@
                   "dir": "Current Year Income - Supporting Documents",
                   "customClass": "font-weight-bold",
                   "validate": {
-                    "required": true
+                    "required": false,
+                    "custom": "const maxUploadedFiles = 25; const files = data[instance.key] || []; valid = !files.length ? 'At least one file is required' : files.length > maxUploadedFiles ? `Maximum ${maxUploadedFiles} files allowed` : true;"
                   },
                   "lockKey": true
                 },
@@ -25919,7 +25918,7 @@
                   "validateOn": "change",
                   "validate": {
                     "required": false,
-                    "custom": "",
+                    "custom": "const maxUploadedFiles = 25; const files = data[instance.key] || []; valid = !files.length ? 'At least one file is required' : files.length > maxUploadedFiles ? `Maximum ${maxUploadedFiles} files allowed` : true;",
                     "customPrivate": false,
                     "strictDateValidation": false,
                     "multiple": false,
@@ -29653,7 +29652,7 @@
                       "className": ""
                     },
                     {
-                      "label": "Upload supporting documents (optional):",
+                      "label": "Upload supporting documents",
                       "hideLabel": true,
                       "tableView": false,
                       "storage": "url",
@@ -29702,7 +29701,7 @@
                       "validateOn": "change",
                       "validate": {
                         "required": false,
-                        "custom": "",
+                        "custom": "const maxUploadedFiles = 25; const files = data[instance.key] || []; valid = !files.length ? 'At least one file is required' : files.length > maxUploadedFiles ? `Maximum ${maxUploadedFiles} files allowed` : true;",
                         "customPrivate": false,
                         "strictDateValidation": false,
                         "multiple": false,
@@ -31738,7 +31737,7 @@
                       "tags": []
                     },
                     {
-                      "label": "Upload supporting documents (optional):",
+                      "label": "Upload supporting documents",
                       "customClass": "font-weight-bold",
                       "hideLabel": true,
                       "tableView": false,
@@ -31787,8 +31786,8 @@
                       "attributes": {},
                       "validateOn": "change",
                       "validate": {
-                        "required": true,
-                        "custom": "",
+                        "required": false,
+                        "custom": "const maxUploadedFiles = 25; const files = data[instance.key] || []; valid = !files.length ? 'At least one file is required' : files.length > maxUploadedFiles ? `Maximum ${maxUploadedFiles} files allowed` : true;",
                         "customPrivate": false,
                         "strictDateValidation": false,
                         "multiple": false,

--- a/sources/packages/forms/src/form-definitions/sfaa2023-24.json
+++ b/sources/packages/forms/src/form-definitions/sfaa2023-24.json
@@ -7900,7 +7900,8 @@
                   "allowCalculateOverride": false,
                   "validate": {
                     "required": true,
-                    "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? `Maximum ${data.maxUploadedFiles} files allowed` : true;",
+                    "customMessage": "You must upload at least one file, and the total number of uploaded files cannot exceed {{data.maxUploadedFiles}}.",
+                    "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? false : true;",
                     "customPrivate": false,
                     "json": "",
                     "strictDateValidation": false,
@@ -9305,7 +9306,8 @@
                       "validateOn": "change",
                       "validate": {
                         "required": true,
-                        "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? `Maximum ${data.maxUploadedFiles} files allowed` : true;",
+                        "customMessage": "You must upload at least one file, and the total number of uploaded files cannot exceed {{data.maxUploadedFiles}}.",
+                        "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? false : true;",
                         "customPrivate": false,
                         "strictDateValidation": false,
                         "multiple": false,
@@ -13888,7 +13890,8 @@
                               "redrawOn": "dependants.declaredOnTaxes",
                               "validate": {
                                 "required": true,
-                                "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? `Maximum ${data.maxUploadedFiles} files allowed` : true;",
+                                "customMessage": "You must upload at least one file, and the total number of uploaded files cannot exceed {{data.maxUploadedFiles}}.",
+                                "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? false : true;",
                                 "customPrivate": false,
                                 "strictDateValidation": false,
                                 "multiple": false,
@@ -14949,7 +14952,8 @@
                   "allowCalculateOverride": false,
                   "validate": {
                     "required": true,
-                    "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? `Maximum ${data.maxUploadedFiles} files allowed` : true;",
+                    "customMessage": "You must upload at least one file, and the total number of uploaded files cannot exceed {{data.maxUploadedFiles}}.",
+                    "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? false : true;",
                     "customPrivate": false,
                     "json": "",
                     "strictDateValidation": false,
@@ -16853,7 +16857,8 @@
                   "lockKey": true,
                   "validate": {
                     "required": true,
-                    "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? `Maximum ${data.maxUploadedFiles} files allowed` : true;"
+                    "customMessage": "You must upload at least one file, and the total number of uploaded files cannot exceed {{data.maxUploadedFiles}}.",
+                    "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? false : true;"
                   }
                 },
                 {
@@ -21153,7 +21158,8 @@
               "allowCalculateOverride": false,
               "validate": {
                 "required": true,
-                "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? `Maximum ${data.maxUploadedFiles} files allowed` : true;",
+                "customMessage": "You must upload at least one file, and the total number of uploaded files cannot exceed {{data.maxUploadedFiles}}.",
+                "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? false : true;",
                 "customPrivate": false,
                 "json": "",
                 "strictDateValidation": false,
@@ -22186,7 +22192,8 @@
                   "validateOn": "change",
                   "validate": {
                     "required": true,
-                    "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? `Maximum ${data.maxUploadedFiles} files allowed` : true;",
+                    "customMessage": "You must upload at least one file, and the total number of uploaded files cannot exceed {{data.maxUploadedFiles}}.",
+                    "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? false : true;",
                     "customPrivate": false,
                     "strictDateValidation": false,
                     "multiple": false,
@@ -24730,7 +24737,8 @@
                   "customClass": "font-weight-bold",
                   "validate": {
                     "required": true,
-                    "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? `Maximum ${data.maxUploadedFiles} files allowed` : true;"
+                    "customMessage": "You must upload at least one file, and the total number of uploaded files cannot exceed {{data.maxUploadedFiles}}.",
+                    "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? false : true;"
                   },
                   "lockKey": true
                 },
@@ -25939,7 +25947,8 @@
                   "validateOn": "change",
                   "validate": {
                     "required": true,
-                    "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? `Maximum ${data.maxUploadedFiles} files allowed` : true;",
+                    "customMessage": "You must upload at least one file, and the total number of uploaded files cannot exceed {{data.maxUploadedFiles}}.",
+                    "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? false : true;",
                     "customPrivate": false,
                     "strictDateValidation": false,
                     "multiple": false,
@@ -29722,7 +29731,8 @@
                       "validateOn": "change",
                       "validate": {
                         "required": true,
-                        "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? `Maximum ${data.maxUploadedFiles} files allowed` : true;",
+                        "customMessage": "You must upload at least one file, and the total number of uploaded files cannot exceed {{data.maxUploadedFiles}}.",
+                        "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? false : true;",
                         "customPrivate": false,
                         "strictDateValidation": false,
                         "multiple": false,
@@ -31808,7 +31818,8 @@
                       "validateOn": "change",
                       "validate": {
                         "required": true,
-                        "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? `Maximum ${data.maxUploadedFiles} files allowed` : true;",
+                        "customMessage": "You must upload at least one file, and the total number of uploaded files cannot exceed {{data.maxUploadedFiles}}.",
+                        "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? false : true;",
                         "customPrivate": false,
                         "strictDateValidation": false,
                         "multiple": false,

--- a/sources/packages/forms/src/form-definitions/sfaa2023-24.json
+++ b/sources/packages/forms/src/form-definitions/sfaa2023-24.json
@@ -7899,8 +7899,8 @@
                   "calculateServer": false,
                   "allowCalculateOverride": false,
                   "validate": {
-                    "required": false,
-                    "custom": "const maxUploadedFiles = 25; const files = data[instance.key] || []; valid = !files.length ? 'At least one file is required' : files.length > maxUploadedFiles ? `Maximum ${maxUploadedFiles} files allowed` : true;",
+                    "required": true,
+                    "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? `Maximum ${data.maxUploadedFiles} files allowed` : true;",
                     "customPrivate": false,
                     "json": "",
                     "strictDateValidation": false,
@@ -9304,8 +9304,8 @@
                       "attributes": {},
                       "validateOn": "change",
                       "validate": {
-                        "required": false,
-                        "custom": "const maxUploadedFiles = 25; const files = data[instance.key] || []; valid = !files.length ? 'At least one file is required' : files.length > maxUploadedFiles ? `Maximum ${maxUploadedFiles} files allowed` : true;",
+                        "required": true,
+                        "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? `Maximum ${data.maxUploadedFiles} files allowed` : true;",
                         "customPrivate": false,
                         "strictDateValidation": false,
                         "multiple": false,
@@ -12288,6 +12288,27 @@
           },
           "properties": {},
           "lockKey": true
+        },
+        {
+          "input": true,
+          "tableView": true,
+          "key": "maxUploadedFiles",
+          "label": "maxUploadedFiles",
+          "protected": false,
+          "unique": false,
+          "persistent": false,
+          "type": "hidden",
+          "tags": [],
+          "conditional": {
+            "show": "",
+            "when": null,
+            "eq": ""
+          },
+          "properties": {},
+          "defaultValue": "",
+          "lockKey": true,
+          "calculateValue": "value = 25;",
+          "calculateServer": true
         }
       ],
       "input": false,
@@ -13866,8 +13887,8 @@
                               "multiple": true,
                               "redrawOn": "dependants.declaredOnTaxes",
                               "validate": {
-                                "required": false,
-                                "custom": "const maxUploadedFiles = 25; const files = data[instance.key] || []; valid = !files.length ? 'At least one file is required' : files.length > maxUploadedFiles ? `Maximum ${maxUploadedFiles} files allowed` : true;",
+                                "required": true,
+                                "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? `Maximum ${data.maxUploadedFiles} files allowed` : true;",
                                 "customPrivate": false,
                                 "strictDateValidation": false,
                                 "multiple": false,
@@ -14927,8 +14948,8 @@
                   "calculateServer": false,
                   "allowCalculateOverride": false,
                   "validate": {
-                    "required": false,
-                    "custom": "const maxUploadedFiles = 25; const files = data[instance.key] || []; valid = !files.length ? 'At least one file is required' : files.length > maxUploadedFiles ? `Maximum ${maxUploadedFiles} files allowed` : true;",
+                    "required": true,
+                    "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? `Maximum ${data.maxUploadedFiles} files allowed` : true;",
                     "customPrivate": false,
                     "json": "",
                     "strictDateValidation": false,
@@ -16809,7 +16830,7 @@
                   "image": false,
                   "imageSize": "200",
                   "placeholder": "",
-                  "multiple": false,
+                  "multiple": true,
                   "defaultValue": "",
                   "protected": false,
                   "persistent": true,
@@ -16831,8 +16852,8 @@
                   "url": "student/files",
                   "lockKey": true,
                   "validate": {
-                    "required": false,
-                    "custom": "const maxUploadedFiles = 25; const files = data[instance.key] || []; valid = !files.length ? 'At least one file is required' : files.length > maxUploadedFiles ? `Maximum ${maxUploadedFiles} files allowed` : true;"
+                    "required": true,
+                    "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? `Maximum ${data.maxUploadedFiles} files allowed` : true;"
                   }
                 },
                 {
@@ -21131,8 +21152,8 @@
               "calculateServer": false,
               "allowCalculateOverride": false,
               "validate": {
-                "required": false,
-                "custom": "const maxUploadedFiles = 25; const files = data[instance.key] || []; valid = !files.length ? 'At least one file is required' : files.length > maxUploadedFiles ? `Maximum ${maxUploadedFiles} files allowed` : true;",
+                "required": true,
+                "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? `Maximum ${data.maxUploadedFiles} files allowed` : true;",
                 "customPrivate": false,
                 "json": "",
                 "strictDateValidation": false,
@@ -22138,7 +22159,7 @@
                   "prefix": "",
                   "customClass": "",
                   "suffix": "",
-                  "multiple": false,
+                  "multiple": true,
                   "defaultValue": null,
                   "protected": false,
                   "unique": false,
@@ -22164,8 +22185,8 @@
                   "attributes": {},
                   "validateOn": "change",
                   "validate": {
-                    "required": false,
-                    "custom": "const maxUploadedFiles = 25; const files = data[instance.key] || []; valid = !files.length ? 'At least one file is required' : files.length > maxUploadedFiles ? `Maximum ${maxUploadedFiles} files allowed` : true;",
+                    "required": true,
+                    "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? `Maximum ${data.maxUploadedFiles} files allowed` : true;",
                     "customPrivate": false,
                     "strictDateValidation": false,
                     "multiple": false,
@@ -24708,8 +24729,8 @@
                   "dir": "Current Year Income - Supporting Documents",
                   "customClass": "font-weight-bold",
                   "validate": {
-                    "required": false,
-                    "custom": "const maxUploadedFiles = 25; const files = data[instance.key] || []; valid = !files.length ? 'At least one file is required' : files.length > maxUploadedFiles ? `Maximum ${maxUploadedFiles} files allowed` : true;"
+                    "required": true,
+                    "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? `Maximum ${data.maxUploadedFiles} files allowed` : true;"
                   },
                   "lockKey": true
                 },
@@ -25917,8 +25938,8 @@
                   "attributes": {},
                   "validateOn": "change",
                   "validate": {
-                    "required": false,
-                    "custom": "const maxUploadedFiles = 25; const files = data[instance.key] || []; valid = !files.length ? 'At least one file is required' : files.length > maxUploadedFiles ? `Maximum ${maxUploadedFiles} files allowed` : true;",
+                    "required": true,
+                    "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? `Maximum ${data.maxUploadedFiles} files allowed` : true;",
                     "customPrivate": false,
                     "strictDateValidation": false,
                     "multiple": false,
@@ -29700,8 +29721,8 @@
                       "attributes": {},
                       "validateOn": "change",
                       "validate": {
-                        "required": false,
-                        "custom": "const maxUploadedFiles = 25; const files = data[instance.key] || []; valid = !files.length ? 'At least one file is required' : files.length > maxUploadedFiles ? `Maximum ${maxUploadedFiles} files allowed` : true;",
+                        "required": true,
+                        "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? `Maximum ${data.maxUploadedFiles} files allowed` : true;",
                         "customPrivate": false,
                         "strictDateValidation": false,
                         "multiple": false,
@@ -31786,8 +31807,8 @@
                       "attributes": {},
                       "validateOn": "change",
                       "validate": {
-                        "required": false,
-                        "custom": "const maxUploadedFiles = 25; const files = data[instance.key] || []; valid = !files.length ? 'At least one file is required' : files.length > maxUploadedFiles ? `Maximum ${maxUploadedFiles} files allowed` : true;",
+                        "required": true,
+                        "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? `Maximum ${data.maxUploadedFiles} files allowed` : true;",
                         "customPrivate": false,
                         "strictDateValidation": false,
                         "multiple": false,

--- a/sources/packages/forms/src/form-definitions/sfaa2024-25.json
+++ b/sources/packages/forms/src/form-definitions/sfaa2024-25.json
@@ -7899,8 +7899,8 @@
                   "calculateServer": false,
                   "allowCalculateOverride": false,
                   "validate": {
-                    "required": false,
-                    "custom": "const maxUploadedFiles = 25; const files = data[instance.key] || []; valid = !files.length ? 'At least one file is required' : files.length > maxUploadedFiles ? `Maximum ${maxUploadedFiles} files allowed` : true;",
+                    "required": true,
+                    "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? `Maximum ${data.maxUploadedFiles} files allowed` : true;",
                     "customPrivate": false,
                     "json": "",
                     "strictDateValidation": false,
@@ -9304,8 +9304,8 @@
                       "attributes": {},
                       "validateOn": "change",
                       "validate": {
-                        "required": false,
-                        "custom": "const maxUploadedFiles = 25; const files = data[instance.key] || []; valid = !files.length ? 'At least one file is required' : files.length > maxUploadedFiles ? `Maximum ${maxUploadedFiles} files allowed` : true;",
+                        "required": true,
+                        "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? `Maximum ${data.maxUploadedFiles} files allowed` : true;",
                         "customPrivate": false,
                         "strictDateValidation": false,
                         "multiple": false,
@@ -12288,6 +12288,27 @@
           },
           "properties": {},
           "lockKey": true
+        },
+        {
+          "input": true,
+          "tableView": true,
+          "key": "maxUploadedFiles",
+          "label": "maxUploadedFiles",
+          "protected": false,
+          "unique": false,
+          "persistent": false,
+          "type": "hidden",
+          "tags": [],
+          "conditional": {
+            "show": "",
+            "when": null,
+            "eq": ""
+          },
+          "properties": {},
+          "defaultValue": "",
+          "lockKey": true,
+          "calculateValue": "value = 25;",
+          "calculateServer": true
         }
       ],
       "input": false,
@@ -13866,8 +13887,8 @@
                               "multiple": true,
                               "redrawOn": "dependants.declaredOnTaxes",
                               "validate": {
-                                "required": false,
-                                "custom": "const maxUploadedFiles = 25; const files = data[instance.key] || []; valid = !files.length ? 'At least one file is required' : files.length > maxUploadedFiles ? `Maximum ${maxUploadedFiles} files allowed` : true;",
+                                "required": true,
+                                "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? `Maximum ${data.maxUploadedFiles} files allowed` : true;",
                                 "customPrivate": false,
                                 "strictDateValidation": false,
                                 "multiple": false,
@@ -14927,8 +14948,8 @@
                   "calculateServer": false,
                   "allowCalculateOverride": false,
                   "validate": {
-                    "required": false,
-                    "custom": "const maxUploadedFiles = 25; const files = data[instance.key] || []; valid = !files.length ? 'At least one file is required' : files.length > maxUploadedFiles ? `Maximum ${maxUploadedFiles} files allowed` : true;",
+                    "required": true,
+                    "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? `Maximum ${data.maxUploadedFiles} files allowed` : true;",
                     "customPrivate": false,
                     "json": "",
                     "strictDateValidation": false,
@@ -16809,7 +16830,7 @@
                   "image": false,
                   "imageSize": "200",
                   "placeholder": "",
-                  "multiple": false,
+                  "multiple": true,
                   "defaultValue": "",
                   "protected": false,
                   "persistent": true,
@@ -16831,8 +16852,8 @@
                   "url": "student/files",
                   "lockKey": true,
                   "validate": {
-                    "required": false,
-                    "custom": "const maxUploadedFiles = 25; const files = data[instance.key] || []; valid = !files.length ? 'At least one file is required' : files.length > maxUploadedFiles ? `Maximum ${maxUploadedFiles} files allowed` : true;"
+                    "required": true,
+                    "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? `Maximum ${data.maxUploadedFiles} files allowed` : true;"
                   }
                 },
                 {
@@ -21131,8 +21152,8 @@
               "calculateServer": false,
               "allowCalculateOverride": false,
               "validate": {
-                "required": false,
-                "custom": "const maxUploadedFiles = 25; const files = data[instance.key] || []; valid = !files.length ? 'At least one file is required' : files.length > maxUploadedFiles ? `Maximum ${maxUploadedFiles} files allowed` : true;",
+                "required": true,
+                "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? `Maximum ${data.maxUploadedFiles} files allowed` : true;",
                 "customPrivate": false,
                 "json": "",
                 "strictDateValidation": false,
@@ -22138,7 +22159,7 @@
                   "prefix": "",
                   "customClass": "",
                   "suffix": "",
-                  "multiple": false,
+                  "multiple": true,
                   "defaultValue": null,
                   "protected": false,
                   "unique": false,
@@ -22164,8 +22185,8 @@
                   "attributes": {},
                   "validateOn": "change",
                   "validate": {
-                    "required": false,
-                    "custom": "const maxUploadedFiles = 25; const files = data[instance.key] || []; valid = !files.length ? 'At least one file is required' : files.length > maxUploadedFiles ? `Maximum ${maxUploadedFiles} files allowed` : true;",
+                    "required": true,
+                    "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? `Maximum ${data.maxUploadedFiles} files allowed` : true;",
                     "customPrivate": false,
                     "strictDateValidation": false,
                     "multiple": false,
@@ -24708,8 +24729,8 @@
                   "dir": "Current Year Income - Supporting Documents",
                   "customClass": "font-weight-bold",
                   "validate": {
-                    "required": false,
-                    "custom": "const maxUploadedFiles = 25; const files = data[instance.key] || []; valid = !files.length ? 'At least one file is required' : files.length > maxUploadedFiles ? `Maximum ${maxUploadedFiles} files allowed` : true;"
+                    "required": true,
+                    "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? `Maximum ${data.maxUploadedFiles} files allowed` : true;"
                   },
                   "lockKey": true
                 },
@@ -25917,8 +25938,8 @@
                   "attributes": {},
                   "validateOn": "change",
                   "validate": {
-                    "required": false,
-                    "custom": "const maxUploadedFiles = 25; const files = data[instance.key] || []; valid = !files.length ? 'At least one file is required' : files.length > maxUploadedFiles ? `Maximum ${maxUploadedFiles} files allowed` : true;",
+                    "required": true,
+                    "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? `Maximum ${data.maxUploadedFiles} files allowed` : true;",
                     "customPrivate": false,
                     "strictDateValidation": false,
                     "multiple": false,
@@ -29700,8 +29721,8 @@
                       "attributes": {},
                       "validateOn": "change",
                       "validate": {
-                        "required": false,
-                        "custom": "const maxUploadedFiles = 25; const files = data[instance.key] || []; valid = !files.length ? 'At least one file is required' : files.length > maxUploadedFiles ? `Maximum ${maxUploadedFiles} files allowed` : true;",
+                        "required": true,
+                        "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? `Maximum ${data.maxUploadedFiles} files allowed` : true;",
                         "customPrivate": false,
                         "strictDateValidation": false,
                         "multiple": false,
@@ -31581,8 +31602,8 @@
                         "eq": ""
                       },
                       "properties": {},
-                      "customClass": "banner-warning",
-                      "hideLabel": true
+                      "hideLabel": true,
+                      "customClass": "banner-warning"
                     },
                     {
                       "label": "HTML",
@@ -31786,8 +31807,8 @@
                       "attributes": {},
                       "validateOn": "change",
                       "validate": {
-                        "required": false,
-                        "custom": "const maxUploadedFiles = 25; const files = data[instance.key] || []; valid = !files.length ? 'At least one file is required' : files.length > maxUploadedFiles ? `Maximum ${maxUploadedFiles} files allowed` : true;",
+                        "required": true,
+                        "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? `Maximum ${data.maxUploadedFiles} files allowed` : true;",
                         "customPrivate": false,
                         "strictDateValidation": false,
                         "multiple": false,

--- a/sources/packages/forms/src/form-definitions/sfaa2024-25.json
+++ b/sources/packages/forms/src/form-definitions/sfaa2024-25.json
@@ -7899,9 +7899,8 @@
                   "calculateServer": false,
                   "allowCalculateOverride": false,
                   "validate": {
-                    "required": true,
-                    "customMessage": "",
-                    "custom": "",
+                    "required": false,
+                    "custom": "const maxUploadedFiles = 25; const files = data[instance.key] || []; valid = !files.length ? 'At least one file is required' : files.length > maxUploadedFiles ? `Maximum ${maxUploadedFiles} files allowed` : true;",
                     "customPrivate": false,
                     "json": "",
                     "strictDateValidation": false,
@@ -9257,7 +9256,7 @@
                       "id": "ekl3d6"
                     },
                     {
-                      "label": "Upload supporting documents (optional):",
+                      "label": "Upload supporting documents",
                       "customClass": "font-weight-bold",
                       "hideLabel": true,
                       "tableView": false,
@@ -9305,8 +9304,8 @@
                       "attributes": {},
                       "validateOn": "change",
                       "validate": {
-                        "required": true,
-                        "custom": "",
+                        "required": false,
+                        "custom": "const maxUploadedFiles = 25; const files = data[instance.key] || []; valid = !files.length ? 'At least one file is required' : files.length > maxUploadedFiles ? `Maximum ${maxUploadedFiles} files allowed` : true;",
                         "customPrivate": false,
                         "strictDateValidation": false,
                         "multiple": false,
@@ -13867,8 +13866,8 @@
                               "multiple": true,
                               "redrawOn": "dependants.declaredOnTaxes",
                               "validate": {
-                                "required": true,
-                                "custom": "",
+                                "required": false,
+                                "custom": "const maxUploadedFiles = 25; const files = data[instance.key] || []; valid = !files.length ? 'At least one file is required' : files.length > maxUploadedFiles ? `Maximum ${maxUploadedFiles} files allowed` : true;",
                                 "customPrivate": false,
                                 "strictDateValidation": false,
                                 "multiple": false,
@@ -14928,9 +14927,8 @@
                   "calculateServer": false,
                   "allowCalculateOverride": false,
                   "validate": {
-                    "required": true,
-                    "customMessage": "",
-                    "custom": "",
+                    "required": false,
+                    "custom": "const maxUploadedFiles = 25; const files = data[instance.key] || []; valid = !files.length ? 'At least one file is required' : files.length > maxUploadedFiles ? `Maximum ${maxUploadedFiles} files allowed` : true;",
                     "customPrivate": false,
                     "json": "",
                     "strictDateValidation": false,
@@ -16833,7 +16831,8 @@
                   "url": "student/files",
                   "lockKey": true,
                   "validate": {
-                    "required": true
+                    "required": false,
+                    "custom": "const maxUploadedFiles = 25; const files = data[instance.key] || []; valid = !files.length ? 'At least one file is required' : files.length > maxUploadedFiles ? `Maximum ${maxUploadedFiles} files allowed` : true;"
                   }
                 },
                 {
@@ -21091,7 +21090,7 @@
               "id": "ecfi9yd"
             },
             {
-              "label": "Upload supporting documents (optional):",
+              "label": "Upload supporting documents",
               "labelPosition": "top",
               "labelWidth": "",
               "labelMargin": "",
@@ -21133,8 +21132,7 @@
               "allowCalculateOverride": false,
               "validate": {
                 "required": false,
-                "customMessage": "",
-                "custom": "",
+                "custom": "const maxUploadedFiles = 25; const files = data[instance.key] || []; valid = !files.length ? 'At least one file is required' : files.length > maxUploadedFiles ? `Maximum ${maxUploadedFiles} files allowed` : true;",
                 "customPrivate": false,
                 "json": "",
                 "strictDateValidation": false,
@@ -22167,7 +22165,7 @@
                   "validateOn": "change",
                   "validate": {
                     "required": false,
-                    "custom": "",
+                    "custom": "const maxUploadedFiles = 25; const files = data[instance.key] || []; valid = !files.length ? 'At least one file is required' : files.length > maxUploadedFiles ? `Maximum ${maxUploadedFiles} files allowed` : true;",
                     "customPrivate": false,
                     "strictDateValidation": false,
                     "multiple": false,
@@ -24710,7 +24708,8 @@
                   "dir": "Current Year Income - Supporting Documents",
                   "customClass": "font-weight-bold",
                   "validate": {
-                    "required": true
+                    "required": false,
+                    "custom": "const maxUploadedFiles = 25; const files = data[instance.key] || []; valid = !files.length ? 'At least one file is required' : files.length > maxUploadedFiles ? `Maximum ${maxUploadedFiles} files allowed` : true;"
                   },
                   "lockKey": true
                 },
@@ -25919,7 +25918,7 @@
                   "validateOn": "change",
                   "validate": {
                     "required": false,
-                    "custom": "",
+                    "custom": "const maxUploadedFiles = 25; const files = data[instance.key] || []; valid = !files.length ? 'At least one file is required' : files.length > maxUploadedFiles ? `Maximum ${maxUploadedFiles} files allowed` : true;",
                     "customPrivate": false,
                     "strictDateValidation": false,
                     "multiple": false,
@@ -29653,7 +29652,7 @@
                       "className": ""
                     },
                     {
-                      "label": "Upload supporting documents (optional):",
+                      "label": "Upload supporting documents",
                       "hideLabel": true,
                       "tableView": false,
                       "storage": "url",
@@ -29702,7 +29701,7 @@
                       "validateOn": "change",
                       "validate": {
                         "required": false,
-                        "custom": "",
+                        "custom": "const maxUploadedFiles = 25; const files = data[instance.key] || []; valid = !files.length ? 'At least one file is required' : files.length > maxUploadedFiles ? `Maximum ${maxUploadedFiles} files allowed` : true;",
                         "customPrivate": false,
                         "strictDateValidation": false,
                         "multiple": false,
@@ -31738,7 +31737,7 @@
                       "tags": []
                     },
                     {
-                      "label": "Upload supporting documents (optional):",
+                      "label": "Upload supporting documents",
                       "customClass": "font-weight-bold",
                       "hideLabel": true,
                       "tableView": false,
@@ -31787,8 +31786,8 @@
                       "attributes": {},
                       "validateOn": "change",
                       "validate": {
-                        "required": true,
-                        "custom": "",
+                        "required": false,
+                        "custom": "const maxUploadedFiles = 25; const files = data[instance.key] || []; valid = !files.length ? 'At least one file is required' : files.length > maxUploadedFiles ? `Maximum ${maxUploadedFiles} files allowed` : true;",
                         "customPrivate": false,
                         "strictDateValidation": false,
                         "multiple": false,

--- a/sources/packages/forms/src/form-definitions/sfaa2024-25.json
+++ b/sources/packages/forms/src/form-definitions/sfaa2024-25.json
@@ -7900,7 +7900,8 @@
                   "allowCalculateOverride": false,
                   "validate": {
                     "required": true,
-                    "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? `Maximum ${data.maxUploadedFiles} files allowed` : true;",
+                    "customMessage": "You must upload at least one file, and the total number of uploaded files cannot exceed {{data.maxUploadedFiles}}.",
+                    "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? false : true;",
                     "customPrivate": false,
                     "json": "",
                     "strictDateValidation": false,
@@ -9305,7 +9306,8 @@
                       "validateOn": "change",
                       "validate": {
                         "required": true,
-                        "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? `Maximum ${data.maxUploadedFiles} files allowed` : true;",
+                        "customMessage": "You must upload at least one file, and the total number of uploaded files cannot exceed {{data.maxUploadedFiles}}.",
+                        "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? false : true;",
                         "customPrivate": false,
                         "strictDateValidation": false,
                         "multiple": false,
@@ -13888,7 +13890,8 @@
                               "redrawOn": "dependants.declaredOnTaxes",
                               "validate": {
                                 "required": true,
-                                "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? `Maximum ${data.maxUploadedFiles} files allowed` : true;",
+                                "customMessage": "You must upload at least one file, and the total number of uploaded files cannot exceed {{data.maxUploadedFiles}}.",
+                                "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? false : true;",
                                 "customPrivate": false,
                                 "strictDateValidation": false,
                                 "multiple": false,
@@ -14949,7 +14952,8 @@
                   "allowCalculateOverride": false,
                   "validate": {
                     "required": true,
-                    "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? `Maximum ${data.maxUploadedFiles} files allowed` : true;",
+                    "customMessage": "You must upload at least one file, and the total number of uploaded files cannot exceed {{data.maxUploadedFiles}}.",
+                    "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? false : true;",
                     "customPrivate": false,
                     "json": "",
                     "strictDateValidation": false,
@@ -16853,7 +16857,8 @@
                   "lockKey": true,
                   "validate": {
                     "required": true,
-                    "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? `Maximum ${data.maxUploadedFiles} files allowed` : true;"
+                    "customMessage": "You must upload at least one file, and the total number of uploaded files cannot exceed {{data.maxUploadedFiles}}.",
+                    "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? false : true;"
                   }
                 },
                 {
@@ -21153,7 +21158,8 @@
               "allowCalculateOverride": false,
               "validate": {
                 "required": true,
-                "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? `Maximum ${data.maxUploadedFiles} files allowed` : true;",
+                "customMessage": "You must upload at least one file, and the total number of uploaded files cannot exceed {{data.maxUploadedFiles}}.",
+                "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? false : true;",
                 "customPrivate": false,
                 "json": "",
                 "strictDateValidation": false,
@@ -22186,7 +22192,8 @@
                   "validateOn": "change",
                   "validate": {
                     "required": true,
-                    "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? `Maximum ${data.maxUploadedFiles} files allowed` : true;",
+                    "customMessage": "You must upload at least one file, and the total number of uploaded files cannot exceed {{data.maxUploadedFiles}}.",
+                    "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? false : true;",
                     "customPrivate": false,
                     "strictDateValidation": false,
                     "multiple": false,
@@ -24730,7 +24737,8 @@
                   "customClass": "font-weight-bold",
                   "validate": {
                     "required": true,
-                    "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? `Maximum ${data.maxUploadedFiles} files allowed` : true;"
+                    "customMessage": "You must upload at least one file, and the total number of uploaded files cannot exceed {{data.maxUploadedFiles}}.",
+                    "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? false : true;"
                   },
                   "lockKey": true
                 },
@@ -25939,7 +25947,8 @@
                   "validateOn": "change",
                   "validate": {
                     "required": true,
-                    "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? `Maximum ${data.maxUploadedFiles} files allowed` : true;",
+                    "customMessage": "You must upload at least one file, and the total number of uploaded files cannot exceed {{data.maxUploadedFiles}}.",
+                    "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? false : true;",
                     "customPrivate": false,
                     "strictDateValidation": false,
                     "multiple": false,
@@ -29722,7 +29731,8 @@
                       "validateOn": "change",
                       "validate": {
                         "required": true,
-                        "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? `Maximum ${data.maxUploadedFiles} files allowed` : true;",
+                        "customMessage": "You must upload at least one file, and the total number of uploaded files cannot exceed {{data.maxUploadedFiles}}.",
+                        "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? false : true;",
                         "customPrivate": false,
                         "strictDateValidation": false,
                         "multiple": false,
@@ -31808,7 +31818,8 @@
                       "validateOn": "change",
                       "validate": {
                         "required": true,
-                        "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? `Maximum ${data.maxUploadedFiles} files allowed` : true;",
+                        "customMessage": "You must upload at least one file, and the total number of uploaded files cannot exceed {{data.maxUploadedFiles}}.",
+                        "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? false : true;",
                         "customPrivate": false,
                         "strictDateValidation": false,
                         "multiple": false,

--- a/sources/packages/forms/src/form-definitions/sfaa2025-26.json
+++ b/sources/packages/forms/src/form-definitions/sfaa2025-26.json
@@ -7900,7 +7900,8 @@
                   "allowCalculateOverride": false,
                   "validate": {
                     "required": true,
-                    "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? `Maximum ${data.maxUploadedFiles} files allowed` : true;",
+                    "customMessage": "You must upload at least one file, and the total number of uploaded files cannot exceed {{data.maxUploadedFiles}}.",
+                    "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? false : true;",
                     "customPrivate": false,
                     "json": "",
                     "strictDateValidation": false,
@@ -10669,7 +10670,8 @@
                       "validateOn": "change",
                       "validate": {
                         "required": true,
-                        "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? `Maximum ${data.maxUploadedFiles} files allowed` : true;",
+                        "customMessage": "You must upload at least one file, and the total number of uploaded files cannot exceed {{data.maxUploadedFiles}}.",
+                        "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? false : true;",
                         "customPrivate": false,
                         "strictDateValidation": false,
                         "multiple": false,
@@ -13799,7 +13801,8 @@
                           "redrawOn": "dependants.declaredOnTaxes",
                           "validate": {
                             "required": true,
-                            "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? `Maximum ${data.maxUploadedFiles} files allowed` : true;",
+                            "customMessage": "You must upload at least one file, and the total number of uploaded files cannot exceed {{data.maxUploadedFiles}}.",
+                            "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? false : true;",
                             "customPrivate": false,
                             "strictDateValidation": false,
                             "multiple": false,
@@ -14690,7 +14693,8 @@
                           "allowCalculateOverride": false,
                           "validate": {
                             "required": true,
-                            "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? `Maximum ${data.maxUploadedFiles} files allowed` : true;",
+                            "customMessage": "You must upload at least one file, and the total number of uploaded files cannot exceed {{data.maxUploadedFiles}}.",
+                            "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? false : true;",
                             "customPrivate": false,
                             "json": "",
                             "strictDateValidation": false,
@@ -17250,7 +17254,8 @@
                   "lockKey": true,
                   "validate": {
                     "required": true,
-                    "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? `Maximum ${data.maxUploadedFiles} files allowed` : true;"
+                    "customMessage": "You must upload at least one file, and the total number of uploaded files cannot exceed {{data.maxUploadedFiles}}.",
+                    "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? false : true;"
                   }
                 },
                 {
@@ -21788,7 +21793,8 @@
               "allowCalculateOverride": false,
               "validate": {
                 "required": true,
-                "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? `Maximum ${data.maxUploadedFiles} files allowed` : true;",
+                "customMessage": "You must upload at least one file, and the total number of uploaded files cannot exceed {{data.maxUploadedFiles}}.",
+                "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? false : true;",
                 "customPrivate": false,
                 "json": "",
                 "strictDateValidation": false,
@@ -24292,7 +24298,8 @@
                   "customClass": "font-weight-bold",
                   "validate": {
                     "required": true,
-                    "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? `Maximum ${data.maxUploadedFiles} files allowed` : true;"
+                    "customMessage": "You must upload at least one file, and the total number of uploaded files cannot exceed {{data.maxUploadedFiles}}.",
+                    "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? false : true;"
                   },
                   "lockKey": true
                 },
@@ -25501,7 +25508,8 @@
                   "validateOn": "change",
                   "validate": {
                     "required": true,
-                    "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? `Maximum ${data.maxUploadedFiles} files allowed` : true;",
+                    "customMessage": "You must upload at least one file, and the total number of uploaded files cannot exceed {{data.maxUploadedFiles}}.",
+                    "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? false : true;",
                     "customPrivate": false,
                     "strictDateValidation": false,
                     "multiple": false,
@@ -28794,7 +28802,8 @@
                       "validateOn": "change",
                       "validate": {
                         "required": true,
-                        "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? `Maximum ${data.maxUploadedFiles} files allowed` : true;",
+                        "customMessage": "You must upload at least one file, and the total number of uploaded files cannot exceed {{data.maxUploadedFiles}}.",
+                        "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? false : true;",
                         "customPrivate": false,
                         "strictDateValidation": false,
                         "multiple": false,
@@ -30880,7 +30889,8 @@
                       "validateOn": "change",
                       "validate": {
                         "required": true,
-                        "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? `Maximum ${data.maxUploadedFiles} files allowed` : true;",
+                        "customMessage": "You must upload at least one file, and the total number of uploaded files cannot exceed {{data.maxUploadedFiles}}.",
+                        "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? false : true;",
                         "customPrivate": false,
                         "strictDateValidation": false,
                         "multiple": false,

--- a/sources/packages/forms/src/form-definitions/sfaa2025-26.json
+++ b/sources/packages/forms/src/form-definitions/sfaa2025-26.json
@@ -7899,8 +7899,8 @@
                   "calculateServer": false,
                   "allowCalculateOverride": false,
                   "validate": {
-                    "required": false,
-                    "custom": "const maxUploadedFiles = 25; const files = data[instance.key] || []; valid = !files.length ? 'At least one file is required' : files.length > maxUploadedFiles ? `Maximum ${maxUploadedFiles} files allowed` : true;",
+                    "required": true,
+                    "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? `Maximum ${data.maxUploadedFiles} files allowed` : true;",
                     "customPrivate": false,
                     "json": "",
                     "strictDateValidation": false,
@@ -10668,8 +10668,8 @@
                       "attributes": {},
                       "validateOn": "change",
                       "validate": {
-                        "required": false,
-                        "custom": "const maxUploadedFiles = 25; const files = data[instance.key] || []; valid = !files.length ? 'At least one file is required' : files.length > maxUploadedFiles ? `Maximum ${maxUploadedFiles} files allowed` : true;",
+                        "required": true,
+                        "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? `Maximum ${data.maxUploadedFiles} files allowed` : true;",
                         "customPrivate": false,
                         "strictDateValidation": false,
                         "multiple": false,
@@ -12483,6 +12483,27 @@
         },
         {
           "input": true,
+          "tableView": true,
+          "key": "maxUploadedFiles",
+          "label": "maxUploadedFiles",
+          "protected": false,
+          "unique": false,
+          "persistent": false,
+          "type": "hidden",
+          "tags": [],
+          "conditional": {
+            "show": "",
+            "when": null,
+            "eq": ""
+          },
+          "properties": {},
+          "defaultValue": "",
+          "lockKey": true,
+          "calculateValue": "value = 25;",
+          "calculateServer": true
+        },
+        {
+          "input": true,
           "tableView": false,
           "key": "dependantstatus",
           "label": "Dependant Status",
@@ -13777,8 +13798,8 @@
                           "multiple": true,
                           "redrawOn": "dependants.declaredOnTaxes",
                           "validate": {
-                            "required": false,
-                            "custom": "const maxUploadedFiles = 25; const files = data[instance.key] || []; valid = !files.length ? 'At least one file is required' : files.length > maxUploadedFiles ? `Maximum ${maxUploadedFiles} files allowed` : true;",
+                            "required": true,
+                            "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? `Maximum ${data.maxUploadedFiles} files allowed` : true;",
                             "customPrivate": false,
                             "strictDateValidation": false,
                             "multiple": false,
@@ -14668,8 +14689,8 @@
                           "calculateServer": false,
                           "allowCalculateOverride": false,
                           "validate": {
-                            "required": false,
-                            "custom": "const maxUploadedFiles = 25; const files = data[instance.key] || []; valid = !files.length ? 'At least one file is required' : files.length > maxUploadedFiles ? `Maximum ${maxUploadedFiles} files allowed` : true;",
+                            "required": true,
+                            "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? `Maximum ${data.maxUploadedFiles} files allowed` : true;",
                             "customPrivate": false,
                             "json": "",
                             "strictDateValidation": false,
@@ -17206,7 +17227,7 @@
                   "image": false,
                   "imageSize": "200",
                   "placeholder": "",
-                  "multiple": false,
+                  "multiple": true,
                   "defaultValue": "",
                   "protected": false,
                   "persistent": true,
@@ -17228,8 +17249,8 @@
                   "url": "student/files",
                   "lockKey": true,
                   "validate": {
-                    "required": false,
-                    "custom": "const maxUploadedFiles = 25; const files = data[instance.key] || []; valid = !files.length ? 'At least one file is required' : files.length > maxUploadedFiles ? `Maximum ${maxUploadedFiles} files allowed` : true;"
+                    "required": true,
+                    "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? `Maximum ${data.maxUploadedFiles} files allowed` : true;"
                   }
                 },
                 {
@@ -21766,8 +21787,8 @@
               "calculateServer": false,
               "allowCalculateOverride": false,
               "validate": {
-                "required": false,
-                "custom": "const maxUploadedFiles = 25; const files = data[instance.key] || []; valid = !files.length ? 'At least one file is required' : files.length > maxUploadedFiles ? `Maximum ${maxUploadedFiles} files allowed` : true;",
+                "required": true,
+                "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? `Maximum ${data.maxUploadedFiles} files allowed` : true;",
                 "customPrivate": false,
                 "json": "",
                 "strictDateValidation": false,
@@ -24270,8 +24291,8 @@
                   "dir": "Current Year Income - Supporting Documents",
                   "customClass": "font-weight-bold",
                   "validate": {
-                    "required": false,
-                    "custom": "const maxUploadedFiles = 25; const files = data[instance.key] || []; valid = !files.length ? 'At least one file is required' : files.length > maxUploadedFiles ? `Maximum ${maxUploadedFiles} files allowed` : true;"
+                    "required": true,
+                    "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? `Maximum ${data.maxUploadedFiles} files allowed` : true;"
                   },
                   "lockKey": true
                 },
@@ -25479,8 +25500,8 @@
                   "attributes": {},
                   "validateOn": "change",
                   "validate": {
-                    "required": false,
-                    "custom": "const maxUploadedFiles = 25; const files = data[instance.key] || []; valid = !files.length ? 'At least one file is required' : files.length > maxUploadedFiles ? `Maximum ${maxUploadedFiles} files allowed` : true;",
+                    "required": true,
+                    "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? `Maximum ${data.maxUploadedFiles} files allowed` : true;",
                     "customPrivate": false,
                     "strictDateValidation": false,
                     "multiple": false,
@@ -28772,8 +28793,8 @@
                       "attributes": {},
                       "validateOn": "change",
                       "validate": {
-                        "required": false,
-                        "custom": "const maxUploadedFiles = 25; const files = data[instance.key] || []; valid = !files.length ? 'At least one file is required' : files.length > maxUploadedFiles ? `Maximum ${maxUploadedFiles} files allowed` : true;",
+                        "required": true,
+                        "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? `Maximum ${data.maxUploadedFiles} files allowed` : true;",
                         "customPrivate": false,
                         "strictDateValidation": false,
                         "multiple": false,
@@ -30858,8 +30879,8 @@
                       "attributes": {},
                       "validateOn": "change",
                       "validate": {
-                        "required": false,
-                        "custom": "const maxUploadedFiles = 25; const files = data[instance.key] || []; valid = !files.length ? 'At least one file is required' : files.length > maxUploadedFiles ? `Maximum ${maxUploadedFiles} files allowed` : true;",
+                        "required": true,
+                        "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? `Maximum ${data.maxUploadedFiles} files allowed` : true;",
                         "customPrivate": false,
                         "strictDateValidation": false,
                         "multiple": false,

--- a/sources/packages/forms/src/form-definitions/sfaa2025-26.json
+++ b/sources/packages/forms/src/form-definitions/sfaa2025-26.json
@@ -7899,9 +7899,8 @@
                   "calculateServer": false,
                   "allowCalculateOverride": false,
                   "validate": {
-                    "required": true,
-                    "customMessage": "",
-                    "custom": "",
+                    "required": false,
+                    "custom": "const maxUploadedFiles = 25; const files = data[instance.key] || []; valid = !files.length ? 'At least one file is required' : files.length > maxUploadedFiles ? `Maximum ${maxUploadedFiles} files allowed` : true;",
                     "customPrivate": false,
                     "json": "",
                     "strictDateValidation": false,
@@ -10621,7 +10620,7 @@
                       "id": "ekl3d6"
                     },
                     {
-                      "label": "Upload supporting documents (optional):",
+                      "label": "Upload supporting documents",
                       "customClass": "font-weight-bold",
                       "hideLabel": true,
                       "tableView": false,
@@ -10669,8 +10668,8 @@
                       "attributes": {},
                       "validateOn": "change",
                       "validate": {
-                        "required": true,
-                        "custom": "",
+                        "required": false,
+                        "custom": "const maxUploadedFiles = 25; const files = data[instance.key] || []; valid = !files.length ? 'At least one file is required' : files.length > maxUploadedFiles ? `Maximum ${maxUploadedFiles} files allowed` : true;",
                         "customPrivate": false,
                         "strictDateValidation": false,
                         "multiple": false,
@@ -13778,8 +13777,8 @@
                           "multiple": true,
                           "redrawOn": "dependants.declaredOnTaxes",
                           "validate": {
-                            "required": true,
-                            "custom": "",
+                            "required": false,
+                            "custom": "const maxUploadedFiles = 25; const files = data[instance.key] || []; valid = !files.length ? 'At least one file is required' : files.length > maxUploadedFiles ? `Maximum ${maxUploadedFiles} files allowed` : true;",
                             "customPrivate": false,
                             "strictDateValidation": false,
                             "multiple": false,
@@ -14669,9 +14668,8 @@
                           "calculateServer": false,
                           "allowCalculateOverride": false,
                           "validate": {
-                            "required": true,
-                            "customMessage": "",
-                            "custom": "",
+                            "required": false,
+                            "custom": "const maxUploadedFiles = 25; const files = data[instance.key] || []; valid = !files.length ? 'At least one file is required' : files.length > maxUploadedFiles ? `Maximum ${maxUploadedFiles} files allowed` : true;",
                             "customPrivate": false,
                             "json": "",
                             "strictDateValidation": false,
@@ -17230,7 +17228,8 @@
                   "url": "student/files",
                   "lockKey": true,
                   "validate": {
-                    "required": true
+                    "required": false,
+                    "custom": "const maxUploadedFiles = 25; const files = data[instance.key] || []; valid = !files.length ? 'At least one file is required' : files.length > maxUploadedFiles ? `Maximum ${maxUploadedFiles} files allowed` : true;"
                   }
                 },
                 {
@@ -21726,7 +21725,7 @@
               "id": "ecfi9yd"
             },
             {
-              "label": "Upload supporting documents (optional):",
+              "label": "Upload supporting documents",
               "labelPosition": "top",
               "labelWidth": "",
               "labelMargin": "",
@@ -21767,9 +21766,8 @@
               "calculateServer": false,
               "allowCalculateOverride": false,
               "validate": {
-                "required": true,
-                "customMessage": "",
-                "custom": "",
+                "required": false,
+                "custom": "const maxUploadedFiles = 25; const files = data[instance.key] || []; valid = !files.length ? 'At least one file is required' : files.length > maxUploadedFiles ? `Maximum ${maxUploadedFiles} files allowed` : true;",
                 "customPrivate": false,
                 "json": "",
                 "strictDateValidation": false,
@@ -24272,7 +24270,8 @@
                   "dir": "Current Year Income - Supporting Documents",
                   "customClass": "font-weight-bold",
                   "validate": {
-                    "required": true
+                    "required": false,
+                    "custom": "const maxUploadedFiles = 25; const files = data[instance.key] || []; valid = !files.length ? 'At least one file is required' : files.length > maxUploadedFiles ? `Maximum ${maxUploadedFiles} files allowed` : true;"
                   },
                   "lockKey": true
                 },
@@ -25481,7 +25480,7 @@
                   "validateOn": "change",
                   "validate": {
                     "required": false,
-                    "custom": "",
+                    "custom": "const maxUploadedFiles = 25; const files = data[instance.key] || []; valid = !files.length ? 'At least one file is required' : files.length > maxUploadedFiles ? `Maximum ${maxUploadedFiles} files allowed` : true;",
                     "customPrivate": false,
                     "strictDateValidation": false,
                     "multiple": false,
@@ -28725,7 +28724,7 @@
                       "className": ""
                     },
                     {
-                      "label": "Upload supporting documents (optional):",
+                      "label": "Upload supporting documents",
                       "hideLabel": true,
                       "tableView": false,
                       "storage": "url",
@@ -28774,7 +28773,7 @@
                       "validateOn": "change",
                       "validate": {
                         "required": false,
-                        "custom": "",
+                        "custom": "const maxUploadedFiles = 25; const files = data[instance.key] || []; valid = !files.length ? 'At least one file is required' : files.length > maxUploadedFiles ? `Maximum ${maxUploadedFiles} files allowed` : true;",
                         "customPrivate": false,
                         "strictDateValidation": false,
                         "multiple": false,
@@ -30810,7 +30809,7 @@
                       "tags": []
                     },
                     {
-                      "label": "Upload supporting documents (optional):",
+                      "label": "Upload supporting documents",
                       "customClass": "font-weight-bold",
                       "hideLabel": true,
                       "tableView": false,
@@ -30859,8 +30858,8 @@
                       "attributes": {},
                       "validateOn": "change",
                       "validate": {
-                        "required": true,
-                        "custom": "",
+                        "required": false,
+                        "custom": "const maxUploadedFiles = 25; const files = data[instance.key] || []; valid = !files.length ? 'At least one file is required' : files.length > maxUploadedFiles ? `Maximum ${maxUploadedFiles} files allowed` : true;",
                         "customPrivate": false,
                         "strictDateValidation": false,
                         "multiple": false,

--- a/sources/packages/forms/src/form-definitions/studentadditionaltransportationappeal.json
+++ b/sources/packages/forms/src/form-definitions/studentadditionaltransportationappeal.json
@@ -864,7 +864,8 @@
                       "validateOn": "change",
                       "validate": {
                         "required": true,
-                        "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? `Maximum ${data.maxUploadedFiles} files allowed` : true;",
+                        "customMessage": "You must upload at least one file, and the total number of uploaded files cannot exceed {{data.maxUploadedFiles}}.",
+                        "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? false : true;",
                         "customPrivate": false,
                         "strictDateValidation": false,
                         "multiple": false,

--- a/sources/packages/forms/src/form-definitions/studentadditionaltransportationappeal.json
+++ b/sources/packages/forms/src/form-definitions/studentadditionaltransportationappeal.json
@@ -814,7 +814,7 @@
                       "tags": []
                     },
                     {
-                      "label": "Upload supporting documents (optional):",
+                      "label": "Upload supporting documents",
                       "customClass": "font-weight-bold",
                       "hideLabel": true,
                       "tableView": false,
@@ -863,8 +863,8 @@
                       "attributes": {},
                       "validateOn": "change",
                       "validate": {
-                        "required": true,
-                        "custom": "",
+                        "required": false,
+                        "custom": "const maxUploadedFiles = 25; const files = data[instance.key] || []; valid = !files.length ? 'At least one file is required' : files.length > maxUploadedFiles ? `Maximum ${maxUploadedFiles} files allowed` : true;",
                         "customPrivate": false,
                         "strictDateValidation": false,
                         "multiple": false,

--- a/sources/packages/forms/src/form-definitions/studentadditionaltransportationappeal.json
+++ b/sources/packages/forms/src/form-definitions/studentadditionaltransportationappeal.json
@@ -863,8 +863,8 @@
                       "attributes": {},
                       "validateOn": "change",
                       "validate": {
-                        "required": false,
-                        "custom": "const maxUploadedFiles = 25; const files = data[instance.key] || []; valid = !files.length ? 'At least one file is required' : files.length > maxUploadedFiles ? `Maximum ${maxUploadedFiles} files allowed` : true;",
+                        "required": true,
+                        "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? `Maximum ${data.maxUploadedFiles} files allowed` : true;",
                         "customPrivate": false,
                         "strictDateValidation": false,
                         "multiple": false,
@@ -1260,6 +1260,27 @@
           },
           "properties": {},
           "lockKey": true
+        },
+        {
+          "input": true,
+          "tableView": true,
+          "key": "maxUploadedFiles",
+          "label": "maxUploadedFiles",
+          "protected": false,
+          "unique": false,
+          "persistent": false,
+          "type": "hidden",
+          "tags": [],
+          "conditional": {
+            "show": "",
+            "when": null,
+            "eq": ""
+          },
+          "properties": {},
+          "defaultValue": "",
+          "lockKey": true,
+          "calculateValue": "value = 25;",
+          "calculateServer": true
         }
       ],
       "type": "panel",

--- a/sources/packages/forms/src/form-definitions/studentdependantsappeal.json
+++ b/sources/packages/forms/src/form-definitions/studentdependantsappeal.json
@@ -489,7 +489,8 @@
                           "dir": "PD Dependent",
                           "validate": {
                             "required": true,
-                            "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? `Maximum ${data.maxUploadedFiles} files allowed` : true;"
+                            "customMessage": "You must upload at least one file, and the total number of uploaded files cannot exceed {{data.maxUploadedFiles}}.",
+                            "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? false : true;"
                           },
                           "lockKey": true
                         },
@@ -799,7 +800,8 @@
               "dir": "Dependant custody",
               "validate": {
                 "required": true,
-                "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? `Maximum ${data.maxUploadedFiles} files allowed` : true;"
+                "customMessage": "You must upload at least one file, and the total number of uploaded files cannot exceed {{data.maxUploadedFiles}}.",
+                "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? false : true;"
               },
               "lockKey": true,
               "url": "student/files"

--- a/sources/packages/forms/src/form-definitions/studentdependantsappeal.json
+++ b/sources/packages/forms/src/form-definitions/studentdependantsappeal.json
@@ -488,7 +488,8 @@
                           "url": "student/files",
                           "dir": "PD Dependent",
                           "validate": {
-                            "required": true
+                            "required": false,
+                            "custom": "const maxUploadedFiles = 25; const files = data[instance.key] || []; valid = !files.length ? 'At least one file is required' : files.length > maxUploadedFiles ? `Maximum ${maxUploadedFiles} files allowed` : true;"
                           },
                           "lockKey": true
                         },
@@ -797,7 +798,8 @@
               "storage": "url",
               "dir": "Dependant custody",
               "validate": {
-                "required": true
+                "required": false,
+                "custom": "const maxUploadedFiles = 25; const files = data[instance.key] || []; valid = !files.length ? 'At least one file is required' : files.length > maxUploadedFiles ? `Maximum ${maxUploadedFiles} files allowed` : true;"
               },
               "lockKey": true,
               "url": "student/files"

--- a/sources/packages/forms/src/form-definitions/studentdependantsappeal.json
+++ b/sources/packages/forms/src/form-definitions/studentdependantsappeal.json
@@ -488,8 +488,8 @@
                           "url": "student/files",
                           "dir": "PD Dependent",
                           "validate": {
-                            "required": false,
-                            "custom": "const maxUploadedFiles = 25; const files = data[instance.key] || []; valid = !files.length ? 'At least one file is required' : files.length > maxUploadedFiles ? `Maximum ${maxUploadedFiles} files allowed` : true;"
+                            "required": true,
+                            "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? `Maximum ${data.maxUploadedFiles} files allowed` : true;"
                           },
                           "lockKey": true
                         },
@@ -798,8 +798,8 @@
               "storage": "url",
               "dir": "Dependant custody",
               "validate": {
-                "required": false,
-                "custom": "const maxUploadedFiles = 25; const files = data[instance.key] || []; valid = !files.length ? 'At least one file is required' : files.length > maxUploadedFiles ? `Maximum ${maxUploadedFiles} files allowed` : true;"
+                "required": true,
+                "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? `Maximum ${data.maxUploadedFiles} files allowed` : true;"
               },
               "lockKey": true,
               "url": "student/files"
@@ -917,6 +917,27 @@
           "calculateValue": "const [programYear] = data.programYear ? data.programYear.split(\"-\") : [];\nvalue = programYear ? programYear -1: \"\";",
           "calculateServer": true,
           "lockKey": true
+        },
+        {
+          "input": true,
+          "tableView": true,
+          "key": "maxUploadedFiles",
+          "label": "maxUploadedFiles",
+          "protected": false,
+          "unique": false,
+          "persistent": false,
+          "type": "hidden",
+          "tags": [],
+          "conditional": {
+            "show": "",
+            "when": null,
+            "eq": ""
+          },
+          "properties": {},
+          "defaultValue": "",
+          "lockKey": true,
+          "calculateValue": "value = 25;",
+          "calculateServer": true
         }
       ],
       "type": "panel",

--- a/sources/packages/forms/src/form-definitions/studentfinancialinformationappeal.json
+++ b/sources/packages/forms/src/form-definitions/studentfinancialinformationappeal.json
@@ -1206,7 +1206,8 @@
               "customClass": "font-weight-bold",
               "validate": {
                 "required": true,
-                "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? `Maximum ${data.maxUploadedFiles} files allowed` : true;"
+                "customMessage": "You must upload at least one file, and the total number of uploaded files cannot exceed {{data.maxUploadedFiles}}.",
+                "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? false : true;"
               },
               "lockKey": true
             },

--- a/sources/packages/forms/src/form-definitions/studentfinancialinformationappeal.json
+++ b/sources/packages/forms/src/form-definitions/studentfinancialinformationappeal.json
@@ -88,6 +88,27 @@
       "lockKey": true
     },
     {
+      "input": true,
+      "tableView": true,
+      "key": "maxUploadedFiles",
+      "label": "maxUploadedFiles",
+      "protected": false,
+      "unique": false,
+      "persistent": false,
+      "type": "hidden",
+      "tags": [],
+      "conditional": {
+        "show": "",
+        "when": null,
+        "eq": ""
+      },
+      "properties": {},
+      "defaultValue": "",
+      "lockKey": true,
+      "calculateValue": "value = 25;",
+      "calculateServer": true
+    },
+    {
       "key": "financialInformation",
       "label": "Financial Information",
       "input": false,
@@ -1184,8 +1205,8 @@
               "dir": "Current Year Income - Supporting Documents",
               "customClass": "font-weight-bold",
               "validate": {
-                "required": false,
-                "custom": "const maxUploadedFiles = 25; const files = data[instance.key] || []; valid = !files.length ? 'At least one file is required' : files.length > maxUploadedFiles ? `Maximum ${maxUploadedFiles} files allowed` : true;"
+                "required": true,
+                "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? `Maximum ${data.maxUploadedFiles} files allowed` : true;"
               },
               "lockKey": true
             },

--- a/sources/packages/forms/src/form-definitions/studentfinancialinformationappeal.json
+++ b/sources/packages/forms/src/form-definitions/studentfinancialinformationappeal.json
@@ -1184,7 +1184,8 @@
               "dir": "Current Year Income - Supporting Documents",
               "customClass": "font-weight-bold",
               "validate": {
-                "required": true
+                "required": false,
+                "custom": "const maxUploadedFiles = 25; const files = data[instance.key] || []; valid = !files.length ? 'At least one file is required' : files.length > maxUploadedFiles ? `Maximum ${maxUploadedFiles} files allowed` : true;"
               },
               "lockKey": true
             },

--- a/sources/packages/forms/src/form-definitions/uploadstudentdocuments.json
+++ b/sources/packages/forms/src/form-definitions/uploadstudentdocuments.json
@@ -856,8 +856,8 @@
           "calculateServer": false,
           "allowCalculateOverride": false,
           "validate": {
-            "required": false,
-            "custom": "const maxUploadedFiles = 25; const files = data[instance.key] || []; valid = !files.length ? 'At least one file is required' : files.length > maxUploadedFiles ? `Maximum ${maxUploadedFiles} files allowed` : true;",
+            "required": true,
+            "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? `Maximum ${data.maxUploadedFiles} files allowed` : true;",
             "customPrivate": false,
             "json": "",
             "strictDateValidation": false,
@@ -1332,6 +1332,27 @@
       "inputType": "hidden",
       "id": "e6z1qd9",
       "addons": []
+    },
+    {
+      "input": true,
+      "tableView": true,
+      "key": "maxUploadedFiles",
+      "label": "maxUploadedFiles",
+      "protected": false,
+      "unique": false,
+      "persistent": false,
+      "type": "hidden",
+      "tags": [],
+      "conditional": {
+        "show": "",
+        "when": null,
+        "eq": ""
+      },
+      "properties": {},
+      "defaultValue": "",
+      "lockKey": true,
+      "calculateValue": "value = 25;",
+      "calculateServer": true
     }
   ],
   "created": "2023-01-11T21:27:08.929Z",

--- a/sources/packages/forms/src/form-definitions/uploadstudentdocuments.json
+++ b/sources/packages/forms/src/form-definitions/uploadstudentdocuments.json
@@ -857,7 +857,8 @@
           "allowCalculateOverride": false,
           "validate": {
             "required": true,
-            "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? `Maximum ${data.maxUploadedFiles} files allowed` : true;",
+            "customMessage": "You must upload at least one file, and the total number of uploaded files cannot exceed {{data.maxUploadedFiles}}.",
+            "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? false : true;",
             "customPrivate": false,
             "json": "",
             "strictDateValidation": false,

--- a/sources/packages/forms/src/form-definitions/uploadstudentdocuments.json
+++ b/sources/packages/forms/src/form-definitions/uploadstudentdocuments.json
@@ -856,9 +856,8 @@
           "calculateServer": false,
           "allowCalculateOverride": false,
           "validate": {
-            "required": true,
-            "customMessage": "",
-            "custom": "",
+            "required": false,
+            "custom": "const maxUploadedFiles = 25; const files = data[instance.key] || []; valid = !files.length ? 'At least one file is required' : files.length > maxUploadedFiles ? `Maximum ${maxUploadedFiles} files allowed` : true;",
             "customPrivate": false,
             "json": "",
             "strictDateValidation": false,

--- a/sources/packages/forms/src/form-definitions/uploadstudentdocumentsaest.json
+++ b/sources/packages/forms/src/form-definitions/uploadstudentdocumentsaest.json
@@ -335,8 +335,8 @@
           "calculateServer": false,
           "allowCalculateOverride": false,
           "validate": {
-            "required": false,
-            "custom": "const maxUploadedFiles = 25; const files = data[instance.key] || []; valid = !files.length ? 'At least one file is required' : files.length > maxUploadedFiles ? `Maximum ${maxUploadedFiles} files allowed` : true;",
+            "required": true,
+            "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? `Maximum ${data.maxUploadedFiles} files allowed` : true;",
             "customPrivate": false,
             "json": "",
             "strictDateValidation": false,
@@ -646,6 +646,27 @@
       "addons": [],
       "inputType": "hidden",
       "id": "eq2uq2d"
+    },
+    {
+      "input": true,
+      "tableView": true,
+      "key": "maxUploadedFiles",
+      "label": "maxUploadedFiles",
+      "protected": false,
+      "unique": false,
+      "persistent": false,
+      "type": "hidden",
+      "tags": [],
+      "conditional": {
+        "show": "",
+        "when": null,
+        "eq": ""
+      },
+      "properties": {},
+      "defaultValue": "",
+      "lockKey": true,
+      "calculateValue": "value = 25;",
+      "calculateServer": true
     }
   ]
 }

--- a/sources/packages/forms/src/form-definitions/uploadstudentdocumentsaest.json
+++ b/sources/packages/forms/src/form-definitions/uploadstudentdocumentsaest.json
@@ -335,9 +335,8 @@
           "calculateServer": false,
           "allowCalculateOverride": false,
           "validate": {
-            "required": true,
-            "customMessage": "Please provide at least one file to be uploaded",
-            "custom": "",
+            "required": false,
+            "custom": "const maxUploadedFiles = 25; const files = data[instance.key] || []; valid = !files.length ? 'At least one file is required' : files.length > maxUploadedFiles ? `Maximum ${maxUploadedFiles} files allowed` : true;",
             "customPrivate": false,
             "json": "",
             "strictDateValidation": false,

--- a/sources/packages/forms/src/form-definitions/uploadstudentdocumentsaest.json
+++ b/sources/packages/forms/src/form-definitions/uploadstudentdocumentsaest.json
@@ -336,7 +336,8 @@
           "allowCalculateOverride": false,
           "validate": {
             "required": true,
-            "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? `Maximum ${data.maxUploadedFiles} files allowed` : true;",
+            "customMessage": "You must upload at least one file, and the total number of uploaded files cannot exceed {{data.maxUploadedFiles}}.",
+            "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? false : true;",
             "customPrivate": false,
             "json": "",
             "strictDateValidation": false,


### PR DESCRIPTION
- Set max number of documents to 25. Added a hidden component in each form to have it server calculated;
- All fileUploaders should be required to have at least 1 file;
- Changed some fileUploaders to allow multiple files (they allowed only one file to be uploaded);
- Removed "optional" of some labels;
- Kept same custom validation to all fileUploaders so it's easy to change it all occurrences across the forms:
```json
"validate": {
                "required": true,
                "customMessage": "You must upload at least one file, and the total number of uploaded files cannot exceed {{data.maxUploadedFiles}}.",
                "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? false : true;"
              }
```

![image](https://github.com/user-attachments/assets/88bed1ef-2b68-4ba8-9e15-6358dd4f2a56)
![image](https://github.com/user-attachments/assets/7665c862-3dac-4334-9c09-20b096ecbde7)

![image](https://github.com/user-attachments/assets/4270e54c-2444-40f0-9b8d-36e05a5c9fc6)
![image](https://github.com/user-attachments/assets/fe2c34d4-72fd-4bf9-b35e-090634f36a38)
