### PR TITLE
#4652 - PR 1: Convert currency inputs to number-currency

### DIFF
--- a/sources/packages/forms/src/form-definitions/partnerinformationandincomeappeal.json
+++ b/sources/packages/forms/src/form-definitions/partnerinformationandincomeappeal.json
@@ -180,25 +180,25 @@
         {
           "label": "Enter your spouse/common-law partner's reported total income from line 15000 of their {{data.calculatedTaxYear}} income tax return. If they did not file a {{data.calculatedTaxYear}} income tax return, enter their total income from all sources both inside and outside of Canada.",
           "prefix": "$",
-          "customClass": "font-weight-bold",
+          "applyMaskOn": "change",
           "mask": false,
-          "spellcheck": true,
           "tableView": false,
-          "currency": "CAD",
+          "delimiter": true,
+          "requireDecimal": false,
           "inputFormat": "plain",
+          "truncateMultipleSpaces": false,
           "validate": {
-            "required": true
+            "required": true,
+            "custom": "valid = (input >= 0 && input < data.maxIncome) ? true : 'The number you have entered is outside the expected range.';"
           },
+          "validateWhenHidden": false,
           "key": "partnerEstimatedIncome",
           "conditional": {
-            "show": "true"
+            "show": true
           },
-          "type": "currency",
-          "input": true,
-          "delimiter": true,
-          "inputType": "text",
+          "type": "number",
           "decimalLimit": 0,
-          "requireDecimal": false
+          "input": true
         }
       ],
       "allowPrevious": false,
@@ -332,29 +332,27 @@
             {
               "label": "My spouse/common-law partner's current year gross income is:",
               "prefix": "$",
-              "customClass": "font-weight-bold",
+              "applyMaskOn": "change",
               "mask": false,
-              "spellcheck": true,
               "tableView": false,
-              "currency": "CAD",
+              "delimiter": true,
+              "requireDecimal": false,
               "inputFormat": "plain",
+              "truncateMultipleSpaces": false,
               "validate": {
                 "required": true,
-                "custom": "valid = (input >= 0 && input < data.maxMoneyValue) ? true : 'The number you have entered is outside the expected range.';"
+                "custom": "valid = (input >= 0 && input < data.maxIncome) ? true : 'The number you have entered is outside the expected range.';"
               },
+              "validateWhenHidden": false,
               "key": "currentYearPartnerIncome",
               "conditional": {
-                "show": "true",
+                "show": true,
                 "when": "hasCurrentYearPartnerIncome",
                 "eq": "yes"
               },
-              "type": "currency",
-              "input": true,
-              "delimiter": true,
-              "inputType": "text",
+              "type": "number",
               "decimalLimit": 0,
-              "requireDecimal": false,
-              "lockKey": true
+              "input": true
             },
             {
               "label": "Select the reason for your spouse/common-law partner's significant decrease in gross income:",

--- a/sources/packages/forms/src/form-definitions/partnerinformationandincomeappeal.json
+++ b/sources/packages/forms/src/form-definitions/partnerinformationandincomeappeal.json
@@ -189,7 +189,7 @@
           "truncateMultipleSpaces": false,
           "validate": {
             "required": true,
-            "custom": "valid = (input >= 0 && input < data.maxIncome) ? true : 'The number you have entered is outside the expected range.';"
+            "custom": "valid = (input >= 0 && input < data.maxMoneyValue) ? true : 'The number you have entered is outside the expected range.';"
           },
           "validateWhenHidden": false,
           "key": "partnerEstimatedIncome",
@@ -341,7 +341,7 @@
               "truncateMultipleSpaces": false,
               "validate": {
                 "required": true,
-                "custom": "valid = (input >= 0 && input < data.maxIncome) ? true : 'The number you have entered is outside the expected range.';"
+                "custom": "valid = (input >= 0 && input < data.maxMoneyValue) ? true : 'The number you have entered is outside the expected range.';"
               },
               "validateWhenHidden": false,
               "key": "currentYearPartnerIncome",

--- a/sources/packages/forms/src/form-definitions/reportscholasticstandingchange.json
+++ b/sources/packages/forms/src/form-definitions/reportscholasticstandingchange.json
@@ -1201,22 +1201,22 @@
                           "label": "Tuition",
                           "prefix": "$",
                           "customClass": "font-weight-bold w-50",
+                          "applyMaskOn": "change",
                           "mask": false,
-                          "spellcheck": true,
                           "tableView": false,
-                          "currency": "USD",
+                          "delimiter": true,
+                          "requireDecimal": false,
                           "inputFormat": "plain",
                           "truncateMultipleSpaces": false,
                           "validate": {
-                            "required": true
+                            "required": true,
+                            "custom": "valid = (input >= 0 && input < data.maxIncome) ? true : 'The number you have entered is outside the expected range.';"
                           },
+                          "validateWhenHidden": false,
                           "key": "tuition",
-                          "type": "currency",
-                          "input": true,
-                          "delimiter": true,
-                          "inputType": "text",
-                          "decimalLimit": 2,
-                          "requireDecimal": true
+                          "type": "number",
+                          "decimalLimit": 0,
+                          "input": true
                         }
                       ],
                       "width": 6,
@@ -1231,22 +1231,23 @@
                         {
                           "label": "Mandatory fees",
                           "prefix": "$",
+                          "applyMaskOn": "change",
                           "customClass": "font-weight-bold w-50",
                           "mask": false,
-                          "spellcheck": true,
                           "tableView": false,
-                          "currency": "USD",
-                          "inputFormat": "plain",
-                          "validate": {
-                            "required": true
-                          },
-                          "key": "mandatoryFees",
-                          "type": "currency",
-                          "input": true,
                           "delimiter": true,
-                          "inputType": "text",
-                          "decimalLimit": 2,
-                          "requireDecimal": true
+                          "requireDecimal": false,
+                          "inputFormat": "plain",
+                          "truncateMultipleSpaces": false,
+                          "validate": {
+                            "required": true,
+                            "custom": "valid = (input >= 0 && input < data.maxIncome) ? true : 'The number you have entered is outside the expected range.';"
+                          },
+                          "validateWhenHidden": false,
+                          "key": "mandatoryFees",
+                          "type": "number",
+                          "decimalLimit": 0,
+                          "input": true
                         }
                       ],
                       "width": 6,
@@ -1271,23 +1272,23 @@
                         {
                           "label": "Books and supplies",
                           "prefix": "$",
+                          "applyMaskOn": "change",
                           "customClass": "font-weight-bold w-50",
                           "mask": false,
-                          "spellcheck": true,
                           "tableView": false,
-                          "currency": "USD",
+                          "delimiter": true,
+                          "requireDecimal": false,
                           "inputFormat": "plain",
                           "truncateMultipleSpaces": false,
                           "validate": {
-                            "required": true
+                            "required": true,
+                            "custom": "valid = (input >= 0 && input < data.maxIncome) ? true : 'The number you have entered is outside the expected range.';"
                           },
+                          "validateWhenHidden": false,
                           "key": "booksAndSupplies",
-                          "type": "currency",
-                          "input": true,
-                          "delimiter": true,
-                          "inputType": "text",
-                          "decimalLimit": 2,
-                          "requireDecimal": true
+                          "type": "number",
+                          "decimalLimit": 0,
+                          "input": true
                         }
                       ],
                       "width": 6,
@@ -1302,23 +1303,23 @@
                         {
                           "label": "Exceptional costs",
                           "prefix": "$",
+                          "applyMaskOn": "change",
                           "customClass": "font-weight-bold w-50",
                           "mask": false,
-                          "spellcheck": true,
                           "tableView": false,
-                          "currency": "USD",
+                          "delimiter": true,
+                          "requireDecimal": false,
                           "inputFormat": "plain",
                           "truncateMultipleSpaces": false,
                           "validate": {
-                            "required": true
+                            "required": true,
+                            "custom": "valid = (input >= 0 && input < data.maxIncome) ? true : 'The number you have entered is outside the expected range.';"
                           },
+                          "validateWhenHidden": false,
                           "key": "exceptionalCosts",
-                          "type": "currency",
-                          "input": true,
-                          "delimiter": true,
-                          "inputType": "text",
-                          "decimalLimit": 2,
-                          "requireDecimal": true
+                          "type": "number",
+                          "decimalLimit": 0,
+                          "input": true
                         }
                       ],
                       "width": 6,

--- a/sources/packages/forms/src/form-definitions/reportscholasticstandingchange.json
+++ b/sources/packages/forms/src/form-definitions/reportscholasticstandingchange.json
@@ -27,6 +27,17 @@
       "isNew": false
     },
     {
+      "input": true,
+      "tableView": false,
+      "key": "maxMoneyValue",
+      "label": "Max Money Value",
+      "persistent": false,
+      "type": "hidden",
+      "lockKey": true,
+      "calculateValue": "value = 100000000;",
+      "calculateServer": true
+    },
+    {
       "label": "Offering Intensity (Part Time or Full Time) - Used to define custom labels",
       "key": "applicationOfferingIntensity",
       "type": "hidden",

--- a/sources/packages/forms/src/form-definitions/reportscholasticstandingchange.json
+++ b/sources/packages/forms/src/form-definitions/reportscholasticstandingchange.json
@@ -1210,7 +1210,7 @@
                           "truncateMultipleSpaces": false,
                           "validate": {
                             "required": true,
-                            "custom": "valid = (input >= 0 && input < data.maxIncome) ? true : 'The number you have entered is outside the expected range.';"
+                            "custom": "valid = (input >= 0 && input < data.maxMoneyValue) ? true : 'The number you have entered is outside the expected range.';"
                           },
                           "validateWhenHidden": false,
                           "key": "tuition",
@@ -1241,7 +1241,7 @@
                           "truncateMultipleSpaces": false,
                           "validate": {
                             "required": true,
-                            "custom": "valid = (input >= 0 && input < data.maxIncome) ? true : 'The number you have entered is outside the expected range.';"
+                            "custom": "valid = (input >= 0 && input < data.maxMoneyValue) ? true : 'The number you have entered is outside the expected range.';"
                           },
                           "validateWhenHidden": false,
                           "key": "mandatoryFees",
@@ -1282,7 +1282,7 @@
                           "truncateMultipleSpaces": false,
                           "validate": {
                             "required": true,
-                            "custom": "valid = (input >= 0 && input < data.maxIncome) ? true : 'The number you have entered is outside the expected range.';"
+                            "custom": "valid = (input >= 0 && input < data.maxMoneyValue) ? true : 'The number you have entered is outside the expected range.';"
                           },
                           "validateWhenHidden": false,
                           "key": "booksAndSupplies",
@@ -1313,7 +1313,7 @@
                           "truncateMultipleSpaces": false,
                           "validate": {
                             "required": true,
-                            "custom": "valid = (input >= 0 && input < data.maxIncome) ? true : 'The number you have entered is outside the expected range.';"
+                            "custom": "valid = (input >= 0 && input < data.maxMoneyValue) ? true : 'The number you have entered is outside the expected range.';"
                           },
                           "validateWhenHidden": false,
                           "key": "exceptionalCosts",

--- a/sources/packages/forms/src/form-definitions/sfaa2024-25.json
+++ b/sources/packages/forms/src/form-definitions/sfaa2024-25.json
@@ -7555,7 +7555,7 @@
                   "inputFormat": "plain",
                   "truncateMultipleSpaces": false,
                   "validate": {
-                    "required": true,
+                    "required": false,
                     "custom": "valid = (input >= 0 && input < data.maxIncome) ? true : 'The number you have entered is outside the expected range.';"
                   },
                   "validateWhenHidden": false,

--- a/sources/packages/forms/src/form-definitions/sfaa2024-25.json
+++ b/sources/packages/forms/src/form-definitions/sfaa2024-25.json
@@ -392,7 +392,6 @@
                   "hideLabel": true,
                   "tableView": false,
                   "defaultValue": {
-                    "z": false,
                     "programnotListed": false
                   },
                   "values": [
@@ -4019,28 +4018,27 @@
             {
               "label": "Enter your spouse/common-law partner's reported total income from line 15000 of their {{data.calculatedTaxYear}} income tax return. If they did not file a {{data.calculatedTaxYear}} income tax return, enter their total income from all sources both inside and outside of Canada.",
               "prefix": "$",
-              "customClass": "font-weight-bold",
+              "applyMaskOn": "change",
               "mask": false,
-              "spellcheck": true,
               "tableView": false,
-              "currency": "CAD",
+              "delimiter": true,
+              "requireDecimal": false,
               "inputFormat": "plain",
+              "truncateMultipleSpaces": false,
               "validate": {
                 "required": true,
                 "custom": "valid = (input >= 0 && input < data.maxIncome) ? true : 'The number you have entered is outside the expected range.';"
               },
+              "validateWhenHidden": false,
               "key": "estimatedSpouseIncome",
               "conditional": {
-                "show": "true",
+                "show": true,
                 "when": "hasCurrentYearPartnerIncome",
                 "eq": "no"
               },
-              "type": "currency",
-              "input": true,
-              "delimiter": true,
-              "inputType": "text",
+              "type": "number",
               "decimalLimit": 0,
-              "requireDecimal": false
+              "input": true
             },
             {
               "key": "partnerIncomePanelPanel",
@@ -4065,21 +4063,24 @@
                   "tableView": false
                 },
                 {
-                  "input": true,
-                  "tableView": true,
-                  "inputType": "text",
                   "label": "My spouse/common-law partner's current year gross income is:",
-                  "key": "currentYearPartnerIncome",
                   "prefix": "$",
+                  "applyMaskOn": "change",
+                  "mask": false,
+                  "tableView": false,
                   "delimiter": true,
-                  "decimalLimit": 0,
                   "requireDecimal": false,
+                  "inputFormat": "plain",
+                  "truncateMultipleSpaces": false,
                   "validate": {
                     "required": true,
-                    "custom": "valid = (input >= 0 && input <= data.maxIncome) ? true : 'The number you have entered is outside the expected range.';"
+                    "custom": "valid = (input >= 0 && input < data.maxIncome) ? true : 'The number you have entered is outside the expected range.';"
                   },
-                  "type": "currency",
-                  "lockKey": true
+                  "validateWhenHidden": false,
+                  "key": "currentYearPartnerIncome",
+                  "type": "number",
+                  "decimalLimit": 0,
+                  "input": true
                 },
                 {
                   "input": true,
@@ -4659,26 +4660,27 @@
                 {
                   "label": "Enter amount that your partner will pay during your study period.",
                   "prefix": "$",
+                  "applyMaskOn": "change",
                   "mask": false,
-                  "spellcheck": true,
                   "tableView": false,
-                  "currency": "CAD",
+                  "delimiter": true,
+                  "requireDecimal": false,
                   "inputFormat": "plain",
+                  "truncateMultipleSpaces": false,
                   "validate": {
-                    "required": true
+                    "required": true,
+                    "custom": "valid = (input >= 0 && input < data.maxIncome) ? true : 'The number you have entered is outside the expected range.';"
                   },
+                  "validateWhenHidden": false,
                   "key": "partnerstudentloanCosts",
                   "conditional": {
                     "show": true,
                     "when": "partnerstudentLoan",
                     "eq": "yes"
                   },
-                  "type": "currency",
-                  "input": true,
-                  "delimiter": true,
-                  "inputType": "text",
-                  "decimalLimit": 2,
-                  "requireDecimal": true
+                  "type": "number",
+                  "decimalLimit": 0,
+                  "input": true
                 }
               ],
               "allowPrevious": false
@@ -4740,26 +4742,27 @@
                 {
                   "label": "Enter amount that your partner will pay during your study period.",
                   "prefix": "$",
+                  "applyMaskOn": "change",
                   "mask": false,
-                  "spellcheck": true,
                   "tableView": false,
-                  "currency": "CAD",
+                  "delimiter": true,
+                  "requireDecimal": false,
                   "inputFormat": "plain",
+                  "truncateMultipleSpaces": false,
                   "validate": {
-                    "required": true
+                    "required": true,
+                    "custom": "valid = (input >= 0 && input < data.maxIncome) ? true : 'The number you have entered is outside the expected range.';"
                   },
+                  "validateWhenHidden": false,
                   "key": "partnerchildsupportCosts",
                   "conditional": {
                     "show": true,
                     "when": "partnerchildSupport",
                     "eq": "yes"
                   },
-                  "type": "currency",
-                  "input": true,
-                  "delimiter": true,
-                  "inputType": "text",
-                  "decimalLimit": 2,
-                  "requireDecimal": true
+                  "type": "number",
+                  "decimalLimit": 0,
+                  "input": true
                 }
               ],
               "allowPrevious": false
@@ -5077,66 +5080,62 @@
                 {
                   "label": "How much will your parent(s)/step-parent/sponsor/legal guardian be giving you to help meet your specific educational costs during this study period?",
                   "prefix": "$",
+                  "applyMaskOn": "change",
                   "mask": false,
-                  "spellcheck": true,
                   "tableView": false,
-                  "currency": "CAD",
-                  "inputFormat": "plain",
-                  "truncateMultipleSpaces": false,
-                  "validate": {
-                    "required": true
-                  },
-                  "key": "studentParentsNetContribution",
-                  "type": "currency",
-                  "input": true,
                   "delimiter": true,
-                  "inputType": "text",
-                  "decimalLimit": 2,
-                  "requireDecimal": true,
-                  "lockKey": true
-                },
-                {
-                  "label": "Enter the reported total income from line 15000 of your parent(s)/step-parent/sponsor/legal guardian {{data.calculatedTaxYear}} income tax return. If they did not file a {{data.calculatedTaxYear}} income tax return, enter the total income from all sources both inside and outside of Canada.",
-                  "prefix": "$",
-                  "mask": false,
-                  "spellcheck": true,
-                  "tableView": false,
-                  "currency": "CAD",
+                  "requireDecimal": false,
                   "inputFormat": "plain",
                   "truncateMultipleSpaces": false,
                   "validate": {
                     "required": true,
                     "custom": "valid = (input >= 0 && input < data.maxIncome) ? true : 'The number you have entered is outside the expected range.';"
                   },
-                  "key": "studentParentsTotalIncome",
-                  "type": "currency",
-                  "input": true,
+                  "validateWhenHidden": false,
+                  "key": "studentParentsNetContribution",
+                  "type": "number",
+                  "decimalLimit": 0,
+                  "input": true
+                },
+                {
+                  "label": "Enter the reported total income from line 15000 of your parent(s)/step-parent/sponsor/legal guardian {{data.calculatedTaxYear}} income tax return. If they did not file a {{data.calculatedTaxYear}} income tax return, enter the total income from all sources both inside and outside of Canada.",
+                  "prefix": "$",
+                  "applyMaskOn": "change",
+                  "mask": false,
+                  "tableView": false,
                   "delimiter": true,
-                  "inputType": "text",
-                  "decimalLimit": 2,
                   "requireDecimal": false,
-                  "lockKey": true
+                  "inputFormat": "plain",
+                  "truncateMultipleSpaces": false,
+                  "validate": {
+                    "required": true,
+                    "custom": "valid = (input >= 0 && input < data.maxIncome) ? true : 'The number you have entered is outside the expected range.';"
+                  },
+                  "validateWhenHidden": false,
+                  "key": "studentParentsTotalIncome",
+                  "type": "number",
+                  "decimalLimit": 0,
+                  "input": true
                 },
                 {
                   "label": "Enter the total net value of all Canadian and foreign assets (do not include RRSPs, principal residence or business). Enter ‘0’ if none.",
                   "prefix": "$",
+                  "applyMaskOn": "change",
                   "mask": false,
-                  "spellcheck": true,
                   "tableView": false,
-                  "currency": "CAD",
+                  "delimiter": true,
+                  "requireDecimal": false,
                   "inputFormat": "plain",
                   "truncateMultipleSpaces": false,
                   "validate": {
-                    "required": true
+                    "required": true,
+                    "custom": "valid = (input >= 0 && input < data.maxIncome) ? true : 'The number you have entered is outside the expected range.';"
                   },
+                  "validateWhenHidden": false,
                   "key": "studentParentsNetAssests",
-                  "type": "currency",
-                  "input": true,
-                  "delimiter": true,
-                  "inputType": "text",
-                  "decimalLimit": 2,
-                  "requireDecimal": true,
-                  "lockKey": true
+                  "type": "number",
+                  "decimalLimit": 0,
+                  "input": true
                 },
                 {
                   "label": "HTML",
@@ -5970,23 +5969,22 @@
             {
               "label": "My total income in {{data.calculatedTaxYear}} was:",
               "prefix": "$",
-              "customClass": "font-weight-bold",
+              "applyMaskOn": "change",
               "mask": false,
-              "spellcheck": true,
               "tableView": false,
-              "currency": "CAD",
+              "delimiter": true,
+              "requireDecimal": false,
               "inputFormat": "plain",
+              "truncateMultipleSpaces": false,
               "validate": {
                 "required": true,
                 "custom": "valid = (input >= 0 && input < data.maxIncome) ? true : 'The number you have entered is outside the expected range.';"
               },
+              "validateWhenHidden": false,
               "key": "taxReturnIncome",
-              "type": "currency",
-              "input": true,
-              "delimiter": true,
-              "inputType": "text",
+              "type": "number",
               "decimalLimit": 0,
-              "requireDecimal": false
+              "input": true
             },
             {
               "title": "CRA consent panel",
@@ -6283,29 +6281,27 @@
                 {
                   "label": "My total current year gross income is:",
                   "prefix": "$",
-                  "customClass": "font-weight-bold",
+                  "applyMaskOn": "change",
                   "mask": false,
-                  "spellcheck": true,
                   "tableView": false,
-                  "currency": "CAD",
+                  "delimiter": true,
+                  "requireDecimal": false,
                   "inputFormat": "plain",
+                  "truncateMultipleSpaces": false,
                   "validate": {
                     "required": true,
                     "custom": "valid = (input >= 0 && input < data.maxIncome) ? true : 'The number you have entered is outside the expected range.';"
                   },
+                  "validateWhenHidden": false,
                   "key": "currentYearIncome",
                   "conditional": {
-                    "show": "true",
+                    "show": true,
                     "when": "hasSignificantDegreeOfIncome",
                     "eq": "yes"
                   },
-                  "type": "currency",
-                  "input": true,
-                  "delimiter": true,
-                  "inputType": "text",
+                  "type": "number",
                   "decimalLimit": 0,
-                  "requireDecimal": false,
-                  "lockKey": true
+                  "input": true
                 },
                 {
                   "label": "Select the reason for your significant decrease in gross income.",
@@ -6985,27 +6981,27 @@
                 {
                   "label": "What are the daycare costs that you incur for your child(ren) age 11 years or under?",
                   "prefix": "$",
+                  "applyMaskOn": "change",
                   "mask": false,
-                  "spellcheck": true,
                   "tableView": false,
-                  "currency": "CAD",
+                  "delimiter": true,
+                  "requireDecimal": false,
                   "inputFormat": "plain",
                   "truncateMultipleSpaces": false,
                   "validate": {
-                    "required": true
+                    "required": true,
+                    "custom": "valid = (input >= 0 && input < data.maxIncome) ? true : 'The number you have entered is outside the expected range.';"
                   },
+                  "validateWhenHidden": false,
                   "key": "daycareCosts11YearsOrUnder",
                   "conditional": {
                     "show": true,
                     "when": "haveDaycareCosts11YearsOrUnder",
                     "eq": "yes"
                   },
-                  "type": "currency",
-                  "input": true,
-                  "delimiter": true,
-                  "inputType": "text",
-                  "decimalLimit": 2,
-                  "requireDecimal": true
+                  "type": "number",
+                  "decimalLimit": 0,
+                  "input": true
                 }
               ],
               "allowPrevious": false
@@ -7068,27 +7064,27 @@
                 {
                   "label": "What are the total unsubsidized day-care costs during class hours for the proposed study period for disabled/infirm dependants 12 years of age and older?",
                   "prefix": "$",
+                  "applyMaskOn": "change",
                   "mask": false,
-                  "spellcheck": true,
                   "tableView": false,
-                  "currency": "CAD",
+                  "delimiter": true,
+                  "requireDecimal": false,
                   "inputFormat": "plain",
                   "truncateMultipleSpaces": false,
                   "validate": {
-                    "required": true
+                    "required": true,
+                    "custom": "valid = (input >= 0 && input < data.maxIncome) ? true : 'The number you have entered is outside the expected range.';"
                   },
+                  "validateWhenHidden": false,
                   "key": "daycareCosts12YearsOrOver",
                   "conditional": {
                     "show": true,
                     "when": "haveDaycareCosts12YearsOrOver",
                     "eq": "yes"
                   },
-                  "type": "currency",
-                  "input": true,
-                  "delimiter": true,
-                  "inputType": "text",
-                  "decimalLimit": 2,
-                  "requireDecimal": true
+                  "type": "number",
+                  "decimalLimit": 0,
+                  "input": true
                 }
               ],
               "allowPrevious": false
@@ -7151,27 +7147,27 @@
                 {
                   "label": "Enter the amount that you will pay during your study period.",
                   "prefix": "$",
+                  "applyMaskOn": "change",
                   "mask": false,
-                  "spellcheck": true,
                   "tableView": false,
-                  "currency": "CAD",
+                  "delimiter": true,
+                  "requireDecimal": false,
                   "inputFormat": "plain",
                   "truncateMultipleSpaces": false,
                   "validate": {
-                    "required": true
+                    "required": true,
+                    "custom": "valid = (input >= 0 && input < data.maxIncome) ? true : 'The number you have entered is outside the expected range.';"
                   },
+                  "validateWhenHidden": false,
                   "key": "childsupportCosts",
                   "conditional": {
                     "show": true,
                     "when": "childSupport",
                     "eq": "yes"
                   },
-                  "type": "currency",
-                  "input": true,
-                  "delimiter": true,
-                  "inputType": "text",
-                  "decimalLimit": 2,
-                  "requireDecimal": true
+                  "type": "number",
+                  "decimalLimit": 0,
+                  "input": true
                 }
               ],
               "allowPrevious": false
@@ -7256,28 +7252,27 @@
                 {
                   "label": "Enter the amount that you will receive from merit-based scholarships or need-based bursaries (including provincial government scholarships) during your study period.",
                   "prefix": "$",
-                  "customClass": "font-weight-bold",
+                  "applyMaskOn": "change",
                   "mask": false,
-                  "spellcheck": true,
                   "tableView": false,
-                  "currency": "CAD",
+                  "delimiter": true,
+                  "requireDecimal": false,
                   "inputFormat": "plain",
                   "truncateMultipleSpaces": false,
                   "validate": {
-                    "required": true
+                    "required": true,
+                    "custom": "valid = (input >= 0 && input < data.maxIncome) ? true : 'The number you have entered is outside the expected range.';"
                   },
+                  "validateWhenHidden": false,
                   "key": "scholarshipsreceviedCosts",
                   "conditional": {
                     "show": true,
                     "when": "scholarshipsReceived",
                     "eq": "yes"
                   },
-                  "type": "currency",
-                  "input": true,
-                  "delimiter": true,
-                  "inputType": "text",
-                  "decimalLimit": 2,
-                  "requireDecimal": true
+                  "type": "number",
+                  "decimalLimit": 0,
+                  "input": true
                 }
               ]
             },
@@ -7332,28 +7327,27 @@
                 {
                   "label": "Enter the estimated amount that you will receive from your parent(s)/step-parent/sponsor/legal guardian.",
                   "prefix": "$",
-                  "customClass": "font-weight-bold",
+                  "applyMaskOn": "change",
                   "mask": false,
-                  "spellcheck": true,
                   "tableView": false,
-                  "currency": "CAD",
+                  "delimiter": true,
+                  "requireDecimal": false,
                   "inputFormat": "plain",
                   "truncateMultipleSpaces": false,
                   "validate": {
-                    "required": true
+                    "required": true,
+                    "custom": "valid = (input >= 0 && input < data.maxIncome) ? true : 'The number you have entered is outside the expected range.';"
                   },
+                  "validateWhenHidden": false,
                   "key": "parentvoluntarycontributionsCosts",
                   "conditional": {
                     "show": true,
                     "when": "parentvoluntaryContributions",
                     "eq": "yes"
                   },
-                  "type": "currency",
-                  "input": true,
-                  "delimiter": true,
-                  "inputType": "text",
-                  "decimalLimit": 2,
-                  "requireDecimal": true
+                  "type": "number",
+                  "decimalLimit": 0,
+                  "input": true
                 }
               ]
             },
@@ -7408,28 +7402,27 @@
                 {
                   "label": "Enter the amount of government funding that you will receive during your study period.",
                   "prefix": "$",
-                  "customClass": "font-weight-bold",
+                  "applyMaskOn": "change",
                   "mask": false,
-                  "spellcheck": true,
                   "tableView": false,
-                  "currency": "CAD",
+                  "delimiter": true,
+                  "requireDecimal": false,
                   "inputFormat": "plain",
                   "truncateMultipleSpaces": false,
                   "validate": {
-                    "required": true
+                    "required": true,
+                    "custom": "valid = (input >= 0 && input < data.maxIncome) ? true : 'The number you have entered is outside the expected range.';"
                   },
+                  "validateWhenHidden": false,
                   "key": "governmentFundingCosts",
                   "conditional": {
                     "show": true,
                     "when": "governmentFunding",
                     "eq": "yes"
                   },
-                  "type": "currency",
-                  "input": true,
-                  "delimiter": true,
-                  "inputType": "text",
-                  "decimalLimit": 2,
-                  "requireDecimal": true
+                  "type": "number",
+                  "decimalLimit": 0,
+                  "input": true
                 }
               ]
             },
@@ -7484,28 +7477,27 @@
                 {
                   "label": "Enter the amount of non-government (private sector) funding that you will receive during your study period.",
                   "prefix": "$",
-                  "customClass": "font-weight-bold",
+                  "applyMaskOn": "change",
                   "mask": false,
-                  "spellcheck": true,
                   "tableView": false,
-                  "currency": "CAD",
+                  "delimiter": true,
+                  "requireDecimal": false,
                   "inputFormat": "plain",
                   "truncateMultipleSpaces": false,
                   "validate": {
-                    "required": true
+                    "required": true,
+                    "custom": "valid = (input >= 0 && input < data.maxIncome) ? true : 'The number you have entered is outside the expected range.';"
                   },
+                  "validateWhenHidden": false,
                   "key": "nonGovernmentFundingCosts",
                   "conditional": {
                     "show": true,
                     "when": "nonGovernmentFunding",
                     "eq": "yes"
                   },
-                  "type": "currency",
-                  "input": true,
-                  "delimiter": true,
-                  "inputType": "text",
-                  "decimalLimit": 2,
-                  "requireDecimal": true
+                  "type": "number",
+                  "decimalLimit": 0,
+                  "input": true
                 }
               ]
             },
@@ -7555,24 +7547,27 @@
                 {
                   "label": "Enter the estimated amount of B.C. income assistance that you will receive during your study period.",
                   "prefix": "$",
+                  "applyMaskOn": "change",
                   "mask": false,
-                  "spellcheck": true,
                   "tableView": false,
-                  "currency": "USD",
+                  "delimiter": true,
+                  "requireDecimal": false,
                   "inputFormat": "plain",
                   "truncateMultipleSpaces": false,
+                  "validate": {
+                    "required": true,
+                    "custom": "valid = (input >= 0 && input < data.maxIncome) ? true : 'The number you have entered is outside the expected range.';"
+                  },
+                  "validateWhenHidden": false,
                   "key": "incomeAssistanceAmount",
                   "conditional": {
                     "show": true,
                     "when": "bcIncomeassistanceforDisabilities",
                     "eq": "yes"
                   },
-                  "type": "currency",
-                  "input": true,
-                  "delimiter": true,
-                  "inputType": "text",
-                  "decimalLimit": 2,
-                  "requireDecimal": true
+                  "type": "number",
+                  "decimalLimit": 0,
+                  "input": true
                 }
               ]
             }
@@ -8024,26 +8019,27 @@
                 {
                   "label": "If you must relocate to a different city to attend school and you will return home at least once during your study period, what is the cost of one return trip home?",
                   "prefix": "$",
+                  "applyMaskOn": "change",
                   "mask": false,
-                  "spellcheck": true,
                   "tableView": false,
-                  "currency": "CAD",
+                  "delimiter": true,
+                  "requireDecimal": false,
                   "inputFormat": "plain",
+                  "truncateMultipleSpaces": false,
                   "validate": {
-                    "required": true
+                    "required": true,
+                    "custom": "valid = (input >= 0 && input < data.maxIncome) ? true : 'The number you have entered is outside the expected range.';"
                   },
+                  "validateWhenHidden": false,
                   "key": "returnTripHomeCost",
                   "conditional": {
-                    "show": "true",
+                    "show": true,
                     "when": "considerCostToRelocateToDifferentCity",
                     "eq": "yes"
                   },
-                  "type": "currency",
-                  "input": true,
-                  "delimiter": true,
-                  "inputType": "text",
-                  "decimalLimit": 2,
-                  "requireDecimal": true
+                  "type": "number",
+                  "decimalLimit": 0,
+                  "input": true
                 }
               ],
               "allowPrevious": false

--- a/sources/packages/forms/src/form-definitions/supportingusersparent2024-2025.json
+++ b/sources/packages/forms/src/form-definitions/supportingusersparent2024-2025.json
@@ -491,22 +491,19 @@
                   "applyMaskOn": "change",
                   "mask": false,
                   "tableView": false,
-                  "currency": "CAD",
+                  "delimiter": true,
+                  "requireDecimal": false,
                   "inputFormat": "plain",
                   "truncateMultipleSpaces": false,
                   "validate": {
-                    "required": true
+                    "required": true,
+                    "custom": "valid = (input >= 0 && input < data.maxIncome) ? true : 'The number you have entered is outside the expected range.';"
                   },
                   "validateWhenHidden": false,
                   "key": "parentalContributions",
-                  "type": "currency",
-                  "spellcheck": true,
-                  "input": true,
-                  "delimiter": true,
-                  "hideOnChildrenHidden": false,
-                  "inputType": "text",
-                  "decimalLimit": 2,
-                  "requireDecimal": true
+                  "type": "number",
+                  "decimalLimit": 0,
+                  "input": true
                 },
                 {
                   "label": "Enter your reported total income from line 15000 of your {{data.calculatedTaxYear}} income tax return. If you did not file a {{data.calculatedTaxYear}} income tax return, enter your total income from all sources both inside and outside of Canada",
@@ -514,7 +511,8 @@
                   "applyMaskOn": "change",
                   "mask": false,
                   "tableView": false,
-                  "currency": "CAD",
+                  "delimiter": true,
+                  "requireDecimal": false,
                   "inputFormat": "plain",
                   "truncateMultipleSpaces": false,
                   "validate": {
@@ -523,14 +521,9 @@
                   },
                   "validateWhenHidden": false,
                   "key": "totalIncome",
-                  "type": "currency",
-                  "spellcheck": true,
-                  "input": true,
-                  "delimiter": true,
-                  "hideOnChildrenHidden": false,
-                  "inputType": "text",
+                  "type": "number",
                   "decimalLimit": 0,
-                  "requireDecimal": false
+                  "input": true
                 },
                 {
                   "label": "Canada Pension Plan contributions (CPP) from line 30800 (contributions through employment). Enter ‘0’ if none.",
@@ -538,102 +531,99 @@
                   "applyMaskOn": "change",
                   "mask": false,
                   "tableView": false,
-                  "currency": "CAD",
+                  "delimiter": true,
+                  "requireDecimal": false,
                   "inputFormat": "plain",
                   "truncateMultipleSpaces": false,
                   "validate": {
-                    "required": true
+                    "required": true,
+                    "custom": "valid = (input >= 0 && input < data.maxIncome) ? true : 'The number you have entered is outside the expected range.';"
                   },
                   "validateWhenHidden": false,
                   "key": "cppLine30800",
-                  "type": "currency",
-                  "spellcheck": true,
-                  "input": true,
-                  "delimiter": true,
-                  "hideOnChildrenHidden": false,
-                  "inputType": "text",
-                  "decimalLimit": 2,
-                  "requireDecimal": true
+                  "type": "number",
+                  "decimalLimit": 0,
+                  "input": true
                 },
                 {
                   "label": "Enter the total net value of all Canadian and foreign assets (do not include RRSPs, principal residence or business). Enter ‘0’ if none.",
                   "prefix": "$",
+                  "applyMaskOn": "change",
                   "mask": false,
-                  "spellcheck": true,
                   "tableView": false,
-                  "currency": "CAD",
-                  "inputFormat": "plain",
-                  "validate": {
-                    "required": true
-                  },
-                  "key": "foreignAssets",
-                  "type": "currency",
-                  "input": true,
                   "delimiter": true,
-                  "hideOnChildrenHidden": false,
-                  "inputType": "text",
-                  "decimalLimit": 2,
-                  "requireDecimal": true
+                  "requireDecimal": false,
+                  "inputFormat": "plain",
+                  "truncateMultipleSpaces": false,
+                  "validate": {
+                    "required": true,
+                    "custom": "valid = (input >= 0 && input < data.maxIncome) ? true : 'The number you have entered is outside the expected range.';"
+                  },
+                  "validateWhenHidden": false,
+                  "key": "foreignAssets",
+                  "type": "number",
+                  "decimalLimit": 0,
+                  "input": true
                 },
                 {
                   "label": "Canada Pension Plan contributions (CPP) from line 31000 (contributions payable on self-employment and other earnings). Enter ‘0’ if none.",
                   "prefix": "$",
+                  "applyMaskOn": "change",
                   "mask": false,
-                  "spellcheck": true,
                   "tableView": false,
-                  "currency": "CAD",
-                  "inputFormat": "plain",
-                  "validate": {
-                    "required": true
-                  },
-                  "key": "cppLine31000",
-                  "type": "currency",
-                  "input": true,
                   "delimiter": true,
-                  "hideOnChildrenHidden": false,
-                  "inputType": "text",
-                  "decimalLimit": 2,
-                  "requireDecimal": true
+                  "requireDecimal": false,
+                  "inputFormat": "plain",
+                  "truncateMultipleSpaces": false,
+                  "validate": {
+                    "required": true,
+                    "custom": "valid = (input >= 0 && input < data.maxIncome) ? true : 'The number you have entered is outside the expected range.';"
+                  },
+                  "validateWhenHidden": false,
+                  "key": "cppLine31000",
+                  "type": "number",
+                  "decimalLimit": 0,
+                  "input": true
                 },
                 {
-                  "label": "Total income tax from line 43500. Enter ‘0’ if none",
+                  "label": "Total income tax from line 43500. Enter ‘0’ if none.",
                   "prefix": "$",
+                  "applyMaskOn": "change",
                   "mask": false,
-                  "spellcheck": true,
                   "tableView": false,
-                  "currency": "CAD",
-                  "inputFormat": "plain",
-                  "validate": {
-                    "required": true
-                  },
-                  "key": "totalIncomeTaxLine43500",
-                  "type": "currency",
-                  "input": true,
                   "delimiter": true,
-                  "hideOnChildrenHidden": false,
-                  "inputType": "text",
-                  "decimalLimit": 2,
-                  "requireDecimal": true
+                  "requireDecimal": false,
+                  "inputFormat": "plain",
+                  "truncateMultipleSpaces": false,
+                  "validate": {
+                    "required": true,
+                    "custom": "valid = (input >= 0 && input < data.maxIncome) ? true : 'The number you have entered is outside the expected range.';"
+                  },
+                  "validateWhenHidden": false,
+                  "key": "totalIncomeTaxLine43500",
+                  "type": "number",
+                  "decimalLimit": 0,
+                  "input": true
                 },
                 {
                   "label": "Employment insurance (EI) from line 31200. Enter ‘0’ if none.",
                   "prefix": "$",
+                  "applyMaskOn": "change",
                   "mask": false,
-                  "spellcheck": true,
                   "tableView": false,
-                  "currency": "CAD",
-                  "inputFormat": "plain",
-                  "validate": {
-                    "required": true
-                  },
-                  "key": "eiLine31200",
-                  "type": "currency",
-                  "input": true,
                   "delimiter": true,
-                  "hideOnChildrenHidden": false,
-                  "inputType": "text",
-                  "decimalLimit": 2,
-                  "requireDecimal": true
+                  "requireDecimal": false,
+                  "inputFormat": "plain",
+                  "truncateMultipleSpaces": false,
+                  "validate": {
+                    "required": true,
+                    "custom": "valid = (input >= 0 && input < data.maxIncome) ? true : 'The number you have entered is outside the expected range.';"
+                  },
+                  "validateWhenHidden": false,
+                  "key": "eiLine31200",
+                  "type": "number",
+                  "decimalLimit": 0,
+                  "input": true
                 },
                 {
                   "label": "Do you have any dependant(s) other than the Student?",

--- a/sources/packages/forms/src/form-definitions/supportingusersparent2024-2025.json
+++ b/sources/packages/forms/src/form-definitions/supportingusersparent2024-2025.json
@@ -488,19 +488,19 @@
                   "label": "How much will you and your spouse/common-law partner be giving the student to help meet their specific educational costs during this study period?",
                   "description": "Please include money, total cashed Registered Education Savings Plans (RESPs) and scholarship trust funds",
                   "prefix": "$",
+                  "applyMaskOn": "change",
                   "mask": false,
-                  "spellcheck": true,
                   "tableView": false,
-                  "defaultValue": [
-                    null
-                  ],
                   "currency": "CAD",
                   "inputFormat": "plain",
+                  "truncateMultipleSpaces": false,
                   "validate": {
                     "required": true
                   },
+                  "validateWhenHidden": false,
                   "key": "parentalContributions",
                   "type": "currency",
+                  "spellcheck": true,
                   "input": true,
                   "delimiter": true,
                   "hideOnChildrenHidden": false,
@@ -511,17 +511,20 @@
                 {
                   "label": "Enter your reported total income from line 15000 of your {{data.calculatedTaxYear}} income tax return. If you did not file a {{data.calculatedTaxYear}} income tax return, enter your total income from all sources both inside and outside of Canada",
                   "prefix": "$",
+                  "applyMaskOn": "change",
                   "mask": false,
-                  "spellcheck": true,
                   "tableView": false,
                   "currency": "CAD",
                   "inputFormat": "plain",
+                  "truncateMultipleSpaces": false,
                   "validate": {
                     "required": true,
                     "custom": "valid = (input >= 0 && input < data.maxIncome) ? true : 'The number you have entered is outside the expected range.';"
                   },
+                  "validateWhenHidden": false,
                   "key": "totalIncome",
                   "type": "currency",
+                  "spellcheck": true,
                   "input": true,
                   "delimiter": true,
                   "hideOnChildrenHidden": false,
@@ -532,16 +535,19 @@
                 {
                   "label": "Canada Pension Plan contributions (CPP) from line 30800 (contributions through employment). Enter ‘0’ if none.",
                   "prefix": "$",
+                  "applyMaskOn": "change",
                   "mask": false,
-                  "spellcheck": true,
                   "tableView": false,
                   "currency": "CAD",
                   "inputFormat": "plain",
+                  "truncateMultipleSpaces": false,
                   "validate": {
                     "required": true
                   },
+                  "validateWhenHidden": false,
                   "key": "cppLine30800",
                   "type": "currency",
+                  "spellcheck": true,
                   "input": true,
                   "delimiter": true,
                   "hideOnChildrenHidden": false,

--- a/sources/packages/web/src/types/formio/custom-components/inputs/number-currency.ts
+++ b/sources/packages/web/src/types/formio/custom-components/inputs/number-currency.ts
@@ -1,6 +1,6 @@
 export const CURRENCY = {
   title: "Number - Currency",
-  icon: "money",
+  icon: "currency-dollar",
   schema: {
     label: "Currency",
     prefix: "$",


### PR DESCRIPTION
- Converts all currency inputs to use new "number-currency" custom component, which includes validation for negative numbers, delimiter, and no decimals.

![image](https://github.com/user-attachments/assets/d503a477-13bb-4a6f-88e3-04cde6bc7a5a)
 
- This PR includes the following files: 
    - partner information income appeal 
    - report scholastic standing change
    - sfaa2024-25
    - supporting users parent 2024-25
- includes fix to icon for number-currency component 