### PR TITLE
#4520 -  FormIO split final part - cleanup and backward compatibility

### DIFF
--- a/sources/packages/backend/apps/api/src/route-controllers/application-offering-change-request/_tests_/e2e/application-offering-change-request.institutions.controller.createApplicationOfferingChangeRequest.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/application-offering-change-request/_tests_/e2e/application-offering-change-request.institutions.controller.createApplicationOfferingChangeRequest.e2e-spec.ts
@@ -78,8 +78,6 @@ describe("ApplicationOfferingChangeRequestInstitutionsController(e2e)-createAppl
     application.student.sinValidation = createFakeSINValidation({
       student: application.student,
     });
-    application.data.howWillYouBeAttendingTheProgram =
-      OfferingIntensity.fullTime;
 
     await db.student.save(application.student);
     await db.application.save(application);
@@ -210,8 +208,7 @@ describe("ApplicationOfferingChangeRequestInstitutionsController(e2e)-createAppl
         student: student,
       },
     );
-    applicationRequestForChange.data.howWillYouBeAttendingTheProgram =
-      OfferingIntensity.fullTime;
+
     applicationRequestForChange.offeringIntensity = OfferingIntensity.fullTime;
 
     await db.student.save(applicationRequestForChange.student);
@@ -276,8 +273,6 @@ describe("ApplicationOfferingChangeRequestInstitutionsController(e2e)-createAppl
     application.student.sinValidation = createFakeSINValidation({
       student: application.student,
     });
-    application.data.howWillYouBeAttendingTheProgram =
-      OfferingIntensity.fullTime;
 
     await db.student.save(application.student);
     await db.application.save(application);
@@ -326,8 +321,6 @@ describe("ApplicationOfferingChangeRequestInstitutionsController(e2e)-createAppl
     application.student.sinValidation = createFakeSINValidation({
       student: application.student,
     });
-    application.data.howWillYouBeAttendingTheProgram =
-      OfferingIntensity.fullTime;
 
     await db.student.save(application.student);
     await db.application.save(application);
@@ -460,8 +453,6 @@ describe("ApplicationOfferingChangeRequestInstitutionsController(e2e)-createAppl
     application.student.sinValidation = createFakeSINValidation({
       student: application.student,
     });
-    application.data.howWillYouBeAttendingTheProgram =
-      OfferingIntensity.fullTime;
 
     await db.student.save(application.student);
     await db.application.save(application);
@@ -516,8 +507,6 @@ describe("ApplicationOfferingChangeRequestInstitutionsController(e2e)-createAppl
     application.student.sinValidation = createFakeSINValidation({
       student: application.student,
     });
-    application.data.howWillYouBeAttendingTheProgram =
-      OfferingIntensity.fullTime;
 
     await db.student.save(application.student);
     await db.application.save(application);

--- a/sources/packages/backend/apps/api/src/route-controllers/application/application.controller.service.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/application/application.controller.service.ts
@@ -960,9 +960,8 @@ export class ApplicationControllerService {
     // For program years still relying on the form.io variable howWillYouBeAttendingTheProgram
     // to determine the offering intensity, we need to set the value in the payload
     // to the offering intensity value from the database.
-    if (payload.data.howWillYouBeAttendingTheProgram) {
-      payload.data.howWillYouBeAttendingTheProgram = offeringIntensity;
-    }
+    // TODO: Remove this once the program year 2024-2025 is no longer active.
+    payload.data.howWillYouBeAttendingTheProgram = offeringIntensity;
 
     // studyStartDate from payload is set as studyStartDate
     let studyStartDate = payload.data.studystartDate;

--- a/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/sfas-integration/_tests_/sims-to-sfas-integration.scheduler.e2e-spec.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/sfas-integration/_tests_/sims-to-sfas-integration.scheduler.e2e-spec.ts
@@ -644,7 +644,6 @@ describe(describeProcessorRootTest(QueueNames.SIMSToSFASIntegration), () => {
         { student },
         {
           applicationData: {
-            howWillYouBeAttendingTheProgram: OfferingIntensity.partTime,
             studystartDate: studyStartDate,
             studyendDate: studyEndDate,
           } as ApplicationData,

--- a/sources/packages/forms/src/form-definitions/sfaa2022-23.json
+++ b/sources/packages/forms/src/form-definitions/sfaa2022-23.json
@@ -1507,7 +1507,7 @@
               "tooltip": "A student is considered to be in part-time studies when taking between 20% and 59% of a full-time course load in a course or continuous period of study.",
               "customClass": "font-weight-bold",
               "disabled": true,
-              "calculateValue": "",
+              "calculateValue": "value = data.howWillYouBeAttendingTheProgram ? utils.custom.mapOfferingIntensity(data.howWillYouBeAttendingTheProgram) : '';",
               "lockKey": true
             },
             {

--- a/sources/packages/forms/src/form-definitions/sfaa2023-24.json
+++ b/sources/packages/forms/src/form-definitions/sfaa2023-24.json
@@ -1507,7 +1507,7 @@
               "tooltip": "A student is considered to be in part-time studies when taking between 20% and 59% of a full-time course load in a course or continuous period of study.",
               "customClass": "font-weight-bold",
               "disabled": true,
-              "calculateValue": "",
+              "calculateValue": "value = data.howWillYouBeAttendingTheProgram ? utils.custom.mapOfferingIntensity(data.howWillYouBeAttendingTheProgram) : '';",
               "lockKey": true
             },
             {

--- a/sources/packages/forms/src/form-definitions/sfaa2024-25.json
+++ b/sources/packages/forms/src/form-definitions/sfaa2024-25.json
@@ -1507,7 +1507,7 @@
               "tooltip": "A student is considered to be in part-time studies when taking between 20% and 59% of a full-time course load in a course or continuous period of study.",
               "customClass": "font-weight-bold",
               "disabled": true,
-              "calculateValue": "",
+              "calculateValue": "value = data.howWillYouBeAttendingTheProgram ? utils.custom.mapOfferingIntensity(data.howWillYouBeAttendingTheProgram) : '';",
               "lockKey": true
             },
             {

--- a/sources/packages/web/src/components/common/StudentApplication.vue
+++ b/sources/packages/web/src/components/common/StudentApplication.vue
@@ -141,8 +141,7 @@ export default defineComponent({
         // Program year forms older than 2025-26 required offering intensity to be injected to the form.
         // Check if the form has the offering intensity component and if so, inject the values.
         if (applicationIntensityComponent) {
-          formData.value.howWillYouBeAttendingTheProgram =
-            props.initialData.applicationOfferingIntensityValue;
+          formData.value.howWillYouBeAttendingTheProgram = offeringIntensity;
         }
         // When the form is editable, load locations and programs.
         if (!props.isReadOnly) {

--- a/sources/packages/web/src/components/common/StudentApplication.vue
+++ b/sources/packages/web/src/components/common/StudentApplication.vue
@@ -60,7 +60,6 @@ import {
   useFormioComponentLoader,
   useFormioDropdownLoader,
   useFormioUtils,
-  useOffering,
 } from "@/composables";
 
 export default defineComponent({
@@ -115,7 +114,6 @@ export default defineComponent({
     const PROGRAM_NOT_LISTED = "myProgramNotListed";
     const OFFERING_NOT_LISTED = "myStudyPeriodIsntListed";
     let formInstance: any;
-    const { mapOfferingIntensity } = useOffering();
     const formioUtils = useFormioUtils();
     const formioDataLoader = useFormioDropdownLoader();
     const formioComponentLoader = useFormioComponentLoader();
@@ -145,8 +143,6 @@ export default defineComponent({
         if (applicationIntensityComponent) {
           formData.value.howWillYouBeAttendingTheProgram =
             props.initialData.applicationOfferingIntensityValue;
-          formData.value.applicationOfferingIntensity =
-            mapOfferingIntensity(offeringIntensity);
         }
         // When the form is editable, load locations and programs.
         if (!props.isReadOnly) {

--- a/sources/packages/web/src/components/common/StudentApplication.vue
+++ b/sources/packages/web/src/components/common/StudentApplication.vue
@@ -1,7 +1,7 @@
 <template>
   <formio
     :formName="selectedForm"
-    :data="initialData"
+    :data="formData"
     :readOnly="isReadOnly"
     @loaded="formLoaded"
     @changed="formChanged"
@@ -53,12 +53,14 @@ import {
   WizardNavigationEvent,
   FormIOCustomEvent,
   FormIOForm,
+  StudentApplicationFormData,
 } from "@/types";
-import { ref, watch, defineComponent, computed } from "vue";
+import { ref, watch, defineComponent, computed, PropType } from "vue";
 import {
   useFormioComponentLoader,
   useFormioDropdownLoader,
   useFormioUtils,
+  useOffering,
 } from "@/composables";
 
 export default defineComponent({
@@ -73,7 +75,7 @@ export default defineComponent({
   ],
   props: {
     initialData: {
-      type: Object,
+      type: Object as PropType<StudentApplicationFormData>,
       required: true,
     },
     selectedForm: {
@@ -113,12 +115,15 @@ export default defineComponent({
     const PROGRAM_NOT_LISTED = "myProgramNotListed";
     const OFFERING_NOT_LISTED = "myStudyPeriodIsntListed";
     let formInstance: any;
+    const { mapOfferingIntensity } = useOffering();
     const formioUtils = useFormioUtils();
     const formioDataLoader = useFormioDropdownLoader();
     const formioComponentLoader = useFormioComponentLoader();
     const isFirstPage = ref(true);
     const isLastPage = ref(false);
     const showNav = ref(false);
+    const formData = ref({} as StudentApplicationFormData);
+    let offeringIntensity: OfferingIntensity;
 
     const isSaveDraftAllowed = computed(
       () => !props.notDraft && !isFirstPage.value && !props.processing,
@@ -129,50 +134,62 @@ export default defineComponent({
     };
 
     const loadFormDependencies = async () => {
-      if (!props.isReadOnly && !!formInstance) {
-        await formioDataLoader.loadLocations(
-          formInstance,
-          LOCATIONS_DROPDOWN_KEY,
+      if (formInstance && props.initialData) {
+        formData.value = props.initialData;
+        offeringIntensity = formData.value.applicationOfferingIntensityValue;
+        const applicationIntensityComponent = formInstance.getComponent(
+          OFFERING_INTENSITY_KEY,
         );
-        const selectedLocationId = getSelectedId(formInstance);
-
-        if (selectedLocationId) {
-          // when isReadOnly.value is true, then consider
-          // both active and inactive program year.
-          await formioDataLoader.loadProgramsForLocation(
-            formInstance,
-            +selectedLocationId,
-            PROGRAMS_DROPDOWN_KEY,
-            props.programYearId,
-            props.isReadOnly,
-          );
+        // Program year forms older than 2025-26 required offering intensity to be injected to the form.
+        // Check if the form has the offering intensity component and if so, inject the values.
+        if (applicationIntensityComponent) {
+          formData.value.howWillYouBeAttendingTheProgram =
+            props.initialData.applicationOfferingIntensityValue;
+          formData.value.applicationOfferingIntensity =
+            mapOfferingIntensity(offeringIntensity);
         }
-        const selectedProgramId = formioUtils.getComponentValueByKey(
-          formInstance,
-          PROGRAMS_DROPDOWN_KEY,
-        );
-        const selectedIntensity: OfferingIntensity =
-          formioUtils.getComponentValueByKey(
+        // When the form is editable, load locations and programs.
+        if (!props.isReadOnly) {
+          await formioDataLoader.loadLocations(
             formInstance,
-            OFFERING_INTENSITY_KEY,
+            LOCATIONS_DROPDOWN_KEY,
           );
-        if (selectedProgramId && selectedIntensity) {
-          await formioComponentLoader.loadProgramDesc(
+          const selectedLocationId = getSelectedId(formInstance);
+
+          if (selectedLocationId) {
+            // when isReadOnly.value is true, then consider
+            // both active and inactive program year.
+            await formioDataLoader.loadProgramsForLocation(
+              formInstance,
+              +selectedLocationId,
+              PROGRAMS_DROPDOWN_KEY,
+              props.programYearId,
+              props.isReadOnly,
+            );
+          }
+          const selectedProgramId = formioUtils.getComponentValueByKey(
             formInstance,
-            selectedProgramId,
-            SELECTED_PROGRAM_DESC_KEY,
+            PROGRAMS_DROPDOWN_KEY,
           );
-          // when isReadOnly.value is true, then consider
-          // both active and inactive program year.
-          await formioDataLoader.loadOfferingsForLocation(
-            formInstance,
-            selectedProgramId,
-            selectedLocationId,
-            OFFERINGS_DROPDOWN_KEY,
-            props.programYearId,
-            selectedIntensity,
-            props.isReadOnly,
-          );
+
+          if (selectedProgramId && offeringIntensity) {
+            await formioComponentLoader.loadProgramDesc(
+              formInstance,
+              selectedProgramId,
+              SELECTED_PROGRAM_DESC_KEY,
+            );
+            // when isReadOnly.value is true, then consider
+            // both active and inactive program year.
+            await formioDataLoader.loadOfferingsForLocation(
+              formInstance,
+              selectedProgramId,
+              selectedLocationId,
+              OFFERINGS_DROPDOWN_KEY,
+              props.programYearId,
+              offeringIntensity,
+              props.isReadOnly,
+            );
+          }
         }
       }
     };
@@ -225,11 +242,9 @@ export default defineComponent({
     };
 
     const getOfferingDetails = async (form: FormIOForm, locationId: number) => {
-      const selectedIntensity: OfferingIntensity =
-        formioUtils.getComponentValueByKey(form, OFFERING_INTENSITY_KEY);
       const educationProgramIdFromForm: number =
         formioUtils.getComponentValueByKey(form, PROGRAMS_DROPDOWN_KEY);
-      if (educationProgramIdFromForm && selectedIntensity) {
+      if (educationProgramIdFromForm && offeringIntensity) {
         // when isReadOnly.value is true, then consider
         // both active and inactive program year.
         formioUtils.setComponentValue(form, OFFERINGS_DROPDOWN_KEY, "");
@@ -239,7 +254,7 @@ export default defineComponent({
           locationId,
           OFFERINGS_DROPDOWN_KEY,
           props.programYearId,
-          selectedIntensity,
+          offeringIntensity,
           props.isReadOnly,
         );
       }
@@ -366,6 +381,7 @@ export default defineComponent({
       customEvent,
       showNav,
       isSaveDraftAllowed,
+      formData,
     };
   },
 });

--- a/sources/packages/web/src/components/common/StudentApplication.vue
+++ b/sources/packages/web/src/components/common/StudentApplication.vue
@@ -168,7 +168,7 @@ export default defineComponent({
             PROGRAMS_DROPDOWN_KEY,
           );
 
-          if (selectedProgramId && offeringIntensity) {
+          if (selectedProgramId) {
             await formioComponentLoader.loadProgramDesc(
               formInstance,
               selectedProgramId,
@@ -240,7 +240,7 @@ export default defineComponent({
     const getOfferingDetails = async (form: FormIOForm, locationId: number) => {
       const educationProgramIdFromForm: number =
         formioUtils.getComponentValueByKey(form, PROGRAMS_DROPDOWN_KEY);
-      if (educationProgramIdFromForm && offeringIntensity) {
+      if (educationProgramIdFromForm) {
         // when isReadOnly.value is true, then consider
         // both active and inactive program year.
         formioUtils.setComponentValue(form, OFFERINGS_DROPDOWN_KEY, "");

--- a/sources/packages/web/src/components/generic/formio.vue
+++ b/sources/packages/web/src/components/generic/formio.vue
@@ -25,7 +25,7 @@ import {
 } from "@/types";
 import { v4 as uuid } from "uuid";
 import { AppConfigService } from "@/services/AppConfigService";
-import { useFormatters, useFormioUtils } from "@/composables";
+import { useFormatters, useFormioUtils, useOffering } from "@/composables";
 
 export default defineComponent({
   emits: {
@@ -65,8 +65,10 @@ export default defineComponent({
   setup(props, context) {
     const { registerUtilsMethod } = useFormioUtils();
     const { currencyFormatter } = useFormatters();
+    const { mapOfferingIntensity } = useOffering();
     // Register global utils functions.
     registerUtilsMethod("currencyFormatter", currencyFormatter);
+    registerUtilsMethod("mapOfferingIntensity", mapOfferingIntensity);
 
     const formioContainerRef = ref(null);
     // Wait to show the spinner when there is an API call.

--- a/sources/packages/web/src/types/contracts/student/ApplicationContract.ts
+++ b/sources/packages/web/src/types/contracts/student/ApplicationContract.ts
@@ -228,3 +228,11 @@ export enum SuccessWaitingStatus {
   Success = "Success",
   Waiting = "Waiting",
 }
+
+/**
+ * Represents the data of student application form.
+ */
+export type StudentApplicationFormData = {
+  applicationOfferingIntensityValue: OfferingIntensity;
+} & ApplicationData &
+  Record<string, unknown>;

--- a/sources/packages/web/src/views/aest/StudentApplicationView.vue
+++ b/sources/packages/web/src/views/aest/StudentApplicationView.vue
@@ -36,12 +36,13 @@ import {
 import { ApplicationService } from "@/services/ApplicationService";
 import { useFormatters } from "@/composables/useFormatters";
 import StudentApplication from "@/components/common/StudentApplication.vue";
-import { useFormioUtils, useOffering } from "@/composables";
+import { useFormioUtils } from "@/composables";
 import {
   ChangeTypes,
   FormIOComponent,
   FormIOForm,
   FromIOComponentTypes,
+  StudentApplicationFormData,
 } from "@/types";
 
 export default defineComponent({
@@ -64,10 +65,9 @@ export default defineComponent({
   },
   setup(props) {
     const { emptyStringFiller } = useFormatters();
-    const { mapOfferingIntensity } = useOffering();
     const { searchByKey } = useFormioUtils();
     const applicationDetail = ref({} as ApplicationSupplementalDataAPIOutDTO);
-    const initialData = ref({});
+    const initialData = ref({} as StudentApplicationFormData);
     const selectedForm = ref();
     let applicationWizard: FormIOForm;
 
@@ -96,9 +96,8 @@ export default defineComponent({
       selectedForm.value = applicationDetail.value.applicationFormName;
       initialData.value = {
         ...applicationDetail.value.data,
-        applicationOfferingIntensity: mapOfferingIntensity(
+        applicationOfferingIntensityValue:
           applicationDetail.value.applicationOfferingIntensity,
-        ),
         isReadOnly: true,
       };
     });

--- a/sources/packages/web/src/views/institution/student/InstitutionStudentApplicationView.vue
+++ b/sources/packages/web/src/views/institution/student/InstitutionStudentApplicationView.vue
@@ -30,7 +30,7 @@ import { InstitutionRoutesConst } from "@/constants/routes/RouteConstants";
 import { ApplicationBaseAPIOutDTO } from "@/services/http/dto";
 import { ApplicationService } from "@/services/ApplicationService";
 import StudentApplication from "@/components/common/StudentApplication.vue";
-import { useOffering } from "@/composables";
+import { StudentApplicationFormData } from "@/types";
 
 export default defineComponent({
   components: {
@@ -48,8 +48,7 @@ export default defineComponent({
   },
   setup(props) {
     const applicationDetail = ref({} as ApplicationBaseAPIOutDTO);
-    const { mapOfferingIntensity } = useOffering();
-    const initialData = ref({});
+    const initialData = ref({} as StudentApplicationFormData);
     const selectedForm = ref();
 
     onMounted(async () => {
@@ -63,9 +62,8 @@ export default defineComponent({
       selectedForm.value = applicationDetail.value.applicationFormName;
       initialData.value = {
         ...applicationDetail.value.data,
-        applicationOfferingIntensity: mapOfferingIntensity(
+        applicationOfferingIntensityValue:
           applicationDetail.value.applicationOfferingIntensity,
-        ),
         isReadOnly: true,
       };
     });

--- a/sources/packages/web/src/views/student/financial-aid-application/FullTimeApplication.vue
+++ b/sources/packages/web/src/views/student/financial-aid-application/FullTimeApplication.vue
@@ -174,7 +174,7 @@ export default defineComponent({
     let savedDraftData: string;
     const isFirstPage = ref(true);
     const isLastPage = ref(false);
-    const isReadOnly = ref(false);
+    const isReadOnly = ref(!!props.readOnly);
     const notDraft = ref(false);
     const existingApplication = ref({} as ApplicationDataAPIOutDTO);
     const editApplicationModal = ref({} as ModalDialog<boolean>);

--- a/sources/packages/web/src/views/student/financial-aid-application/FullTimeApplication.vue
+++ b/sources/packages/web/src/views/student/financial-aid-application/FullTimeApplication.vue
@@ -108,7 +108,6 @@ import {
   useSnackBar,
   ModalDialog,
   useFormatters,
-  useOffering,
 } from "@/composables";
 import {
   FormIOCustomEvent,
@@ -117,6 +116,7 @@ import {
   ApiProcessError,
   BannerTypes,
   FormIOForm,
+  StudentApplicationFormData,
 } from "@/types";
 import { ApplicationDataAPIOutDTO } from "@/services/http/dto";
 import { StudentRoutesConst } from "@/constants/routes/RouteConstants";
@@ -162,9 +162,9 @@ export default defineComponent({
       getFormattedAddress,
       disabilityStatusToDisplay,
     } = useFormatters();
-    const { mapOfferingIntensity } = useOffering();
+
     const router = useRouter();
-    const initialData = ref({});
+    const initialData = ref({} as StudentApplicationFormData);
     const isStudyEndDateWithinDeadline = ref(true);
     const formioUtils = useFormioUtils();
     const snackBar = useSnackBar();
@@ -251,11 +251,8 @@ export default defineComponent({
       };
       initialData.value = {
         ...applicationData.data,
-        howWillYouBeAttendingTheProgram:
+        applicationOfferingIntensityValue:
           applicationData.applicationOfferingIntensity,
-        applicationOfferingIntensity: mapOfferingIntensity(
-          applicationData.applicationOfferingIntensity,
-        ),
         ...studentFormData,
         ...programYear,
         isReadOnly: isReadOnly.value,


### PR DESCRIPTION
# FormIO split final part

## Conditional variable injections

- [x] The formio hidden component value `howWillYouBeAttendingTheProgram` is injected conditionally based on the component being present in form. This component is present only until PY 2024-25.
- [x] The offering intensity is being displayed as read only text-input in all the older forms until PY 2024-25. The value for this text input is calculated(NOT calculated on server as it is not required) in the form itself delegating the logic to the form.
![image](https://github.com/user-attachments/assets/7629e05d-4bc7-460a-bbea-e274dd690ab6)

## API Dry run submission backward compatibility
- [x] The API dry run submission was not failing when `howWillYouBeAttendingTheProgram` is missing for forms until PY 2024-25 allowing the erroneous data to be saved. Hence updated the injection of  `howWillYouBeAttendingTheProgram` always on server side from the application's offering intensity. Added a TODO comment there to remove this injection once PY 2024-25 is set to be inactive.
## E2E Tests

- [x] Removed `howWillYouBeAttendingTheProgram` in the E2E tests wherever it is applicable.
- [x] Added an E2E test for application submit for the latest active PY to ensure that the newly configured program year has all required configurations to submit applications.