### PR TITLE
#4511 - DB Migration and populate institution type on API response

### DIFF
--- a/sources/packages/backend/apps/api/src/route-controllers/education-program-offering/_tests_/e2e/education-program-offering.institutions.controller.createOffering.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/education-program-offering/_tests_/e2e/education-program-offering.institutions.controller.createOffering.e2e-spec.ts
@@ -427,6 +427,11 @@ describe("EducationProgramOfferingInstitutionsController(e2e)-createOffering", (
         offeringStatus: OfferingStatus.CreationPending,
         submittedDate: expect.any(Date),
         courseLoad: null,
+        onlineInstructionMode: null,
+        isOnlineDurationSameAlways: null,
+        totalOnlineDuration: null,
+        minimumOnlineDuration: null,
+        maximumOnlineDuration: null,
       });
     },
   );
@@ -498,6 +503,11 @@ describe("EducationProgramOfferingInstitutionsController(e2e)-createOffering", (
         offeringStatus: OfferingStatus.CreationPending,
         submittedDate: expect.any(Date),
         courseLoad: null,
+        onlineInstructionMode: null,
+        isOnlineDurationSameAlways: null,
+        totalOnlineDuration: null,
+        minimumOnlineDuration: null,
+        maximumOnlineDuration: null,
       });
     },
   );

--- a/sources/packages/backend/apps/api/src/route-controllers/education-program-offering/_tests_/e2e/education-program-offering.institutions.controller.updateProgramOffering.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/education-program-offering/_tests_/e2e/education-program-offering.institutions.controller.updateProgramOffering.e2e-spec.ts
@@ -435,6 +435,11 @@ describe("EducationProgramOfferingInstitutionsController(e2e)-updateProgramOffer
         offeringStatus: OfferingStatus.CreationPending,
         submittedDate: expect.any(Date),
         courseLoad: expect.any(Number),
+        onlineInstructionMode: null,
+        isOnlineDurationSameAlways: null,
+        totalOnlineDuration: null,
+        minimumOnlineDuration: null,
+        maximumOnlineDuration: null,
       });
     },
   );

--- a/sources/packages/backend/apps/api/src/route-controllers/education-program-offering/_tests_/e2e/education-program-offering.institutions.controller.updateProgramOffering.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/education-program-offering/_tests_/e2e/education-program-offering.institutions.controller.updateProgramOffering.e2e-spec.ts
@@ -533,6 +533,11 @@ describe("EducationProgramOfferingInstitutionsController(e2e)-updateProgramOffer
         offeringStatus: OfferingStatus.CreationPending,
         submittedDate: expect.any(Date),
         courseLoad: expect.any(Number),
+        onlineInstructionMode: null,
+        isOnlineDurationSameAlways: null,
+        totalOnlineDuration: null,
+        minimumOnlineDuration: null,
+        maximumOnlineDuration: null,
       });
     },
   );

--- a/sources/packages/backend/apps/api/src/route-controllers/education-program-offering/education-program-offering.controller.service.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/education-program-offering/education-program-offering.controller.service.ts
@@ -369,6 +369,10 @@ export class EducationProgramOfferingControllerService {
         (warning) => warning.typeCode,
       ),
       parentOfferingId: offering.parentOffering.id,
+      isInstitutionBCPrivate:
+        offering.institutionLocation.institution.institutionType.isBCPrivate,
+      isInstitutionBCPublic:
+        offering.institutionLocation.institution.institutionType.isBCPublic,
     };
   }
 

--- a/sources/packages/backend/apps/api/src/route-controllers/education-program-offering/models/education-program-offering.dto.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/education-program-offering/models/education-program-offering.dto.ts
@@ -126,6 +126,8 @@ export class EducationProgramOfferingAPIOutDTO {
   validationWarnings: string[];
   validationInfos: string[];
   parentOfferingId: number;
+  isInstitutionBCPublic: boolean;
+  isInstitutionBCPrivate: boolean;
 }
 
 export class EducationProgramOfferingSummaryViewAPIOutDTO {

--- a/sources/packages/backend/apps/api/src/services/education-program-offering/education-program-offering.service.ts
+++ b/sources/packages/backend/apps/api/src/services/education-program-offering/education-program-offering.service.ts
@@ -454,12 +454,14 @@ export class EducationProgramOfferingService extends RecordDataModelService<Educ
         "institutionLocation.name",
         "institution.legalOperatingName",
         "institution.operatingName",
+        "institutionType.id",
         "educationProgram.isActive",
         "educationProgram.effectiveEndDate",
       ])
       .innerJoin("offerings.educationProgram", "educationProgram")
       .innerJoin("offerings.institutionLocation", "institutionLocation")
       .innerJoin("institutionLocation.institution", "institution")
+      .innerJoin("institution.institutionType", "institutionType")
       .leftJoin("offerings.assessedBy", "assessedBy")
       .innerJoin("offerings.parentOffering", "parentOffering")
       .andWhere("offerings.id= :offeringId", {
@@ -866,6 +868,7 @@ export class EducationProgramOfferingService extends RecordDataModelService<Educ
         "institution.id",
         "institution.legalOperatingName",
         "institution.operatingName",
+        "institutionType.id",
         "educationProgram.id",
         "educationProgram.name",
         "educationProgram.description",
@@ -879,6 +882,7 @@ export class EducationProgramOfferingService extends RecordDataModelService<Educ
       .innerJoin("offering.educationProgram", "educationProgram")
       .innerJoin("offering.institutionLocation", "institutionLocation")
       .innerJoin("institutionLocation.institution", "institution")
+      .innerJoin("institution.institutionType", "institutionType")
       .leftJoin("offering.assessedBy", "assessedBy")
       .leftJoin("offering.precedingOffering", "precedingOffering")
       .innerJoin("offering.parentOffering", "parentOffering")

--- a/sources/packages/backend/apps/db-migrations/src/migrations/1743799586745-OfferingAddOnlineInstructionColumns.ts
+++ b/sources/packages/backend/apps/db-migrations/src/migrations/1743799586745-OfferingAddOnlineInstructionColumns.ts
@@ -1,0 +1,24 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+import { getSQLFileData } from "../utilities/sqlLoader";
+
+export class OfferingAddOnlineInstructionColumns1743799586745
+  implements MigrationInterface
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      getSQLFileData(
+        "Add-online-instruction-columns.sql",
+        "EducationProgramsOfferings",
+      ),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      getSQLFileData(
+        "Rollback-add-online-instruction-columns.sql",
+        "EducationProgramsOfferings",
+      ),
+    );
+  }
+}

--- a/sources/packages/backend/apps/db-migrations/src/sql/EducationProgramsOfferings/Add-online-instruction-columns.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/EducationProgramsOfferings/Add-online-instruction-columns.sql
@@ -20,3 +20,27 @@ COMMENT ON COLUMN sims.education_programs_offerings.total_online_duration IS 'Pe
 COMMENT ON COLUMN sims.education_programs_offerings.minimum_online_duration IS 'Percentage of minimum duration that will be provided by online delivery in the blended offering.';
 
 COMMENT ON COLUMN sims.education_programs_offerings.maximum_online_duration IS 'Percentage of maximum duration that will be provided by online delivery in the blended offering.';
+
+-- Add new columns to the history table. 
+ALTER TABLE
+    sims.education_programs_offerings_history
+ADD
+    COLUMN online_instruction_mode VARCHAR(50),
+ADD
+    COLUMN is_online_duration_same_always VARCHAR(3),
+ADD
+    COLUMN total_online_duration SMALLINT,
+ADD
+    COLUMN minimum_online_duration SMALLINT,
+ADD
+    COLUMN maximum_online_duration SMALLINT;
+
+COMMENT ON COLUMN sims.education_programs_offerings_history.online_instruction_mode IS 'Historical data from the original table. See original table comments for details.';
+
+COMMENT ON COLUMN sims.education_programs_offerings_history.is_online_duration_same_always IS 'Historical data from the original table. See original table comments for details.';
+
+COMMENT ON COLUMN sims.education_programs_offerings_history.total_online_duration IS 'Historical data from the original table. See original table comments for details.';
+
+COMMENT ON COLUMN sims.education_programs_offerings_history.minimum_online_duration IS 'Historical data from the original table. See original table comments for details.';
+
+COMMENT ON COLUMN sims.education_programs_offerings_history.maximum_online_duration IS 'Historical data from the original table. See original table comments for details.';

--- a/sources/packages/backend/apps/db-migrations/src/sql/EducationProgramsOfferings/Add-online-instruction-columns.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/EducationProgramsOfferings/Add-online-instruction-columns.sql
@@ -1,0 +1,22 @@
+ALTER TABLE
+    sims.education_programs_offerings
+ADD
+    COLUMN online_instruction_mode VARCHAR(50),
+ADD
+    COLUMN is_online_duration_same_always VARCHAR(3),
+ADD
+    COLUMN total_online_duration SMALLINT,
+ADD
+    COLUMN minimum_online_duration SMALLINT,
+ADD
+    COLUMN maximum_online_duration SMALLINT;
+
+COMMENT ON COLUMN sims.education_programs_offerings.online_instruction_mode IS 'Offering mode(s) of online instruction.';
+
+COMMENT ON COLUMN sims.education_programs_offerings.is_online_duration_same_always IS 'Specifies if the blended offering will always be provided with the same total duration of online delivery.';
+
+COMMENT ON COLUMN sims.education_programs_offerings.total_online_duration IS 'Percentage of total duration that will be provided by online delivery in the blended offering.';
+
+COMMENT ON COLUMN sims.education_programs_offerings.minimum_online_duration IS 'Percentage of minimum duration that will be provided by online delivery in the blended offering.';
+
+COMMENT ON COLUMN sims.education_programs_offerings.maximum_online_duration IS 'Percentage of maximum duration that will be provided by online delivery in the blended offering.';

--- a/sources/packages/backend/apps/db-migrations/src/sql/EducationProgramsOfferings/Rollback-add-online-instruction-columns.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/EducationProgramsOfferings/Rollback-add-online-instruction-columns.sql
@@ -1,0 +1,6 @@
+ALTER TABLE
+    sims.education_programs_offerings DROP COLUMN online_instruction_mode,
+    DROP COLUMN is_online_duration_same_always,
+    DROP COLUMN total_online_duration,
+    DROP COLUMN minimum_online_duration,
+    DROP COLUMN maximum_online_duration;

--- a/sources/packages/backend/apps/db-migrations/src/sql/EducationProgramsOfferings/Rollback-add-online-instruction-columns.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/EducationProgramsOfferings/Rollback-add-online-instruction-columns.sql
@@ -4,3 +4,11 @@ ALTER TABLE
     DROP COLUMN total_online_duration,
     DROP COLUMN minimum_online_duration,
     DROP COLUMN maximum_online_duration;
+
+-- Drop new columns from the history table.
+ALTER TABLE
+    sims.education_programs_offerings_history DROP COLUMN online_instruction_mode,
+    DROP COLUMN is_online_duration_same_always,
+    DROP COLUMN total_online_duration,
+    DROP COLUMN minimum_online_duration,
+    DROP COLUMN maximum_online_duration;

--- a/sources/packages/backend/libs/sims-db/src/entities/education-program-offering.model.ts
+++ b/sources/packages/backend/libs/sims-db/src/entities/education-program-offering.model.ts
@@ -271,6 +271,55 @@ export class EducationProgramOffering extends RecordDataModel {
     referencedColumnName: ColumnNames.ID,
   })
   precedingOffering?: EducationProgramOffering;
+
+  /**
+   * Offering mode(s) of online instruction.
+   */
+  @Column({
+    name: "online_instruction_mode",
+    nullable: true,
+  })
+  onlineInstructionMode?: string;
+
+  /**
+   * Specifies if the blended offering will always be provided with the same total duration of online delivery.
+   * Values can be "yes" or "no".
+   */
+  @Column({
+    name: "is_online_duration_same_always",
+    nullable: true,
+  })
+  isOnlineDurationSameAlways?: string;
+
+  /**
+   * Percentage of total duration that will be provided by online delivery in the blended offering.
+   */
+  @Column({
+    name: "total_online_duration",
+    type: "smallint",
+    nullable: true,
+  })
+  totalOnlineDuration?: number;
+
+  /**
+   * Percentage of minimum duration that will be provided by online delivery in the blended offering.
+   */
+  @Column({
+    name: "minimum_online_duration",
+    type: "smallint",
+    nullable: true,
+  })
+  minimumOnlineDuration?: number;
+
+  /**
+   * Percentage of maximum duration that will be provided by online delivery in the blended offering.
+   */
+  @Column({
+    name: "maximum_online_duration",
+    type: "smallint",
+    nullable: true,
+  })
+  maximumOnlineDuration?: number;
 }
 
 /**

--- a/sources/packages/web/src/components/common/OfferingForm.vue
+++ b/sources/packages/web/src/components/common/OfferingForm.vue
@@ -76,7 +76,9 @@ export default defineComponent({
       required: false,
     },
     data: {
-      type: Object as PropType<OfferingFormModel>,
+      type: Object as PropType<
+        OfferingFormModel | EducationProgramOfferingAPIOutDTO
+      >,
       required: false,
     },
     formMode: {

--- a/sources/packages/web/src/components/common/OfferingForm.vue
+++ b/sources/packages/web/src/components/common/OfferingForm.vue
@@ -47,7 +47,7 @@
 <script lang="ts">
 import { FormIOForm, OfferingFormModel, OfferingFormModes } from "@/types";
 import { defineComponent, PropType, computed, ref, watchEffect } from "vue";
-import { useInstitutionState, useOffering } from "@/composables";
+import { useOffering } from "@/composables";
 import {
   EducationProgramOfferingAPIInDTO,
   EducationProgramOfferingAPIOutDTO,
@@ -98,30 +98,15 @@ export default defineComponent({
     },
   },
   setup(props, context) {
-    const { institutionState } = useInstitutionState();
     const offeringData = ref(
       {} as EducationProgramOfferingAPIOutDTO | OfferingFormModel,
     );
     watchEffect(async () => {
-      // If the offeringId is provided, fetch the offering details based on the offeringId.
-      if (props.offeringId) {
-        offeringData.value =
-          await EducationProgramOfferingService.shared.getOfferingDetails(
+      offeringData.value = props.offeringId
+        ? await EducationProgramOfferingService.shared.getOfferingDetails(
             props.offeringId,
-          );
-      }
-      // If the data is provided, set the offeringData to the data passed in.
-      else if (props.data) {
-        offeringData.value = props.data as OfferingFormModel;
-      }
-      // When the offering is created, the component will neither receive the data nor the offeringId.
-      // In this case, set the initial data that is required for the form on the initialization.
-      else {
-        offeringData.value = {
-          isInstitutionBCPublic: institutionState.value.isBCPublic,
-          isInstitutionBCPrivate: institutionState.value.isBCPrivate,
-        } as EducationProgramOfferingAPIOutDTO;
-      }
+          )
+        : (props.data as OfferingFormModel);
     });
     const { mapOfferingChipStatus } = useOffering();
     const submitOffering = (

--- a/sources/packages/web/src/components/common/OfferingFormSubmit.vue
+++ b/sources/packages/web/src/components/common/OfferingFormSubmit.vue
@@ -156,6 +156,8 @@ export default defineComponent({
             warningsTypes,
           );
         }
+        // Update the validation date from the API result.
+        lastCalculationDate = validationResult.validationDate;
       }
       return validationResult;
     };

--- a/sources/packages/web/src/services/http/dto/EducationProgramOffering.dto.ts
+++ b/sources/packages/web/src/services/http/dto/EducationProgramOffering.dto.ts
@@ -135,6 +135,8 @@ export interface EducationProgramOfferingAPIOutDTO {
   validationWarnings: string[];
   validationInfos: string[];
   parentOfferingId: number;
+  isInstitutionBCPublic: boolean;
+  isInstitutionBCPrivate: boolean;
 }
 
 export interface StudyBreakAPIOutDTO {

--- a/sources/packages/web/src/views/institution/locations/offerings/OfferingCreate.vue
+++ b/sources/packages/web/src/views/institution/locations/offerings/OfferingCreate.vue
@@ -10,6 +10,7 @@
     <offering-form-submit
       submitLabel="Add offering now"
       :formMode="OfferingFormModes.Editable"
+      :data="initialData"
       :locationId="locationId"
       :programId="programId"
       @submit="submit"
@@ -31,8 +32,15 @@ import { InstitutionRoutesConst } from "@/constants/routes/RouteConstants";
 import OfferingFormSubmit from "@/components/common/OfferingFormSubmit.vue";
 import { BannerTypes } from "@/types/contracts/Banner";
 import { EducationProgramOfferingService } from "@/services/EducationProgramOfferingService";
-import { EducationProgramOfferingAPIInDTO } from "@/services/http/dto";
-import { useFormioUtils, useSnackBar } from "@/composables";
+import {
+  EducationProgramOfferingAPIInDTO,
+  EducationProgramOfferingAPIOutDTO,
+} from "@/services/http/dto";
+import {
+  useFormioUtils,
+  useInstitutionState,
+  useSnackBar,
+} from "@/composables";
 
 export default defineComponent({
   components: {
@@ -55,8 +63,18 @@ export default defineComponent({
   setup(props) {
     const snackBar = useSnackBar();
     const { excludeExtraneousValues } = useFormioUtils();
+    const { institutionState } = useInstitutionState();
     const router = useRouter();
     const processing = ref(false);
+
+    // Populate the institution type data for form input loading variations.
+    const initialData = computed(
+      () =>
+        ({
+          isInstitutionBCPublic: institutionState.value.isBCPublic,
+          isInstitutionBCPrivate: institutionState.value.isBCPrivate,
+        } as EducationProgramOfferingAPIOutDTO),
+    );
 
     const routeLocation = computed(() => ({
       name: InstitutionRoutesConst.VIEW_LOCATION_PROGRAMS,
@@ -105,6 +123,7 @@ export default defineComponent({
       goBack,
       OfferingFormModes,
       submit,
+      initialData,
     };
   },
 });

--- a/sources/packages/web/src/views/institution/locations/offerings/OfferingCreate.vue
+++ b/sources/packages/web/src/views/institution/locations/offerings/OfferingCreate.vue
@@ -10,7 +10,6 @@
     <offering-form-submit
       submitLabel="Add offering now"
       :formMode="OfferingFormModes.Editable"
-      :data="initialData"
       :locationId="locationId"
       :programId="programId"
       @submit="submit"
@@ -32,15 +31,8 @@ import { InstitutionRoutesConst } from "@/constants/routes/RouteConstants";
 import OfferingFormSubmit from "@/components/common/OfferingFormSubmit.vue";
 import { BannerTypes } from "@/types/contracts/Banner";
 import { EducationProgramOfferingService } from "@/services/EducationProgramOfferingService";
-import {
-  EducationProgramOfferingAPIInDTO,
-  EducationProgramOfferingAPIOutDTO,
-} from "@/services/http/dto";
-import {
-  useFormioUtils,
-  useInstitutionState,
-  useSnackBar,
-} from "@/composables";
+import { EducationProgramOfferingAPIInDTO } from "@/services/http/dto";
+import { useFormioUtils, useSnackBar } from "@/composables";
 
 export default defineComponent({
   components: {
@@ -63,18 +55,8 @@ export default defineComponent({
   setup(props) {
     const snackBar = useSnackBar();
     const { excludeExtraneousValues } = useFormioUtils();
-    const { institutionState } = useInstitutionState();
     const router = useRouter();
     const processing = ref(false);
-
-    // Populate the institution type data for form input loading variations.
-    const initialData = computed(
-      () =>
-        ({
-          isInstitutionBCPublic: institutionState.value.isBCPublic,
-          isInstitutionBCPrivate: institutionState.value.isBCPrivate,
-        } as EducationProgramOfferingAPIOutDTO),
-    );
 
     const routeLocation = computed(() => ({
       name: InstitutionRoutesConst.VIEW_LOCATION_PROGRAMS,
@@ -123,7 +105,6 @@ export default defineComponent({
       goBack,
       OfferingFormModes,
       submit,
-      initialData,
     };
   },
 });

--- a/sources/packages/web/src/views/institution/locations/offerings/OfferingCreate.vue
+++ b/sources/packages/web/src/views/institution/locations/offerings/OfferingCreate.vue
@@ -10,6 +10,7 @@
     <offering-form-submit
       submitLabel="Add offering now"
       :formMode="OfferingFormModes.Editable"
+      :data="initialData"
       :locationId="locationId"
       :programId="programId"
       @submit="submit"
@@ -31,8 +32,15 @@ import { InstitutionRoutesConst } from "@/constants/routes/RouteConstants";
 import OfferingFormSubmit from "@/components/common/OfferingFormSubmit.vue";
 import { BannerTypes } from "@/types/contracts/Banner";
 import { EducationProgramOfferingService } from "@/services/EducationProgramOfferingService";
-import { EducationProgramOfferingAPIInDTO } from "@/services/http/dto";
-import { useFormioUtils, useSnackBar } from "@/composables";
+import {
+  EducationProgramOfferingAPIInDTO,
+  EducationProgramOfferingAPIOutDTO,
+} from "@/services/http/dto";
+import {
+  useFormioUtils,
+  useInstitutionState,
+  useSnackBar,
+} from "@/composables";
 
 export default defineComponent({
   components: {
@@ -55,8 +63,18 @@ export default defineComponent({
   setup(props) {
     const snackBar = useSnackBar();
     const { excludeExtraneousValues } = useFormioUtils();
+    const { institutionState } = useInstitutionState();
     const router = useRouter();
     const processing = ref(false);
+
+    // During the creation, set the initial data that is required for the form on the initialization.
+    const initialData = computed(
+      () =>
+        ({
+          isInstitutionBCPublic: institutionState.value.isBCPublic,
+          isInstitutionBCPrivate: institutionState.value.isBCPrivate,
+        } as EducationProgramOfferingAPIOutDTO),
+    );
 
     const routeLocation = computed(() => ({
       name: InstitutionRoutesConst.VIEW_LOCATION_PROGRAMS,
@@ -105,6 +123,7 @@ export default defineComponent({
       goBack,
       OfferingFormModes,
       submit,
+      initialData,
     };
   },
 });


### PR DESCRIPTION
## DB Migration and institution type related variables in API Response

- [x]  Added DB Migration for the new offering data collection fields including the history table as they must go together.
- [x] Added variables to indicate the institution type if it is `BCPublic` or `BC Private` in API responses to be sent to form.io
- [x] During Offering creation, load institution type related properties from store to inject to form.io, as the offering form in this case does not have `initialData` or `offeringId`.


## Rollback Evidence

![image](https://github.com/user-attachments/assets/56c30725-b494-41c2-9cd7-91cb43b90748)

![image](https://github.com/user-attachments/assets/653157b6-5423-424f-b4e2-847cbbda36ea)

![image](https://github.com/user-attachments/assets/73b71aa4-e140-4002-adb6-94014abbd70a)

## Upcoming PR

- Form.io definition changes
- Offering validation model changes
- E2E changes/adjustments
