### PR TITLE
#4727 - Add OpenShift Spec to Crunchy-PostGres configuration

### DIFF
--- a/devops/helm/crunchy-postgres/templates/PostgresCluster.yaml
+++ b/devops/helm/crunchy-postgres/templates/PostgresCluster.yaml
@@ -6,6 +6,7 @@ metadata:
     {{ include "crunchy-postgres.labels" . | nindent 4 }}
     app.kubernetes.io/part-of: {{ template "crunchy-postgres.fullname" . }}
 spec:
+  openshift: true
   metadata:
     labels: 
       {{ include "crunchy-postgres.labels" . | nindent 6 }}


### PR DESCRIPTION
- adds configuration for detecting Crunchy availability in openshift, removing dependency on crunchy operator. 