### PR TITLE
#4452 - Read-only application view: Remove FAED warning banner

### DIFF
--- a/sources/packages/forms/src/form-definitions/sfaa2022-23.json
+++ b/sources/packages/forms/src/form-definitions/sfaa2022-23.json
@@ -3715,7 +3715,7 @@
                   },
                   "properties": {},
                   "customClass": "banner-warning",
-                  "customConditional": "show = !!!data.isReadOnly && !!data.studyEndDateBeforeSixWeeksFromToday;",
+                  "customConditional": "show = !!!data.isReadOnly && !!data.selectedStudyEndDateBeforeSixWeeksFromToday;",
                   "hideLabel": true
                 },
                 {

--- a/sources/packages/forms/src/form-definitions/sfaa2022-23.json
+++ b/sources/packages/forms/src/form-definitions/sfaa2022-23.json
@@ -1508,8 +1508,7 @@
               "customClass": "font-weight-bold",
               "disabled": true,
               "calculateValue": "",
-              "lockKey": true,
-              "isNew": false
+              "lockKey": true
             },
             {
               "title": "Program",
@@ -2627,13 +2626,13 @@
                       "hideLabel": true,
                       "tags": [],
                       "conditional": {
-                        "show": "true",
-                        "when": "studyEndDateBeforeSixWeeksFromToday",
-                        "eq": "true"
+                        "show": "",
+                        "when": "",
+                        "eq": ""
                       },
                       "properties": {},
                       "customClass": "banner-warning",
-                      "customConditional": ""
+                      "customConditional": "show = !!!data.isReadOnly && !!data.studyEndDateBeforeSixWeeksFromToday;"
                     }
                   ],
                   "allowPrevious": false,
@@ -3710,13 +3709,13 @@
                   "type": "htmlelement",
                   "tags": [],
                   "conditional": {
-                    "show": "true",
-                    "when": "selectedStudyEndDateBeforeSixWeeksFromToday",
-                    "eq": "true"
+                    "show": "",
+                    "when": "",
+                    "eq": ""
                   },
                   "properties": {},
                   "customClass": "banner-warning",
-                  "customConditional": "",
+                  "customConditional": "show = !!!data.isReadOnly && !!data.studyEndDateBeforeSixWeeksFromToday;",
                   "hideLabel": true
                 },
                 {

--- a/sources/packages/forms/src/form-definitions/sfaa2023-24.json
+++ b/sources/packages/forms/src/form-definitions/sfaa2023-24.json
@@ -3715,7 +3715,7 @@
                   },
                   "properties": {},
                   "customClass": "banner-warning",
-                  "customConditional": "show = !!!data.isReadOnly && !!data.studyEndDateBeforeSixWeeksFromToday;",
+                  "customConditional": "show = !!!data.isReadOnly && !!data.selectedStudyEndDateBeforeSixWeeksFromToday;",
                   "hideLabel": true
                 },
                 {

--- a/sources/packages/forms/src/form-definitions/sfaa2023-24.json
+++ b/sources/packages/forms/src/form-definitions/sfaa2023-24.json
@@ -1508,8 +1508,7 @@
               "customClass": "font-weight-bold",
               "disabled": true,
               "calculateValue": "",
-              "lockKey": true,
-              "isNew": false
+              "lockKey": true
             },
             {
               "title": "Program",
@@ -2627,13 +2626,13 @@
                       "hideLabel": true,
                       "tags": [],
                       "conditional": {
-                        "show": "true",
-                        "when": "studyEndDateBeforeSixWeeksFromToday",
-                        "eq": "true"
+                        "show": "",
+                        "when": "",
+                        "eq": ""
                       },
                       "properties": {},
                       "customClass": "banner-warning",
-                      "customConditional": ""
+                      "customConditional": "show = !!!data.isReadOnly && !!data.studyEndDateBeforeSixWeeksFromToday;"
                     }
                   ],
                   "allowPrevious": false,
@@ -3710,13 +3709,13 @@
                   "type": "htmlelement",
                   "tags": [],
                   "conditional": {
-                    "show": "true",
-                    "when": "selectedStudyEndDateBeforeSixWeeksFromToday",
-                    "eq": "true"
+                    "show": "",
+                    "when": "",
+                    "eq": ""
                   },
                   "properties": {},
                   "customClass": "banner-warning",
-                  "customConditional": "",
+                  "customConditional": "show = !!!data.isReadOnly && !!data.studyEndDateBeforeSixWeeksFromToday;",
                   "hideLabel": true
                 },
                 {

--- a/sources/packages/forms/src/form-definitions/sfaa2024-25.json
+++ b/sources/packages/forms/src/form-definitions/sfaa2024-25.json
@@ -3715,7 +3715,7 @@
                   },
                   "properties": {},
                   "customClass": "banner-warning",
-                  "customConditional": "show = !!!data.isReadOnly && !!data.studyEndDateBeforeSixWeeksFromToday;",
+                  "customConditional": "show = !!!data.isReadOnly && !!data.selectedStudyEndDateBeforeSixWeeksFromToday;",
                   "hideLabel": true
                 },
                 {

--- a/sources/packages/forms/src/form-definitions/sfaa2024-25.json
+++ b/sources/packages/forms/src/form-definitions/sfaa2024-25.json
@@ -1508,8 +1508,7 @@
               "customClass": "font-weight-bold",
               "disabled": true,
               "calculateValue": "",
-              "lockKey": true,
-              "isNew": false
+              "lockKey": true
             },
             {
               "title": "Program",
@@ -2627,13 +2626,13 @@
                       "hideLabel": true,
                       "tags": [],
                       "conditional": {
-                        "show": "true",
-                        "when": "studyEndDateBeforeSixWeeksFromToday",
-                        "eq": "true"
+                        "show": "",
+                        "when": "",
+                        "eq": ""
                       },
                       "properties": {},
                       "customClass": "banner-warning",
-                      "customConditional": ""
+                      "customConditional": "show = !!!data.isReadOnly && !!data.studyEndDateBeforeSixWeeksFromToday;"
                     }
                   ],
                   "allowPrevious": false,
@@ -3710,13 +3709,13 @@
                   "type": "htmlelement",
                   "tags": [],
                   "conditional": {
-                    "show": "true",
-                    "when": "selectedStudyEndDateBeforeSixWeeksFromToday",
-                    "eq": "true"
+                    "show": "",
+                    "when": "",
+                    "eq": ""
                   },
                   "properties": {},
                   "customClass": "banner-warning",
-                  "customConditional": "",
+                  "customConditional": "show = !!!data.isReadOnly && !!data.studyEndDateBeforeSixWeeksFromToday;",
                   "hideLabel": true
                 },
                 {

--- a/sources/packages/forms/src/form-definitions/sfaa2025-26.json
+++ b/sources/packages/forms/src/form-definitions/sfaa2025-26.json
@@ -3717,7 +3717,7 @@
                   },
                   "properties": {},
                   "customClass": "banner-warning",
-                  "customConditional": "show = !!!data.isReadOnly && !!data.studyEndDateBeforeSixWeeksFromToday;",
+                  "customConditional": "show = !!!data.isReadOnly && !!data.selectedStudyEndDateBeforeSixWeeksFromToday;",
                   "hideLabel": true
                 },
                 {

--- a/sources/packages/forms/src/form-definitions/sfaa2025-26.json
+++ b/sources/packages/forms/src/form-definitions/sfaa2025-26.json
@@ -2628,13 +2628,13 @@
                       "hideLabel": true,
                       "tags": [],
                       "conditional": {
-                        "show": "true",
-                        "when": "studyEndDateBeforeSixWeeksFromToday",
-                        "eq": "true"
+                        "show": "",
+                        "when": "",
+                        "eq": ""
                       },
                       "properties": {},
                       "customClass": "banner-warning",
-                      "customConditional": ""
+                      "customConditional": "show = !!!data.isReadOnly && !!data.studyEndDateBeforeSixWeeksFromToday;"
                     }
                   ],
                   "allowPrevious": false,
@@ -3711,13 +3711,13 @@
                   "type": "htmlelement",
                   "tags": [],
                   "conditional": {
-                    "show": "true",
-                    "when": "selectedStudyEndDateBeforeSixWeeksFromToday",
-                    "eq": "true"
+                    "show": "",
+                    "when": "",
+                    "eq": ""
                   },
                   "properties": {},
                   "customClass": "banner-warning",
-                  "customConditional": "",
+                  "customConditional": "show = !!!data.isReadOnly && !!data.studyEndDateBeforeSixWeeksFromToday;",
                   "hideLabel": true
                 },
                 {


### PR DESCRIPTION
## As a part of this PR, the following was completed:

- Removed the below shown FAED warning banner in read-only view for student, institution and ministry for both part-time and full-time applications.

**Removed the following mentioned banner for read-only view:**

![image](https://github.com/user-attachments/assets/91833d86-be79-4710-b06d-b4b281808791)

### **Screenshots:**

**Non-readonly Mode:**

<img width="1918" alt="image" src="https://github.com/user-attachments/assets/1f1d85eb-e489-4fbf-8bfa-4e909578e96f" />

--------------------------------------------------------------------------------------------------------------------------------------------

**Institution View (readonly):**

<img width="1918" alt="image" src="https://github.com/user-attachments/assets/1f0a8533-f32f-40bc-94fc-c91e6e746ce6" />

--------------------------------------------------------------------------------------------------------------------------------------------

**Ministry View (readonly):**

<img width="1921" alt="image" src="https://github.com/user-attachments/assets/1d8aceb7-5852-477c-8599-02d29b4b3191" />

--------------------------------------------------------------------------------------------------------------------------------------------

**Student View (readonly):**

<img width="1919" alt="image" src="https://github.com/user-attachments/assets/60e5b593-5f70-4b9e-86c5-fb7b16033a60" />
