### PR TITLE
#4438 - MSFAA Sequence Group update

### DIFF
--- a/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/esdc-integration/msfaa-integration/_tests_/msfaa-full-time-process-integration.scheduler.e2e-spec.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/esdc-integration/msfaa-integration/_tests_/msfaa-full-time-process-integration.scheduler.e2e-spec.ts
@@ -1,0 +1,154 @@
+import { DeepMocked } from "@golevelup/ts-jest";
+import { INestApplication } from "@nestjs/common";
+import { QueueNames, getISODateOnlyString } from "@sims/utilities";
+import {
+  createTestingAppModule,
+  describeProcessorRootTest,
+  mockBullJob,
+} from "../../../../../../test/helpers";
+import { FullTimeMSFAAProcessIntegrationScheduler } from "../msfaa-full-time-process-integration.scheduler";
+import { E2EDataSources, createE2EDataSources } from "@sims/test-utils";
+import { getUploadedFile } from "@sims/test-utils/mocks";
+import * as Client from "ssh2-sftp-client";
+import { In, IsNull } from "typeorm";
+import { saveMSFAATestInputsData } from "./msfaa-factory";
+import {
+  MSFAA_FULL_TIME_MARRIED,
+  MSFAA_FULL_TIME_OTHER_COUNTRY,
+  MSFAA_FULL_TIME_RELATIONSHIP_OTHER,
+} from "./msfaa-process-integration.scheduler.models";
+import { OfferingIntensity } from "@sims/sims-db";
+import {
+  createMSFAARequestContentSpyOnMock,
+  getMSFAASequenceGroupName,
+  getProcessDateFromMSFAARequestContent,
+} from "./msfaa-helper";
+import * as dayjs from "dayjs";
+
+describe(describeProcessorRootTest(QueueNames.FullTimeMSFAAIntegration), () => {
+  let app: INestApplication;
+  let processor: FullTimeMSFAAProcessIntegrationScheduler;
+  let db: E2EDataSources;
+  let sftpClientMock: DeepMocked<Client>;
+  let msfaaLifeTimeSequenceGroupName: string;
+
+  beforeAll(async () => {
+    const { nestApplication, dataSource, sshClientMock } =
+      await createTestingAppModule();
+    app = nestApplication;
+    db = createE2EDataSources(dataSource);
+    sftpClientMock = sshClientMock;
+    // Processor under test.
+    processor = app.get(FullTimeMSFAAProcessIntegrationScheduler);
+  });
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    // Expected life time sequence control group name.
+    msfaaLifeTimeSequenceGroupName = getMSFAASequenceGroupName(
+      OfferingIntensity.fullTime,
+    );
+    // Expected daily file sequence control group name.
+    const msfaaDailyFileSequenceGroupName = getMSFAASequenceGroupName(
+      OfferingIntensity.fullTime,
+      true,
+    );
+    // Reset MSFAA Full-time sequence number.
+    await db.sequenceControl.delete({
+      sequenceName: In([
+        msfaaLifeTimeSequenceGroupName,
+        msfaaDailyFileSequenceGroupName,
+      ]),
+    });
+    // Cancel any pending MSFAA.
+    await db.msfaaNumber.update(
+      { cancelledDate: IsNull() },
+      { cancelledDate: getISODateOnlyString(new Date()) },
+    );
+  });
+
+  it("Should generate an MSFAA Full-time file and update the dateRequested when there are pending MSFAA records.", async () => {
+    // Arrange
+    // Set the life time sequence value to ensure it is different from the file name sequence value.
+    const lifeTimeSequenceValue = "100";
+    await db.sequenceControl.insert({
+      sequenceName: msfaaLifeTimeSequenceGroupName,
+      sequenceNumber: lifeTimeSequenceValue,
+    });
+    const msfaaInputData = [
+      MSFAA_FULL_TIME_MARRIED,
+      MSFAA_FULL_TIME_OTHER_COUNTRY,
+      MSFAA_FULL_TIME_RELATIONSHIP_OTHER,
+    ];
+    const createdMSFAARecords = await saveMSFAATestInputsData(
+      db,
+      msfaaInputData,
+    );
+    // Queued job.
+    const mockedJob = mockBullJob<void>();
+    // Spy on the MSFAA content creation to intercept the process date and time used.
+    const createMSFAARequestContentMock =
+      createMSFAARequestContentSpyOnMock(app);
+
+    // Act
+    const result = await processor.processQueue(mockedJob.job);
+
+    // Assert
+    expect(createMSFAARequestContentMock).toHaveBeenCalledTimes(1);
+    const { processDate, processDateFormatted, processTimeFormatted } =
+      getProcessDateFromMSFAARequestContent(createMSFAARequestContentMock);
+    const uploadedFile = getUploadedFile(sftpClientMock);
+    // Assert file name with the sequence gap added.
+    expect(uploadedFile.remoteFilePath).toBe(
+      `MSFT-Request\\DPBC.EDU.MSFA.SENT.${processDateFormatted}.010`,
+    );
+    // Assert process result.
+    expect(result).toStrictEqual([
+      `Generated file: ${uploadedFile.remoteFilePath}`,
+      `Uploaded records: ${msfaaInputData.length}`,
+    ]);
+    // Assert file output.
+    expect(uploadedFile.fileLines?.length).toBe(msfaaInputData.length + 2);
+    const [
+      header,
+      msfaaFullTimeMarried,
+      msfaaFullTimeOtherCountry,
+      msfaaFullTimeRelationshipOther,
+      footer,
+    ] = uploadedFile.fileLines;
+    // Validate header.
+    expect(header).toBe(
+      `100BC  MSFAA SENT                              ${processDateFormatted}${processTimeFormatted}000101                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       `,
+    );
+    // Validate records.
+    expect(msfaaFullTimeMarried).toBe(
+      `2000000001000900000000PABCD19950630${processDateFormatted}Doe AAAAAAC              John EEEEIIII     MMNOOOOO Address Line 1                   UUUU Address Line 2                     Calgary                  AB  H1H 1H1         Canada              00000000001111111111john.doe@somedomain.com                                                                                                                                                                                                                    FT                                                                                                              `,
+    );
+    expect(msfaaFullTimeOtherCountry).toBe(
+      `2000000001001900000001PEFDG20000101${processDateFormatted}Other Doe aaaaaac        Jane eeeeiiii      Snooooo Address Line 1                                                           Some city in the United S                    United States       00000000000000000049jane.doe@somedomain.com                                                                                                                                                                                                                    FT                                                                                                              `,
+    );
+    expect(msfaaFullTimeRelationshipOther).toBe(
+      `2000000001002900000002PIHKL20011231${processDateFormatted}Other Doe uuuuyy         Other John ????   FOAddress Line 1                          Address Line 2                          Victoria                 BC  H1H 1H1         Canada              99999999999999999999jane.doe@someotherdomain.com                                                                                                                                                                                                               FT                                                                                                              `,
+    );
+    // Validate static footer.
+    expect(footer).toBe(
+      "999MSFAA SENT                              000000003000002700000003                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     ",
+    );
+
+    // Assert database changes.
+    // Find the updated MSFAA records previously created.
+    const msfaaIDs = createdMSFAARecords.map((msfaa) => msfaa.id);
+    const msfaaUpdatedRecords = await db.msfaaNumber.find({
+      select: {
+        dateRequested: true,
+      },
+      where: {
+        id: In(msfaaIDs),
+      },
+    });
+    const allMSFAAsHaveDateRequested = msfaaUpdatedRecords.every((msfaa) =>
+      dayjs(msfaa.dateRequested).isSame(processDate),
+    );
+    expect(allMSFAAsHaveDateRequested).toBe(true);
+  });
+});

--- a/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/esdc-integration/msfaa-integration/_tests_/msfaa-helper.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/esdc-integration/msfaa-integration/_tests_/msfaa-helper.ts
@@ -13,14 +13,18 @@ export const THROW_AWAY_MSFAA_NUMBER = "3000";
 /**
  * Creates the sequence group name by the offering intensity.
  * @param offeringIntensity offering intensity.
+ * @param isDailyFileSequence indicates if the sequence is for a daily file.
  * @returns the sequence group name by the offering intensity.
  */
 export function getMSFAASequenceGroupName(
   offeringIntensity: OfferingIntensity,
+  isDailyFileSequence = false,
 ): string {
-  return `MSFAA_${offeringIntensity}_SENT_FILE_${getISODateOnlyString(
-    new Date(),
-  )}`;
+  const sequenceName = `MSFAA_${offeringIntensity}_SENT_FILE`;
+  if (isDailyFileSequence) {
+    return `${sequenceName}_${getISODateOnlyString(new Date())}`;
+  }
+  return sequenceName;
 }
 
 /**

--- a/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/esdc-integration/msfaa-integration/_tests_/msfaa-part-time-process-integration.scheduler.e2e-spec.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/esdc-integration/msfaa-integration/_tests_/msfaa-part-time-process-integration.scheduler.e2e-spec.ts
@@ -32,6 +32,7 @@ describe(
     let processor: PartTimeMSFAAProcessIntegrationScheduler;
     let db: E2EDataSources;
     let sftpClientMock: DeepMocked<Client>;
+    let msfaaLifeTimeSequenceGroupName: string;
 
     beforeAll(async () => {
       const { nestApplication, dataSource, sshClientMock } =
@@ -46,7 +47,7 @@ describe(
     beforeEach(async () => {
       jest.clearAllMocks();
       // Expected life time sequence control group name.
-      const msfaaLifeTimeSequenceGroupName = getMSFAASequenceGroupName(
+      msfaaLifeTimeSequenceGroupName = getMSFAASequenceGroupName(
         OfferingIntensity.partTime,
       );
       // Expected daily file sequence control group name.
@@ -54,7 +55,7 @@ describe(
         OfferingIntensity.partTime,
         true,
       );
-      // Reset MSFAA part time number.
+      // Reset MSFAA Part-time sequence number.
       await db.sequenceControl.delete({
         sequenceName: In([
           msfaaLifeTimeSequenceGroupName,
@@ -68,8 +69,14 @@ describe(
       );
     });
 
-    it("Should generate an MSFAA part-time file and update the dateRequested when there are pending MSFAA records.", async () => {
+    it("Should generate an MSFAA Part-time file and update the dateRequested when there are pending MSFAA records.", async () => {
       // Arrange
+      // Set the life time sequence value to ensure it is different from the file name sequence value.
+      const lifeTimeSequenceValue = "100";
+      await db.sequenceControl.insert({
+        sequenceName: msfaaLifeTimeSequenceGroupName,
+        sequenceNumber: lifeTimeSequenceValue,
+      });
       const msfaaInputData = [
         MSFAA_PART_TIME_MARRIED,
         MSFAA_PART_TIME_OTHER_COUNTRY,
@@ -112,7 +119,7 @@ describe(
       ] = uploadedFile.fileLines;
       // Validate header.
       expect(header).toBe(
-        `100BC  MSFAA SENT                              ${processDateFormatted}${processTimeFormatted}000001                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       `,
+        `100BC  MSFAA SENT                              ${processDateFormatted}${processTimeFormatted}000101                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       `,
       );
       // Validate records.
       expect(msfaaPartTimeMarried).toBe(

--- a/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/esdc-integration/msfaa-integration/_tests_/msfaa-part-time-process-integration.scheduler.e2e-spec.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/esdc-integration/msfaa-integration/_tests_/msfaa-part-time-process-integration.scheduler.e2e-spec.ts
@@ -45,12 +45,22 @@ describe(
 
     beforeEach(async () => {
       jest.clearAllMocks();
-      // Expected sequence control group name.
-      const msfaaSequenceGroupName = getMSFAASequenceGroupName(
+      // Expected life time sequence control group name.
+      const msfaaLifeTimeSequenceGroupName = getMSFAASequenceGroupName(
         OfferingIntensity.partTime,
       );
+      // Expected daily file sequence control group name.
+      const msfaaDailyFileSequenceGroupName = getMSFAASequenceGroupName(
+        OfferingIntensity.partTime,
+        true,
+      );
       // Reset MSFAA part time number.
-      await db.sequenceControl.delete({ sequenceName: msfaaSequenceGroupName });
+      await db.sequenceControl.delete({
+        sequenceName: In([
+          msfaaLifeTimeSequenceGroupName,
+          msfaaDailyFileSequenceGroupName,
+        ]),
+      });
       // Cancel any pending MSFAA.
       await db.msfaaNumber.update(
         { cancelledDate: IsNull() },
@@ -84,7 +94,7 @@ describe(
         getProcessDateFromMSFAARequestContent(createMSFAARequestContentMock);
       const uploadedFile = getUploadedFile(sftpClientMock);
       expect(uploadedFile.remoteFilePath).toBe(
-        `MSFT-Request\\DPBC.EDU.MSFA.SENT.PT.${processDateFormatted}.010`,
+        `MSFT-Request\\DPBC.EDU.MSFA.SENT.PT.${processDateFormatted}.001`,
       );
       // Assert process result.
       expect(result).toStrictEqual([
@@ -102,7 +112,7 @@ describe(
       ] = uploadedFile.fileLines;
       // Validate header.
       expect(header).toBe(
-        `100BC  MSFAA SENT                              ${processDateFormatted}${processTimeFormatted}000010                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       `,
+        `100BC  MSFAA SENT                              ${processDateFormatted}${processTimeFormatted}000001                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       `,
       );
       // Validate records.
       expect(msfaaPartTimeMarried).toBe(

--- a/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/esdc-integration/msfaa-integration/_tests_/msfaa-process-integration.scheduler.models.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/esdc-integration/msfaa-integration/_tests_/msfaa-process-integration.scheduler.models.ts
@@ -29,7 +29,7 @@ export interface MSFAATestInputData {
   offeringIntensity: OfferingIntensity;
 }
 
-export const MSFAA_PART_TIME_MARRIED: MSFAATestInputData = {
+const MSFAA_STUDENT_MARRIED: Omit<MSFAATestInputData, "offeringIntensity"> = {
   msfaaNumber: "1000",
   sin: "900000000",
   institutionCode: "ABCD",
@@ -46,10 +46,12 @@ export const MSFAA_PART_TIME_MARRIED: MSFAATestInputData = {
   country: "Canada",
   phone: "1111111111",
   email: "john.doe@somedomain.com",
-  offeringIntensity: OfferingIntensity.partTime,
 };
 
-export const MSFAA_PART_TIME_OTHER_COUNTRY: MSFAATestInputData = {
+const MSFAA_STUDENT_OTHER_COUNTRY: Omit<
+  MSFAATestInputData,
+  "offeringIntensity"
+> = {
   msfaaNumber: "1001",
   sin: "900000001",
   institutionCode: "EFDG",
@@ -66,10 +68,12 @@ export const MSFAA_PART_TIME_OTHER_COUNTRY: MSFAATestInputData = {
   country: "United States",
   phone: "####4*****^%$#@$^9",
   email: "jane.doe@somedomain.com",
-  offeringIntensity: OfferingIntensity.partTime,
 };
 
-export const MSFAA_PART_TIME_RELATIONSHIP_OTHER: MSFAATestInputData = {
+const MSFAA_STUDENT_RELATIONSHIP_OTHER: Omit<
+  MSFAATestInputData,
+  "offeringIntensity"
+> = {
   msfaaNumber: "1002",
   sin: "900000002",
   institutionCode: "IHKL",
@@ -86,5 +90,34 @@ export const MSFAA_PART_TIME_RELATIONSHIP_OTHER: MSFAATestInputData = {
   country: "Canada",
   phone: "99999999999999999999",
   email: "jane.doe@someotherdomain.com",
+};
+
+export const MSFAA_PART_TIME_MARRIED: MSFAATestInputData = {
+  ...MSFAA_STUDENT_MARRIED,
   offeringIntensity: OfferingIntensity.partTime,
+};
+
+export const MSFAA_FULL_TIME_MARRIED: MSFAATestInputData = {
+  ...MSFAA_STUDENT_MARRIED,
+  offeringIntensity: OfferingIntensity.fullTime,
+};
+
+export const MSFAA_PART_TIME_OTHER_COUNTRY: MSFAATestInputData = {
+  ...MSFAA_STUDENT_OTHER_COUNTRY,
+  offeringIntensity: OfferingIntensity.partTime,
+};
+
+export const MSFAA_FULL_TIME_OTHER_COUNTRY: MSFAATestInputData = {
+  ...MSFAA_STUDENT_OTHER_COUNTRY,
+  offeringIntensity: OfferingIntensity.fullTime,
+};
+
+export const MSFAA_PART_TIME_RELATIONSHIP_OTHER: MSFAATestInputData = {
+  ...MSFAA_STUDENT_RELATIONSHIP_OTHER,
+  offeringIntensity: OfferingIntensity.partTime,
+};
+
+export const MSFAA_FULL_TIME_RELATIONSHIP_OTHER: MSFAATestInputData = {
+  ...MSFAA_STUDENT_RELATIONSHIP_OTHER,
+  offeringIntensity: OfferingIntensity.fullTime,
 };

--- a/sources/packages/backend/libs/integrations/src/esdc-integration/msfaa-integration/msfaa-request.processing.service.ts
+++ b/sources/packages/backend/libs/integrations/src/esdc-integration/msfaa-integration/msfaa-request.processing.service.ts
@@ -17,8 +17,8 @@ import { MSFAAIntegrationService } from "./msfaa.integration.service";
 import { ESDCFileHandler } from "../esdc-file-handler";
 import { ConfigService } from "@sims/utilities/config";
 import { MSFAANumberService } from "@sims/integrations/services";
-import { MSFAA_SEQUENCE_GAP } from "@sims/services/constants";
 import { CreateRequestFileNameResult } from "@sims/integrations/esdc-integration/models/esdc-integration.model";
+import { MSFAA_SEQUENCE_GAP } from "@sims/services/constants";
 
 @Injectable()
 export class MSFAARequestProcessingService extends ESDCFileHandler {
@@ -98,14 +98,6 @@ export class MSFAARequestProcessingService extends ESDCFileHandler {
           lifeTimeSequenceName,
           transactionalEntityManager,
           async (nextSequenceNumber: number) => {
-            if (offeringIntensity === OfferingIntensity.fullTime) {
-              // Applying MSFAA sequence gap only for Full-time MSFAA files to avoid conflict with legacy MSFAA files.
-              // This is not applicable for Part-time MSFAA files as there is no legacy MSFAA files for Part-time.
-              processSummary.info(
-                `Applying MSFAA sequence gap to the sequence number. Current sequence gap ${MSFAA_SEQUENCE_GAP}.`,
-              );
-              nextSequenceNumber += MSFAA_SEQUENCE_GAP;
-            }
             processSummary.info("Creating MSFAA request content.");
             // Create the Request content for the MSFAA file by populating the
             // header, footer and trailer content.
@@ -122,6 +114,14 @@ export class MSFAARequestProcessingService extends ESDCFileHandler {
           dailyFileNameSequenceName,
           transactionalEntityManager,
           async (nextSequenceNumber: number) => {
+            if (offeringIntensity === OfferingIntensity.fullTime) {
+              // Applying MSFAA sequence gap only for Full-time MSFAA files to avoid conflict with legacy MSFAA files.
+              // This is not applicable for Part-time MSFAA files as there is no legacy MSFAA files for Part-time.
+              processSummary.info(
+                `Applying MSFAA sequence gap to the sequence number. Current sequence gap ${MSFAA_SEQUENCE_GAP}.`,
+              );
+              nextSequenceNumber += MSFAA_SEQUENCE_GAP;
+            }
             // Create the request filename with the file path for the MSFAA Request
             // sent File.
             fileInfo = this.createRequestFileName(fileCode, nextSequenceNumber);

--- a/sources/packages/backend/libs/integrations/src/esdc-integration/msfaa-integration/msfaa-request.processing.service.ts
+++ b/sources/packages/backend/libs/integrations/src/esdc-integration/msfaa-integration/msfaa-request.processing.service.ts
@@ -109,7 +109,7 @@ export class MSFAARequestProcessingService extends ESDCFileHandler {
             );
           },
         );
-        // Create MSFSAA file name with daily file name sequence.
+        // Create MSFAA file name with daily file name sequence.
         await this.sequenceService.consumeNextSequenceWithExistingEntityManager(
           dailyFileNameSequenceName,
           transactionalEntityManager,

--- a/sources/packages/backend/libs/integrations/src/esdc-integration/msfaa-integration/msfaa.integration.service.ts
+++ b/sources/packages/backend/libs/integrations/src/esdc-integration/msfaa-integration/msfaa.integration.service.ts
@@ -46,7 +46,7 @@ export class MSFAAIntegrationService extends SFTPIntegrationBase<MSFAASFTPRespon
    * Header, Detail and trailer records.
    * @param msfaaRecords - MSFAA, Student, User and application.
    * objects data.
-   * @param fileSequence unique file sequence.
+   * @param lifeTimeSequence life time sequence number.
    * @param totalSINHash sum hash total of the Student's SIN.
    * @param processDate process date to be added to the generated content.
    * @returns Complete MSFAAFileLines appending the header, footer
@@ -54,7 +54,7 @@ export class MSFAAIntegrationService extends SFTPIntegrationBase<MSFAASFTPRespon
    */
   createMSFAARequestContent(
     msfaaRecords: MSFAARecord[],
-    fileSequence: number,
+    lifeTimeSequence: number,
     totalSINHash: number,
     processDate: Date,
   ): MSFAARequestFileLine[] {
@@ -63,7 +63,7 @@ export class MSFAAIntegrationService extends SFTPIntegrationBase<MSFAASFTPRespon
     const msfaaHeader = new MSFAAFileHeader();
     msfaaHeader.transactionCode = RecordTypeCodes.MSFAAHeader;
     msfaaHeader.processDate = processDate;
-    msfaaHeader.sequence = fileSequence;
+    msfaaHeader.sequence = lifeTimeSequence;
     msfaaFileLines.push(msfaaHeader);
     // Detail records
     const fileRecords = msfaaRecords.map((msfaaRecord) => {


### PR DESCRIPTION
## MSFAA Sequences update

### Release instructions

Note:  Please coordinate with the business to set the life-time sequence number as a part of release instructions for the Full-time and Part-time sequence groups.

### MSFAA lifetime sequence

- [x] Based on the sequence group name `MSFAA_${offeringIntensity}_SENT_FILE` updated the MSFAA header for PT and FT to include a lifetime sequence number.

 Full time: 

![image](https://github.com/user-attachments/assets/d02bc138-c6be-4b6c-87b3-f046d0818758)

![image](https://github.com/user-attachments/assets/48cd750b-55d6-474f-8aad-9d5c0d8e66b9)


Part Time: 

![image](https://github.com/user-attachments/assets/0a93ddc7-8ec9-4ab7-be1b-db9a2b0b9184)

![image](https://github.com/user-attachments/assets/35c81a91-d7fc-4e81-a91c-132e08763129)

## MSFAA Daily filename sequence

- [x] Daily filename sequence is an existing sequence where a sequence gap has been added to the daily file name sequence to avoid the conflict with legacy. This sequence gap has been removed for Part-time as the legacy MSFAA generation is no longer applicable to it. But the Full-time MSFAA still has the sequence gap added.

Full time: 

![image](https://github.com/user-attachments/assets/ee925018-8697-4a90-8d2f-80a27728bff7)

![image](https://github.com/user-attachments/assets/c6e1cf72-c5a7-4927-b6e4-5c58340d6007)

Part time: 

![image](https://github.com/user-attachments/assets/b7655763-b07c-453c-805f-81919921aabd)

![image](https://github.com/user-attachments/assets/513c1c82-cd52-488a-b29c-624b553f6cb6)

## E2E Tests

- [x] Updated the PT E2E Test
- [x] Added a FT E2E Test
