### PR TITLE
#4511 - Offering data collection - API Validation and Form Inputs

### DIFF
--- a/sources/packages/backend/apps/api/src/route-controllers/education-program-offering/_tests_/e2e/education-program-offering.institutions.controller.createOffering.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/education-program-offering/_tests_/e2e/education-program-offering.institutions.controller.createOffering.e2e-spec.ts
@@ -35,7 +35,7 @@ import {
   StudyBreakAPIOutDTO,
   StudyBreaksAndWeeksOutDTO,
 } from "../../models/education-program-offering.dto";
-import { WILComponentOptions } from "../../../../services";
+import { OfferingYesNoOptions } from "../../../../services";
 import { getISODateOnlyString } from "@sims/utilities";
 import { InstitutionUserTypes } from "../../../../auth";
 
@@ -80,7 +80,7 @@ describe("EducationProgramOfferingInstitutionsController(e2e)-createOffering", (
       yearOfStudy: 1,
       offeringIntensity: OfferingIntensity.fullTime,
       offeringDelivered: OfferingDeliveryOptions.Onsite,
-      hasOfferingWILComponent: WILComponentOptions.No,
+      hasOfferingWILComponent: OfferingYesNoOptions.No,
       studyStartDate: "2023-09-01",
       studyEndDate: "2024-06-30",
       lacksStudyBreaks: false,

--- a/sources/packages/backend/apps/api/src/route-controllers/education-program-offering/education-program-offering.controller.service.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/education-program-offering/education-program-offering.controller.service.ts
@@ -197,6 +197,11 @@ export class EducationProgramOfferingControllerService {
       primaryEmail: institutionLocation.institution.primaryEmail,
       studyBreaks: payload.studyBreaks,
       programContext: program,
+      institutionContext: {
+        isBCPrivate:
+          institutionLocation.institution.institutionType.isBCPrivate,
+        isBCPublic: institutionLocation.institution.institutionType.isBCPublic,
+      },
     };
   }
 

--- a/sources/packages/backend/apps/api/src/route-controllers/education-program-offering/education-program-offering.controller.service.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/education-program-offering/education-program-offering.controller.service.ts
@@ -29,6 +29,8 @@ import {
   OfferingValidationModel,
   CreateFromValidatedOfferingError,
   InstitutionLocationService,
+  OnlineInstructionModeOptions,
+  OfferingYesNoOptions,
 } from "../../services";
 import {
   credentialTypeToDisplay,
@@ -188,10 +190,6 @@ export class EducationProgramOfferingControllerService {
     // Get institution location details.
     const institutionLocation =
       await this.institutionLocationService.getInstitutionLocation(locationId);
-    console.log(
-      "Is BC Public",
-      institutionLocation.institution.institutionType.isBCPrivate,
-    );
     return {
       ...payload,
       locationId,
@@ -382,6 +380,13 @@ export class EducationProgramOfferingControllerService {
         offering.institutionLocation.institution.institutionType.isBCPrivate,
       isInstitutionBCPublic:
         offering.institutionLocation.institution.institutionType.isBCPublic,
+      onlineInstructionMode:
+        offering.onlineInstructionMode as OnlineInstructionModeOptions,
+      isOnlineDurationSameAlways:
+        offering.isOnlineDurationSameAlways as OfferingYesNoOptions,
+      totalOnlineDuration: offering.totalOnlineDuration,
+      minimumOnlineDuration: offering.minimumOnlineDuration,
+      maximumOnlineDuration: offering.maximumOnlineDuration,
     };
   }
 

--- a/sources/packages/backend/apps/api/src/route-controllers/education-program-offering/education-program-offering.controller.service.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/education-program-offering/education-program-offering.controller.service.ts
@@ -188,6 +188,10 @@ export class EducationProgramOfferingControllerService {
     // Get institution location details.
     const institutionLocation =
       await this.institutionLocationService.getInstitutionLocation(locationId);
+    console.log(
+      "Is BC Public",
+      institutionLocation.institution.institutionType.isBCPrivate,
+    );
     return {
       ...payload,
       locationId,

--- a/sources/packages/backend/apps/api/src/route-controllers/education-program-offering/education-program-offering.controller.service.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/education-program-offering/education-program-offering.controller.service.ts
@@ -376,9 +376,9 @@ export class EducationProgramOfferingControllerService {
         (warning) => warning.typeCode,
       ),
       parentOfferingId: offering.parentOffering.id,
-      isInstitutionBCPrivate:
+      isBCPrivate:
         offering.institutionLocation.institution.institutionType.isBCPrivate,
-      isInstitutionBCPublic:
+      isBCPublic:
         offering.institutionLocation.institution.institutionType.isBCPublic,
       onlineInstructionMode:
         offering.onlineInstructionMode as OnlineInstructionModeOptions,

--- a/sources/packages/backend/apps/api/src/route-controllers/education-program-offering/education-program-offering.institutions.controller.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/education-program-offering/education-program-offering.institutions.controller.ts
@@ -125,7 +125,6 @@ export class EducationProgramOfferingInstitutionsController extends BaseControll
         programId,
         payload,
       );
-
     const offeringValidation =
       this.offeringValidationService.validateOfferingModel(
         offeringValidationModel,
@@ -261,7 +260,6 @@ export class EducationProgramOfferingInstitutionsController extends BaseControll
     }
 
     try {
-      console.log("Online mode payload", payload.onlineInstructionMode);
       const offeringValidationModel =
         await this.educationProgramOfferingControllerService.buildOfferingValidationModel(
           userToken.authorizations.institutionId,

--- a/sources/packages/backend/apps/api/src/route-controllers/education-program-offering/education-program-offering.institutions.controller.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/education-program-offering/education-program-offering.institutions.controller.ts
@@ -261,6 +261,7 @@ export class EducationProgramOfferingInstitutionsController extends BaseControll
     }
 
     try {
+      console.log("Online mode payload", payload.onlineInstructionMode);
       const offeringValidationModel =
         await this.educationProgramOfferingControllerService.buildOfferingValidationModel(
           userToken.authorizations.institutionId,

--- a/sources/packages/backend/apps/api/src/route-controllers/education-program-offering/education-program-offering.institutions.controller.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/education-program-offering/education-program-offering.institutions.controller.ts
@@ -125,6 +125,7 @@ export class EducationProgramOfferingInstitutionsController extends BaseControll
         programId,
         payload,
       );
+
     const offeringValidation =
       this.offeringValidationService.validateOfferingModel(
         offeringValidationModel,

--- a/sources/packages/backend/apps/api/src/route-controllers/education-program-offering/models/education-program-offering.dto.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/education-program-offering/models/education-program-offering.dto.ts
@@ -82,6 +82,16 @@ export class EducationProgramOfferingAPIInDTO {
   studyBreaks: StudyBreakInDTO[];
   @Allow()
   courseLoad?: number;
+  @Allow()
+  onlineInstructionMode?: string;
+  @Allow()
+  isOnlineDurationSameAlways?: string;
+  @Allow()
+  totalOnlineDuration?: number;
+  @Allow()
+  minimumOnlineDuration?: number;
+  @Allow()
+  maximumOnlineDuration?: number;
 }
 
 /**

--- a/sources/packages/backend/apps/api/src/route-controllers/education-program-offering/models/education-program-offering.dto.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/education-program-offering/models/education-program-offering.dto.ts
@@ -9,7 +9,8 @@ import { Allow, IsEnum, IsIn, IsNotEmpty, MaxLength } from "class-validator";
 import { Type } from "class-transformer";
 import {
   OfferingDeliveryOptions,
-  WILComponentOptions,
+  OnlineInstructionModeOptions,
+  OfferingYesNoOptions,
 } from "../../../services";
 
 export class StudyBreakAPIOutDTO {
@@ -68,7 +69,7 @@ export class EducationProgramOfferingAPIInDTO {
   @Allow()
   yearOfStudy: number;
   @Allow()
-  hasOfferingWILComponent: WILComponentOptions;
+  hasOfferingWILComponent: OfferingYesNoOptions;
   @Allow()
   offeringDeclaration: boolean;
   @Allow()
@@ -83,9 +84,9 @@ export class EducationProgramOfferingAPIInDTO {
   @Allow()
   courseLoad?: number;
   @Allow()
-  onlineInstructionMode?: string;
+  onlineInstructionMode?: OnlineInstructionModeOptions;
   @Allow()
-  isOnlineDurationSameAlways?: string;
+  isOnlineDurationSameAlways?: OfferingYesNoOptions;
   @Allow()
   totalOnlineDuration?: number;
   @Allow()

--- a/sources/packages/backend/apps/api/src/route-controllers/education-program-offering/models/education-program-offering.dto.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/education-program-offering/models/education-program-offering.dto.ts
@@ -139,6 +139,11 @@ export class EducationProgramOfferingAPIOutDTO {
   parentOfferingId: number;
   isInstitutionBCPublic: boolean;
   isInstitutionBCPrivate: boolean;
+  onlineInstructionMode?: OnlineInstructionModeOptions;
+  isOnlineDurationSameAlways?: OfferingYesNoOptions;
+  totalOnlineDuration?: number;
+  minimumOnlineDuration?: number;
+  maximumOnlineDuration?: number;
 }
 
 export class EducationProgramOfferingSummaryViewAPIOutDTO {

--- a/sources/packages/backend/apps/api/src/route-controllers/education-program-offering/models/education-program-offering.dto.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/education-program-offering/models/education-program-offering.dto.ts
@@ -137,8 +137,8 @@ export class EducationProgramOfferingAPIOutDTO {
   validationWarnings: string[];
   validationInfos: string[];
   parentOfferingId: number;
-  isInstitutionBCPublic: boolean;
-  isInstitutionBCPrivate: boolean;
+  isBCPublic: boolean;
+  isBCPrivate: boolean;
   onlineInstructionMode?: OnlineInstructionModeOptions;
   isOnlineDurationSameAlways?: OfferingYesNoOptions;
   totalOnlineDuration?: number;

--- a/sources/packages/backend/apps/api/src/services/education-program-offering/custom-validators/program-allows-offering-wil.ts
+++ b/sources/packages/backend/apps/api/src/services/education-program-offering/custom-validators/program-allows-offering-wil.ts
@@ -7,7 +7,7 @@ import {
 } from "class-validator";
 import {
   OfferingValidationModel,
-  WILComponentOptions,
+  OfferingYesNoOptions,
 } from "../education-program-offering-validation.models";
 
 /**
@@ -19,7 +19,7 @@ class ProgramAllowsOfferingWILConstraint
   implements ValidatorConstraintInterface
 {
   validate(
-    offeringWIL: WILComponentOptions,
+    offeringWIL: OfferingYesNoOptions,
     args: ValidationArguments,
   ): boolean {
     const offeringModel = args.object as OfferingValidationModel;
@@ -27,8 +27,8 @@ class ProgramAllowsOfferingWILConstraint
       return false;
     }
     if (
-      offeringWIL === WILComponentOptions.Yes &&
-      offeringModel.programContext.hasWILComponent === WILComponentOptions.No
+      offeringWIL === OfferingYesNoOptions.Yes &&
+      offeringModel.programContext.hasWILComponent === OfferingYesNoOptions.No
     ) {
       return false;
     }
@@ -38,7 +38,7 @@ class ProgramAllowsOfferingWILConstraint
   defaultMessage(args: ValidationArguments) {
     const [propertyDisplayName] = args.constraints;
     return `${propertyDisplayName ?? args.property} is defined as ${
-      WILComponentOptions.Yes
+      OfferingYesNoOptions.Yes
     } but the program does not allow WIL(work-integrated learning).`;
   }
 }

--- a/sources/packages/backend/apps/api/src/services/education-program-offering/education-program-offering-import-csv.service.ts
+++ b/sources/packages/backend/apps/api/src/services/education-program-offering/education-program-offering-import-csv.service.ts
@@ -3,7 +3,7 @@ import { EducationProgram, OfferingTypes } from "@sims/sims-db";
 import { EducationProgramService, InstitutionLocationService } from "..";
 import {
   OfferingValidationModel,
-  WILComponentOptions,
+  OfferingYesNoOptions,
 } from "./education-program-offering-validation.models";
 import {
   CSVHeaders,
@@ -65,8 +65,8 @@ export class EducationProgramOfferingImportCSVService {
       offeringDelivered: csvModel.offeringDelivered,
       hasOfferingWILComponent:
         csvModel.WILComponent === YesNoOptions.Yes
-          ? WILComponentOptions.Yes
-          : WILComponentOptions.No,
+          ? OfferingYesNoOptions.Yes
+          : OfferingYesNoOptions.No,
       offeringWILComponentType: csvModel.WILComponentType,
       studyStartDate: csvModel.studyStartDate,
       studyEndDate: csvModel.studyEndDate,

--- a/sources/packages/backend/apps/api/src/services/education-program-offering/education-program-offering-validation.models.ts
+++ b/sources/packages/backend/apps/api/src/services/education-program-offering/education-program-offering-validation.models.ts
@@ -675,6 +675,10 @@ export class OfferingValidationModel {
         OfferingDeliveryOptions.Online,
         OfferingDeliveryOptions.Blended,
       ].includes(offering.offeringDelivered),
+    undefined,
+    {
+      message: `${userFriendlyNames.onlineInstructionMode} is not allowed for provided institution type or offering delivery type and offering online delivery inputs.`,
+    },
   )
   @IsEnum(OnlineInstructionModeOptions, {
     message: getEnumFormatMessage(
@@ -701,6 +705,10 @@ export class OfferingValidationModel {
       (offering.institutionContext?.isBCPrivate ||
         offering.institutionContext?.isBCPublic) &&
       offering.offeringDelivered == OfferingDeliveryOptions.Blended,
+    undefined,
+    {
+      message: `${userFriendlyNames.isOnlineDurationSameAlways} is not allowed for provided institution type or offering delivery type and offering online delivery inputs.`,
+    },
   )
   @IsEnum(OfferingYesNoOptions, {
     message: getEnumFormatMessage(
@@ -730,6 +738,10 @@ export class OfferingValidationModel {
         offering.institutionContext?.isBCPublic) &&
       offering.offeringDelivered == OfferingDeliveryOptions.Blended &&
       offering.isOnlineDurationSameAlways === OfferingYesNoOptions.Yes,
+    undefined,
+    {
+      message: `${userFriendlyNames.totalOnlineDuration} is not allowed for provided institution type or offering delivery type and offering online delivery inputs.`,
+    },
   )
   @IsNumber()
   @Min(1, {
@@ -758,6 +770,10 @@ export class OfferingValidationModel {
         offering.institutionContext?.isBCPublic) &&
       offering.offeringDelivered == OfferingDeliveryOptions.Blended &&
       offering.isOnlineDurationSameAlways === OfferingYesNoOptions.No,
+    undefined,
+    {
+      message: `${userFriendlyNames.minimumOnlineDuration} is not allowed for provided institution type or offering delivery type and offering online delivery inputs.`,
+    },
   )
   @IsNumber()
   @Min(1, {
@@ -788,6 +804,10 @@ export class OfferingValidationModel {
         offering.institutionContext?.isBCPublic) &&
       offering.offeringDelivered == OfferingDeliveryOptions.Blended &&
       offering.isOnlineDurationSameAlways === OfferingYesNoOptions.No,
+    undefined,
+    {
+      message: `${userFriendlyNames.maximumOnlineDuration} is not allowed for provided institution type or offering delivery type and offering online delivery inputs.`,
+    },
   )
   @IsNumber()
   @Min(1, {

--- a/sources/packages/backend/apps/api/src/services/education-program-offering/education-program-offering-validation.models.ts
+++ b/sources/packages/backend/apps/api/src/services/education-program-offering/education-program-offering-validation.models.ts
@@ -21,6 +21,7 @@ import {
   OFFERING_NAME_MAX_LENGTH,
   OFFERING_WIL_TYPE_MAX_LENGTH,
   StudyBreaksAndWeeks,
+  InstitutionType,
 } from "@sims/sims-db";
 import {
   IsPeriodStartDate,
@@ -163,6 +164,14 @@ export type EducationProgramForOfferingValidationContext = Pick<
   | "hasWILComponent"
   | "deliveredOnSite"
   | "deliveredOnline"
+>;
+
+/**
+ * Institution details required to perform the offering validations.
+ */
+export type InstitutionValidationContext = Pick<
+  InstitutionType,
+  "isBCPublic" | "isBCPrivate"
 >;
 
 /**
@@ -614,6 +623,12 @@ export class OfferingValidationModel {
       "Not able to find a program related to this offering or it was not provided.",
   })
   programContext: EducationProgramForOfferingValidationContext;
+
+  @ValidateIf((offering: OfferingValidationModel) => !!offering.locationId)
+  @IsNotEmptyObject(undefined, {
+    message: "Not able to find the institution of the offering.",
+  })
+  institutionContext: InstitutionValidationContext;
 }
 
 /**

--- a/sources/packages/backend/apps/api/src/services/education-program-offering/education-program-offering-validation.models.ts
+++ b/sources/packages/backend/apps/api/src/services/education-program-offering/education-program-offering-validation.models.ts
@@ -36,6 +36,7 @@ import {
   ValidationContext,
   IsMaxCostValue,
   AllowIf,
+  IsNumberGreaterThan,
 } from "../../utilities/class-validation";
 import { Type } from "class-transformer";
 import { ProgramAllowsOfferingIntensity } from "./custom-validators/program-allows-offering-intensity";
@@ -87,6 +88,8 @@ const userFriendlyNames = {
   onlineInstructionMode: "Online instruction mode",
   isOnlineDurationSameAlways: "Online duration same always",
   totalOnlineDuration: "Total online duration",
+  minimumOnlineDuration: "Minimum online duration",
+  maximumOnlineDuration: "Maximum online duration",
 };
 
 /**
@@ -760,7 +763,9 @@ export class OfferingValidationModel {
   @Min(1, {
     message: getMinFormatMessage(userFriendlyNames.totalOnlineDuration),
   })
-  @Max(99)
+  @Max(99, {
+    message: getMaxFormatMessage(userFriendlyNames.maximumOnlineDuration, 99),
+  })
   minimumOnlineDuration?: number;
 
   /**
@@ -786,9 +791,18 @@ export class OfferingValidationModel {
   )
   @IsNumber()
   @Min(1, {
-    message: getMinFormatMessage(userFriendlyNames.totalOnlineDuration),
+    message: getMinFormatMessage(userFriendlyNames.maximumOnlineDuration, 1),
   })
-  @Max(99)
+  @Max(99, {
+    message: getMaxFormatMessage(userFriendlyNames.maximumOnlineDuration, 99),
+  })
+  @IsNumberGreaterThan(
+    (offering: OfferingValidationModel) => offering.minimumOnlineDuration,
+    undefined,
+    {
+      message: `${userFriendlyNames.maximumOnlineDuration} must be greater than ${userFriendlyNames.minimumOnlineDuration}.`,
+    },
+  )
   maximumOnlineDuration?: number;
 }
 

--- a/sources/packages/backend/apps/api/src/services/education-program-offering/education-program-offering-validation.models.ts
+++ b/sources/packages/backend/apps/api/src/services/education-program-offering/education-program-offering-validation.models.ts
@@ -7,6 +7,7 @@ import {
   IsNotEmptyObject,
   IsNumber,
   IsNumberOptions,
+  IsOptional,
   IsPositive,
   Max,
   MaxLength,
@@ -642,7 +643,8 @@ export class OfferingValidationModel {
   /**
    * Institution information required to execute the offering validation.
    */
-  @ValidateIf((offering: OfferingValidationModel) => !!offering.locationId)
+  @IsOptional()
+  // When the context is provided, it must be valid.
   @IsNotEmptyObject(undefined, {
     message: "Not able to find the institution of the offering.",
   })

--- a/sources/packages/backend/apps/api/src/services/education-program-offering/education-program-offering.service.ts
+++ b/sources/packages/backend/apps/api/src/services/education-program-offering/education-program-offering.service.ts
@@ -449,6 +449,11 @@ export class EducationProgramOfferingService extends RecordDataModelService<Educ
         "offerings.offeringStatus",
         "offerings.courseLoad",
         "offerings.parentOffering",
+        "offerings.onlineInstructionMode",
+        "offerings.isOnlineDurationSameAlways",
+        "offerings.totalOnlineDuration",
+        "offerings.maximumOnlineDuration",
+        "offerings.minimumOnlineDuration",
         "assessedBy.firstName",
         "assessedBy.lastName",
         "institutionLocation.name",
@@ -577,7 +582,6 @@ export class EducationProgramOfferingService extends RecordDataModelService<Educ
   private populateProgramOffering(
     educationProgramOffering: OfferingValidationModel,
   ): EducationProgramOffering {
-    console.log(educationProgramOffering);
     const programOffering = new EducationProgramOffering();
     programOffering.name = educationProgramOffering.offeringName;
     programOffering.studyStartDate = educationProgramOffering.studyStartDate;
@@ -621,6 +625,14 @@ export class EducationProgramOfferingService extends RecordDataModelService<Educ
       EducationProgramOfferingService.assignStudyBreaks(calculatedBreaks);
     programOffering.onlineInstructionMode =
       educationProgramOffering.onlineInstructionMode;
+    programOffering.isOnlineDurationSameAlways =
+      educationProgramOffering.isOnlineDurationSameAlways;
+    programOffering.totalOnlineDuration =
+      educationProgramOffering.totalOnlineDuration;
+    programOffering.minimumOnlineDuration =
+      educationProgramOffering.minimumOnlineDuration;
+    programOffering.maximumOnlineDuration =
+      educationProgramOffering.maximumOnlineDuration;
 
     return programOffering;
   }
@@ -863,6 +875,11 @@ export class EducationProgramOfferingService extends RecordDataModelService<Educ
         "offering.assessedDate",
         "offering.submittedDate",
         "offering.courseLoad",
+        "offering.onlineInstructionMode",
+        "offering.isOnlineDurationSameAlways",
+        "offering.totalOnlineDuration",
+        "offering.minimumOnlineDuration",
+        "offering.maximumOnlineDuration",
         "offering.offeringStatus",
         "precedingOffering.id",
         "assessedBy.firstName",

--- a/sources/packages/backend/apps/api/src/services/education-program-offering/education-program-offering.service.ts
+++ b/sources/packages/backend/apps/api/src/services/education-program-offering/education-program-offering.service.ts
@@ -64,7 +64,7 @@ import {
   OfferingValidationResult,
   OfferingValidationModel,
   OfferingDeliveryOptions,
-  WILComponentOptions,
+  OfferingYesNoOptions,
 } from "./education-program-offering-validation.models";
 import { EducationProgramOfferingValidationService } from "./education-program-offering-validation.service";
 import { LoggerService, InjectLogger } from "@sims/utilities/logger";
@@ -577,6 +577,7 @@ export class EducationProgramOfferingService extends RecordDataModelService<Educ
   private populateProgramOffering(
     educationProgramOffering: OfferingValidationModel,
   ): EducationProgramOffering {
+    console.log(educationProgramOffering);
     const programOffering = new EducationProgramOffering();
     programOffering.name = educationProgramOffering.offeringName;
     programOffering.studyStartDate = educationProgramOffering.studyStartDate;
@@ -618,6 +619,8 @@ export class EducationProgramOfferingService extends RecordDataModelService<Educ
       );
     programOffering.studyBreaks =
       EducationProgramOfferingService.assignStudyBreaks(calculatedBreaks);
+    programOffering.onlineInstructionMode =
+      educationProgramOffering.onlineInstructionMode;
 
     return programOffering;
   }
@@ -670,7 +673,7 @@ export class EducationProgramOfferingService extends RecordDataModelService<Educ
     offeringValidationModel.offeringIntensity = offering.offeringIntensity;
     offeringValidationModel.yearOfStudy = offering.yearOfStudy;
     offeringValidationModel.hasOfferingWILComponent =
-      offering.hasOfferingWILComponent as WILComponentOptions;
+      offering.hasOfferingWILComponent as OfferingYesNoOptions;
     offeringValidationModel.offeringWILComponentType = offering.offeringWILType;
     offeringValidationModel.offeringDeclaration = offering.offeringDeclaration;
     offeringValidationModel.offeringType = offering.offeringType;

--- a/sources/packages/backend/apps/api/src/services/institution-location/institution-location.service.ts
+++ b/sources/packages/backend/apps/api/src/services/institution-location/institution-location.service.ts
@@ -181,8 +181,10 @@ export class InstitutionLocationService extends RecordDataModelService<Instituti
         "institution.operatingName",
         "institution.legalOperatingName",
         "institution.primaryEmail",
+        "institutionType.id",
       ])
       .innerJoin("institutionLocation.institution", "institution")
+      .innerJoin("institution.institutionType", "institutionType")
       .where("institutionLocation.id = :locationId", {
         locationId: locationId,
       });

--- a/sources/packages/backend/apps/api/src/utilities/class-validation/custom-validators/allow-if.ts
+++ b/sources/packages/backend/apps/api/src/utilities/class-validation/custom-validators/allow-if.ts
@@ -7,8 +7,8 @@ import {
 } from "class-validator";
 
 /**
- *  Allow a value to the property only if a condition is met.
- *  This validates the property against receiving a value when is it not suppose to.
+ * Allow a value to the property only if a condition is met.
+ * This validates the property against receiving a value when is it not suppose to.
  */
 @ValidatorConstraint()
 class AllowIfConstraint implements ValidatorConstraintInterface {

--- a/sources/packages/backend/apps/api/src/utilities/class-validation/custom-validators/allow-if.ts
+++ b/sources/packages/backend/apps/api/src/utilities/class-validation/custom-validators/allow-if.ts
@@ -1,0 +1,51 @@
+import {
+  ValidatorConstraint,
+  ValidatorConstraintInterface,
+  ValidationArguments,
+  registerDecorator,
+  ValidationOptions,
+} from "class-validator";
+
+/**
+ *  Allow a value to the property only if a condition is met.
+ *  This validates the property against receiving a value when is it not suppose to.
+ */
+@ValidatorConstraint()
+class AllowIfConstraint implements ValidatorConstraintInterface {
+  validate(value: unknown, args: ValidationArguments): boolean {
+    if (value === null || value === undefined || value === "") {
+      return true;
+    }
+    const [condition] = args.constraints;
+    const isAllowed = condition(args.object) as boolean;
+    return isAllowed;
+  }
+
+  defaultMessage(args: ValidationArguments) {
+    const [, propertyDisplayName] = args.constraints;
+    return `${propertyDisplayName ?? args.property} input is not allowed.`;
+  }
+}
+
+/**
+ * Allow a value to the property only if a condition is met.
+ * @param condition condition to allow value to a property.
+ * @param propertyDisplayName property display name.
+ * @param validationOptions validations options.
+ */
+export function AllowIf(
+  condition: (object: unknown) => boolean,
+  propertyDisplayName?: string,
+  validationOptions?: ValidationOptions,
+) {
+  return (object: unknown, propertyName: string) => {
+    registerDecorator({
+      name: "AllowIf",
+      target: object.constructor,
+      propertyName,
+      options: validationOptions,
+      constraints: [condition, propertyDisplayName],
+      validator: AllowIfConstraint,
+    });
+  };
+}

--- a/sources/packages/backend/apps/api/src/utilities/class-validation/custom-validators/is-number-greater-than.ts
+++ b/sources/packages/backend/apps/api/src/utilities/class-validation/custom-validators/is-number-greater-than.ts
@@ -7,13 +7,13 @@ import {
 } from "class-validator";
 
 /**
- *  Check if the value is greater than the reference number.
+ * Check if the value is greater than the reference number.
  */
 @ValidatorConstraint()
 class IsNumberGreaterThanConstraint implements ValidatorConstraintInterface {
   validate(value: number, args: ValidationArguments): boolean {
-    const [condition] = args.constraints;
-    const referenceNumber = condition(args.object) as number;
+    const [getReferenceNumber] = args.constraints;
+    const referenceNumber = getReferenceNumber(args.object) as number;
     if (referenceNumber === null || referenceNumber === undefined) {
       return false;
     }
@@ -21,8 +21,11 @@ class IsNumberGreaterThanConstraint implements ValidatorConstraintInterface {
   }
 
   defaultMessage(args: ValidationArguments) {
-    const [, propertyDisplayName] = args.constraints;
-    return `${propertyDisplayName ?? args.property} input is not allowed.`;
+    const [getReferenceNumber, propertyDisplayName] = args.constraints;
+    const referenceNumber = getReferenceNumber(args.object) as number;
+    return `${
+      propertyDisplayName ?? args.property
+    } must be greater than ${referenceNumber}.`;
   }
 }
 

--- a/sources/packages/backend/apps/api/src/utilities/class-validation/custom-validators/is-number-greater-than.ts
+++ b/sources/packages/backend/apps/api/src/utilities/class-validation/custom-validators/is-number-greater-than.ts
@@ -14,7 +14,11 @@ class IsNumberGreaterThanConstraint implements ValidatorConstraintInterface {
   validate(value: number, args: ValidationArguments): boolean {
     const [getReferenceNumber] = args.constraints;
     const referenceNumber = getReferenceNumber(args.object) as number;
-    if (referenceNumber === null || referenceNumber === undefined) {
+    if (
+      referenceNumber === null ||
+      referenceNumber === undefined ||
+      isNaN(referenceNumber)
+    ) {
       return false;
     }
     return value > referenceNumber;

--- a/sources/packages/backend/apps/api/src/utilities/class-validation/custom-validators/is-number-greater-than.ts
+++ b/sources/packages/backend/apps/api/src/utilities/class-validation/custom-validators/is-number-greater-than.ts
@@ -1,0 +1,50 @@
+import {
+  ValidatorConstraint,
+  ValidatorConstraintInterface,
+  ValidationArguments,
+  registerDecorator,
+  ValidationOptions,
+} from "class-validator";
+
+/**
+ *  Check if the value is greater than the reference number.
+ */
+@ValidatorConstraint()
+class IsNumberGreaterThanConstraint implements ValidatorConstraintInterface {
+  validate(value: number, args: ValidationArguments): boolean {
+    const [condition] = args.constraints;
+    const referenceNumber = condition(args.object) as number;
+    if (referenceNumber === null || referenceNumber === undefined) {
+      return false;
+    }
+    return value > referenceNumber;
+  }
+
+  defaultMessage(args: ValidationArguments) {
+    const [, propertyDisplayName] = args.constraints;
+    return `${propertyDisplayName ?? args.property} input is not allowed.`;
+  }
+}
+
+/**
+ * Check if the value is greater than the reference number.
+ * @param getReferenceNumber get reference number.
+ * @param propertyDisplayName property display name.
+ * @param validationOptions validations options.
+ */
+export function IsNumberGreaterThan(
+  getReferenceNumber: (object: unknown) => number,
+  propertyDisplayName?: string,
+  validationOptions?: ValidationOptions,
+) {
+  return (object: unknown, propertyName: string) => {
+    registerDecorator({
+      name: "IsNumberGreaterThan",
+      target: object.constructor,
+      propertyName,
+      options: validationOptions,
+      constraints: [getReferenceNumber, propertyDisplayName],
+      validator: IsNumberGreaterThanConstraint,
+    });
+  };
+}

--- a/sources/packages/backend/apps/api/src/utilities/class-validation/index.ts
+++ b/sources/packages/backend/apps/api/src/utilities/class-validation/index.ts
@@ -10,3 +10,4 @@ export * from "./custom-validators/is-date-after";
 export * from "./custom-validators/json-max-size";
 export * from "./custom-validators/is-max-cost-value";
 export * from "./custom-validators/allow-if";
+export * from "./custom-validators/is-number-greater-than";

--- a/sources/packages/backend/apps/api/src/utilities/class-validation/index.ts
+++ b/sources/packages/backend/apps/api/src/utilities/class-validation/index.ts
@@ -9,3 +9,4 @@ export * from "./validation-utils";
 export * from "./custom-validators/is-date-after";
 export * from "./custom-validators/json-max-size";
 export * from "./custom-validators/is-max-cost-value";
+export * from "./custom-validators/allow-if";

--- a/sources/packages/backend/apps/api/src/utilities/system-configurations-constants.ts
+++ b/sources/packages/backend/apps/api/src/utilities/system-configurations-constants.ts
@@ -120,3 +120,13 @@ export const PART_TIME_SCHOLASTIC_STANDING_RESTRICTIONS: RestrictionCode[] = [
   RestrictionCode.PTSSR,
   RestrictionCode.PTWTHD,
 ];
+
+/**
+ * Minimum percentage of an offering duration that should be online.
+ */
+export const OFFERING_MINIMUM_ONLINE_DURATION_PERCENTAGE = 1;
+
+/**
+ * Maximum percentage of an offering duration that should be online.
+ */
+export const OFFERING_MAXIMUM_ONLINE_DURATION_PERCENTAGE = 99;

--- a/sources/packages/forms/src/form-definitions/educationprogramoffering.json
+++ b/sources/packages/forms/src/form-definitions/educationprogramoffering.json
@@ -955,8 +955,7 @@
                   "addons": [],
                   "id": "emuvfb",
                   "defaultValue": "",
-                  "inputType": "number",
-                  "isNew": false
+                  "inputType": "number"
                 }
               ],
               "placeholder": "",
@@ -1118,7 +1117,6 @@
               "fieldSet": false,
               "id": "edsywf7",
               "defaultValue": "",
-              "isNew": false,
               "lockKey": true
             },
             {
@@ -1410,8 +1408,7 @@
                   "properties": {},
                   "requireDecimal": false,
                   "delimiter": false,
-                  "lockKey": true,
-                  "isNew": false
+                  "lockKey": true
                 },
                 {
                   "autofocus": false,
@@ -1471,8 +1468,7 @@
                     "eq": "no"
                   },
                   "properties": {},
-                  "lockKey": true,
-                  "isNew": false
+                  "lockKey": true
                 },
                 {
                   "autofocus": false,
@@ -1545,8 +1541,7 @@
                 "eq": ""
               },
               "properties": {},
-              "customConditional": "/**\n * Allow the online delivery option inputs only for\n * BC Public and BC Private Institutions\n * when the delivery type is either online or blended.\n */\nshow = ['online','blended'].includes(data.offeringDelivered) && (data.isInstitutionBCPublic || data.isInstitutionBCPrivate);",
-              "isNew": false
+              "customConditional": "/**\n * Allow the online delivery option inputs only for\n * BC Public and BC Private Institutions\n * when the delivery type is either online or blended.\n */\nshow = ['online','blended'].includes(data.offeringDelivered) && (data.isInstitutionBCPublic || data.isInstitutionBCPrivate);"
             },
             {
               "label": "Does this contain a work-integrated learning component?",
@@ -3695,8 +3690,7 @@
                               },
                               "properties": {},
                               "disabled": true,
-                              "lockKey": true,
-                              "isNew": false
+                              "lockKey": true
                             }
                           ],
                           "width": 6,
@@ -3742,8 +3736,7 @@
                               },
                               "properties": {},
                               "lockKey": true,
-                              "disabled": true,
-                              "isNew": false
+                              "disabled": true
                             }
                           ],
                           "width": 6,
@@ -3789,8 +3782,7 @@
                               },
                               "properties": {},
                               "disabled": true,
-                              "lockKey": true,
-                              "isNew": false
+                              "lockKey": true
                             }
                           ],
                           "size": "md",
@@ -3836,8 +3828,7 @@
                               },
                               "properties": {},
                               "disabled": true,
-                              "lockKey": true,
-                              "isNew": false
+                              "lockKey": true
                             }
                           ],
                           "size": "md",
@@ -5954,8 +5945,7 @@
       "properties": {},
       "lockKey": true,
       "customDefaultValue": "",
-      "calculateValue": "value = data.offeringIntensity === 'Full Time' ? 84 : 42;",
-      "isNew": false
+      "calculateValue": "value = data.offeringIntensity === 'Full Time' ? 84 : 42;"
     },
     {
       "input": true,
@@ -5974,8 +5964,7 @@
       },
       "properties": {},
       "defaultValue": "365",
-      "lockKey": true,
-      "isNew": false
+      "lockKey": true
     },
     {
       "input": true,
@@ -6014,7 +6003,7 @@
       },
       "properties": {},
       "lockKey": true,
-      "calculateValue": "console.log(\"allowOnlineDeliveryInputs: \",allowOnlineDeliveryInputs);\nvalue = data.offeringIntensity === 'Full Time' ? 'Full-time' : 'Part-time';"
+      "calculateValue": "value = data.offeringIntensity === 'Full Time' ? 'Full-time' : 'Part-time';"
     },
     {
       "input": true,
@@ -6050,8 +6039,7 @@
         "eq": ""
       },
       "properties": {},
-      "lockKey": true,
-      "isNew": false
+      "lockKey": true
     },
     {
       "input": true,
@@ -6070,8 +6058,7 @@
       },
       "properties": {},
       "lockKey": true,
-      "calculateValue": "value = data.isInstitutionBCPublic || data.isInstitutionBCPrivate;",
-      "isNew": false
+      "calculateValue": "value = data.isInstitutionBCPublic || data.isInstitutionBCPrivate;"
     }
   ]
 }

--- a/sources/packages/forms/src/form-definitions/educationprogramoffering.json
+++ b/sources/packages/forms/src/form-definitions/educationprogramoffering.json
@@ -6040,25 +6040,6 @@
       },
       "properties": {},
       "lockKey": true
-    },
-    {
-      "input": true,
-      "tableView": false,
-      "key": "allowOnlineDeliveryInputs",
-      "label": "Allow online delivery inputs",
-      "protected": false,
-      "unique": false,
-      "persistent": false,
-      "type": "hidden",
-      "tags": [],
-      "conditional": {
-        "show": "",
-        "when": null,
-        "eq": ""
-      },
-      "properties": {},
-      "lockKey": true,
-      "calculateValue": "value = data.isBCPublic || data.isBCPrivate;"
     }
   ]
 }

--- a/sources/packages/forms/src/form-definitions/educationprogramoffering.json
+++ b/sources/packages/forms/src/form-definitions/educationprogramoffering.json
@@ -1223,7 +1223,7 @@
                         "type": "simple",
                         "simple": {
                           "show": true,
-                          "when": "isInstitutionBCPrivate",
+                          "when": "isBCPrivate",
                           "eq": "true"
                         }
                       },
@@ -1295,7 +1295,7 @@
                         "type": "simple",
                         "simple": {
                           "show": true,
-                          "when": "isInstitutionBCPrivate",
+                          "when": "isBCPrivate",
                           "eq": "true"
                         }
                       },
@@ -1362,7 +1362,7 @@
                         "type": "simple",
                         "simple": {
                           "show": true,
-                          "when": "isInstitutionBCPrivate",
+                          "when": "isBCPrivate",
                           "eq": "true"
                         }
                       },
@@ -1424,7 +1424,7 @@
                         "type": "simple",
                         "simple": {
                           "show": true,
-                          "when": "isInstitutionBCPrivate",
+                          "when": "isBCPrivate",
                           "eq": "true"
                         }
                       },
@@ -1484,7 +1484,7 @@
                         "type": "simple",
                         "simple": {
                           "show": true,
-                          "when": "isInstitutionBCPrivate",
+                          "when": "isBCPrivate",
                           "eq": "true"
                         }
                       },
@@ -1541,7 +1541,7 @@
                 "eq": ""
               },
               "properties": {},
-              "customConditional": "/**\n * Allow the online delivery option inputs only for\n * BC Public and BC Private Institutions\n * when the delivery type is either online or blended.\n */\nshow = ['online','blended'].includes(data.offeringDelivered) && (data.isInstitutionBCPublic || data.isInstitutionBCPrivate);"
+              "customConditional": "/**\n * Allow the online delivery option inputs only for\n * BC Public and BC Private Institutions\n * when the delivery type is either online or blended.\n */\nshow = ['online','blended'].includes(data.offeringDelivered) && (data.isBCPublic || data.isBCPrivate);"
             },
             {
               "label": "Does this contain a work-integrated learning component?",
@@ -6008,8 +6008,8 @@
     {
       "input": true,
       "tableView": false,
-      "key": "isInstitutionBCPublic",
-      "label": "Is institution BC Public",
+      "key": "isBCPublic",
+      "label": "Is BC Public",
       "protected": false,
       "unique": false,
       "persistent": false,
@@ -6026,8 +6026,8 @@
     {
       "input": true,
       "tableView": false,
-      "key": "isInstitutionBCPrivate",
-      "label": "Is institution BC Private",
+      "key": "isBCPrivate",
+      "label": "Is BC Private",
       "protected": false,
       "unique": false,
       "persistent": false,
@@ -6058,7 +6058,7 @@
       },
       "properties": {},
       "lockKey": true,
-      "calculateValue": "value = data.isInstitutionBCPublic || data.isInstitutionBCPrivate;"
+      "calculateValue": "value = data.isBCPublic || data.isBCPrivate;"
     }
   ]
 }

--- a/sources/packages/forms/src/form-definitions/educationprogramoffering.json
+++ b/sources/packages/forms/src/form-definitions/educationprogramoffering.json
@@ -955,7 +955,8 @@
                   "addons": [],
                   "id": "emuvfb",
                   "defaultValue": "",
-                  "inputType": "number"
+                  "inputType": "number",
+                  "isNew": false
                 }
               ],
               "placeholder": "",
@@ -1116,7 +1117,9 @@
               "inputType": "radio",
               "fieldSet": false,
               "id": "edsywf7",
-              "defaultValue": ""
+              "defaultValue": "",
+              "isNew": false,
+              "lockKey": true
             },
             {
               "label": "HTML",
@@ -1199,6 +1202,351 @@
               "allowMultipleMasks": false,
               "addons": [],
               "id": "e0fns5b"
+            },
+            {
+              "clearOnHide": false,
+              "key": "panelPanel",
+              "input": false,
+              "title": "Online delivery instructions panel",
+              "theme": "default",
+              "tableView": false,
+              "components": [
+                {
+                  "autofocus": false,
+                  "input": true,
+                  "tableView": true,
+                  "inputType": "radio",
+                  "label": "Please indicate the option that best describes this offering's mode(s) of online instruction.",
+                  "key": "onlineInstructionMode",
+                  "logic": [
+                    {
+                      "name": "Mandatory for BC Private",
+                      "trigger": {
+                        "type": "simple",
+                        "simple": {
+                          "show": true,
+                          "when": "isInstitutionBCPrivate",
+                          "eq": "true"
+                        }
+                      },
+                      "actions": [
+                        {
+                          "name": "Set Mandatory",
+                          "type": "property",
+                          "property": {
+                            "label": "Required",
+                            "value": "validate.required",
+                            "type": "boolean"
+                          },
+                          "state": true
+                        }
+                      ]
+                    }
+                  ],
+                  "values": [
+                    {
+                      "value": "synchronousOnly",
+                      "label": "Synchronous only",
+                      "shortcut": ""
+                    },
+                    {
+                      "value": "asynchronousOnly",
+                      "label": "Asynchronous only",
+                      "shortcut": ""
+                    },
+                    {
+                      "value": "synchronousAndAsynchronous",
+                      "label": "Synchronous and Asynchronous",
+                      "shortcut": ""
+                    }
+                  ],
+                  "defaultValue": "",
+                  "protected": false,
+                  "fieldSet": false,
+                  "persistent": true,
+                  "hidden": false,
+                  "clearOnHide": true,
+                  "validate": {
+                    "required": false,
+                    "custom": "",
+                    "customPrivate": false
+                  },
+                  "type": "radio",
+                  "labelPosition": "top",
+                  "optionsLabelPosition": "right",
+                  "tags": [],
+                  "conditional": {
+                    "show": "",
+                    "when": null,
+                    "eq": ""
+                  },
+                  "properties": {},
+                  "lockKey": true
+                },
+                {
+                  "autofocus": false,
+                  "input": true,
+                  "tableView": true,
+                  "inputType": "radio",
+                  "label": "Will this offering always be provided with the same total duration of online delivery?",
+                  "key": "isOnlineDurationSameAlways",
+                  "logic": [
+                    {
+                      "name": "Mandatory for BC Private",
+                      "trigger": {
+                        "type": "simple",
+                        "simple": {
+                          "show": true,
+                          "when": "isInstitutionBCPrivate",
+                          "eq": "true"
+                        }
+                      },
+                      "actions": [
+                        {
+                          "name": "Set Mandatory",
+                          "type": "property",
+                          "property": {
+                            "label": "Required",
+                            "value": "validate.required",
+                            "type": "boolean"
+                          },
+                          "state": true
+                        }
+                      ]
+                    }
+                  ],
+                  "values": [
+                    {
+                      "value": "yes",
+                      "label": "Yes",
+                      "shortcut": ""
+                    },
+                    {
+                      "value": "no",
+                      "label": "No",
+                      "shortcut": ""
+                    }
+                  ],
+                  "defaultValue": "",
+                  "protected": false,
+                  "fieldSet": false,
+                  "persistent": true,
+                  "hidden": false,
+                  "clearOnHide": true,
+                  "validate": {
+                    "required": false,
+                    "custom": "",
+                    "customPrivate": false
+                  },
+                  "type": "radio",
+                  "labelPosition": "top",
+                  "optionsLabelPosition": "right",
+                  "tags": [],
+                  "conditional": {
+                    "show": "true",
+                    "when": "offeringDelivered",
+                    "eq": "blended"
+                  },
+                  "properties": {},
+                  "lockKey": true
+                },
+                {
+                  "autofocus": false,
+                  "input": true,
+                  "tableView": true,
+                  "inputType": "number",
+                  "label": "What percentage of this blended offering total duration will be provided by online delivery?",
+                  "key": "totalOnlineDuration",
+                  "logic": [
+                    {
+                      "name": "Mandatory for BC Private",
+                      "trigger": {
+                        "type": "simple",
+                        "simple": {
+                          "show": true,
+                          "when": "isInstitutionBCPrivate",
+                          "eq": "true"
+                        }
+                      },
+                      "actions": [
+                        {
+                          "name": "Set Mandatory",
+                          "type": "property",
+                          "property": {
+                            "label": "Required",
+                            "value": "validate.required",
+                            "type": "boolean"
+                          },
+                          "state": true
+                        }
+                      ]
+                    }
+                  ],
+                  "placeholder": "",
+                  "prefix": "",
+                  "suffix": "",
+                  "defaultValue": "",
+                  "protected": false,
+                  "persistent": true,
+                  "hidden": false,
+                  "clearOnHide": true,
+                  "validate": {
+                    "required": false,
+                    "min": 1,
+                    "max": 99,
+                    "step": "any",
+                    "integer": "",
+                    "multiple": "",
+                    "custom": ""
+                  },
+                  "type": "number",
+                  "labelPosition": "top",
+                  "tags": [],
+                  "conditional": {
+                    "show": "true",
+                    "when": "isOnlineDurationSameAlways",
+                    "eq": "yes"
+                  },
+                  "properties": {},
+                  "requireDecimal": false,
+                  "delimiter": false,
+                  "lockKey": true,
+                  "isNew": false
+                },
+                {
+                  "autofocus": false,
+                  "input": true,
+                  "tableView": true,
+                  "inputType": "number",
+                  "label": "What is the minimum duration as a percentage that this offering will be delivered online?",
+                  "key": "minimumOnlineDuration",
+                  "logic": [
+                    {
+                      "name": "Mandatory for BC Private",
+                      "trigger": {
+                        "type": "simple",
+                        "simple": {
+                          "show": true,
+                          "when": "isInstitutionBCPrivate",
+                          "eq": "true"
+                        }
+                      },
+                      "actions": [
+                        {
+                          "name": "Set Mandatory",
+                          "type": "property",
+                          "property": {
+                            "label": "Required",
+                            "value": "validate.required",
+                            "type": "boolean"
+                          },
+                          "state": true
+                        }
+                      ]
+                    }
+                  ],
+                  "placeholder": "",
+                  "prefix": "",
+                  "suffix": "",
+                  "defaultValue": "",
+                  "protected": false,
+                  "persistent": true,
+                  "hidden": false,
+                  "clearOnHide": true,
+                  "validate": {
+                    "required": false,
+                    "min": 1,
+                    "max": 99,
+                    "step": "any",
+                    "integer": "",
+                    "multiple": "",
+                    "custom": ""
+                  },
+                  "type": "number",
+                  "labelPosition": "top",
+                  "tags": [],
+                  "conditional": {
+                    "show": "true",
+                    "when": "isOnlineDurationSameAlways",
+                    "eq": "no"
+                  },
+                  "properties": {},
+                  "lockKey": true,
+                  "isNew": false
+                },
+                {
+                  "autofocus": false,
+                  "input": true,
+                  "tableView": true,
+                  "inputType": "number",
+                  "label": "What is the maximum duration as a percentage that this offering will be delivered online?",
+                  "key": "maximumOnlineDuration",
+                  "logic": [
+                    {
+                      "name": "Mandatory for BC Private",
+                      "trigger": {
+                        "type": "simple",
+                        "simple": {
+                          "show": true,
+                          "when": "isInstitutionBCPrivate",
+                          "eq": "true"
+                        }
+                      },
+                      "actions": [
+                        {
+                          "name": "Set Mandatory",
+                          "type": "property",
+                          "property": {
+                            "label": "Required",
+                            "value": "validate.required",
+                            "type": "boolean"
+                          },
+                          "state": true
+                        }
+                      ]
+                    }
+                  ],
+                  "placeholder": "",
+                  "prefix": "",
+                  "suffix": "",
+                  "defaultValue": "",
+                  "protected": false,
+                  "persistent": true,
+                  "hidden": false,
+                  "clearOnHide": true,
+                  "validate": {
+                    "required": false,
+                    "min": 1,
+                    "max": 99,
+                    "step": "any",
+                    "integer": "",
+                    "multiple": "",
+                    "custom": "valid = input > data.minimumOnlineDuration ? true : \"The maximum percentage must be greater than the minimum percentage\""
+                  },
+                  "type": "number",
+                  "labelPosition": "top",
+                  "tags": [],
+                  "conditional": {
+                    "show": "true",
+                    "when": "isOnlineDurationSameAlways",
+                    "eq": "no"
+                  },
+                  "properties": {},
+                  "lockKey": true
+                }
+              ],
+              "type": "panel",
+              "breadcrumb": "default",
+              "hideLabel": true,
+              "tags": [],
+              "conditional": {
+                "show": "",
+                "when": null,
+                "eq": ""
+              },
+              "properties": {},
+              "customConditional": "/**\n * Allow the online delivery option inputs only for\n * BC Public and BC Private Institutions\n * when the delivery type is either online or blended.\n */\nshow = ['online','blended'].includes(data.offeringDelivered) && (data.isInstitutionBCPublic || data.isInstitutionBCPrivate);",
+              "isNew": false
             },
             {
               "label": "Does this contain a work-integrated learning component?",
@@ -5606,7 +5954,8 @@
       "properties": {},
       "lockKey": true,
       "customDefaultValue": "",
-      "calculateValue": "value = data.offeringIntensity === 'Full Time' ? 84 : 42;"
+      "calculateValue": "value = data.offeringIntensity === 'Full Time' ? 84 : 42;",
+      "isNew": false
     },
     {
       "input": true,
@@ -5625,7 +5974,8 @@
       },
       "properties": {},
       "defaultValue": "365",
-      "lockKey": true
+      "lockKey": true,
+      "isNew": false
     },
     {
       "input": true,
@@ -5664,7 +6014,64 @@
       },
       "properties": {},
       "lockKey": true,
-      "calculateValue": "value = data.offeringIntensity === 'Full Time' ? 'Full-time' : 'Part-time';"
+      "calculateValue": "console.log(\"allowOnlineDeliveryInputs: \",allowOnlineDeliveryInputs);\nvalue = data.offeringIntensity === 'Full Time' ? 'Full-time' : 'Part-time';"
+    },
+    {
+      "input": true,
+      "tableView": false,
+      "key": "isInstitutionBCPublic",
+      "label": "Is institution BC Public",
+      "protected": false,
+      "unique": false,
+      "persistent": false,
+      "type": "hidden",
+      "tags": [],
+      "conditional": {
+        "show": "",
+        "when": null,
+        "eq": ""
+      },
+      "properties": {},
+      "lockKey": true
+    },
+    {
+      "input": true,
+      "tableView": false,
+      "key": "isInstitutionBCPrivate",
+      "label": "Is institution BC Private",
+      "protected": false,
+      "unique": false,
+      "persistent": false,
+      "type": "hidden",
+      "tags": [],
+      "conditional": {
+        "show": "",
+        "when": null,
+        "eq": ""
+      },
+      "properties": {},
+      "lockKey": true,
+      "isNew": false
+    },
+    {
+      "input": true,
+      "tableView": false,
+      "key": "allowOnlineDeliveryInputs",
+      "label": "Allow online delivery inputs",
+      "protected": false,
+      "unique": false,
+      "persistent": false,
+      "type": "hidden",
+      "tags": [],
+      "conditional": {
+        "show": "",
+        "when": null,
+        "eq": ""
+      },
+      "properties": {},
+      "lockKey": true,
+      "calculateValue": "value = data.isInstitutionBCPublic || data.isInstitutionBCPrivate;",
+      "isNew": false
     }
   ]
 }

--- a/sources/packages/web/src/services/http/dto/EducationProgramOffering.dto.ts
+++ b/sources/packages/web/src/services/http/dto/EducationProgramOffering.dto.ts
@@ -154,8 +154,8 @@ export interface EducationProgramOfferingAPIOutDTO {
   validationWarnings: string[];
   validationInfos: string[];
   parentOfferingId: number;
-  isInstitutionBCPublic: boolean;
-  isInstitutionBCPrivate: boolean;
+  isBCPublic: boolean;
+  isBCPrivate: boolean;
   onlineInstructionMode?: OnlineInstructionModeOptions;
   isOnlineDurationSameAlways?: OfferingYesNoOptions;
   totalOnlineDuration?: number;

--- a/sources/packages/web/src/services/http/dto/EducationProgramOffering.dto.ts
+++ b/sources/packages/web/src/services/http/dto/EducationProgramOffering.dto.ts
@@ -156,6 +156,11 @@ export interface EducationProgramOfferingAPIOutDTO {
   parentOfferingId: number;
   isInstitutionBCPublic: boolean;
   isInstitutionBCPrivate: boolean;
+  onlineInstructionMode?: OnlineInstructionModeOptions;
+  isOnlineDurationSameAlways?: OfferingYesNoOptions;
+  totalOnlineDuration?: number;
+  minimumOnlineDuration?: number;
+  maximumOnlineDuration?: number;
 }
 
 export interface StudyBreakAPIOutDTO {

--- a/sources/packages/web/src/services/http/dto/EducationProgramOffering.dto.ts
+++ b/sources/packages/web/src/services/http/dto/EducationProgramOffering.dto.ts
@@ -70,7 +70,7 @@ export class EducationProgramOfferingAPIInDTO {
   @Expose()
   yearOfStudy: number;
   @Expose()
-  hasOfferingWILComponent: WILComponentOptions;
+  hasOfferingWILComponent: OfferingYesNoOptions;
   @Expose()
   offeringDeclaration: boolean;
   @Expose()
@@ -84,6 +84,16 @@ export class EducationProgramOfferingAPIInDTO {
   studyBreaks: StudyBreakInDTO[];
   @Expose()
   courseLoad?: number;
+  @Expose()
+  onlineInstructionMode?: OnlineInstructionModeOptions;
+  @Expose()
+  isOnlineDurationSameAlways?: OfferingYesNoOptions;
+  @Expose()
+  totalOnlineDuration?: number;
+  @Expose()
+  minimumOnlineDuration?: number;
+  @Expose()
+  maximumOnlineDuration?: number;
 }
 
 /**
@@ -96,11 +106,20 @@ export enum OfferingDeliveryOptions {
 }
 
 /**
- * WIL(work-integrated learning) options.
+ * Offering Yes/No options.
  */
-export enum WILComponentOptions {
+export enum OfferingYesNoOptions {
   Yes = "yes",
   No = "no",
+}
+
+/**
+ * Offering online instruction modes.
+ */
+export enum OnlineInstructionModeOptions {
+  SynchronousOnly = "synchronousOnly",
+  AsynchronousOnly = "asynchronousOnly",
+  SynchronousAndAsynchronous = "synchronousAndAsynchronous",
 }
 
 export interface EducationProgramOfferingAPIOutDTO {

--- a/sources/packages/web/src/views/institution/locations/offerings/OfferingCreate.vue
+++ b/sources/packages/web/src/views/institution/locations/offerings/OfferingCreate.vue
@@ -71,8 +71,8 @@ export default defineComponent({
     const initialData = computed(
       () =>
         ({
-          isInstitutionBCPublic: institutionState.value.isBCPublic,
-          isInstitutionBCPrivate: institutionState.value.isBCPrivate,
+          isBCPublic: institutionState.value.isBCPublic,
+          isBCPrivate: institutionState.value.isBCPrivate,
         } as EducationProgramOfferingAPIOutDTO),
     );
 


### PR DESCRIPTION
#  API Validation and Form Inputs

## FormIO Changes
- [x] Added new formio fields that appear only for `BC Private` and `BC Public` institutions for data collections.
![image](https://github.com/user-attachments/assets/c26321ac-0496-430f-be06-e06486a70f00)

![image](https://github.com/user-attachments/assets/52c15af9-a9d7-4597-8b92-864ff6cf96bc)

- [x] Added formio logic to make these fields as mandatory for `BC Private`
![image](https://github.com/user-attachments/assets/9e7dd042-f58b-4023-a644-73ea8b3c4a02)

![image](https://github.com/user-attachments/assets/fc879657-87de-4896-a1df-2eb6535c0714)

## API Validation

- [x] Added new class validator constraints `AllowIf` and `IsNumberGreaterThan` to perform API validation with class-validators.
- [x] Added `institutionContext` to `OfferingValidationModel` to perform institution type based validations. This context is not added for bulk upload as it is not required.
- [x] Validated all the new fields with class validators for all different institution types.

## Upcoming PR

- E2E Tests will be part of upcoming PR.

