### PR TITLE
#4711 - Revise FT application: Unsuccessful Completion Week Count (e2e tests)

### DIFF
--- a/sources/packages/backend/apps/api/src/route-controllers/student-scholastic-standings/_tests_/e2e/student-scholastic-standings.institutions.controller.saveScholasticStanding.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/student-scholastic-standings/_tests_/e2e/student-scholastic-standings.institutions.controller.saveScholasticStanding.e2e-spec.ts
@@ -794,6 +794,10 @@ describe("StudentScholasticStandingsInstitutionsController(e2e)-saveScholasticSt
       },
       where: { id: application.id },
     });
+    expect(
+      queryApplication.currentAssessment.studentScholasticStanding
+        .unsuccessfulWeeks,
+    ).toBe(5);
     expect(queryApplication.currentAssessment.id).toBe(
       application.currentAssessment.id,
     );

--- a/sources/packages/backend/apps/api/src/route-controllers/student-scholastic-standings/_tests_/e2e/student-scholastic-standings.institutions.controller.saveScholasticStanding.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/student-scholastic-standings/_tests_/e2e/student-scholastic-standings.institutions.controller.saveScholasticStanding.e2e-spec.ts
@@ -707,6 +707,101 @@ describe("StudentScholasticStandingsInstitutionsController(e2e)-saveScholasticSt
       });
   });
 
+  it("Should not create new scholastic standing 'Student did not complete program' for a part-time application when number of unsuccessful completion weeks is greater than the total number of offering weeks.", async () => {
+    // Arrange
+    mockFormioDryRun({
+      studentScholasticStandingChangeType:
+        StudentScholasticStandingChangeType.StudentDidNotCompleteProgram,
+      numberOfUnsuccessfulWeeks: 50,
+    });
+    const application = await saveFakeApplication(
+      db.dataSource,
+      {
+        institutionLocation: collegeFLocation,
+      },
+      {
+        offeringIntensity: OfferingIntensity.partTime,
+        applicationStatus: ApplicationStatus.Completed,
+      },
+    );
+    // Institution token.
+    const institutionUserToken = await getInstitutionToken(
+      InstitutionTokenTypes.CollegeFUser,
+    );
+    const endpoint = `/institutions/scholastic-standing/location/${collegeFLocation.id}/application/${application.id}`;
+
+    // Act/Assert
+    await request(app.getHttpServer())
+      .post(endpoint)
+      .send(payload)
+      .auth(institutionUserToken, BEARER_AUTH_TYPE)
+      .expect(HttpStatus.UNPROCESSABLE_ENTITY)
+      .expect({
+        message:
+          "Number of unsuccessful weeks cannot exceed the number of offering weeks.",
+        errorType: "INVALID_UNSUCCESSFUL_COMPLETION_WEEKS",
+      });
+  });
+
+  it("Should create new scholastic standing 'Student did not complete program' for a part-time application when number of unsuccessful completion weeks is less than the total number of offering weeks.", async () => {
+    // Arrange
+    const application = await saveFakeApplication(
+      db.dataSource,
+      {
+        institutionLocation: collegeFLocation,
+      },
+      {
+        offeringIntensity: OfferingIntensity.partTime,
+        applicationStatus: ApplicationStatus.Completed,
+      },
+    );
+    // Institution token.
+    const institutionUserToken = await getInstitutionToken(
+      InstitutionTokenTypes.CollegeFUser,
+    );
+
+    // Mock with a valid number of unsuccessful weeks (smaller than total offering weeks).
+    mockFormioDryRun({
+      studentScholasticStandingChangeType:
+        StudentScholasticStandingChangeType.StudentDidNotCompleteProgram,
+      numberOfUnsuccessfulWeeks: 5,
+    });
+
+    const endpoint = `/institutions/scholastic-standing/location/${collegeFLocation.id}/application/${application.id}`;
+
+    // Act/Assert
+    await request(app.getHttpServer())
+      .post(endpoint)
+      .send(payload)
+      .auth(institutionUserToken, BEARER_AUTH_TYPE)
+      .expect(HttpStatus.CREATED)
+      .expect((response) => {
+        expect(response.body.id).toBeGreaterThan(0);
+      });
+    const queryApplication = await db.application.findOne({
+      select: {
+        id: true,
+        currentAssessment: {
+          id: true,
+          triggerType: true,
+          studentScholasticStanding: { id: true },
+        },
+      },
+      relations: {
+        currentAssessment: {
+          studentScholasticStanding: true,
+        },
+      },
+      where: { id: application.id },
+    });
+    expect(queryApplication.currentAssessment.id).toBe(
+      application.currentAssessment.id,
+    );
+    expect(queryApplication.currentAssessment.triggerType).toBe(
+      AssessmentTriggerType.OriginalAssessment,
+    );
+  });
+
   it("Should not create new scholastic standing 'Student withdrew from program' for a part-time application when date of withdrawal is greater than current date.", async () => {
     // Arrange
     mockFormioDryRun({
@@ -789,6 +884,7 @@ describe("StudentScholasticStandingsInstitutionsController(e2e)-saveScholasticSt
    * - `dateOfChange`: Date of change used during the School Transfer scholastic standing.
    * - `dateOfCompletion`: Date of change used during the Student completed program early scholastic standing.
    * - `dateOfWithdrawal`: Date of change used during the Student withdrew from program scholastic standing.
+   * - `numberOfUnsuccessfulWeeks`: Number of unsuccessful weeks used during the 'Student did not complete program' scholastic standing.
    */
   //TODO - When formio container is available, remove the mock.
   function mockFormioDryRun(options?: {
@@ -797,6 +893,7 @@ describe("StudentScholasticStandingsInstitutionsController(e2e)-saveScholasticSt
     dateOfChange?: string;
     dateOfCompletion?: string;
     dateOfWithdrawal?: string;
+    numberOfUnsuccessfulWeeks?: number;
   }): void {
     const validDryRun = options?.validDryRun ?? true;
     const scholasticStandingChangeType =
@@ -818,6 +915,10 @@ describe("StudentScholasticStandingsInstitutionsController(e2e)-saveScholasticSt
         break;
       case StudentScholasticStandingChangeType.SchoolTransfer:
         payload.data.dateOfChange = options?.dateOfChange ?? fallbackDate;
+        break;
+      case StudentScholasticStandingChangeType.StudentDidNotCompleteProgram:
+        payload.data.numberOfUnsuccessfulWeeks =
+          options?.numberOfUnsuccessfulWeeks ?? 1;
         break;
     }
 

--- a/sources/packages/backend/apps/api/src/route-controllers/student-scholastic-standings/_tests_/e2e/student-scholastic-standings.institutions.controller.saveScholasticStanding.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/student-scholastic-standings/_tests_/e2e/student-scholastic-standings.institutions.controller.saveScholasticStanding.e2e-spec.ts
@@ -795,8 +795,7 @@ describe("StudentScholasticStandingsInstitutionsController(e2e)-saveScholasticSt
       where: { id: application.id },
     });
     expect(
-      queryApplication.currentAssessment.studentScholasticStanding
-        .unsuccessfulWeeks,
+      application.currentAssessment.studentScholasticStanding.unsuccessfulWeeks,
     ).toBe(5);
     expect(queryApplication.currentAssessment.id).toBe(
       application.currentAssessment.id,

--- a/sources/packages/backend/libs/test-utils/src/factories/education-program-offering.ts
+++ b/sources/packages/backend/libs/test-utils/src/factories/education-program-offering.ts
@@ -69,6 +69,7 @@ export function createFakeEducationProgramOffering(
     getISODateOnlyString(faker.date.soon(30));
   offering.studyBreaks = {
     totalFundedWeeks: 16,
+    totalDays: 210,
   } as StudyBreaksAndWeeks;
   offering.offeringStatus = OfferingStatus.Approved;
   offering.parentOffering = offering;

--- a/sources/packages/backend/libs/test-utils/src/factories/education-program-offering.ts
+++ b/sources/packages/backend/libs/test-utils/src/factories/education-program-offering.ts
@@ -69,7 +69,7 @@ export function createFakeEducationProgramOffering(
     getISODateOnlyString(faker.date.soon(30));
   offering.studyBreaks = {
     totalFundedWeeks: 16,
-    totalDays: 210,
+    totalDays: 210, // 30 offering weeks * 7 days,
   } as StudyBreaksAndWeeks;
   offering.offeringStatus = OfferingStatus.Approved;
   offering.parentOffering = offering;


### PR DESCRIPTION
### As a part of this PR, the following e2e tests were written:

**StudentScholasticStandingsInstitutionsController(e2e)-saveScholasticStanding.**
    √ Should not create new scholastic standing 'Student did not complete program' for a part-time application when number of unsuccessful completion weeks is greater than the total number of offering weeks.
    √ Should create new scholastic standing 'Student did not complete program' for a part-time application when number of unsuccessful completion weeks is less than the total number of offering weeks.

**Screenshot of passing tests:**

<img width="1447" alt="image" src="https://github.com/user-attachments/assets/d815f328-46e5-49fa-900c-82663ad11ec7" />