### PR TITLE
#4328 - Student Profile - Bridge/Legacy Matching Management -  Display Existing Match if exists

### DIFF
--- a/sources/packages/backend/apps/api/src/route-controllers/student/_tests_/e2e/student.aest.controller.getStudentProfile.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/student/_tests_/e2e/student.aest.controller.getStudentProfile.e2e-spec.ts
@@ -26,7 +26,7 @@ describe("StudentAESTController(e2e)-getStudentProfile", () => {
     db = dataSource;
   });
 
-  it("Should get the student profile when student the student exists and no legacy profile is associated.", async () => {
+  it("Should get the student profile when the student exists and no legacy profile is associated.", async () => {
     // Arrange
     const user = createFakeUser();
     user.identityProviderType = IdentityProviders.BCSC;
@@ -66,7 +66,7 @@ describe("StudentAESTController(e2e)-getStudentProfile", () => {
       });
   });
 
-  it("Should get the student profile when student the student exists and legacy profile is associated.", async () => {
+  it("Should get the student profile when the student exists and legacy profile is associated.", async () => {
     // Arrange
     const user = createFakeUser();
     user.identityProviderType = IdentityProviders.BCSC;

--- a/sources/packages/backend/apps/api/src/route-controllers/student/_tests_/e2e/student.aest.controller.getStudentProfile.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/student/_tests_/e2e/student.aest.controller.getStudentProfile.e2e-spec.ts
@@ -1,0 +1,139 @@
+import { HttpStatus, INestApplication } from "@nestjs/common";
+import * as request from "supertest";
+import { DataSource } from "typeorm";
+import {
+  BEARER_AUTH_TYPE,
+  createTestingAppModule,
+  AESTGroups,
+  getAESTToken,
+} from "../../../../testHelpers";
+import {
+  createFakeUser,
+  saveFakeSFASIndividual,
+  saveFakeStudent,
+} from "@sims/test-utils";
+import { getUserFullName } from "../../../../utilities";
+import { getISODateOnlyString } from "@sims/utilities";
+import { IdentityProviders } from "@sims/sims-db";
+
+describe("StudentAESTController(e2e)-getStudentProfile", () => {
+  let app: INestApplication;
+  let db: DataSource;
+
+  beforeAll(async () => {
+    const { nestApplication, dataSource } = await createTestingAppModule();
+    app = nestApplication;
+    db = dataSource;
+  });
+
+  it("Should get the student profile when student the student exists and no legacy profile is associated.", async () => {
+    // Arrange
+    const user = createFakeUser();
+    user.identityProviderType = IdentityProviders.BCSC;
+    const student = await saveFakeStudent(db, { user });
+    const aestUserToken = await getAESTToken(AESTGroups.BusinessAdministrators);
+    const endpoint = `/aest/student/${student.id}`;
+
+    // Act/Assert
+    await request(app.getHttpServer())
+      .get(endpoint)
+      .auth(aestUserToken, BEARER_AUTH_TYPE)
+      .expect(HttpStatus.OK)
+      .expect({
+        firstName: student.user.firstName,
+        lastName: student.user.lastName,
+        fullName: getUserFullName(student.user),
+        email: student.user.email,
+        gender: student.gender,
+        dateOfBirth: getISODateOnlyString(student.birthDate),
+        contact: {
+          address: {
+            addressLine1: student.contactInfo.address.addressLine1,
+            provinceState: student.contactInfo.address.provinceState,
+            country: student.contactInfo.address.country,
+            city: student.contactInfo.address.city,
+            postalCode: student.contactInfo.address.postalCode,
+            canadaPostalCode: student.contactInfo.address.postalCode,
+            selectedCountry: student.contactInfo.address.selectedCountry,
+          },
+          phone: student.contactInfo.phone,
+        },
+        disabilityStatus: student.disabilityStatus,
+        validSin: student.sinValidation.isValidSIN,
+        hasRestriction: false,
+        identityProviderType: IdentityProviders.BCSC,
+        sin: student.sinValidation.sin,
+      });
+  });
+
+  it("Should get the student profile when student the student exists and legacy profile is associated.", async () => {
+    // Arrange
+    const user = createFakeUser();
+    user.identityProviderType = IdentityProviders.BCSC;
+    const student = await saveFakeStudent(db, { user });
+    const legacyProfile = await saveFakeSFASIndividual(db, {
+      initialValues: { student },
+    });
+    const aestUserToken = await getAESTToken(AESTGroups.BusinessAdministrators);
+    const endpoint = `/aest/student/${student.id}`;
+
+    // Act/Assert
+    await request(app.getHttpServer())
+      .get(endpoint)
+      .auth(aestUserToken, BEARER_AUTH_TYPE)
+      .expect(HttpStatus.OK)
+      .expect({
+        firstName: student.user.firstName,
+        lastName: student.user.lastName,
+        fullName: getUserFullName(student.user),
+        email: student.user.email,
+        gender: student.gender,
+        dateOfBirth: getISODateOnlyString(student.birthDate),
+        contact: {
+          address: {
+            addressLine1: student.contactInfo.address.addressLine1,
+            provinceState: student.contactInfo.address.provinceState,
+            country: student.contactInfo.address.country,
+            city: student.contactInfo.address.city,
+            postalCode: student.contactInfo.address.postalCode,
+            canadaPostalCode: student.contactInfo.address.postalCode,
+            selectedCountry: student.contactInfo.address.selectedCountry,
+          },
+          phone: student.contactInfo.phone,
+        },
+        disabilityStatus: student.disabilityStatus,
+        validSin: student.sinValidation.isValidSIN,
+        hasRestriction: false,
+        identityProviderType: IdentityProviders.BCSC,
+        sin: student.sinValidation.sin,
+        legacyProfile: {
+          id: legacyProfile.id,
+          firstName: legacyProfile.firstName,
+          lastName: legacyProfile.lastName,
+          dateOfBirth: legacyProfile.birthDate,
+          sin: legacyProfile.sin,
+        },
+      });
+  });
+
+  it("Should throw a NotFoundException when the student was not found.", async () => {
+    // Arrange
+    const aestUserToken = await getAESTToken(AESTGroups.BusinessAdministrators);
+    const endpoint = `/aest/student/999999`;
+
+    // Act/Assert
+    await request(app.getHttpServer())
+      .get(endpoint)
+      .auth(aestUserToken, BEARER_AUTH_TYPE)
+      .expect(HttpStatus.NOT_FOUND)
+      .expect({
+        message: "Student not found.",
+        error: "Not Found",
+        statusCode: HttpStatus.NOT_FOUND,
+      });
+  });
+
+  afterAll(async () => {
+    await app?.close();
+  });
+});

--- a/sources/packages/backend/apps/api/src/route-controllers/student/_tests_/e2e/student.aest.controller.getStudentProfile.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/student/_tests_/e2e/student.aest.controller.getStudentProfile.e2e-spec.ts
@@ -68,7 +68,7 @@ describe("StudentAESTController(e2e)-getStudentProfile", () => {
       });
   });
 
-  it("Should get the student profile when the student exists and legacy one profile is associated.", async () => {
+  it("Should get the student profile when the student exists and one legacy profile is associated.", async () => {
     // Arrange
     const user = createFakeUser();
     user.identityProviderType = IdentityProviders.BCSC;

--- a/sources/packages/backend/apps/api/src/route-controllers/student/models/student.dto.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/student/models/student.dto.ts
@@ -189,6 +189,11 @@ export class LegacyStudentProfileAPIOutDTO {
   lastName: string;
   dateOfBirth: string;
   sin: string;
+  /**
+   * Indicates if the student on SIMS is associated
+   * with multiple profiles on the legacy system.
+   */
+  hasMultipleProfiles: boolean;
 }
 
 export class StudentProfileAPIOutDTO {

--- a/sources/packages/backend/apps/api/src/route-controllers/student/models/student.dto.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/student/models/student.dto.ts
@@ -183,6 +183,14 @@ export class StudentFileMetadataAPIOutDTO {
   applicationNumber?: string;
 }
 
+export class LegacyStudentProfileAPIOutDTO {
+  id: number;
+  firstName: string;
+  lastName: string;
+  dateOfBirth: string;
+  sin: string;
+}
+
 export class StudentProfileAPIOutDTO {
   firstName: string;
   lastName: string;
@@ -202,6 +210,7 @@ export class InstitutionStudentProfileAPIOutDTO extends StudentProfileAPIOutDTO 
 export class AESTStudentProfileAPIOutDTO extends InstitutionStudentProfileAPIOutDTO {
   hasRestriction: boolean;
   identityProviderType: SpecificIdentityProviders;
+  legacyProfile?: LegacyStudentProfileAPIOutDTO;
 }
 
 export class AESTFileUploadToStudentAPIInDTO {

--- a/sources/packages/backend/apps/api/src/route-controllers/student/student.controller.service.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/student/student.controller.service.ts
@@ -283,13 +283,16 @@ export class StudentControllerService {
         identityProviderType: student.user
           .identityProviderType as SpecificIdentityProviders,
       };
-      if (student.sfasIndividual) {
+      if (student.sfasIndividuals.length) {
+        // Get the most recently updated profile.
+        const [profile] = student.sfasIndividuals;
         legacyProfile = {
-          id: student.sfasIndividual.id,
-          firstName: student.sfasIndividual.firstName,
-          lastName: student.sfasIndividual.lastName,
-          dateOfBirth: student.sfasIndividual.birthDate,
-          sin: student.sfasIndividual.sin,
+          id: profile.id,
+          firstName: profile.firstName,
+          lastName: profile.lastName,
+          dateOfBirth: profile.birthDate,
+          sin: profile.sin,
+          hasMultipleProfiles: student.sfasIndividuals.length > 1,
         };
       }
     }

--- a/sources/packages/backend/apps/api/src/route-controllers/student/student.controller.service.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/student/student.controller.service.ts
@@ -265,7 +265,7 @@ export class StudentControllerService {
       validSin: student.sinValidation.isValidSIN,
     };
     // Optionally load specific data for the Ministry.
-    let legacyProfile: LegacyStudentProfileAPIOutDTO = undefined;
+    let legacyProfile: LegacyStudentProfileAPIOutDTO;
     let specificData: Pick<
       AESTStudentProfileAPIOutDTO,
       "hasRestriction" | "identityProviderType"

--- a/sources/packages/backend/apps/api/src/services/student/student.service.ts
+++ b/sources/packages/backend/apps/api/src/services/student/student.service.ts
@@ -59,10 +59,15 @@ export class StudentService extends RecordDataModelService<Student> {
   /**
    * Gets the student by id.
    * @param studentId student id.
+   * @param options options to include legacy data.
+   * - `includeLegacy`: if true, include legacy profile data.
    * @returns the student found or null.
    */
-  async getStudentById(studentId: number): Promise<Student> {
-    return this.repo
+  async getStudentById(
+    studentId: number,
+    options?: { includeLegacy?: boolean },
+  ): Promise<Student> {
+    const studentQuery = this.repo
       .createQueryBuilder("student")
       .select([
         "student.id",
@@ -83,8 +88,19 @@ export class StudentService extends RecordDataModelService<Student> {
       ])
       .innerJoin("student.user", "user")
       .leftJoin("student.sinValidation", "sinValidation")
-      .where("student.id = :studentId", { studentId })
-      .getOne();
+      .where("student.id = :studentId", { studentId });
+    if (options?.includeLegacy) {
+      studentQuery
+        .addSelect([
+          "sfasIndividual.id",
+          "sfasIndividual.firstName",
+          "sfasIndividual.lastName",
+          "sfasIndividual.birthDate",
+          "sfasIndividual.sin",
+        ])
+        .leftJoin("student.sfasIndividual", "sfasIndividual");
+    }
+    return studentQuery.getOne();
   }
 
   /**

--- a/sources/packages/backend/apps/api/src/services/student/student.service.ts
+++ b/sources/packages/backend/apps/api/src/services/student/student.service.ts
@@ -92,13 +92,14 @@ export class StudentService extends RecordDataModelService<Student> {
     if (options?.includeLegacy) {
       studentQuery
         .addSelect([
-          "sfasIndividual.id",
-          "sfasIndividual.firstName",
-          "sfasIndividual.lastName",
-          "sfasIndividual.birthDate",
-          "sfasIndividual.sin",
+          "sfasIndividuals.id",
+          "sfasIndividuals.firstName",
+          "sfasIndividuals.lastName",
+          "sfasIndividuals.birthDate",
+          "sfasIndividuals.sin",
         ])
-        .leftJoin("student.sfasIndividual", "sfasIndividual");
+        .leftJoin("student.sfasIndividuals", "sfasIndividuals")
+        .orderBy("sfasIndividuals.updatedAt", "DESC");
     }
     return studentQuery.getOne();
   }

--- a/sources/packages/backend/libs/sims-db/src/entities/student.model.ts
+++ b/sources/packages/backend/libs/sims-db/src/entities/student.model.ts
@@ -154,9 +154,11 @@ export class Student extends RecordDataModel {
 
   /**
    * Legacy student profile.
+   * The student can potentially be associated with multiple legacy profiles,
+   * but only one is currently supported.
    */
-  @OneToOne(() => SFASIndividual, (sfasIndividual) => sfasIndividual.student, {
+  @OneToMany(() => SFASIndividual, (sfasIndividual) => sfasIndividual.student, {
     nullable: true,
   })
-  sfasIndividual?: SFASIndividual;
+  sfasIndividuals?: SFASIndividual[];
 }

--- a/sources/packages/backend/libs/sims-db/src/entities/student.model.ts
+++ b/sources/packages/backend/libs/sims-db/src/entities/student.model.ts
@@ -19,6 +19,7 @@ import {
   CASSupplier,
   DisbursementOveraward,
   Application,
+  SFASIndividual,
 } from ".";
 import { SINValidation } from "./sin-validation.model";
 
@@ -150,4 +151,12 @@ export class Student extends RecordDataModel {
     cascade: false,
   })
   applications?: Application[];
+
+  /**
+   * Legacy student profile.
+   */
+  @OneToOne(() => SFASIndividual, (sfasIndividual) => sfasIndividual.student, {
+    nullable: true,
+  })
+  sfasIndividual?: SFASIndividual;
 }

--- a/sources/packages/backend/libs/test-utils/src/factories/sfas-individuals.ts
+++ b/sources/packages/backend/libs/test-utils/src/factories/sfas-individuals.ts
@@ -11,7 +11,7 @@ import { createFakeStudent } from "@sims/test-utils/factories/student";
  * - `includeAddressLine2` include address line 2.
  * @returns created sfas individual.
  */
-function createFakeSFASIndividual(options?: {
+export function createFakeSFASIndividual(options?: {
   initialValues?: Partial<SFASIndividual>;
   includeAddressLine2?: boolean;
 }) {
@@ -67,6 +67,7 @@ function createFakeSFASIndividual(options?: {
     sfasIndividual.addressLine2 =
       options?.initialValues?.addressLine2 ?? faker.address.secondaryAddress();
   }
+  sfasIndividual.updatedAt = options?.initialValues?.updatedAt;
   return sfasIndividual;
 }
 

--- a/sources/packages/web/src/components/common/students/StudentProfile.vue
+++ b/sources/packages/web/src/components/common/students/StudentProfile.vue
@@ -136,14 +136,13 @@
         <v-col
           ><title-value
             propertyTitle="SIN"
-            :propertyValue="sinDisplayFormat(studentDetail.legacyProfile?.sin)"
+            :propertyValue="sinDisplayFormat(studentDetail.legacyProfile.sin)"
           />
         </v-col>
       </v-row>
-      <v-row>
+      <v-row v-if="studentDetail.legacyProfile.hasMultipleProfiles">
         <v-col
           ><banner
-            v-if="studentDetail.legacyProfile?.hasMultipleProfiles"
             :type="BannerTypes.Warning"
             summary="The student is associated with multiple legacy profiles; the most recent update is shown."
           ></banner>

--- a/sources/packages/web/src/components/common/students/StudentProfile.vue
+++ b/sources/packages/web/src/components/common/students/StudentProfile.vue
@@ -140,6 +140,15 @@
           />
         </v-col>
       </v-row>
+      <v-row>
+        <v-col
+          ><banner
+            v-if="studentDetail.legacyProfile?.hasMultipleProfiles"
+            :type="BannerTypes.Warning"
+            summary="The student is associated with multiple legacy profiles. Above is shown the most recent updated profile."
+          ></banner>
+        </v-col>
+      </v-row>
     </content-group>
     <banner
       v-else

--- a/sources/packages/web/src/components/common/students/StudentProfile.vue
+++ b/sources/packages/web/src/components/common/students/StudentProfile.vue
@@ -145,7 +145,7 @@
           ><banner
             v-if="studentDetail.legacyProfile?.hasMultipleProfiles"
             :type="BannerTypes.Warning"
-            summary="The student is associated with multiple legacy profiles. Above is shown the most recent updated profile."
+            summary="The student is associated with multiple legacy profiles; the most recent update is shown."
           ></banner>
         </v-col>
       </v-row>

--- a/sources/packages/web/src/components/common/students/StudentProfile.vue
+++ b/sources/packages/web/src/components/common/students/StudentProfile.vue
@@ -127,7 +127,9 @@
         <v-col>
           <title-value
             propertyTitle="Date of birth"
-            :propertyValue="studentDetail.legacyProfile.dateOfBirth"
+            :propertyValue="
+              dateOnlyLongString(studentDetail.legacyProfile.dateOfBirth)
+            "
         /></v-col>
       </v-row>
       <v-row>
@@ -195,8 +197,12 @@ export default defineComponent({
     );
     const studentDetail = ref({} as SharedStudentProfile);
     const address = ref({} as AddressAPIOutDTO);
-    const { genderDisplayFormat, sinDisplayFormat, emptyStringFiller } =
-      useFormatters();
+    const {
+      genderDisplayFormat,
+      sinDisplayFormat,
+      emptyStringFiller,
+      dateOnlyLongString,
+    } = useFormatters();
 
     const loadStudentProfile = async () => {
       studentDetail.value = (await StudentService.shared.getStudentProfile(
@@ -250,6 +256,7 @@ export default defineComponent({
       address,
       sinDisplayFormat,
       genderDisplayFormat,
+      dateOnlyLongString,
       emptyStringFiller,
       loadStudentProfile,
       Role,

--- a/sources/packages/web/src/components/common/students/StudentProfile.vue
+++ b/sources/packages/web/src/components/common/students/StudentProfile.vue
@@ -24,7 +24,7 @@
         <v-col
           ><title-value
             propertyTitle="Given names"
-            :propertyValue="studentDetail.firstName"
+            :propertyValue="emptyStringFiller(studentDetail.firstName)"
           />
         </v-col>
         <v-col
@@ -115,7 +115,9 @@
         <v-col
           ><title-value
             propertyTitle="Given names"
-            :propertyValue="studentDetail.legacyProfile.firstName"
+            :propertyValue="
+              emptyStringFiller(studentDetail.legacyProfile.firstName)
+            "
           />
         </v-col>
         <v-col

--- a/sources/packages/web/src/components/common/students/StudentProfile.vue
+++ b/sources/packages/web/src/components/common/students/StudentProfile.vue
@@ -109,6 +109,41 @@
         /></v-col>
       </v-row>
     </content-group>
+    <h3 class="category-header-medium mt-4">Legacy Match</h3>
+    <content-group v-if="studentDetail.legacyProfile">
+      <v-row>
+        <v-col
+          ><title-value
+            propertyTitle="Given names"
+            :propertyValue="studentDetail.legacyProfile.firstName"
+          />
+        </v-col>
+        <v-col
+          ><title-value
+            propertyTitle="Last name"
+            :propertyValue="studentDetail.legacyProfile.lastName"
+          />
+        </v-col>
+        <v-col>
+          <title-value
+            propertyTitle="Date of birth"
+            :propertyValue="studentDetail.legacyProfile.dateOfBirth"
+        /></v-col>
+      </v-row>
+      <v-row>
+        <v-col
+          ><title-value
+            propertyTitle="SIN"
+            :propertyValue="sinDisplayFormat(studentDetail.legacyProfile?.sin)"
+          />
+        </v-col>
+      </v-row>
+    </content-group>
+    <banner
+      v-else
+      :type="BannerTypes.Info"
+      summary="The student is not currently associated with any legacy record."
+    ></banner>
     <edit-student-profile-modal
       ref="studentEditProfile"
     ></edit-student-profile-modal>
@@ -123,7 +158,7 @@ import {
   AddressAPIOutDTO,
   UpdateStudentDetailsAPIInDTO,
 } from "@/services/http/dto";
-import { IdentityProviders, Role, StudentProfile } from "@/types";
+import { IdentityProviders, Role, StudentProfile, BannerTypes } from "@/types";
 import DisabilityStatusUpdateTileValue from "@/components/aest/students/DisabilityStatusUpdateTileValue.vue";
 import EditStudentProfileModal from "@/components/aest/students/modals/EditStudentProfileModal.vue";
 import CheckPermissionRole from "@/components/generic/CheckPermissionRole.vue";
@@ -221,6 +256,7 @@ export default defineComponent({
       editStudentProfile,
       canEditProfile,
       studentEditProfile,
+      BannerTypes,
     };
   },
 });

--- a/sources/packages/web/src/composables/useFormatters.ts
+++ b/sources/packages/web/src/composables/useFormatters.ts
@@ -298,7 +298,7 @@ export function useFormatters() {
    * @param sin value to be converted to be displayed.
    * @returns SIN formatted as 999 999 999.
    */
-  const sinDisplayFormat = (sin: string): string | undefined => {
+  const sinDisplayFormat = (sin?: string): string | undefined => {
     if (!sin) {
       return DEFAULT_EMPTY_VALUE;
     }

--- a/sources/packages/web/src/services/http/dto/Student.dto.ts
+++ b/sources/packages/web/src/services/http/dto/Student.dto.ts
@@ -53,6 +53,11 @@ export interface LegacyStudentProfileAPIOutDTO {
   lastName: string;
   dateOfBirth: string;
   sin: string;
+  /**
+   * Indicates if the student on SIMS is associated
+   * with multiple profiles on the legacy system.
+   */
+  hasMultipleProfiles: boolean;
 }
 
 export interface StudentProfileAPIOutDTO {

--- a/sources/packages/web/src/services/http/dto/Student.dto.ts
+++ b/sources/packages/web/src/services/http/dto/Student.dto.ts
@@ -47,6 +47,14 @@ export interface UpdateStudentDetailsAPIInDTO {
   noteDescription: string;
 }
 
+export interface LegacyStudentProfileAPIOutDTO {
+  id: number;
+  firstName: string;
+  lastName: string;
+  dateOfBirth: string;
+  sin: string;
+}
+
 export interface StudentProfileAPIOutDTO {
   firstName: string;
   lastName: string;
@@ -69,6 +77,7 @@ export interface AESTStudentProfileAPIOutDTO
   extends InstitutionStudentProfileAPIOutDTO {
   hasRestriction: boolean;
   identityProvider: SpecificIdentityProviders;
+  legacyProfile?: LegacyStudentProfileAPIOutDTO;
 }
 
 /**

--- a/sources/packages/web/src/types/contracts/StudentContract.ts
+++ b/sources/packages/web/src/types/contracts/StudentContract.ts
@@ -2,6 +2,7 @@ import {
   AddressDetailsFormAPIDTO,
   AESTStudentProfileAPIOutDTO,
   InstitutionStudentProfileAPIOutDTO,
+  LegacyStudentProfileAPIOutDTO,
   SINValidationsAPIOutDTO,
   StudentProfileAPIOutDTO,
 } from "@/services/http/dto";
@@ -13,6 +14,7 @@ export type StudentProfile =
       | InstitutionStudentProfileAPIOutDTO
       | AESTStudentProfileAPIOutDTO
     ) & {
+      legacyProfile?: LegacyStudentProfileAPIOutDTO;
       birthDateFormatted: string;
     };
 


### PR DESCRIPTION
- Exposed the legacy profile data in the student API for Ministry users only
  - Included information to allow the user to know if the student has multiple legacy profiles, as the most recent AC added.
- Add E2Es for the endpoint to cover students with and without a legacy profile associated.

## Existing Match Found

![image](https://github.com/user-attachments/assets/5c54dedd-1e91-4e07-9ae6-7cbc73337b63)

## No Existing Match Found

![image](https://github.com/user-attachments/assets/490c0ff2-3d9a-4f24-96df-a08c22af3d2a)

## Multiple Matches

![image](https://github.com/user-attachments/assets/84fa6b85-4b15-405b-ace5-ac8b2e6ec00f)

## To be implemented

Add an action to the banner to allow the Ministry user to execute the search that will display a list of options to be selected.

![image](https://github.com/user-attachments/assets/13da0bf5-8589-4bad-bb59-4d1aa1198f61)


