### PR TITLE
#4328 - Student Profile - Bridge/Legacy Matching Management - E2E Tests

### DIFF
--- a/sources/packages/backend/apps/api/src/route-controllers/student/_tests_/e2e/student.aest.controller.associateLegacyStudent.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/student/_tests_/e2e/student.aest.controller.associateLegacyStudent.e2e-spec.ts
@@ -20,13 +20,12 @@ import { getISODateOnlyString } from "@sims/utilities";
 import { NoteType } from "@sims/sims-db";
 
 /**
- * Creates a random SIN with the intention to be unique and not interfere
- * in other tests potentially conflicting with other tests.
+ * Creates a random SIN with the intention to be unique and not interfere in other tests
  */
 const UNIQUE_SIN = "#1234567#";
 /**
  * Creates a random SFAS individual ID with the intention to be unique
- * and not potentially interfere in other tests.
+ * and potentially not interfere in other tests.
  * SFAS IDs are not generated automatically.
  */
 const UNIQUE_SFAS_RESTRICTION_ID = 999955551;
@@ -206,7 +205,7 @@ describe("StudentAESTController(e2e)-associateLegacyStudent", () => {
       });
   });
 
-  it("Should throw an NotFoundException when the student does not exist.", async () => {
+  it("Should throw a NotFoundException when the student does not exist.", async () => {
     // Arrange.
     const aestUserToken = await getAESTToken(AESTGroups.BusinessAdministrators);
     const endpoint = `/aest/student/99999999/legacy-match`;

--- a/sources/packages/backend/apps/api/src/route-controllers/student/_tests_/e2e/student.aest.controller.associateLegacyStudent.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/student/_tests_/e2e/student.aest.controller.associateLegacyStudent.e2e-spec.ts
@@ -24,7 +24,7 @@ import { NoteType } from "@sims/sims-db";
  */
 const UNIQUE_SIN = "#1234567#";
 /**
- * Creates a random SFAS individual ID with the intention to be unique
+ * Creates a random SFAS restriction ID with the intention to be unique
  * and potentially not interfere in other tests.
  * SFAS IDs are not generated automatically.
  */

--- a/sources/packages/backend/apps/api/src/route-controllers/student/_tests_/e2e/student.aest.controller.associateLegacyStudent.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/student/_tests_/e2e/student.aest.controller.associateLegacyStudent.e2e-spec.ts
@@ -1,0 +1,164 @@
+import { HttpStatus, INestApplication } from "@nestjs/common";
+import * as request from "supertest";
+import {
+  BEARER_AUTH_TYPE,
+  createTestingAppModule,
+  getAESTToken,
+  AESTGroups,
+} from "../../../../testHelpers";
+import {
+  saveFakeStudent,
+  saveFakeSFASIndividual,
+  E2EDataSources,
+  createE2EDataSources,
+  createFakeUser,
+  createFakeSFASRestriction,
+} from "@sims/test-utils";
+import * as faker from "faker";
+import { getISODateOnlyString } from "@sims/utilities";
+import { NoteType } from "@sims/sims-db";
+
+const UNIQUE_SIN = "#1234567#";
+const UNIQUE_SFAS_RESTRICTION_ID = 999955551;
+
+describe("StudentAESTController(e2e)-associateLegacyStudent", () => {
+  let app: INestApplication;
+  let db: E2EDataSources;
+
+  beforeAll(async () => {
+    const { nestApplication, dataSource } = await createTestingAppModule();
+    app = nestApplication;
+    db = createE2EDataSources(dataSource);
+  });
+
+  beforeEach(async () => {
+    await Promise.all([
+      db.sfasIndividual.delete({ sin: UNIQUE_SIN }),
+      db.sfasRestriction.delete({ id: UNIQUE_SFAS_RESTRICTION_ID }),
+    ]);
+  });
+
+  it(
+    "Should associate a student to a legacy profile, create a note, and set restriction as processed false" +
+      " when the student is not associated yet to a legacy profile and a legacy profile is a potential match.",
+    async () => {
+      // Arrange.
+      const user = createFakeUser();
+      const userLastName = faker.datatype.uuid();
+      user.lastName = userLastName;
+      const birthDate = getISODateOnlyString(new Date());
+      const student = await saveFakeStudent(
+        db.dataSource,
+        { user },
+        { initialValue: { birthDate } },
+      );
+      const legacyProfileMatch = await saveFakeSFASIndividual(db.dataSource, {
+        initialValues: { lastName: userLastName, birthDate },
+      });
+      const processedSFASRestriction = createFakeSFASRestriction({
+        initialValues: {
+          id: UNIQUE_SFAS_RESTRICTION_ID,
+          individualId: legacyProfileMatch.id,
+          processed: true,
+        },
+      });
+      await db.sfasRestriction.save(processedSFASRestriction);
+
+      const aestUserToken = await getAESTToken(
+        AESTGroups.BusinessAdministrators,
+      );
+      const payload = {
+        individualId: legacyProfileMatch.id,
+        noteDescription: faker.datatype.uuid(),
+      };
+      const endpoint = `/aest/student/${student.id}/legacy-match`;
+
+      // Act/Assert.
+      await request(app.getHttpServer())
+        .patch(endpoint)
+        .send(payload)
+        .auth(aestUserToken, BEARER_AUTH_TYPE)
+        .expect(HttpStatus.OK);
+      // Validates legacy profile update.
+      const updateSFASIndividual = await db.sfasIndividual.findOne({
+        select: {
+          id: true,
+          student: { id: true },
+        },
+        relations: {
+          student: true,
+        },
+        where: {
+          id: legacyProfileMatch.id,
+        },
+      });
+      expect(updateSFASIndividual.student.id).toBe(student.id);
+      // Validates restriction update.
+      const updatedSFASRestriction = await db.sfasRestriction.findOne({
+        select: {
+          id: true,
+          processed: true,
+        },
+        where: {
+          id: processedSFASRestriction.id,
+        },
+      });
+      expect(updatedSFASRestriction.processed).toBe(false);
+      // Validates student note creation.
+      const studentNote = await db.student.findOne({
+        select: {
+          id: true,
+          notes: {
+            id: true,
+            description: true,
+            noteType: true,
+          },
+        },
+        relations: {
+          notes: true,
+        },
+        where: {
+          id: student.id,
+        },
+        loadEagerRelations: false,
+      });
+      expect(studentNote).toEqual({
+        id: student.id,
+        notes: [
+          {
+            id: expect.any(Number),
+            description: payload.noteDescription,
+            noteType: NoteType.General,
+          },
+        ],
+      });
+    },
+  );
+
+  it("Should throw an NotFoundException when the student does not exists.", async () => {
+    // Arrange.
+    // Ministry user token.
+    const aestUserToken = await getAESTToken(AESTGroups.BusinessAdministrators);
+    // Endpoint to test.
+    const endpoint = `/aest/student/99999999/legacy-match`;
+
+    // Act/Assert.
+    await request(app.getHttpServer())
+      .patch(endpoint)
+      .send({
+        individualId: 1,
+        noteDescription: "some description",
+      })
+      .auth(aestUserToken, BEARER_AUTH_TYPE)
+      .expect(HttpStatus.NOT_FOUND)
+      .expect({
+        message: "Student not found.",
+        error: "Not Found",
+        statusCode: HttpStatus.NOT_FOUND,
+      });
+  });
+
+  afterAll(async () => {
+    await app?.close();
+  });
+});

--- a/sources/packages/backend/apps/api/src/route-controllers/student/_tests_/e2e/student.aest.controller.getStudentLegacyMatches.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/student/_tests_/e2e/student.aest.controller.getStudentLegacyMatches.e2e-spec.ts
@@ -158,7 +158,7 @@ describe("StudentAESTController(e2e)-getStudentLegacyMatches", () => {
       });
   });
 
-  it("Should throw an NotFoundException when the student does not exists.", async () => {
+  it("Should throw a NotFoundException when the student does not exist.", async () => {
     // Arrange.
     // Ministry user token.
     const aestUserToken = await getAESTToken(AESTGroups.BusinessAdministrators);

--- a/sources/packages/backend/apps/api/src/route-controllers/student/_tests_/e2e/student.aest.controller.getStudentLegacyMatches.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/student/_tests_/e2e/student.aest.controller.getStudentLegacyMatches.e2e-spec.ts
@@ -1,0 +1,180 @@
+import { HttpStatus, INestApplication } from "@nestjs/common";
+import * as request from "supertest";
+import {
+  BEARER_AUTH_TYPE,
+  createTestingAppModule,
+  getAESTToken,
+  AESTGroups,
+} from "../../../../testHelpers";
+import {
+  saveFakeStudent,
+  saveFakeSFASIndividual,
+  E2EDataSources,
+  createE2EDataSources,
+  createFakeUser,
+} from "@sims/test-utils";
+import * as faker from "faker";
+import { getISODateOnlyString } from "@sims/utilities";
+
+const UNIQUE_SIN = "#1234567#";
+
+describe("StudentAESTController(e2e)-getStudentLegacyMatches", () => {
+  let app: INestApplication;
+  let db: E2EDataSources;
+
+  beforeAll(async () => {
+    const { nestApplication, dataSource } = await createTestingAppModule();
+    app = nestApplication;
+    db = createE2EDataSources(dataSource);
+  });
+
+  beforeEach(async () => {
+    await db.sfasIndividual.delete({ sin: UNIQUE_SIN });
+  });
+
+  it("Should get potential student matches from legacy when there is an exact SIN match.", async () => {
+    // Arrange.
+    const sfasIndividualMatch = await saveFakeSFASIndividual(db.dataSource, {
+      initialValues: { sin: UNIQUE_SIN },
+    });
+    const student = await saveFakeStudent(db.dataSource, null, {
+      sinValidationInitialValue: { sin: UNIQUE_SIN },
+    });
+
+    // Ministry user token.
+    const aestUserToken = await getAESTToken(AESTGroups.BusinessAdministrators);
+
+    // Endpoint to test.
+    const endpoint = `/aest/student/${student.id}/legacy-match`;
+
+    // Act/Assert.
+    await request(app.getHttpServer())
+      .get(endpoint)
+      .auth(aestUserToken, BEARER_AUTH_TYPE)
+      .expect(HttpStatus.OK)
+      .expect({
+        matches: [
+          {
+            individualId: sfasIndividualMatch.id,
+            firstName: sfasIndividualMatch.firstName,
+            lastName: sfasIndividualMatch.lastName,
+            birthDate: sfasIndividualMatch.birthDate,
+            sin: UNIQUE_SIN,
+          },
+        ],
+      });
+  });
+
+  it("Should not get a potential student match from legacy when there is an exact SIN match but there is already a student associated with.", async () => {
+    // Arrange.
+    const alreadyAssociatedStudent = await saveFakeStudent(db.dataSource);
+    await saveFakeSFASIndividual(db.dataSource, {
+      initialValues: { sin: UNIQUE_SIN, student: alreadyAssociatedStudent },
+    });
+    const student = await saveFakeStudent(db.dataSource, null, {
+      sinValidationInitialValue: { sin: UNIQUE_SIN },
+    });
+
+    // Ministry user token.
+    const aestUserToken = await getAESTToken(AESTGroups.BusinessAdministrators);
+
+    // Endpoint to test.
+    const endpoint = `/aest/student/${student.id}/legacy-match`;
+
+    // Act/Assert.
+    await request(app.getHttpServer())
+      .get(endpoint)
+      .auth(aestUserToken, BEARER_AUTH_TYPE)
+      .expect(HttpStatus.OK)
+      .expect({
+        matches: [],
+      });
+  });
+
+  it("Should throw an UnprocessableEntityException when the student requesting potential matches is already linked to a legacy profile.", async () => {
+    // Arrange.
+    const student = await saveFakeStudent(db.dataSource, null, {
+      sinValidationInitialValue: { sin: UNIQUE_SIN },
+    });
+    await saveFakeSFASIndividual(db.dataSource, {
+      initialValues: { sin: UNIQUE_SIN, student },
+    });
+    // Ministry user token.
+    const aestUserToken = await getAESTToken(AESTGroups.BusinessAdministrators);
+    // Endpoint to test.
+    const endpoint = `/aest/student/${student.id}/legacy-match`;
+
+    // Act/Assert.
+    await request(app.getHttpServer())
+      .get(endpoint)
+      .auth(aestUserToken, BEARER_AUTH_TYPE)
+      .expect(HttpStatus.UNPROCESSABLE_ENTITY)
+      .expect({
+        message: "Student already has a legacy profile associated.",
+        error: "Unprocessable Entity",
+        statusCode: HttpStatus.UNPROCESSABLE_ENTITY,
+      });
+  });
+
+  it("Should get potential student matches from legacy when there is an exact last name (case insensitive) and DOB match.", async () => {
+    // Arrange.
+    const user = createFakeUser();
+    const userLastName = faker.datatype.uuid();
+    user.lastName = userLastName.toLowerCase();
+    const birthDate = getISODateOnlyString(new Date());
+    const student = await saveFakeStudent(
+      db.dataSource,
+      { user },
+      { initialValue: { birthDate } },
+    );
+    const sfasIndividualMatch = await saveFakeSFASIndividual(db.dataSource, {
+      initialValues: { lastName: userLastName.toUpperCase(), birthDate },
+    });
+
+    // Ministry user token.
+    const aestUserToken = await getAESTToken(AESTGroups.BusinessAdministrators);
+
+    // Endpoint to test.
+    const endpoint = `/aest/student/${student.id}/legacy-match`;
+
+    // Act/Assert.
+    await request(app.getHttpServer())
+      .get(endpoint)
+      .auth(aestUserToken, BEARER_AUTH_TYPE)
+      .expect(HttpStatus.OK)
+      .expect({
+        matches: [
+          {
+            individualId: sfasIndividualMatch.id,
+            firstName: sfasIndividualMatch.firstName,
+            lastName: sfasIndividualMatch.lastName,
+            birthDate: sfasIndividualMatch.birthDate,
+            sin: sfasIndividualMatch.sin,
+          },
+        ],
+      });
+  });
+
+  it("Should throw an NotFoundException when the student does not exists.", async () => {
+    // Arrange.
+    // Ministry user token.
+    const aestUserToken = await getAESTToken(AESTGroups.BusinessAdministrators);
+    // Endpoint to test.
+    const endpoint = `/aest/student/99999999/legacy-match`;
+
+    // Act/Assert.
+    await request(app.getHttpServer())
+      .get(endpoint)
+      .auth(aestUserToken, BEARER_AUTH_TYPE)
+      .expect(HttpStatus.NOT_FOUND)
+      .expect({
+        message: "Student not found.",
+        error: "Not Found",
+        statusCode: HttpStatus.NOT_FOUND,
+      });
+  });
+
+  afterAll(async () => {
+    await app?.close();
+  });
+});

--- a/sources/packages/backend/apps/api/src/route-controllers/student/_tests_/e2e/student.aest.controller.getStudentLegacyMatches.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/student/_tests_/e2e/student.aest.controller.getStudentLegacyMatches.e2e-spec.ts
@@ -16,6 +16,9 @@ import {
 import * as faker from "faker";
 import { getISODateOnlyString } from "@sims/utilities";
 
+/**
+ * Creates a random SIN with the intention to be unique and not interfere in other tests
+ */
 const UNIQUE_SIN = "#1234567#";
 
 describe("StudentAESTController(e2e)-getStudentLegacyMatches", () => {

--- a/sources/packages/backend/libs/test-utils/src/factories/sfas-restriction.ts
+++ b/sources/packages/backend/libs/test-utils/src/factories/sfas-restriction.ts
@@ -5,7 +5,7 @@ import * as faker from "faker";
 /**
  * Create and save fake SFAS restriction.
  * @param options SFAS restriction options.
- * - `initialValues`initial values.
+ * - `initialValues` initial values.
  * @returns SFAS restriction to be persisted.
  */
 export function createFakeSFASRestriction(options?: {

--- a/sources/packages/backend/libs/test-utils/src/factories/sfas-restriction.ts
+++ b/sources/packages/backend/libs/test-utils/src/factories/sfas-restriction.ts
@@ -1,0 +1,27 @@
+import { SFASRestriction } from "@sims/sims-db";
+import { getISODateOnlyString } from "@sims/utilities";
+import * as faker from "faker";
+
+/**
+ * Create and save fake SFAS restriction.
+ * @param options SFAS restriction options.
+ * - `initialValues`initial values.
+ * @returns SFAS restriction to be persisted.
+ */
+export function createFakeSFASRestriction(options?: {
+  initialValues?: Partial<SFASRestriction>;
+}): SFASRestriction {
+  const now = new Date();
+  const restriction = new SFASRestriction();
+  restriction.id = options?.initialValues.id;
+  restriction.individualId = options?.initialValues.individualId;
+  restriction.code =
+    options?.initialValues.code ??
+    faker.random.alpha({ count: 4, upcase: true });
+  restriction.effectiveDate =
+    options?.initialValues.effectiveDate ?? getISODateOnlyString(now);
+  restriction.removalDate = options?.initialValues.removalDate;
+  restriction.extractedAt = options?.initialValues.extractedAt ?? now;
+  restriction.processed = options?.initialValues.processed ?? false;
+  return restriction;
+}

--- a/sources/packages/backend/libs/test-utils/src/index.ts
+++ b/sources/packages/backend/libs/test-utils/src/index.ts
@@ -45,3 +45,4 @@ export * from "./factories/cas-invoice-detail";
 export * from "./factories/sfas-application-dependant";
 export * from "./factories/sfas-application-disbursement";
 export * from "./factories/dynamic-form-configuration";
+export * from "./factories/sfas-restriction";


### PR DESCRIPTION
## E2E Tests for the new endpoints created.

```
StudentAESTController(e2e)-getStudentProfile
    √ Should get the student profile when the student exists and no legacy profile is associated.
    √ Should get the student profile when the student exists and one legacy profile is associated.
    √ Should get the student profile when the student exists and multiple legacy profiles are associated.
    √ Should throw a NotFoundException when the student was not found.
```

```
StudentAESTController(e2e)-associateLegacyStudent
    √ Should associate a student to a legacy profile, create a note, and set restriction as processed false when the student is not associated yet to a legacy profile and a legacy profile is a potential match.
    √ Should throw an UnprocessableEntityException when the legacy profile to be associated with the student is not a valid potential match.                                      
    √ Should throw an UnprocessableEntityException when the student already has a legacy profile associated.                                 
    √ Should throw an NotFoundException when the student does not exist.
```