### PR TITLE
#4619 - Hotfix - Student reported income fix

### DIFF
--- a/sources/packages/backend/apps/workers/src/controllers/cra-integration/cra-integration.controller.ts
+++ b/sources/packages/backend/apps/workers/src/controllers/cra-integration/cra-integration.controller.ts
@@ -64,6 +64,7 @@ export class CRAIntegrationController {
 
       await this.incomeVerificationService.checkForCRAIncomeVerificationBypass(
         identifier.id,
+        job.variables.reportedIncome,
       );
       jobLogger.log("CRA income verification created.");
       return job.complete({ incomeVerificationId: identifier.id });

--- a/sources/packages/backend/apps/workers/src/services/cra-income-verification/cra-income-verification.service.ts
+++ b/sources/packages/backend/apps/workers/src/services/cra-income-verification/cra-income-verification.service.ts
@@ -60,9 +60,11 @@ export class CRAIncomeVerificationService extends RecordDataModelService<CRAInco
    * local developer machine or on an environment where the CRA process is not enabled.
    * !This code should not be executed on production.
    * @param verificationId CRA verification id waiting to be processed.
+   * @param reportedIncome reported income by the user.
    */
   async checkForCRAIncomeVerificationBypass(
     verificationId: number,
+    reportedIncome: number,
   ): Promise<void> {
     if (this.configService.bypassCRAIncomeVerification !== true) {
       return;
@@ -78,6 +80,8 @@ export class CRAIncomeVerificationService extends RecordDataModelService<CRAInco
         matchStatusCode: "01",
         requestStatusCode: "01",
         inactiveCode: "00",
+        // When the income verification is bypassed, set the CRA reported income as the user reported income.
+        craReportedIncome: reportedIncome,
       },
     );
     await this.workflowClientService.sendCRAIncomeVerificationCompletedMessage(

--- a/sources/packages/backend/apps/workers/src/services/student-assessment/student-assessment.service.ts
+++ b/sources/packages/backend/apps/workers/src/services/student-assessment/student-assessment.service.ts
@@ -152,7 +152,7 @@ export class StudentAssessmentService extends RecordDataModelService<StudentAsse
         "craIncomeVerification.id",
         "craIncomeVerification.craReportedIncome",
         "craIncomeVerification.taxYear",
-        "incomeVerificationSupportingUser.id",
+        "craIncomeVerificationSupportingUser.id",
         "studentAppeal.id",
         "appealRequest.id",
         "institutionLocation.data",
@@ -178,7 +178,7 @@ export class StudentAssessmentService extends RecordDataModelService<StudentAsse
       .leftJoin("application.craIncomeVerifications", "craIncomeVerification")
       .leftJoin(
         "craIncomeVerification.supportingUser",
-        "incomeVerificationSupportingUser",
+        "craIncomeVerificationSupportingUser",
       )
       .where("assessment.id = :assessmentId", {
         assessmentId,

--- a/sources/packages/backend/apps/workers/src/services/student-assessment/student-assessment.service.ts
+++ b/sources/packages/backend/apps/workers/src/services/student-assessment/student-assessment.service.ts
@@ -152,7 +152,7 @@ export class StudentAssessmentService extends RecordDataModelService<StudentAsse
         "craIncomeVerification.id",
         "craIncomeVerification.craReportedIncome",
         "craIncomeVerification.taxYear",
-        "craIncomeVerification.supportingUser.id",
+        "incomeVerificationSupportingUser.id",
         "studentAppeal.id",
         "appealRequest.id",
         "institutionLocation.data",
@@ -176,6 +176,10 @@ export class StudentAssessmentService extends RecordDataModelService<StudentAsse
         { appealStatus: StudentAppealStatus.Approved },
       )
       .leftJoin("application.craIncomeVerifications", "craIncomeVerification")
+      .leftJoin(
+        "craIncomeVerification.supportingUser",
+        "incomeVerificationSupportingUser",
+      )
       .where("assessment.id = :assessmentId", {
         assessmentId,
       })


### PR DESCRIPTION
## Issue

When an application has a supporting user and the supporting user has successful income verification, 
then the student reported income `studentDataCRAReportedIncome` is set  with partner's CRA Reported income value
by the worker job `loadAssessmentConsolidatedData` [loadAssessmentConsolidatedData](https://github.com/bcgov/SIMS/blob/main/sources/packages/backend/apps/workers/src/controllers/assessment/assessment.controller.ts#L149)
  
This is because following logic receives both student and supporting user income verifications after filter BECAUSE the SQL query does not return the supporting user id.
![image](https://github.com/user-attachments/assets/2caaf474-8f53-417e-bafe-82591c8b6c2d)


## Solution
The bug has been introduced since we removed TypeOrm `RelationId` property and referenced the relational object in a way that wasn't working so left join was added to fix the issue and used the join object to select.

## Update to the income verification bypass.

- [x]  In the local environment, we bypass the CRA income verifications to allow the workflow to proceed. During this process updated the logic to save CRA Reported Income as User provided income to allow  manual tests to be easier in local which involves CRA reported income.


## Manual testing with supporting user

CRA Income verifications table

![image](https://github.com/user-attachments/assets/fa330efd-32fb-40ef-9ac4-4ae04715cff5)

Camunda variable

![image](https://github.com/user-attachments/assets/0f45844c-22e1-4d47-b04a-aba6718a0cb7)
