### PR TITLE
#4690 - Update Deploy-All to use tag Git Reference - Build-ref Fallback

### DIFF
--- a/.github/workflows/release-deploy-all.yml
+++ b/.github/workflows/release-deploy-all.yml
@@ -145,156 +145,156 @@ jobs:
       - name: Print env
         run: |
           echo Deploy Environment: ${{ inputs.environment }}
-          echo GIT REF: ${{ env.BUILD_REF }}
+          echo GIT REF: ${{ needs.env-setup.outputs.build-ref }}
           echo BUILD NAMESPACE: $BUILD_NAMESPACE
           echo OC CLI Version: $(oc version)
-      - name: Checkout Target Branch
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ needs.env-setup.outputs.build-ref }}
-      - name: Log in to OpenShift
-        run: |
-          oc login --token=${{ secrets.SA_TOKEN }} --server=${{ vars.OPENSHIFT_CLUSTER_URL }}
-      - name: Run db-migrations
-        working-directory: "./devops/"
-        run: |
-          make oc-run-db-migrations
+  #     - name: Checkout Target Branch
+  #       uses: actions/checkout@v4
+  #       with:
+  #         ref: ${{ needs.env-setup.outputs.build-ref }}
+  #     - name: Log in to OpenShift
+  #       run: |
+  #         oc login --token=${{ secrets.SA_TOKEN }} --server=${{ vars.OPENSHIFT_CLUSTER_URL }}
+  #     - name: Run db-migrations
+  #       working-directory: "./devops/"
+  #       run: |
+  #         make oc-run-db-migrations
 
-  # Deploy SIMS API.
-  deploy-sims-api:
-    name: Deploy SIMS-API
-    environment: ${{ inputs.environment }}
-    runs-on: ubuntu-latest
-    needs: [env-setup, run-db-migrations]
-    steps:
-      - name: Install CLI tools from OpenShift Mirror
-        uses: redhat-actions/openshift-tools-installer@v1
-        with:
-          oc: "4"
-      - name: Print env
-        run: |
-          echo Deploy ENVIRONMENT: ${{ inputs.environment }}
-          echo GIT REF: ${{ env.BUILD_REF }}
-          echo BUILD NAMESPACE: $BUILD_NAMESPACE
-          echo OC CLI Version: $(oc version)
-      - name: Checkout Target Branch
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ needs.env-setup.outputs.build-ref }}
-      - name: Log in to OpenShift
-        run: |
-          oc login --token=${{ secrets.SA_TOKEN }} --server=${{ vars.OPENSHIFT_CLUSTER_URL }}
-      - name: Deploy SIMS-API
-        working-directory: "./devops/"
-        run: |
-          make oc-deploy-api
+  # # Deploy SIMS API.
+  # deploy-sims-api:
+  #   name: Deploy SIMS-API
+  #   environment: ${{ inputs.environment }}
+  #   runs-on: ubuntu-latest
+  #   needs: [env-setup, run-db-migrations]
+  #   steps:
+  #     - name: Install CLI tools from OpenShift Mirror
+  #       uses: redhat-actions/openshift-tools-installer@v1
+  #       with:
+  #         oc: "4"
+  #     - name: Print env
+  #       run: |
+  #         echo Deploy ENVIRONMENT: ${{ inputs.environment }}
+  #         echo GIT REF: ${{ env.BUILD_REF }}
+  #         echo BUILD NAMESPACE: $BUILD_NAMESPACE
+  #         echo OC CLI Version: $(oc version)
+  #     - name: Checkout Target Branch
+  #       uses: actions/checkout@v4
+  #       with:
+  #         ref: ${{ needs.env-setup.outputs.build-ref }}
+  #     - name: Log in to OpenShift
+  #       run: |
+  #         oc login --token=${{ secrets.SA_TOKEN }} --server=${{ vars.OPENSHIFT_CLUSTER_URL }}
+  #     - name: Deploy SIMS-API
+  #       working-directory: "./devops/"
+  #       run: |
+  #         make oc-deploy-api
 
-  # Deploy workers.
-  deploy-workers:
-    name: Deploy Workers
-    environment: ${{ inputs.environment }}
-    env:
-      DISABLE_ORM_CACHE: true
-    runs-on: ubuntu-latest
-    needs: [env-setup, run-db-migrations]
-    steps:
-      - name: Install CLI tools from OpenShift Mirror
-        uses: redhat-actions/openshift-tools-installer@v1
-        with:
-          oc: "4"
-      - name: Print env
-        run: |
-          echo BUILD ENVIRONMENT: ${{ inputs.environment }}
-          echo GIT REF: ${{ env.BUILD_REF }}
-          echo OC CLI Version: $(oc version)
-      - name: Checkout Target Branch
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ needs.env-setup.outputs.build-ref }}
-      - name: Log in to OpenShift
-        run: |
-          oc login --token=${{ secrets.SA_TOKEN }} --server=${{ vars.OPENSHIFT_CLUSTER_URL }}
-      - name: Deploy Workers
-        working-directory: "./devops/"
-        run: |
-          make oc-deploy-workers
+  # # Deploy workers.
+  # deploy-workers:
+  #   name: Deploy Workers
+  #   environment: ${{ inputs.environment }}
+  #   env:
+  #     DISABLE_ORM_CACHE: true
+  #   runs-on: ubuntu-latest
+  #   needs: [env-setup, run-db-migrations]
+  #   steps:
+  #     - name: Install CLI tools from OpenShift Mirror
+  #       uses: redhat-actions/openshift-tools-installer@v1
+  #       with:
+  #         oc: "4"
+  #     - name: Print env
+  #       run: |
+  #         echo BUILD ENVIRONMENT: ${{ inputs.environment }}
+  #         echo GIT REF: ${{ env.BUILD_REF }}
+  #         echo OC CLI Version: $(oc version)
+  #     - name: Checkout Target Branch
+  #       uses: actions/checkout@v4
+  #       with:
+  #         ref: ${{ needs.env-setup.outputs.build-ref }}
+  #     - name: Log in to OpenShift
+  #       run: |
+  #         oc login --token=${{ secrets.SA_TOKEN }} --server=${{ vars.OPENSHIFT_CLUSTER_URL }}
+  #     - name: Deploy Workers
+  #       working-directory: "./devops/"
+  #       run: |
+  #         make oc-deploy-workers
 
-  # Deploy queue consumers.
-  deploy-queue-consumers:
-    name: Deploy Queue Consumers
-    environment: ${{ inputs.environment }}
-    runs-on: ubuntu-latest
-    needs: [env-setup, run-db-migrations]
-    steps:
-      - name: Install CLI tools from OpenShift Mirror
-        uses: redhat-actions/openshift-tools-installer@v1
-        with:
-          oc: "4"
-      - name: Print env
-        run: |
-          echo Deploy ENVIRONMENT: ${{ inputs.environment }}
-          echo GIT REF: ${{ env.BUILD_REF }}
-          echo BUILD NAMESPACE: $BUILD_NAMESPACE
-          echo OC CLI Version: $(oc version)
-      - name: Checkout Target Branch
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ needs.env-setup.outputs.build-ref }}
-      - name: Log in to OpenShift
-        run: |
-          oc login --token=${{ secrets.SA_TOKEN }} --server=${{ vars.OPENSHIFT_CLUSTER_URL }}
-      - name: Deploy Queue Consumers
-        working-directory: "./devops/"
-        run: |
-          make oc-deploy-queue-consumers
+  # # Deploy queue consumers.
+  # deploy-queue-consumers:
+  #   name: Deploy Queue Consumers
+  #   environment: ${{ inputs.environment }}
+  #   runs-on: ubuntu-latest
+  #   needs: [env-setup, run-db-migrations]
+  #   steps:
+  #     - name: Install CLI tools from OpenShift Mirror
+  #       uses: redhat-actions/openshift-tools-installer@v1
+  #       with:
+  #         oc: "4"
+  #     - name: Print env
+  #       run: |
+  #         echo Deploy ENVIRONMENT: ${{ inputs.environment }}
+  #         echo GIT REF: ${{ env.BUILD_REF }}
+  #         echo BUILD NAMESPACE: $BUILD_NAMESPACE
+  #         echo OC CLI Version: $(oc version)
+  #     - name: Checkout Target Branch
+  #       uses: actions/checkout@v4
+  #       with:
+  #         ref: ${{ needs.env-setup.outputs.build-ref }}
+  #     - name: Log in to OpenShift
+  #       run: |
+  #         oc login --token=${{ secrets.SA_TOKEN }} --server=${{ vars.OPENSHIFT_CLUSTER_URL }}
+  #     - name: Deploy Queue Consumers
+  #       working-directory: "./devops/"
+  #       run: |
+  #         make oc-deploy-queue-consumers
 
-  # Deploy Web/Frontend.
-  deploy-web-frontend:
-    name: Deploy Web/Frontend
-    environment: ${{ inputs.environment }}
-    runs-on: ubuntu-latest
-    needs: [env-setup, run-db-migrations]
-    steps:
-      - name: Install CLI tools from OpenShift Mirror
-        uses: redhat-actions/openshift-tools-installer@v1
-        with:
-          oc: "4"
-      - name: Print env
-        run: |
-          echo Deploy ENVIRONMENT: ${{ inputs.environment }}
-          echo GIT REF: ${{ env.BUILD_REF }}
-          echo BUILD NAMESPACE: $BUILD_NAMESPACE
-          echo OC CLI Version: $(oc version)
-      - name: Checkout Target Branch
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ needs.env-setup.outputs.build-ref }}
-      - name: Log in to OpenShift
-        run: |
-          oc login --token=${{ secrets.SA_TOKEN }} --server=${{ vars.OPENSHIFT_CLUSTER_URL }}
-      - name: Deploy Web/Frontend
-        working-directory: "./devops/"
-        run: |
-          make oc-deploy-web
+  # # Deploy Web/Frontend.
+  # deploy-web-frontend:
+  #   name: Deploy Web/Frontend
+  #   environment: ${{ inputs.environment }}
+  #   runs-on: ubuntu-latest
+  #   needs: [env-setup, run-db-migrations]
+  #   steps:
+  #     - name: Install CLI tools from OpenShift Mirror
+  #       uses: redhat-actions/openshift-tools-installer@v1
+  #       with:
+  #         oc: "4"
+  #     - name: Print env
+  #       run: |
+  #         echo Deploy ENVIRONMENT: ${{ inputs.environment }}
+  #         echo GIT REF: ${{ env.BUILD_REF }}
+  #         echo BUILD NAMESPACE: $BUILD_NAMESPACE
+  #         echo OC CLI Version: $(oc version)
+  #     - name: Checkout Target Branch
+  #       uses: actions/checkout@v4
+  #       with:
+  #         ref: ${{ needs.env-setup.outputs.build-ref }}
+  #     - name: Log in to OpenShift
+  #       run: |
+  #         oc login --token=${{ secrets.SA_TOKEN }} --server=${{ vars.OPENSHIFT_CLUSTER_URL }}
+  #     - name: Deploy Web/Frontend
+  #       working-directory: "./devops/"
+  #       run: |
+  #         make oc-deploy-web
 
-  # Deploy Camunda Definitions
-  deployCamundaDefinitions:
-    if: ${{ inputs.deployCamundaDefinitions }}
-    name: Deploy BPMNs and DMNs to Camunda
-    needs: [env-setup, deploy-sims-api]
-    uses: ./.github/workflows/release-deploy-camunda-definitions.yml
-    with:
-      environment: ${{ inputs.environment }}
-      gitRef: ${{ needs.env-setup.outputs.build-ref }}
-    secrets: inherit
+  # # Deploy Camunda Definitions
+  # deployCamundaDefinitions:
+  #   if: ${{ inputs.deployCamundaDefinitions }}
+  #   name: Deploy BPMNs and DMNs to Camunda
+  #   needs: [env-setup, deploy-sims-api]
+  #   uses: ./.github/workflows/release-deploy-camunda-definitions.yml
+  #   with:
+  #     environment: ${{ inputs.environment }}
+  #     gitRef: ${{ needs.env-setup.outputs.build-ref }}
+  #   secrets: inherit
 
-  # Deploy Formio Definitions
-  deployFormioDefinitions:
-    if: ${{ inputs.deployFormioDefinitions }}
-    name: Deploy Form.io definitions
-    needs: [env-setup, deploy-sims-api]
-    uses: ./.github/workflows/release-deploy-formio-definitions.yml
-    with:
-      environment: ${{ inputs.environment }}
-      gitRef: ${{ needs.env-setup.outputs.build-ref }}
-    secrets: inherit
+  # # Deploy Formio Definitions
+  # deployFormioDefinitions:
+  #   if: ${{ inputs.deployFormioDefinitions }}
+  #   name: Deploy Form.io definitions
+  #   needs: [env-setup, deploy-sims-api]
+  #   uses: ./.github/workflows/release-deploy-formio-definitions.yml
+  #   with:
+  #     environment: ${{ inputs.environment }}
+  #     gitRef: ${{ needs.env-setup.outputs.build-ref }}
+  #   secrets: inherit

--- a/.github/workflows/release-deploy-all.yml
+++ b/.github/workflows/release-deploy-all.yml
@@ -1,5 +1,5 @@
 name: Release - Deploy All
-run-name: Release - Deploy all from main-6573 to ${{ inputs.environment }}
+run-name: Release - Deploy all from ${{ github.ref_name }} to ${{ inputs.environment }}
 
 on:
   workflow_dispatch:
@@ -64,7 +64,7 @@ on:
 
 env:
   NAMESPACE: ${{ secrets.OPENSHIFT_ENV_NAMESPACE }}
-  BUILD_REF: ${{ (github.event_name == 'workflow_call' && inputs.gitRef) || 'main-6573' }}
+  BUILD_REF: ${{ (github.event_name == 'workflow_call' && inputs.gitRef) || github.ref_name }}
   HOST_PREFIX: ${{ secrets.HOST_PREFIX }}
   DOMAIN_PREFIX: ${{ vars.DOMAIN_PREFIX }}
   BUILD_NAMESPACE: ${{ vars.BUILD_NAMESPACE }}

--- a/.github/workflows/release-deploy-all.yml
+++ b/.github/workflows/release-deploy-all.yml
@@ -1,5 +1,5 @@
 name: Release - Deploy All
-run-name: Release - Deploy all from ${{ github.ref_name }} to ${{ inputs.environment }}
+run-name: Release - Deploy all from main-6573 to ${{ inputs.environment }}
 
 on:
   workflow_dispatch:
@@ -64,7 +64,7 @@ on:
 
 env:
   NAMESPACE: ${{ secrets.OPENSHIFT_ENV_NAMESPACE }}
-  BUILD_REF: ${{ (github.event_name == 'workflow_call' && inputs.gitRef) || github.ref_name }}
+  BUILD_REF: ${{ (github.event_name == 'workflow_call' && inputs.gitRef) || 'main-6573' }}
   HOST_PREFIX: ${{ secrets.HOST_PREFIX }}
   DOMAIN_PREFIX: ${{ vars.DOMAIN_PREFIX }}
   BUILD_NAMESPACE: ${{ vars.BUILD_NAMESPACE }}

--- a/.github/workflows/release-deploy-all.yml
+++ b/.github/workflows/release-deploy-all.yml
@@ -126,14 +126,14 @@ jobs:
     outputs:
       build-ref: ${{ steps.set-build-ref.outputs.build-ref }}
     steps:
-      - name: set outputs with default values
+      - name: Set build-ref
         id: set-build-ref
         run: |
           # Set the build ref to be used in the workflow and reusable workflows calls.
           echo "build-ref=${{ env.BUILD_REF }}" >> "$GITHUB_OUTPUT"
   # Run DB migrations.
   run-db-migrations:
-    name: Run db-migrations
+    name: Run DB Migrations
     environment: ${{ inputs.environment }}
     runs-on: ubuntu-latest
     needs: env-setup
@@ -148,153 +148,153 @@ jobs:
           echo GIT REF: ${{ needs.env-setup.outputs.build-ref }}
           echo BUILD NAMESPACE: $BUILD_NAMESPACE
           echo OC CLI Version: $(oc version)
-  #     - name: Checkout Target Branch
-  #       uses: actions/checkout@v4
-  #       with:
-  #         ref: ${{ needs.env-setup.outputs.build-ref }}
-  #     - name: Log in to OpenShift
-  #       run: |
-  #         oc login --token=${{ secrets.SA_TOKEN }} --server=${{ vars.OPENSHIFT_CLUSTER_URL }}
-  #     - name: Run db-migrations
-  #       working-directory: "./devops/"
-  #       run: |
-  #         make oc-run-db-migrations
+      - name: Checkout Target Branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.env-setup.outputs.build-ref }}
+      - name: Log in to OpenShift
+        run: |
+          oc login --token=${{ secrets.SA_TOKEN }} --server=${{ vars.OPENSHIFT_CLUSTER_URL }}
+      - name: Run db-migrations
+        working-directory: "./devops/"
+        run: |
+          make oc-run-db-migrations
 
-  # # Deploy SIMS API.
-  # deploy-sims-api:
-  #   name: Deploy SIMS-API
-  #   environment: ${{ inputs.environment }}
-  #   runs-on: ubuntu-latest
-  #   needs: [env-setup, run-db-migrations]
-  #   steps:
-  #     - name: Install CLI tools from OpenShift Mirror
-  #       uses: redhat-actions/openshift-tools-installer@v1
-  #       with:
-  #         oc: "4"
-  #     - name: Print env
-  #       run: |
-  #         echo Deploy ENVIRONMENT: ${{ inputs.environment }}
-  #         echo GIT REF: ${{ env.BUILD_REF }}
-  #         echo BUILD NAMESPACE: $BUILD_NAMESPACE
-  #         echo OC CLI Version: $(oc version)
-  #     - name: Checkout Target Branch
-  #       uses: actions/checkout@v4
-  #       with:
-  #         ref: ${{ needs.env-setup.outputs.build-ref }}
-  #     - name: Log in to OpenShift
-  #       run: |
-  #         oc login --token=${{ secrets.SA_TOKEN }} --server=${{ vars.OPENSHIFT_CLUSTER_URL }}
-  #     - name: Deploy SIMS-API
-  #       working-directory: "./devops/"
-  #       run: |
-  #         make oc-deploy-api
+  # Deploy SIMS API.
+  deploy-sims-api:
+    name: Deploy SIMS-API
+    environment: ${{ inputs.environment }}
+    runs-on: ubuntu-latest
+    needs: [env-setup, run-db-migrations]
+    steps:
+      - name: Install CLI tools from OpenShift Mirror
+        uses: redhat-actions/openshift-tools-installer@v1
+        with:
+          oc: "4"
+      - name: Print env
+        run: |
+          echo Deploy ENVIRONMENT: ${{ inputs.environment }}
+          echo GIT REF: ${{ needs.env-setup.outputs.build-ref }}
+          echo BUILD NAMESPACE: $BUILD_NAMESPACE
+          echo OC CLI Version: $(oc version)
+      - name: Checkout Target Branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.env-setup.outputs.build-ref }}
+      - name: Log in to OpenShift
+        run: |
+          oc login --token=${{ secrets.SA_TOKEN }} --server=${{ vars.OPENSHIFT_CLUSTER_URL }}
+      - name: Deploy SIMS-API
+        working-directory: "./devops/"
+        run: |
+          make oc-deploy-api
 
-  # # Deploy workers.
-  # deploy-workers:
-  #   name: Deploy Workers
-  #   environment: ${{ inputs.environment }}
-  #   env:
-  #     DISABLE_ORM_CACHE: true
-  #   runs-on: ubuntu-latest
-  #   needs: [env-setup, run-db-migrations]
-  #   steps:
-  #     - name: Install CLI tools from OpenShift Mirror
-  #       uses: redhat-actions/openshift-tools-installer@v1
-  #       with:
-  #         oc: "4"
-  #     - name: Print env
-  #       run: |
-  #         echo BUILD ENVIRONMENT: ${{ inputs.environment }}
-  #         echo GIT REF: ${{ env.BUILD_REF }}
-  #         echo OC CLI Version: $(oc version)
-  #     - name: Checkout Target Branch
-  #       uses: actions/checkout@v4
-  #       with:
-  #         ref: ${{ needs.env-setup.outputs.build-ref }}
-  #     - name: Log in to OpenShift
-  #       run: |
-  #         oc login --token=${{ secrets.SA_TOKEN }} --server=${{ vars.OPENSHIFT_CLUSTER_URL }}
-  #     - name: Deploy Workers
-  #       working-directory: "./devops/"
-  #       run: |
-  #         make oc-deploy-workers
+  # Deploy workers.
+  deploy-workers:
+    name: Deploy Workers
+    environment: ${{ inputs.environment }}
+    env:
+      DISABLE_ORM_CACHE: true
+    runs-on: ubuntu-latest
+    needs: [env-setup, run-db-migrations]
+    steps:
+      - name: Install CLI tools from OpenShift Mirror
+        uses: redhat-actions/openshift-tools-installer@v1
+        with:
+          oc: "4"
+      - name: Print env
+        run: |
+          echo BUILD ENVIRONMENT: ${{ inputs.environment }}
+          echo GIT REF: ${{ needs.env-setup.outputs.build-ref }}
+          echo OC CLI Version: $(oc version)
+      - name: Checkout Target Branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.env-setup.outputs.build-ref }}
+      - name: Log in to OpenShift
+        run: |
+          oc login --token=${{ secrets.SA_TOKEN }} --server=${{ vars.OPENSHIFT_CLUSTER_URL }}
+      - name: Deploy Workers
+        working-directory: "./devops/"
+        run: |
+          make oc-deploy-workers
 
-  # # Deploy queue consumers.
-  # deploy-queue-consumers:
-  #   name: Deploy Queue Consumers
-  #   environment: ${{ inputs.environment }}
-  #   runs-on: ubuntu-latest
-  #   needs: [env-setup, run-db-migrations]
-  #   steps:
-  #     - name: Install CLI tools from OpenShift Mirror
-  #       uses: redhat-actions/openshift-tools-installer@v1
-  #       with:
-  #         oc: "4"
-  #     - name: Print env
-  #       run: |
-  #         echo Deploy ENVIRONMENT: ${{ inputs.environment }}
-  #         echo GIT REF: ${{ env.BUILD_REF }}
-  #         echo BUILD NAMESPACE: $BUILD_NAMESPACE
-  #         echo OC CLI Version: $(oc version)
-  #     - name: Checkout Target Branch
-  #       uses: actions/checkout@v4
-  #       with:
-  #         ref: ${{ needs.env-setup.outputs.build-ref }}
-  #     - name: Log in to OpenShift
-  #       run: |
-  #         oc login --token=${{ secrets.SA_TOKEN }} --server=${{ vars.OPENSHIFT_CLUSTER_URL }}
-  #     - name: Deploy Queue Consumers
-  #       working-directory: "./devops/"
-  #       run: |
-  #         make oc-deploy-queue-consumers
+  # Deploy queue consumers.
+  deploy-queue-consumers:
+    name: Deploy Queue Consumers
+    environment: ${{ inputs.environment }}
+    runs-on: ubuntu-latest
+    needs: [env-setup, run-db-migrations]
+    steps:
+      - name: Install CLI tools from OpenShift Mirror
+        uses: redhat-actions/openshift-tools-installer@v1
+        with:
+          oc: "4"
+      - name: Print env
+        run: |
+          echo Deploy ENVIRONMENT: ${{ inputs.environment }}
+          echo GIT REF: ${{ needs.env-setup.outputs.build-ref }}
+          echo BUILD NAMESPACE: $BUILD_NAMESPACE
+          echo OC CLI Version: $(oc version)
+      - name: Checkout Target Branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.env-setup.outputs.build-ref }}
+      - name: Log in to OpenShift
+        run: |
+          oc login --token=${{ secrets.SA_TOKEN }} --server=${{ vars.OPENSHIFT_CLUSTER_URL }}
+      - name: Deploy Queue Consumers
+        working-directory: "./devops/"
+        run: |
+          make oc-deploy-queue-consumers
 
-  # # Deploy Web/Frontend.
-  # deploy-web-frontend:
-  #   name: Deploy Web/Frontend
-  #   environment: ${{ inputs.environment }}
-  #   runs-on: ubuntu-latest
-  #   needs: [env-setup, run-db-migrations]
-  #   steps:
-  #     - name: Install CLI tools from OpenShift Mirror
-  #       uses: redhat-actions/openshift-tools-installer@v1
-  #       with:
-  #         oc: "4"
-  #     - name: Print env
-  #       run: |
-  #         echo Deploy ENVIRONMENT: ${{ inputs.environment }}
-  #         echo GIT REF: ${{ env.BUILD_REF }}
-  #         echo BUILD NAMESPACE: $BUILD_NAMESPACE
-  #         echo OC CLI Version: $(oc version)
-  #     - name: Checkout Target Branch
-  #       uses: actions/checkout@v4
-  #       with:
-  #         ref: ${{ needs.env-setup.outputs.build-ref }}
-  #     - name: Log in to OpenShift
-  #       run: |
-  #         oc login --token=${{ secrets.SA_TOKEN }} --server=${{ vars.OPENSHIFT_CLUSTER_URL }}
-  #     - name: Deploy Web/Frontend
-  #       working-directory: "./devops/"
-  #       run: |
-  #         make oc-deploy-web
+  # Deploy Web/Frontend.
+  deploy-web-frontend:
+    name: Deploy Web/Frontend
+    environment: ${{ inputs.environment }}
+    runs-on: ubuntu-latest
+    needs: [env-setup, run-db-migrations]
+    steps:
+      - name: Install CLI tools from OpenShift Mirror
+        uses: redhat-actions/openshift-tools-installer@v1
+        with:
+          oc: "4"
+      - name: Print env
+        run: |
+          echo Deploy ENVIRONMENT: ${{ inputs.environment }}
+          echo GIT REF: ${{ needs.env-setup.outputs.build-ref }}
+          echo BUILD NAMESPACE: $BUILD_NAMESPACE
+          echo OC CLI Version: $(oc version)
+      - name: Checkout Target Branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.env-setup.outputs.build-ref }}
+      - name: Log in to OpenShift
+        run: |
+          oc login --token=${{ secrets.SA_TOKEN }} --server=${{ vars.OPENSHIFT_CLUSTER_URL }}
+      - name: Deploy Web/Frontend
+        working-directory: "./devops/"
+        run: |
+          make oc-deploy-web
 
-  # # Deploy Camunda Definitions
-  # deployCamundaDefinitions:
-  #   if: ${{ inputs.deployCamundaDefinitions }}
-  #   name: Deploy BPMNs and DMNs to Camunda
-  #   needs: [env-setup, deploy-sims-api]
-  #   uses: ./.github/workflows/release-deploy-camunda-definitions.yml
-  #   with:
-  #     environment: ${{ inputs.environment }}
-  #     gitRef: ${{ needs.env-setup.outputs.build-ref }}
-  #   secrets: inherit
+  # Deploy Camunda Definitions
+  deployCamundaDefinitions:
+    if: ${{ inputs.deployCamundaDefinitions }}
+    name: Deploy BPMNs and DMNs to Camunda
+    needs: [env-setup, deploy-sims-api]
+    uses: ./.github/workflows/release-deploy-camunda-definitions.yml
+    with:
+      environment: ${{ inputs.environment }}
+      gitRef: ${{ needs.env-setup.outputs.build-ref }}
+    secrets: inherit
 
-  # # Deploy Formio Definitions
-  # deployFormioDefinitions:
-  #   if: ${{ inputs.deployFormioDefinitions }}
-  #   name: Deploy Form.io definitions
-  #   needs: [env-setup, deploy-sims-api]
-  #   uses: ./.github/workflows/release-deploy-formio-definitions.yml
-  #   with:
-  #     environment: ${{ inputs.environment }}
-  #     gitRef: ${{ needs.env-setup.outputs.build-ref }}
-  #   secrets: inherit
+  # Deploy Formio Definitions
+  deployFormioDefinitions:
+    if: ${{ inputs.deployFormioDefinitions }}
+    name: Deploy Form.io definitions
+    needs: [env-setup, deploy-sims-api]
+    uses: ./.github/workflows/release-deploy-formio-definitions.yml
+    with:
+      environment: ${{ inputs.environment }}
+      gitRef: ${{ needs.env-setup.outputs.build-ref }}
+    secrets: inherit

--- a/.github/workflows/release-deploy-all.yml
+++ b/.github/workflows/release-deploy-all.yml
@@ -120,11 +120,23 @@ env:
   HAMONGO_DB_MEMORY_LIMIT: ${{ vars.HAMONGO_DB_MEMORY_LIMIT }}
 
 jobs:
+  env-setup:
+    name: Setup Dynamic Environment Variables
+    runs-on: ubuntu-latest
+    outputs:
+      build-ref: ${{ steps.set-build-ref.outputs.build-ref }}
+    steps:
+      - name: set outputs with default values
+        id: set-build-ref
+        run: |
+          # Set the build ref to be used in the workflow and reusable workflows calls.
+          echo "::set-output name=build-ref::${{ env.BUILD_REF }}"
   # Run DB migrations.
   run-db-migrations:
     name: Run db-migrations
     environment: ${{ inputs.environment }}
     runs-on: ubuntu-latest
+    needs: env-setup
     steps:
       - name: Install CLI tools from OpenShift Mirror
         uses: redhat-actions/openshift-tools-installer@v1
@@ -139,7 +151,7 @@ jobs:
       - name: Checkout Target Branch
         uses: actions/checkout@v4
         with:
-          ref: ${{ env.BUILD_REF }}
+          ref: ${{ needs.env-setup.outputs.build-ref }}
       - name: Log in to OpenShift
         run: |
           oc login --token=${{ secrets.SA_TOKEN }} --server=${{ vars.OPENSHIFT_CLUSTER_URL }}
@@ -153,7 +165,7 @@ jobs:
     name: Deploy SIMS-API
     environment: ${{ inputs.environment }}
     runs-on: ubuntu-latest
-    needs: run-db-migrations
+    needs: [env-setup, run-db-migrations]
     steps:
       - name: Install CLI tools from OpenShift Mirror
         uses: redhat-actions/openshift-tools-installer@v1
@@ -168,7 +180,7 @@ jobs:
       - name: Checkout Target Branch
         uses: actions/checkout@v4
         with:
-          ref: ${{ env.BUILD_REF }}
+          ref: ${{ needs.env-setup.outputs.build-ref }}
       - name: Log in to OpenShift
         run: |
           oc login --token=${{ secrets.SA_TOKEN }} --server=${{ vars.OPENSHIFT_CLUSTER_URL }}
@@ -184,7 +196,7 @@ jobs:
     env:
       DISABLE_ORM_CACHE: true
     runs-on: ubuntu-latest
-    needs: run-db-migrations
+    needs: [env-setup, run-db-migrations]
     steps:
       - name: Install CLI tools from OpenShift Mirror
         uses: redhat-actions/openshift-tools-installer@v1
@@ -198,7 +210,7 @@ jobs:
       - name: Checkout Target Branch
         uses: actions/checkout@v4
         with:
-          ref: ${{ env.BUILD_REF }}
+          ref: ${{ needs.env-setup.outputs.build-ref }}
       - name: Log in to OpenShift
         run: |
           oc login --token=${{ secrets.SA_TOKEN }} --server=${{ vars.OPENSHIFT_CLUSTER_URL }}
@@ -212,7 +224,7 @@ jobs:
     name: Deploy Queue Consumers
     environment: ${{ inputs.environment }}
     runs-on: ubuntu-latest
-    needs: run-db-migrations
+    needs: [env-setup, run-db-migrations]
     steps:
       - name: Install CLI tools from OpenShift Mirror
         uses: redhat-actions/openshift-tools-installer@v1
@@ -227,7 +239,7 @@ jobs:
       - name: Checkout Target Branch
         uses: actions/checkout@v4
         with:
-          ref: ${{ env.BUILD_REF }}
+          ref: ${{ needs.env-setup.outputs.build-ref }}
       - name: Log in to OpenShift
         run: |
           oc login --token=${{ secrets.SA_TOKEN }} --server=${{ vars.OPENSHIFT_CLUSTER_URL }}
@@ -241,7 +253,7 @@ jobs:
     name: Deploy Web/Frontend
     environment: ${{ inputs.environment }}
     runs-on: ubuntu-latest
-    needs: run-db-migrations
+    needs: [env-setup, run-db-migrations]
     steps:
       - name: Install CLI tools from OpenShift Mirror
         uses: redhat-actions/openshift-tools-installer@v1
@@ -256,7 +268,7 @@ jobs:
       - name: Checkout Target Branch
         uses: actions/checkout@v4
         with:
-          ref: ${{ env.BUILD_REF }}
+          ref: ${{ needs.env-setup.outputs.build-ref }}
       - name: Log in to OpenShift
         run: |
           oc login --token=${{ secrets.SA_TOKEN }} --server=${{ vars.OPENSHIFT_CLUSTER_URL }}
@@ -269,20 +281,20 @@ jobs:
   deployCamundaDefinitions:
     if: ${{ inputs.deployCamundaDefinitions }}
     name: Deploy BPMNs and DMNs to Camunda
-    needs: deploy-sims-api
+    needs: [env-setup, deploy-sims-api]
     uses: ./.github/workflows/release-deploy-camunda-definitions.yml
     with:
       environment: ${{ inputs.environment }}
-      gitRef: ${{ env.BUILD_REF }}
+      gitRef: ${{ needs.env-setup.outputs.build-ref }}
     secrets: inherit
 
   # Deploy Formio Definitions
   deployFormioDefinitions:
     if: ${{ inputs.deployFormioDefinitions }}
     name: Deploy Form.io definitions
-    needs: deploy-sims-api
+    needs: [env-setup, deploy-sims-api]
     uses: ./.github/workflows/release-deploy-formio-definitions.yml
     with:
       environment: ${{ inputs.environment }}
-      gitRef: ${{ env.BUILD_REF }}
+      gitRef: ${{ needs.env-setup.outputs.build-ref }}
     secrets: inherit

--- a/.github/workflows/release-deploy-all.yml
+++ b/.github/workflows/release-deploy-all.yml
@@ -64,7 +64,7 @@ on:
 
 env:
   NAMESPACE: ${{ secrets.OPENSHIFT_ENV_NAMESPACE }}
-  BUILD_REF: ${{ github.ref_name }}
+  BUILD_REF: ${{ (github.event_name == 'workflow_call' && inputs.gitRef) || github.ref_name }}
   HOST_PREFIX: ${{ secrets.HOST_PREFIX }}
   DOMAIN_PREFIX: ${{ vars.DOMAIN_PREFIX }}
   BUILD_NAMESPACE: ${{ vars.BUILD_NAMESPACE }}
@@ -133,13 +133,13 @@ jobs:
       - name: Print env
         run: |
           echo Deploy Environment: ${{ inputs.environment }}
-          echo GIT REF: ${{ github.ref_name }}
+          echo GIT REF: ${{ env.BUILD_REF }}
           echo BUILD NAMESPACE: $BUILD_NAMESPACE
           echo OC CLI Version: $(oc version)
       - name: Checkout Target Branch
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.ref_name }}
+          ref: ${{ env.BUILD_REF }}
       - name: Log in to OpenShift
         run: |
           oc login --token=${{ secrets.SA_TOKEN }} --server=${{ vars.OPENSHIFT_CLUSTER_URL }}
@@ -162,13 +162,13 @@ jobs:
       - name: Print env
         run: |
           echo Deploy ENVIRONMENT: ${{ inputs.environment }}
-          echo GIT REF: ${{ github.ref_name }}
+          echo GIT REF: ${{ env.BUILD_REF }}
           echo BUILD NAMESPACE: $BUILD_NAMESPACE
           echo OC CLI Version: $(oc version)
       - name: Checkout Target Branch
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.ref_name }}
+          ref: ${{ env.BUILD_REF }}
       - name: Log in to OpenShift
         run: |
           oc login --token=${{ secrets.SA_TOKEN }} --server=${{ vars.OPENSHIFT_CLUSTER_URL }}
@@ -193,12 +193,12 @@ jobs:
       - name: Print env
         run: |
           echo BUILD ENVIRONMENT: ${{ inputs.environment }}
-          echo GIT REF: ${{ github.ref_name }}
+          echo GIT REF: ${{ env.BUILD_REF }}
           echo OC CLI Version: $(oc version)
       - name: Checkout Target Branch
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.ref_name }}
+          ref: ${{ env.BUILD_REF }}
       - name: Log in to OpenShift
         run: |
           oc login --token=${{ secrets.SA_TOKEN }} --server=${{ vars.OPENSHIFT_CLUSTER_URL }}
@@ -221,13 +221,13 @@ jobs:
       - name: Print env
         run: |
           echo Deploy ENVIRONMENT: ${{ inputs.environment }}
-          echo GIT REF: ${{ github.ref_name }}
+          echo GIT REF: ${{ env.BUILD_REF }}
           echo BUILD NAMESPACE: $BUILD_NAMESPACE
           echo OC CLI Version: $(oc version)
       - name: Checkout Target Branch
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.ref_name }}
+          ref: ${{ env.BUILD_REF }}
       - name: Log in to OpenShift
         run: |
           oc login --token=${{ secrets.SA_TOKEN }} --server=${{ vars.OPENSHIFT_CLUSTER_URL }}
@@ -250,13 +250,13 @@ jobs:
       - name: Print env
         run: |
           echo Deploy ENVIRONMENT: ${{ inputs.environment }}
-          echo GIT REF: ${{ github.ref_name }}
+          echo GIT REF: ${{ env.BUILD_REF }}
           echo BUILD NAMESPACE: $BUILD_NAMESPACE
           echo OC CLI Version: $(oc version)
       - name: Checkout Target Branch
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.ref_name }}
+          ref: ${{ env.BUILD_REF }}
       - name: Log in to OpenShift
         run: |
           oc login --token=${{ secrets.SA_TOKEN }} --server=${{ vars.OPENSHIFT_CLUSTER_URL }}
@@ -273,7 +273,7 @@ jobs:
     uses: ./.github/workflows/release-deploy-camunda-definitions.yml
     with:
       environment: ${{ inputs.environment }}
-      gitRef: ${{ github.ref_name }}
+      gitRef: ${{ env.BUILD_REF }}
     secrets: inherit
 
   # Deploy Formio Definitions
@@ -284,5 +284,5 @@ jobs:
     uses: ./.github/workflows/release-deploy-formio-definitions.yml
     with:
       environment: ${{ inputs.environment }}
-      gitRef: ${{ github.ref_name }}
+      gitRef: ${{ env.BUILD_REF }}
     secrets: inherit

--- a/.github/workflows/release-deploy-all.yml
+++ b/.github/workflows/release-deploy-all.yml
@@ -130,7 +130,7 @@ jobs:
         id: set-build-ref
         run: |
           # Set the build ref to be used in the workflow and reusable workflows calls.
-          echo "::set-output name=build-ref::${{ env.BUILD_REF }}"
+          echo "build-ref=${{ env.BUILD_REF }}" >> "$GITHUB_OUTPUT"
   # Run DB migrations.
   run-db-migrations:
     name: Run db-migrations


### PR DESCRIPTION
Proposed solution to have the GitHub ref provided from both workflow entries: `workflow_dispatch` and `workflow_call`.
When `workflow_call` is executed, it will be provided by the parent workflow.
When `workflow_dispatch` is executed, it will use the `github.ref_name` as the default value.
_Note:_
1 - The env variable is enough to execute the jobs, but it is not accessible from the reusable workflows `with` context for `deployCamundaDefinitions` and `deployFormioDefinitions`.
2 - Reference for the ternary operation used to set the ENV variable: https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/evaluate-expressions-in-workflows-and-actions#example

