### PR TITLE
#4501 - BUG: COE Query Impacting Count and Record Visibility 

### DIFF
--- a/sources/packages/backend/apps/api/src/services/disbursement-schedule/disbursement-schedule-service.ts
+++ b/sources/packages/backend/apps/api/src/services/disbursement-schedule/disbursement-schedule-service.ts
@@ -72,8 +72,16 @@ export class DisbursementScheduleService extends RecordDataModelService<Disburse
           paginationOptions.sortOrder,
         ),
       )
-      .offset(paginationOptions.page * paginationOptions.pageLimit)
-      .limit(paginationOptions.pageLimit);
+      .skip(paginationOptions.page * paginationOptions.pageLimit)
+      .take(paginationOptions.pageLimit);
+
+    // Log the generated SQL query and parameters
+    const [sql, parameters] = disbursementCOEQuery.getQueryAndParameters();
+    console.log("Executing COE query:");
+    console.log(sql);
+    console.log("Parameters:");
+    console.log(parameters);
+
     const [result, count] = await disbursementCOEQuery.getManyAndCount();
     return {
       results: result,

--- a/sources/packages/backend/apps/api/src/services/disbursement-schedule/disbursement-schedule-service.ts
+++ b/sources/packages/backend/apps/api/src/services/disbursement-schedule/disbursement-schedule-service.ts
@@ -75,13 +75,6 @@ export class DisbursementScheduleService extends RecordDataModelService<Disburse
       .skip(paginationOptions.page * paginationOptions.pageLimit)
       .take(paginationOptions.pageLimit);
 
-    // Log the generated SQL query and parameters
-    const [sql, parameters] = disbursementCOEQuery.getQueryAndParameters();
-    console.log("Executing COE query:");
-    console.log(sql);
-    console.log("Parameters:");
-    console.log(parameters);
-
     const [result, count] = await disbursementCOEQuery.getManyAndCount();
     return {
       results: result,

--- a/sources/packages/web/src/views/institution/locations/confirmation-of-enrollment/COESummaryData.vue
+++ b/sources/packages/web/src/views/institution/locations/confirmation-of-enrollment/COESummaryData.vue
@@ -1,10 +1,7 @@
 <template>
   <v-card class="mt-5">
     <v-container :fluid="true">
-      <body-header
-        :title="header"
-        :recordsCount="disbursements.results?.length"
-      >
+      <body-header :title="header" :recordsCount="disbursements.count">
         <template #subtitle>
           <slot name="coeSummarySubtitle">{{ coeSummarySubtitle }}</slot>
         </template>


### PR DESCRIPTION
**Expected Behaviour**
If 10 items per page and there are 10 students for COE they should be displayed on one page
If 12 students, 10 should be listed on one page and 2 students on the other
All students who are required to have COE are displayed - the institution user does not need to search for them


Issue is using 2 query in https://github.com/typeorm/typeorm/issues/320

*Note:
code to use .skip() instead of .offset() and .take() instead of .limit()
