### PR TITLE
#4617 - Ministry View Change Request Revamp (approval and denial) - E2E tests

### DIFF
--- a/sources/packages/backend/apps/api/src/route-controllers/application-change-request/_tests_/e2e/application-change-request.aest.assessApplicationChangeRequest.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/application-change-request/_tests_/e2e/application-change-request.aest.assessApplicationChangeRequest.e2e-spec.ts
@@ -1,0 +1,457 @@
+import { HttpStatus, INestApplication } from "@nestjs/common";
+import * as request from "supertest";
+import { DataSource } from "typeorm";
+import {
+  AESTGroups,
+  BEARER_AUTH_TYPE,
+  createTestingAppModule,
+  getAESTToken,
+  getAESTUser,
+} from "../../../../testHelpers";
+import { ApplicationEditStatus, ApplicationStatus, User } from "@sims/sims-db";
+import * as faker from "faker";
+import {
+  createE2EDataSources,
+  createFakeStudentAppeal,
+  E2EDataSources,
+  saveFakeApplication,
+} from "@sims/test-utils";
+import { ZeebeGrpcClient } from "@camunda8/sdk/dist/zeebe";
+import MockDate from "mockdate";
+
+describe("ApplicationChangeRequestAESTController(e2e)-assessApplicationChangeRequest", () => {
+  let app: INestApplication;
+  let appDataSource: DataSource;
+  let zbClient: ZeebeGrpcClient;
+  let db: E2EDataSources;
+  let ministryUser: User;
+
+  beforeAll(async () => {
+    const { nestApplication, dataSource } = await createTestingAppModule();
+    app = nestApplication;
+    appDataSource = dataSource;
+    zbClient = app.get(ZeebeGrpcClient);
+    db = createE2EDataSources(dataSource);
+    const auditUser = await getAESTUser(
+      dataSource,
+      AESTGroups.BusinessAdministrators,
+    );
+    ministryUser = { id: auditUser.id } as User;
+  });
+
+  beforeEach(async () => {
+    MockDate.reset();
+  });
+
+  it("Should approve a change request and copy the offering and appeal when the application change request is waiting for approval.", async () => {
+    // Arrange
+    // Application to be replaced by the change request.
+    const applicationToBeReplaced = await saveFakeApplication(
+      appDataSource,
+      undefined,
+      {
+        initialValues: {
+          applicationStatus: ApplicationStatus.Completed,
+          applicationEditStatus: ApplicationEditStatus.Original,
+        },
+      },
+    );
+    // Create a student appeal and have it associated with the "applicationToBeReplaced".
+    const appeal = createFakeStudentAppeal({
+      application: applicationToBeReplaced,
+    });
+    applicationToBeReplaced.currentAssessment.studentAppeal = appeal;
+    await db.application.save(applicationToBeReplaced);
+    // Change request to be approved replacing the "applicationToBeReplaced".
+    const changeRequest = await saveFakeApplication(
+      appDataSource,
+      { precedingApplication: applicationToBeReplaced },
+      {
+        initialValues: {
+          applicationStatus: ApplicationStatus.Edited,
+          applicationEditStatus: ApplicationEditStatus.ChangePendingApproval,
+        },
+      },
+    );
+    // Offering to perform the asserts. Expected to be copied.
+    const expectedOffering = {
+      id: applicationToBeReplaced.currentAssessment.offering.id,
+    };
+    // Appeal to perform the asserts. Expected to be copied.
+    const expectedAppeal = { id: appeal.id };
+    const payload = getPayload(ApplicationEditStatus.ChangedWithApproval);
+    const endpoint = `/aest/application-change-request/${changeRequest.id}`;
+    const token = await getAESTToken(AESTGroups.BusinessAdministrators);
+    const now = new Date();
+    MockDate.set(now);
+
+    // Act/Assert
+    await request(app.getHttpServer())
+      .patch(endpoint)
+      .send(payload)
+      .auth(token, BEARER_AUTH_TYPE)
+      .expect(HttpStatus.OK);
+    // Validate workflow message.
+    expect(zbClient.publishMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        correlationKey: changeRequest.id.toString(),
+        name: "application-change-request-status-message",
+        variables: {
+          applicationEditStatus: ApplicationEditStatus.ChangedWithApproval,
+        },
+      }),
+    );
+    // Validate database changes.
+    const applicationChangeRequest = await db.application.findOne({
+      select: {
+        id: true,
+        applicationStatus: true,
+        applicationStatusUpdatedOn: true,
+        currentAssessment: {
+          id: true,
+          offering: {
+            id: true,
+          },
+          studentAppeal: {
+            id: true,
+          },
+        },
+        modifier: {
+          id: true,
+        },
+        updatedAt: true,
+        precedingApplication: {
+          id: true,
+          applicationStatus: true,
+          applicationStatusUpdatedOn: true,
+          applicationEditStatus: true,
+          applicationEditStatusUpdatedOn: true,
+          currentAssessment: {
+            id: true,
+            offering: {
+              id: true,
+            },
+            studentAppeal: {
+              id: true,
+            },
+          },
+          modifier: {
+            id: true,
+          },
+          updatedAt: true,
+        },
+      },
+      relations: {
+        currentAssessment: {
+          offering: true,
+          studentAppeal: true,
+        },
+        modifier: true,
+        precedingApplication: {
+          currentAssessment: {
+            offering: true,
+            studentAppeal: true,
+          },
+          modifier: true,
+        },
+      },
+      where: {
+        id: changeRequest.id,
+      },
+      loadEagerRelations: false,
+    });
+    expect(applicationChangeRequest).toEqual({
+      id: changeRequest.id,
+      applicationStatus: ApplicationStatus.Completed,
+      applicationStatusUpdatedOn: now,
+      currentAssessment: {
+        id: expect.any(Number),
+        offering: expectedOffering,
+        studentAppeal: expectedAppeal,
+      },
+      modifier: ministryUser,
+      updatedAt: now,
+      precedingApplication: {
+        id: applicationToBeReplaced.id,
+        applicationStatus: ApplicationStatus.Edited,
+        applicationStatusUpdatedOn: now,
+        // Ensure value was not updated.
+        applicationEditStatus: applicationToBeReplaced.applicationEditStatus,
+        // Ensure value was not updated.
+        applicationEditStatusUpdatedOn:
+          applicationToBeReplaced.applicationEditStatusUpdatedOn,
+        currentAssessment: {
+          id: applicationToBeReplaced.currentAssessment.id,
+          offering: expectedOffering,
+          studentAppeal: expectedAppeal,
+        },
+        modifier: ministryUser,
+        updatedAt: now,
+      },
+    });
+    // Validate created student note.
+    const student = await db.student.findOne({
+      select: {
+        id: true,
+        notes: { id: true, description: true, creator: { id: true } },
+      },
+      relations: {
+        notes: { creator: true },
+      },
+      where: {
+        id: changeRequest.student.id,
+      },
+      loadEagerRelations: false,
+    });
+    expect(student.notes).toEqual([
+      {
+        id: expect.any(Number),
+        description: payload.note,
+        creator: ministryUser,
+      },
+    ]);
+  });
+
+  it("Should approve a change request and copy the offering and no appeals when the application change request is waiting for approval and no appeals are present.", async () => {
+    // Arrange
+    // Application to be replaced by the change request.
+    const applicationToBeReplaced = await saveFakeApplication(
+      appDataSource,
+      undefined,
+      {
+        initialValues: {
+          applicationStatus: ApplicationStatus.Completed,
+          applicationEditStatus: ApplicationEditStatus.Original,
+        },
+      },
+    );
+    // Change request to be approved replacing the "applicationToBeReplaced".
+    const changeRequest = await saveFakeApplication(
+      appDataSource,
+      { precedingApplication: applicationToBeReplaced },
+      {
+        initialValues: {
+          applicationStatus: ApplicationStatus.Edited,
+          applicationEditStatus: ApplicationEditStatus.ChangePendingApproval,
+        },
+      },
+    );
+    // Offering to perform the asserts. Expected to be copied.
+    const expectedOffering = {
+      id: applicationToBeReplaced.currentAssessment.offering.id,
+    };
+    // Appeal to perform the asserts. Expected to be copied.
+    const payload = getPayload(ApplicationEditStatus.ChangedWithApproval);
+    const endpoint = `/aest/application-change-request/${changeRequest.id}`;
+    const token = await getAESTToken(AESTGroups.BusinessAdministrators);
+    const now = new Date();
+    MockDate.set(now);
+
+    // Act/Assert
+    await request(app.getHttpServer())
+      .patch(endpoint)
+      .send(payload)
+      .auth(token, BEARER_AUTH_TYPE)
+      .expect(HttpStatus.OK);
+    // Validate database changes.
+    const applicationChangeRequest = await db.application.findOne({
+      select: {
+        id: true,
+        currentAssessment: {
+          id: true,
+          offering: {
+            id: true,
+          },
+          studentAppeal: {
+            id: true,
+          },
+        },
+        precedingApplication: {
+          id: true,
+          currentAssessment: {
+            id: true,
+            offering: {
+              id: true,
+            },
+            studentAppeal: {
+              id: true,
+            },
+          },
+        },
+      },
+      relations: {
+        currentAssessment: {
+          offering: true,
+          studentAppeal: true,
+        },
+        precedingApplication: {
+          currentAssessment: {
+            offering: true,
+            studentAppeal: true,
+          },
+        },
+      },
+      where: {
+        id: changeRequest.id,
+      },
+      loadEagerRelations: false,
+    });
+    // Focus on offering and appeal validation only.
+    expect(applicationChangeRequest).toEqual(
+      expect.objectContaining({
+        id: changeRequest.id,
+        currentAssessment: {
+          id: expect.any(Number),
+          offering: expectedOffering,
+          studentAppeal: null,
+        },
+        precedingApplication: {
+          id: applicationToBeReplaced.id,
+          currentAssessment: {
+            id: applicationToBeReplaced.currentAssessment.id,
+            offering: expectedOffering,
+            studentAppeal: null,
+          },
+        },
+      }),
+    );
+  });
+
+  it("Should be able to decline a change request and create a student note when the application change request is waiting for approval.", async () => {
+    // Arrange
+    // Change request to be approved replacing the "applicationToBeReplaced".
+    const changeRequest = await saveFakeApplication(appDataSource, undefined, {
+      initialValues: {
+        applicationStatus: ApplicationStatus.Edited,
+        applicationEditStatus: ApplicationEditStatus.ChangePendingApproval,
+      },
+    });
+    // Appeal to perform the asserts. Expected to be copied.
+    const payload = getPayload(ApplicationEditStatus.ChangeDeclined);
+    const endpoint = `/aest/application-change-request/${changeRequest.id}`;
+    const token = await getAESTToken(AESTGroups.BusinessAdministrators);
+    const now = new Date();
+    MockDate.set(now);
+
+    // Act/Assert
+    await request(app.getHttpServer())
+      .patch(endpoint)
+      .send(payload)
+      .auth(token, BEARER_AUTH_TYPE)
+      .expect(HttpStatus.OK);
+    // Validate workflow message.
+    expect(zbClient.publishMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        correlationKey: changeRequest.id.toString(),
+        name: "application-change-request-status-message",
+        variables: {
+          applicationEditStatus: ApplicationEditStatus.ChangeDeclined,
+        },
+      }),
+    );
+    // Validate database changes.
+    const applicationChangeRequest = await db.application.findOne({
+      select: {
+        id: true,
+        applicationEditStatus: true,
+        applicationEditStatusUpdatedBy: { id: true },
+        applicationEditStatusUpdatedOn: true,
+        modifier: {
+          id: true,
+        },
+        updatedAt: true,
+      },
+      relations: {
+        applicationEditStatusUpdatedBy: true,
+        modifier: true,
+      },
+      where: {
+        id: changeRequest.id,
+      },
+      loadEagerRelations: false,
+    });
+    expect(applicationChangeRequest).toEqual({
+      id: changeRequest.id,
+      applicationEditStatus: ApplicationEditStatus.ChangeDeclined,
+      applicationEditStatusUpdatedBy: ministryUser,
+      applicationEditStatusUpdatedOn: now,
+      modifier: ministryUser,
+      updatedAt: now,
+    });
+    // Validate created student note.
+    const student = await db.student.findOne({
+      select: {
+        id: true,
+        notes: { id: true, description: true, creator: { id: true } },
+      },
+      relations: {
+        notes: { creator: true },
+      },
+      where: {
+        id: changeRequest.student.id,
+      },
+      loadEagerRelations: false,
+    });
+    expect(student.notes).toEqual([
+      {
+        id: expect.any(Number),
+        description: payload.note,
+        creator: ministryUser,
+      },
+    ]);
+  });
+
+  it("Should throw UnprocessableEntityException when the application change request was cancelled.", async () => {
+    // Arrange
+    const changeRequest = await saveFakeApplication(appDataSource, undefined, {
+      initialValues: {
+        applicationStatus: ApplicationStatus.Edited,
+        applicationEditStatus: ApplicationEditStatus.ChangeCancelled,
+      },
+    });
+    const endpoint = `/aest/application-change-request/${changeRequest.id}`;
+    const token = await getAESTToken(AESTGroups.BusinessAdministrators);
+    const payload = getPayload(ApplicationEditStatus.ChangedWithApproval);
+
+    // Act/Assert
+    await request(app.getHttpServer())
+      .patch(endpoint)
+      .send(payload)
+      .auth(token, BEARER_AUTH_TYPE)
+      .expect(HttpStatus.UNPROCESSABLE_ENTITY)
+      .expect({
+        message: `Application ${changeRequest.id} to assess change not in valid status to be updated.`,
+        errorType: "INVALID_APPLICATION_EDIT_STATUS",
+      });
+  });
+
+  it("Should throw NotFoundException when the application change request does not exists.", async () => {
+    // Arrange
+    const endpoint = "/aest/application-change-request/999999";
+    const token = await getAESTToken(AESTGroups.BusinessAdministrators);
+    const payload = getPayload(ApplicationEditStatus.ChangedWithApproval);
+
+    // Act/Assert
+    await request(app.getHttpServer())
+      .patch(endpoint)
+      .send(payload)
+      .auth(token, BEARER_AUTH_TYPE)
+      .expect(HttpStatus.NOT_FOUND)
+      .expect({
+        statusCode: HttpStatus.NOT_FOUND,
+        message: `Application 999999 to assess change not found.`,
+        error: "Not Found",
+      });
+  });
+
+  function getPayload(applicationEditStatus: ApplicationEditStatus) {
+    return {
+      note: faker.datatype.uuid(),
+      applicationEditStatus,
+    };
+  }
+
+  afterAll(async () => {
+    await app?.close();
+  });
+});

--- a/sources/packages/backend/apps/api/src/route-controllers/application-change-request/_tests_/e2e/application-change-request.aest.assessApplicationChangeRequest.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/application-change-request/_tests_/e2e/application-change-request.aest.assessApplicationChangeRequest.e2e-spec.ts
@@ -212,7 +212,7 @@ describe("ApplicationChangeRequestAESTController(e2e)-assessApplicationChangeReq
     ]);
   });
 
-  it("Should approve a change request and copy the offering and no appeals when the application change request is waiting for approval and no appeals are present.", async () => {
+  it("Should approve a change request and copy the offering and no appeals when the application change request is waiting for approval, and no appeals are present.", async () => {
     // Arrange
     // Application to be replaced by the change request.
     const applicationToBeReplaced = await saveFakeApplication(
@@ -401,6 +401,27 @@ describe("ApplicationChangeRequestAESTController(e2e)-assessApplicationChangeReq
     ]);
   });
 
+  it("Should throw a BadRequestException when the application change request approval has an invalid status.", async () => {
+    // Arrange
+    const payload = getPayload(ApplicationEditStatus.ChangeCancelled);
+    const endpoint = `/aest/application-change-request/9999999`;
+    const token = await getAESTToken(AESTGroups.BusinessAdministrators);
+
+    // Act/Assert
+    await request(app.getHttpServer())
+      .patch(endpoint)
+      .send(payload)
+      .auth(token, BEARER_AUTH_TYPE)
+      .expect(HttpStatus.BAD_REQUEST)
+      .expect({
+        message: [
+          "applicationEditStatus must be one of the following values: Changed with approval, Change declined",
+        ],
+        error: "Bad Request",
+        statusCode: HttpStatus.BAD_REQUEST,
+      });
+  });
+
   it("Should throw UnprocessableEntityException when the application change request was cancelled.", async () => {
     // Arrange
     const changeRequest = await saveFakeApplication(appDataSource, undefined, {
@@ -425,7 +446,7 @@ describe("ApplicationChangeRequestAESTController(e2e)-assessApplicationChangeReq
       });
   });
 
-  it("Should throw NotFoundException when the application change request does not exists.", async () => {
+  it("Should throw NotFoundException when the application change request does not exist.", async () => {
     // Arrange
     const endpoint = "/aest/application-change-request/999999";
     const token = await getAESTToken(AESTGroups.BusinessAdministrators);

--- a/sources/packages/backend/apps/api/src/route-controllers/application-change-request/_tests_/e2e/application-change-request.aest.controller.assessApplicationChangeRequest.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/application-change-request/_tests_/e2e/application-change-request.aest.controller.assessApplicationChangeRequest.e2e-spec.ts
@@ -295,27 +295,24 @@ describe("ApplicationChangeRequestAESTController(e2e)-assessApplicationChangeReq
       where: {
         id: changeRequest.id,
       },
-      loadEagerRelations: false,
     });
     // Focus on offering and appeal validation only.
-    expect(applicationChangeRequest).toEqual(
-      expect.objectContaining({
-        id: changeRequest.id,
+    expect(applicationChangeRequest).toEqual({
+      id: changeRequest.id,
+      currentAssessment: {
+        id: expect.any(Number),
+        offering: expectedOffering,
+        studentAppeal: null,
+      },
+      precedingApplication: {
+        id: applicationToBeReplaced.id,
         currentAssessment: {
-          id: expect.any(Number),
+          id: applicationToBeReplaced.currentAssessment.id,
           offering: expectedOffering,
           studentAppeal: null,
         },
-        precedingApplication: {
-          id: applicationToBeReplaced.id,
-          currentAssessment: {
-            id: applicationToBeReplaced.currentAssessment.id,
-            offering: expectedOffering,
-            studentAppeal: null,
-          },
-        },
-      }),
-    );
+      },
+    });
   });
 
   it("Should be able to decline a change request and create a student note when the application change request is waiting for approval.", async () => {

--- a/sources/packages/backend/apps/api/src/route-controllers/application-change-request/_tests_/e2e/application-change-request.aest.controller.assessApplicationChangeRequest.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/application-change-request/_tests_/e2e/application-change-request.aest.controller.assessApplicationChangeRequest.e2e-spec.ts
@@ -108,6 +108,9 @@ describe("ApplicationChangeRequestAESTController(e2e)-assessApplicationChangeReq
         id: true,
         applicationStatus: true,
         applicationStatusUpdatedOn: true,
+        applicationEditStatus: true,
+        applicationEditStatusUpdatedBy: { id: true },
+        applicationEditStatusUpdatedOn: true,
         currentAssessment: {
           id: true,
           offering: {
@@ -143,6 +146,7 @@ describe("ApplicationChangeRequestAESTController(e2e)-assessApplicationChangeReq
         },
       },
       relations: {
+        applicationEditStatusUpdatedBy: true,
         currentAssessment: {
           offering: true,
           studentAppeal: true,
@@ -165,6 +169,9 @@ describe("ApplicationChangeRequestAESTController(e2e)-assessApplicationChangeReq
       id: changeRequest.id,
       applicationStatus: ApplicationStatus.Completed,
       applicationStatusUpdatedOn: now,
+      applicationEditStatus: ApplicationEditStatus.ChangedWithApproval,
+      applicationEditStatusUpdatedBy: ministryUser,
+      applicationEditStatusUpdatedOn: now,
       currentAssessment: {
         id: expect.any(Number),
         offering: expectedOffering,

--- a/sources/packages/backend/apps/api/src/services/application-change-request/application-change-request.service.ts
+++ b/sources/packages/backend/apps/api/src/services/application-change-request/application-change-request.service.ts
@@ -99,6 +99,7 @@ export class ApplicationChangeRequestService {
       const completedApplication =
         changeRequestApplication.precedingApplication;
       completedApplication.applicationStatus = ApplicationStatus.Edited;
+      completedApplication.applicationStatusUpdatedOn = currentDate;
       completedApplication.modifier = auditUser;
       completedApplication.updatedAt = currentDate;
       // Update the approved change request to become the new completed application.

--- a/sources/packages/web/src/components/aest/students/modals/AssessApplicationChangeRequestModal.vue
+++ b/sources/packages/web/src/components/aest/students/modals/AssessApplicationChangeRequestModal.vue
@@ -101,7 +101,7 @@ export default defineComponent({
       if (!validationResult.valid) {
         return;
       }
-      resolvePromise({
+      await resolvePromise({
         note: note.value as string,
         applicationEditStatus: showParameter.value,
       });

--- a/sources/packages/web/src/components/aest/students/modals/AssessApplicationChangeRequestModal.vue
+++ b/sources/packages/web/src/components/aest/students/modals/AssessApplicationChangeRequestModal.vue
@@ -101,15 +101,10 @@ export default defineComponent({
       if (!validationResult.valid) {
         return;
       }
-      resolvePromise(
-        {
-          note: note.value as string,
-          applicationEditStatus: showParameter.value,
-        },
-        {
-          keepModalOpen: true,
-        },
-      );
+      resolvePromise({
+        note: note.value as string,
+        applicationEditStatus: showParameter.value,
+      });
       assessApplicationChangeRequestForm.value.reset();
     };
     return {

--- a/sources/packages/web/src/views/aest/StudentApplicationView.vue
+++ b/sources/packages/web/src/views/aest/StudentApplicationView.vue
@@ -268,7 +268,7 @@ export default defineComponent({
     /**
      * Show the modal for Ministry user confirmation of the
      * change request assessment.
-     * @param applicationChangeRequestStatus
+     * @param applicationChangeRequestStatus change request status.
      */
     const assessApplicationChangeRequest = async (
       applicationChangeRequestStatus:

--- a/sources/packages/web/src/views/aest/StudentApplicationView.vue
+++ b/sources/packages/web/src/views/aest/StudentApplicationView.vue
@@ -120,7 +120,7 @@ export default defineComponent({
     const selectedForm = ref();
     let applicationWizard: FormIOForm;
     const assessApplicationChangeRequestModal = ref(
-      {} as ModalDialog<ApplicationChangeRequestAPIInDTO | false>,
+      {} as ModalDialog<ApplicationChangeRequestAPIInDTO>,
     );
     const snackBar = useSnackBar();
     // Event emitter for application sidebar refresh.
@@ -265,64 +265,70 @@ export default defineComponent({
       document.getElementById(component.id)?.classList.add(cssClass);
     }
 
+    /**
+     * Show the modal for Ministry user confirmation of the
+     * change request assessment.
+     * @param applicationChangeRequestStatus
+     */
     const assessApplicationChangeRequest = async (
       applicationChangeRequestStatus:
         | ApplicationEditStatus.ChangedWithApproval
         | ApplicationEditStatus.ChangeDeclined,
     ) => {
-      const responseData =
-        await assessApplicationChangeRequestModal.value.showModal(
-          applicationChangeRequestStatus,
+      await assessApplicationChangeRequestModal.value.showModal(
+        applicationChangeRequestStatus,
+        processAssessApplicationChangeRequest,
+      );
+    };
+
+    /**
+     * Process the Ministry change request assessment.
+     * @param payload payload with the Ministry assessment.
+     * @returns returns true if the operation was succeeded and
+     * the modal can be close, otherwise keeps the modal open.
+     */
+    const processAssessApplicationChangeRequest = async (
+      payload: ApplicationChangeRequestAPIInDTO,
+    ): Promise<boolean> => {
+      try {
+        await ApplicationChangeRequestService.shared.assessApplicationChangeRequest(
+          props.versionApplicationId as number,
+          payload,
         );
-      if (responseData) {
-        try {
-          assessApplicationChangeRequestModal.value.loading = true;
-          await ApplicationChangeRequestService.shared.assessApplicationChangeRequest(
-            props.versionApplicationId as number,
-            responseData,
-          );
-          // When the change request is approved, the version application becomes the current application.
-          // But when the change request is declined, the current application remains the same.
-          const currentApplicationId =
-            applicationChangeRequestStatus ===
-            ApplicationEditStatus.ChangedWithApproval
-              ? props.versionApplicationId
-              : props.applicationId;
-          if (
-            applicationChangeRequestStatus ===
-            ApplicationEditStatus.ChangedWithApproval
-          ) {
-            snackBar.success("Change approved.");
-            // Redirect to the application details page with the current application ID only when the change is approved.
-            router.push({
-              name: AESTRoutesConst.APPLICATION_DETAILS,
-              params: {
-                applicationId: currentApplicationId,
-                studentId: props.studentId,
-              },
-            });
-          } else {
-            snackBar.success("Change declined.");
-          }
-          assessApplicationChangeRequestModal.value.hideModal();
-          // Hide the buttons after the change request is assessed.
-          showApplicationChangeAssessButtons.value = false;
-          // Emit the event to refresh the application sidebar after the application change request is assessed.
-          refreshApplicationSidebar();
-        } catch (error: unknown) {
-          if (
-            error instanceof ApiProcessError &&
-            error.errorType === INVALID_APPLICATION_EDIT_STATUS
-          ) {
-            snackBar.warn("Change cancelled by student.");
-          } else {
-            snackBar.error(
-              "Unexpected error while updating the application change request.",
-            );
-          }
-        } finally {
-          assessApplicationChangeRequestModal.value.loading = false;
+        if (
+          payload.applicationEditStatus ===
+          ApplicationEditStatus.ChangedWithApproval
+        ) {
+          snackBar.success("Change approved.");
+          // Redirect to the application details page with the current application ID only when the change is approved.
+          router.push({
+            name: AESTRoutesConst.APPLICATION_DETAILS,
+            params: {
+              // When the change request is approved, the version application becomes the current application.
+              applicationId: props.versionApplicationId,
+              studentId: props.studentId,
+            },
+          });
+        } else {
+          snackBar.success("Change declined.");
         }
+        // Hide the buttons after the change request is assessed.
+        showApplicationChangeAssessButtons.value = false;
+        // Emit the event to refresh the application sidebar after the application change request is assessed.
+        refreshApplicationSidebar();
+        return true;
+      } catch (error: unknown) {
+        if (
+          error instanceof ApiProcessError &&
+          error.errorType === INVALID_APPLICATION_EDIT_STATUS
+        ) {
+          snackBar.warn("Change cancelled by student.");
+        } else {
+          snackBar.error(
+            "Unexpected error while updating the application change request.",
+          );
+        }
+        return false;
       }
     };
 


### PR DESCRIPTION
- Minor fix while saving the change request to persist the change date (as pointed out in the previous PR).
- Modal refactor using the most recent practices to control modal processing, loading, and possible errors.

## E2E Tests

ApplicationChangeRequestAESTController(e2e)-assessApplicationChangeRequest
    √ Should approve a change request and copy the offering and appeal when the application change request is waiting for approval.
    √ Should approve a change request and copy the offering, and no appeals when the application change request is waiting for approval, and no appeals are present.
    √ Should be able to decline a change request and create a student note when the application change request is waiting for approval.
    √ Should throw a BadRequestException when the application change request approval has an invalid status.
    √ Should throw UnprocessableEntityException when the application change request was cancelled.
    √ Should throw NotFoundException when the application change request does not exist.
                                                                                                       