### PR TITLE
#4690 - Update Deploy-All to use tag gitreference

### DIFF
--- a/.github/workflows/release-deploy-all.yml
+++ b/.github/workflows/release-deploy-all.yml
@@ -64,7 +64,7 @@ on:
 
 env:
   NAMESPACE: ${{ secrets.OPENSHIFT_ENV_NAMESPACE }}
-  BUILD_REF: ${{ (github.event_name == 'workflow_call' && inputs.gitRef) || github.ref_name }}
+  BUILD_REF: ${{ inputs.gitRef || github.ref_name }}
   HOST_PREFIX: ${{ secrets.HOST_PREFIX }}
   DOMAIN_PREFIX: ${{ vars.DOMAIN_PREFIX }}
   BUILD_NAMESPACE: ${{ vars.BUILD_NAMESPACE }}


### PR DESCRIPTION
Removing event condition. Apparently, the `github.event_name` will never assume the value of `workflow_call`. Its value will be propagated from the calling workflow event.