### PR TITLE
#4489 - Formio Changes: Split FT/PT [Bug Fix]

### DIFF
--- a/sources/packages/web/src/components/common/StudentApplication.vue
+++ b/sources/packages/web/src/components/common/StudentApplication.vue
@@ -232,6 +232,7 @@ export default defineComponent({
       if (educationProgramIdFromForm && selectedIntensity) {
         // when isReadOnly.value is true, then consider
         // both active and inactive program year.
+        formioUtils.setComponentValue(form, OFFERINGS_DROPDOWN_KEY, "");
         await formioDataLoader.loadOfferingsForLocation(
           form,
           educationProgramIdFromForm,
@@ -249,10 +250,7 @@ export default defineComponent({
         form,
         LOCATIONS_DROPDOWN_KEY,
       );
-      if (
-        event.changed?.component.key === LOCATIONS_DROPDOWN_KEY ||
-        event.changed?.component.key === OFFERING_INTENSITY_KEY
-      ) {
+      if (event.changed?.component.key === LOCATIONS_DROPDOWN_KEY) {
         /*
         If `programnotListed` is already checked in the draft and
         when student edit the draft application and changes the
@@ -266,6 +264,7 @@ export default defineComponent({
         if (selectedLocationId) {
           // when isReadOnly.value is true, then consider
           // both active and inactive program year.
+          formioUtils.setComponentValue(form, PROGRAMS_DROPDOWN_KEY, "");
           await formioDataLoader.loadProgramsForLocation(
             form,
             +selectedLocationId,


### PR DESCRIPTION
### As a part of this PR, the following bug was fixed:

**Bug:** When the institution location is selected in the dropdown for the student application, the program component does not refresh properly and still holds the previous (stale) data in the dropdown along with the new data for the newly selected location.

**Fix:** To fix the above issue, I have added the below code snippet to force remove the stale data from both the programs and offerings dropdown before loading the fresh data.

**Code modification:** `formioUtils.setComponentValue(form, PROGRAMS_DROPDOWN_KEY, "");`

