### PR TITLE
#4405 - Exceptional expense exception question - FT Only

### DIFF
--- a/sources/packages/backend/workflow/src/workflow-definitions/load-assessment-consolidated-data.bpmn
+++ b/sources/packages/backend/workflow/src/workflow-definitions/load-assessment-consolidated-data.bpmn
@@ -128,7 +128,7 @@
           <zeebe:header key="partner1HasEmploymentInsuranceBenefits" value="$.supportingUsers.Partner1.supportingData.hasEmploymentInsuranceBenefits" />
           <zeebe:header key="partner1HasFedralProvincialPDReceipt" value="$.supportingUsers.Partner1.supportingData.hasFedralProvincialPDReceipt" />
           <zeebe:header key="partner1HasTotalIncomeAssistance" value="$.supportingUsers.Partner1.supportingData.hasTotalIncomeAssistance" />
-          <zeebe:header key="studentDataExceptionalExpense" value="$.data.exceptionalExpenseAmount" />
+          <zeebe:header key="studentDataExceptionalExpenseAmount" value="$.data.exceptionalExpenseAmount" />
         </zeebe:taskHeaders>
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_1jdhbms</bpmn:incoming>

--- a/sources/packages/backend/workflow/src/workflow-definitions/load-assessment-consolidated-data.bpmn
+++ b/sources/packages/backend/workflow/src/workflow-definitions/load-assessment-consolidated-data.bpmn
@@ -128,6 +128,7 @@
           <zeebe:header key="partner1HasEmploymentInsuranceBenefits" value="$.supportingUsers.Partner1.supportingData.hasEmploymentInsuranceBenefits" />
           <zeebe:header key="partner1HasFedralProvincialPDReceipt" value="$.supportingUsers.Partner1.supportingData.hasFedralProvincialPDReceipt" />
           <zeebe:header key="partner1HasTotalIncomeAssistance" value="$.supportingUsers.Partner1.supportingData.hasTotalIncomeAssistance" />
+          <zeebe:header key="studentDataExceptionalExpense" value="$.data.exceptionalExpenseAmount" />
         </zeebe:taskHeaders>
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_1jdhbms</bpmn:incoming>

--- a/sources/packages/backend/workflow/test/models/assessment.model.ts
+++ b/sources/packages/backend/workflow/test/models/assessment.model.ts
@@ -201,6 +201,7 @@ export interface AssessmentConsolidatedData extends JSONDoc {
   partner1HasEmploymentInsuranceBenefits?: YesNoOptions;
   partner1HasFedralProvincialPDReceipt?: YesNoOptions;
   partner1HasTotalIncomeAssistance?: YesNoOptions;
+  studentDataExceptionalExpense?: number;
 }
 
 /**

--- a/sources/packages/forms/src/form-definitions/sfaa2025-26.json
+++ b/sources/packages/forms/src/form-definitions/sfaa2025-26.json
@@ -22666,7 +22666,8 @@
               "inputMask": "",
               "decimalLimit": 0,
               "requireDecimal": false,
-              "tags": []
+              "tags": [],
+              "isNew": false
             },
             {
               "title": "CRA consent panel",
@@ -24446,7 +24447,7 @@
           "id": "erkahla"
         },
         {
-          "title": "Financial exceptional costs panel",
+          "title": "Financial exceptional expenses panel",
           "labelWidth": "",
           "labelMargin": "",
           "theme": "default",
@@ -24494,7 +24495,7 @@
                   "value": ""
                 }
               ],
-              "content": "Financial exceptional costs",
+              "content": "Financial exceptional expenses",
               "refreshOnChange": false,
               "key": "html88",
               "type": "htmlelement",
@@ -24539,7 +24540,7 @@
                 "unique": false
               },
               "conditional": {
-                "show": null,
+                "show": "",
                 "when": null,
                 "eq": ""
               },
@@ -24557,7 +24558,8 @@
               "properties": {},
               "allowMultipleMasks": false,
               "addons": [],
-              "id": "ejy5akn"
+              "id": "ejy5akn",
+              "tags": []
             },
             {
               "label": "HTML",
@@ -24806,7 +24808,9 @@
                   "allowMultipleMasks": false,
                   "addons": [],
                   "inputType": "hidden",
-                  "id": "e78m1ow"
+                  "id": "e78m1ow",
+                  "isNew": false,
+                  "tags": []
                 },
                 {
                   "label": "HTML",
@@ -25068,90 +25072,42 @@
                   "lockKey": true
                 },
                 {
-                  "label": "<h4 class='category-header-medium-small'>Please explain your situation:</h4><li>Type of expense and</li><li>When expenses occurred and</li><li>Amount</li>",
-                  "autoExpand": false,
-                  "tableView": true,
-                  "key": "otherExceptionalExpenseReason",
-                  "type": "textarea",
+                  "autofocus": false,
                   "input": true,
+                  "tableView": false,
+                  "inputType": "text",
+                  "inputMask": "",
+                  "label": "Please enter the combined exceptional expense amount rounded to the nearest dollar.",
+                  "key": "exceptionalExpenseAmount",
                   "placeholder": "",
-                  "prefix": "",
-                  "customClass": "",
+                  "prefix": "$",
                   "suffix": "",
-                  "multiple": false,
-                  "defaultValue": null,
+                  "defaultValue": "",
                   "protected": false,
-                  "unique": false,
                   "persistent": true,
                   "hidden": false,
                   "clearOnHide": true,
-                  "refreshOn": "",
-                  "redrawOn": "",
-                  "modalEdit": false,
-                  "dataGridLabel": false,
-                  "labelPosition": "top",
-                  "description": "",
-                  "errorLabel": "",
-                  "tooltip": "",
-                  "hideLabel": false,
-                  "tabindex": "",
-                  "disabled": false,
-                  "autofocus": false,
-                  "dbIndex": false,
-                  "customDefaultValue": "",
-                  "calculateValue": "",
-                  "calculateServer": false,
-                  "widget": {
-                    "type": "input"
-                  },
-                  "attributes": {},
-                  "validateOn": "change",
+                  "delimiter": true,
+                  "decimalLimit": 0,
+                  "requireDecimal": true,
                   "validate": {
-                    "required": false,
-                    "custom": "",
-                    "customPrivate": false,
-                    "strictDateValidation": false,
-                    "multiple": false,
-                    "unique": false,
-                    "minLength": "",
-                    "maxLength": "",
-                    "pattern": "",
-                    "minWords": "",
-                    "maxWords": ""
+                    "required": true,
+                    "multiple": "",
+                    "custom": "valid = (input >= 0 && input < 1000000) ? true : 'The number you have entered is outside the expected range.';"
                   },
                   "conditional": {
                     "show": "",
                     "when": null,
                     "eq": ""
                   },
-                  "overlay": {
-                    "style": "",
-                    "left": "",
-                    "top": "",
-                    "width": "",
-                    "height": ""
-                  },
-                  "allowCalculateOverride": false,
-                  "encrypted": false,
-                  "showCharCount": false,
-                  "showWordCount": false,
-                  "properties": {},
-                  "allowMultipleMasks": false,
-                  "addons": [],
-                  "mask": false,
-                  "inputType": "text",
-                  "inputFormat": "html",
-                  "inputMask": "",
-                  "displayMask": "",
-                  "spellcheck": true,
-                  "truncateMultipleSpaces": false,
-                  "rows": 3,
-                  "wysiwyg": false,
-                  "editor": "",
-                  "fixedSize": true,
-                  "id": "ekefms8",
+                  "type": "currency",
+                  "labelPosition": "top",
                   "tags": [],
-                  "lockKey": true
+                  "properties": {},
+                  "lockKey": true,
+                  "customClass": "font-weight-bold",
+                  "currency": "CAD",
+                  "isNew": false
                 },
                 {
                   "label": "HTML",
@@ -25311,7 +25267,7 @@
                       "value": ""
                     }
                   ],
-                  "content": "<h4 class=\"category-header-medium-small\">Documents required:</h4>\r\n<ul>\r\n  <li>A copy of your insurance or claim information</li>\r\n  <li>Receipts showing payment of costs</li>\r\n  <li>Bank statement</li>\r\n</ul>",
+                  "content": "<h4 class=\"category-header-medium-small\">Documents required</h4>\n<h4 class=\"category-header-medium-small\">Please provide:</h4>\n<ul>\n<li>a letter explaining your situation including the type of expense(s) and when the expense(s) occurred</li>\n</ul>\n<h4 class=\"category-header-medium-small\">and</h4>\n<h4 class=\"category-header-medium-small\">Please provide at least one of the following:\n</h4>\n<ul>\n<li>A copy of your insurance documents or claim information</li>\n<li>Receipt showing payment of costs</li>\n<li>Bank statement</li>\n</ul>",
                   "refreshOnChange": false,
                   "customClass": "align-bullets",
                   "key": "html24",
@@ -25356,7 +25312,7 @@
                     "unique": false
                   },
                   "conditional": {
-                    "show": null,
+                    "show": "",
                     "when": null,
                     "eq": ""
                   },
@@ -25376,7 +25332,8 @@
                   "addons": [],
                   "tag": "div",
                   "id": "evksdr7",
-                  "className": ""
+                  "className": "",
+                  "tags": []
                 },
                 {
                   "label": "HTML",
@@ -26232,7 +26189,8 @@
                   "inputType": "text",
                   "inputMask": "",
                   "decimalLimit": 2,
-                  "requireDecimal": true
+                  "requireDecimal": true,
+                  "isNew": false
                 }
               ],
               "allowPrevious": false,

--- a/sources/packages/forms/src/form-definitions/sfaa2025-26.json
+++ b/sources/packages/forms/src/form-definitions/sfaa2025-26.json
@@ -22666,8 +22666,7 @@
               "inputMask": "",
               "decimalLimit": 0,
               "requireDecimal": false,
-              "tags": [],
-              "isNew": false
+              "tags": []
             },
             {
               "title": "CRA consent panel",
@@ -24809,7 +24808,6 @@
                   "addons": [],
                   "inputType": "hidden",
                   "id": "e78m1ow",
-                  "isNew": false,
                   "tags": []
                 },
                 {
@@ -24895,7 +24893,7 @@
                       "value": ""
                     }
                   ],
-                  "content": "If you are living at home and need to pay room and board, additional expenses may be considered as part of your assessment.",
+                  "content": "If you have had exceptional expenses that created financial hardship that affected your ability to start or continue your studies these expenses may be considered as part of your assessment.",
                   "refreshOnChange": false,
                   "key": "html121",
                   "type": "htmlelement",
@@ -24940,7 +24938,7 @@
                     "unique": false
                   },
                   "conditional": {
-                    "show": null,
+                    "show": "",
                     "when": null,
                     "eq": ""
                   },
@@ -24960,7 +24958,8 @@
                   "addons": [],
                   "tag": "p",
                   "id": "e9vsa6r",
-                  "className": ""
+                  "className": "",
+                  "tags": []
                 },
                 {
                   "label": "Select the reason for your significant decrease in gross income:",
@@ -25106,8 +25105,7 @@
                   "properties": {},
                   "lockKey": true,
                   "customClass": "font-weight-bold",
-                  "currency": "CAD",
-                  "isNew": false
+                  "currency": "CAD"
                 },
                 {
                   "label": "HTML",
@@ -25183,81 +25181,6 @@
                   "allowMultipleMasks": false,
                   "addons": [],
                   "id": "eo1cjdj"
-                },
-                {
-                  "label": "HTML",
-                  "attrs": [
-                    {
-                      "attr": "",
-                      "value": ""
-                    }
-                  ],
-                  "content": "Please provide one of the documents below.",
-                  "refreshOnChange": false,
-                  "key": "html92",
-                  "type": "htmlelement",
-                  "input": false,
-                  "tableView": false,
-                  "placeholder": "",
-                  "prefix": "",
-                  "customClass": "",
-                  "suffix": "",
-                  "multiple": false,
-                  "defaultValue": null,
-                  "protected": false,
-                  "unique": false,
-                  "persistent": false,
-                  "hidden": false,
-                  "clearOnHide": true,
-                  "refreshOn": "",
-                  "redrawOn": "",
-                  "modalEdit": false,
-                  "dataGridLabel": false,
-                  "labelPosition": "top",
-                  "description": "",
-                  "errorLabel": "",
-                  "tooltip": "",
-                  "hideLabel": false,
-                  "tabindex": "",
-                  "disabled": false,
-                  "autofocus": false,
-                  "dbIndex": false,
-                  "customDefaultValue": "",
-                  "calculateValue": "",
-                  "calculateServer": false,
-                  "widget": null,
-                  "attributes": {},
-                  "validateOn": "change",
-                  "validate": {
-                    "required": false,
-                    "custom": "",
-                    "customPrivate": false,
-                    "strictDateValidation": false,
-                    "multiple": false,
-                    "unique": false
-                  },
-                  "conditional": {
-                    "show": null,
-                    "when": null,
-                    "eq": ""
-                  },
-                  "overlay": {
-                    "style": "",
-                    "left": "",
-                    "top": "",
-                    "width": "",
-                    "height": ""
-                  },
-                  "allowCalculateOverride": false,
-                  "encrypted": false,
-                  "showCharCount": false,
-                  "showWordCount": false,
-                  "properties": {},
-                  "allowMultipleMasks": false,
-                  "addons": [],
-                  "tag": "div",
-                  "id": "eq7e38",
-                  "className": ""
                 },
                 {
                   "label": "HTML",
@@ -26189,8 +26112,7 @@
                   "inputType": "text",
                   "inputMask": "",
                   "decimalLimit": 2,
-                  "requireDecimal": true,
-                  "isNew": false
+                  "requireDecimal": true
                 }
               ],
               "allowPrevious": false,


### PR DESCRIPTION
- Changed the section name to "Financial exceptional expenses".
- Changed the text under the section title to "If you have had exceptional expenses that created financial hardship that affected your ability to start or continue your studies these expenses may be considered as part of your assessment."
- Removed the current free entry field that exists entirely.
- Created a new numerical field with the following content.
  - Label: "Please enter the combined exceptional expense amount rounded to the nearest dollar."
  - Validation checks up to 6 digits also there can be no negative values. Decimal places is 0.
  - API key: `exceptionalExpenseAmount`.
- Changed the content to texts "Documents Provided" in the AC.
- Ensured that the currency field and the file uploader field are mandatory.
- Added `studentDataExceptionalExpenseAmount` to AssessmentConsolidatedData and load assessment bpmn file

Screenshot of changes on the financial exceptional expenses panel
![Screenshot 2025-03-31 110839](https://github.com/user-attachments/assets/f99e6258-320b-4014-a51d-12725fadefd1)

Screenshot of the exception on the ministry portal
![Screenshot 2025-03-28 101759](https://github.com/user-attachments/assets/2dbf6bd7-7620-4726-9f4e-362b3b91835e)
