### PR TITLE
#4616 - Ministry View Change Request Revamp (Application view menu)

### DIFF
--- a/sources/packages/backend/apps/api/src/route-controllers/application/_tests_/application.aest.controller.getApplicationOverallDetails.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/application/_tests_/application.aest.controller.getApplicationOverallDetails.e2e-spec.ts
@@ -85,6 +85,7 @@ describe("ApplicationAESTController(e2e)-getApplicationOverallDetails", () => {
           id: currentApplication.id,
           submittedDate: currentApplication.submittedDate.toISOString(),
           applicationEditStatus: currentApplication.applicationEditStatus,
+          supportingUsers: [],
         },
         previousVersions: [
           {
@@ -92,12 +93,14 @@ describe("ApplicationAESTController(e2e)-getApplicationOverallDetails", () => {
             submittedDate: secondVersionApplication.submittedDate.toISOString(),
             applicationEditStatus:
               secondVersionApplication.applicationEditStatus,
+            supportingUsers: [],
           },
           {
             id: firstVersionApplication.id,
             submittedDate: firstVersionApplication.submittedDate.toISOString(),
             applicationEditStatus:
               firstVersionApplication.applicationEditStatus,
+            supportingUsers: [],
           },
         ],
       });
@@ -121,6 +124,7 @@ describe("ApplicationAESTController(e2e)-getApplicationOverallDetails", () => {
           id: originalApplication.id,
           submittedDate: originalApplication.submittedDate.toISOString(),
           applicationEditStatus: originalApplication.applicationEditStatus,
+          supportingUsers: [],
         },
         previousVersions: [],
       });
@@ -179,6 +183,7 @@ describe("ApplicationAESTController(e2e)-getApplicationOverallDetails", () => {
             id: currentApplication.id,
             submittedDate: currentApplication.submittedDate.toISOString(),
             applicationEditStatus: currentApplication.applicationEditStatus,
+            supportingUsers: [],
           },
           inProgressChangeRequest: {
             id: changeRequestApplication.id,
@@ -237,6 +242,7 @@ describe("ApplicationAESTController(e2e)-getApplicationOverallDetails", () => {
           id: currentApplication.id,
           submittedDate: currentApplication.submittedDate.toISOString(),
           applicationEditStatus: currentApplication.applicationEditStatus,
+          supportingUsers: [],
         },
         previousVersions: [
           {
@@ -244,6 +250,7 @@ describe("ApplicationAESTController(e2e)-getApplicationOverallDetails", () => {
             submittedDate: changeRequestApplication.submittedDate.toISOString(),
             applicationEditStatus:
               changeRequestApplication.applicationEditStatus,
+            supportingUsers: [],
           },
         ],
       });

--- a/sources/packages/backend/apps/api/src/route-controllers/application/_tests_/application.aest.controller.getApplicationOverallDetails.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/application/_tests_/application.aest.controller.getApplicationOverallDetails.e2e-spec.ts
@@ -75,6 +75,11 @@ describe("ApplicationAESTController(e2e)-getApplicationOverallDetails", () => {
       .auth(token, BEARER_AUTH_TYPE)
       .expect(HttpStatus.OK)
       .expect({
+        currentApplication: {
+          id: currentApplication.id,
+          submittedDate: currentApplication.submittedDate.toISOString(),
+          applicationEditStatus: currentApplication.applicationEditStatus,
+        },
         previousVersions: [
           {
             id: secondVersionApplication.id,
@@ -92,7 +97,7 @@ describe("ApplicationAESTController(e2e)-getApplicationOverallDetails", () => {
       });
   });
 
-  it("Should get no application versions in overall details when there is no edited application associated with the given application.", async () => {
+  it("Should get the original application and no application versions in overall details when there is no edited application associated with the given application.", async () => {
     // Arrange
     // Create the parent application and also the first application version.
     const originalApplication = await saveFakeApplication(db.dataSource);
@@ -106,6 +111,11 @@ describe("ApplicationAESTController(e2e)-getApplicationOverallDetails", () => {
       .auth(token, BEARER_AUTH_TYPE)
       .expect(HttpStatus.OK)
       .expect({
+        currentApplication: {
+          id: originalApplication.id,
+          submittedDate: originalApplication.submittedDate.toISOString(),
+          applicationEditStatus: originalApplication.applicationEditStatus,
+        },
         previousVersions: [],
       });
   });

--- a/sources/packages/backend/apps/api/src/route-controllers/application/_tests_/application.aest.controller.getApplicationOverallDetails.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/application/_tests_/application.aest.controller.getApplicationOverallDetails.e2e-spec.ts
@@ -8,10 +8,16 @@ import {
 } from "../../../testHelpers";
 import {
   createE2EDataSources,
+  createFakeSupportingUser,
   E2EDataSources,
   saveFakeApplication,
 } from "@sims/test-utils";
-import { Application, ApplicationStatus } from "@sims/sims-db";
+import {
+  Application,
+  ApplicationEditStatus,
+  ApplicationStatus,
+  SupportingUserType,
+} from "@sims/sims-db";
 import { addDays } from "@sims/utilities";
 
 describe("ApplicationAESTController(e2e)-getApplicationOverallDetails", () => {
@@ -117,6 +123,225 @@ describe("ApplicationAESTController(e2e)-getApplicationOverallDetails", () => {
           applicationEditStatus: originalApplication.applicationEditStatus,
         },
         previousVersions: [],
+      });
+  });
+
+  it(
+    "Should get the current application and an in-progress change request, including supporting users" +
+      " when the application has an in-progress change request.",
+    async () => {
+      // Arrange
+      // Create the current application.
+      const currentApplication = await saveFakeApplication(
+        db.dataSource,
+        undefined,
+        {
+          applicationStatus: ApplicationStatus.Completed,
+          submittedDate: addDays(-1),
+        },
+      );
+      // Create the in-progress change request.
+      const changeRequestApplication = await saveFakeApplication(
+        db.dataSource,
+        {
+          parentApplication: { id: currentApplication.id } as Application,
+          precedingApplication: {
+            id: currentApplication.id,
+          } as Application,
+        },
+        {
+          submittedDate: new Date(),
+          applicationStatus: ApplicationStatus.Edited,
+          applicationEditStatus: ApplicationEditStatus.ChangeInProgress,
+        },
+      );
+      // Create partner supporting user for the change request application.
+      const partner = createFakeSupportingUser(
+        { application: changeRequestApplication },
+        {
+          initialValues: {
+            supportingUserType: SupportingUserType.Partner,
+          },
+        },
+      );
+      await db.supportingUser.save(partner);
+
+      const token = await getAESTToken(AESTGroups.BusinessAdministrators);
+      const endpoint = `/aest/application/${currentApplication.id}/overall-details`;
+
+      // Act/Assert
+      await request(app.getHttpServer())
+        .get(endpoint)
+        .auth(token, BEARER_AUTH_TYPE)
+        .expect(HttpStatus.OK)
+        .expect({
+          currentApplication: {
+            id: currentApplication.id,
+            submittedDate: currentApplication.submittedDate.toISOString(),
+            applicationEditStatus: currentApplication.applicationEditStatus,
+          },
+          inProgressChangeRequest: {
+            id: changeRequestApplication.id,
+            submittedDate: changeRequestApplication.submittedDate.toISOString(),
+            applicationEditStatus:
+              changeRequestApplication.applicationEditStatus,
+            supportingUsers: [
+              {
+                supportingUserId: partner.id,
+                supportingUserType: partner.supportingUserType,
+              },
+            ],
+          },
+          previousVersions: [],
+        });
+    },
+  );
+
+  it("Should get the current application and an application version when the application has a declined change request.", async () => {
+    // Arrange
+    // Create the current application.
+    const currentApplication = await saveFakeApplication(
+      db.dataSource,
+      undefined,
+      {
+        applicationStatus: ApplicationStatus.Completed,
+        submittedDate: addDays(-1),
+      },
+    );
+    // Create the declined change request.
+    const changeRequestApplication = await saveFakeApplication(
+      db.dataSource,
+      {
+        parentApplication: { id: currentApplication.id } as Application,
+        precedingApplication: {
+          id: currentApplication.id,
+        } as Application,
+      },
+      {
+        submittedDate: new Date(),
+        applicationStatus: ApplicationStatus.Edited,
+        applicationEditStatus: ApplicationEditStatus.ChangeDeclined,
+      },
+    );
+
+    const token = await getAESTToken(AESTGroups.BusinessAdministrators);
+    const endpoint = `/aest/application/${currentApplication.id}/overall-details`;
+
+    // Act/Assert
+    await request(app.getHttpServer())
+      .get(endpoint)
+      .auth(token, BEARER_AUTH_TYPE)
+      .expect(HttpStatus.OK)
+      .expect({
+        currentApplication: {
+          id: currentApplication.id,
+          submittedDate: currentApplication.submittedDate.toISOString(),
+          applicationEditStatus: currentApplication.applicationEditStatus,
+        },
+        previousVersions: [
+          {
+            id: changeRequestApplication.id,
+            submittedDate: changeRequestApplication.submittedDate.toISOString(),
+            applicationEditStatus:
+              changeRequestApplication.applicationEditStatus,
+          },
+        ],
+      });
+  });
+
+  it("Should get the current application and versions supporting users when the application and its versions have supporting users.", async () => {
+    // Arrange
+    // Create the parent application and also the first application version.
+    const firstVersionApplication = await saveFakeApplication(
+      db.dataSource,
+      undefined,
+      {
+        applicationStatus: ApplicationStatus.Edited,
+        submittedDate: addDays(-1),
+      },
+    );
+    // Create the current application.
+    const currentApplication = await saveFakeApplication(
+      db.dataSource,
+      {
+        parentApplication: { id: firstVersionApplication.id } as Application,
+        precedingApplication: {
+          id: firstVersionApplication.id,
+        } as Application,
+      },
+      {
+        applicationNumber: firstVersionApplication.applicationNumber,
+        offeringIntensity:
+          firstVersionApplication.currentAssessment.offering.offeringIntensity,
+        submittedDate: new Date(),
+      },
+    );
+    // Create parents supporting users for the current application.
+    const parent1 = createFakeSupportingUser(
+      { application: currentApplication },
+      {
+        initialValues: {
+          supportingUserType: SupportingUserType.Parent,
+        },
+      },
+    );
+    const parent2 = createFakeSupportingUser(
+      { application: currentApplication },
+      {
+        initialValues: {
+          supportingUserType: SupportingUserType.Parent,
+        },
+      },
+    );
+    // Create partner supporting user for first version of the application.
+    const partner = createFakeSupportingUser(
+      { application: firstVersionApplication },
+      {
+        initialValues: {
+          supportingUserType: SupportingUserType.Partner,
+        },
+      },
+    );
+    await db.supportingUser.save([parent1, parent2, partner]);
+
+    const token = await getAESTToken(AESTGroups.BusinessAdministrators);
+    const endpoint = `/aest/application/${currentApplication.id}/overall-details`;
+
+    // Act/Assert
+    await request(app.getHttpServer())
+      .get(endpoint)
+      .auth(token, BEARER_AUTH_TYPE)
+      .expect(HttpStatus.OK)
+      .expect({
+        currentApplication: {
+          id: currentApplication.id,
+          submittedDate: currentApplication.submittedDate.toISOString(),
+          applicationEditStatus: currentApplication.applicationEditStatus,
+          supportingUsers: [
+            {
+              supportingUserId: parent1.id,
+              supportingUserType: parent1.supportingUserType,
+            },
+            {
+              supportingUserId: parent2.id,
+              supportingUserType: parent2.supportingUserType,
+            },
+          ],
+        },
+        previousVersions: [
+          {
+            id: firstVersionApplication.id,
+            submittedDate: firstVersionApplication.submittedDate.toISOString(),
+            applicationEditStatus:
+              firstVersionApplication.applicationEditStatus,
+            supportingUsers: [
+              {
+                supportingUserId: partner.id,
+                supportingUserType: partner.supportingUserType,
+              },
+            ],
+          },
+        ],
       });
   });
 

--- a/sources/packages/backend/apps/api/src/route-controllers/application/application.controller.service.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/application/application.controller.service.ts
@@ -872,12 +872,10 @@ export class ApplicationControllerService {
       id: application.id,
       submittedDate: application.submittedDate,
       applicationEditStatus: application.applicationEditStatus,
-      supportingUsers: application.supportingUsers.length
-        ? application.supportingUsers.map((user) => ({
-            supportingUserId: user.id,
-            supportingUserType: user.supportingUserType,
-          }))
-        : undefined,
+      supportingUsers: application.supportingUsers.map((user) => ({
+        supportingUserId: user.id,
+        supportingUserType: user.supportingUserType,
+      })),
     };
   }
 

--- a/sources/packages/backend/apps/api/src/route-controllers/application/application.controller.service.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/application/application.controller.service.ts
@@ -872,10 +872,12 @@ export class ApplicationControllerService {
       id: application.id,
       submittedDate: application.submittedDate,
       applicationEditStatus: application.applicationEditStatus,
-      supportingUsers: application.supportingUsers.map((user) => ({
-        supportingUserId: user.id,
-        supportingUserType: user.supportingUserType,
-      })),
+      supportingUsers: application.supportingUsers.length
+        ? application.supportingUsers.map((user) => ({
+            supportingUserId: user.id,
+            supportingUserType: user.supportingUserType,
+          }))
+        : undefined,
     };
   }
 

--- a/sources/packages/backend/apps/api/src/route-controllers/application/models/application.dto.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/application/models/application.dto.ts
@@ -283,7 +283,7 @@ export class ApplicationVersionAPIOutDTO {
   id: number;
   submittedDate: Date;
   applicationEditStatus: ApplicationEditStatus;
-  supportingUsers: ApplicationSupportingUsersAPIOutDTO[];
+  supportingUsers?: ApplicationSupportingUsersAPIOutDTO[];
 }
 
 /**

--- a/sources/packages/backend/apps/api/src/route-controllers/application/models/application.dto.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/application/models/application.dto.ts
@@ -16,6 +16,7 @@ import {
   StudentAssessmentStatus,
   ApplicationEditStatus,
   ApplicationEditStatusInProgress,
+  SupportingUserType,
 } from "@sims/sims-db";
 import { JsonMaxSize } from "../../../utilities/class-validation";
 import { JSON_20KB } from "../../../constants";
@@ -263,12 +264,25 @@ export class ApplicationWarningsAPIOutDTO {
   canAcceptAssessment: boolean;
 }
 
+export interface ApplicationSupportingUsersAPIOutDTO {
+  supportingUserId: number;
+  supportingUserType: SupportingUserType;
+}
+
+export class ApplicationSupportingUsersAPIOutDTO {
+  supportingUserId: number;
+  supportingUserType: SupportingUserType;
+}
+
 export class ApplicationVersionAPIOutDTO {
   id: number;
   submittedDate: Date;
   applicationEditStatus: ApplicationEditStatus;
+  supportingUsers: ApplicationSupportingUsersAPIOutDTO[];
 }
 
 export class ApplicationOverallDetailsAPIOutDTO {
+  currentApplication: ApplicationVersionAPIOutDTO;
+  inProgressChangeRequest?: ApplicationVersionAPIOutDTO;
   previousVersions: ApplicationVersionAPIOutDTO[];
 }

--- a/sources/packages/backend/apps/api/src/route-controllers/application/models/application.dto.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/application/models/application.dto.ts
@@ -274,6 +274,11 @@ export class ApplicationSupportingUsersAPIOutDTO {
   supportingUserType: SupportingUserType;
 }
 
+/**
+ * Represents a version of an application at any given time,
+ * including the current application, any in-progress
+ * change requests, and any past versions.
+ */
 export class ApplicationVersionAPIOutDTO {
   id: number;
   submittedDate: Date;
@@ -281,6 +286,11 @@ export class ApplicationVersionAPIOutDTO {
   supportingUsers: ApplicationSupportingUsersAPIOutDTO[];
 }
 
+/**
+ * Represents the overall details of an application,
+ * including the current application, any in-progress
+ * change requests, and any previous versions.
+ */
 export class ApplicationOverallDetailsAPIOutDTO {
   currentApplication: ApplicationVersionAPIOutDTO;
   inProgressChangeRequest?: ApplicationVersionAPIOutDTO;

--- a/sources/packages/backend/apps/api/src/route-controllers/application/models/application.dto.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/application/models/application.dto.ts
@@ -264,11 +264,6 @@ export class ApplicationWarningsAPIOutDTO {
   canAcceptAssessment: boolean;
 }
 
-export interface ApplicationSupportingUsersAPIOutDTO {
-  supportingUserId: number;
-  supportingUserType: SupportingUserType;
-}
-
 export class ApplicationSupportingUsersAPIOutDTO {
   supportingUserId: number;
   supportingUserType: SupportingUserType;

--- a/sources/packages/backend/apps/api/src/route-controllers/application/models/application.dto.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/application/models/application.dto.ts
@@ -278,7 +278,7 @@ export class ApplicationVersionAPIOutDTO {
   id: number;
   submittedDate: Date;
   applicationEditStatus: ApplicationEditStatus;
-  supportingUsers?: ApplicationSupportingUsersAPIOutDTO[];
+  supportingUsers: ApplicationSupportingUsersAPIOutDTO[];
 }
 
 /**

--- a/sources/packages/backend/apps/api/src/route-controllers/supporting-user/models/supporting-user.dto.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/supporting-user/models/supporting-user.dto.ts
@@ -8,7 +8,6 @@ import {
 } from "class-validator";
 import {
   ContactInfo,
-  SupportingUserType,
   APPLICATION_NUMBER_LENGTH,
   USER_LAST_NAME_MAX_LENGTH,
   OfferingIntensity,
@@ -71,11 +70,6 @@ export class ApplicationAPIOutDTO {
   programYearStartDate: string;
   formName: string;
   offeringIntensity: OfferingIntensity;
-}
-
-export class ApplicationSupportingUsersAPIOutDTO {
-  supportingUserId: number;
-  supportingUserType: SupportingUserType;
 }
 
 export class SupportingUserFormDataAPIOutDTO {

--- a/sources/packages/backend/apps/api/src/route-controllers/supporting-user/supporting-user.aest.controller.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/supporting-user/supporting-user.aest.controller.ts
@@ -9,10 +9,7 @@ import { SupportingUserService } from "../../services";
 import { AuthorizedParties } from "../../auth/authorized-parties.enum";
 import { AllowAuthorizedParty, Groups } from "../../auth/decorators";
 import { UserGroups } from "../../auth/user-groups.enum";
-import {
-  ApplicationSupportingUsersAPIOutDTO,
-  SupportingUserFormDataAPIOutDTO,
-} from "./models/supporting-user.dto";
+import { SupportingUserFormDataAPIOutDTO } from "./models/supporting-user.dto";
 import { getSupportingUserForm } from "../../utilities";
 import { ApiNotFoundResponse, ApiTags } from "@nestjs/swagger";
 import { ClientTypeBaseRoute } from "../../types";
@@ -23,25 +20,6 @@ import { ClientTypeBaseRoute } from "../../types";
 @ApiTags(`${ClientTypeBaseRoute.AEST}-supporting-user`)
 export class SupportingUserAESTController {
   constructor(private readonly supportingUserService: SupportingUserService) {}
-  /**
-   * Get the list of supporting users respective to
-   * an application id for AEST user.
-   * @param applicationId application id.
-   * @return list of supporting users of an application.
-   */
-  @Get("application/:applicationId")
-  async getSupportingUsersOfAnApplication(
-    @Param("applicationId", ParseIntPipe) applicationId: number,
-  ): Promise<ApplicationSupportingUsersAPIOutDTO[]> {
-    const supportingUserForApplication =
-      await this.supportingUserService.getSupportingUsersByApplicationId(
-        applicationId,
-      );
-    return supportingUserForApplication.map((supportingUser) => ({
-      supportingUserId: supportingUser.id,
-      supportingUserType: supportingUser.supportingUserType,
-    }));
-  }
 
   /**
    * Get supporting user formName and the form data

--- a/sources/packages/backend/apps/api/src/services/application/application.service.ts
+++ b/sources/packages/backend/apps/api/src/services/application/application.service.ts
@@ -2171,11 +2171,12 @@ export class ApplicationService extends RecordDataModelService<Application> {
   }
 
   /**
-   * Get all the application versions for an application through parent application.
+   * Get the active application version and all past versions
+   * for an application through parent application.
    * @param applicationId application id.
    * @param options query options.
    * - `studentId` student ID used for authorization.
-   * @returns application versions if any, otherwise empty array.
+   * @returns active (current) application and its versions, if any.
    */
   async getAllApplicationVersions(
     applicationId: number,

--- a/sources/packages/backend/apps/api/src/services/application/application.service.ts
+++ b/sources/packages/backend/apps/api/src/services/application/application.service.ts
@@ -2199,11 +2199,7 @@ export class ApplicationService extends RecordDataModelService<Application> {
         "versionSupportingUser.supportingUserType",
       ])
       .innerJoin("application.parentApplication", "parentApplication")
-      .leftJoin(
-        "application.supportingUsers",
-        "supportingUser",
-        "supportingUser.id IS NOT NULL",
-      )
+      .leftJoin("application.supportingUsers", "supportingUser")
       .leftJoin(
         "parentApplication.versions",
         "version",

--- a/sources/packages/backend/apps/api/src/services/application/application.service.ts
+++ b/sources/packages/backend/apps/api/src/services/application/application.service.ts
@@ -2205,11 +2205,7 @@ export class ApplicationService extends RecordDataModelService<Application> {
         "version.applicationStatus = :editedStatus",
         { editedStatus: ApplicationStatus.Edited },
       )
-      .leftJoin(
-        "version.supportingUsers",
-        "versionSupportingUser",
-        "versionSupportingUser.id IS NOT NULL",
-      )
+      .leftJoin("version.supportingUsers", "versionSupportingUser")
       .where("application.id = :applicationId", {
         applicationId: applicationId,
       })

--- a/sources/packages/web/src/components/layouts/aest/AESTApplicationSideBar.vue
+++ b/sources/packages/web/src/components/layouts/aest/AESTApplicationSideBar.vue
@@ -72,7 +72,7 @@ export default defineComponent({
     };
 
     /**
-     * Create one more more menu items for one to tow parents or one partner.
+     * Create one or more menu items for one to two parents or one partner.
      * @param supportingUsers supporting users information.
      */
     const createSupportingUsersMenu = (

--- a/sources/packages/web/src/components/layouts/aest/AESTApplicationSideBar.vue
+++ b/sources/packages/web/src/components/layouts/aest/AESTApplicationSideBar.vue
@@ -12,7 +12,10 @@ import { AESTRoutesConst } from "@/constants/routes/RouteConstants";
 import { MenuItemModel, SupportingUserType } from "@/types";
 import { ApplicationService } from "@/services/ApplicationService";
 import { useFormatters } from "@/composables";
-import { ApplicationOverallDetailsAPIOutDTO } from "@/services/http/dto";
+import {
+  ApplicationOverallDetailsAPIOutDTO,
+  ApplicationSupportingUsersAPIOutDTO,
+} from "@/services/http/dto";
 
 export interface StudentApplicationMenu {
   studentApplication: MenuItemModel;
@@ -40,10 +43,11 @@ export default defineComponent({
     const { getISODateHourMinuteString } = useFormatters();
     const overallDetails = ref<ApplicationOverallDetailsAPIOutDTO | null>(null);
 
-    const currentApplicationMenuItems = computed(() => {
-      const currentVersion = overallDetails.value?.currentApplication;
-      const supportingUsers =
-        currentVersion?.supportingUsers.map((supportingUser, index) => {
+    const createSupportingUsersMenu = (
+      supportingUsers?: ApplicationSupportingUsersAPIOutDTO[],
+    ) => {
+      return (
+        supportingUsers?.map((supportingUser, index) => {
           const title =
             supportingUser.supportingUserType === SupportingUserType.Parent
               ? `Parent ${index + 1}`
@@ -62,11 +66,22 @@ export default defineComponent({
               },
             },
           };
-        }) ?? [];
+        }) ?? []
+      );
+    };
+
+    const currentApplicationMenuItems = computed(() => {
+      const currentVersion = overallDetails.value?.currentApplication;
+      const supportingUsers = createSupportingUsersMenu(
+        currentVersion?.supportingUsers,
+      );
       return [
         {
           title: "Current application",
           props: {
+            style: {
+              color: "gray",
+            },
             subtitle: `Submitted on ${getISODateHourMinuteString(
               currentVersion?.submittedDate,
             )}`,
@@ -140,6 +155,9 @@ export default defineComponent({
       if (!inProgressChangeRequest) {
         return [];
       }
+      const supportingUsers = createSupportingUsersMenu(
+        inProgressChangeRequest?.supportingUsers,
+      );
       const menuItems = [
         {
           type: "divider",
@@ -153,6 +171,9 @@ export default defineComponent({
         {
           title: "Change request",
           props: {
+            style: {
+              color: "gray",
+            },
             subtitle: `Submitted on ${getISODateHourMinuteString(
               inProgressChangeRequest?.submittedDate,
             )}`,
@@ -175,6 +196,7 @@ export default defineComponent({
             },
           },
         },
+        ...supportingUsers,
       ];
       return menuItems;
     });
@@ -197,6 +219,9 @@ export default defineComponent({
         {
           title: "Versions",
           props: {
+            style: {
+              color: "gray",
+            },
             subtitle: "Past submitted applications",
             slim: true,
           },

--- a/sources/packages/web/src/components/layouts/aest/AESTApplicationSideBar.vue
+++ b/sources/packages/web/src/components/layouts/aest/AESTApplicationSideBar.vue
@@ -68,10 +68,10 @@ export default defineComponent({
      * @param supportingUsers supporting users information.
      */
     const createSupportingUsersMenu = (
-      supportingUsers?: ApplicationSupportingUsersAPIOutDTO[],
+      supportingUsers: ApplicationSupportingUsersAPIOutDTO[],
     ): MenuItemModel[] => {
       return (
-        supportingUsers?.map((supportingUser, index) => {
+        supportingUsers.map((supportingUser, index) => {
           const title =
             supportingUser.supportingUserType === SupportingUserType.Parent
               ? `Parent ${index + 1}`
@@ -129,14 +129,14 @@ export default defineComponent({
       currentVersion: ApplicationVersionAPIOutDTO,
     ): MenuItemModel[] => {
       const supportingUsers = createSupportingUsersMenu(
-        currentVersion?.supportingUsers,
+        currentVersion.supportingUsers,
       );
       return [
         {
           title: "Active",
           props: {
             subtitle: `Submitted on ${getISODateHourMinuteString(
-              currentVersion?.submittedDate,
+              currentVersion.submittedDate,
             )}`,
             slim: true,
           },
@@ -242,9 +242,9 @@ export default defineComponent({
      * @param applicationVersion application version information.
      */
     const createVersionsMenuItems = (
-      versions?: ApplicationVersionAPIOutDTO[],
+      versions: ApplicationVersionAPIOutDTO[],
     ): MenuItemModel[] => {
-      if (!versions?.length) {
+      if (!versions.length) {
         return [];
       }
       const menuItems: MenuItemModel[] = [

--- a/sources/packages/web/src/components/layouts/aest/AESTApplicationSideBar.vue
+++ b/sources/packages/web/src/components/layouts/aest/AESTApplicationSideBar.vue
@@ -258,6 +258,9 @@ export default defineComponent({
         },
       ];
       versions.forEach((version) => {
+        const versionSupportingUsersMenuItems = createSupportingUsersMenu(
+          version.supportingUsers,
+        );
         menuItems.push({
           title: `${getISODateHourMinuteString(version.submittedDate)}`,
           props: {
@@ -282,6 +285,7 @@ export default defineComponent({
                 },
               },
             },
+            ...versionSupportingUsersMenuItems,
           ],
         });
       });

--- a/sources/packages/web/src/components/layouts/aest/AESTApplicationSideBar.vue
+++ b/sources/packages/web/src/components/layouts/aest/AESTApplicationSideBar.vue
@@ -1,76 +1,18 @@
 <template>
-  <!-- TODO: need to use v-list-group and update code with vuetify is -->
-  <v-navigation-drawer app class="body-background" permanent>
-    <v-list-item
-      density="compact"
-      nav
-      :prepend-icon="studentMenu.studentApplication.props?.prependIcon"
-      :title="studentMenu.studentApplication.title"
-      @click="studentMenu.studentApplication.command"
-    />
-    <v-list density="compact" nav v-if="relatedParentPartners.length">
-      <v-list-subheader>Supporting users</v-list-subheader>
-      <v-list-item
-        v-for="relatedParentPartner in relatedParentPartners"
-        :key="relatedParentPartner.title"
-        :prepend-icon="relatedParentPartner.props?.prependIcon"
-        :title="relatedParentPartner.title"
-        @click="relatedParentPartner.command"
-      />
-    </v-list>
-    <v-list-item
-      density="compact"
-      nav
-      :prepend-icon="studentMenu.assessments.props?.prependIcon"
-      :title="studentMenu.assessments.title"
-      @click="studentMenu.assessments.command"
-    />
-    <v-list-item
-      density="compact"
-      nav
-      :prepend-icon="
-        studentMenu.applicationRestrictionsManagement.props?.prependIcon
-      "
-      :title="studentMenu.applicationRestrictionsManagement.title"
-      @click="studentMenu.applicationRestrictionsManagement.command"
-    />
-    <v-list-item
-      density="compact"
-      nav
-      :prepend-icon="studentMenu.applicationStatus.props?.prependIcon"
-      :title="studentMenu.applicationStatus.title"
-      @click="studentMenu.applicationStatus.command"
-    />
-    <v-list v-if="applicationHistory.length" density="compact" nav>
-      <v-list-group
-        v-for="application in applicationHistory"
-        :key="application.title"
-        :title="application.title"
-        :value="application.title"
-      >
-        <template #activator="{ props }">
-          <v-list-item v-bind="props" :title="application.title"></v-list-item>
-        </template>
-        <v-list-item
-          v-for="child in application.children"
-          :key="child.title"
-          :title="child.title"
-          :prepend-icon="child.props?.prependIcon"
-          :to="child.props?.to"
-        ></v-list-item>
-      </v-list-group>
-    </v-list>
+  <v-navigation-drawer permanent width="300">
+    <v-list :items="currentApplicationMenuItems" density="compact"></v-list>
+    <v-list :items="changeRequestMenuItems" density="compact"></v-list>
+    <v-list :items="versionsMenuItems" density="compact"></v-list>
   </v-navigation-drawer>
 </template>
 
 <script lang="ts">
-import { useRouter } from "vue-router";
-import { ref, onMounted, defineComponent } from "vue";
+import { ref, onMounted, defineComponent, computed } from "vue";
 import { AESTRoutesConst } from "@/constants/routes/RouteConstants";
 import { MenuItemModel, SupportingUserType } from "@/types";
-import { SupportingUsersService } from "@/services/SupportingUserService";
 import { ApplicationService } from "@/services/ApplicationService";
 import { useFormatters } from "@/composables";
+import { ApplicationOverallDetailsAPIOutDTO } from "@/services/http/dto";
 
 export interface StudentApplicationMenu {
   studentApplication: MenuItemModel;
@@ -95,133 +37,207 @@ export default defineComponent({
     },
   },
   setup(props) {
-    const router = useRouter();
     const { getISODateHourMinuteString } = useFormatters();
-    const relatedParentPartners = ref([] as MenuItemModel[]);
-    const applicationHistory = ref([] as MenuItemModel[]);
-    const studentMenu = ref<StudentApplicationMenu>({
-      studentApplication: {
-        title: "Application",
-        props: { prependIcon: "mdi-school-outline" },
-        command: () => {
-          router.push({
-            name: AESTRoutesConst.APPLICATION_DETAILS,
-            params: {
-              applicationId: props.applicationId,
-              studentId: props.studentId,
+    const overallDetails = ref<ApplicationOverallDetailsAPIOutDTO | null>(null);
+
+    const currentApplicationMenuItems = computed(() => {
+      const currentVersion = overallDetails.value?.currentApplication;
+      const supportingUsers =
+        currentVersion?.supportingUsers.map((supportingUser, index) => {
+          const title =
+            supportingUser.supportingUserType === SupportingUserType.Parent
+              ? `Parent ${index + 1}`
+              : "Partner";
+          return {
+            title,
+            props: {
+              prependIcon: "mdi-account-outline",
+              slim: true,
+              to: {
+                name: AESTRoutesConst.SUPPORTING_USER_DETAILS,
+                params: {
+                  studentId: props.studentId,
+                  supportingUserId: supportingUser.supportingUserId,
+                },
+              },
             },
-          });
+          };
+        }) ?? [];
+      return [
+        {
+          title: "Current application",
+          props: {
+            subtitle: `Submitted on ${getISODateHourMinuteString(
+              currentVersion?.submittedDate,
+            )}`,
+            slim: true,
+          },
         },
-      },
-      assessments: {
-        title: "Assessments",
-        props: { prependIcon: "mdi-checkbox-marked-outline" },
-        command: () => {
-          router.push({
-            name: AESTRoutesConst.ASSESSMENTS_SUMMARY,
-            params: {
-              applicationId: props.applicationId,
-              studentId: props.studentId,
+        {
+          title: "Application",
+          props: {
+            subtitle: currentVersion?.applicationEditStatus,
+            prependIcon: "mdi-school-outline",
+            slim: true,
+            to: {
+              name: AESTRoutesConst.APPLICATION_DETAILS,
+              params: {
+                applicationId: props.applicationId,
+                studentId: props.studentId,
+              },
             },
-          });
+          },
         },
-      },
-      applicationRestrictionsManagement: {
-        title: "Restrictions Management",
-        props: { prependIcon: "mdi-close-circle-outline" },
-        command: () => {
-          router.push({
-            name: AESTRoutesConst.APPLICATION_RESTRICTIONS_MANAGEMENT,
-            params: {
-              applicationId: props.applicationId,
-              studentId: props.studentId,
+        ...supportingUsers,
+        {
+          title: "Assessments",
+          props: {
+            prependIcon: "mdi-checkbox-marked-outline",
+            slim: true,
+            to: {
+              name: AESTRoutesConst.ASSESSMENTS_SUMMARY,
+              params: {
+                applicationId: props.applicationId,
+                studentId: props.studentId,
+              },
             },
-          });
+          },
         },
-      },
-      applicationStatus: {
-        title: "Application Status",
-        props: { prependIcon: "mdi-information-outline" },
-        command: () => {
-          router.push({
-            name: AESTRoutesConst.APPLICATION_STATUS_TRACKER,
-            params: {
-              applicationId: props.applicationId,
-              studentId: props.studentId,
+        {
+          title: "Restrictions Management",
+          props: {
+            prependIcon: "mdi-close-circle-outline",
+            slim: true,
+            to: {
+              name: AESTRoutesConst.APPLICATION_RESTRICTIONS_MANAGEMENT,
+              params: {
+                applicationId: props.applicationId,
+                studentId: props.studentId,
+              },
             },
-          });
+          },
         },
-      },
+        {
+          title: "Application Status",
+          props: {
+            prependIcon: "mdi-information-outline",
+            slim: true,
+            to: {
+              name: AESTRoutesConst.APPLICATION_STATUS_TRACKER,
+              params: {
+                applicationId: props.applicationId,
+                studentId: props.studentId,
+              },
+            },
+          },
+        },
+      ];
     });
 
-    const goToSupportingUser = (supportingUserId: number) => {
-      router.push({
-        name: AESTRoutesConst.SUPPORTING_USER_DETAILS,
-        params: {
-          studentId: props.studentId,
-          supportingUserId: supportingUserId,
+    const changeRequestMenuItems = computed(() => {
+      const inProgressChangeRequest =
+        overallDetails.value?.inProgressChangeRequest;
+      if (!inProgressChangeRequest) {
+        return [];
+      }
+      const menuItems = [
+        {
+          type: "divider",
+          props: {
+            class: "my-1",
+            style: {
+              backgroundColor: "gray",
+            },
+          },
         },
+        {
+          title: "Change request",
+          props: {
+            subtitle: `Submitted on ${getISODateHourMinuteString(
+              inProgressChangeRequest?.submittedDate,
+            )}`,
+            slim: true,
+          },
+        },
+        {
+          title: "Application",
+          props: {
+            subtitle: inProgressChangeRequest?.applicationEditStatus,
+            prependIcon: "mdi-school-outline",
+            slim: true,
+            to: {
+              name: AESTRoutesConst.APPLICATION_VERSION_DETAILS,
+              params: {
+                studentId: props.studentId,
+                applicationId: props.applicationId,
+                versionApplicationId: inProgressChangeRequest.id,
+              },
+            },
+          },
+        },
+      ];
+      return menuItems;
+    });
+
+    const versionsMenuItems = computed(() => {
+      const versions = overallDetails.value?.previousVersions;
+      if (!versions?.length) {
+        return [];
+      }
+      const menuItems = [
+        {
+          type: "divider",
+          props: {
+            class: "my-1",
+            style: {
+              backgroundColor: "gray",
+            },
+          },
+        },
+        {
+          title: "Versions",
+          props: {
+            subtitle: "Past submitted applications",
+            slim: true,
+          },
+        },
+      ];
+      versions.forEach((version) => {
+        menuItems.push({
+          title: `${getISODateHourMinuteString(version.submittedDate)}`,
+          children: [
+            {
+              title: "Application",
+              props: {
+                prependIcon: "mdi-school-outline",
+                subtitle: version.applicationEditStatus,
+                to: {
+                  name: AESTRoutesConst.APPLICATION_VERSION_DETAILS,
+                  params: {
+                    studentId: props.studentId,
+                    applicationId: props.applicationId,
+                    versionApplicationId: version.id,
+                  },
+                },
+              },
+            },
+          ],
+        });
       });
-    };
+      return menuItems;
+    });
 
     onMounted(async () => {
-      const supportingUsers =
-        await SupportingUsersService.shared.getSupportingUsersForSideBar(
-          props.applicationId,
-        );
-      supportingUsers.forEach((supportingUser, index) => {
-        if (supportingUser.supportingUserType === SupportingUserType.Parent) {
-          relatedParentPartners.value.push({
-            title: `Parent ${index + 1}`,
-            props: { prependIcon: "mdi-account-outline" },
-            command: () => goToSupportingUser(supportingUser.supportingUserId),
-          });
-        }
-        if (supportingUser.supportingUserType === SupportingUserType.Partner) {
-          relatedParentPartners.value.push({
-            title: "Partner",
-            props: { prependIcon: "mdi-account-outline" },
-            command: () => goToSupportingUser(supportingUser.supportingUserId),
-          });
-        }
-      });
-      const applicationOverallDetails =
+      overallDetails.value =
         await ApplicationService.shared.getApplicationOverallDetails(
           props.applicationId,
         );
-      if (applicationOverallDetails.previousVersions.length) {
-        applicationOverallDetails.previousVersions.forEach(
-          (applicationVersion) => {
-            applicationHistory.value.push({
-              title: `${getISODateHourMinuteString(
-                applicationVersion.submittedDate,
-              )}`,
-              children: [
-                {
-                  title: "Application",
-                  props: {
-                    prependIcon: "mdi-school-outline",
-                    to: {
-                      name: AESTRoutesConst.APPLICATION_VERSION_DETAILS,
-                      params: {
-                        studentId: props.studentId,
-                        applicationId: props.applicationId,
-                        versionApplicationId: applicationVersion.id,
-                      },
-                    },
-                  },
-                },
-              ],
-            });
-          },
-        );
-      }
     });
 
     return {
-      studentMenu,
-      relatedParentPartners,
-      applicationHistory,
+      currentApplicationMenuItems,
+      changeRequestMenuItems,
+      versionsMenuItems,
     };
   },
 });

--- a/sources/packages/web/src/composables/useApplication.ts
+++ b/sources/packages/web/src/composables/useApplication.ts
@@ -74,9 +74,24 @@ export function useApplication() {
     }
   };
 
+  /**
+   * Application edit status targeting the Ministry.
+   * @param editStatus application edit status.
+   * @returns Ministry friendly edit status.
+   */
+  const mapApplicationEditStatusForMinistry = (
+    editStatus: ApplicationEditStatus,
+  ): string => {
+    if (editStatus === ApplicationEditStatus.ChangedWithApproval) {
+      return "Changed";
+    }
+    return editStatus;
+  };
+
   return {
     mapApplicationChipStatus,
     mapApplicationDetailHeader,
     mapApplicationEditStatusForStudents,
+    mapApplicationEditStatusForMinistry,
   };
 }

--- a/sources/packages/web/src/services/SupportingUserService.ts
+++ b/sources/packages/web/src/services/SupportingUserService.ts
@@ -3,7 +3,6 @@ import ApiClient from "./http/ApiClient";
 import {
   ApplicationAPIOutDTO,
   ApplicationIdentifierAPIInDTO,
-  ApplicationSupportingUsersAPIOutDTO,
   SupportingUserFormDataAPIOutDTO,
   UpdateSupportingUserAPIInDTO,
 } from "@/services/http/dto";
@@ -33,14 +32,6 @@ export class SupportingUsersService {
     await ApiClient.SupportingUserApi.updateSupportingInformation(
       supportingUserType,
       payload,
-    );
-  }
-
-  async getSupportingUsersForSideBar(
-    applicationId: number,
-  ): Promise<ApplicationSupportingUsersAPIOutDTO[]> {
-    return ApiClient.SupportingUserApi.getSupportingUsersForSideBar(
-      applicationId,
     );
   }
 

--- a/sources/packages/web/src/services/http/SupportingUserApi.ts
+++ b/sources/packages/web/src/services/http/SupportingUserApi.ts
@@ -3,7 +3,6 @@ import HttpBaseClient from "./common/HttpBaseClient";
 import {
   ApplicationAPIOutDTO,
   ApplicationIdentifierAPIInDTO,
-  ApplicationSupportingUsersAPIOutDTO,
   SupportingUserFormDataAPIOutDTO,
   UpdateSupportingUserAPIInDTO,
 } from "@/services/http/dto";
@@ -26,14 +25,6 @@ export class SupportingUserApi extends HttpBaseClient {
     await this.patchCall(
       this.addClientRoot(`supporting-user/${supportingUserType}`),
       payload,
-    );
-  }
-
-  async getSupportingUsersForSideBar(
-    applicationId: number,
-  ): Promise<ApplicationSupportingUsersAPIOutDTO[]> {
-    return this.getCall<ApplicationSupportingUsersAPIOutDTO[]>(
-      this.addClientRoot(`supporting-user/application/${applicationId}`),
     );
   }
 

--- a/sources/packages/web/src/services/http/dto/Application.dto.ts
+++ b/sources/packages/web/src/services/http/dto/Application.dto.ts
@@ -15,6 +15,7 @@ import {
   ECertFailedValidation,
   ChangeTypes,
   ApplicationEditStatus,
+  SupportingUserType,
 } from "@/types";
 
 interface ApplicationSupportingUserDetails {
@@ -220,12 +221,20 @@ export interface ApplicationWarningsAPIOutDTO {
   canAcceptAssessment: boolean;
 }
 
+export class ApplicationSupportingUsersAPIOutDTO {
+  supportingUserId: number;
+  supportingUserType: SupportingUserType;
+}
+
 export interface ApplicationVersionAPIOutDTO {
   id: number;
   submittedDate: Date;
   applicationEditStatus: ApplicationEditStatus;
+  supportingUsers: ApplicationSupportingUsersAPIOutDTO[];
 }
 
 export interface ApplicationOverallDetailsAPIOutDTO {
+  currentApplication: ApplicationVersionAPIOutDTO;
+  inProgressChangeRequest?: ApplicationVersionAPIOutDTO;
   previousVersions: ApplicationVersionAPIOutDTO[];
 }

--- a/sources/packages/web/src/services/http/dto/Application.dto.ts
+++ b/sources/packages/web/src/services/http/dto/Application.dto.ts
@@ -226,6 +226,11 @@ export class ApplicationSupportingUsersAPIOutDTO {
   supportingUserType: SupportingUserType;
 }
 
+/**
+ * Represents a version of an application at any given time,
+ * including the current application, any in-progress
+ * change requests, and any past versions.
+ */
 export interface ApplicationVersionAPIOutDTO {
   id: number;
   submittedDate: Date;

--- a/sources/packages/web/src/services/http/dto/Application.dto.ts
+++ b/sources/packages/web/src/services/http/dto/Application.dto.ts
@@ -235,7 +235,7 @@ export interface ApplicationVersionAPIOutDTO {
   id: number;
   submittedDate: Date;
   applicationEditStatus: ApplicationEditStatus;
-  supportingUsers?: ApplicationSupportingUsersAPIOutDTO[];
+  supportingUsers: ApplicationSupportingUsersAPIOutDTO[];
 }
 
 export interface ApplicationOverallDetailsAPIOutDTO {

--- a/sources/packages/web/src/services/http/dto/Application.dto.ts
+++ b/sources/packages/web/src/services/http/dto/Application.dto.ts
@@ -235,7 +235,7 @@ export interface ApplicationVersionAPIOutDTO {
   id: number;
   submittedDate: Date;
   applicationEditStatus: ApplicationEditStatus;
-  supportingUsers: ApplicationSupportingUsersAPIOutDTO[];
+  supportingUsers?: ApplicationSupportingUsersAPIOutDTO[];
 }
 
 export interface ApplicationOverallDetailsAPIOutDTO {

--- a/sources/packages/web/src/services/http/dto/Application.dto.ts
+++ b/sources/packages/web/src/services/http/dto/Application.dto.ts
@@ -221,7 +221,7 @@ export interface ApplicationWarningsAPIOutDTO {
   canAcceptAssessment: boolean;
 }
 
-export class ApplicationSupportingUsersAPIOutDTO {
+export interface ApplicationSupportingUsersAPIOutDTO {
   supportingUserId: number;
   supportingUserType: SupportingUserType;
 }

--- a/sources/packages/web/src/services/http/dto/SupportingUser.dto.ts
+++ b/sources/packages/web/src/services/http/dto/SupportingUser.dto.ts
@@ -1,4 +1,4 @@
-import { OfferingIntensity, SupportingUserType } from "@/types";
+import { OfferingIntensity } from "@/types";
 import { ContactInformationAPIOutDTO } from "./Address.dto";
 import { Expose } from "class-transformer";
 
@@ -46,11 +46,6 @@ export interface ApplicationAPIOutDTO {
   programYearStartDate: string;
   formName: string;
   offeringIntensity: OfferingIntensity;
-}
-
-export interface ApplicationSupportingUsersAPIOutDTO {
-  supportingUserId: number;
-  supportingUserType: SupportingUserType;
 }
 
 export interface SupportingUserFormDataAPIOutDTO {

--- a/sources/packages/web/src/types/contracts/Common.ts
+++ b/sources/packages/web/src/types/contracts/Common.ts
@@ -16,8 +16,13 @@ export interface MenuModel {
 export interface MenuItemModel {
   title?: string;
   props?: {
+    subtitle?: string;
+    class?: string;
     prependIcon?: string;
     to?: RouteLocationRaw;
+    slim?: boolean;
+    color?: string | null;
+    opacity?: number;
   };
   type?: string;
   children?: MenuItemModel[];


### PR DESCRIPTION
# API Related Changes

- Change the API that retrieves the application's overall information to also get the supporting users' information, which allowed the old API method to be removed as planned in the previous efforts.
  - Kept the logic to decide which application version is an "in-progress change request" in the API, which means that the API is responsible for returning a change request in an explicit way (DTO property `inProgressChangeRequest`).
  - Considered all applications as a version of itself, which means current, change request, and past versions share the same output DTO.
  - As a side effect of having the supporting users associated with change requests, every version now can easily display supporting users in the UI (it is just not enabled yet because it is not part of the ACs).
- Added the below E2E for the new scenarios
  - Should get the original application and no application versions in overall details when there is no edited application associated with the given application.
  - Should get the current application and an in-progress change request, including supporting users when the application has an in-progress change request.
  - Should get the current application and an application version when the application has a declined change request.
  - Should get the current application and versions supporting users when the application and its versions have supporting users.

# UI related changes

- Refactored the Ministry applications menu to look more like the Ministry main left menu.
  - The menu is now integrated with the routes and has the `active` behavior.
- The route for the pending change request is the same as any other application version, and the "change request" is treated as a regular past version.

## In-progress change request

![image](https://github.com/user-attachments/assets/72d21812-a656-40b6-8068-a7a7ede79280)

## Parents and Partner with pending change request

![image](https://github.com/user-attachments/assets/7c43bb3b-9b72-4981-9925-19a0f662948c)

## Active application with versions and no pending request

![image](https://github.com/user-attachments/assets/18cbd362-159e-497f-a0e6-9419f273459a)

## How it was displayed on Edge (previously, there was extra white space between the icons)

![image](https://github.com/user-attachments/assets/6f134a77-b4c1-4b45-9d9c-76eb09c8f19d)

## Local change only to allow displaying the `Changed with approval` renamed to `Changed`

![image](https://github.com/user-attachments/assets/d8a21626-b283-41f7-88ef-4734ccc668de)
