### PR TITLE
#4653 - Add concurrency to build all

### DIFF
--- a/.github/workflows/release-build-all.yml
+++ b/.github/workflows/release-build-all.yml
@@ -1,6 +1,8 @@
 name: Release - Build All
 run-name: Release - Build all from ${{ github.ref_name }}(build ${{ github.run_number }})
 
+concurrency: release-build-all
+
 on:
   pull_request:
     types: [opened, reopened, synchronize, closed]


### PR DESCRIPTION
- adds concurrency lock to GitHub Build All function. This should resolve build errors when PRs are merged within close proximity to one another. 