### PR TITLE
#4707 - Change to CSGD eligibility and 2 workflows for calculation

### DIFF
--- a/sources/packages/backend/workflow/src/workflow-definitions/parttime-assessment-2024-2025.bpmn
+++ b/sources/packages/backend/workflow/src/workflow-definitions/parttime-assessment-2024-2025.bpmn
@@ -853,7 +853,7 @@ dmnX (comes from dmn)</bpmn:text>
     <bpmn:intermediateThrowEvent id="Event_1yndxhv" name="awardEligibilityCSGD">
       <bpmn:extensionElements>
         <zeebe:ioMapping>
-          <zeebe:output source="=if (calculatedDataTotalAssessedNeed &#62;= 1)&#10;    and (calculatedDataTotalEligibleDependants &#62;= 1)&#10;    and (calculatedDataTotalFamilyIncome &#60; dmnPartTimeAwardFamilySizeVariables.limitAwardCSGDThresholdIncome)&#10;then true&#10;else false" target="awardEligibilityCSGD" />
+          <zeebe:output source="=if (calculatedDataTotalAssessedNeed &#62;= 1)&#10;    and ((calculatedDataDependants11YearsOrUnder +&#10;calculatedDataDependants12YearsOverOnTaxes) &#62;= 1)&#10;    and (calculatedDataTotalFamilyIncome &#60; dmnPartTimeAwardFamilySizeVariables.limitAwardCSGDThresholdIncome)&#10;then true&#10;else false" target="awardEligibilityCSGD" />
         </zeebe:ioMapping>
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_0f51edb</bpmn:incoming>
@@ -1163,10 +1163,12 @@ dmnX (comes from dmn)</bpmn:text>
     <bpmn:sequenceFlow id="Flow_1p7fyev" sourceRef="Gateway_03c2fh6" targetRef="Activity_0pvobml" />
     <bpmn:sequenceFlow id="Flow_04d0tld" sourceRef="Event_0jmbywn" targetRef="Gateway_04hunux" />
     <bpmn:sequenceFlow id="Flow_1lswqbt" name="Less than 3 dependants" sourceRef="Gateway_04hunux" targetRef="Event_1iix0z3">
-      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=calculatedDataTotalEligibleDependants &lt;= 2</bpmn:conditionExpression>
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=(calculatedDataDependants11YearsOrUnder +
+calculatedDataDependants12YearsOverOnTaxes) &lt;= 2</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
     <bpmn:sequenceFlow id="Flow_0luqxk1" name="3 or more dependants" sourceRef="Gateway_04hunux" targetRef="Event_10par1m">
-      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=calculatedDataTotalEligibleDependants &gt;= 3</bpmn:conditionExpression>
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=(calculatedDataDependants11YearsOrUnder +
+calculatedDataDependants12YearsOverOnTaxes) &gt;= 3</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
     <bpmn:sequenceFlow id="Flow_0foajxm" sourceRef="Event_1otxsj1" targetRef="Event_1xl9u43" />
     <bpmn:sequenceFlow id="Flow_1rnodvu" sourceRef="Event_13hierd" targetRef="Event_19hr2p7" />

--- a/sources/packages/backend/workflow/test/2024-2025/parttime-assessment/awards-amounts/parttime-assessment-awards-amount-CSGD.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2024-2025/parttime-assessment/awards-amounts/parttime-assessment-awards-amount-CSGD.e2e-spec.ts
@@ -5,9 +5,9 @@ import {
   executePartTimeAssessmentForProgramYear,
 } from "../../../test-utils";
 import {
-  DependentEligibility,
+  DependentChildCareEligibility,
   createFakeStudentDependentBornAfterStudyEndDate,
-  createFakeStudentDependentEligible,
+  createFakeStudentDependentEligibleForChildcareCost,
 } from "../../../test-utils/factories";
 import { YesNoOptions } from "@sims/test-utils";
 
@@ -22,17 +22,17 @@ describe(`E2E Test Workflow parttime-assessment-${PROGRAM_YEAR}-awards-amount-CS
     assessmentConsolidatedData.partner1CRAReportedIncome = 20000;
     assessmentConsolidatedData.studentDataHasDependents = YesNoOptions.Yes;
     assessmentConsolidatedData.studentDataDependants = [
-      createFakeStudentDependentEligible(
-        DependentEligibility.Eligible0To18YearsOld,
-        { referenceDate: assessmentConsolidatedData.offeringStudyStartDate },
+      createFakeStudentDependentEligibleForChildcareCost(
+        DependentChildCareEligibility.Eligible0To11YearsOld,
+        assessmentConsolidatedData.offeringStudyStartDate,
       ),
-      createFakeStudentDependentEligible(
-        DependentEligibility.Eligible0To18YearsOld,
-        { referenceDate: assessmentConsolidatedData.offeringStudyStartDate },
+      createFakeStudentDependentEligibleForChildcareCost(
+        DependentChildCareEligibility.Eligible12YearsAndOver,
+        assessmentConsolidatedData.offeringStudyStartDate,
       ),
-      createFakeStudentDependentEligible(
-        DependentEligibility.Eligible0To18YearsOld,
-        { referenceDate: assessmentConsolidatedData.offeringStudyStartDate },
+      createFakeStudentDependentEligibleForChildcareCost(
+        DependentChildCareEligibility.Eligible12YearsAndOver,
+        assessmentConsolidatedData.offeringStudyStartDate,
       ),
     ];
     assessmentConsolidatedData.studentDataHasDependents = YesNoOptions.Yes;
@@ -64,17 +64,17 @@ describe(`E2E Test Workflow parttime-assessment-${PROGRAM_YEAR}-awards-amount-CS
     assessmentConsolidatedData.partner1CRAReportedIncome = 42000;
     assessmentConsolidatedData.studentDataHasDependents = YesNoOptions.Yes;
     assessmentConsolidatedData.studentDataDependants = [
-      createFakeStudentDependentEligible(
-        DependentEligibility.Eligible0To18YearsOld,
-        { referenceDate: assessmentConsolidatedData.offeringStudyStartDate },
+      createFakeStudentDependentEligibleForChildcareCost(
+        DependentChildCareEligibility.Eligible0To11YearsOld,
+        assessmentConsolidatedData.offeringStudyStartDate,
       ),
-      createFakeStudentDependentEligible(
-        DependentEligibility.Eligible0To18YearsOld,
-        { referenceDate: assessmentConsolidatedData.offeringStudyStartDate },
+      createFakeStudentDependentEligibleForChildcareCost(
+        DependentChildCareEligibility.Eligible0To11YearsOld,
+        assessmentConsolidatedData.offeringStudyStartDate,
       ),
-      createFakeStudentDependentEligible(
-        DependentEligibility.Eligible0To18YearsOld,
-        { referenceDate: assessmentConsolidatedData.offeringStudyStartDate },
+      createFakeStudentDependentEligibleForChildcareCost(
+        DependentChildCareEligibility.Eligible12YearsAndOver,
+        assessmentConsolidatedData.offeringStudyStartDate,
       ),
     ];
     assessmentConsolidatedData.studentDataHasDependents = YesNoOptions.Yes;
@@ -142,13 +142,13 @@ describe(`E2E Test Workflow parttime-assessment-${PROGRAM_YEAR}-awards-amount-CS
     assessmentConsolidatedData.partner1CRAReportedIncome = 20000;
     assessmentConsolidatedData.studentDataHasDependents = YesNoOptions.Yes;
     assessmentConsolidatedData.studentDataDependants = [
-      createFakeStudentDependentEligible(
-        DependentEligibility.Eligible0To18YearsOld,
-        { referenceDate: assessmentConsolidatedData.offeringStudyStartDate },
+      createFakeStudentDependentEligibleForChildcareCost(
+        DependentChildCareEligibility.Eligible0To11YearsOld,
+        assessmentConsolidatedData.offeringStudyStartDate,
       ),
-      createFakeStudentDependentEligible(
-        DependentEligibility.Eligible18To22YearsOldAttendingHighSchool,
-        { referenceDate: assessmentConsolidatedData.offeringStudyStartDate },
+      createFakeStudentDependentEligibleForChildcareCost(
+        DependentChildCareEligibility.Eligible12YearsAndOver,
+        assessmentConsolidatedData.offeringStudyStartDate,
       ),
       // Dependent(s) born after study end date are not considered
       // as eligible for any calculation.
@@ -186,9 +186,9 @@ describe(`E2E Test Workflow parttime-assessment-${PROGRAM_YEAR}-awards-amount-CS
     assessmentConsolidatedData.partner1CRAReportedIncome = 35000;
     assessmentConsolidatedData.studentDataHasDependents = YesNoOptions.Yes;
     assessmentConsolidatedData.studentDataDependants = [
-      createFakeStudentDependentEligible(
-        DependentEligibility.Eligible0To18YearsOld,
-        { referenceDate: assessmentConsolidatedData.offeringStudyStartDate },
+      createFakeStudentDependentEligibleForChildcareCost(
+        DependentChildCareEligibility.Eligible0To11YearsOld,
+        assessmentConsolidatedData.offeringStudyStartDate,
       ),
     ];
     // Act
@@ -255,9 +255,9 @@ describe(`E2E Test Workflow parttime-assessment-${PROGRAM_YEAR}-awards-amount-CS
     assessmentConsolidatedData.partner1CRAReportedIncome = 35000;
     assessmentConsolidatedData.studentDataHasDependents = YesNoOptions.Yes;
     assessmentConsolidatedData.studentDataDependants = [
-      createFakeStudentDependentEligible(
-        DependentEligibility.Eligible0To18YearsOld,
-        { referenceDate: assessmentConsolidatedData.offeringStudyStartDate },
+      createFakeStudentDependentEligibleForChildcareCost(
+        DependentChildCareEligibility.Eligible0To11YearsOld,
+        assessmentConsolidatedData.offeringStudyStartDate,
       ),
     ];
     assessmentConsolidatedData.programYearTotalPartTimeCSGD = undefined;


### PR DESCRIPTION
Hotfix changes to CSGD (CSG-PTDEP)

- `awardEligibilityCSGD` to include dependants <=11 or 12+ on taxes instead of total eligible dependants
- workflows based on the CSGD eligible dependants (above) instead of total eligible:
![image](https://github.com/user-attachments/assets/adf09016-8ec5-4a0c-a7e7-715dba4cfe66)
- E2E tests for eligibility copied from the 2025-26 changes, which means `parttime-assessment-eligibility-CSGD.e2e-spec.ts` for both year are the same since the logic is now the same.
- E2E tests for amount verification were adapted to ensure the eligibility was `true` to check the amounts.
