### PR TITLE
#4328 - Student Profile - Bridge/Legacy Matching Management - Student Link

### DIFF
--- a/sources/packages/backend/apps/api/src/auth/roles.enum.ts
+++ b/sources/packages/backend/apps/api/src/auth/roles.enum.ts
@@ -13,6 +13,7 @@ export enum Role {
   AESTCASExpenseAuthority = "aest-cas-expense-authority",
   AESTBypassStudentRestriction = "aest-bypass-student-restriction",
   AESTQueueDashboardAdmin = "aest-queue-dashboard-admin",
+  AESTStudentLinkLegacyProfile = "aest-student-link-legacy-profile",
   StudentAddRestriction = "student-add-restriction",
   StudentResolveRestriction = "student-resolve-restriction",
   StudentUploadFile = "student-upload-file",

--- a/sources/packages/backend/apps/api/src/auth/roles.enum.ts
+++ b/sources/packages/backend/apps/api/src/auth/roles.enum.ts
@@ -13,7 +13,7 @@ export enum Role {
   AESTCASExpenseAuthority = "aest-cas-expense-authority",
   AESTBypassStudentRestriction = "aest-bypass-student-restriction",
   AESTQueueDashboardAdmin = "aest-queue-dashboard-admin",
-  AESTStudentLinkLegacyProfile = "aest-student-link-legacy-profile",
+  StudentLinkLegacyProfile = "student-link-legacy-profile",
   StudentAddRestriction = "student-add-restriction",
   StudentResolveRestriction = "student-resolve-restriction",
   StudentUploadFile = "student-upload-file",

--- a/sources/packages/backend/apps/api/src/route-controllers/student/models/student.dto.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/student/models/student.dto.ts
@@ -9,6 +9,7 @@ import {
   IsEnum,
   IsNotEmpty,
   IsOptional,
+  IsPositive,
   Length,
   MaxLength,
   ValidateIf,
@@ -332,7 +333,7 @@ export class UpdateStudentDetailsAPIInDTO {
 }
 
 export class LegacyStudentMatchAPIOutDTO {
-  studentId: number;
+  individualId: number;
   firstName?: string;
   lastName: string;
   birthDate: string;
@@ -341,4 +342,12 @@ export class LegacyStudentMatchAPIOutDTO {
 
 export class LegacyStudentMatchesAPIOutDTO {
   matches: LegacyStudentMatchAPIOutDTO[];
+}
+
+export class LegacyStudentMatchesAPIInDTO {
+  @IsPositive()
+  individualId: number;
+  @IsNotEmpty()
+  @MaxLength(NOTE_DESCRIPTION_MAX_LENGTH)
+  noteDescription: string;
 }

--- a/sources/packages/backend/apps/api/src/route-controllers/student/models/student.dto.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/student/models/student.dto.ts
@@ -330,3 +330,15 @@ export class UpdateStudentDetailsAPIInDTO {
   @MaxLength(NOTE_DESCRIPTION_MAX_LENGTH)
   noteDescription: string;
 }
+
+export class LegacyStudentMatchAPIOutDTO {
+  studentId: number;
+  firstName?: string;
+  lastName: string;
+  birthDate: string;
+  sin: string;
+}
+
+export class LegacyStudentMatchesAPIOutDTO {
+  matches: LegacyStudentMatchAPIOutDTO[];
+}

--- a/sources/packages/backend/apps/api/src/route-controllers/student/student.aest.controller.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/student/student.aest.controller.ts
@@ -474,7 +474,7 @@ export class StudentAESTController extends BaseController {
    * @param studentId student ID to retrieve the data.
    * @returns student legacy profile details.
    */
-  @Roles(Role.AESTStudentLinkLegacyProfile)
+  @Roles(Role.StudentLinkLegacyProfile)
   @Get(":studentId/legacy-match")
   @ApiNotFoundResponse({ description: "Student not found." })
   @ApiUnprocessableEntityResponse({
@@ -503,7 +503,7 @@ export class StudentAESTController extends BaseController {
    * @param studentId student ID to be associated with the legacy profile.
    * @param payload legacy profile to be associated.
    */
-  @Roles(Role.AESTStudentLinkLegacyProfile)
+  @Roles(Role.StudentLinkLegacyProfile)
   @Patch(":studentId/legacy-match")
   @ApiNotFoundResponse({ description: "Student not found." })
   @ApiUnprocessableEntityResponse({

--- a/sources/packages/backend/apps/api/src/route-controllers/student/student.controller.service.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/student/student.controller.service.ts
@@ -422,7 +422,7 @@ export class StudentControllerService {
   /**
    * Validate the conditions to allow the student to be associated with a legacy profile.
    * @param studentId student ID to have a legacy profile associated with.
-   * @returns possible legacy profile that matches the student data.
+   * @returns possible legacy profiles that matches the student data.
    */
   async validateAndGetStudentLegacyMatches(
     studentId: number,

--- a/sources/packages/backend/apps/api/src/route-controllers/student/student.controller.service.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/student/student.controller.service.ts
@@ -419,6 +419,11 @@ export class StudentControllerService {
     }));
   }
 
+  /**
+   * Validate the conditions to allow the student to be associated with a legacy profile.
+   * @param studentId student ID to have a legacy profile associated with.
+   * @returns possible legacy profile that matches the student data.
+   */
   async validateAndGetStudentLegacyMatches(
     studentId: number,
   ): Promise<SFASIndividual[]> {

--- a/sources/packages/backend/apps/api/src/route-controllers/student/student.controller.service.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/student/student.controller.service.ts
@@ -3,6 +3,7 @@ import {
   Injectable,
   InternalServerErrorException,
   NotFoundException,
+  UnprocessableEntityException,
 } from "@nestjs/common";
 import { Response } from "express";
 import {
@@ -28,6 +29,7 @@ import {
 import {
   AddressInfo,
   Application,
+  SFASIndividual,
   SpecificIdentityProviders,
   Student,
   VirusScanStatus,
@@ -53,6 +55,7 @@ import {
   LoggerService,
   ProcessSummary,
 } from "@sims/utilities/logger";
+import { SFASIndividualService } from "@sims/services";
 
 @Injectable()
 export class StudentControllerService {
@@ -62,6 +65,7 @@ export class StudentControllerService {
     private readonly studentRestrictionService: StudentRestrictionService,
     private readonly applicationService: ApplicationService,
     private readonly objectStorageService: ObjectStorageService,
+    private readonly sfasIndividualService: SFASIndividualService,
   ) {}
 
   /**
@@ -413,6 +417,27 @@ export class StudentControllerService {
       birthDate: getISODateOnlyString(eachStudent.birthDate),
       sin: eachStudent.sinValidation.sin,
     }));
+  }
+
+  async validateAndGetStudentLegacyMatches(
+    studentId: number,
+  ): Promise<SFASIndividual[]> {
+    const student = await this.studentService.getStudentById(studentId, {
+      includeLegacy: true,
+    });
+    if (!student) {
+      throw new NotFoundException("Student not found.");
+    }
+    if (student.sfasIndividuals.length) {
+      throw new UnprocessableEntityException(
+        "Student already has a legacy profile associated.",
+      );
+    }
+    return this.sfasIndividualService.getIndividualStudentPartialMatchForAssociation(
+      student.user.lastName,
+      student.birthDate,
+      student.sinValidation.sin,
+    );
   }
 
   @InjectLogger()

--- a/sources/packages/backend/libs/services/src/sfas/sfas-individual.service.ts
+++ b/sources/packages/backend/libs/services/src/sfas/sfas-individual.service.ts
@@ -137,7 +137,7 @@ export class SFASIndividualService {
    * @param individualId legacy individual to have the student associated.
    * @param studentId student to be associated to the legacy profile.
    * @param noteDescription note description to be added to the student notes.
-   * @param auditUserId user crating the profile link.
+   * @param auditUserId user creating the profile link.
    */
   async associateStudentProfile(
     individualId: number,

--- a/sources/packages/backend/libs/services/src/sfas/sfas-individual.service.ts
+++ b/sources/packages/backend/libs/services/src/sfas/sfas-individual.service.ts
@@ -136,6 +136,8 @@ export class SFASIndividualService {
    * to allow them to be reprocessed and associated with the new student.
    * @param individualId legacy individual to have the student associated.
    * @param studentId student to be associated to the legacy profile.
+   * @param noteDescription note description to be added to the student notes.
+   * @param auditUserId user crating the profile link.
    */
   async associateStudentProfile(
     individualId: number,
@@ -155,7 +157,7 @@ export class SFASIndividualService {
           `Error while associating student ID ${studentId} to legacy individual ID ${individualId}. The individual was not found or a student ID is already associated with it.`,
         );
       }
-      const updateRestrictions = entityManager
+      const updateRestrictionsPromise = entityManager
         .getRepository(SFASRestriction)
         .update({ individualId, processed: true }, { processed: false });
       const createNotePromise = this.noteSharedService.createStudentNote(
@@ -165,7 +167,7 @@ export class SFASIndividualService {
         auditUserId,
         entityManager,
       );
-      await Promise.all([updateRestrictions, createNotePromise]);
+      await Promise.all([updateRestrictionsPromise, createNotePromise]);
     });
   }
 

--- a/sources/packages/web/src/components/aest/students/modals/StudentProfileLegacyMatchesModal.vue
+++ b/sources/packages/web/src/components/aest/students/modals/StudentProfileLegacyMatchesModal.vue
@@ -3,7 +3,7 @@
     <modal-dialog-base :showDialog="showDialog" title="Confirm profile link"
       ><template #content
         ><p>
-          Please provide some notes and confirm the legacy profile link<br />
+          Please provide some notes and confirm the legacy profile link.<br />
           <strong>Please note that this action cannot be undone.</strong>
         </p>
         <v-textarea

--- a/sources/packages/web/src/components/aest/students/modals/StudentProfileLegacyMatchesModal.vue
+++ b/sources/packages/web/src/components/aest/students/modals/StudentProfileLegacyMatchesModal.vue
@@ -1,8 +1,9 @@
 <template>
   <v-form ref="linkProfileForm">
     <modal-dialog-base :showDialog="showDialog" title="Confirm profile link"
-      ><template #content
-        ><p>Add a note and confirm the legacy profile link.</p>
+      ><template #content>
+        <error-summary :errors="linkProfileForm.errors" />
+        <p>Add a note and confirm the legacy profile link.</p>
         <strong>This action cannot be undone.</strong>
         <v-textarea
           v-model="noteDescription"

--- a/sources/packages/web/src/components/aest/students/modals/StudentProfileLegacyMatchesModal.vue
+++ b/sources/packages/web/src/components/aest/students/modals/StudentProfileLegacyMatchesModal.vue
@@ -3,7 +3,7 @@
     <modal-dialog-base :showDialog="showDialog" title="Confirm profile link"
       ><template #content
         ><p>
-          Please provide some notes and confirm the legacy profile link?<br />
+          Please provide some notes and confirm the legacy profile link<br />
           <strong>Please note that this action cannot be undone.</strong>
         </p>
         <v-textarea

--- a/sources/packages/web/src/components/aest/students/modals/StudentProfileLegacyMatchesModal.vue
+++ b/sources/packages/web/src/components/aest/students/modals/StudentProfileLegacyMatchesModal.vue
@@ -1,0 +1,81 @@
+<template>
+  <v-form ref="linkProfileForm">
+    <modal-dialog-base :showDialog="showDialog" title="Confirm profile link"
+      ><template #content
+        ><p>
+          Please provide some notes and confirm the legacy profile link?<br />
+          <strong>Please note that this action cannot be undone.</strong>
+        </p>
+        <v-textarea
+          v-model="noteDescription"
+          variant="outlined"
+          label="Note"
+          :rules="[checkNotesLengthRule]"
+          required
+          class="mt-4"
+          hide-details="auto"
+        ></v-textarea>
+      </template>
+      <template #footer>
+        <footer-buttons
+          primaryLabel="Link profile"
+          @primaryClick="linkProfile"
+          @secondaryClick="cancel"
+          :processing="loading"
+        />
+      </template>
+    </modal-dialog-base>
+  </v-form>
+</template>
+<script lang="ts">
+import { ref, defineComponent } from "vue";
+import { useModalDialog, useRules } from "@/composables";
+import { VForm } from "@/types";
+import { LegacyStudentMatchesAPIInDTO } from "@/services/http/dto";
+
+export default defineComponent({
+  setup() {
+    const {
+      showDialog,
+      resolvePromise,
+      showModal,
+      loading,
+      hideModal,
+      showParameter,
+    } = useModalDialog<LegacyStudentMatchesAPIInDTO | false>();
+    const { checkNotesLengthRule } = useRules();
+    const noteDescription = ref("");
+    const linkProfileForm = ref({} as VForm);
+
+    const linkProfile = async () => {
+      const validationResult = await linkProfileForm.value.validate();
+      if (!validationResult.valid) {
+        return;
+      }
+      const payload = {
+        individualId: showParameter.value,
+        noteDescription: noteDescription.value,
+      };
+      await resolvePromise(payload);
+      linkProfileForm.value.reset();
+    };
+
+    const cancel = () => {
+      linkProfileForm.value.reset();
+      resolvePromise(false);
+      hideModal();
+    };
+
+    return {
+      noteDescription,
+      linkProfileForm,
+      showDialog,
+      showModal,
+      loading,
+      checkNotesLengthRule,
+      linkProfile,
+      cancel,
+    };
+  },
+});
+</script>

--- a/sources/packages/web/src/components/aest/students/modals/StudentProfileLegacyMatchesModal.vue
+++ b/sources/packages/web/src/components/aest/students/modals/StudentProfileLegacyMatchesModal.vue
@@ -2,16 +2,15 @@
   <v-form ref="linkProfileForm">
     <modal-dialog-base :showDialog="showDialog" title="Confirm profile link"
       ><template #content
-        ><p>
-          Please provide some notes and confirm the legacy profile link.<br />
-          <strong>Please note that this action cannot be undone.</strong>
-        </p>
+        ><p>Add a note and confirm the legacy profile link.</p>
+        <strong>This action cannot be undone.</strong>
         <v-textarea
           v-model="noteDescription"
           variant="outlined"
           label="Note"
           :rules="[checkNotesLengthRule]"
           required
+          :min-width="isMobile ? undefined : 600"
           class="mt-4"
           hide-details="auto"
         ></v-textarea>
@@ -32,6 +31,7 @@ import { ref, defineComponent } from "vue";
 import { useModalDialog, useRules } from "@/composables";
 import { VForm } from "@/types";
 import { LegacyStudentMatchesAPIInDTO } from "@/services/http/dto";
+import { useDisplay } from "vuetify/lib/framework.mjs";
 
 export default defineComponent({
   setup() {
@@ -43,6 +43,7 @@ export default defineComponent({
       hideModal,
       showParameter,
     } = useModalDialog<LegacyStudentMatchesAPIInDTO | false>();
+    const { mobile: isMobile } = useDisplay();
     const { checkNotesLengthRule } = useRules();
     const noteDescription = ref("");
     const linkProfileForm = ref({} as VForm);
@@ -75,6 +76,7 @@ export default defineComponent({
       checkNotesLengthRule,
       linkProfile,
       cancel,
+      isMobile,
     };
   },
 });

--- a/sources/packages/web/src/components/common/students/StudentProfile.vue
+++ b/sources/packages/web/src/components/common/students/StudentProfile.vue
@@ -115,12 +115,12 @@
         <StudentProfileLegacyMatches
           :studentId="studentId"
           :legacyProfile="studentDetail.legacyProfile"
+          @legacyProfileLinked="loadStudentProfile"
         />
       </content-group>
     </template>
     <edit-student-profile-modal
       ref="studentEditProfile"
-      @legacyProfileLinked="loadStudentProfile"
     ></edit-student-profile-modal>
   </body-header-container>
 </template>

--- a/sources/packages/web/src/components/common/students/StudentProfile.vue
+++ b/sources/packages/web/src/components/common/students/StudentProfile.vue
@@ -112,7 +112,7 @@
     <template v-if="showLegacyMatch">
       <h3 class="category-header-medium mt-4">Legacy match</h3>
       <content-group>
-        <StudentProfileLegacyMatches
+        <student-profile-legacy-matches
           :studentId="studentId"
           :legacyProfile="studentDetail.legacyProfile"
           @legacyProfileLinked="loadStudentProfile"

--- a/sources/packages/web/src/components/common/students/StudentProfile.vue
+++ b/sources/packages/web/src/components/common/students/StudentProfile.vue
@@ -113,9 +113,9 @@
       <h3 class="category-header-medium mt-4">Legacy match</h3>
       <content-group>
         <student-profile-legacy-matches
-          :studentId="studentId"
-          :legacyProfile="studentDetail.legacyProfile"
-          @legacyProfileLinked="loadStudentProfile"
+          :student-id="studentId"
+          :legacy-profile="studentDetail.legacyProfile"
+          @legacy-profile-linked="loadStudentProfile"
         />
       </content-group>
     </template>

--- a/sources/packages/web/src/components/common/students/StudentProfileLegacyMatches.vue
+++ b/sources/packages/web/src/components/common/students/StudentProfileLegacyMatches.vue
@@ -77,7 +77,7 @@
           {{ sinDisplayFormat(item.sin) }}
         </template>
         <template #[`item.actions`]="{ item }">
-          <check-permission-role :role="Role.AESTStudentLinkLegacyProfile">
+          <check-permission-role :role="Role.StudentLinkLegacyProfile">
             <template #="{ notAllowed }">
               <v-btn
                 color="primary"
@@ -148,7 +148,7 @@ export default defineComponent({
         const legacyMatches =
           await StudentService.shared.getStudentLegacyMatches(props.studentId);
         legacyStudentMatches.value = legacyMatches.matches;
-      } catch (error) {
+      } catch {
         snackBar.error(
           "An unexpected error happened while loading the legacy matches.",
         );

--- a/sources/packages/web/src/components/common/students/StudentProfileLegacyMatches.vue
+++ b/sources/packages/web/src/components/common/students/StudentProfileLegacyMatches.vue
@@ -73,6 +73,9 @@
         <template #[`item.birthDate`]="{ item }">
           {{ dateOnlyLongString(item.birthDate) }}
         </template>
+        <template #[`item.sin`]="{ item }">
+          {{ sinDisplayFormat(item.sin) }}
+        </template>
         <template #[`item.actions`]="{ item }">
           <check-permission-role :role="Role.AESTStudentLinkLegacyProfile">
             <template #="{ notAllowed }">

--- a/sources/packages/web/src/components/common/students/StudentProfileLegacyMatches.vue
+++ b/sources/packages/web/src/components/common/students/StudentProfileLegacyMatches.vue
@@ -65,7 +65,7 @@
           <v-skeleton-loader type="table-row@3"></v-skeleton-loader>
         </template>
         <template #[`item.firstName`]="{ item }">
-          {{ item.firstName }}
+          {{ emptyStringFiller(item.firstName) }}
         </template>
         <template #[`item.lastName`]="{ item }">
           {{ item.lastName }}

--- a/sources/packages/web/src/components/common/students/StudentProfileLegacyMatches.vue
+++ b/sources/packages/web/src/components/common/students/StudentProfileLegacyMatches.vue
@@ -68,6 +68,7 @@
         :items="legacyStudentMatches"
         :loading="studentLegacyMatchesLoading"
         :items-per-page="-1"
+        hide-default-footer
       >
         <template v-slot:loading>
           <v-skeleton-loader type="table-row@3"></v-skeleton-loader>

--- a/sources/packages/web/src/components/common/students/StudentProfileLegacyMatches.vue
+++ b/sources/packages/web/src/components/common/students/StudentProfileLegacyMatches.vue
@@ -1,0 +1,197 @@
+<template>
+  <template v-if="legacyProfile">
+    <v-row>
+      <v-col
+        ><title-value
+          propertyTitle="Given names"
+          :propertyValue="emptyStringFiller(legacyProfile.firstName)"
+        />
+      </v-col>
+      <v-col
+        ><title-value
+          propertyTitle="Last name"
+          :propertyValue="legacyProfile.lastName"
+        />
+      </v-col>
+      <v-col>
+        <title-value
+          propertyTitle="Date of birth"
+          :propertyValue="dateOnlyLongString(legacyProfile.dateOfBirth)"
+      /></v-col>
+    </v-row>
+    <v-row>
+      <v-col
+        ><title-value
+          propertyTitle="SIN"
+          :propertyValue="sinDisplayFormat(legacyProfile.sin)"
+        />
+      </v-col>
+    </v-row>
+    <v-row v-if="legacyProfile.hasMultipleProfiles">
+      <v-col
+        ><banner
+          :type="BannerTypes.Warning"
+          summary="The student is associated with multiple legacy profiles; the most recent update is shown."
+        ></banner>
+      </v-col>
+    </v-row>
+  </template>
+  <template v-else>
+    <banner
+      :type="BannerTypes.Info"
+      summary="The student is not currently associated with any legacy record. Please check the legacy match information to see if there are any potential matches."
+    >
+      <template #actions>
+        <v-btn color="primary" @click="loadStudentLegacyMatches()">
+          Check for legacy matches
+          <v-tooltip activator="parent" location="start"
+            >Click to check for potential legacy matches.</v-tooltip
+          >
+        </v-btn></template
+      >
+    </banner>
+    <toggle-content
+      v-if="showLegacyMatches"
+      :toggled="!legacyStudentMatches?.length && !studentLegacyMatchesLoading"
+      message="No potential legacy matches found."
+    >
+      <v-data-table
+        :headers="StudentProfileLegacyMatchHeaders"
+        :items="legacyStudentMatches"
+        :loading="studentLegacyMatchesLoading"
+        :items-per-page="-1"
+      >
+        <template v-slot:loading>
+          <v-skeleton-loader type="table-row@3"></v-skeleton-loader>
+        </template>
+        <template #[`item.firstName`]="{ item }">
+          {{ item.firstName }}
+        </template>
+        <template #[`item.lastName`]="{ item }">
+          {{ item.lastName }}
+        </template>
+        <template #[`item.birthDate`]="{ item }">
+          {{ dateOnlyLongString(item.birthDate) }}
+        </template>
+        <template #[`item.actions`]="{ item }">
+          <check-permission-role :role="Role.AESTStudentLinkLegacyProfile">
+            <template #="{ notAllowed }">
+              <v-btn
+                color="primary"
+                :disabled="notAllowed"
+                @click="showLinkProfileModal(item.individualId)"
+              >
+                Link
+                <v-tooltip activator="parent" location="start"
+                  >Click to link student with this legacy profile.</v-tooltip
+                >
+              </v-btn>
+            </template>
+          </check-permission-role>
+        </template>
+        <template #bottom></template>
+      </v-data-table>
+    </toggle-content>
+    <student-profile-legacy-matches-modal ref="legacyMatchesModal" />
+  </template>
+</template>
+
+<script lang="ts">
+import { ref, defineComponent } from "vue";
+import { StudentService } from "@/services/StudentService";
+import { ModalDialog, useFormatters, useSnackBar } from "@/composables";
+import {
+  LegacyStudentMatchAPIOutDTO,
+  LegacyStudentMatchesAPIInDTO,
+  LegacyStudentProfileAPIOutDTO,
+} from "@/services/http/dto";
+import { Role, BannerTypes, StudentProfileLegacyMatchHeaders } from "@/types";
+import CheckPermissionRole from "@/components/generic/CheckPermissionRole.vue";
+import StudentProfileLegacyMatchesModal from "@/components/aest/students/modals/StudentProfileLegacyMatchesModal.vue";
+
+export default defineComponent({
+  emits: {
+    legacyProfileLinked: null,
+  },
+  components: {
+    CheckPermissionRole,
+    StudentProfileLegacyMatchesModal,
+  },
+  props: {
+    studentId: {
+      type: Number,
+      required: true,
+    },
+    legacyProfile: {
+      type: Object as () => LegacyStudentProfileAPIOutDTO,
+      required: false,
+    },
+  },
+  setup(props, { emit }) {
+    const snackBar = useSnackBar();
+    const { sinDisplayFormat, emptyStringFiller, dateOnlyLongString } =
+      useFormatters();
+    const legacyStudentMatches = ref<LegacyStudentMatchAPIOutDTO[]>();
+    const studentLegacyMatchesLoading = ref(false);
+    const showLegacyMatches = ref(false);
+    const legacyMatchesModal = ref(
+      {} as ModalDialog<LegacyStudentMatchesAPIInDTO>,
+    );
+
+    const loadStudentLegacyMatches = async (): Promise<void> => {
+      studentLegacyMatchesLoading.value = true;
+      showLegacyMatches.value = true;
+      try {
+        const legacyMatches =
+          await StudentService.shared.getStudentLegacyMatches(props.studentId);
+        legacyStudentMatches.value = legacyMatches.matches;
+      } catch (error) {
+        snackBar.error(
+          "An unexpected error happened while loading the legacy matches.",
+        );
+      } finally {
+        studentLegacyMatchesLoading.value = false;
+      }
+    };
+
+    const showLinkProfileModal = async (
+      individualId: number,
+    ): Promise<void> => {
+      await legacyMatchesModal.value.showModal(individualId, linkLegacyProfile);
+    };
+
+    const linkLegacyProfile = async (
+      payload: LegacyStudentMatchesAPIInDTO,
+    ): Promise<boolean> => {
+      try {
+        await StudentService.shared.associateLegacyStudent(props.studentId, {
+          ...payload,
+        });
+        snackBar.success("Legacy profile linked successfully.");
+        emit("legacyProfileLinked");
+        return true;
+      } catch {
+        snackBar.error(
+          "An unexpected error happened while linking the legacy profile.",
+        );
+      }
+      return false;
+    };
+
+    return {
+      sinDisplayFormat,
+      dateOnlyLongString,
+      emptyStringFiller,
+      Role,
+      BannerTypes,
+      legacyStudentMatches,
+      loadStudentLegacyMatches,
+      studentLegacyMatchesLoading,
+      StudentProfileLegacyMatchHeaders,
+      showLegacyMatches,
+      legacyMatchesModal,
+      showLinkProfileModal,
+    };
+  },
+});
+</script>

--- a/sources/packages/web/src/services/StudentService.ts
+++ b/sources/packages/web/src/services/StudentService.ts
@@ -15,6 +15,7 @@ import {
   UpdateDisabilityStatusAPIInDTO,
   UpdateStudentDetailsAPIInDTO,
   AESTStudentFileDetailsAPIOutDTO,
+  LegacyStudentMatchesAPIOutDTO,
 } from "@/services/http/dto";
 import { AxiosResponse } from "axios";
 
@@ -244,5 +245,16 @@ export class StudentService {
     payload: UpdateDisabilityStatusAPIInDTO,
   ): Promise<void> {
     await ApiClient.Students.updateDisabilityStatus(studentId, payload);
+  }
+
+  /**
+   * Get possible matches for the student from the legacy system.
+   * @param studentId student ID to retrieve the data.
+   * @returns student legacy profile details.
+   */
+  async getStudentLegacyMatches(
+    studentId: number,
+  ): Promise<LegacyStudentMatchesAPIOutDTO> {
+    return ApiClient.Students.getStudentLegacyMatches(studentId);
   }
 }

--- a/sources/packages/web/src/services/StudentService.ts
+++ b/sources/packages/web/src/services/StudentService.ts
@@ -16,6 +16,7 @@ import {
   UpdateStudentDetailsAPIInDTO,
   AESTStudentFileDetailsAPIOutDTO,
   LegacyStudentMatchesAPIOutDTO,
+  LegacyStudentMatchesAPIInDTO,
 } from "@/services/http/dto";
 import { AxiosResponse } from "axios";
 
@@ -256,5 +257,17 @@ export class StudentService {
     studentId: number,
   ): Promise<LegacyStudentMatchesAPIOutDTO> {
     return ApiClient.Students.getStudentLegacyMatches(studentId);
+  }
+
+  /**
+   * Associates a student with a legacy profile.
+   * @param studentId student ID to be associated with the legacy profile.
+   * @param payload legacy profile to be associated.
+   */
+  async associateLegacyStudent(
+    studentId: number,
+    payload: LegacyStudentMatchesAPIInDTO,
+  ): Promise<void> {
+    await ApiClient.Students.associateLegacyStudent(studentId, payload);
   }
 }

--- a/sources/packages/web/src/services/http/StudentApi.ts
+++ b/sources/packages/web/src/services/http/StudentApi.ts
@@ -17,6 +17,7 @@ import {
   UpdateDisabilityStatusAPIInDTO,
   UpdateStudentDetailsAPIInDTO,
   AESTStudentFileDetailsAPIOutDTO,
+  LegacyStudentMatchesAPIOutDTO,
 } from "@/services/http/dto";
 
 export class StudentApi extends HttpBaseClient {
@@ -224,6 +225,19 @@ export class StudentApi extends HttpBaseClient {
     await this.patchCall(
       this.addClientRoot(`student/${studentId}/disability-status`),
       payload,
+    );
+  }
+
+  /**
+   * Get possible matches for the student from the legacy system.
+   * @param studentId student ID to retrieve the data.
+   * @returns student legacy profile details.
+   */
+  async getStudentLegacyMatches(
+    studentId: number,
+  ): Promise<LegacyStudentMatchesAPIOutDTO> {
+    return this.getCall(
+      this.addClientRoot(`student/${studentId}/legacy-match`),
     );
   }
 }

--- a/sources/packages/web/src/services/http/StudentApi.ts
+++ b/sources/packages/web/src/services/http/StudentApi.ts
@@ -18,6 +18,7 @@ import {
   UpdateStudentDetailsAPIInDTO,
   AESTStudentFileDetailsAPIOutDTO,
   LegacyStudentMatchesAPIOutDTO,
+  LegacyStudentMatchesAPIInDTO,
 } from "@/services/http/dto";
 
 export class StudentApi extends HttpBaseClient {
@@ -238,6 +239,21 @@ export class StudentApi extends HttpBaseClient {
   ): Promise<LegacyStudentMatchesAPIOutDTO> {
     return this.getCall(
       this.addClientRoot(`student/${studentId}/legacy-match`),
+    );
+  }
+
+  /**
+   * Associates a student with a legacy profile.
+   * @param studentId student ID to be associated with the legacy profile.
+   * @param payload legacy profile to be associated.
+   */
+  async associateLegacyStudent(
+    studentId: number,
+    payload: LegacyStudentMatchesAPIInDTO,
+  ): Promise<void> {
+    await this.patchCall(
+      this.addClientRoot(`student/${studentId}/legacy-match`),
+      payload,
     );
   }
 }

--- a/sources/packages/web/src/services/http/dto/Student.dto.ts
+++ b/sources/packages/web/src/services/http/dto/Student.dto.ts
@@ -225,7 +225,7 @@ export interface UpdateDisabilityStatusAPIInDTO {
 }
 
 export interface LegacyStudentMatchAPIOutDTO {
-  studentId: number;
+  individualId: number;
   firstName?: string;
   lastName: string;
   birthDate: string;
@@ -234,4 +234,9 @@ export interface LegacyStudentMatchAPIOutDTO {
 
 export interface LegacyStudentMatchesAPIOutDTO {
   matches: LegacyStudentMatchAPIOutDTO[];
+}
+
+export interface LegacyStudentMatchesAPIInDTO {
+  individualId: number;
+  noteDescription: string;
 }

--- a/sources/packages/web/src/services/http/dto/Student.dto.ts
+++ b/sources/packages/web/src/services/http/dto/Student.dto.ts
@@ -223,3 +223,15 @@ export interface UpdateDisabilityStatusAPIInDTO {
   disabilityStatus: DisabilityStatus;
   noteDescription: string;
 }
+
+export interface LegacyStudentMatchAPIOutDTO {
+  studentId: number;
+  firstName?: string;
+  lastName: string;
+  birthDate: string;
+  sin: string;
+}
+
+export interface LegacyStudentMatchesAPIOutDTO {
+  matches: LegacyStudentMatchAPIOutDTO[];
+}

--- a/sources/packages/web/src/types/contracts/DataTableContract.ts
+++ b/sources/packages/web/src/types/contracts/DataTableContract.ts
@@ -512,3 +512,11 @@ export const PIRSummaryHeaders = [
   { title: "Status", key: "pirStatus", sortable: true },
   { title: "Actions", key: "actions", sortable: false },
 ];
+
+export const StudentProfileLegacyMatchHeaders = [
+  { title: "Given Names", key: "firstName", sortable: false },
+  { title: "Last Name", key: "lastName", sortable: false },
+  { title: "Date of Birth ", key: "birthDate", sortable: false },
+  { title: "SIN", key: "sin", sortable: false },
+  { title: "Actions", key: "actions", sortable: false },
+];

--- a/sources/packages/web/src/types/contracts/DataTableContract.ts
+++ b/sources/packages/web/src/types/contracts/DataTableContract.ts
@@ -516,7 +516,7 @@ export const PIRSummaryHeaders = [
 export const StudentProfileLegacyMatchHeaders = [
   { title: "Given Names", key: "firstName", sortable: false },
   { title: "Last Name", key: "lastName", sortable: false },
-  { title: "Date of Birth ", key: "birthDate", sortable: false },
+  { title: "Date of Birth", key: "birthDate", sortable: false },
   { title: "SIN", key: "sin", sortable: false },
   { title: "Actions", key: "actions", sortable: false },
 ];

--- a/sources/packages/web/src/types/contracts/DataTableContract.ts
+++ b/sources/packages/web/src/types/contracts/DataTableContract.ts
@@ -514,9 +514,9 @@ export const PIRSummaryHeaders = [
 ];
 
 export const StudentProfileLegacyMatchHeaders = [
-  { title: "Given Names", key: "firstName", sortable: false },
-  { title: "Last Name", key: "lastName", sortable: false },
-  { title: "Date of Birth", key: "birthDate", sortable: false },
+  { title: "Given names", key: "firstName", sortable: false },
+  { title: "Last name", key: "lastName", sortable: false },
+  { title: "Date of birth", key: "birthDate", sortable: false },
   { title: "SIN", key: "sin", sortable: false },
   { title: "Actions", key: "actions", sortable: false },
 ];

--- a/sources/packages/web/src/types/contracts/aest/roles.ts
+++ b/sources/packages/web/src/types/contracts/aest/roles.ts
@@ -13,6 +13,7 @@ export enum Role {
   AESTCASExpenseAuthority = "aest-cas-expense-authority",
   AESTBypassStudentRestriction = "aest-bypass-student-restriction",
   AESTQueueDashboardAdmin = "aest-queue-dashboard-admin",
+  AESTStudentLinkLegacyProfile = "aest-student-link-legacy-profile",
   StudentAddRestriction = "student-add-restriction",
   StudentResolveRestriction = "student-resolve-restriction",
   StudentUploadFile = "student-upload-file",

--- a/sources/packages/web/src/types/contracts/aest/roles.ts
+++ b/sources/packages/web/src/types/contracts/aest/roles.ts
@@ -13,7 +13,7 @@ export enum Role {
   AESTCASExpenseAuthority = "aest-cas-expense-authority",
   AESTBypassStudentRestriction = "aest-bypass-student-restriction",
   AESTQueueDashboardAdmin = "aest-queue-dashboard-admin",
-  AESTStudentLinkLegacyProfile = "aest-student-link-legacy-profile",
+  StudentLinkLegacyProfile = "student-link-legacy-profile",
   StudentAddRestriction = "student-add-restriction",
   StudentResolveRestriction = "student-resolve-restriction",
   StudentUploadFile = "student-upload-file",

--- a/sources/packages/web/src/views/aest/student/Profile.vue
+++ b/sources/packages/web/src/views/aest/student/Profile.vue
@@ -3,6 +3,7 @@
     <student-profile
       :studentId="studentId"
       :allowDisabilityStatusUpdate="true"
+      :showLegacyMatch="true"
     />
   </tab-container>
 </template>


### PR DESCRIPTION
- Created a new role to allow the Ministry to link the student to the legacy profile: `student-link-legacy-profile`.
- New endpoints created to get the possible matches and also create the association (E2Es to be added in the next PR).
- Create the 'StudentProfileLegacyMatchesModal.vue' to simplify the student profile page.
- DataTable configured to display all records (` :items-per-page="-1"`) and hide the footer.

## Linked profile

![image](https://github.com/user-attachments/assets/54e536d0-79eb-47d0-bd94-b37f9a27ee47)

## No profile linked

![image](https://github.com/user-attachments/assets/b20ed2e7-4c10-46b2-877c-950e38ab6944)

## Available profiles to be linked

![image](https://github.com/user-attachments/assets/f77fef04-be4c-46ee-984c-edf5bbb9d66f)

## Modal to capture the notes and link the profile

![image](https://github.com/user-attachments/assets/765be79d-49ff-4d42-bf39-3d6781ef4d56)

## No possible matches available

![image](https://github.com/user-attachments/assets/825a0d70-ce95-4874-a962-c5488c263df2)





