### PR TITLE
#4445 - Program deactivate action bug fix

### DIFF
--- a/sources/packages/web/src/components/common/ProgramDetails.vue
+++ b/sources/packages/web/src/components/common/ProgramDetails.vue
@@ -33,12 +33,7 @@
           >
             <template #="{ notAllowed }">
               <v-list-item
-                :disabled="
-                  !educationProgram.isActive ||
-                  educationProgram.isExpired ||
-                  isReadOnlyUser(locationId) ||
-                  notAllowed
-                "
+                :disabled="isProgramDeactivationDisabled || notAllowed"
                 base-color="danger"
                 @click="deactivate"
                 title="Deactivate"
@@ -117,7 +112,7 @@
 
 <script lang="ts">
 import { useRouter } from "vue-router";
-import { computed, defineComponent, ref } from "vue";
+import { computed, defineComponent, PropType, ref } from "vue";
 import {
   InstitutionRoutesConst,
   AESTRoutesConst,
@@ -154,7 +149,7 @@ export default defineComponent({
       required: true,
     },
     educationProgram: {
-      type: Object,
+      type: Object as PropType<EducationProgramAPIOutDTO>,
       required: true,
       default: {} as EducationProgramAPIOutDTO,
     },
@@ -165,6 +160,14 @@ export default defineComponent({
     const { isReadOnlyUser } = useInstitutionAuth();
     const deactivateEducationProgramModal = ref(
       {} as ModalDialog<DeactivateProgramAPIInDTO | boolean>,
+    );
+
+    const isProgramDeactivationDisabled = computed<boolean>(
+      () =>
+        !props.educationProgram.isActive ||
+        props.educationProgram.isExpired ||
+        (AuthService.shared.authClientType === ClientIdType.Institution &&
+          isReadOnlyUser(props.locationId)),
     );
 
     const programActionLabel = computed(() => {
@@ -229,7 +232,7 @@ export default defineComponent({
     };
 
     return {
-      isReadOnlyUser,
+      isProgramDeactivationDisabled,
       goToProgram,
       ProgramIntensity,
       programActionLabel,


### PR DESCRIPTION
## Bug fix on common component shared between Institutions and Ministry

### Root Cause
- The common component has a condition to disable the `Deactivate` button based on the institution user data from institution store. This condition results in a runtime error when the component is loaded from a ministry user view because of the absence of Institution store and so the institution user data. 

## Solution
- Validation of institution user data is applied conditionally when the user type is `Institution` skipping the same for a ministry view. 
Note: We generally avoid using the auth client type based logic in the components `AuthService.shared.authClientType === ClientIdType.Institution`. But this component being very old and already using similar condition in other places, the auth client type is used here as quick solution. 

### Outcome Ministry

![image](https://github.com/user-attachments/assets/b7dab337-8ddf-4fb2-97ae-8569fa550ce2)


### Outcome Institution(No changes introduced here by PR)

![image](https://github.com/user-attachments/assets/e9508d61-078a-48de-b017-500611f86ba5)


