### PR TITLE
#4415 - Ministry: Add student information header to additional pages

### DIFF
--- a/sources/packages/web/src/components/common/students/applicationDetails/ApplicationExceptionsApproval.vue
+++ b/sources/packages/web/src/components/common/students/applicationDetails/ApplicationExceptionsApproval.vue
@@ -6,6 +6,7 @@
         subTitle="View request(s)"
         :routeLocation="backRouteLocation"
       />
+      <application-header-title :application-id="applicationId" />
     </template>
     <template #sub-header>
       <header-title-value title="Submitted date" :value="submittedDate"
@@ -45,6 +46,7 @@ import {
 import { useAssessment, useFormatters } from "@/composables";
 import HeaderTitleValue from "@/components/generic/HeaderTitleValue.vue";
 import CheckPermissionRole from "@/components/generic/CheckPermissionRole.vue";
+import ApplicationHeaderTitle from "@/components/aest/students/ApplicationHeaderTitle.vue";
 
 /**
  * Model to be used to populate the form.io.
@@ -88,7 +90,7 @@ export default defineComponent({
       return !!form;
     },
   },
-  components: { HeaderTitleValue, CheckPermissionRole },
+  components: { HeaderTitleValue, CheckPermissionRole, ApplicationHeaderTitle },
   props: {
     studentId: {
       type: Number,
@@ -119,7 +121,7 @@ export default defineComponent({
     },
     applicationId: {
       type: Number,
-      required: false,
+      required: true,
     },
   },
   setup(props) {

--- a/sources/packages/web/src/views/aest/StudentApplicationView.vue
+++ b/sources/packages/web/src/views/aest/StudentApplicationView.vue
@@ -44,11 +44,9 @@
           </check-permission-role>
         </template>
       </header-navigator>
+      <application-header-title :application-id="applicationId" />
     </template>
-    <h2 class="color-blue pb-4">
-      Student Application Details
-      {{ emptyStringFiller(applicationDetail.applicationNumber) }}
-    </h2>
+    <h2 class="color-blue pb-4">Student Application Details</h2>
     <StudentApplication
       @render="formRender"
       :selectedForm="selectedForm"
@@ -91,12 +89,14 @@ import AssessApplicationChangeRequestModal from "@/components/aest/students/moda
 import CheckPermissionRole from "@/components/generic/CheckPermissionRole.vue";
 import useEmitterEvents from "@/composables/useEmitterEvents";
 import { INVALID_APPLICATION_EDIT_STATUS } from "@/constants";
+import ApplicationHeaderTitle from "@/components/aest/students/ApplicationHeaderTitle.vue";
 
 export default defineComponent({
   components: {
     StudentApplication,
     AssessApplicationChangeRequestModal,
     CheckPermissionRole,
+    ApplicationHeaderTitle,
   },
   props: {
     studentId: {

--- a/sources/packages/web/src/views/aest/student/applicationDetails/ApplicationExceptionsApproval.vue
+++ b/sources/packages/web/src/views/aest/student/applicationDetails/ApplicationExceptionsApproval.vue
@@ -1,6 +1,7 @@
 <template>
   <application-exceptions-approval
     :exceptionId="exceptionId"
+    :applicationId="applicationId"
     :backRouteLocation="assessmentsSummaryRoute"
     :processing="processing"
     :showStaffApproval="true"

--- a/sources/packages/web/src/views/aest/student/applicationDetails/StudentAppealRequestsApproval.vue
+++ b/sources/packages/web/src/views/aest/student/applicationDetails/StudentAppealRequestsApproval.vue
@@ -6,6 +6,7 @@
         subTitle="View request(s)"
         :routeLocation="assessmentsSummaryRoute"
       />
+      <application-header-title :application-id="applicationId" />
     </template>
     <student-appeal-requests-approval
       :appealId="appealId"
@@ -25,10 +26,12 @@ import { useSnackBar } from "@/composables";
 import { StudentAppealApproval, ApiProcessError } from "@/types";
 import { ASSESSMENT_ALREADY_IN_PROGRESS } from "@/services/http/dto/Assessment.dto";
 import StudentAppealRequestsApproval from "@/components/common/students/applicationDetails/StudentAppealRequestsApproval.vue";
+import ApplicationHeaderTitle from "@/components/aest/students/ApplicationHeaderTitle.vue";
 
 export default defineComponent({
   components: {
     StudentAppealRequestsApproval,
+    ApplicationHeaderTitle,
   },
   props: {
     studentId: {


### PR DESCRIPTION
*Acceptance Criteria:*

- [X] Student information header follows the existing design as seen on the assessment page (style, spacing, font and information)
- [x] Ministry view update only (if it automatically changes the view of BC publics that is fine but no extra effort required to make their view match this functionality)
- [x] Student Information header added at the top of the Application Page
- [x] Student Information header added at the top of the Exceptions Page
- [x] Student Information header added at the top of the Change Request Page
- [x] Student Information head added at the top of the "new" change request page
- [x] Remove the large application number in the ministry view of the application

*Demo*
1. 
![image](https://github.com/user-attachments/assets/19da276d-e762-48ad-a543-b491b612a06e)
