### PR TITLE
#4520 - Formio split part-1

### DIFF
--- a/sources/packages/backend/apps/api/src/app.module.ts
+++ b/sources/packages/backend/apps/api/src/app.module.ts
@@ -33,6 +33,7 @@ import { QueueModule } from "@sims/services/queue";
 import { AppExternalModule } from "./app.external.module";
 import { AccessLoggerMiddleware } from "./middlewares";
 import { TerminusModule } from "@nestjs/terminus";
+import { DynamicFormConfigurationModule } from "./dynamic-form-configuration.module";
 
 @Module({
   imports: [
@@ -51,6 +52,7 @@ import { TerminusModule } from "@nestjs/terminus";
     QueueModule,
     ClamAntivirusModule,
     TerminusModule,
+    DynamicFormConfigurationModule,
     RouterModule.register([
       {
         path: ClientTypeBaseRoute.Institution,

--- a/sources/packages/backend/apps/api/src/dynamic-form-configuration.module.ts
+++ b/sources/packages/backend/apps/api/src/dynamic-form-configuration.module.ts
@@ -1,0 +1,9 @@
+import { Global, Module } from "@nestjs/common";
+import { DynamicFormConfigurationService } from "./services";
+
+@Global()
+@Module({
+  providers: [DynamicFormConfigurationService],
+  exports: [DynamicFormConfigurationService],
+})
+export class DynamicFormConfigurationModule {}

--- a/sources/packages/backend/apps/api/src/dynamic-form-configuration.module.ts
+++ b/sources/packages/backend/apps/api/src/dynamic-form-configuration.module.ts
@@ -1,9 +1,25 @@
-import { Global, Module } from "@nestjs/common";
+import { Global, LoggerService, Module, OnModuleInit } from "@nestjs/common";
 import { DynamicFormConfigurationService } from "./services";
+import { InjectLogger } from "@sims/utilities/logger";
 
 @Global()
 @Module({
   providers: [DynamicFormConfigurationService],
   exports: [DynamicFormConfigurationService],
 })
-export class DynamicFormConfigurationModule {}
+export class DynamicFormConfigurationModule implements OnModuleInit {
+  constructor(
+    private readonly dynamicFormConfigurationService: DynamicFormConfigurationService,
+  ) {}
+
+  /**
+   * Execute module initialization actions.
+   */
+  async onModuleInit(): Promise<void> {
+    this.logger.log("Loading dynamic form configurations.");
+    await this.dynamicFormConfigurationService.loadAllDynamicFormConfigurations();
+  }
+
+  @InjectLogger()
+  logger: LoggerService;
+}

--- a/sources/packages/backend/apps/api/src/main.ts
+++ b/sources/packages/backend/apps/api/src/main.ts
@@ -12,6 +12,7 @@ import { KeycloakConfig } from "@sims/auth/config";
 import helmet from "helmet";
 import { SystemUsersService } from "@sims/services";
 import { AppExternalModule } from "./app.external.module";
+import { DynamicFormConfigurationService } from "apps/api/src/services";
 
 async function bootstrap() {
   await KeycloakConfig.load();
@@ -26,6 +27,12 @@ async function bootstrap() {
   logger.log("Loading system user...");
   const systemUsersService = app.get(SystemUsersService);
   await systemUsersService.loadSystemUser();
+
+  // Load dynamic form configurations.
+  const dynamicFormConfigurationService = app.get(
+    DynamicFormConfigurationService,
+  );
+  await dynamicFormConfigurationService.loadAllDynamicFormConfigurations();
 
   // Setting global prefix
   app.setGlobalPrefix("api", { exclude: ["health"] });

--- a/sources/packages/backend/apps/api/src/main.ts
+++ b/sources/packages/backend/apps/api/src/main.ts
@@ -12,7 +12,6 @@ import { KeycloakConfig } from "@sims/auth/config";
 import helmet from "helmet";
 import { SystemUsersService } from "@sims/services";
 import { AppExternalModule } from "./app.external.module";
-import { DynamicFormConfigurationService } from "apps/api/src/services";
 
 async function bootstrap() {
   await KeycloakConfig.load();
@@ -27,12 +26,6 @@ async function bootstrap() {
   logger.log("Loading system user...");
   const systemUsersService = app.get(SystemUsersService);
   await systemUsersService.loadSystemUser();
-
-  // Load dynamic form configurations.
-  const dynamicFormConfigurationService = app.get(
-    DynamicFormConfigurationService,
-  );
-  await dynamicFormConfigurationService.loadAllDynamicFormConfigurations();
 
   // Setting global prefix
   app.setGlobalPrefix("api", { exclude: ["health"] });

--- a/sources/packages/backend/apps/api/src/services/dynamic-form-configuration/dynamic-form-configuration.service.ts
+++ b/sources/packages/backend/apps/api/src/services/dynamic-form-configuration/dynamic-form-configuration.service.ts
@@ -27,7 +27,7 @@ export class DynamicFormConfigurationService {
         select: {
           id: true,
           formType: true,
-          programYear: { id: true, programYear: true },
+          programYear: { id: true },
           offeringIntensity: true,
           formDefinitionName: true,
         },
@@ -44,7 +44,7 @@ export class DynamicFormConfigurationService {
    * @param offeringIntensity offering intensity.
    * @returns form definition name.
    */
-  getFormByFormTypeAndProgramYear(
+  getDynamicFormName(
     dynamicFormType: DynamicFormType,
     programYearId: number,
     offeringIntensity?: OfferingIntensity,

--- a/sources/packages/backend/apps/api/src/services/dynamic-form-configuration/dynamic-form-configuration.service.ts
+++ b/sources/packages/backend/apps/api/src/services/dynamic-form-configuration/dynamic-form-configuration.service.ts
@@ -1,0 +1,67 @@
+import { Injectable } from "@nestjs/common";
+import { InjectRepository } from "@nestjs/typeorm";
+import {
+  DynamicFormConfiguration,
+  DynamicFormType,
+  OfferingIntensity,
+} from "@sims/sims-db";
+import { Repository } from "typeorm";
+
+@Injectable()
+export class DynamicFormConfigurationService {
+  /**
+   * All dynamic form configurations.
+   */
+  private dynamicFormConfigurations: DynamicFormConfiguration[] = [];
+  constructor(
+    @InjectRepository(DynamicFormConfiguration)
+    private readonly dynamicFormConfigurationRepo: Repository<DynamicFormConfiguration>,
+  ) {}
+
+  /**
+   * Load all dynamic form configurations.
+   */
+  async loadAllDynamicFormConfigurations(): Promise<void> {
+    this.dynamicFormConfigurations =
+      await this.dynamicFormConfigurationRepo.find({
+        select: {
+          id: true,
+          formType: true,
+          programYear: { id: true, programYear: true },
+          offeringIntensity: true,
+          formDefinitionName: true,
+        },
+        relations: {
+          programYear: true,
+        },
+      });
+  }
+
+  /**
+   * Get form definition name by form type and program year.
+   * @param dynamicFormType dynamic form type.
+   * @param programYearId program year id.
+   * @param offeringIntensity offering intensity.
+   * @returns form definition name.
+   */
+  getFormByFormTypeAndProgramYear(
+    dynamicFormType: DynamicFormType,
+    programYearId: number,
+    offeringIntensity?: OfferingIntensity,
+  ): string {
+    const offeringIntensityConfiguration = offeringIntensity ?? null;
+    const dynamicForm = this.dynamicFormConfigurations.find(
+      (dynamicFormConfiguration) =>
+        dynamicFormConfiguration.formType === dynamicFormType &&
+        dynamicFormConfiguration.programYear.id === programYearId &&
+        dynamicFormConfiguration.offeringIntensity ===
+          offeringIntensityConfiguration,
+    );
+    if (!dynamicForm) {
+      throw new Error(
+        "Form definition for the provided configuration not found.",
+      );
+    }
+    return dynamicForm.formDefinitionName;
+  }
+}

--- a/sources/packages/backend/apps/api/src/services/dynamic-form-configuration/dynamic-form-configuration.service.ts
+++ b/sources/packages/backend/apps/api/src/services/dynamic-form-configuration/dynamic-form-configuration.service.ts
@@ -10,7 +10,7 @@ import { Repository } from "typeorm";
 @Injectable()
 export class DynamicFormConfigurationService {
   /**
-   * All dynamic form configurations.
+   * @private All dynamic form configurations.
    */
   private dynamicFormConfigurations: DynamicFormConfiguration[] = [];
   constructor(

--- a/sources/packages/backend/apps/api/src/services/index.ts
+++ b/sources/packages/backend/apps/api/src/services/index.ts
@@ -55,3 +55,4 @@ export * from "./cas-invoice-batch/cas-invoice-batch.service";
 export * from "./cas-invoice-batch/cas-invoice-batch-report.service";
 export * from "./cas-invoice/cas-invoice.service";
 export * from "./student/student-information.service";
+export * from "./dynamic-form-configuration/dynamic-form-configuration.service";

--- a/sources/packages/backend/apps/db-migrations/src/migrations/1745432641611-CreateDynamicFormConfigurationsTable.ts
+++ b/sources/packages/backend/apps/db-migrations/src/migrations/1745432641611-CreateDynamicFormConfigurationsTable.ts
@@ -1,0 +1,24 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+import { getSQLFileData } from "../utilities/sqlLoader";
+
+export class CreateDynamicFormConfigurationsTable1745432641611
+  implements MigrationInterface
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      getSQLFileData(
+        "Create-dynamic-form-configurations-table.sql",
+        "DynamicFormConfigurations",
+      ),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      getSQLFileData(
+        "Rollback-create-dynamic-form-configurations-table.sql",
+        "DynamicFormConfigurations",
+      ),
+    );
+  }
+}

--- a/sources/packages/backend/apps/db-migrations/src/migrations/1745432641611-CreateDynamicFormConfigurationsTable.ts
+++ b/sources/packages/backend/apps/db-migrations/src/migrations/1745432641611-CreateDynamicFormConfigurationsTable.ts
@@ -11,6 +11,45 @@ export class CreateDynamicFormConfigurationsTable1745432641611
         "DynamicFormConfigurations",
       ),
     );
+    // Insert configurations for program year 2021-2022.
+    await queryRunner.query(
+      getSQLFileData(
+        "Insert-dynamic-form-configurations-2021-2022.sql",
+        "DynamicFormConfigurations",
+      ),
+    );
+
+    // Insert configurations for program year 2022-2023.
+    await queryRunner.query(
+      getSQLFileData(
+        "Insert-dynamic-form-configurations-2022-2023.sql",
+        "DynamicFormConfigurations",
+      ),
+    );
+
+    // Insert configurations for program year 2023-2024.
+    await queryRunner.query(
+      getSQLFileData(
+        "Insert-dynamic-form-configurations-2023-2024.sql",
+        "DynamicFormConfigurations",
+      ),
+    );
+
+    // Insert configurations for program year 2024-2025.
+    await queryRunner.query(
+      getSQLFileData(
+        "Insert-dynamic-form-configurations-2024-2025.sql",
+        "DynamicFormConfigurations",
+      ),
+    );
+
+    // Insert configurations for program year 2025-2026.
+    await queryRunner.query(
+      getSQLFileData(
+        "Insert-dynamic-form-configurations-2025-2026.sql",
+        "DynamicFormConfigurations",
+      ),
+    );
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {

--- a/sources/packages/backend/apps/db-migrations/src/sql/DynamicFormConfigurations/Create-dynamic-form-configurations-table.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/DynamicFormConfigurations/Create-dynamic-form-configurations-table.sql
@@ -16,7 +16,7 @@ COMMENT ON TABLE sims.dynamic_form_configurations IS 'Dynamic form configuration
 
 COMMENT ON COLUMN sims.dynamic_form_configurations.id IS 'Auto-generated sequential primary key column.';
 
-COMMENT ON COLUMN sims.dynamic_form_configurations.form_type IS 'Form type which is configured.';
+COMMENT ON COLUMN sims.dynamic_form_configurations.form_type IS 'Form type which is dynamically configured.';
 
 COMMENT ON COLUMN sims.dynamic_form_configurations.program_year_id IS 'Program year to identify the dynamic form for the form type.';
 

--- a/sources/packages/backend/apps/db-migrations/src/sql/DynamicFormConfigurations/Create-dynamic-form-configurations-table.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/DynamicFormConfigurations/Create-dynamic-form-configurations-table.sql
@@ -1,28 +1,31 @@
 CREATE TABLE sims.dynamic_form_configurations(
     id SERIAL PRIMARY KEY,
     form_type VARCHAR(100) NOT NULL,
-    offering_intensity sims.offering_intensity,
     program_year_id INT REFERENCES sims.program_years(id),
+    offering_intensity sims.offering_intensity,
     form_definition_name VARCHAR(100) NOT NULL,
-    -- Audit columns
+    -- Audit columns.
     -- Creator and modifier are not provided as the configurations cannot by created or updated by application users.
     created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
-    updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
+    updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    CONSTRAINT form_type_program_year_offering_intensity_unique UNIQUE (form_type, program_year_id, offering_intensity)
 );
 
--- ## Comments
+-- Comments.
 COMMENT ON TABLE sims.dynamic_form_configurations IS 'Dynamic form configurations based on form type.';
 
 COMMENT ON COLUMN sims.dynamic_form_configurations.id IS 'Auto-generated sequential primary key column';
 
 COMMENT ON COLUMN sims.dynamic_form_configurations.form_type IS 'Form type which is configured.';
 
-COMMENT ON COLUMN sims.dynamic_form_configurations.offering_intensity IS 'Offering intensity to identify the dynamic form.';
-
 COMMENT ON COLUMN sims.dynamic_form_configurations.program_year_id IS 'Program year to identify the dynamic form.';
+
+COMMENT ON COLUMN sims.dynamic_form_configurations.offering_intensity IS 'Offering intensity to identify the dynamic form.';
 
 COMMENT ON COLUMN sims.dynamic_form_configurations.form_definition_name IS 'Form definition for the form type based on configurations.';
 
 COMMENT ON COLUMN sims.dynamic_form_configurations.created_at IS 'Record creation timestamp.';
 
 COMMENT ON COLUMN sims.dynamic_form_configurations.updated_at IS 'Record update timestamp.';
+
+COMMENT ON CONSTRAINT form_type_program_year_offering_intensity_unique ON sims.dynamic_form_configurations IS 'Ensure that configuration is unique based on form type, program year and offering intensity.';

--- a/sources/packages/backend/apps/db-migrations/src/sql/DynamicFormConfigurations/Create-dynamic-form-configurations-table.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/DynamicFormConfigurations/Create-dynamic-form-configurations-table.sql
@@ -22,7 +22,7 @@ COMMENT ON COLUMN sims.dynamic_form_configurations.program_year_id IS 'Program y
 
 COMMENT ON COLUMN sims.dynamic_form_configurations.offering_intensity IS 'Offering intensity to identify the dynamic form for the form type.';
 
-COMMENT ON COLUMN sims.dynamic_form_configurations.form_definition_name IS 'Form definition for the form type based on configurations.';
+COMMENT ON COLUMN sims.dynamic_form_configurations.form_definition_name IS 'Form definition name for the form type based on configurations.';
 
 COMMENT ON COLUMN sims.dynamic_form_configurations.created_at IS 'Record creation timestamp.';
 

--- a/sources/packages/backend/apps/db-migrations/src/sql/DynamicFormConfigurations/Create-dynamic-form-configurations-table.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/DynamicFormConfigurations/Create-dynamic-form-configurations-table.sql
@@ -5,7 +5,7 @@ CREATE TABLE sims.dynamic_form_configurations(
     offering_intensity sims.offering_intensity,
     form_definition_name VARCHAR(100) NOT NULL,
     -- Audit columns.
-    -- Creator and modifier are not provided as the configurations cannot by created or updated by application users.
+    -- Creator and modifier are not provided as the configurations cannot be created or updated by application users.
     created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
     updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
     CONSTRAINT form_type_program_year_offering_intensity_unique UNIQUE (form_type, program_year_id, offering_intensity)

--- a/sources/packages/backend/apps/db-migrations/src/sql/DynamicFormConfigurations/Create-dynamic-form-configurations-table.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/DynamicFormConfigurations/Create-dynamic-form-configurations-table.sql
@@ -14,13 +14,13 @@ CREATE TABLE sims.dynamic_form_configurations(
 -- Comments.
 COMMENT ON TABLE sims.dynamic_form_configurations IS 'Dynamic form configurations based on form type.';
 
-COMMENT ON COLUMN sims.dynamic_form_configurations.id IS 'Auto-generated sequential primary key column';
+COMMENT ON COLUMN sims.dynamic_form_configurations.id IS 'Auto-generated sequential primary key column.';
 
 COMMENT ON COLUMN sims.dynamic_form_configurations.form_type IS 'Form type which is configured.';
 
-COMMENT ON COLUMN sims.dynamic_form_configurations.program_year_id IS 'Program year to identify the dynamic form.';
+COMMENT ON COLUMN sims.dynamic_form_configurations.program_year_id IS 'Program year to identify the dynamic form for the form type.';
 
-COMMENT ON COLUMN sims.dynamic_form_configurations.offering_intensity IS 'Offering intensity to identify the dynamic form.';
+COMMENT ON COLUMN sims.dynamic_form_configurations.offering_intensity IS 'Offering intensity to identify the dynamic form for the form type.';
 
 COMMENT ON COLUMN sims.dynamic_form_configurations.form_definition_name IS 'Form definition for the form type based on configurations.';
 

--- a/sources/packages/backend/apps/db-migrations/src/sql/DynamicFormConfigurations/Create-dynamic-form-configurations-table.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/DynamicFormConfigurations/Create-dynamic-form-configurations-table.sql
@@ -1,0 +1,28 @@
+CREATE TABLE sims.dynamic_form_configurations(
+    id SERIAL PRIMARY KEY,
+    form_type VARCHAR(100) NOT NULL,
+    offering_intensity sims.offering_intensity,
+    program_year_id INT REFERENCES sims.program_years(id),
+    form_definition_name VARCHAR(100) NOT NULL,
+    -- Audit columns
+    -- Creator and modifier are not provided as the configurations cannot by created or updated by application users.
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
+);
+
+-- ## Comments
+COMMENT ON TABLE sims.dynamic_form_configurations IS 'Dynamic form configurations based on form type.';
+
+COMMENT ON COLUMN sims.dynamic_form_configurations.id IS 'Auto-generated sequential primary key column';
+
+COMMENT ON COLUMN sims.dynamic_form_configurations.form_type IS 'Form type which is configured.';
+
+COMMENT ON COLUMN sims.dynamic_form_configurations.offering_intensity IS 'Offering intensity to identify the dynamic form.';
+
+COMMENT ON COLUMN sims.dynamic_form_configurations.program_year_id IS 'Program year to identify the dynamic form.';
+
+COMMENT ON COLUMN sims.dynamic_form_configurations.form_definition_name IS 'Form definition for the form type based on configurations.';
+
+COMMENT ON COLUMN sims.dynamic_form_configurations.created_at IS 'Record creation timestamp.';
+
+COMMENT ON COLUMN sims.dynamic_form_configurations.updated_at IS 'Record update timestamp.';

--- a/sources/packages/backend/apps/db-migrations/src/sql/DynamicFormConfigurations/Insert-dynamic-form-configurations-2021-2022.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/DynamicFormConfigurations/Insert-dynamic-form-configurations-2021-2022.sql
@@ -1,0 +1,77 @@
+-- Insert configurations for student financial aid application form type.
+INSERT INTO
+    sims.dynamic_form_configurations (
+        form_type,
+        program_year_id,
+        offering_intensity,
+        form_definition_name
+    )
+VALUES
+    (
+        'Student financial aid application',
+        (
+            select
+                id
+            from
+                sims.program_years
+            where
+                program_year = '2021-2022'
+        ),
+        'Full Time',
+        'SFAA2021-22'
+    ),
+    (
+        'Student financial aid application',
+        (
+            select
+                id
+            from
+                sims.program_years
+            where
+                program_year = '2021-2022'
+        ),
+        'Part Time',
+        'SFAA2021-22'
+    );
+
+-- Insert configurations for supporting users parent form type.
+INSERT INTO
+    sims.dynamic_form_configurations (
+        form_type,
+        program_year_id,
+        form_definition_name
+    )
+VALUES
+    (
+        'Supporting users parent',
+        (
+            select
+                id
+            from
+                sims.program_years
+            where
+                program_year = '2021-2022'
+        ),
+        'supportingusersparent2022-2023'
+    );
+
+-- Insert configurations for supporting users partner form type.
+INSERT INTO
+    sims.dynamic_form_configurations (
+        form_type,
+        program_year_id,
+        form_definition_name
+    )
+VALUES
+    (
+        'Supporting users partner',
+        (
+            select
+                id
+            from
+                sims.program_years
+            where
+                program_year = '2021-2022'
+        ),
+        'supportinguserspartner2022-2023'
+    );

--- a/sources/packages/backend/apps/db-migrations/src/sql/DynamicFormConfigurations/Insert-dynamic-form-configurations-2022-2023.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/DynamicFormConfigurations/Insert-dynamic-form-configurations-2022-2023.sql
@@ -1,0 +1,77 @@
+-- Insert configurations for student financial aid application form type.
+INSERT INTO
+    sims.dynamic_form_configurations (
+        form_type,
+        program_year_id,
+        offering_intensity,
+        form_definition_name
+    )
+VALUES
+    (
+        'Student financial aid application',
+        (
+            select
+                id
+            from
+                sims.program_years
+            where
+                program_year = '2022-2023'
+        ),
+        'Full Time',
+        'SFAA2022-23'
+    ),
+    (
+        'Student financial aid application',
+        (
+            select
+                id
+            from
+                sims.program_years
+            where
+                program_year = '2022-2023'
+        ),
+        'Part Time',
+        'SFAA2022-23'
+    );
+
+-- Insert configurations for supporting users parent form type.
+INSERT INTO
+    sims.dynamic_form_configurations (
+        form_type,
+        program_year_id,
+        form_definition_name
+    )
+VALUES
+    (
+        'Supporting users parent',
+        (
+            select
+                id
+            from
+                sims.program_years
+            where
+                program_year = '2022-2023'
+        ),
+        'supportingusersparent2022-2023'
+    );
+
+-- Insert configurations for supporting users partner form type.
+INSERT INTO
+    sims.dynamic_form_configurations (
+        form_type,
+        program_year_id,
+        form_definition_name
+    )
+VALUES
+    (
+        'Supporting users partner',
+        (
+            select
+                id
+            from
+                sims.program_years
+            where
+                program_year = '2022-2023'
+        ),
+        'supportinguserspartner2022-2023'
+    );

--- a/sources/packages/backend/apps/db-migrations/src/sql/DynamicFormConfigurations/Insert-dynamic-form-configurations-2023-2024.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/DynamicFormConfigurations/Insert-dynamic-form-configurations-2023-2024.sql
@@ -1,0 +1,77 @@
+-- Insert configurations for student financial aid application form type.
+INSERT INTO
+    sims.dynamic_form_configurations (
+        form_type,
+        program_year_id,
+        offering_intensity,
+        form_definition_name
+    )
+VALUES
+    (
+        'Student financial aid application',
+        (
+            select
+                id
+            from
+                sims.program_years
+            where
+                program_year = '2023-2024'
+        ),
+        'Full Time',
+        'SFAA2023-24'
+    ),
+    (
+        'Student financial aid application',
+        (
+            select
+                id
+            from
+                sims.program_years
+            where
+                program_year = '2023-2024'
+        ),
+        'Part Time',
+        'SFAA2023-24'
+    );
+
+-- Insert configurations for supporting users parent form type.
+INSERT INTO
+    sims.dynamic_form_configurations (
+        form_type,
+        program_year_id,
+        form_definition_name
+    )
+VALUES
+    (
+        'Supporting users parent',
+        (
+            select
+                id
+            from
+                sims.program_years
+            where
+                program_year = '2023-2024'
+        ),
+        'supportingusersparent2022-2023'
+    );
+
+-- Insert configurations for supporting users partner form type.
+INSERT INTO
+    sims.dynamic_form_configurations (
+        form_type,
+        program_year_id,
+        form_definition_name
+    )
+VALUES
+    (
+        'Supporting users partner',
+        (
+            select
+                id
+            from
+                sims.program_years
+            where
+                program_year = '2023-2024'
+        ),
+        'supportinguserspartner2022-2023'
+    );

--- a/sources/packages/backend/apps/db-migrations/src/sql/DynamicFormConfigurations/Insert-dynamic-form-configurations-2024-2025.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/DynamicFormConfigurations/Insert-dynamic-form-configurations-2024-2025.sql
@@ -1,0 +1,77 @@
+-- Insert configurations for student financial aid application form type.
+INSERT INTO
+    sims.dynamic_form_configurations (
+        form_type,
+        program_year_id,
+        offering_intensity,
+        form_definition_name
+    )
+VALUES
+    (
+        'Student financial aid application',
+        (
+            select
+                id
+            from
+                sims.program_years
+            where
+                program_year = '2024-2025'
+        ),
+        'Full Time',
+        'SFAA2024-25'
+    ),
+    (
+        'Student financial aid application',
+        (
+            select
+                id
+            from
+                sims.program_years
+            where
+                program_year = '2024-2025'
+        ),
+        'Part Time',
+        'SFAA2024-25'
+    );
+
+-- Insert configurations for supporting users parent form type.
+INSERT INTO
+    sims.dynamic_form_configurations (
+        form_type,
+        program_year_id,
+        form_definition_name
+    )
+VALUES
+    (
+        'Supporting users parent',
+        (
+            select
+                id
+            from
+                sims.program_years
+            where
+                program_year = '2024-2025'
+        ),
+        'supportingusersparent2024-2025'
+    );
+
+-- Insert configurations for supporting users partner form type.
+INSERT INTO
+    sims.dynamic_form_configurations (
+        form_type,
+        program_year_id,
+        form_definition_name
+    )
+VALUES
+    (
+        'Supporting users partner',
+        (
+            select
+                id
+            from
+                sims.program_years
+            where
+                program_year = '2024-2025'
+        ),
+        'supportinguserspartner2024-2025'
+    );

--- a/sources/packages/backend/apps/db-migrations/src/sql/DynamicFormConfigurations/Insert-dynamic-form-configurations-2025-2026.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/DynamicFormConfigurations/Insert-dynamic-form-configurations-2025-2026.sql
@@ -1,0 +1,77 @@
+-- Insert configurations for student financial aid application form type.
+INSERT INTO
+    sims.dynamic_form_configurations (
+        form_type,
+        program_year_id,
+        offering_intensity,
+        form_definition_name
+    )
+VALUES
+    (
+        'Student financial aid application',
+        (
+            select
+                id
+            from
+                sims.program_years
+            where
+                program_year = '2025-2026'
+        ),
+        'Full Time',
+        'SFAA2025-26-FT'
+    ),
+    (
+        'Student financial aid application',
+        (
+            select
+                id
+            from
+                sims.program_years
+            where
+                program_year = '2025-2026'
+        ),
+        'Part Time',
+        'SFAA2025-26-PT'
+    );
+
+-- Insert configurations for supporting users parent form type.
+INSERT INTO
+    sims.dynamic_form_configurations (
+        form_type,
+        program_year_id,
+        form_definition_name
+    )
+VALUES
+    (
+        'Supporting users parent',
+        (
+            select
+                id
+            from
+                sims.program_years
+            where
+                program_year = '2025-2026'
+        ),
+        'supportingusersparent2025-2026'
+    );
+
+-- Insert configurations for supporting users partner form type.
+INSERT INTO
+    sims.dynamic_form_configurations (
+        form_type,
+        program_year_id,
+        form_definition_name
+    )
+VALUES
+    (
+        'Supporting users partner',
+        (
+            select
+                id
+            from
+                sims.program_years
+            where
+                program_year = '2025-2026'
+        ),
+        'supportinguserspartner2025-2026'
+    );

--- a/sources/packages/backend/apps/db-migrations/src/sql/DynamicFormConfigurations/Rollback-create-dynamic-form-configurations-table.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/DynamicFormConfigurations/Rollback-create-dynamic-form-configurations-table.sql
@@ -1,0 +1,1 @@
+DROP TABLE sims.dynamic_form_configurations;

--- a/sources/packages/backend/libs/sims-db/src/constant.ts
+++ b/sources/packages/backend/libs/sims-db/src/constant.ts
@@ -71,6 +71,7 @@ export const TableNames = {
   ApplicationRestrictionBypasses: "application_restriction_bypasses",
   BetaUsersAuthorizations: "beta_users_authorizations",
   SFASBridgeLogs: "sfas_bridge_logs",
+  DynamicFormConfigurations: "dynamic_form_configurations",
 };
 
 export const INSTITUTION_TYPE_BC_PUBLIC = 1;

--- a/sources/packages/backend/libs/sims-db/src/data-source.ts
+++ b/sources/packages/backend/libs/sims-db/src/data-source.ts
@@ -66,6 +66,7 @@ import {
   CASDistributionAccount,
   SFASApplicationDependant,
   SFASApplicationDisbursement,
+  DynamicFormConfiguration,
 } from "./entities";
 import { ClusterNode, ClusterOptions, RedisOptions } from "ioredis";
 import {
@@ -230,4 +231,5 @@ export const DBEntities = [
   CASDistributionAccount,
   BetaUsersAuthorizations,
   SFASBridgeLog,
+  DynamicFormConfiguration,
 ];

--- a/sources/packages/backend/libs/sims-db/src/entities/dynamic-form-configuration.model.ts
+++ b/sources/packages/backend/libs/sims-db/src/entities/dynamic-form-configuration.model.ts
@@ -1,0 +1,59 @@
+import {
+  Column,
+  Entity,
+  JoinColumn,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+} from "typeorm";
+import { BaseModel, OfferingIntensity, ProgramYear } from ".";
+import { ColumnNames, TableNames } from "../constant";
+
+/**
+ * Dynamic form configurations based on form type.
+ */
+@Entity({ name: TableNames.DynamicFormConfigurations })
+export class DynamicFormConfiguration extends BaseModel {
+  /**
+   * Auto-generated sequential primary key column.
+   */
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  /**
+   * Form type which is configured.
+   */
+  @Column({
+    name: "form_type",
+  })
+  formType: string;
+
+  /**
+   * Program year to identify the dynamic form for the form type.
+   */
+  @ManyToOne(() => ProgramYear, { nullable: true })
+  @JoinColumn({
+    name: "program_year_id",
+    referencedColumnName: ColumnNames.ID,
+  })
+  programYear?: ProgramYear;
+
+  /**
+   * Offering intensity to identify the dynamic form for the form type.
+   */
+  @Column({
+    name: "offering_intensity",
+    type: "enum",
+    enum: OfferingIntensity,
+    enumName: "OfferingIntensity",
+    nullable: true,
+  })
+  offeringIntensity?: OfferingIntensity;
+
+  /**
+   * Form definition for the form type based on configurations.
+   */
+  @Column({
+    name: "form_definition_name",
+  })
+  formDefinitionName: string;
+}

--- a/sources/packages/backend/libs/sims-db/src/entities/dynamic-form-configuration.model.ts
+++ b/sources/packages/backend/libs/sims-db/src/entities/dynamic-form-configuration.model.ts
@@ -53,7 +53,7 @@ export class DynamicFormConfiguration extends BaseModel {
   offeringIntensity?: OfferingIntensity;
 
   /**
-   * Form definition for the form type based on configurations.
+   * Form definition name for the form type based on configurations.
    */
   @Column({
     name: "form_definition_name",

--- a/sources/packages/backend/libs/sims-db/src/entities/dynamic-form-configuration.model.ts
+++ b/sources/packages/backend/libs/sims-db/src/entities/dynamic-form-configuration.model.ts
@@ -21,9 +21,12 @@ export class DynamicFormConfiguration extends BaseModel {
 
   /**
    * Form type which is dynamically configured.
+   * The column is a varchar in the database to allow for future expansion of form types
+   * without database migrations.
    */
   @Column({
     name: "form_type",
+    type: "varchar",
   })
   formType: DynamicFormType;
 

--- a/sources/packages/backend/libs/sims-db/src/entities/dynamic-form-configuration.model.ts
+++ b/sources/packages/backend/libs/sims-db/src/entities/dynamic-form-configuration.model.ts
@@ -5,7 +5,7 @@ import {
   ManyToOne,
   PrimaryGeneratedColumn,
 } from "typeorm";
-import { BaseModel, OfferingIntensity, ProgramYear } from ".";
+import { BaseModel, DynamicFormType, OfferingIntensity, ProgramYear } from ".";
 import { ColumnNames, TableNames } from "../constant";
 
 /**
@@ -20,12 +20,12 @@ export class DynamicFormConfiguration extends BaseModel {
   id: number;
 
   /**
-   * Form type which is configured.
+   * Form type which is dynamically configured.
    */
   @Column({
     name: "form_type",
   })
-  formType: string;
+  formType: DynamicFormType;
 
   /**
    * Program year to identify the dynamic form for the form type.

--- a/sources/packages/backend/libs/sims-db/src/entities/dynamic-form-type.ts
+++ b/sources/packages/backend/libs/sims-db/src/entities/dynamic-form-type.ts
@@ -1,0 +1,8 @@
+/**
+ * Form type which is dynamically configured.
+ */
+export enum DynamicFormType {
+  StudentFinancialAidApplication = "Student financial aid application",
+  SupportingUsersParent = "Supporting users parent",
+  SupportingUsersPartner = "Supporting users partner",
+}

--- a/sources/packages/backend/libs/sims-db/src/entities/index.ts
+++ b/sources/packages/backend/libs/sims-db/src/entities/index.ts
@@ -110,4 +110,5 @@ export * from "./restriction-bypass-behaviors.type";
 export * from "./beta-users-authorizations.model";
 export * from "./sfas-bridge-log.model";
 export * from "./application-edit-status.type";
+export * from "./dynamic-form-type";
 export * from "./dynamic-form-configuration.model";

--- a/sources/packages/backend/libs/sims-db/src/entities/index.ts
+++ b/sources/packages/backend/libs/sims-db/src/entities/index.ts
@@ -110,3 +110,4 @@ export * from "./restriction-bypass-behaviors.type";
 export * from "./beta-users-authorizations.model";
 export * from "./sfas-bridge-log.model";
 export * from "./application-edit-status.type";
+export * from "./dynamic-form-configuration.model";


### PR DESCRIPTION
# Formio split part-1

## DB Migration

- [x] Created new table `sims.dynamic_form_configurations` to configure the form definition extraction of dynamic forms.
- [x] Added a constraint in the table to avoid configuration duplicates.
- [x] Inserted the dynamic form configuration values into the new table based on existing values from `sims.program_years`.

## Rollback Evidence
![image](https://github.com/user-attachments/assets/69129d49-9469-4b04-998a-0fb1b65c8e32)

## Dynamic form configuration service

- [x] Created `DynamicFormConfigurationService` which is added to `DynamicFormConfigurationModule` which is created as global module and added to `AppModule`.
- [x] All the dynamic form configurations are loaded on start-up to avoid going to DB every time when dynamic form is looked up. This approach is done as these configurations are very rarely expected to be modified. But if modified, it will require `restart rollout` for the changes to take effect.
