### PR TITLE
#4459 - Set max documents for application uploaders to 25 (#4537) cherry pick

### DIFF
--- a/sources/packages/forms/src/form-definitions/partnerinformationandincomeappeal.json
+++ b/sources/packages/forms/src/form-definitions/partnerinformationandincomeappeal.json
@@ -141,6 +141,27 @@
       "lockKey": true
     },
     {
+      "input": true,
+      "tableView": true,
+      "key": "maxUploadedFiles",
+      "label": "maxUploadedFiles",
+      "protected": false,
+      "unique": false,
+      "persistent": false,
+      "type": "hidden",
+      "tags": [],
+      "conditional": {
+        "show": "",
+        "when": null,
+        "eq": ""
+      },
+      "properties": {},
+      "defaultValue": "",
+      "lockKey": true,
+      "calculateValue": "value = 25;",
+      "calculateServer": true
+    },
+    {
       "label": "HTML",
       "labelWidth": "",
       "labelMargin": "",
@@ -1689,7 +1710,9 @@
               "dir": "Current Year Income - Supporting Documents",
               "customClass": "font-weight-bold",
               "validate": {
-                "required": true
+                "required": true,
+                "customMessage": "You must upload at least one file, and the total number of uploaded files cannot exceed {{data.maxUploadedFiles}}.",
+                "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? false : true;"
               },
               "lockKey": true
             },

--- a/sources/packages/forms/src/form-definitions/sfaa2022-23.json
+++ b/sources/packages/forms/src/form-definitions/sfaa2022-23.json
@@ -7900,8 +7900,8 @@
                   "allowCalculateOverride": false,
                   "validate": {
                     "required": true,
-                    "customMessage": "",
-                    "custom": "",
+                    "customMessage": "You must upload at least one file, and the total number of uploaded files cannot exceed {{data.maxUploadedFiles}}.",
+                    "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? false : true;",
                     "customPrivate": false,
                     "json": "",
                     "strictDateValidation": false,
@@ -9257,7 +9257,7 @@
                       "id": "ekl3d6"
                     },
                     {
-                      "label": "Upload supporting documents (optional):",
+                      "label": "Upload supporting documents",
                       "customClass": "font-weight-bold",
                       "hideLabel": true,
                       "tableView": false,
@@ -9306,7 +9306,8 @@
                       "validateOn": "change",
                       "validate": {
                         "required": true,
-                        "custom": "",
+                        "customMessage": "You must upload at least one file, and the total number of uploaded files cannot exceed {{data.maxUploadedFiles}}.",
+                        "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? false : true;",
                         "customPrivate": false,
                         "strictDateValidation": false,
                         "multiple": false,
@@ -12289,6 +12290,27 @@
           },
           "properties": {},
           "lockKey": true
+        },
+        {
+          "input": true,
+          "tableView": true,
+          "key": "maxUploadedFiles",
+          "label": "maxUploadedFiles",
+          "protected": false,
+          "unique": false,
+          "persistent": false,
+          "type": "hidden",
+          "tags": [],
+          "conditional": {
+            "show": "",
+            "when": null,
+            "eq": ""
+          },
+          "properties": {},
+          "defaultValue": "",
+          "lockKey": true,
+          "calculateValue": "value = 25;",
+          "calculateServer": true
         }
       ],
       "input": false,
@@ -13868,7 +13890,8 @@
                               "redrawOn": "dependants.declaredOnTaxes",
                               "validate": {
                                 "required": true,
-                                "custom": "",
+                                "customMessage": "You must upload at least one file, and the total number of uploaded files cannot exceed {{data.maxUploadedFiles}}.",
+                                "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? false : true;",
                                 "customPrivate": false,
                                 "strictDateValidation": false,
                                 "multiple": false,
@@ -14929,8 +14952,8 @@
                   "allowCalculateOverride": false,
                   "validate": {
                     "required": true,
-                    "customMessage": "",
-                    "custom": "",
+                    "customMessage": "You must upload at least one file, and the total number of uploaded files cannot exceed {{data.maxUploadedFiles}}.",
+                    "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? false : true;",
                     "customPrivate": false,
                     "json": "",
                     "strictDateValidation": false,
@@ -16811,7 +16834,7 @@
                   "image": false,
                   "imageSize": "200",
                   "placeholder": "",
-                  "multiple": false,
+                  "multiple": true,
                   "defaultValue": "",
                   "protected": false,
                   "persistent": true,
@@ -16833,7 +16856,9 @@
                   "url": "student/files",
                   "lockKey": true,
                   "validate": {
-                    "required": true
+                    "required": true,
+                    "customMessage": "You must upload at least one file, and the total number of uploaded files cannot exceed {{data.maxUploadedFiles}}.",
+                    "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? false : true;"
                   }
                 },
                 {
@@ -21091,7 +21116,7 @@
               "id": "ecfi9yd"
             },
             {
-              "label": "Upload supporting documents (optional):",
+              "label": "Upload supporting documents",
               "labelPosition": "top",
               "labelWidth": "",
               "labelMargin": "",
@@ -21132,9 +21157,9 @@
               "calculateServer": false,
               "allowCalculateOverride": false,
               "validate": {
-                "required": false,
-                "customMessage": "",
-                "custom": "",
+                "required": true,
+                "customMessage": "You must upload at least one file, and the total number of uploaded files cannot exceed {{data.maxUploadedFiles}}.",
+                "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? false : true;",
                 "customPrivate": false,
                 "json": "",
                 "strictDateValidation": false,
@@ -22140,7 +22165,7 @@
                   "prefix": "",
                   "customClass": "",
                   "suffix": "",
-                  "multiple": false,
+                  "multiple": true,
                   "defaultValue": null,
                   "protected": false,
                   "unique": false,
@@ -22166,8 +22191,9 @@
                   "attributes": {},
                   "validateOn": "change",
                   "validate": {
-                    "required": false,
-                    "custom": "",
+                    "required": true,
+                    "customMessage": "You must upload at least one file, and the total number of uploaded files cannot exceed {{data.maxUploadedFiles}}.",
+                    "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? false : true;",
                     "customPrivate": false,
                     "strictDateValidation": false,
                     "multiple": false,
@@ -24710,7 +24736,9 @@
                   "dir": "Current Year Income - Supporting Documents",
                   "customClass": "font-weight-bold",
                   "validate": {
-                    "required": true
+                    "required": true,
+                    "customMessage": "You must upload at least one file, and the total number of uploaded files cannot exceed {{data.maxUploadedFiles}}.",
+                    "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? false : true;"
                   },
                   "lockKey": true
                 },
@@ -25918,8 +25946,9 @@
                   "attributes": {},
                   "validateOn": "change",
                   "validate": {
-                    "required": false,
-                    "custom": "",
+                    "required": true,
+                    "customMessage": "You must upload at least one file, and the total number of uploaded files cannot exceed {{data.maxUploadedFiles}}.",
+                    "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? false : true;",
                     "customPrivate": false,
                     "strictDateValidation": false,
                     "multiple": false,
@@ -29653,7 +29682,7 @@
                       "className": ""
                     },
                     {
-                      "label": "Upload supporting documents (optional):",
+                      "label": "Upload supporting documents",
                       "hideLabel": true,
                       "tableView": false,
                       "storage": "url",
@@ -29701,8 +29730,9 @@
                       "attributes": {},
                       "validateOn": "change",
                       "validate": {
-                        "required": false,
-                        "custom": "",
+                        "required": true,
+                        "customMessage": "You must upload at least one file, and the total number of uploaded files cannot exceed {{data.maxUploadedFiles}}.",
+                        "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? false : true;",
                         "customPrivate": false,
                         "strictDateValidation": false,
                         "multiple": false,
@@ -31738,7 +31768,7 @@
                       "tags": []
                     },
                     {
-                      "label": "Upload supporting documents (optional):",
+                      "label": "Upload supporting documents",
                       "customClass": "font-weight-bold",
                       "hideLabel": true,
                       "tableView": false,
@@ -31788,7 +31818,8 @@
                       "validateOn": "change",
                       "validate": {
                         "required": true,
-                        "custom": "",
+                        "customMessage": "You must upload at least one file, and the total number of uploaded files cannot exceed {{data.maxUploadedFiles}}.",
+                        "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? false : true;",
                         "customPrivate": false,
                         "strictDateValidation": false,
                         "multiple": false,

--- a/sources/packages/forms/src/form-definitions/sfaa2023-24.json
+++ b/sources/packages/forms/src/form-definitions/sfaa2023-24.json
@@ -7900,8 +7900,8 @@
                   "allowCalculateOverride": false,
                   "validate": {
                     "required": true,
-                    "customMessage": "",
-                    "custom": "",
+                    "customMessage": "You must upload at least one file, and the total number of uploaded files cannot exceed {{data.maxUploadedFiles}}.",
+                    "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? false : true;",
                     "customPrivate": false,
                     "json": "",
                     "strictDateValidation": false,
@@ -9257,7 +9257,7 @@
                       "id": "ekl3d6"
                     },
                     {
-                      "label": "Upload supporting documents (optional):",
+                      "label": "Upload supporting documents",
                       "customClass": "font-weight-bold",
                       "hideLabel": true,
                       "tableView": false,
@@ -9306,7 +9306,8 @@
                       "validateOn": "change",
                       "validate": {
                         "required": true,
-                        "custom": "",
+                        "customMessage": "You must upload at least one file, and the total number of uploaded files cannot exceed {{data.maxUploadedFiles}}.",
+                        "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? false : true;",
                         "customPrivate": false,
                         "strictDateValidation": false,
                         "multiple": false,
@@ -12289,6 +12290,27 @@
           },
           "properties": {},
           "lockKey": true
+        },
+        {
+          "input": true,
+          "tableView": true,
+          "key": "maxUploadedFiles",
+          "label": "maxUploadedFiles",
+          "protected": false,
+          "unique": false,
+          "persistent": false,
+          "type": "hidden",
+          "tags": [],
+          "conditional": {
+            "show": "",
+            "when": null,
+            "eq": ""
+          },
+          "properties": {},
+          "defaultValue": "",
+          "lockKey": true,
+          "calculateValue": "value = 25;",
+          "calculateServer": true
         }
       ],
       "input": false,
@@ -13868,7 +13890,8 @@
                               "redrawOn": "dependants.declaredOnTaxes",
                               "validate": {
                                 "required": true,
-                                "custom": "",
+                                "customMessage": "You must upload at least one file, and the total number of uploaded files cannot exceed {{data.maxUploadedFiles}}.",
+                                "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? false : true;",
                                 "customPrivate": false,
                                 "strictDateValidation": false,
                                 "multiple": false,
@@ -14929,8 +14952,8 @@
                   "allowCalculateOverride": false,
                   "validate": {
                     "required": true,
-                    "customMessage": "",
-                    "custom": "",
+                    "customMessage": "You must upload at least one file, and the total number of uploaded files cannot exceed {{data.maxUploadedFiles}}.",
+                    "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? false : true;",
                     "customPrivate": false,
                     "json": "",
                     "strictDateValidation": false,
@@ -16811,7 +16834,7 @@
                   "image": false,
                   "imageSize": "200",
                   "placeholder": "",
-                  "multiple": false,
+                  "multiple": true,
                   "defaultValue": "",
                   "protected": false,
                   "persistent": true,
@@ -16833,7 +16856,9 @@
                   "url": "student/files",
                   "lockKey": true,
                   "validate": {
-                    "required": true
+                    "required": true,
+                    "customMessage": "You must upload at least one file, and the total number of uploaded files cannot exceed {{data.maxUploadedFiles}}.",
+                    "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? false : true;"
                   }
                 },
                 {
@@ -21091,7 +21116,7 @@
               "id": "ecfi9yd"
             },
             {
-              "label": "Upload supporting documents (optional):",
+              "label": "Upload supporting documents",
               "labelPosition": "top",
               "labelWidth": "",
               "labelMargin": "",
@@ -21132,9 +21157,9 @@
               "calculateServer": false,
               "allowCalculateOverride": false,
               "validate": {
-                "required": false,
-                "customMessage": "",
-                "custom": "",
+                "required": true,
+                "customMessage": "You must upload at least one file, and the total number of uploaded files cannot exceed {{data.maxUploadedFiles}}.",
+                "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? false : true;",
                 "customPrivate": false,
                 "json": "",
                 "strictDateValidation": false,
@@ -22140,7 +22165,7 @@
                   "prefix": "",
                   "customClass": "",
                   "suffix": "",
-                  "multiple": false,
+                  "multiple": true,
                   "defaultValue": null,
                   "protected": false,
                   "unique": false,
@@ -22166,8 +22191,9 @@
                   "attributes": {},
                   "validateOn": "change",
                   "validate": {
-                    "required": false,
-                    "custom": "",
+                    "required": true,
+                    "customMessage": "You must upload at least one file, and the total number of uploaded files cannot exceed {{data.maxUploadedFiles}}.",
+                    "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? false : true;",
                     "customPrivate": false,
                     "strictDateValidation": false,
                     "multiple": false,
@@ -24710,7 +24736,9 @@
                   "dir": "Current Year Income - Supporting Documents",
                   "customClass": "font-weight-bold",
                   "validate": {
-                    "required": true
+                    "required": true,
+                    "customMessage": "You must upload at least one file, and the total number of uploaded files cannot exceed {{data.maxUploadedFiles}}.",
+                    "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? false : true;"
                   },
                   "lockKey": true
                 },
@@ -25918,8 +25946,9 @@
                   "attributes": {},
                   "validateOn": "change",
                   "validate": {
-                    "required": false,
-                    "custom": "",
+                    "required": true,
+                    "customMessage": "You must upload at least one file, and the total number of uploaded files cannot exceed {{data.maxUploadedFiles}}.",
+                    "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? false : true;",
                     "customPrivate": false,
                     "strictDateValidation": false,
                     "multiple": false,
@@ -29653,7 +29682,7 @@
                       "className": ""
                     },
                     {
-                      "label": "Upload supporting documents (optional):",
+                      "label": "Upload supporting documents",
                       "hideLabel": true,
                       "tableView": false,
                       "storage": "url",
@@ -29701,8 +29730,9 @@
                       "attributes": {},
                       "validateOn": "change",
                       "validate": {
-                        "required": false,
-                        "custom": "",
+                        "required": true,
+                        "customMessage": "You must upload at least one file, and the total number of uploaded files cannot exceed {{data.maxUploadedFiles}}.",
+                        "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? false : true;",
                         "customPrivate": false,
                         "strictDateValidation": false,
                         "multiple": false,
@@ -31738,7 +31768,7 @@
                       "tags": []
                     },
                     {
-                      "label": "Upload supporting documents (optional):",
+                      "label": "Upload supporting documents",
                       "customClass": "font-weight-bold",
                       "hideLabel": true,
                       "tableView": false,
@@ -31788,7 +31818,8 @@
                       "validateOn": "change",
                       "validate": {
                         "required": true,
-                        "custom": "",
+                        "customMessage": "You must upload at least one file, and the total number of uploaded files cannot exceed {{data.maxUploadedFiles}}.",
+                        "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? false : true;",
                         "customPrivate": false,
                         "strictDateValidation": false,
                         "multiple": false,

--- a/sources/packages/forms/src/form-definitions/sfaa2024-25.json
+++ b/sources/packages/forms/src/form-definitions/sfaa2024-25.json
@@ -7900,8 +7900,8 @@
                   "allowCalculateOverride": false,
                   "validate": {
                     "required": true,
-                    "customMessage": "",
-                    "custom": "",
+                    "customMessage": "You must upload at least one file, and the total number of uploaded files cannot exceed {{data.maxUploadedFiles}}.",
+                    "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? false : true;",
                     "customPrivate": false,
                     "json": "",
                     "strictDateValidation": false,
@@ -9257,7 +9257,7 @@
                       "id": "ekl3d6"
                     },
                     {
-                      "label": "Upload supporting documents (optional):",
+                      "label": "Upload supporting documents",
                       "customClass": "font-weight-bold",
                       "hideLabel": true,
                       "tableView": false,
@@ -9306,7 +9306,8 @@
                       "validateOn": "change",
                       "validate": {
                         "required": true,
-                        "custom": "",
+                        "customMessage": "You must upload at least one file, and the total number of uploaded files cannot exceed {{data.maxUploadedFiles}}.",
+                        "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? false : true;",
                         "customPrivate": false,
                         "strictDateValidation": false,
                         "multiple": false,
@@ -12289,6 +12290,27 @@
           },
           "properties": {},
           "lockKey": true
+        },
+        {
+          "input": true,
+          "tableView": true,
+          "key": "maxUploadedFiles",
+          "label": "maxUploadedFiles",
+          "protected": false,
+          "unique": false,
+          "persistent": false,
+          "type": "hidden",
+          "tags": [],
+          "conditional": {
+            "show": "",
+            "when": null,
+            "eq": ""
+          },
+          "properties": {},
+          "defaultValue": "",
+          "lockKey": true,
+          "calculateValue": "value = 25;",
+          "calculateServer": true
         }
       ],
       "input": false,
@@ -13868,7 +13890,8 @@
                               "redrawOn": "dependants.declaredOnTaxes",
                               "validate": {
                                 "required": true,
-                                "custom": "",
+                                "customMessage": "You must upload at least one file, and the total number of uploaded files cannot exceed {{data.maxUploadedFiles}}.",
+                                "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? false : true;",
                                 "customPrivate": false,
                                 "strictDateValidation": false,
                                 "multiple": false,
@@ -14929,8 +14952,8 @@
                   "allowCalculateOverride": false,
                   "validate": {
                     "required": true,
-                    "customMessage": "",
-                    "custom": "",
+                    "customMessage": "You must upload at least one file, and the total number of uploaded files cannot exceed {{data.maxUploadedFiles}}.",
+                    "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? false : true;",
                     "customPrivate": false,
                     "json": "",
                     "strictDateValidation": false,
@@ -16811,7 +16834,7 @@
                   "image": false,
                   "imageSize": "200",
                   "placeholder": "",
-                  "multiple": false,
+                  "multiple": true,
                   "defaultValue": "",
                   "protected": false,
                   "persistent": true,
@@ -16833,7 +16856,9 @@
                   "url": "student/files",
                   "lockKey": true,
                   "validate": {
-                    "required": true
+                    "required": true,
+                    "customMessage": "You must upload at least one file, and the total number of uploaded files cannot exceed {{data.maxUploadedFiles}}.",
+                    "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? false : true;"
                   }
                 },
                 {
@@ -21091,7 +21116,7 @@
               "id": "ecfi9yd"
             },
             {
-              "label": "Upload supporting documents (optional):",
+              "label": "Upload supporting documents",
               "labelPosition": "top",
               "labelWidth": "",
               "labelMargin": "",
@@ -21132,9 +21157,9 @@
               "calculateServer": false,
               "allowCalculateOverride": false,
               "validate": {
-                "required": false,
-                "customMessage": "",
-                "custom": "",
+                "required": true,
+                "customMessage": "You must upload at least one file, and the total number of uploaded files cannot exceed {{data.maxUploadedFiles}}.",
+                "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? false : true;",
                 "customPrivate": false,
                 "json": "",
                 "strictDateValidation": false,
@@ -22140,7 +22165,7 @@
                   "prefix": "",
                   "customClass": "",
                   "suffix": "",
-                  "multiple": false,
+                  "multiple": true,
                   "defaultValue": null,
                   "protected": false,
                   "unique": false,
@@ -22166,8 +22191,9 @@
                   "attributes": {},
                   "validateOn": "change",
                   "validate": {
-                    "required": false,
-                    "custom": "",
+                    "required": true,
+                    "customMessage": "You must upload at least one file, and the total number of uploaded files cannot exceed {{data.maxUploadedFiles}}.",
+                    "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? false : true;",
                     "customPrivate": false,
                     "strictDateValidation": false,
                     "multiple": false,
@@ -24710,7 +24736,9 @@
                   "dir": "Current Year Income - Supporting Documents",
                   "customClass": "font-weight-bold",
                   "validate": {
-                    "required": true
+                    "required": true,
+                    "customMessage": "You must upload at least one file, and the total number of uploaded files cannot exceed {{data.maxUploadedFiles}}.",
+                    "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? false : true;"
                   },
                   "lockKey": true
                 },
@@ -25918,8 +25946,9 @@
                   "attributes": {},
                   "validateOn": "change",
                   "validate": {
-                    "required": false,
-                    "custom": "",
+                    "required": true,
+                    "customMessage": "You must upload at least one file, and the total number of uploaded files cannot exceed {{data.maxUploadedFiles}}.",
+                    "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? false : true;",
                     "customPrivate": false,
                     "strictDateValidation": false,
                     "multiple": false,
@@ -29653,7 +29682,7 @@
                       "className": ""
                     },
                     {
-                      "label": "Upload supporting documents (optional):",
+                      "label": "Upload supporting documents",
                       "hideLabel": true,
                       "tableView": false,
                       "storage": "url",
@@ -29701,8 +29730,9 @@
                       "attributes": {},
                       "validateOn": "change",
                       "validate": {
-                        "required": false,
-                        "custom": "",
+                        "required": true,
+                        "customMessage": "You must upload at least one file, and the total number of uploaded files cannot exceed {{data.maxUploadedFiles}}.",
+                        "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? false : true;",
                         "customPrivate": false,
                         "strictDateValidation": false,
                         "multiple": false,
@@ -31582,8 +31612,8 @@
                         "eq": ""
                       },
                       "properties": {},
-                      "customClass": "banner-warning",
-                      "hideLabel": true
+                      "hideLabel": true,
+                      "customClass": "banner-warning"
                     },
                     {
                       "label": "HTML",
@@ -31738,7 +31768,7 @@
                       "tags": []
                     },
                     {
-                      "label": "Upload supporting documents (optional):",
+                      "label": "Upload supporting documents",
                       "customClass": "font-weight-bold",
                       "hideLabel": true,
                       "tableView": false,
@@ -31788,7 +31818,8 @@
                       "validateOn": "change",
                       "validate": {
                         "required": true,
-                        "custom": "",
+                        "customMessage": "You must upload at least one file, and the total number of uploaded files cannot exceed {{data.maxUploadedFiles}}.",
+                        "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? false : true;",
                         "customPrivate": false,
                         "strictDateValidation": false,
                         "multiple": false,

--- a/sources/packages/forms/src/form-definitions/sfaa2025-26.json
+++ b/sources/packages/forms/src/form-definitions/sfaa2025-26.json
@@ -7900,8 +7900,8 @@
                   "allowCalculateOverride": false,
                   "validate": {
                     "required": true,
-                    "customMessage": "",
-                    "custom": "",
+                    "customMessage": "You must upload at least one file, and the total number of uploaded files cannot exceed {{data.maxUploadedFiles}}.",
+                    "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? false : true;",
                     "customPrivate": false,
                     "json": "",
                     "strictDateValidation": false,
@@ -10621,7 +10621,7 @@
                       "id": "ekl3d6"
                     },
                     {
-                      "label": "Upload supporting documents (optional):",
+                      "label": "Upload supporting documents",
                       "customClass": "font-weight-bold",
                       "hideLabel": true,
                       "tableView": false,
@@ -10670,7 +10670,8 @@
                       "validateOn": "change",
                       "validate": {
                         "required": true,
-                        "custom": "",
+                        "customMessage": "You must upload at least one file, and the total number of uploaded files cannot exceed {{data.maxUploadedFiles}}.",
+                        "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? false : true;",
                         "customPrivate": false,
                         "strictDateValidation": false,
                         "multiple": false,
@@ -12484,6 +12485,27 @@
         },
         {
           "input": true,
+          "tableView": true,
+          "key": "maxUploadedFiles",
+          "label": "maxUploadedFiles",
+          "protected": false,
+          "unique": false,
+          "persistent": false,
+          "type": "hidden",
+          "tags": [],
+          "conditional": {
+            "show": "",
+            "when": null,
+            "eq": ""
+          },
+          "properties": {},
+          "defaultValue": "",
+          "lockKey": true,
+          "calculateValue": "value = 25;",
+          "calculateServer": true
+        },
+        {
+          "input": true,
           "tableView": false,
           "key": "dependantstatus",
           "label": "Dependant Status",
@@ -13779,7 +13801,8 @@
                           "redrawOn": "dependants.declaredOnTaxes",
                           "validate": {
                             "required": true,
-                            "custom": "",
+                            "customMessage": "You must upload at least one file, and the total number of uploaded files cannot exceed {{data.maxUploadedFiles}}.",
+                            "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? false : true;",
                             "customPrivate": false,
                             "strictDateValidation": false,
                             "multiple": false,
@@ -14670,8 +14693,8 @@
                           "allowCalculateOverride": false,
                           "validate": {
                             "required": true,
-                            "customMessage": "",
-                            "custom": "",
+                            "customMessage": "You must upload at least one file, and the total number of uploaded files cannot exceed {{data.maxUploadedFiles}}.",
+                            "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? false : true;",
                             "customPrivate": false,
                             "json": "",
                             "strictDateValidation": false,
@@ -17208,7 +17231,7 @@
                   "image": false,
                   "imageSize": "200",
                   "placeholder": "",
-                  "multiple": false,
+                  "multiple": true,
                   "defaultValue": "",
                   "protected": false,
                   "persistent": true,
@@ -17230,7 +17253,9 @@
                   "url": "student/files",
                   "lockKey": true,
                   "validate": {
-                    "required": true
+                    "required": true,
+                    "customMessage": "You must upload at least one file, and the total number of uploaded files cannot exceed {{data.maxUploadedFiles}}.",
+                    "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? false : true;"
                   }
                 },
                 {
@@ -21726,7 +21751,7 @@
               "id": "ecfi9yd"
             },
             {
-              "label": "Upload supporting documents (optional):",
+              "label": "Upload supporting documents",
               "labelPosition": "top",
               "labelWidth": "",
               "labelMargin": "",
@@ -21768,8 +21793,8 @@
               "allowCalculateOverride": false,
               "validate": {
                 "required": true,
-                "customMessage": "",
-                "custom": "",
+                "customMessage": "You must upload at least one file, and the total number of uploaded files cannot exceed {{data.maxUploadedFiles}}.",
+                "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? false : true;",
                 "customPrivate": false,
                 "json": "",
                 "strictDateValidation": false,
@@ -24272,7 +24297,9 @@
                   "dir": "Current Year Income - Supporting Documents",
                   "customClass": "font-weight-bold",
                   "validate": {
-                    "required": true
+                    "required": true,
+                    "customMessage": "You must upload at least one file, and the total number of uploaded files cannot exceed {{data.maxUploadedFiles}}.",
+                    "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? false : true;"
                   },
                   "lockKey": true
                 },
@@ -25480,8 +25507,9 @@
                   "attributes": {},
                   "validateOn": "change",
                   "validate": {
-                    "required": false,
-                    "custom": "",
+                    "required": true,
+                    "customMessage": "You must upload at least one file, and the total number of uploaded files cannot exceed {{data.maxUploadedFiles}}.",
+                    "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? false : true;",
                     "customPrivate": false,
                     "strictDateValidation": false,
                     "multiple": false,
@@ -28725,7 +28753,7 @@
                       "className": ""
                     },
                     {
-                      "label": "Upload supporting documents (optional):",
+                      "label": "Upload supporting documents",
                       "hideLabel": true,
                       "tableView": false,
                       "storage": "url",
@@ -28773,8 +28801,9 @@
                       "attributes": {},
                       "validateOn": "change",
                       "validate": {
-                        "required": false,
-                        "custom": "",
+                        "required": true,
+                        "customMessage": "You must upload at least one file, and the total number of uploaded files cannot exceed {{data.maxUploadedFiles}}.",
+                        "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? false : true;",
                         "customPrivate": false,
                         "strictDateValidation": false,
                         "multiple": false,
@@ -30810,7 +30839,7 @@
                       "tags": []
                     },
                     {
-                      "label": "Upload supporting documents (optional):",
+                      "label": "Upload supporting documents",
                       "customClass": "font-weight-bold",
                       "hideLabel": true,
                       "tableView": false,
@@ -30860,7 +30889,8 @@
                       "validateOn": "change",
                       "validate": {
                         "required": true,
-                        "custom": "",
+                        "customMessage": "You must upload at least one file, and the total number of uploaded files cannot exceed {{data.maxUploadedFiles}}.",
+                        "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? false : true;",
                         "customPrivate": false,
                         "strictDateValidation": false,
                         "multiple": false,

--- a/sources/packages/forms/src/form-definitions/studentadditionaltransportationappeal.json
+++ b/sources/packages/forms/src/form-definitions/studentadditionaltransportationappeal.json
@@ -814,7 +814,7 @@
                       "tags": []
                     },
                     {
-                      "label": "Upload supporting documents (optional):",
+                      "label": "Upload supporting documents",
                       "customClass": "font-weight-bold",
                       "hideLabel": true,
                       "tableView": false,
@@ -864,7 +864,8 @@
                       "validateOn": "change",
                       "validate": {
                         "required": true,
-                        "custom": "",
+                        "customMessage": "You must upload at least one file, and the total number of uploaded files cannot exceed {{data.maxUploadedFiles}}.",
+                        "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? false : true;",
                         "customPrivate": false,
                         "strictDateValidation": false,
                         "multiple": false,
@@ -1260,6 +1261,27 @@
           },
           "properties": {},
           "lockKey": true
+        },
+        {
+          "input": true,
+          "tableView": true,
+          "key": "maxUploadedFiles",
+          "label": "maxUploadedFiles",
+          "protected": false,
+          "unique": false,
+          "persistent": false,
+          "type": "hidden",
+          "tags": [],
+          "conditional": {
+            "show": "",
+            "when": null,
+            "eq": ""
+          },
+          "properties": {},
+          "defaultValue": "",
+          "lockKey": true,
+          "calculateValue": "value = 25;",
+          "calculateServer": true
         }
       ],
       "type": "panel",

--- a/sources/packages/forms/src/form-definitions/studentdependantsappeal.json
+++ b/sources/packages/forms/src/form-definitions/studentdependantsappeal.json
@@ -488,7 +488,9 @@
                           "url": "student/files",
                           "dir": "PD Dependent",
                           "validate": {
-                            "required": true
+                            "required": true,
+                            "customMessage": "You must upload at least one file, and the total number of uploaded files cannot exceed {{data.maxUploadedFiles}}.",
+                            "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? false : true;"
                           },
                           "lockKey": true
                         },
@@ -797,7 +799,9 @@
               "storage": "url",
               "dir": "Dependant custody",
               "validate": {
-                "required": true
+                "required": true,
+                "customMessage": "You must upload at least one file, and the total number of uploaded files cannot exceed {{data.maxUploadedFiles}}.",
+                "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? false : true;"
               },
               "lockKey": true,
               "url": "student/files"
@@ -915,6 +919,27 @@
           "calculateValue": "const [programYear] = data.programYear ? data.programYear.split(\"-\") : [];\nvalue = programYear ? programYear -1: \"\";",
           "calculateServer": true,
           "lockKey": true
+        },
+        {
+          "input": true,
+          "tableView": true,
+          "key": "maxUploadedFiles",
+          "label": "maxUploadedFiles",
+          "protected": false,
+          "unique": false,
+          "persistent": false,
+          "type": "hidden",
+          "tags": [],
+          "conditional": {
+            "show": "",
+            "when": null,
+            "eq": ""
+          },
+          "properties": {},
+          "defaultValue": "",
+          "lockKey": true,
+          "calculateValue": "value = 25;",
+          "calculateServer": true
         }
       ],
       "type": "panel",

--- a/sources/packages/forms/src/form-definitions/studentfinancialinformationappeal.json
+++ b/sources/packages/forms/src/form-definitions/studentfinancialinformationappeal.json
@@ -88,6 +88,27 @@
       "lockKey": true
     },
     {
+      "input": true,
+      "tableView": true,
+      "key": "maxUploadedFiles",
+      "label": "maxUploadedFiles",
+      "protected": false,
+      "unique": false,
+      "persistent": false,
+      "type": "hidden",
+      "tags": [],
+      "conditional": {
+        "show": "",
+        "when": null,
+        "eq": ""
+      },
+      "properties": {},
+      "defaultValue": "",
+      "lockKey": true,
+      "calculateValue": "value = 25;",
+      "calculateServer": true
+    },
+    {
       "key": "financialInformation",
       "label": "Financial Information",
       "input": false,
@@ -1184,7 +1205,9 @@
               "dir": "Current Year Income - Supporting Documents",
               "customClass": "font-weight-bold",
               "validate": {
-                "required": true
+                "required": true,
+                "customMessage": "You must upload at least one file, and the total number of uploaded files cannot exceed {{data.maxUploadedFiles}}.",
+                "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? false : true;"
               },
               "lockKey": true
             },

--- a/sources/packages/forms/src/form-definitions/uploadstudentdocuments.json
+++ b/sources/packages/forms/src/form-definitions/uploadstudentdocuments.json
@@ -857,8 +857,8 @@
           "allowCalculateOverride": false,
           "validate": {
             "required": true,
-            "customMessage": "",
-            "custom": "",
+            "customMessage": "You must upload at least one file, and the total number of uploaded files cannot exceed {{data.maxUploadedFiles}}.",
+            "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? false : true;",
             "customPrivate": false,
             "json": "",
             "strictDateValidation": false,
@@ -1333,6 +1333,27 @@
       "inputType": "hidden",
       "id": "e6z1qd9",
       "addons": []
+    },
+    {
+      "input": true,
+      "tableView": true,
+      "key": "maxUploadedFiles",
+      "label": "maxUploadedFiles",
+      "protected": false,
+      "unique": false,
+      "persistent": false,
+      "type": "hidden",
+      "tags": [],
+      "conditional": {
+        "show": "",
+        "when": null,
+        "eq": ""
+      },
+      "properties": {},
+      "defaultValue": "",
+      "lockKey": true,
+      "calculateValue": "value = 25;",
+      "calculateServer": true
     }
   ],
   "created": "2023-01-11T21:27:08.929Z",

--- a/sources/packages/forms/src/form-definitions/uploadstudentdocumentsaest.json
+++ b/sources/packages/forms/src/form-definitions/uploadstudentdocumentsaest.json
@@ -336,8 +336,8 @@
           "allowCalculateOverride": false,
           "validate": {
             "required": true,
-            "customMessage": "Please provide at least one file to be uploaded",
-            "custom": "",
+            "customMessage": "You must upload at least one file, and the total number of uploaded files cannot exceed {{data.maxUploadedFiles}}.",
+            "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? false : true;",
             "customPrivate": false,
             "json": "",
             "strictDateValidation": false,
@@ -647,6 +647,27 @@
       "addons": [],
       "inputType": "hidden",
       "id": "eq2uq2d"
+    },
+    {
+      "input": true,
+      "tableView": true,
+      "key": "maxUploadedFiles",
+      "label": "maxUploadedFiles",
+      "protected": false,
+      "unique": false,
+      "persistent": false,
+      "type": "hidden",
+      "tags": [],
+      "conditional": {
+        "show": "",
+        "when": null,
+        "eq": ""
+      },
+      "properties": {},
+      "defaultValue": "",
+      "lockKey": true,
+      "calculateValue": "value = 25;",
+      "calculateServer": true
     }
   ]
 }


### PR DESCRIPTION
- Set max number of documents to 25. Added a hidden component in each form to have it server calculated;
- All fileUploaders should be required to have at least 1 file;
- Changed some fileUploaders to allow multiple files (they allowed only one file to be uploaded);
- Removed "optional" of some labels;
- Kept same custom validation to all fileUploaders so it's easy to change it all occurrences across the forms:
```json
"validate": {
                "required": true,
                "customMessage": "You must upload at least one file, and the total number of uploaded files cannot exceed {{data.maxUploadedFiles}}.",
                "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? false : true;"
              }
```


![image](https://github.com/user-attachments/assets/88bed1ef-2b68-4ba8-9e15-6358dd4f2a56)

![image](https://github.com/user-attachments/assets/7665c862-3dac-4334-9c09-20b096ecbde7)


![image](https://github.com/user-attachments/assets/4270e54c-2444-40f0-9b8d-36e05a5c9fc6)

![image](https://github.com/user-attachments/assets/fe2c34d4-72fd-4bf9-b35e-090634f36a38)