### PR TITLE
#4511 - Offering data collection - E2E Tests and Form content duplication fix

### DIFF
--- a/sources/packages/backend/apps/api/src/route-controllers/education-program-offering/_tests_/e2e/education-program-offering.institutions.controller.createOffering.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/education-program-offering/_tests_/e2e/education-program-offering.institutions.controller.createOffering.e2e-spec.ts
@@ -46,12 +46,12 @@ describe("EducationProgramOfferingInstitutionsController(e2e)-createOffering", (
   let app: INestApplication;
   let db: E2EDataSources;
   let collegeF: Institution;
-  // BC Private Institution.
+  // BC Private institution.
   let institutionCollegeC: Institution;
   let collegeFLocation: InstitutionLocation;
   let collegeCLocation: InstitutionLocation;
   let collegeFUser: User;
-  // BC Public Institution.
+  // BC Private institution user.
   let institutionCollegeCUser: User;
   let studyPeriodBreakdown: Omit<StudyBreaksAndWeeksOutDTO, "studyBreaks">;
   let payload: Partial<EducationProgramOfferingAPIInDTO>;
@@ -65,7 +65,7 @@ describe("EducationProgramOfferingInstitutionsController(e2e)-createOffering", (
       db.dataSource,
       InstitutionTokenTypes.CollegeFUser,
     );
-    // Get BC Private Institution and institution user.
+    // Get BC Private institution and institution user.
     const { institution: collegeC, user: collegeCUser } =
       await getAuthRelatedEntities(
         db.dataSource,
@@ -622,6 +622,8 @@ describe("EducationProgramOfferingInstitutionsController(e2e)-createOffering", (
             offeringDeclaration: true,
             offeringStatus: true,
             onlineInstructionMode: true,
+            isOnlineDurationSameAlways: true,
+            totalOnlineDuration: true,
           },
           where: { id: educationProgramOfferingId },
         });
@@ -657,6 +659,8 @@ describe("EducationProgramOfferingInstitutionsController(e2e)-createOffering", (
         offeringDeclaration: payload.offeringDeclaration,
         offeringStatus: OfferingStatus.CreationPending,
         onlineInstructionMode: payload.onlineInstructionMode,
+        isOnlineDurationSameAlways: payload.isOnlineDurationSameAlways,
+        totalOnlineDuration: payload.totalOnlineDuration,
       });
     },
   );

--- a/sources/packages/backend/apps/api/src/route-controllers/education-program-offering/_tests_/e2e/education-program-offering.institutions.controller.createOffering.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/education-program-offering/_tests_/e2e/education-program-offering.institutions.controller.createOffering.e2e-spec.ts
@@ -93,21 +93,26 @@ describe("EducationProgramOfferingInstitutionsController(e2e)-createOffering", (
     collegeDLocation = createFakeInstitutionLocation({
       institution: institutionCollegeD,
     });
-    await authorizeUserTokenForLocation(
+    const authorizeCollegeFPromise = authorizeUserTokenForLocation(
       db.dataSource,
       InstitutionTokenTypes.CollegeFUser,
       collegeFLocation,
     );
-    await authorizeUserTokenForLocation(
+    const authorizeCollegeCPromise = authorizeUserTokenForLocation(
       db.dataSource,
       InstitutionTokenTypes.CollegeCUser,
       collegeCLocation,
     );
-    await authorizeUserTokenForLocation(
+    const authorizeCollegeDPromise = authorizeUserTokenForLocation(
       db.dataSource,
       InstitutionTokenTypes.CollegeDUser,
       collegeDLocation,
     );
+    await Promise.all([
+      authorizeCollegeFPromise,
+      authorizeCollegeCPromise,
+      authorizeCollegeDPromise,
+    ]);
     studyBreak = {
       breakStartDate: "2023-12-01",
       breakEndDate: "2024-01-01",
@@ -268,7 +273,6 @@ describe("EducationProgramOfferingInstitutionsController(e2e)-createOffering", (
         institution: collegeF,
         user: collegeFUser,
       });
-      fakeEducationProgram.sabcCode = faker.random.alpha({ count: 4 });
       const savedFakeEducationProgram = await db.educationProgram.save(
         fakeEducationProgram,
       );
@@ -389,7 +393,6 @@ describe("EducationProgramOfferingInstitutionsController(e2e)-createOffering", (
         institution: collegeF,
         user: collegeFUser,
       });
-      fakeEducationProgram.sabcCode = faker.random.alpha({ count: 4 });
       const savedFakeEducationProgram = await db.educationProgram.save(
         fakeEducationProgram,
       );
@@ -449,7 +452,6 @@ describe("EducationProgramOfferingInstitutionsController(e2e)-createOffering", (
       institution: institutionCollegeC,
       user: institutionCollegeCUser,
     });
-    fakeEducationProgram.sabcCode = faker.random.alpha({ count: 4 });
     const savedFakeEducationProgram = await db.educationProgram.save(
       fakeEducationProgram,
     );
@@ -569,7 +571,6 @@ describe("EducationProgramOfferingInstitutionsController(e2e)-createOffering", (
         institution: institutionCollegeC,
         user: institutionCollegeCUser,
       });
-      fakeEducationProgram.sabcCode = faker.random.alpha({ count: 4 });
       const savedFakeEducationProgram = await db.educationProgram.save(
         fakeEducationProgram,
       );
@@ -693,7 +694,6 @@ describe("EducationProgramOfferingInstitutionsController(e2e)-createOffering", (
       institution: institutionCollegeC,
       user: institutionCollegeCUser,
     });
-    fakeEducationProgram.sabcCode = faker.random.alpha({ count: 4 });
     const savedFakeEducationProgram = await db.educationProgram.save(
       fakeEducationProgram,
     );

--- a/sources/packages/backend/apps/api/src/route-controllers/education-program-offering/_tests_/e2e/education-program-offering.institutions.controller.createOffering.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/education-program-offering/_tests_/e2e/education-program-offering.institutions.controller.createOffering.e2e-spec.ts
@@ -423,6 +423,7 @@ describe("EducationProgramOfferingInstitutionsController(e2e)-createOffering", (
 
   it("Should create a new offering for a BC Private institution when the offering delivery is online.", async () => {
     // Arrange
+    // College C is a BC Private institution.
     const institutionUserToken = await getInstitutionToken(
       InstitutionTokenTypes.CollegeCUser,
     );
@@ -535,6 +536,188 @@ describe("EducationProgramOfferingInstitutionsController(e2e)-createOffering", (
       offeringStatus: OfferingStatus.CreationPending,
       onlineInstructionMode: payload.onlineInstructionMode,
     });
+  });
+
+  it(
+    "Should create a new offering for a BC Private institution when the offering delivery is blended" +
+      " and percentage of online duration is always the same.",
+    async () => {
+      // Arrange
+      // College C is a BC Private institution.
+      const institutionUserToken = await getInstitutionToken(
+        InstitutionTokenTypes.CollegeCUser,
+      );
+      const fakeEducationProgram = createFakeEducationProgram({
+        institution: institutionCollegeC,
+        user: institutionCollegeCUser,
+      });
+      fakeEducationProgram.sabcCode = faker.random.alpha({ count: 4 });
+      const savedFakeEducationProgram = await db.educationProgram.save(
+        fakeEducationProgram,
+      );
+      const endpoint = `/institutions/education-program-offering/location/${collegeCLocation.id}/education-program/${savedFakeEducationProgram.id}`;
+      const studyBreak = {
+        breakStartDate: "2023-12-01",
+        breakEndDate: "2024-01-01",
+      };
+      const studyPeriodBreakdown = {
+        totalDays: 304,
+        totalFundedWeeks: 42,
+        fundedStudyPeriodDays: 293,
+        unfundedStudyPeriodDays: 11,
+      };
+      const payload: Partial<EducationProgramOfferingAPIInDTO> = {
+        offeringName: "Offering 1",
+        yearOfStudy: 1,
+        offeringIntensity: OfferingIntensity.fullTime,
+        offeringDelivered: OfferingDeliveryOptions.Blended,
+        hasOfferingWILComponent: OfferingYesNoOptions.No,
+        studyStartDate: "2023-09-01",
+        studyEndDate: "2024-06-30",
+        lacksStudyBreaks: false,
+        studyBreaks: [
+          {
+            breakStartDate: studyBreak.breakStartDate,
+            breakEndDate: studyBreak.breakEndDate,
+          },
+        ],
+        offeringType: OfferingTypes.Public,
+        offeringDeclaration: true,
+        actualTuitionCosts: 1234,
+        programRelatedCosts: 3211,
+        mandatoryFees: 456,
+        exceptionalExpenses: 555,
+        onlineInstructionMode: OnlineInstructionModeOptions.SynchronousOnly,
+        isOnlineDurationSameAlways: OfferingYesNoOptions.Yes,
+        totalOnlineDuration: 45,
+      };
+
+      // Act/Assert
+      let educationProgramOfferingId: number;
+      await request(app.getHttpServer())
+        .post(endpoint)
+        .send(payload)
+        .auth(institutionUserToken, BEARER_AUTH_TYPE)
+        .then((response) => {
+          expect(response.body.id).toBeGreaterThan(0);
+          educationProgramOfferingId = response.body.id;
+        });
+      const createdEducationProgramOffering =
+        await db.educationProgramOffering.findOne({
+          select: {
+            name: true,
+            studyStartDate: true,
+            studyEndDate: true,
+            actualTuitionCosts: true,
+            programRelatedCosts: true,
+            mandatoryFees: true,
+            exceptionalExpenses: true,
+            offeringDelivered: true,
+            lacksStudyBreaks: true,
+            offeringType: true,
+            offeringIntensity: true,
+            yearOfStudy: true,
+            hasOfferingWILComponent: true,
+            studyBreaks: true as unknown,
+            offeringDeclaration: true,
+            offeringStatus: true,
+            onlineInstructionMode: true,
+          },
+          where: { id: educationProgramOfferingId },
+        });
+      expect(createdEducationProgramOffering).toEqual({
+        name: payload.offeringName,
+        studyStartDate: payload.studyStartDate,
+        studyEndDate: payload.studyEndDate,
+        actualTuitionCosts: payload.actualTuitionCosts,
+        programRelatedCosts: payload.programRelatedCosts,
+        mandatoryFees: payload.mandatoryFees,
+        exceptionalExpenses: payload.exceptionalExpenses,
+        offeringDelivered: payload.offeringDelivered,
+        lacksStudyBreaks: payload.lacksStudyBreaks,
+        offeringType: payload.offeringType,
+        offeringIntensity: payload.offeringIntensity,
+        yearOfStudy: payload.yearOfStudy,
+        hasOfferingWILComponent: payload.hasOfferingWILComponent,
+        studyBreaks: {
+          totalDays: studyPeriodBreakdown.totalDays,
+          studyBreaks: [
+            {
+              breakStartDate: studyBreak.breakStartDate,
+              breakEndDate: studyBreak.breakEndDate,
+              breakDays: 32,
+              eligibleBreakDays: 21,
+              ineligibleBreakDays: 11,
+            },
+          ],
+          totalFundedWeeks: studyPeriodBreakdown.totalFundedWeeks,
+          fundedStudyPeriodDays: studyPeriodBreakdown.fundedStudyPeriodDays,
+          unfundedStudyPeriodDays: studyPeriodBreakdown.unfundedStudyPeriodDays,
+        },
+        offeringDeclaration: payload.offeringDeclaration,
+        offeringStatus: OfferingStatus.CreationPending,
+        onlineInstructionMode: payload.onlineInstructionMode,
+      });
+    },
+  );
+
+  it("Should throw bad request error when trying to create offering for a BC Private institution when the offering delivery is online and mode of online instruction is not provided.", async () => {
+    // Arrange
+    // College C is a BC Private institution.
+    const institutionUserToken = await getInstitutionToken(
+      InstitutionTokenTypes.CollegeCUser,
+    );
+    const fakeEducationProgram = createFakeEducationProgram({
+      institution: institutionCollegeC,
+      user: institutionCollegeCUser,
+    });
+    fakeEducationProgram.sabcCode = faker.random.alpha({ count: 4 });
+    const savedFakeEducationProgram = await db.educationProgram.save(
+      fakeEducationProgram,
+    );
+    const endpoint = `/institutions/education-program-offering/location/${collegeCLocation.id}/education-program/${savedFakeEducationProgram.id}`;
+    const studyBreak = {
+      breakStartDate: "2023-12-01",
+      breakEndDate: "2024-01-01",
+    };
+    const payload: Partial<EducationProgramOfferingAPIInDTO> = {
+      offeringName: "Offering 1",
+      yearOfStudy: 1,
+      offeringIntensity: OfferingIntensity.fullTime,
+      offeringDelivered: OfferingDeliveryOptions.Online,
+      hasOfferingWILComponent: OfferingYesNoOptions.No,
+      studyStartDate: "2023-09-01",
+      studyEndDate: "2024-06-30",
+      lacksStudyBreaks: false,
+      studyBreaks: [
+        {
+          breakStartDate: studyBreak.breakStartDate,
+          breakEndDate: studyBreak.breakEndDate,
+        },
+      ],
+      offeringType: OfferingTypes.Public,
+      offeringDeclaration: true,
+      actualTuitionCosts: 1234,
+      programRelatedCosts: 3211,
+      mandatoryFees: 456,
+      exceptionalExpenses: 555,
+    };
+
+    // Act/Assert
+    await request(app.getHttpServer())
+      .post(endpoint)
+      .send(payload)
+      .auth(institutionUserToken, BEARER_AUTH_TYPE)
+      .expect(HttpStatus.BAD_REQUEST)
+      .expect({
+        statusCode: HttpStatus.BAD_REQUEST,
+        message: [
+          `Online instruction mode must be one of the following options: ${Object.values(
+            OnlineInstructionModeOptions,
+          ).join(",")}`,
+        ],
+        error: "The validated offerings have critical errors.",
+      });
   });
 
   it("Should not create a new offering when user is read-only.", async () => {

--- a/sources/packages/backend/apps/api/src/route-controllers/education-program-offering/_tests_/e2e/education-program-offering.institutions.controller.updateProgramOffering.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/education-program-offering/_tests_/e2e/education-program-offering.institutions.controller.updateProgramOffering.e2e-spec.ts
@@ -32,6 +32,11 @@ import {
 } from "../../../../utilities";
 import { getISODateOnlyString } from "@sims/utilities";
 import { InstitutionUserTypes } from "../../../../auth";
+import { EducationProgramOfferingAPIInDTO } from "apps/api/src/route-controllers/education-program-offering/models/education-program-offering.dto";
+import {
+  OfferingYesNoOptions,
+  OnlineInstructionModeOptions,
+} from "../../../../services";
 
 describe("EducationProgramOfferingInstitutionsController(e2e)-updateProgramOffering", () => {
   let app: INestApplication;
@@ -39,6 +44,10 @@ describe("EducationProgramOfferingInstitutionsController(e2e)-updateProgramOffer
   let collegeF: Institution;
   let collegeFLocation: InstitutionLocation;
   let collegeFUser: User;
+  // BC Private Institution.
+  let institutionCollegeC: Institution;
+  let institutionCollegeCUser: User;
+  let collegeCLocation: InstitutionLocation;
 
   beforeAll(async () => {
     const { nestApplication, dataSource } = await createTestingAppModule();
@@ -48,13 +57,29 @@ describe("EducationProgramOfferingInstitutionsController(e2e)-updateProgramOffer
       db.dataSource,
       InstitutionTokenTypes.CollegeFUser,
     );
+    // Get BC Private institution and institution user.
+    const { institution: collegeC, user: collegeCUser } =
+      await getAuthRelatedEntities(
+        db.dataSource,
+        InstitutionTokenTypes.CollegeCUser,
+      );
     collegeF = institution;
     collegeFUser = institutionUser;
+    institutionCollegeC = collegeC;
+    institutionCollegeCUser = collegeCUser;
     collegeFLocation = createFakeInstitutionLocation({ institution: collegeF });
+    collegeCLocation = createFakeInstitutionLocation({
+      institution: institutionCollegeC,
+    });
     await authorizeUserTokenForLocation(
       db.dataSource,
       InstitutionTokenTypes.CollegeFUser,
       collegeFLocation,
+    );
+    await authorizeUserTokenForLocation(
+      db.dataSource,
+      InstitutionTokenTypes.CollegeCUser,
+      collegeCLocation,
     );
   });
 
@@ -161,6 +186,266 @@ describe("EducationProgramOfferingInstitutionsController(e2e)-updateProgramOffer
       }),
     );
   });
+
+  it(
+    "Should update an existing offering for a BC Public institution when the delivery mode is online" +
+      " and mode of online instruction is provided.",
+    async () => {
+      // Arrange
+      const institutionUserToken = await getInstitutionToken(
+        InstitutionTokenTypes.CollegeFUser,
+      );
+      const fakeEducationProgram = createFakeEducationProgram({
+        institution: collegeF,
+        user: collegeFUser,
+      });
+      fakeEducationProgram.sabcCode = faker.random.alpha({ count: 4 });
+      const savedFakeEducationProgram = await db.educationProgram.save(
+        fakeEducationProgram,
+      );
+      const newOffering = createFakeEducationProgramOffering(
+        savedFakeEducationProgram,
+        collegeFLocation,
+      );
+      newOffering.parentOffering = newOffering;
+      const savedEducationProgramOffering =
+        await db.educationProgramOffering.save(newOffering);
+
+      const endpoint = `/institutions/education-program-offering/location/${collegeFLocation.id}/education-program/${savedFakeEducationProgram.id}/offering/${savedEducationProgramOffering.id}`;
+      const studyBreak = {
+        breakStartDate: "2023-12-01",
+        breakEndDate: "2024-01-01",
+      };
+      const studyPeriodBreakdown = {
+        totalDays: 304,
+        totalFundedWeeks: 42,
+        fundedStudyPeriodDays: 293,
+        unfundedStudyPeriodDays: 11,
+      };
+      const payload: Partial<EducationProgramOfferingAPIInDTO> = {
+        offeringName: "Updated offering name",
+        yearOfStudy: 1,
+        offeringIntensity: OfferingIntensity.fullTime,
+        offeringDelivered: OfferingDeliveryOptions.Online,
+        hasOfferingWILComponent: OfferingYesNoOptions.No,
+        studyStartDate: "2023-09-01",
+        studyEndDate: "2024-06-30",
+        lacksStudyBreaks: false,
+        studyBreaks: [
+          {
+            breakStartDate: studyBreak.breakStartDate,
+            breakEndDate: studyBreak.breakEndDate,
+          },
+        ],
+        offeringType: OfferingTypes.Public,
+        offeringDeclaration: true,
+        actualTuitionCosts: 1234,
+        programRelatedCosts: 3211,
+        mandatoryFees: 456,
+        exceptionalExpenses: 555,
+        onlineInstructionMode: OnlineInstructionModeOptions.SynchronousOnly,
+      };
+
+      // Act/Assert
+      await request(app.getHttpServer())
+        .patch(endpoint)
+        .send(payload)
+        .auth(institutionUserToken, BEARER_AUTH_TYPE)
+        .expect(HttpStatus.OK)
+        .expect({});
+      const updatedEducationProgramOffering =
+        await db.educationProgramOffering.findOne({
+          select: {
+            name: true,
+            studyStartDate: true,
+            studyEndDate: true,
+            actualTuitionCosts: true,
+            programRelatedCosts: true,
+            mandatoryFees: true,
+            exceptionalExpenses: true,
+            offeringDelivered: true,
+            lacksStudyBreaks: true,
+            offeringType: true,
+            offeringIntensity: true,
+            yearOfStudy: true,
+            hasOfferingWILComponent: true,
+            studyBreaks: true as unknown,
+            offeringDeclaration: true,
+            offeringStatus: true,
+            onlineInstructionMode: true,
+          },
+          where: { id: savedEducationProgramOffering.id },
+        });
+      expect(updatedEducationProgramOffering).toEqual({
+        name: payload.offeringName,
+        studyStartDate: payload.studyStartDate,
+        studyEndDate: payload.studyEndDate,
+        actualTuitionCosts: payload.actualTuitionCosts,
+        programRelatedCosts: payload.programRelatedCosts,
+        mandatoryFees: payload.mandatoryFees,
+        exceptionalExpenses: payload.exceptionalExpenses,
+        offeringDelivered: payload.offeringDelivered,
+        lacksStudyBreaks: payload.lacksStudyBreaks,
+        offeringType: payload.offeringType,
+        offeringIntensity: payload.offeringIntensity,
+        yearOfStudy: payload.yearOfStudy,
+        hasOfferingWILComponent: payload.hasOfferingWILComponent,
+        studyBreaks: {
+          totalDays: studyPeriodBreakdown.totalDays,
+          studyBreaks: [
+            {
+              breakStartDate: studyBreak.breakStartDate,
+              breakEndDate: studyBreak.breakEndDate,
+              breakDays: 32,
+              eligibleBreakDays: 21,
+              ineligibleBreakDays: 11,
+            },
+          ],
+          totalFundedWeeks: studyPeriodBreakdown.totalFundedWeeks,
+          fundedStudyPeriodDays: studyPeriodBreakdown.fundedStudyPeriodDays,
+          unfundedStudyPeriodDays: studyPeriodBreakdown.unfundedStudyPeriodDays,
+        },
+        offeringDeclaration: payload.offeringDeclaration,
+        offeringStatus: OfferingStatus.CreationPending,
+        onlineInstructionMode: payload.onlineInstructionMode,
+      });
+    },
+  );
+
+  it(
+    "Should update an existing offering for a BC Private institution when the delivery mode is blended" +
+      " and percentage of online duration is not always the same.",
+    async () => {
+      // Arrange
+      // College C is a BC Private institution.
+      const institutionUserToken = await getInstitutionToken(
+        InstitutionTokenTypes.CollegeCUser,
+      );
+      const fakeEducationProgram = createFakeEducationProgram({
+        institution: institutionCollegeC,
+        user: institutionCollegeCUser,
+      });
+      fakeEducationProgram.sabcCode = faker.random.alpha({ count: 4 });
+      const savedFakeEducationProgram = await db.educationProgram.save(
+        fakeEducationProgram,
+      );
+      const newOffering = createFakeEducationProgramOffering(
+        savedFakeEducationProgram,
+        collegeCLocation,
+      );
+      newOffering.parentOffering = newOffering;
+      const savedEducationProgramOffering =
+        await db.educationProgramOffering.save(newOffering);
+
+      const endpoint = `/institutions/education-program-offering/location/${collegeCLocation.id}/education-program/${savedFakeEducationProgram.id}/offering/${savedEducationProgramOffering.id}`;
+      const studyBreak = {
+        breakStartDate: "2023-12-01",
+        breakEndDate: "2024-01-01",
+      };
+      const studyPeriodBreakdown = {
+        totalDays: 304,
+        totalFundedWeeks: 42,
+        fundedStudyPeriodDays: 293,
+        unfundedStudyPeriodDays: 11,
+      };
+      const payload: Partial<EducationProgramOfferingAPIInDTO> = {
+        offeringName: "Updated offering name",
+        yearOfStudy: 1,
+        offeringIntensity: OfferingIntensity.fullTime,
+        offeringDelivered: OfferingDeliveryOptions.Blended,
+        hasOfferingWILComponent: OfferingYesNoOptions.No,
+        studyStartDate: "2023-09-01",
+        studyEndDate: "2024-06-30",
+        lacksStudyBreaks: false,
+        studyBreaks: [
+          {
+            breakStartDate: studyBreak.breakStartDate,
+            breakEndDate: studyBreak.breakEndDate,
+          },
+        ],
+        offeringType: OfferingTypes.Public,
+        offeringDeclaration: true,
+        actualTuitionCosts: 1234,
+        programRelatedCosts: 3211,
+        mandatoryFees: 456,
+        exceptionalExpenses: 555,
+        onlineInstructionMode: OnlineInstructionModeOptions.SynchronousOnly,
+        isOnlineDurationSameAlways: OfferingYesNoOptions.No,
+        minimumOnlineDuration: 45,
+        maximumOnlineDuration: 60,
+      };
+
+      // Act/Assert
+      await request(app.getHttpServer())
+        .patch(endpoint)
+        .send(payload)
+        .auth(institutionUserToken, BEARER_AUTH_TYPE)
+        .expect(HttpStatus.OK)
+        .expect({});
+      const updatedEducationProgramOffering =
+        await db.educationProgramOffering.findOne({
+          select: {
+            name: true,
+            studyStartDate: true,
+            studyEndDate: true,
+            actualTuitionCosts: true,
+            programRelatedCosts: true,
+            mandatoryFees: true,
+            exceptionalExpenses: true,
+            offeringDelivered: true,
+            lacksStudyBreaks: true,
+            offeringType: true,
+            offeringIntensity: true,
+            yearOfStudy: true,
+            hasOfferingWILComponent: true,
+            studyBreaks: true as unknown,
+            offeringDeclaration: true,
+            offeringStatus: true,
+            onlineInstructionMode: true,
+            isOnlineDurationSameAlways: true,
+            minimumOnlineDuration: true,
+            maximumOnlineDuration: true,
+          },
+          where: { id: savedEducationProgramOffering.id },
+        });
+      expect(updatedEducationProgramOffering).toEqual({
+        name: payload.offeringName,
+        studyStartDate: payload.studyStartDate,
+        studyEndDate: payload.studyEndDate,
+        actualTuitionCosts: payload.actualTuitionCosts,
+        programRelatedCosts: payload.programRelatedCosts,
+        mandatoryFees: payload.mandatoryFees,
+        exceptionalExpenses: payload.exceptionalExpenses,
+        offeringDelivered: payload.offeringDelivered,
+        lacksStudyBreaks: payload.lacksStudyBreaks,
+        offeringType: payload.offeringType,
+        offeringIntensity: payload.offeringIntensity,
+        yearOfStudy: payload.yearOfStudy,
+        hasOfferingWILComponent: payload.hasOfferingWILComponent,
+        studyBreaks: {
+          totalDays: studyPeriodBreakdown.totalDays,
+          studyBreaks: [
+            {
+              breakStartDate: studyBreak.breakStartDate,
+              breakEndDate: studyBreak.breakEndDate,
+              breakDays: 32,
+              eligibleBreakDays: 21,
+              ineligibleBreakDays: 11,
+            },
+          ],
+          totalFundedWeeks: studyPeriodBreakdown.totalFundedWeeks,
+          fundedStudyPeriodDays: studyPeriodBreakdown.fundedStudyPeriodDays,
+          unfundedStudyPeriodDays: studyPeriodBreakdown.unfundedStudyPeriodDays,
+        },
+        offeringDeclaration: payload.offeringDeclaration,
+        offeringStatus: OfferingStatus.CreationPending,
+        onlineInstructionMode: payload.onlineInstructionMode,
+        isOnlineDurationSameAlways: payload.isOnlineDurationSameAlways,
+        minimumOnlineDuration: payload.minimumOnlineDuration,
+        maximumOnlineDuration: payload.maximumOnlineDuration,
+      });
+    },
+  );
 
   it("Should not update a new offering when requested by a read-only user.", async () => {
     // Arrange

--- a/sources/packages/backend/apps/api/src/route-controllers/education-program-offering/_tests_/e2e/education-program-offering.institutions.controller.updateProgramOffering.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/education-program-offering/_tests_/e2e/education-program-offering.institutions.controller.updateProgramOffering.e2e-spec.ts
@@ -71,16 +71,17 @@ describe("EducationProgramOfferingInstitutionsController(e2e)-updateProgramOffer
     collegeCLocation = createFakeInstitutionLocation({
       institution: institutionCollegeC,
     });
-    await authorizeUserTokenForLocation(
+    const authorizeCollegeFPromise = authorizeUserTokenForLocation(
       db.dataSource,
       InstitutionTokenTypes.CollegeFUser,
       collegeFLocation,
     );
-    await authorizeUserTokenForLocation(
+    const authorizeCollegeCPromise = authorizeUserTokenForLocation(
       db.dataSource,
       InstitutionTokenTypes.CollegeCUser,
       collegeCLocation,
     );
+    await Promise.all([authorizeCollegeFPromise, authorizeCollegeCPromise]);
   });
 
   it("Should update a new offering when passed valid data.", async () => {
@@ -199,7 +200,6 @@ describe("EducationProgramOfferingInstitutionsController(e2e)-updateProgramOffer
         institution: collegeF,
         user: collegeFUser,
       });
-      fakeEducationProgram.sabcCode = faker.random.alpha({ count: 4 });
       const savedFakeEducationProgram = await db.educationProgram.save(
         fakeEducationProgram,
       );
@@ -325,7 +325,6 @@ describe("EducationProgramOfferingInstitutionsController(e2e)-updateProgramOffer
         institution: institutionCollegeC,
         user: institutionCollegeCUser,
       });
-      fakeEducationProgram.sabcCode = faker.random.alpha({ count: 4 });
       const savedFakeEducationProgram = await db.educationProgram.save(
         fakeEducationProgram,
       );

--- a/sources/packages/backend/apps/test-db-seeding/src/db-seeding/institution/basic-seeding/create-institutions-and-authentication-users.model.ts
+++ b/sources/packages/backend/apps/test-db-seeding/src/db-seeding/institution/basic-seeding/create-institutions-and-authentication-users.model.ts
@@ -33,6 +33,7 @@ export interface InstitutionBaseData {
   institutionTypeId: number;
   users: InstitutionUserBaseData[];
 }
+const INSTITUTION_TYPE_OUT_OF_PROVINCE = 3;
 
 export const INSTITUTIONS_INITIAL_DATA: InstitutionBaseData[] = [
   {
@@ -61,7 +62,7 @@ export const INSTITUTIONS_INITIAL_DATA: InstitutionBaseData[] = [
     legalOperatingName: "College D - Business BCeID",
     operatingName: "College D (non-legal operating name)",
     businessGuid: COLLEGE_D_BUSINESS_GUID,
-    institutionTypeId: INSTITUTION_TYPE_BC_PRIVATE,
+    institutionTypeId: INSTITUTION_TYPE_OUT_OF_PROVINCE,
     users: [
       {
         userName: SIMS_COLLD_ADMIN_NON_LEGAL_SIGNING_USER,

--- a/sources/packages/forms/src/form-definitions/educationprogramoffering.json
+++ b/sources/packages/forms/src/form-definitions/educationprogramoffering.json
@@ -2578,7 +2578,9 @@
                   "properties": {},
                   "allowMultipleMasks": false,
                   "addons": [],
-                  "id": "eod06e7"
+                  "id": "eod06e7",
+                  "isNew": false,
+                  "tags": []
                 },
                 {
                   "label": "HTML",
@@ -2650,7 +2652,7 @@
                   "properties": {},
                   "allowMultipleMasks": false,
                   "addons": [],
-                  "tag": "p",
+                  "tag": "div",
                   "id": "eity25i",
                   "className": "",
                   "tags": [],


### PR DESCRIPTION
# Offering data collection - E2E Tests and Form content duplication fix

## FormIO content duplication fix for study breaks(AC added to the ticket)
![image](https://github.com/user-attachments/assets/23dee905-71a1-4658-997b-e0a66197505c)

## E2E Tests
- [x] In the data-seed, institution type of College D is set to `Out of Province` to have an institution type other than `BC Public` and `BC Private`
- [x] Added E2E tests for `Create offering` API
![image](https://github.com/user-attachments/assets/e8876e73-db86-4f9c-b66a-fe218ce201a5)
- [x] Added E2E tests for `Update offering` API
![image](https://github.com/user-attachments/assets/71c58db1-0fe8-4445-804d-004355e6d1af)

