### PR TITLE
#4752 - FT Assessment tests - child care costs

### DIFF
--- a/sources/packages/backend/workflow/test/2025-2026/fulltime-assessment/costs/fulltime-assessment-costs-child-care-cost.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2025-2026/fulltime-assessment/costs/fulltime-assessment-costs-child-care-cost.e2e-spec.ts
@@ -97,7 +97,7 @@ describe(`E2E Test Workflow part-time-assessment-${PROGRAM_YEAR}-costs-child-car
       // married to a full-time student who is studying for 12 or more weeks during this study period
       expect(
         calculatedAssessment.variables.calculatedDataTotalChildCareCost
-      ).toBe(500);
+      ).toBe(1000);
     }
   );
 

--- a/sources/packages/backend/workflow/test/2025-2026/fulltime-assessment/costs/fulltime-assessment-costs-child-care-cost.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2025-2026/fulltime-assessment/costs/fulltime-assessment-costs-child-care-cost.e2e-spec.ts
@@ -6,9 +6,7 @@ import {
 import { PROGRAM_YEAR } from "../../constants/program-year.constants";
 import {
   DependentChildCareEligibility,
-  createFakeStudentDependentBornAfterStudyEndDate,
   createFakeStudentDependentEligibleForChildcareCost,
-  createFakeStudentDependentNotEligibleForChildcareCost,
 } from "../../../test-utils/factories";
 import { YesNoOptions } from "@sims/test-utils";
 

--- a/sources/packages/backend/workflow/test/2025-2026/fulltime-assessment/costs/fulltime-assessment-costs-child-care-cost.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2025-2026/fulltime-assessment/costs/fulltime-assessment-costs-child-care-cost.e2e-spec.ts
@@ -69,6 +69,9 @@ describe(`E2E Test Workflow part-time-assessment-${PROGRAM_YEAR}-costs-child-car
       assessmentConsolidatedData.offeringWeeks = 18;
       assessmentConsolidatedData.studentDataRelationshipStatus = "married";
       assessmentConsolidatedData.studentDataPartnerStudyWeeks = 3;
+      assessmentConsolidatedData.studentDataIsYourPartnerAbleToReport = false;
+      assessmentConsolidatedData.studentDataEstimatedSpouseIncome = 10000;
+      assessmentConsolidatedData.studentDataTaxReturnIncome = 10002;
       // Creates 1 eligible dependent.
       assessmentConsolidatedData.studentDataHasDependents = YesNoOptions.Yes;
       assessmentConsolidatedData.studentDataDependants = [
@@ -112,6 +115,9 @@ describe(`E2E Test Workflow part-time-assessment-${PROGRAM_YEAR}-costs-child-car
       assessmentConsolidatedData.offeringWeeks = 18;
       assessmentConsolidatedData.studentDataRelationshipStatus = "married";
       assessmentConsolidatedData.studentDataPartnerStudyWeeks = 13;
+      assessmentConsolidatedData.studentDataIsYourPartnerAbleToReport = false;
+      assessmentConsolidatedData.studentDataEstimatedSpouseIncome = 10000;
+      assessmentConsolidatedData.studentDataTaxReturnIncome = 10002;
       // Creates 1 eligible dependent.
       assessmentConsolidatedData.studentDataHasDependents = YesNoOptions.Yes;
       assessmentConsolidatedData.studentDataDependants = [

--- a/sources/packages/backend/workflow/test/2025-2026/fulltime-assessment/costs/fulltime-assessment-costs-child-care-cost.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2025-2026/fulltime-assessment/costs/fulltime-assessment-costs-child-care-cost.e2e-spec.ts
@@ -24,7 +24,7 @@ describe(`E2E Test Workflow part-time-assessment-${PROGRAM_YEAR}-costs-child-car
       assessmentConsolidatedData.studentDataDaycareCosts11YearsOrUnder = 1000;
       assessmentConsolidatedData.offeringWeeks = 18;
       assessmentConsolidatedData.studentDataRelationshipStatus = "single";
-      // Creates 1 eligible dependent.
+      // Creates 1 eligible dependant.
       assessmentConsolidatedData.studentDataHasDependents = YesNoOptions.Yes;
       assessmentConsolidatedData.studentDataDependants = [
         createFakeStudentDependentEligibleForChildcareCost(

--- a/sources/packages/backend/workflow/test/2025-2026/fulltime-assessment/costs/fulltime-assessment-costs-child-care-cost.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2025-2026/fulltime-assessment/costs/fulltime-assessment-costs-child-care-cost.e2e-spec.ts
@@ -68,7 +68,7 @@ describe(`E2E Test Workflow part-time-assessment-${PROGRAM_YEAR}-costs-child-car
       assessmentConsolidatedData.studentDataDaycareCosts11YearsOrUnder = 1000;
       assessmentConsolidatedData.offeringWeeks = 18;
       assessmentConsolidatedData.studentDataRelationshipStatus = "married";
-      assessmentConsolidatedData.calculatedDataPartnerStudyWeeks = "3";
+      assessmentConsolidatedData.studentDataPartnerStudyWeeks = 3;
       // Creates 1 eligible dependent.
       assessmentConsolidatedData.studentDataHasDependents = YesNoOptions.Yes;
       assessmentConsolidatedData.studentDataDependants = [
@@ -111,7 +111,7 @@ describe(`E2E Test Workflow part-time-assessment-${PROGRAM_YEAR}-costs-child-car
       assessmentConsolidatedData.studentDataDaycareCosts11YearsOrUnder = 1000;
       assessmentConsolidatedData.offeringWeeks = 18;
       assessmentConsolidatedData.studentDataRelationshipStatus = "married";
-      assessmentConsolidatedData.calculatedDataPartnerStudyWeeks = "13";
+      assessmentConsolidatedData.studentDataPartnerStudyWeeks = 13;
       // Creates 1 eligible dependent.
       assessmentConsolidatedData.studentDataHasDependents = YesNoOptions.Yes;
       assessmentConsolidatedData.studentDataDependants = [

--- a/sources/packages/backend/workflow/test/2025-2026/fulltime-assessment/costs/fulltime-assessment-costs-child-care-cost.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2025-2026/fulltime-assessment/costs/fulltime-assessment-costs-child-care-cost.e2e-spec.ts
@@ -1,0 +1,248 @@
+import {
+  ZeebeMockedClient,
+  createFakeConsolidatedFulltimeData,
+  executeFullTimeAssessmentForProgramYear,
+} from "../../../test-utils";
+import { PROGRAM_YEAR } from "../../constants/program-year.constants";
+import {
+  DependentChildCareEligibility,
+  createFakeStudentDependentBornAfterStudyEndDate,
+  createFakeStudentDependentEligibleForChildcareCost,
+  createFakeStudentDependentNotEligibleForChildcareCost,
+} from "../../../test-utils/factories";
+import { YesNoOptions } from "@sims/test-utils";
+
+describe(`E2E Test Workflow part-time-assessment-${PROGRAM_YEAR}-costs-child-care-costs.`, () => {
+  it(
+    "Should calculate total child care cost as sum of values in student application when " +
+      "student has one dependent 11 years or under and " +
+      "child care costs entered does not reach maximum allowable limit for the " +
+      "given number of dependents and offering weeks " +
+      "and student is single.",
+    async () => {
+      // Arrange
+      const assessmentConsolidatedData =
+        createFakeConsolidatedFulltimeData(PROGRAM_YEAR);
+      assessmentConsolidatedData.studentDataDaycareCosts11YearsOrUnder = 1000;
+      assessmentConsolidatedData.offeringWeeks = 18;
+      assessmentConsolidatedData.studentDataRelationshipStatus = "single";
+      // Creates 1 eligible dependent.
+      assessmentConsolidatedData.studentDataHasDependents = YesNoOptions.Yes;
+      assessmentConsolidatedData.studentDataDependants = [
+        createFakeStudentDependentEligibleForChildcareCost(
+          DependentChildCareEligibility.Eligible0To11YearsOld,
+          assessmentConsolidatedData.offeringStudyStartDate
+        ),
+      ];
+
+      // Act
+      const calculatedAssessment =
+        await executeFullTimeAssessmentForProgramYear(
+          PROGRAM_YEAR,
+          assessmentConsolidatedData
+        );
+      // Assert
+      // Lesser of the child care costs submitted in application or the number of offering weeks times weekly limit
+      // Submitted costs are less (1000) than maximum (18 * $268 = $4824)
+      expect(calculatedAssessment.variables.calculatedDataChildCareCost).toBe(
+        1000
+      );
+      // Total calculated childcare costs are changed from the calculated child care costs above if student is
+      // married to a full-time student who is studying for 12 or more weeks during this study period
+      expect(
+        calculatedAssessment.variables.calculatedDataTotalChildCareCost
+      ).toBe(1000);
+    }
+  );
+
+  it(
+    "Should calculate total child care cost as sum of values in student application when " +
+      "student has one dependent 11 years or under and " +
+      "child care costs entered does not reach maximum allowable limit for the " +
+      "given number of dependents and offering weeks " +
+      "and student is married to a full-time student of less than 12 weeks.",
+    async () => {
+      // Arrange
+      const assessmentConsolidatedData =
+        createFakeConsolidatedFulltimeData(PROGRAM_YEAR);
+      assessmentConsolidatedData.studentDataDaycareCosts11YearsOrUnder = 1000;
+      assessmentConsolidatedData.offeringWeeks = 18;
+      assessmentConsolidatedData.studentDataRelationshipStatus = "married";
+      assessmentConsolidatedData.calculatedDataPartnerStudyWeeks = "3";
+      // Creates 1 eligible dependent.
+      assessmentConsolidatedData.studentDataHasDependents = YesNoOptions.Yes;
+      assessmentConsolidatedData.studentDataDependants = [
+        createFakeStudentDependentEligibleForChildcareCost(
+          DependentChildCareEligibility.Eligible0To11YearsOld,
+          assessmentConsolidatedData.offeringStudyStartDate
+        ),
+      ];
+
+      // Act
+      const calculatedAssessment =
+        await executeFullTimeAssessmentForProgramYear(
+          PROGRAM_YEAR,
+          assessmentConsolidatedData
+        );
+      // Assert
+      // Lesser of the child care costs submitted in application or the number of offering weeks times weekly limit
+      // Submitted costs are less (1000) than maximum (18 * $268 = $4824)
+      expect(calculatedAssessment.variables.calculatedDataChildCareCost).toBe(
+        1000
+      );
+      // Total calculated childcare costs are changed from the calculated child care costs above if student is
+      // married to a full-time student who is studying for 12 or more weeks during this study period
+      expect(
+        calculatedAssessment.variables.calculatedDataTotalChildCareCost
+      ).toBe(500);
+    }
+  );
+
+  it(
+    "Should calculate total child care cost as sum of values in student application when " +
+      "student has one dependent 11 years or under and " +
+      "child care costs entered does not reach maximum allowable limit for the " +
+      "given number of dependents and offering weeks " +
+      "and student is married to a full-time student of more than 12 weeks.",
+    async () => {
+      // Arrange
+      const assessmentConsolidatedData =
+        createFakeConsolidatedFulltimeData(PROGRAM_YEAR);
+      assessmentConsolidatedData.studentDataDaycareCosts11YearsOrUnder = 1000;
+      assessmentConsolidatedData.offeringWeeks = 18;
+      assessmentConsolidatedData.studentDataRelationshipStatus = "married";
+      assessmentConsolidatedData.calculatedDataPartnerStudyWeeks = "13";
+      // Creates 1 eligible dependent.
+      assessmentConsolidatedData.studentDataHasDependents = YesNoOptions.Yes;
+      assessmentConsolidatedData.studentDataDependants = [
+        createFakeStudentDependentEligibleForChildcareCost(
+          DependentChildCareEligibility.Eligible0To11YearsOld,
+          assessmentConsolidatedData.offeringStudyStartDate
+        ),
+      ];
+
+      // Act
+      const calculatedAssessment =
+        await executeFullTimeAssessmentForProgramYear(
+          PROGRAM_YEAR,
+          assessmentConsolidatedData
+        );
+      // Assert
+      // Lesser of the child care costs submitted in application or the number of offering weeks times weekly limit
+      // Submitted costs are less (1000) than maximum (18 * $268 = $4824)
+      expect(calculatedAssessment.variables.calculatedDataChildCareCost).toBe(
+        1000
+      );
+      // Total calculated childcare costs are changed from the calculated child care costs above if student is
+      // married to a full-time student who is studying for 12 or more weeks during this study period
+      expect(
+        calculatedAssessment.variables.calculatedDataTotalChildCareCost
+      ).toBe(500);
+    }
+  );
+
+  it(
+    "Should calculate total child care cost as sum of values in student application when " +
+      "student has three dependents 11 years or under and " +
+      "child care costs entered does not reach maximum allowable limit for the " +
+      "given number of dependents and offering weeks " +
+      "and student is single.",
+    async () => {
+      // Arrange
+      const assessmentConsolidatedData =
+        createFakeConsolidatedFulltimeData(PROGRAM_YEAR);
+      assessmentConsolidatedData.studentDataDaycareCosts11YearsOrUnder = 14000;
+      assessmentConsolidatedData.offeringWeeks = 18;
+      assessmentConsolidatedData.studentDataRelationshipStatus = "single";
+      // Creates 1 eligible dependent.
+      assessmentConsolidatedData.studentDataHasDependents = YesNoOptions.Yes;
+      assessmentConsolidatedData.studentDataDependants = [
+        createFakeStudentDependentEligibleForChildcareCost(
+          DependentChildCareEligibility.Eligible0To11YearsOld,
+          assessmentConsolidatedData.offeringStudyStartDate
+        ),
+        createFakeStudentDependentEligibleForChildcareCost(
+          DependentChildCareEligibility.Eligible0To11YearsOld,
+          assessmentConsolidatedData.offeringStudyStartDate
+        ),
+        createFakeStudentDependentEligibleForChildcareCost(
+          DependentChildCareEligibility.Eligible0To11YearsOld,
+          assessmentConsolidatedData.offeringStudyStartDate
+        ),
+      ];
+
+      // Act
+      const calculatedAssessment =
+        await executeFullTimeAssessmentForProgramYear(
+          PROGRAM_YEAR,
+          assessmentConsolidatedData
+        );
+      // Assert
+      // Lesser of the child care costs submitted in application or the number of offering weeks times weekly limit
+      // Submitted costs are less (1000) than maximum (18 * $268 * 3 = $14,472)
+      expect(calculatedAssessment.variables.calculatedDataChildCareCost).toBe(
+        14000
+      );
+      // Total calculated childcare costs are changed from the calculated child care costs above if student is
+      // married to a full-time student who is studying for 12 or more weeks during this study period
+      expect(
+        calculatedAssessment.variables.calculatedDataTotalChildCareCost
+      ).toBe(14000);
+    }
+  );
+
+  it(
+    "Should calculate total child care cost as sum of values in student application when " +
+      "student has three dependents 11 years or under and " +
+      "child care costs entered is greater than the maximum allowable limit for the " +
+      "given number of dependents and offering weeks " +
+      "and student is single.",
+    async () => {
+      // Arrange
+      const assessmentConsolidatedData =
+        createFakeConsolidatedFulltimeData(PROGRAM_YEAR);
+      assessmentConsolidatedData.studentDataDaycareCosts11YearsOrUnder = 45000;
+      assessmentConsolidatedData.offeringWeeks = 18;
+      assessmentConsolidatedData.studentDataRelationshipStatus = "single";
+      // Creates 1 eligible dependent.
+      assessmentConsolidatedData.studentDataHasDependents = YesNoOptions.Yes;
+      assessmentConsolidatedData.studentDataDependants = [
+        createFakeStudentDependentEligibleForChildcareCost(
+          DependentChildCareEligibility.Eligible0To11YearsOld,
+          assessmentConsolidatedData.offeringStudyStartDate
+        ),
+        createFakeStudentDependentEligibleForChildcareCost(
+          DependentChildCareEligibility.Eligible0To11YearsOld,
+          assessmentConsolidatedData.offeringStudyStartDate
+        ),
+        createFakeStudentDependentEligibleForChildcareCost(
+          DependentChildCareEligibility.Eligible0To11YearsOld,
+          assessmentConsolidatedData.offeringStudyStartDate
+        ),
+      ];
+
+      // Act
+      const calculatedAssessment =
+        await executeFullTimeAssessmentForProgramYear(
+          PROGRAM_YEAR,
+          assessmentConsolidatedData
+        );
+      // Assert
+      // Lesser of the child care costs submitted in application or the number of offering weeks times weekly limit
+      // Submitted costs are less (1000) than maximum (18 * $268 * 3 = $14,472)
+      expect(calculatedAssessment.variables.calculatedDataChildCareCost).toBe(
+        14472
+      );
+      // Total calculated childcare costs are changed from the calculated child care costs above if student is
+      // married to a full-time student who is studying for 12 or more weeks during this study period
+      expect(
+        calculatedAssessment.variables.calculatedDataTotalChildCareCost
+      ).toBe(14472);
+    }
+  );
+
+  afterAll(async () => {
+    // Closes the singleton instance created during test executions.
+    await ZeebeMockedClient.getMockedZeebeInstance().close();
+  });
+});


### PR DESCRIPTION
Net new tests in the /costs/ folder for FT

Child care cost tests:
    - single + 1 dep + declared childcare costs under maximum (total is student declared)
    - single + 3 deps + declared childcare costs over maximum (total is max allowable)
    - married + 1 dep + partner full time student >12 weeks (total reduced)
    - married + 1 dep + partner full time student < 12 weeks (no reduction to total)
