### PR TITLE
#4476 - E-cert cancellation db migrations

### DIFF
--- a/sources/packages/backend/apps/db-migrations/src/migrations/1748893791404-AddDisbursementScheduleStatusRejected.ts
+++ b/sources/packages/backend/apps/db-migrations/src/migrations/1748893791404-AddDisbursementScheduleStatusRejected.ts
@@ -1,0 +1,21 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+import { getSQLFileData } from "../utilities/sqlLoader";
+
+export class AddDisbursementScheduleStatusRejected1748893791404
+  implements MigrationInterface
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      getSQLFileData("Add-disbursement-schedule-status-rejected.sql", "Types"),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      getSQLFileData(
+        "Rollback-add-disbursement-schedule-status-rejected.sql",
+        "Types",
+      ),
+    );
+  }
+}

--- a/sources/packages/backend/apps/db-migrations/src/migrations/1748915343561-AddDisbursementScheduleStatusAuditCols.ts
+++ b/sources/packages/backend/apps/db-migrations/src/migrations/1748915343561-AddDisbursementScheduleStatusAuditCols.ts
@@ -1,0 +1,24 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+import { getSQLFileData } from "../utilities/sqlLoader";
+
+export class AddDisbursementScheduleStatusAuditCols1748915343561
+  implements MigrationInterface
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      getSQLFileData(
+        "Add-disbursement-schedule-status-audit-cols.sql",
+        "DisbursementSchedules",
+      ),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      getSQLFileData(
+        "Rollback-add-disbursement-schedule-status-audit-cols.sql",
+        "DisbursementSchedules",
+      ),
+    );
+  }
+}

--- a/sources/packages/backend/apps/db-migrations/src/migrations/1748978283307-UpdateDisbursementScheduleStatusRejected.ts
+++ b/sources/packages/backend/apps/db-migrations/src/migrations/1748978283307-UpdateDisbursementScheduleStatusRejected.ts
@@ -1,0 +1,24 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+import { getSQLFileData } from "../utilities/sqlLoader";
+
+export class UpdateDisbursementScheduleStatusRejected1748978283307
+  implements MigrationInterface
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      getSQLFileData(
+        "Update-disbursement-schedule-status-rejected.sql",
+        "DisbursementSchedules",
+      ),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      getSQLFileData(
+        "Rollback-update-disbursement-schedule-status-rejected.sql",
+        "DisbursementSchedules",
+      ),
+    );
+  }
+}

--- a/sources/packages/backend/apps/db-migrations/src/migrations/1748982079368-AddOverawardOriginTypeAwardDeductedRejected.ts
+++ b/sources/packages/backend/apps/db-migrations/src/migrations/1748982079368-AddOverawardOriginTypeAwardDeductedRejected.ts
@@ -1,0 +1,24 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+import { getSQLFileData } from "../utilities/sqlLoader";
+
+export class AddOverawardOriginTypeAwardDeductedRejected1748982079368
+  implements MigrationInterface
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      getSQLFileData(
+        "Add-overaward-origin-type-award-deducted-rejected.sql",
+        "Types",
+      ),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      getSQLFileData(
+        "Rollback-add-overaward-origin-type-award-deducted-rejected.sql",
+        "Types",
+      ),
+    );
+  }
+}

--- a/sources/packages/backend/apps/db-migrations/src/migrations/1748994454302-AddECertCancellationResponseIntegration.ts
+++ b/sources/packages/backend/apps/db-migrations/src/migrations/1748994454302-AddECertCancellationResponseIntegration.ts
@@ -1,0 +1,24 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+import { getSQLFileData } from "../utilities/sqlLoader";
+
+export class AddECertCancellationResponseIntegration1748994454302
+  implements MigrationInterface
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      getSQLFileData(
+        "Add-ecert-cancellation-response-integration.sql",
+        "Queue",
+      ),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      getSQLFileData(
+        "Rollback-add-ecert-cancellation-response-integration.sql",
+        "Queue",
+      ),
+    );
+  }
+}

--- a/sources/packages/backend/apps/db-migrations/src/sql/DisbursementSchedules/Add-disbursement-schedule-status-audit-cols.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/DisbursementSchedules/Add-disbursement-schedule-status-audit-cols.sql
@@ -1,0 +1,10 @@
+ALTER TABLE
+    sims.disbursement_schedules
+ADD
+    COLUMN disbursement_schedule_status_updated_by INT REFERENCES sims.users(id),
+ADD
+    COLUMN disbursement_schedule_status_updated_on TIMESTAMP WITH TIME ZONE;
+
+COMMENT ON COLUMN sims.disbursement_schedules.disbursement_schedule_status_updated_by IS 'User who updated the disbursement schedule status.';
+
+COMMENT ON COLUMN sims.disbursement_schedules.disbursement_schedule_status_updated_on IS 'Date and time when the disbursement schedule status was updated.';

--- a/sources/packages/backend/apps/db-migrations/src/sql/DisbursementSchedules/Rollback-add-disbursement-schedule-status-audit-cols.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/DisbursementSchedules/Rollback-add-disbursement-schedule-status-audit-cols.sql
@@ -1,0 +1,3 @@
+ALTER TABLE
+    sims.disbursement_schedules DROP COLUMN disbursement_schedule_status_updated_by,
+    DROP COLUMN disbursement_schedule_status_updated_on;

--- a/sources/packages/backend/apps/db-migrations/src/sql/DisbursementSchedules/Rollback-update-disbursement-schedule-status-rejected.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/DisbursementSchedules/Rollback-update-disbursement-schedule-status-rejected.sql
@@ -1,0 +1,9 @@
+update
+    sims.disbursement_schedules
+set
+    disbursement_schedule_status = 'Cancelled',
+    disbursement_schedule_status_updated_by = NULL,
+    disbursement_schedule_status_updated_on = NULL
+where
+    disbursement_schedule_status = 'Rejected'
+    AND date_sent IS NOT NULL;

--- a/sources/packages/backend/apps/db-migrations/src/sql/DisbursementSchedules/Rollback-update-disbursement-schedule-status-rejected.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/DisbursementSchedules/Rollback-update-disbursement-schedule-status-rejected.sql
@@ -1,9 +1,9 @@
-update
+UPDATE
     sims.disbursement_schedules
-set
+SET
     disbursement_schedule_status = 'Cancelled',
     disbursement_schedule_status_updated_by = NULL,
     disbursement_schedule_status_updated_on = NULL
-where
+WHERE
     disbursement_schedule_status = 'Rejected'
     AND date_sent IS NOT NULL;

--- a/sources/packages/backend/apps/db-migrations/src/sql/DisbursementSchedules/Update-disbursement-schedule-status-rejected.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/DisbursementSchedules/Update-disbursement-schedule-status-rejected.sql
@@ -1,17 +1,17 @@
-update
+UPDATE
     sims.disbursement_schedules
-set
+SET
     disbursement_schedule_status = 'Rejected',
     disbursement_schedule_status_updated_by = (
-        select
+        SELECT
             id
-        from
+        FROM
             sims.users
-        where
+        WHERE
             -- System user.
             user_name = '8fb44f70-6ce6-11ed-b307-8743a2da47ef@system'
     ),
     disbursement_schedule_status_updated_on = now()
-where
+WHERE
     disbursement_schedule_status = 'Cancelled'
     AND date_sent IS NOT NULL;

--- a/sources/packages/backend/apps/db-migrations/src/sql/DisbursementSchedules/Update-disbursement-schedule-status-rejected.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/DisbursementSchedules/Update-disbursement-schedule-status-rejected.sql
@@ -1,0 +1,17 @@
+update
+    sims.disbursement_schedules
+set
+    disbursement_schedule_status = 'Rejected',
+    disbursement_schedule_status_updated_by = (
+        select
+            id
+        from
+            sims.users
+        where
+            -- System user.
+            user_name = '8fb44f70-6ce6-11ed-b307-8743a2da47ef@system'
+    ),
+    disbursement_schedule_status_updated_on = now()
+where
+    disbursement_schedule_status = 'Cancelled'
+    AND date_sent IS NOT NULL;

--- a/sources/packages/backend/apps/db-migrations/src/sql/Queue/Add-ecert-cancellation-response-integration.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/Queue/Add-ecert-cancellation-response-integration.sql
@@ -10,10 +10,10 @@ VALUES
             "cleanUpPeriod": 2592000000,
             "retryInterval": 180000,
             "dashboardReadonly": false
-        }' :: json,
+        }' :: jsonb,
         '{ 
             "maxStalledCount": 0,
             "lockDuration": 60000,
             "lockRenewTime": 5000
-        }' :: json
+        }' :: jsonb
     );

--- a/sources/packages/backend/apps/db-migrations/src/sql/Queue/Add-ecert-cancellation-response-integration.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/Queue/Add-ecert-cancellation-response-integration.sql
@@ -1,0 +1,19 @@
+-- The scheduler is set to run at 5 p.m. UTC which is 9 a.m. PST every day.
+INSERT INTO
+    sims.queue_configurations(queue_name, queue_configuration, queue_settings)
+VALUES
+    (
+        'e-cert-cancellation-response-integration',
+        '{
+            "cron": "0 17 * * *",
+            "retry": 3,
+            "cleanUpPeriod": 2592000000,
+            "retryInterval": 180000,
+            "dashboardReadonly": false
+        }' :: json,
+        '{ 
+            "maxStalledCount": 0,
+            "lockDuration": 60000,
+            "lockRenewTime": 5000
+        }' :: json
+    );

--- a/sources/packages/backend/apps/db-migrations/src/sql/Queue/Rollback-add-ecert-cancellation-response-integration.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/Queue/Rollback-add-ecert-cancellation-response-integration.sql
@@ -1,4 +1,4 @@
-DELETE from
+DELETE FROM
     sims.queue_configurations
-where
+WHERE
     queue_name = 'e-cert-cancellation-response-integration';

--- a/sources/packages/backend/apps/db-migrations/src/sql/Queue/Rollback-add-ecert-cancellation-response-integration.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/Queue/Rollback-add-ecert-cancellation-response-integration.sql
@@ -1,0 +1,4 @@
+DELETE from
+    sims.queue_configurations
+where
+    queue_name = 'e-cert-cancellation-response-integration';

--- a/sources/packages/backend/apps/db-migrations/src/sql/Types/Add-disbursement-schedule-status-rejected.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/Types/Add-disbursement-schedule-status-rejected.sql
@@ -1,0 +1,34 @@
+-- Recreate the enums types when the new item must be added.
+CREATE TYPE sims.disbursement_schedule_status_to_be_updated AS ENUM (
+    'Pending',
+    'Ready to send',
+    'Sent',
+    'Cancelled',
+    'Rejected'
+);
+
+-- Needs to drop the default constraint to allow the ALTER column.
+ALTER TABLE
+    sims.disbursement_schedules
+ALTER COLUMN
+    disbursement_schedule_status DROP DEFAULT;
+
+-- Update the dependent column to start using the new enum with the expected values.
+ALTER TABLE
+    sims.disbursement_schedules
+ALTER COLUMN
+    disbursement_schedule_status TYPE sims.disbursement_schedule_status_to_be_updated USING (disbursement_schedule_status :: text) :: sims.disbursement_schedule_status_to_be_updated;
+
+-- Remove the entire enum that is no longer being used.
+DROP TYPE sims.disbursement_schedule_status;
+
+-- Rename the enum to what it was in the beginning.
+ALTER TYPE sims.disbursement_schedule_status_to_be_updated RENAME TO disbursement_schedule_status;
+
+-- Add the previously removed default constraint.
+ALTER TABLE
+    sims.disbursement_schedules
+ALTER COLUMN
+    disbursement_schedule_status
+SET
+    DEFAULT 'Pending';

--- a/sources/packages/backend/apps/db-migrations/src/sql/Types/Add-overaward-origin-type-award-deducted-rejected.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/Types/Add-overaward-origin-type-award-deducted-rejected.sql
@@ -1,0 +1,20 @@
+-- Recreate the enums types when the new item must be added.
+CREATE TYPE sims.disbursement_overaward_origin_types_to_be_updated AS ENUM (
+    'Reassessment overaward',
+    'Award deducted',
+    'Manual record',
+    'Legacy overaward',
+    'Award deducted rejected'
+);
+
+-- Update the dependent column to start using the new enum with the expected values.
+ALTER TABLE
+    sims.disbursement_overawards
+ALTER COLUMN
+    origin_type TYPE sims.disbursement_overaward_origin_types_to_be_updated USING (origin_type :: text) :: sims.disbursement_overaward_origin_types_to_be_updated;
+
+-- Remove the entire enum that is no longer being used.
+DROP TYPE sims.disbursement_overaward_origin_types;
+
+-- Rename the enum to what it was in the beginning.
+ALTER TYPE sims.disbursement_overaward_origin_types_to_be_updated RENAME TO disbursement_overaward_origin_types;

--- a/sources/packages/backend/apps/db-migrations/src/sql/Types/Add-overaward-origin-type-award-deducted-rejected.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/Types/Add-overaward-origin-type-award-deducted-rejected.sql
@@ -4,7 +4,7 @@ CREATE TYPE sims.disbursement_overaward_origin_types_to_be_updated AS ENUM (
     'Award deducted',
     'Manual record',
     'Legacy overaward',
-    'Award deducted rejected'
+    'Award rejected deducted'
 );
 
 -- Update the dependent column to start using the new enum with the expected values.

--- a/sources/packages/backend/apps/db-migrations/src/sql/Types/Rollback-add-disbursement-schedule-status-rejected.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/Types/Rollback-add-disbursement-schedule-status-rejected.sql
@@ -1,0 +1,36 @@
+-- Postgres does not allow the removal of items of an enum, only add or rename.
+-- To remove the previously added items, a temporary enum will be created to
+-- allow the creation of the enum as it was before.
+CREATE TYPE sims.disbursement_schedule_status_rollback AS ENUM ('Pending', 'Ready to send', 'Sent', 'Cancelled');
+
+-- Needs to drop the default constraint to allow the ALTER column rollback.
+ALTER TABLE
+    sims.disbursement_schedules
+ALTER COLUMN
+    disbursement_schedule_status DROP DEFAULT;
+
+-- Update the dependent column to start using the new enum with the expected values.
+ALTER TABLE
+    sims.disbursement_schedules
+ALTER COLUMN
+    disbursement_schedule_status TYPE sims.disbursement_schedule_status_rollback USING (
+        CASE
+            disbursement_schedule_status :: text
+            WHEN 'Rejected' THEN 'Cancelled'
+            ELSE disbursement_schedule_status :: text
+        END
+    ) :: sims.disbursement_schedule_status_rollback;
+
+-- Remove the entire enum that is no longer being used.
+DROP TYPE sims.disbursement_schedule_status;
+
+-- Rename the enum to what it was in the beginning.
+ALTER TYPE sims.disbursement_schedule_status_rollback RENAME TO disbursement_schedule_status;
+
+-- Add the previously removed default constraint.
+ALTER TABLE
+    sims.disbursement_schedules
+ALTER COLUMN
+    disbursement_schedule_status
+SET
+    DEFAULT 'Pending';

--- a/sources/packages/backend/apps/db-migrations/src/sql/Types/Rollback-add-overaward-origin-type-award-deducted-rejected.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/Types/Rollback-add-overaward-origin-type-award-deducted-rejected.sql
@@ -1,0 +1,27 @@
+-- Postgres does not allow the removal of items of an enum, only add or rename.
+-- To remove the previously added items, a temporary enum will be created to
+-- allow the creation of the enum as it was before.
+CREATE TYPE sims.disbursement_overaward_origin_types_to_rollback AS ENUM (
+    'Reassessment overaward',
+    'Award deducted',
+    'Manual record',
+    'Legacy overaward'
+);
+
+-- Update the dependent column to start using the new enum with the expected values.
+ALTER TABLE
+    sims.disbursement_overawards
+ALTER COLUMN
+    origin_type TYPE sims.disbursement_overaward_origin_types_to_rollback USING (
+        CASE
+            origin_type :: text
+            WHEN 'Award deducted rejected' THEN 'Award deducted'
+            ELSE origin_type :: text
+        END
+    ) :: sims.disbursement_overaward_origin_types_to_rollback;
+
+-- Remove the entire enum that is no longer being used.
+DROP TYPE sims.disbursement_overaward_origin_types;
+
+-- Rename the enum to what it was in the beginning.
+ALTER TYPE sims.disbursement_overaward_origin_types_to_rollback RENAME TO disbursement_overaward_origin_types;

--- a/sources/packages/backend/apps/db-migrations/src/sql/Types/Rollback-add-overaward-origin-type-award-deducted-rejected.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/Types/Rollback-add-overaward-origin-type-award-deducted-rejected.sql
@@ -15,7 +15,7 @@ ALTER COLUMN
     origin_type TYPE sims.disbursement_overaward_origin_types_to_rollback USING (
         CASE
             origin_type :: text
-            WHEN 'Award deducted rejected' THEN 'Award deducted'
+            WHEN 'Award rejected deducted' THEN 'Award deducted'
             ELSE origin_type :: text
         END
     ) :: sims.disbursement_overaward_origin_types_to_rollback;

--- a/sources/packages/backend/apps/queue-consumers/src/processors/index.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/processors/index.ts
@@ -32,3 +32,4 @@ export * from "./schedulers/student-application-notifications/student-applicatio
 export * from "./schedulers/sfas-integration/sims-to-sfas-integration.scheduler";
 export * from "./schedulers/cas-integration/cas-invoices-batches-creation.scheduler";
 export * from "./schedulers/cas-integration/cas-send-invoices.scheduler";
+export * from "./schedulers/esdc-integration/ecert-integration/ecert-cancellation-response-integration.scheduler";

--- a/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/esdc-integration/ecert-integration/ecert-cancellation-response-integration.scheduler.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/esdc-integration/ecert-integration/ecert-cancellation-response-integration.scheduler.ts
@@ -1,0 +1,47 @@
+import { InjectQueue, Processor } from "@nestjs/bull";
+import { QueueService } from "@sims/services/queue";
+import { Job, Queue } from "bull";
+import { BaseScheduler } from "../../base-scheduler";
+import {
+  InjectLogger,
+  LoggerService,
+  ProcessSummary,
+} from "@sims/utilities/logger";
+import { QueueNames } from "@sims/utilities";
+
+@Processor(QueueNames.ECertCancellationResponseIntegration)
+export class ECertCancellationResponseIntegrationScheduler extends BaseScheduler<void> {
+  constructor(
+    @InjectQueue(QueueNames.ECertCancellationResponseIntegration)
+    schedulerQueue: Queue<void>,
+    queueService: QueueService,
+  ) {
+    super(schedulerQueue, queueService);
+  }
+
+  /**
+   * Process the e-cert cancellation file(s) and update the disbursements.
+   * Both Full-time and Part-time e-Cert cancellation files are processed by this scheduler.
+   * @param _job process job.
+   * @param processSummary process summary for logging.
+   * @returns process summary.
+   */
+  protected async process(
+    _job: Job<void>,
+    processSummary: ProcessSummary,
+  ): Promise<string[]> {
+    processSummary.info(
+      "E-Cert cancellation response integration Scheduler is not implemented.",
+    );
+    return [];
+  }
+
+  /**
+   * Setting the logger here allows the correct context to be set
+   * during the property injection.
+   * Even if the logger is not used, it is required to be set, to
+   * allow the base classes to write logs using the correct context.
+   */
+  @InjectLogger()
+  logger: LoggerService;
+}

--- a/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/esdc-integration/ecert-integration/ecert-cancellation-response-integration.scheduler.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/esdc-integration/ecert-integration/ecert-cancellation-response-integration.scheduler.ts
@@ -31,7 +31,7 @@ export class ECertCancellationResponseIntegrationScheduler extends BaseScheduler
     processSummary: ProcessSummary,
   ): Promise<string[]> {
     processSummary.info(
-      "E-Cert cancellation response integration Scheduler is not implemented.",
+      "E-Cert cancellation response integration scheduler is not implemented.",
     );
     return [];
   }

--- a/sources/packages/backend/apps/queue-consumers/src/queue-consumers.module.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/queue-consumers.module.ts
@@ -32,6 +32,7 @@ import {
   SIMSToSFASIntegrationScheduler,
   CASInvoicesBatchesCreationScheduler,
   CASSendInvoicesScheduler,
+  ECertCancellationResponseIntegrationScheduler,
 } from "./processors";
 import {
   DisbursementScheduleSharedService,
@@ -180,6 +181,7 @@ import { QueuesMetricsModule } from "./queues-metrics.module.module";
     CASInvoiceService,
     CASInvoicesBatchesCreationScheduler,
     CASSendInvoicesScheduler,
+    ECertCancellationResponseIntegrationScheduler,
   ],
   controllers: [HealthController, MetricsController],
 })

--- a/sources/packages/backend/libs/integrations/src/esdc-integration/e-cert-integration/e-cert-file-handler.ts
+++ b/sources/packages/backend/libs/integrations/src/esdc-integration/e-cert-integration/e-cert-file-handler.ts
@@ -168,6 +168,7 @@ export abstract class ECertFileHandler extends ESDCFileHandler {
     await eCertIntegrationService.uploadContent(fileContent, fileInfo.filePath);
     // Mark all disbursements as sent.
     const dateSent = new Date();
+    const auditUser = this.systemUserService.systemUser;
     const disbursementScheduleRepo =
       entityManager.getRepository(DisbursementSchedule);
     await processInParallel((disbursement) => {
@@ -177,7 +178,9 @@ export abstract class ECertFileHandler extends ESDCFileHandler {
           dateSent,
           disbursementScheduleStatus: DisbursementScheduleStatus.Sent,
           updatedAt: dateSent,
-          modifier: this.systemUserService.systemUser,
+          modifier: auditUser,
+          disbursementScheduleStatusUpdatedBy: auditUser,
+          disbursementScheduleStatusUpdatedOn: dateSent,
         },
       );
     }, disbursements);

--- a/sources/packages/backend/libs/integrations/src/services/disbursement-schedule/e-cert-processing-steps/persist-calculations-step.ts
+++ b/sources/packages/backend/libs/integrations/src/services/disbursement-schedule/e-cert-processing-steps/persist-calculations-step.ts
@@ -34,6 +34,7 @@ export class PersistCalculationsStep implements ECertProcessStep {
     log.info("Saving all e-Cert calculations.");
     const now = new Date();
     const disbursement = eCertDisbursement.disbursement;
+    const auditUser = this.systemUsersService.systemUser;
     // Persists the changes to the disbursement.
     // Using update instead save for better performance.
     const disbursementScheduleRepo =
@@ -45,8 +46,10 @@ export class PersistCalculationsStep implements ECertProcessStep {
         readyToSendDate: now,
         tuitionRemittanceEffectiveAmount:
           disbursement.tuitionRemittanceEffectiveAmount,
-        modifier: this.systemUsersService.systemUser,
+        modifier: auditUser,
         updatedAt: now,
+        disbursementScheduleStatusUpdatedBy: auditUser,
+        disbursementScheduleStatusUpdatedOn: now,
       },
     );
     // Persist the changes to the disbursement values.

--- a/sources/packages/backend/libs/services/src/confirmation-of-enrollment/confirmation-of-enrollment.service.ts
+++ b/sources/packages/backend/libs/services/src/confirmation-of-enrollment/confirmation-of-enrollment.service.ts
@@ -502,6 +502,8 @@ export class ConfirmationOfEnrollmentService {
             coeDeniedOtherDesc: declinedReason.otherReasonDesc,
             modifier: auditUser,
             updatedAt: now,
+            disbursementScheduleStatusUpdatedBy: auditUser,
+            disbursementScheduleStatusUpdatedOn: now,
           },
         );
 

--- a/sources/packages/backend/libs/services/src/disbursement-schedule/disbursement-schedule-shared.service.ts
+++ b/sources/packages/backend/libs/services/src/disbursement-schedule/disbursement-schedule-shared.service.ts
@@ -407,9 +407,13 @@ export class DisbursementScheduleSharedService extends RecordDataModelService<Di
       entityManager,
     );
     for (const pendingDisbursement of pendingDisbursements) {
+      const now = new Date();
       pendingDisbursement.modifier = auditUser;
       pendingDisbursement.disbursementScheduleStatus =
         DisbursementScheduleStatus.Cancelled;
+      pendingDisbursement.updatedAt = now;
+      pendingDisbursement.disbursementScheduleStatusUpdatedBy = auditUser;
+      pendingDisbursement.disbursementScheduleStatusUpdatedOn = now;
     }
     // Save all the pending awards that were changed to cancelled.
     await entityManager

--- a/sources/packages/backend/libs/sims-db/src/entities/disbursement-overaward-origin.type.ts
+++ b/sources/packages/backend/libs/sims-db/src/entities/disbursement-overaward-origin.type.ts
@@ -22,7 +22,7 @@ export enum DisbursementOverawardOriginType {
   LegacyOveraward = "Legacy overaward",
   /**
    * Overaward paid by a disbursement award deduction was rejected
-   * due to the disbursement being rejected by EDSC.
+   * due to the disbursement being rejected by ESDC.
    */
-  AwardDeductedRejected = "Award deducted rejected",
+  AwardRejectedDeducted = "Award rejected deducted",
 }

--- a/sources/packages/backend/libs/sims-db/src/entities/disbursement-overaward-origin.type.ts
+++ b/sources/packages/backend/libs/sims-db/src/entities/disbursement-overaward-origin.type.ts
@@ -20,4 +20,9 @@ export enum DisbursementOverawardOriginType {
    * data is imported to the system.
    */
   LegacyOveraward = "Legacy overaward",
+  /**
+   * Overaward paid by a disbursement award deduction was rejected
+   * due to the disbursement being rejected by EDSC.
+   */
+  AwardDeductedRejected = "Award deducted rejected",
 }

--- a/sources/packages/backend/libs/sims-db/src/entities/disbursement-schedule-status.type.ts
+++ b/sources/packages/backend/libs/sims-db/src/entities/disbursement-schedule-status.type.ts
@@ -25,4 +25,9 @@ export enum DisbursementScheduleStatus {
    * application is canceled.
    */
   Cancelled = "Cancelled",
+  /**
+   * The status indicates that the disbursement has been rejected by ESDC
+   * after being sent.
+   */
+  Rejected = "Rejected",
 }

--- a/sources/packages/backend/libs/sims-db/src/entities/disbursement-schedule.model.ts
+++ b/sources/packages/backend/libs/sims-db/src/entities/disbursement-schedule.model.ts
@@ -79,7 +79,6 @@ export class DisbursementSchedule extends RecordDataModel {
     },
   )
   disbursementValues?: DisbursementValue[];
-
   /**
    * COE approval status of disbursement.
    */
@@ -90,7 +89,6 @@ export class DisbursementSchedule extends RecordDataModel {
     enumName: "COEStatus",
   })
   coeStatus: COEStatus;
-
   /**
    * User who approved/rejected COE.
    */
@@ -100,7 +98,6 @@ export class DisbursementSchedule extends RecordDataModel {
     referencedColumnName: ColumnNames.ID,
   })
   coeUpdatedBy?: User;
-
   /**
    * Date on which COE is approved/rejected.
    */
@@ -110,7 +107,6 @@ export class DisbursementSchedule extends RecordDataModel {
     nullable: true,
   })
   coeUpdatedAt?: Date;
-
   /**
    * COE denied reason for denied COEs.
    */
@@ -124,7 +120,6 @@ export class DisbursementSchedule extends RecordDataModel {
     referencedColumnName: ColumnNames.ID,
   })
   coeDeniedReason?: COEDeniedReason;
-
   /**
    * If the COE denied reason is other, the description of other reason.
    */
@@ -183,7 +178,6 @@ export class DisbursementSchedule extends RecordDataModel {
     transformer: numericTransformer,
   })
   tuitionRemittanceEffectiveAmount?: number;
-
   /**
    * MSFAA (Master Student Financial Aid Agreement)
    * number generated for a student.
@@ -198,7 +192,6 @@ export class DisbursementSchedule extends RecordDataModel {
     referencedColumnName: ColumnNames.ID,
   })
   msfaaNumber?: MSFAANumber;
-
   /**
    * Disbursement receipts for a disbursement schedule.
    ** Every disbursement schedule has disbursement receipt
@@ -214,7 +207,6 @@ export class DisbursementSchedule extends RecordDataModel {
     },
   )
   disbursementReceipts?: DisbursementReceipt[];
-
   /**
    * Disbursement feedback errors for a disbursement schedule.
    */
@@ -229,7 +221,6 @@ export class DisbursementSchedule extends RecordDataModel {
     },
   )
   disbursementFeedbackErrors?: DisbursementFeedbackErrors[];
-
   /**
    * Indication for whether the disbursement has estimated awards greater than $0.
    */
@@ -239,4 +230,22 @@ export class DisbursementSchedule extends RecordDataModel {
     nullable: false,
   })
   hasEstimatedAwards: boolean;
+  /**
+   * User who updated the disbursement schedule status.
+   */
+  @ManyToOne(() => User, { nullable: true })
+  @JoinColumn({
+    name: "disbursement_schedule_status_updated_by",
+    referencedColumnName: ColumnNames.ID,
+  })
+  disbursementScheduleStatusUpdatedBy?: User;
+  /**
+   * Date and time when the disbursement schedule status was updated.
+   */
+  @Column({
+    name: "disbursement_schedule_status_updated_on",
+    type: "timestamptz",
+    nullable: true,
+  })
+  disbursementScheduleStatusUpdatedOn?: Date;
 }

--- a/sources/packages/backend/libs/utilities/src/queue.constant.ts
+++ b/sources/packages/backend/libs/utilities/src/queue.constant.ts
@@ -34,4 +34,5 @@ export enum QueueNames {
   ApplicationChangesReportIntegration = "application-changes-report-integration",
   StudentApplicationNotifications = "student-application-notifications",
   SIMSToSFASIntegration = "sims-to-sfas-integration",
+  ECertCancellationResponseIntegration = "e-cert-cancellation-response-integration",
 }

--- a/sources/packages/web/src/types/contracts/Overaward.ts
+++ b/sources/packages/web/src/types/contracts/Overaward.ts
@@ -22,7 +22,7 @@ export enum DisbursementOverawardOriginType {
   LegacyOveraward = "Legacy overaward",
   /**
    * Overaward paid by a disbursement award deduction was rejected
-   * due to the disbursement being rejected by EDSC.
+   * due to the disbursement being rejected by ESDC.
    */
-  AwardDeductedRejected = "Award deducted rejected",
+  AwardRejectedDeducted = "Award rejected deducted",
 }

--- a/sources/packages/web/src/types/contracts/Overaward.ts
+++ b/sources/packages/web/src/types/contracts/Overaward.ts
@@ -20,4 +20,9 @@ export enum DisbursementOverawardOriginType {
    * data is imported to the system.
    */
   LegacyOveraward = "Legacy overaward",
+  /**
+   * Overaward paid by a disbursement award deduction was rejected
+   * due to the disbursement being rejected by EDSC.
+   */
+  AwardDeductedRejected = "Award deducted rejected",
 }

--- a/sources/packages/web/src/types/contracts/institution/ConfirmationOfEnrollment.ts
+++ b/sources/packages/web/src/types/contracts/institution/ConfirmationOfEnrollment.ts
@@ -89,4 +89,9 @@ export enum DisbursementScheduleStatus {
    * application is canceled.
    */
   Cancelled = "Cancelled",
+  /**
+   * The status indicates that the disbursement has been rejected by ESDC
+   * after being sent.
+   */
+  Rejected = "Rejected",
 }


### PR DESCRIPTION
# DB Migrations and Scheduler boiler plate

## DB Migrations

- [x] DB Migration to add a new disbursement schedule status `Rejected`
- [x] DB Migration to add columns `disbursement_schedule_status_updated_by` and `disbursement_schedule_status_updated_on` to audit updates to the column `disbursement_schedule_status` of `sims.disbursement_schedules`.
- [x] DB Migration to set the `disbursement_schedule_status` column to `Rejected` when `date_sent` is not NULL to change the temporary state of disbursement records currently handled. This updated is executed with `system-user` as `audit user`.
- [x] DB Migration to add a disbursement overaward origin type `Award deducted rejected`

## Capturing audit on disbursement schedule status updates
- [x] Update the `disbursement_status_status` audit columns `disbursement_schedule_status_updated_by` and `disbursement_schedule_status_updated_on` on all instances of update to the status.

## Rollback evidence

![image](https://github.com/user-attachments/assets/cce1a138-c590-437b-93da-aff5506db9b2)

![image](https://github.com/user-attachments/assets/08b8b71a-f6fd-40d8-b9a9-55a2247edcbc)

![image](https://github.com/user-attachments/assets/36dd1523-1a7a-4f7e-98bc-3e914f85beeb)

![image](https://github.com/user-attachments/assets/7c97ae3a-2852-4002-8abd-0373a28a9b99)

![image](https://github.com/user-attachments/assets/75c21f5a-d7c8-40c6-adc6-50fd0143d141)

## Scheduler

- [x] Added scheduler `e-cert-cancellation-response-integration` scheduled to run daily at `17:00 UTC` -> `9:00 a.m. PST`

