### PR TITLE
#4414 - Interface Policy Questions 

### DIFF
--- a/sources/packages/backend/workflow/src/workflow-definitions/load-assessment-consolidated-data.bpmn
+++ b/sources/packages/backend/workflow/src/workflow-definitions/load-assessment-consolidated-data.bpmn
@@ -125,7 +125,7 @@
           <zeebe:header key="studentDataPartnerHasEmploymentInsuranceBenefits" value="$.data.partnerHasEmploymentInsuranceBenefits" />
           <zeebe:header key="studentDataPartnerHasFedralProvincialPDReceipt" value="$.data.partnerHasFedralProvincialPDReceipt" />
           <zeebe:header key="studentDataPartnerHasTotalIncomeAssistance" value="$.data.partnerHasTotalIncomeAssistance" />
-          <zeebe:header key="studentDataPartnerBCEAIncomeAssistanceAmount" value="$.data.partnerBCEAIncomeAssistanceAmount" />
+          <zeebe:header key="studentDataPartnerBCEAIncomeAssistanceAmount" value="$.data.partnerBceaIncomeAssistanceAmount" />
           <zeebe:header key="partner1HasEmploymentInsuranceBenefits" value="$.supportingUsers.Partner1.supportingData.hasEmploymentInsuranceBenefits" />
           <zeebe:header key="partner1HasFedralProvincialPDReceipt" value="$.supportingUsers.Partner1.supportingData.hasFedralProvincialPDReceipt" />
           <zeebe:header key="partner1HasTotalIncomeAssistance" value="$.supportingUsers.Partner1.supportingData.hasTotalIncomeAssistance" />

--- a/sources/packages/backend/workflow/src/workflow-definitions/load-assessment-consolidated-data.bpmn
+++ b/sources/packages/backend/workflow/src/workflow-definitions/load-assessment-consolidated-data.bpmn
@@ -129,7 +129,7 @@
           <zeebe:header key="partner1HasEmploymentInsuranceBenefits" value="$.supportingUsers.Partner1.supportingData.hasEmploymentInsuranceBenefits" />
           <zeebe:header key="partner1HasFedralProvincialPDReceipt" value="$.supportingUsers.Partner1.supportingData.hasFedralProvincialPDReceipt" />
           <zeebe:header key="partner1HasTotalIncomeAssistance" value="$.supportingUsers.Partner1.supportingData.hasTotalIncomeAssistance" />
-          <zeebe:header key="partner1BCEAIncomeAssistanceAmount" value="$.supportingUsers.Partner1.supportingData.bceaIncomeAssistanceAmount" />
+          <zeebe:header key="partner1BCEAIncomeAssistanceAmount" value="$.supportingUsers.Partner1.supportingData.partnerBceaIncomeAssistanceAmount" />
           <zeebe:header key="studentDataExceptionalExpenseAmount" value="$.data.exceptionalExpenseAmount" />
         </zeebe:taskHeaders>
       </bpmn:extensionElements>

--- a/sources/packages/backend/workflow/src/workflow-definitions/load-assessment-consolidated-data.bpmn
+++ b/sources/packages/backend/workflow/src/workflow-definitions/load-assessment-consolidated-data.bpmn
@@ -125,11 +125,11 @@
           <zeebe:header key="studentDataPartnerHasEmploymentInsuranceBenefits" value="$.data.partnerHasEmploymentInsuranceBenefits" />
           <zeebe:header key="studentDataPartnerHasFedralProvincialPDReceipt" value="$.data.partnerHasFedralProvincialPDReceipt" />
           <zeebe:header key="studentDataPartnerHasTotalIncomeAssistance" value="$.data.partnerHasTotalIncomeAssistance" />
-          <zeebe:header key="studentDataPartnerBCEAIncomeAssistanceAmount" value="$.data.studentDataPartnerBCEAIncomeAssistanceAmount" />
+          <zeebe:header key="studentDataPartnerBCEAIncomeAssistanceAmount" value="$.data.partnerBCEAIncomeAssistanceAmount" />
           <zeebe:header key="partner1HasEmploymentInsuranceBenefits" value="$.supportingUsers.Partner1.supportingData.hasEmploymentInsuranceBenefits" />
           <zeebe:header key="partner1HasFedralProvincialPDReceipt" value="$.supportingUsers.Partner1.supportingData.hasFedralProvincialPDReceipt" />
           <zeebe:header key="partner1HasTotalIncomeAssistance" value="$.supportingUsers.Partner1.supportingData.hasTotalIncomeAssistance" />
-          <zeebe:header key="partner1BCEAIncomeAssistanceAmount" value="$.supportingUsers.Partner1.supportingData.partner1BCEAIncomeAssistanceAmount" />
+          <zeebe:header key="partner1BCEAIncomeAssistanceAmount" value="$.supportingUsers.Partner1.supportingData.bceaIncomeAssistanceAmount" />
           <zeebe:header key="studentDataExceptionalExpenseAmount" value="$.data.exceptionalExpenseAmount" />
         </zeebe:taskHeaders>
       </bpmn:extensionElements>

--- a/sources/packages/backend/workflow/src/workflow-definitions/load-assessment-consolidated-data.bpmn
+++ b/sources/packages/backend/workflow/src/workflow-definitions/load-assessment-consolidated-data.bpmn
@@ -125,11 +125,11 @@
           <zeebe:header key="studentDataPartnerHasEmploymentInsuranceBenefits" value="$.data.partnerHasEmploymentInsuranceBenefits" />
           <zeebe:header key="studentDataPartnerHasFedralProvincialPDReceipt" value="$.data.partnerHasFedralProvincialPDReceipt" />
           <zeebe:header key="studentDataPartnerHasTotalIncomeAssistance" value="$.data.partnerHasTotalIncomeAssistance" />
-          <zeebe:header key="studentDataPartnerBCEAIncomeAssistanceAmount" value="$.data.partnerBceaIncomeAssistanceAmount" />
+          <zeebe:header key="studentDataPartnerBCEAIncomeAssistanceAmount" value="$.data.partnerBCEAIncomeAssistanceAmount" />
           <zeebe:header key="partner1HasEmploymentInsuranceBenefits" value="$.supportingUsers.Partner1.supportingData.hasEmploymentInsuranceBenefits" />
           <zeebe:header key="partner1HasFedralProvincialPDReceipt" value="$.supportingUsers.Partner1.supportingData.hasFedralProvincialPDReceipt" />
           <zeebe:header key="partner1HasTotalIncomeAssistance" value="$.supportingUsers.Partner1.supportingData.hasTotalIncomeAssistance" />
-          <zeebe:header key="partner1BCEAIncomeAssistanceAmount" value="$.supportingUsers.Partner1.supportingData.partnerBceaIncomeAssistanceAmount" />
+          <zeebe:header key="partner1BCEAIncomeAssistanceAmount" value="$.supportingUsers.Partner1.supportingData.partnerBCEAIncomeAssistanceAmount" />
           <zeebe:header key="studentDataExceptionalExpenseAmount" value="$.data.exceptionalExpenseAmount" />
         </zeebe:taskHeaders>
       </bpmn:extensionElements>

--- a/sources/packages/backend/workflow/src/workflow-definitions/load-assessment-consolidated-data.bpmn
+++ b/sources/packages/backend/workflow/src/workflow-definitions/load-assessment-consolidated-data.bpmn
@@ -125,9 +125,11 @@
           <zeebe:header key="studentDataPartnerHasEmploymentInsuranceBenefits" value="$.data.partnerHasEmploymentInsuranceBenefits" />
           <zeebe:header key="studentDataPartnerHasFedralProvincialPDReceipt" value="$.data.partnerHasFedralProvincialPDReceipt" />
           <zeebe:header key="studentDataPartnerHasTotalIncomeAssistance" value="$.data.partnerHasTotalIncomeAssistance" />
+          <zeebe:header key="studentDataPartnerBCEAIncomeAssistanceAmount" value="$.data.studentDataPartnerBCEAIncomeAssistanceAmount" />
           <zeebe:header key="partner1HasEmploymentInsuranceBenefits" value="$.supportingUsers.Partner1.supportingData.hasEmploymentInsuranceBenefits" />
           <zeebe:header key="partner1HasFedralProvincialPDReceipt" value="$.supportingUsers.Partner1.supportingData.hasFedralProvincialPDReceipt" />
           <zeebe:header key="partner1HasTotalIncomeAssistance" value="$.supportingUsers.Partner1.supportingData.hasTotalIncomeAssistance" />
+          <zeebe:header key="partner1BCEAIncomeAssistanceAmount" value="$.supportingUsers.Partner1.supportingData.partner1BCEAIncomeAssistanceAmount" />
           <zeebe:header key="studentDataExceptionalExpenseAmount" value="$.data.exceptionalExpenseAmount" />
         </zeebe:taskHeaders>
       </bpmn:extensionElements>

--- a/sources/packages/backend/workflow/src/workflow-definitions/load-assessment-consolidated-data.bpmn
+++ b/sources/packages/backend/workflow/src/workflow-definitions/load-assessment-consolidated-data.bpmn
@@ -129,7 +129,7 @@
           <zeebe:header key="partner1HasEmploymentInsuranceBenefits" value="$.supportingUsers.Partner1.supportingData.hasEmploymentInsuranceBenefits" />
           <zeebe:header key="partner1HasFedralProvincialPDReceipt" value="$.supportingUsers.Partner1.supportingData.hasFedralProvincialPDReceipt" />
           <zeebe:header key="partner1HasTotalIncomeAssistance" value="$.supportingUsers.Partner1.supportingData.hasTotalIncomeAssistance" />
-          <zeebe:header key="partner1BCEAIncomeAssistanceAmount" value="$.supportingUsers.Partner1.supportingData.partnerBCEAIncomeAssistanceAmount" />
+          <zeebe:header key="partner1BCEAIncomeAssistanceAmount" value="$.supportingUsers.Partner1.supportingData.BCEAIncomeAssistanceAmount" />
           <zeebe:header key="studentDataExceptionalExpenseAmount" value="$.data.exceptionalExpenseAmount" />
         </zeebe:taskHeaders>
       </bpmn:extensionElements>

--- a/sources/packages/backend/workflow/src/workflow-definitions/load-assessment-consolidated-data.bpmn
+++ b/sources/packages/backend/workflow/src/workflow-definitions/load-assessment-consolidated-data.bpmn
@@ -129,7 +129,7 @@
           <zeebe:header key="partner1HasEmploymentInsuranceBenefits" value="$.supportingUsers.Partner1.supportingData.hasEmploymentInsuranceBenefits" />
           <zeebe:header key="partner1HasFedralProvincialPDReceipt" value="$.supportingUsers.Partner1.supportingData.hasFedralProvincialPDReceipt" />
           <zeebe:header key="partner1HasTotalIncomeAssistance" value="$.supportingUsers.Partner1.supportingData.hasTotalIncomeAssistance" />
-          <zeebe:header key="partner1BCEAIncomeAssistanceAmount" value="$.supportingUsers.Partner1.supportingData.BCEAIncomeAssistanceAmount" />
+          <zeebe:header key="partner1BCEAIncomeAssistanceAmount" value="$.supportingUsers.Partner1.supportingData.bceaIncomeAssistanceAmount" />
           <zeebe:header key="studentDataExceptionalExpenseAmount" value="$.data.exceptionalExpenseAmount" />
         </zeebe:taskHeaders>
       </bpmn:extensionElements>

--- a/sources/packages/forms/src/form-definitions/sfaa2025-26-ft.json
+++ b/sources/packages/forms/src/form-definitions/sfaa2025-26-ft.json
@@ -5412,7 +5412,7 @@
                 "custom": "valid = (input >= 0 && input < data.maxIncome) ? true : 'The number you have entered is outside the expected range.';"
               },
               "validateWhenHidden": false,
-              "key": "partnerBCEAIncomeAssistanceAmount",
+              "key": "partnerBceaIncomeAssistanceAmount",
               "conditional": {
                 "show": true,
                 "when": "studentPartnerBceaIncomeAssistance",

--- a/sources/packages/forms/src/form-definitions/sfaa2025-26-ft.json
+++ b/sources/packages/forms/src/form-definitions/sfaa2025-26-ft.json
@@ -5412,7 +5412,7 @@
               "key": "partnerBceaIncomeAssistanceAmount",
               "conditional": {
                 "show": true,
-                "when": "studentPartnerBceaIncomeAssistance",
+                "when": "partnerHasBceaIncomeAssistance",
                 "eq": "yes"
               },
               "type": "number",

--- a/sources/packages/forms/src/form-definitions/sfaa2025-26-ft.json
+++ b/sources/packages/forms/src/form-definitions/sfaa2025-26-ft.json
@@ -5395,10 +5395,10 @@
               "input": true
             },
             {
-              "title": "Partner Receives BCEA Income Assistance Panel",
+              "title": "Student Partner Receives BCEA Income Assistance Panel",
               "collapsible": false,
               "hideLabel": true,
-              "key": "partnerReceivesBceaIncomeAssistance",
+              "key": "studentPartnerReceivesBceaIncomeAssistance",
               "conditional": {
                 "show": true,
                 "when": "partnerHasBceaIncomeAssistance",

--- a/sources/packages/forms/src/form-definitions/sfaa2025-26-ft.json
+++ b/sources/packages/forms/src/form-definitions/sfaa2025-26-ft.json
@@ -5412,7 +5412,7 @@
                 "custom": "valid = (input >= 0 && input < data.maxIncome) ? true : 'The number you have entered is outside the expected range.';"
               },
               "validateWhenHidden": false,
-              "key": "studentDataPartnerBCEAIncomeAssistanceAmount",
+              "key": "partnerBCEAIncomeAssistanceAmount",
               "conditional": {
                 "show": true,
                 "when": "studentPartnerBceaIncomeAssistance",

--- a/sources/packages/forms/src/form-definitions/sfaa2025-26-ft.json
+++ b/sources/packages/forms/src/form-definitions/sfaa2025-26-ft.json
@@ -5390,7 +5390,7 @@
                 "onlyAvailableItems": true
               },
               "validateWhenHidden": false,
-              "key": "partnerHasBceaIncomeAssistance",
+              "key": "partnerHasBCEAIncomeAssistance",
               "type": "radio",
               "input": true
             },
@@ -5398,10 +5398,10 @@
               "title": "Student Partner Receives BCEA Income Assistance Panel",
               "collapsible": false,
               "hideLabel": true,
-              "key": "studentPartnerReceivesBceaIncomeAssistance",
+              "key": "studentPartnerReceivesBCEAIncomeAssistance",
               "conditional": {
                 "show": true,
-                "when": "partnerHasBceaIncomeAssistance",
+                "when": "partnerHasBCEAIncomeAssistance",
                 "eq": "yes"
               },
               "type": "panel",
@@ -5431,7 +5431,7 @@
                     "custom": "valid = (input >= 0 && input < data.maxIncome) ? true : 'The number you have entered is outside the expected range.';"
                   },
                   "validateWhenHidden": false,
-                  "key": "partnerBceaIncomeAssistanceAmount",
+                  "key": "partnerBCEAIncomeAssistanceAmount",
                   "type": "number",
                   "decimalLimit": 0,
                   "input": true

--- a/sources/packages/forms/src/form-definitions/sfaa2025-26-ft.json
+++ b/sources/packages/forms/src/form-definitions/sfaa2025-26-ft.json
@@ -5395,7 +5395,7 @@
               "input": true
             },
             {
-              "label": "Enter the amount of assistance you will receive during the applicant's study period",
+              "label": "Enter the amount of assistance they will receive during the applicant's study period",
               "prefix": "$",
               "applyMaskOn": "change",
               "mask": false,

--- a/sources/packages/forms/src/form-definitions/sfaa2025-26-ft.json
+++ b/sources/packages/forms/src/form-definitions/sfaa2025-26-ft.json
@@ -5369,6 +5369,60 @@
               "lockKey": true
             },
             {
+              "label": "Will your partner receive B.C. income assistance for persons with disabilities under the Employment and Assistance for Persons with Disabilities Act during your study period?",
+              "optionsLabelPosition": "right",
+              "inline": false,
+              "tableView": false,
+              "values": [
+                {
+                  "label": "Yes",
+                  "value": "yes",
+                  "shortcut": ""
+                },
+                {
+                  "label": "No",
+                  "value": "no",
+                  "shortcut": ""
+                }
+              ],
+              "validate": {
+                "required": true,
+                "onlyAvailableItems": true
+              },
+              "validateWhenHidden": false,
+              "key": "partnerHasBceaIncomeAssistance",
+              "attributes": {
+                "data-cy": "partnercaringforeligibleDependent"
+              },
+              "type": "radio",
+              "input": true
+            },
+            {
+              "label": "Enter the amount of assistance you will receive during the applicant's study period",
+              "prefix": "$",
+              "applyMaskOn": "change",
+              "mask": false,
+              "tableView": false,
+              "delimiter": true,
+              "requireDecimal": false,
+              "inputFormat": "plain",
+              "truncateMultipleSpaces": false,
+              "validate": {
+                "required": true,
+                "custom": "valid = (input >= 0 && input < data.maxIncome) ? true : 'The number you have entered is outside the expected range.';"
+              },
+              "validateWhenHidden": false,
+              "key": "studentDataPartnerBCEAIncomeAssistanceAmount",
+              "conditional": {
+                "show": true,
+                "when": "studentPartnerBceaIncomeAssistance",
+                "eq": "yes"
+              },
+              "type": "number",
+              "decimalLimit": 0,
+              "input": true
+            },
+            {
               "label": "Will your partner be at home caring for eligible dependent children on a full-time basis during your entire study period?",
               "optionsLabelPosition": "right",
               "inline": false,

--- a/sources/packages/forms/src/form-definitions/sfaa2025-26-ft.json
+++ b/sources/packages/forms/src/form-definitions/sfaa2025-26-ft.json
@@ -5391,9 +5391,6 @@
               },
               "validateWhenHidden": false,
               "key": "partnerHasBceaIncomeAssistance",
-              "attributes": {
-                "data-cy": "partnercaringforeligibleDependent"
-              },
               "type": "radio",
               "input": true
             },

--- a/sources/packages/forms/src/form-definitions/sfaa2025-26-ft.json
+++ b/sources/packages/forms/src/form-definitions/sfaa2025-26-ft.json
@@ -5395,29 +5395,48 @@
               "input": true
             },
             {
-              "label": "Enter the amount of assistance they will receive during the applicant's study period",
-              "prefix": "$",
-              "applyMaskOn": "change",
-              "mask": false,
-              "tableView": false,
-              "delimiter": true,
-              "requireDecimal": false,
-              "inputFormat": "plain",
-              "truncateMultipleSpaces": false,
-              "validate": {
-                "required": true,
-                "custom": "valid = (input >= 0 && input < data.maxIncome) ? true : 'The number you have entered is outside the expected range.';"
-              },
-              "validateWhenHidden": false,
-              "key": "partnerBceaIncomeAssistanceAmount",
+              "title": "Partner Receives BCEA Income Assistance Panel",
+              "collapsible": false,
+              "hideLabel": true,
+              "key": "partnerReceivesBceaIncomeAssistance",
               "conditional": {
                 "show": true,
                 "when": "partnerHasBceaIncomeAssistance",
                 "eq": "yes"
               },
-              "type": "number",
-              "decimalLimit": 0,
-              "input": true
+              "type": "panel",
+              "label": "Panel",
+              "breadcrumbClickable": false,
+              "allowPrevious": false,
+              "buttonSettings": {
+                "previous": false,
+                "cancel": false,
+                "next": false
+              },
+              "input": false,
+              "tableView": false,
+              "components": [
+                {
+                  "label": "Enter the amount of assistance they will receive during the applicant's study period",
+                  "prefix": "$",
+                  "applyMaskOn": "change",
+                  "mask": false,
+                  "tableView": false,
+                  "delimiter": true,
+                  "requireDecimal": false,
+                  "inputFormat": "plain",
+                  "truncateMultipleSpaces": false,
+                  "validate": {
+                    "required": true,
+                    "custom": "valid = (input >= 0 && input < data.maxIncome) ? true : 'The number you have entered is outside the expected range.';"
+                  },
+                  "validateWhenHidden": false,
+                  "key": "partnerBceaIncomeAssistanceAmount",
+                  "type": "number",
+                  "decimalLimit": 0,
+                  "input": true
+                }
+              ]
             },
             {
               "label": "Will your partner be at home caring for eligible dependent children on a full-time basis during your entire study period?",

--- a/sources/packages/forms/src/form-definitions/supportinguserspartner2025-2026.json
+++ b/sources/packages/forms/src/form-definitions/supportinguserspartner2025-2026.json
@@ -629,6 +629,7 @@
                 {
                   "title": "Partner Receives BCEA Income Assistance Panel",
                   "collapsible": false,
+                  "hideLabel": true,
                   "key": "partnerReceivesBceaIncomeAssistance",
                   "conditional": {
                     "show": true,
@@ -833,20 +834,21 @@
                 {
                   "title": "<strong>Will you be paying a Canada Student Loan and/or a provincial student loan regular scheduled payments during your Partner's study period?</strong>",
                   "collapsible": false,
+                  "hideLabel": true,
                   "key": "willYourPartnerBePayingACanadaStudentLoanAndOrAProvincialStudentLoanRegularScheduledPaymentsDuringTheYourStudyPeriodPanel",
                   "conditional": {
-                    "show": "true",
+                    "show": true,
                     "when": "partnerPayStudentLoan",
                     "eq": "yes"
                   },
                   "type": "panel",
                   "label": "Will you be paying a Canada Student Loan and/or a provincial student loan regular scheduled payments during the your Partner's study period?",
+                  "breadcrumbClickable": true,
                   "buttonSettings": {
                     "previous": true,
                     "cancel": true,
                     "next": true
                   },
-                  "breadcrumbClickable": true,
                   "scrollToTop": false,
                   "input": false,
                   "tableView": false,

--- a/sources/packages/forms/src/form-definitions/supportinguserspartner2025-2026.json
+++ b/sources/packages/forms/src/form-definitions/supportinguserspartner2025-2026.json
@@ -617,7 +617,7 @@
                     "onlyAvailableItems": true
                   },
                   "validateWhenHidden": false,
-                  "key": "hasBceaIncomeAssistance",
+                  "key": "hasBCEAIncomeAssistance",
                   "conditional": {
                     "show": true,
                     "when": "offeringIntensity",
@@ -630,10 +630,10 @@
                   "title": "Partner Receives BCEA Income Assistance Panel",
                   "collapsible": false,
                   "hideLabel": true,
-                  "key": "partnerReceivesBceaIncomeAssistance",
+                  "key": "partnerReceivesBCEAIncomeAssistance",
                   "conditional": {
                     "show": true,
-                    "when": "supportingData.hasBceaIncomeAssistance",
+                    "when": "supportingData.hasBCEAIncomeAssistance",
                     "eq": "yes"
                   },
                   "type": "panel",
@@ -663,7 +663,7 @@
                         "custom": "valid = (input >= 0 && input < data.maxIncome) ? true : 'The number you have entered is outside the expected range.';"
                       },
                       "validateWhenHidden": false,
-                      "key": "partnerBceaIncomeAssistanceAmount",
+                      "key": "partnerBCEAIncomeAssistanceAmount",
                       "type": "number",
                       "decimalLimit": 0,
                       "input": true

--- a/sources/packages/forms/src/form-definitions/supportinguserspartner2025-2026.json
+++ b/sources/packages/forms/src/form-definitions/supportinguserspartner2025-2026.json
@@ -663,7 +663,7 @@
                         "custom": "valid = (input >= 0 && input < data.maxIncome) ? true : 'The number you have entered is outside the expected range.';"
                       },
                       "validateWhenHidden": false,
-                      "key": "bceaIncomeAssistanceAmount",
+                      "key": "partnerBceaIncomeAssistanceAmount",
                       "type": "number",
                       "decimalLimit": 0,
                       "input": true

--- a/sources/packages/forms/src/form-definitions/supportinguserspartner2025-2026.json
+++ b/sources/packages/forms/src/form-definitions/supportinguserspartner2025-2026.json
@@ -596,6 +596,65 @@
                   "lockKey": true
                 },
                 {
+                  "label": "During the applicant's study period, will you receive B.C. income assistance for persons with disabilities under the Employment and Assistance for Persons with Disabilities Act?",
+                  "optionsLabelPosition": "right",
+                  "inline": false,
+                  "tableView": false,
+                  "values": [
+                    {
+                      "label": "Yes",
+                      "value": "yes",
+                      "shortcut": ""
+                    },
+                    {
+                      "label": "No",
+                      "value": "no",
+                      "shortcut": ""
+                    }
+                  ],
+                  "validate": {
+                    "required": true,
+                    "onlyAvailableItems": true
+                  },
+                  "validateWhenHidden": false,
+                  "key": "hasBceaIncomeAssistance",
+                  "conditional": {
+                    "show": true,
+                    "when": "offeringIntensity",
+                    "eq": "Full Time"
+                  },
+                  "attributes": {
+                    "data-cy": "partnercaringforeligibleDependent"
+                  },
+                  "type": "radio",
+                  "input": true
+                },
+                {
+                  "label": "Enter the amount of assistance you will receive during the applicant's study period",
+                  "prefix": "$",
+                  "applyMaskOn": "change",
+                  "mask": false,
+                  "tableView": false,
+                  "delimiter": true,
+                  "requireDecimal": false,
+                  "inputFormat": "plain",
+                  "truncateMultipleSpaces": false,
+                  "validate": {
+                    "required": true,
+                    "custom": "valid = (input >= 0 && input < data.maxIncome) ? true : 'The number you have entered is outside the expected range.';"
+                  },
+                  "validateWhenHidden": false,
+                  "key": "partner1BCEAIncomeAssistanceAmount",
+                  "conditional": {
+                    "show": true,
+                    "when": "supportingData.hasBceaIncomeAssistance",
+                    "eq": "yes"
+                  },
+                  "type": "number",
+                  "decimalLimit": 0,
+                  "input": true
+                },
+                {
                   "label": "Will you be at home caring for eligible dependant children on a full-time basis during your Partner's entire study period?",
                   "optionsLabelPosition": "right",
                   "inline": false,

--- a/sources/packages/forms/src/form-definitions/supportinguserspartner2025-2026.json
+++ b/sources/packages/forms/src/form-definitions/supportinguserspartner2025-2026.json
@@ -630,7 +630,7 @@
                   "title": "Partner Receives BCEA Income Assistance Panel",
                   "collapsible": false,
                   "hideLabel": true,
-                  "key": "partnerReceivesBCEAIncomeAssistance",
+                  "key": "receivesBCEAIncomeAssistance",
                   "conditional": {
                     "show": true,
                     "when": "supportingData.hasBCEAIncomeAssistance",
@@ -663,7 +663,7 @@
                         "custom": "valid = (input >= 0 && input < data.maxIncome) ? true : 'The number you have entered is outside the expected range.';"
                       },
                       "validateWhenHidden": false,
-                      "key": "BCEAIncomeAssistanceAmount",
+                      "key": "bceaIncomeAssistanceAmount",
                       "type": "number",
                       "decimalLimit": 0,
                       "input": true

--- a/sources/packages/forms/src/form-definitions/supportinguserspartner2025-2026.json
+++ b/sources/packages/forms/src/form-definitions/supportinguserspartner2025-2026.json
@@ -663,7 +663,7 @@
                         "custom": "valid = (input >= 0 && input < data.maxIncome) ? true : 'The number you have entered is outside the expected range.';"
                       },
                       "validateWhenHidden": false,
-                      "key": "partnerBCEAIncomeAssistanceAmount",
+                      "key": "BCEAIncomeAssistanceAmount",
                       "type": "number",
                       "decimalLimit": 0,
                       "input": true

--- a/sources/packages/forms/src/form-definitions/supportinguserspartner2025-2026.json
+++ b/sources/packages/forms/src/form-definitions/supportinguserspartner2025-2026.json
@@ -644,7 +644,7 @@
                     "custom": "valid = (input >= 0 && input < data.maxIncome) ? true : 'The number you have entered is outside the expected range.';"
                   },
                   "validateWhenHidden": false,
-                  "key": "partner1BCEAIncomeAssistanceAmount",
+                  "key": "bceaIncomeAssistanceAmount",
                   "conditional": {
                     "show": true,
                     "when": "supportingData.hasBceaIncomeAssistance",

--- a/sources/packages/forms/src/form-definitions/supportinguserspartner2025-2026.json
+++ b/sources/packages/forms/src/form-definitions/supportinguserspartner2025-2026.json
@@ -627,29 +627,47 @@
                   "input": true
                 },
                 {
-                  "label": "Enter the amount of assistance you will receive during the applicant's study period",
-                  "prefix": "$",
-                  "applyMaskOn": "change",
-                  "mask": false,
-                  "tableView": false,
-                  "delimiter": true,
-                  "requireDecimal": false,
-                  "inputFormat": "plain",
-                  "truncateMultipleSpaces": false,
-                  "validate": {
-                    "required": true,
-                    "custom": "valid = (input >= 0 && input < data.maxIncome) ? true : 'The number you have entered is outside the expected range.';"
-                  },
-                  "validateWhenHidden": false,
-                  "key": "bceaIncomeAssistanceAmount",
+                  "title": "Partner Receives BCEA Income Assistance Panel",
+                  "collapsible": false,
+                  "key": "partnerReceivesBceaIncomeAssistance",
                   "conditional": {
                     "show": true,
                     "when": "supportingData.hasBceaIncomeAssistance",
                     "eq": "yes"
                   },
-                  "type": "number",
-                  "decimalLimit": 0,
-                  "input": true
+                  "type": "panel",
+                  "label": "Will you be paying a Canada Student Loan and/or a provincial student loan regular scheduled payments during the your Partner's study period?",
+                  "breadcrumbClickable": true,
+                  "buttonSettings": {
+                    "previous": true,
+                    "cancel": true,
+                    "next": true
+                  },
+                  "scrollToTop": false,
+                  "input": false,
+                  "tableView": false,
+                  "components": [
+                    {
+                      "label": "Enter the amount of assistance you will receive during the applicant's study period",
+                      "prefix": "$",
+                      "applyMaskOn": "change",
+                      "mask": false,
+                      "tableView": false,
+                      "delimiter": true,
+                      "requireDecimal": false,
+                      "inputFormat": "plain",
+                      "truncateMultipleSpaces": false,
+                      "validate": {
+                        "required": true,
+                        "custom": "valid = (input >= 0 && input < data.maxIncome) ? true : 'The number you have entered is outside the expected range.';"
+                      },
+                      "validateWhenHidden": false,
+                      "key": "bceaIncomeAssistanceAmount",
+                      "type": "number",
+                      "decimalLimit": 0,
+                      "input": true
+                    }
+                  ]
                 },
                 {
                   "label": "Will you be at home caring for eligible dependant children on a full-time basis during your Partner's entire study period?",

--- a/sources/packages/forms/src/form-definitions/supportinguserspartner2025-2026.json
+++ b/sources/packages/forms/src/form-definitions/supportinguserspartner2025-2026.json
@@ -905,20 +905,21 @@
                 {
                   "title": "Will your partner be paying for child support and/or spousal support during your study period Panel",
                   "collapsible": false,
+                  "hideLabel": true,
                   "key": "willYourPartnerBePayingForChildSupportAndOrSpousalSupportDuringTheYourStudyPeriodPanel",
                   "conditional": {
-                    "show": "true",
+                    "show": true,
                     "when": "partnerPaySupport",
                     "eq": "yes"
                   },
                   "type": "panel",
                   "label": "Will your partner be paying for child support and/or spousal support during the your study period Panel",
+                  "breadcrumbClickable": true,
                   "buttonSettings": {
                     "previous": true,
                     "cancel": true,
                     "next": true
                   },
-                  "breadcrumbClickable": true,
                   "scrollToTop": false,
                   "input": false,
                   "tableView": false,

--- a/sources/packages/forms/src/form-definitions/supportinguserspartner2025-2026.json
+++ b/sources/packages/forms/src/form-definitions/supportinguserspartner2025-2026.json
@@ -623,9 +623,6 @@
                     "when": "offeringIntensity",
                     "eq": "Full Time"
                   },
-                  "attributes": {
-                    "data-cy": "partnercaringforeligibleDependent"
-                  },
                   "type": "radio",
                   "input": true
                 },


### PR DESCRIPTION
## Changes
- [x] Adds interface policy questions for partner to student and supporting user 25/26 FT application
- [x] Added BCEA income amounts as keys to consolidated data
- [x] Minor fixes to hide panel labels in supporting user 25/26 form 

## Supporting User: 
![image](https://github.com/user-attachments/assets/84c20f21-f594-427d-84eb-a8ca242f5901)


## Student 25/26 FT: 
![image](https://github.com/user-attachments/assets/884dd879-55c0-4515-9770-a0b5d975cc04)

