### PR TITLE
#4490 - FormIO - Enable Editor in Test & PR Process - Fixes and Improvements

### DIFF
--- a/sources/packages/backend/apps/api/src/app.module.ts
+++ b/sources/packages/backend/apps/api/src/app.module.ts
@@ -12,6 +12,7 @@ import {
   AuditController,
   ConfigController,
   DynamicFormController,
+  DynamicFormAESTController,
   HealthController,
 } from "./route-controllers";
 import { AuthModule } from "./auth/auth.module";
@@ -99,7 +100,7 @@ export class AppModule implements NestModule {
     // Allow the configuration of the body parser for individual routes.
     consumer
       .apply(json({ limit: JSON_200KB }))
-      .forRoutes(DynamicFormController);
+      .forRoutes(DynamicFormAESTController);
     // Apply the body parser global configuration after the specific ones to allow the proper evaluation of the routes.
     consumer.apply(json()).forRoutes("*");
   }

--- a/sources/packages/web/nginx/default.conf.dev.template
+++ b/sources/packages/web/nginx/default.conf.dev.template
@@ -19,7 +19,7 @@ server {
     try_files $uri $uri/ /index.html;
   }
   add_header 'X-Content-Type-Options' "nosniff";
-  add_header 'Content-Security-Policy' "default-src 'self'; connect-src 'self' *.gov.bc.ca http://localhost:*; script-src 'self' 'unsafe-eval' https://cdn.form.io/flatpickr-formio/ https://cdn.form.io/ace/ https://cdn.form.io/ckeditor/; style-src 'self' 'unsafe-inline' https://cdn.form.io/flatpickr-formio/; font-src 'self' data:; img-src 'self' data:";
+  add_header 'Content-Security-Policy' "default-src 'self'; connect-src 'self' *.gov.bc.ca http://localhost:*; script-src 'self' 'unsafe-eval' https://cdn.form.io/flatpickr-formio/ https://cdn.form.io/ace/ https://cdn.form.io/ckeditor/; style-src 'self' 'unsafe-inline' https://cdn.form.io/flatpickr-formio/; font-src 'self' data:; img-src 'self' data:; worker-src 'self' blob:;";
   add_header 'Strict-Transport-Security' "max-age=31536000; includeSubDomains; preload";
   add_header 'Referrer-Policy' "same-origin";
   add_header 'X-Frame-Options' "sameorigin";

--- a/sources/packages/web/nginx/default.conf.dev.template
+++ b/sources/packages/web/nginx/default.conf.dev.template
@@ -19,7 +19,7 @@ server {
     try_files $uri $uri/ /index.html;
   }
   add_header 'X-Content-Type-Options' "nosniff";
-  add_header 'Content-Security-Policy' "default-src 'self'; connect-src 'self' *.gov.bc.ca http://localhost:*; script-src 'self' 'unsafe-eval' https://cdn.form.io/flatpickr-formio/; style-src 'self' 'unsafe-inline' https://cdn.form.io/flatpickr-formio/; font-src 'self' data:; img-src 'self' data:";
+  add_header 'Content-Security-Policy' "default-src 'self'; connect-src 'self' *.gov.bc.ca http://localhost:*; script-src 'self' 'unsafe-eval' https://cdn.form.io/flatpickr-formio/ https://cdn.form.io/ace/ https://cdn.form.io/ckeditor/; style-src 'self' 'unsafe-inline' https://cdn.form.io/flatpickr-formio/; font-src 'self' data:; img-src 'self' data:";
   add_header 'Strict-Transport-Security' "max-age=31536000; includeSubDomains; preload";
   add_header 'Referrer-Policy' "same-origin";
   add_header 'X-Frame-Options' "sameorigin";

--- a/sources/packages/web/nginx/default.conf.template
+++ b/sources/packages/web/nginx/default.conf.template
@@ -19,7 +19,7 @@ server {
     try_files $uri $uri/ /index.html;
   }
   add_header 'X-Content-Type-Options' "nosniff";
-  add_header 'Content-Security-Policy' "default-src 'self'; connect-src 'self' *.gov.bc.ca; script-src 'self' 'unsafe-eval' https://cdn.form.io/flatpickr-formio/; style-src 'self' 'unsafe-inline' https://cdn.form.io/flatpickr-formio/; font-src 'self' data:; img-src 'self' data:";
+  add_header 'Content-Security-Policy' "default-src 'self'; connect-src 'self' *.gov.bc.ca; script-src 'self' 'unsafe-eval' https://cdn.form.io/flatpickr-formio/ https://cdn.form.io/ace/ https://cdn.form.io/ckeditor/; style-src 'self' 'unsafe-inline' https://cdn.form.io/flatpickr-formio/; font-src 'self' data:; img-src 'self' data:";
   add_header 'Strict-Transport-Security' "max-age=31536000; includeSubDomains; preload";
   add_header 'Referrer-Policy' "same-origin";
   add_header 'X-Frame-Options' "sameorigin";

--- a/sources/packages/web/nginx/default.conf.template
+++ b/sources/packages/web/nginx/default.conf.template
@@ -19,7 +19,7 @@ server {
     try_files $uri $uri/ /index.html;
   }
   add_header 'X-Content-Type-Options' "nosniff";
-  add_header 'Content-Security-Policy' "default-src 'self'; connect-src 'self' *.gov.bc.ca; script-src 'self' 'unsafe-eval' https://cdn.form.io/flatpickr-formio/ https://cdn.form.io/ace/ https://cdn.form.io/ckeditor/; style-src 'self' 'unsafe-inline' https://cdn.form.io/flatpickr-formio/; font-src 'self' data:; img-src 'self' data:";
+  add_header 'Content-Security-Policy' "default-src 'self'; connect-src 'self' *.gov.bc.ca; script-src 'self' 'unsafe-eval' https://cdn.form.io/flatpickr-formio/ https://cdn.form.io/ace/ https://cdn.form.io/ckeditor/; style-src 'self' 'unsafe-inline' https://cdn.form.io/flatpickr-formio/; font-src 'self' data:; img-src 'self' data:; worker-src 'self' blob:;";
   add_header 'Strict-Transport-Security' "max-age=31536000; includeSubDomains; preload";
   add_header 'Referrer-Policy' "same-origin";
   add_header 'X-Frame-Options' "sameorigin";

--- a/sources/packages/web/src/components/generic/formio.vue
+++ b/sources/packages/web/src/components/generic/formio.vue
@@ -24,7 +24,6 @@ import {
   FormIOForm,
 } from "@/types";
 import { v4 as uuid } from "uuid";
-import { AppConfigService } from "@/services/AppConfigService";
 import { useFormatters, useFormioUtils, useOffering } from "@/composables";
 
 export default defineComponent({
@@ -63,7 +62,7 @@ export default defineComponent({
     },
   },
   setup(props, context) {
-    const { registerUtilsMethod } = useFormioUtils();
+    const { registerUtilsMethod, createCacheIdentifier } = useFormioUtils();
     const { currencyFormatter } = useFormatters();
     const { mapOfferingIntensity } = useOffering();
     // Register global utils functions.
@@ -89,9 +88,7 @@ export default defineComponent({
     };
 
     onMounted(async () => {
-      const { version } = await AppConfigService.shared.config();
-      const cachedFormName = `${props.formName}-${version}`;
-
+      const cachedFormName = await createCacheIdentifier(props.formName);
       let cachedFormDefinition: string | null = null;
       // Avoid caching during development to allow that the changes
       // on form.io definitions have effect immediately.

--- a/sources/packages/web/src/composables/useFormioUtils.ts
+++ b/sources/packages/web/src/composables/useFormioUtils.ts
@@ -1,6 +1,7 @@
 import { FormIOComponent, FormIOForm } from "@/types";
 import { ClassConstructor, plainToClass } from "class-transformer";
 import { Utils } from "@formio/js";
+import { AppConfigService } from "@/services/AppConfigService";
 
 const UTILS_COMMON_OBJECT_NAME = "custom";
 
@@ -308,6 +309,16 @@ export function useFormioUtils() {
     );
   };
 
+  /**
+   * Create a cache identifier for the form path.
+   * @param formPath form path to be used as a cache identifier.
+   * @returns cache identifier string.
+   */
+  const createCacheIdentifier = async (formPath: string): Promise<string> => {
+    const { version } = await AppConfigService.shared.config();
+    return `${formPath}-${version}`.toLowerCase();
+  };
+
   return {
     getComponent,
     getFirstComponent,
@@ -327,5 +338,6 @@ export function useFormioUtils() {
     registerUtilsMethod,
     getReadyToSaveFormDefinition,
     getFormattedFormDefinition,
+    createCacheIdentifier,
   };
 }

--- a/sources/packages/web/src/views/aest/FormioEditor.vue
+++ b/sources/packages/web/src/views/aest/FormioEditor.vue
@@ -40,27 +40,37 @@
               :disabled="!selectedForm"
               >Repo</v-btn
             >
-            <v-autocomplete
-              v-model="selectedForm"
-              :items="formsListOptions"
-              label="Select a dynamic form"
-              item-text="title"
-              item-value="path"
-              :clearable="true"
-              :loading="formsListOptionsLoading"
-              :disabled="formsListOptionsLoading"
-              :return-object="true"
-              variant="outlined"
-              density="compact"
-              class="mr-2 float-right"
-              width="400"
-              hide-details="auto"
-              @update:modelValue="formSelected"
-            ></v-autocomplete>
           </template>
         </body-header>
       </template>
       <content-group>
+        <v-autocomplete
+          v-model="selectedForm"
+          :items="formsListOptions"
+          placeholder="Select a dynamic form"
+          item-text="title"
+          item-value="path"
+          :clearable="true"
+          :loading="formsListOptionsLoading"
+          :disabled="formsListOptionsLoading"
+          :return-object="true"
+          variant="outlined"
+          density="compact"
+          hide-details="auto"
+          class="mb-4"
+          @update:modelValue="formSelected"
+        >
+          <template v-slot:selection="{ item }">
+            <span>{{ item.title }} ({{ item.value }})</span>
+          </template>
+          <template v-slot:item="{ item, props }">
+            <v-list-item v-bind="props">
+              <v-list-item-content>
+                <v-list-item-subtitle v-text="item.value" />
+              </v-list-item-content>
+            </v-list-item>
+          </template>
+        </v-autocomplete>
         <toggle-content
           :toggled="!selectedForm"
           message="Please select a dynamic form to be edited."

--- a/sources/packages/web/src/views/aest/FormioEditor.vue
+++ b/sources/packages/web/src/views/aest/FormioEditor.vue
@@ -138,8 +138,11 @@ export default defineComponent({
   },
   setup() {
     const snackBar = useSnackBar();
-    const { getReadyToSaveFormDefinition, getFormattedFormDefinition } =
-      useFormioUtils();
+    const {
+      getReadyToSaveFormDefinition,
+      getFormattedFormDefinition,
+      createCacheIdentifier,
+    } = useFormioUtils();
     const saveDynamicFormModal = ref({} as ModalDialog<boolean>);
     const applyDynamicFormDefinitionModal = ref({} as ModalDialog<boolean>);
     const formioBuilderRef = ref();
@@ -222,6 +225,10 @@ export default defineComponent({
         await ApiClient.DynamicForms.updateForm(selectedForm.value.path, {
           formDefinition: getReadyToSaveFormDefinition(builder.schema),
         });
+        const cachedFormName = await createCacheIdentifier(
+          selectedForm.value.path,
+        );
+        sessionStorage.removeItem(cachedFormName);
         snackBar.success("Form definition saved.");
       } catch {
         snackBar.error("Unexpected error saving form definition.");


### PR DESCRIPTION
- Removes the cached form.io definition to allow immediate visualization of saved changes.
- Fix for the content submission of a large payload due to a controller change in the previous PR.
- Add missing links to the content security policy that were preventing some components in the editor not to being displayed.

![image](https://github.com/user-attachments/assets/a7f139a0-745e-4985-a609-e69e1182787a)

## UI Changes

Added the form path to the auto-complete list, as shown below, to allow differentiation between forms with the same title.

![image](https://github.com/user-attachments/assets/b136730f-7763-4daa-b644-76dff66a31a6)

![image](https://github.com/user-attachments/assets/7c2d78e7-5f1e-4a60-be71-fd1a920ede76)
