### PR TITLE
#4740 - Parent update first effort - CRA Request Scheduler Changes

### DIFF
--- a/sims.code-workspace
+++ b/sims.code-workspace
@@ -156,6 +156,7 @@
       "BCSG",
       "bcsl",
       "bgpd",
+      "CCRA",
       "Clamav",
       "composables",
       "CSGD",

--- a/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/cra-integration/_tests_/cra-process-integration.scheduler.e2e-spec.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/cra-integration/_tests_/cra-process-integration.scheduler.e2e-spec.ts
@@ -62,7 +62,7 @@ describe(describeProcessorRootTest(QueueNames.CRAProcessIntegration), () => {
   });
 
   it("Should create one CRA file request with two income verification records when there are pending requests for a student and a parent and both have a SIN.", async () => {
-    // Arrange.
+    // Arrange
     const {
       student,
       parent,
@@ -134,7 +134,7 @@ describe(describeProcessorRootTest(QueueNames.CRAProcessIntegration), () => {
   });
 
   it("Should create one CRA file request with one income verification when there are pending requests for a student and a parent and only the student has a SIN.", async () => {
-    // Arrange.
+    // Arrange
     const { student } = await createApplicationWithParent();
     const now = new Date();
     MockDate.set(now);

--- a/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/cra-integration/_tests_/cra-process-integration.scheduler.e2e-spec.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/cra-integration/_tests_/cra-process-integration.scheduler.e2e-spec.ts
@@ -1,6 +1,6 @@
 import { DeepMocked } from "@golevelup/ts-jest";
 import { INestApplication } from "@nestjs/common";
-import { QueueNames, StringBuilder } from "@sims/utilities";
+import { QueueNames } from "@sims/utilities";
 import {
   createTestingAppModule,
   describeProcessorRootTest,
@@ -17,21 +17,26 @@ import {
 } from "@sims/test-utils";
 import * as Client from "ssh2-sftp-client";
 import { CRAProcessIntegrationScheduler } from "../cra-process-integration.scheduler";
-import { ApplicationStatus } from "@sims/sims-db";
+import {
+  ApplicationStatus,
+  CRAIncomeVerification,
+  Student,
+  SupportingUser,
+} from "@sims/sims-db";
 import { getUploadedFile } from "@sims/test-utils/mocks";
 import { IsNull } from "typeorm";
 import MockDate from "mockdate";
-import * as dayjs from "dayjs";
+import {
+  CRA_PROGRAM_AREA_CODE,
+  CRARequestRecordParser,
+} from "./parsers/cra-request-record-parser";
 
 describe(describeProcessorRootTest(QueueNames.CRAProcessIntegration), () => {
   let app: INestApplication;
   let processor: CRAProcessIntegrationScheduler;
   let db: E2EDataSources;
   let sftpClientMock: DeepMocked<Client>;
-  const CRA_PROGRAM_AREA_CODE = "BCSL";
   const SEQUENCE_NAME = `CRA_${CRA_PROGRAM_AREA_CODE}`;
-  const DATE_FORMAT = "YYYYMMDD";
-  const SPACE_FILLER = " ";
 
   beforeAll(async () => {
     process.env.CRA_PROGRAM_AREA_CODE = CRA_PROGRAM_AREA_CODE;
@@ -54,8 +59,136 @@ describe(describeProcessorRootTest(QueueNames.CRAProcessIntegration), () => {
     await db.sequenceControl.delete({ sequenceName: SEQUENCE_NAME });
   });
 
-  it("Should create the SIN file request when there are pending requests with an associated SIN.", async () => {
+  it("Should create one CRA file request with two income verification records when there are pending requests for a student and a parent and both have a SIN.", async () => {
     // Arrange.
+    const {
+      student,
+      parent,
+      studentCRAIncomeVerification,
+      parentCRAIncomeVerification,
+    } = await createApplicationWithParent({
+      parentSin: "999999999",
+    });
+    const now = new Date();
+    MockDate.set(now);
+    // Queued job.
+    const mockedJob = mockBullJob<void>();
+
+    // Act
+    const result = await processor.processQueue(mockedJob.job);
+
+    // Assert
+    // Assert uploaded file.
+    const uploadedFile = getUploadedFile(sftpClientMock);
+    const uploadedFileName = "OUT\\CCRA_REQUEST_A00001.DAT";
+    expect(uploadedFile.remoteFilePath).toBe(uploadedFileName);
+    expect(result).toStrictEqual([
+      `Generated file: ${uploadedFileName}`,
+      "Uploaded records: 2",
+    ]);
+    const [header, studentRecord, parentRecord, footer] =
+      uploadedFile.fileLines;
+    // Validate header.
+    const headerParsed = new CRARequestRecordParser(header);
+    expect(
+      headerParsed.matchHeaderData({
+        fileDate: now,
+        sequenceNumber: 1,
+      }),
+    ).toBe(true);
+    // Validate student record.
+    const studentRecordParsed = new CRARequestRecordParser(studentRecord);
+    expect(
+      studentRecordParsed.matchIncomeData(
+        studentCRAIncomeVerification.id,
+        student.user.firstName,
+        student.user.lastName,
+        student.sinValidation.sin,
+        student.birthDate,
+        studentCRAIncomeVerification.taxYear,
+      ),
+    ).toBe(true);
+    // Validate parent record.
+    const parentRecordParsed = new CRARequestRecordParser(parentRecord);
+    expect(
+      parentRecordParsed.matchIncomeData(
+        parentCRAIncomeVerification.id,
+        parent.user.firstName,
+        parent.user.lastName,
+        parent.sin,
+        parent.birthDate,
+        parentCRAIncomeVerification.taxYear,
+      ),
+    ).toBe(true);
+    // Validate footer.
+    const footerParsed = new CRARequestRecordParser(footer);
+    expect(
+      footerParsed.matchFooterData({
+        fileDate: now,
+        sequenceNumber: 1,
+        totalRecords: 4,
+      }),
+    ).toBe(true);
+  });
+
+  it("Should create one CRA file request with one income verification when there are pending requests for a student and a parent and only the student has a SIN.", async () => {
+    // Arrange.
+    const { student } = await createApplicationWithParent();
+    const now = new Date();
+    MockDate.set(now);
+    // Queued job.
+    const mockedJob = mockBullJob<void>();
+
+    // Act
+    const result = await processor.processQueue(mockedJob.job);
+
+    // Assert
+    const uploadedFile = getUploadedFile(sftpClientMock);
+    expect(result).toStrictEqual([
+      `Generated file: ${uploadedFile.remoteFilePath}`,
+      "Uploaded records: 1",
+    ]);
+    const [header, studentRecord, footer] = uploadedFile.fileLines;
+    // Validate header.
+    const headerParsed = new CRARequestRecordParser(header);
+    expect(
+      headerParsed.matchHeaderData({
+        fileDate: now,
+        sequenceNumber: 1,
+      }),
+    ).toBe(true);
+    // Validate if the record belongs to the student.
+    const studentRecordParsed = new CRARequestRecordParser(studentRecord);
+    expect(
+      studentRecordParsed.matchIndividual(
+        student.user.lastName,
+        student.user.firstName,
+      ),
+    ).toBe(true);
+    // Validate footer.
+    const footerParsed = new CRARequestRecordParser(footer);
+    expect(
+      footerParsed.matchFooterData({
+        fileDate: now,
+        sequenceNumber: 1,
+        totalRecords: 3,
+      }),
+    ).toBe(true);
+  });
+
+  /**
+   * Creates a student and a parent with the option to specify the parent's SIN.
+   * @param options - Options for creating the application.
+   * @returns created student, parent, and their CRA income verifications.
+   */
+  async function createApplicationWithParent(options?: {
+    parentSin?: string;
+  }): Promise<{
+    student: Student;
+    parent: SupportingUser;
+    studentCRAIncomeVerification: CRAIncomeVerification;
+    parentCRAIncomeVerification: CRAIncomeVerification;
+  }> {
     // Create the student with a valid SIN.
     const student = await saveFakeStudent(db.dataSource);
     // Crate an application with a student that will always have a SIN.
@@ -71,13 +204,13 @@ describe(describeProcessorRootTest(QueueNames.CRAProcessIntegration), () => {
       { application, user: parentUser },
       {
         initialValues: {
-          sin: "999999999",
+          sin: options?.parentSin,
+          birthDate: "1990-01-01",
         },
       },
     );
-    // Crate an application a parent with the ability to have an income check executed since it has a SIN.
+    // Create an application a parent with the ability to have an income check executed since it has a SIN.
     await db.supportingUser.save(parent);
-
     // Create CRA income verifications for student.
     const studentCRAIncomeVerification = createFakeCRAIncomeVerification({
       application,
@@ -90,78 +223,11 @@ describe(describeProcessorRootTest(QueueNames.CRAProcessIntegration), () => {
       studentCRAIncomeVerification,
       parentCRAIncomeVerification,
     ]);
-    const now = new Date();
-    MockDate.set(now);
-    // Queued job.
-    const mockedJob = mockBullJob<void>();
-
-    // Act
-    const result = await processor.processQueue(mockedJob.job);
-    // Assert
-    // Assert uploaded file.
-    const uploadedFile = getUploadedFile(sftpClientMock);
-    const uploadedFileName = "OUT\\CCRA_REQUEST_A00001.DAT";
-    expect(uploadedFile.remoteFilePath).toBe(uploadedFileName);
-    expect(result).toStrictEqual([
-      `Generated file: ${uploadedFileName}`,
-      "Uploaded records: 2",
-    ]);
-    const [header, studentRecord, parentRecord, footer] =
-      uploadedFile.fileLines;
-    // Validate header.
-    const isoNow = dayjs(now).format(DATE_FORMAT);
-    expect(header).toBe(
-      `7100                        ${isoNow} ${CRA_PROGRAM_AREA_CODE}A00001                                                                                                   0`,
-    );
-    // Validate student record.
-    const studentRecordExpected = createSINRecord(
-      studentCRAIncomeVerification.id,
-      student.user.firstName,
-      student.user.lastName,
-      student.sinValidation.sin,
-      student.birthDate,
-      studentCRAIncomeVerification.taxYear,
-    );
-    // Validate parent record.
-    expect(studentRecord).toBe(studentRecordExpected);
-    const parentRecordExpected = createSINRecord(
-      parentCRAIncomeVerification.id,
-      parent.user.firstName,
-      parent.user.lastName,
-      parent.sin,
-      parent.birthDate,
-      parentCRAIncomeVerification.taxYear,
-    );
-    expect(parentRecord).toBe(parentRecordExpected);
-    // Validate footer.
-    expect(footer.substring(0, 18)).toBe("999NEW ENTITLEMENT");
-  });
-
-  function createSINRecord(
-    craIncomeVerificationId: number,
-    firstName: string,
-    lastName: string,
-    sin: string,
-    birthDate: string,
-    taxYear?: number,
-  ) {
-    const record = new StringBuilder();
-    record.append("7101");
-    record.append(sin);
-    record.repeatAppend(SPACE_FILLER, 4);
-    record.append("0020");
-    record.appendWithEndFiller(lastName, 30, SPACE_FILLER);
-    record.appendWithEndFiller(firstName ?? "", 30, SPACE_FILLER);
-    record.appendDate(birthDate, DATE_FORMAT);
-    record.appendWithEndFiller((taxYear ?? "").toString(), 20, SPACE_FILLER);
-    record.append(CRA_PROGRAM_AREA_CODE);
-    record.appendWithEndFiller(
-      `VERIFICATION_ID:${craIncomeVerificationId}`,
-      30,
-      SPACE_FILLER,
-    );
-    record.repeatAppend(SPACE_FILLER, 3);
-    record.append("0");
-    return record.toString();
+    return {
+      student,
+      parent,
+      studentCRAIncomeVerification,
+      parentCRAIncomeVerification,
+    };
   }
 });

--- a/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/cra-integration/_tests_/cra-process-integration.scheduler.e2e-spec.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/cra-integration/_tests_/cra-process-integration.scheduler.e2e-spec.ts
@@ -93,7 +93,7 @@ describe(describeProcessorRootTest(QueueNames.CRAProcessIntegration), () => {
     // Validate header.
     const headerParsed = new CRARequestRecordParser(header);
     expect(
-      headerParsed.matchHeaderData({
+      headerParsed.matchHeader({
         fileDate: now,
         sequenceNumber: 1,
       }),
@@ -101,31 +101,31 @@ describe(describeProcessorRootTest(QueueNames.CRAProcessIntegration), () => {
     // Validate student record.
     const studentRecordParsed = new CRARequestRecordParser(studentRecord);
     expect(
-      studentRecordParsed.matchIncomeData(
-        studentCRAIncomeVerification.id,
-        student.user.firstName,
-        student.user.lastName,
-        student.sinValidation.sin,
-        student.birthDate,
-        studentCRAIncomeVerification.taxYear,
-      ),
+      studentRecordParsed.matchIncome({
+        id: studentCRAIncomeVerification.id,
+        firstName: student.user.firstName,
+        lastName: student.user.lastName,
+        sin: student.sinValidation.sin,
+        birthDate: student.birthDate,
+        taxYear: studentCRAIncomeVerification.taxYear,
+      }),
     ).toBe(true);
     // Validate parent record.
     const parentRecordParsed = new CRARequestRecordParser(parentRecord);
     expect(
-      parentRecordParsed.matchIncomeData(
-        parentCRAIncomeVerification.id,
-        parent.user.firstName,
-        parent.user.lastName,
-        parent.sin,
-        parent.birthDate,
-        parentCRAIncomeVerification.taxYear,
-      ),
+      parentRecordParsed.matchIncome({
+        id: parentCRAIncomeVerification.id,
+        firstName: parent.user.firstName,
+        lastName: parent.user.lastName,
+        sin: parent.sin,
+        birthDate: parent.birthDate,
+        taxYear: parentCRAIncomeVerification.taxYear,
+      }),
     ).toBe(true);
     // Validate footer.
     const footerParsed = new CRARequestRecordParser(footer);
     expect(
-      footerParsed.matchFooterData({
+      footerParsed.matchFooter({
         fileDate: now,
         sequenceNumber: 1,
         totalRecords: 4,
@@ -154,7 +154,7 @@ describe(describeProcessorRootTest(QueueNames.CRAProcessIntegration), () => {
     // Validate header.
     const headerParsed = new CRARequestRecordParser(header);
     expect(
-      headerParsed.matchHeaderData({
+      headerParsed.matchHeader({
         fileDate: now,
         sequenceNumber: 1,
       }),
@@ -170,7 +170,7 @@ describe(describeProcessorRootTest(QueueNames.CRAProcessIntegration), () => {
     // Validate footer.
     const footerParsed = new CRARequestRecordParser(footer);
     expect(
-      footerParsed.matchFooterData({
+      footerParsed.matchFooter({
         fileDate: now,
         sequenceNumber: 1,
         totalRecords: 3,

--- a/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/cra-integration/_tests_/cra-process-integration.scheduler.e2e-spec.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/cra-integration/_tests_/cra-process-integration.scheduler.e2e-spec.ts
@@ -1,0 +1,167 @@
+import { DeepMocked } from "@golevelup/ts-jest";
+import { INestApplication } from "@nestjs/common";
+import { QueueNames, StringBuilder } from "@sims/utilities";
+import {
+  createTestingAppModule,
+  describeProcessorRootTest,
+  mockBullJob,
+} from "../../../../../test/helpers";
+import {
+  E2EDataSources,
+  createE2EDataSources,
+  createFakeCRAIncomeVerification,
+  createFakeSupportingUser,
+  createFakeUser,
+  saveFakeApplication,
+  saveFakeStudent,
+} from "@sims/test-utils";
+import * as Client from "ssh2-sftp-client";
+import { CRAProcessIntegrationScheduler } from "../cra-process-integration.scheduler";
+import { ApplicationStatus } from "@sims/sims-db";
+import { getUploadedFile } from "@sims/test-utils/mocks";
+import { IsNull } from "typeorm";
+import MockDate from "mockdate";
+import * as dayjs from "dayjs";
+
+describe(describeProcessorRootTest(QueueNames.CRAProcessIntegration), () => {
+  let app: INestApplication;
+  let processor: CRAProcessIntegrationScheduler;
+  let db: E2EDataSources;
+  let sftpClientMock: DeepMocked<Client>;
+  const CRA_PROGRAM_AREA_CODE = "BCSL";
+  const SEQUENCE_NAME = `CRA_${CRA_PROGRAM_AREA_CODE}`;
+  const DATE_FORMAT = "YYYYMMDD";
+  const SPACE_FILLER = " ";
+
+  beforeAll(async () => {
+    process.env.CRA_PROGRAM_AREA_CODE = CRA_PROGRAM_AREA_CODE;
+    const { nestApplication, dataSource, sshClientMock } =
+      await createTestingAppModule();
+    app = nestApplication;
+    db = createE2EDataSources(dataSource);
+    sftpClientMock = sshClientMock;
+    processor = app.get(CRAProcessIntegrationScheduler);
+  });
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    MockDate.reset();
+    // Ensure all the CRA income verifications are sent.
+    await db.craIncomeVerification.update(
+      { dateSent: IsNull() },
+      { dateSent: new Date() },
+    );
+    await db.sequenceControl.delete({ sequenceName: SEQUENCE_NAME });
+  });
+
+  it("Should create the SIN file request when there are pending requests with an associated SIN.", async () => {
+    // Arrange.
+    // Create the student with a valid SIN.
+    const student = await saveFakeStudent(db.dataSource);
+    // Crate an application with a student that will always have a SIN.
+    const application = await saveFakeApplication(
+      db.dataSource,
+      { student },
+      {
+        applicationStatus: ApplicationStatus.InProgress,
+      },
+    );
+    const parentUser = await db.user.save(createFakeUser());
+    const parent = createFakeSupportingUser(
+      { application, user: parentUser },
+      {
+        initialValues: {
+          sin: "999999999",
+        },
+      },
+    );
+    // Crate an application a parent with the ability to have an income check executed since it has a SIN.
+    await db.supportingUser.save(parent);
+
+    // Create CRA income verifications for student.
+    const studentCRAIncomeVerification = createFakeCRAIncomeVerification({
+      application,
+    });
+    const parentCRAIncomeVerification = createFakeCRAIncomeVerification({
+      application,
+      supportingUser: parent,
+    });
+    await db.craIncomeVerification.save([
+      studentCRAIncomeVerification,
+      parentCRAIncomeVerification,
+    ]);
+    const now = new Date();
+    MockDate.set(now);
+    // Queued job.
+    const mockedJob = mockBullJob<void>();
+
+    // Act
+    const result = await processor.processQueue(mockedJob.job);
+    // Assert
+    // Assert uploaded file.
+    const uploadedFile = getUploadedFile(sftpClientMock);
+    const uploadedFileName = "OUT\\CCRA_REQUEST_A00001.DAT";
+    expect(uploadedFile.remoteFilePath).toBe(uploadedFileName);
+    expect(result).toStrictEqual([
+      `Generated file: ${uploadedFileName}`,
+      "Uploaded records: 2",
+    ]);
+    const [header, studentRecord, parentRecord, footer] =
+      uploadedFile.fileLines;
+    // Validate header.
+    const isoNow = dayjs(now).format(DATE_FORMAT);
+    expect(header).toBe(
+      `7100                        ${isoNow} ${CRA_PROGRAM_AREA_CODE}A00001                                                                                                   0`,
+    );
+    // Validate student record.
+    const studentRecordExpected = createSINRecord(
+      studentCRAIncomeVerification.id,
+      student.user.firstName,
+      student.user.lastName,
+      student.sinValidation.sin,
+      student.birthDate,
+      studentCRAIncomeVerification.taxYear,
+    );
+    // Validate parent record.
+    expect(studentRecord).toBe(studentRecordExpected);
+    const parentRecordExpected = createSINRecord(
+      parentCRAIncomeVerification.id,
+      parent.user.firstName,
+      parent.user.lastName,
+      parent.sin,
+      parent.birthDate,
+      parentCRAIncomeVerification.taxYear,
+    );
+    expect(parentRecord).toBe(parentRecordExpected);
+    // Validate footer.
+    expect(footer.substring(0, 18)).toBe("999NEW ENTITLEMENT");
+  });
+
+  function createSINRecord(
+    craIncomeVerificationId: number,
+    firstName: string,
+    lastName: string,
+    sin: string,
+    birthDate: string,
+    taxYear?: number,
+  ) {
+    const record = new StringBuilder();
+    record.append("7101");
+    record.append(sin);
+    record.repeatAppend(SPACE_FILLER, 4);
+    record.append("0020");
+    record.appendWithEndFiller(lastName, 30, SPACE_FILLER);
+    record.appendWithEndFiller(firstName ?? "", 30, SPACE_FILLER);
+    record.appendDate(birthDate, DATE_FORMAT);
+    record.appendWithEndFiller((taxYear ?? "").toString(), 20, SPACE_FILLER);
+    record.append(CRA_PROGRAM_AREA_CODE);
+    record.appendWithEndFiller(
+      `VERIFICATION_ID:${craIncomeVerificationId}`,
+      30,
+      SPACE_FILLER,
+    );
+    record.repeatAppend(SPACE_FILLER, 3);
+    record.append("0");
+    return record.toString();
+  }
+});

--- a/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/cra-integration/_tests_/cra-process-integration.scheduler.e2e-spec.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/cra-integration/_tests_/cra-process-integration.scheduler.e2e-spec.ts
@@ -41,6 +41,7 @@ describe(describeProcessorRootTest(QueueNames.CRAProcessIntegration), () => {
   beforeAll(async () => {
     process.env.CRA_PROGRAM_AREA_CODE = CRA_PROGRAM_AREA_CODE;
     process.env.CRA_REQUEST_FOLDER = "OUT";
+    process.env.CRA_ENVIRONMENT_CODE = "A";
     const { nestApplication, dataSource, sshClientMock } =
       await createTestingAppModule();
     app = nestApplication;

--- a/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/cra-integration/_tests_/cra-process-integration.scheduler.e2e-spec.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/cra-integration/_tests_/cra-process-integration.scheduler.e2e-spec.ts
@@ -40,6 +40,7 @@ describe(describeProcessorRootTest(QueueNames.CRAProcessIntegration), () => {
 
   beforeAll(async () => {
     process.env.CRA_PROGRAM_AREA_CODE = CRA_PROGRAM_AREA_CODE;
+    process.env.CRA_REQUEST_FOLDER = "OUT";
     const { nestApplication, dataSource, sshClientMock } =
       await createTestingAppModule();
     app = nestApplication;
@@ -177,8 +178,9 @@ describe(describeProcessorRootTest(QueueNames.CRAProcessIntegration), () => {
   });
 
   /**
-   * Creates a student and a parent with the option to specify the parent's SIN.
-   * @param options - Options for creating the application.
+   * Creates a Student Application with an associated parent and CRA income verification records.
+   * @param options options for creating the application.
+   * - `parentSin`: if provided, the parent will be created with this SIN.
    * @returns created student, parent, and their CRA income verifications.
    */
   async function createApplicationWithParent(options?: {
@@ -191,7 +193,7 @@ describe(describeProcessorRootTest(QueueNames.CRAProcessIntegration), () => {
   }> {
     // Create the student with a valid SIN.
     const student = await saveFakeStudent(db.dataSource);
-    // Crate an application with a student that will always have a SIN.
+    // Create an application with a student that will always have a SIN.
     const application = await saveFakeApplication(
       db.dataSource,
       { student },
@@ -209,9 +211,7 @@ describe(describeProcessorRootTest(QueueNames.CRAProcessIntegration), () => {
         },
       },
     );
-    // Create an application a parent with the ability to have an income check executed since it has a SIN.
     await db.supportingUser.save(parent);
-    // Create CRA income verifications for student.
     const studentCRAIncomeVerification = createFakeCRAIncomeVerification({
       application,
     });

--- a/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/cra-integration/_tests_/parsers/cra-request-record-parser.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/cra-integration/_tests_/parsers/cra-request-record-parser.ts
@@ -51,8 +51,6 @@ export class CRARequestRecordParser {
 
   /**
    * Check if the record matches the provided data.
-   * @param craIncomeVerificationId CRA income verification ID.
-   * This is used to identify the record in the CRA response.
    * @param incomeData object containing the individual's income data.
    * - `id` CRA income verification ID.
    * - `firstName` individual's first name.
@@ -68,7 +66,7 @@ export class CRARequestRecordParser {
     lastName: string;
     sin: string;
     birthDate: string;
-    taxYear?: number;
+    taxYear: number;
   }): boolean {
     const formattedBirthDate = dayjs(incomeData.birthDate).format(DATE_FORMAT);
     const freeProjectArea = `VERIFICATION_ID:${incomeData.id}`.padEnd(

--- a/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/cra-integration/_tests_/parsers/cra-request-record-parser.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/cra-integration/_tests_/parsers/cra-request-record-parser.ts
@@ -22,13 +22,6 @@ export class CRARequestRecordParser {
   constructor(private readonly record: string) {}
 
   /**
-   * Record type.
-   */
-  get recordType(): string {
-    return this.record.substring(0, 3);
-  }
-
-  /**
    * Student's first name.
    */
   get firstName(): string {

--- a/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/cra-integration/_tests_/parsers/cra-request-record-parser.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/cra-integration/_tests_/parsers/cra-request-record-parser.ts
@@ -1,0 +1,134 @@
+import * as dayjs from "dayjs";
+
+/**
+ * Max allowed first name and last name length.
+ */
+const MAX_NAME_LENGTH = 30;
+
+const SPACE_FILLER = " ";
+
+export const DATE_FORMAT = "YYYYMMDD";
+
+export const CRA_PROGRAM_AREA_CODE = "BCSL";
+
+/**
+ * Parses CRA income request record information.
+ */
+export class CRARequestRecordParser {
+  /**
+   * Initializes a new CRA income request parser.
+   * @param record record to be parsed.
+   */
+  constructor(private readonly record: string) {}
+
+  /**
+   * Record type.
+   */
+  get recordType(): string {
+    return this.record.substring(0, 3);
+  }
+
+  /**
+   * Student's first name.
+   */
+  get firstName(): string {
+    return this.record.substring(51, 51 + MAX_NAME_LENGTH);
+  }
+
+  /**
+   * Student's last name.
+   */
+  get lastName(): string {
+    return this.record.substring(21, 21 + MAX_NAME_LENGTH);
+  }
+
+  /**
+   * Validate if the first name and last names belongs to the
+   * provided individual.
+   * @param firstName first name to be checked.
+   * @param lastName last name to be checked.
+   * @returns true if the individual's first name and last name matches.
+   */
+  matchIndividual(lastName: string, firstName?: string): boolean {
+    return (
+      this.getNameWithFiller(lastName) === this.lastName &&
+      this.getNameWithFiller(firstName) === this.firstName
+    );
+  }
+
+  /**
+   * Check if the record matches the provided data.
+   * @param craIncomeVerificationId CRA income verification ID.
+   * This is used to identify the record in the CRA response.
+   * @param firstName individual's first name.
+   * @param lastName individual's last name.
+   * @param sin individual's Social Insurance Number (SIN).
+   * @param birthDate individual's birth date.
+   * @param taxYear individual's tax year for the income verification.
+   * @returns true if the record matches the provided data, false otherwise.
+   */
+  matchIncomeData(
+    craIncomeVerificationId: number,
+    firstName: string,
+    lastName: string,
+    sin: string,
+    birthDate: string,
+    taxYear?: number,
+  ): boolean {
+    const formattedBirthDate = dayjs(birthDate).format(DATE_FORMAT);
+    const freeProjectArea = `VERIFICATION_ID:${craIncomeVerificationId}`.padEnd(
+      30,
+      SPACE_FILLER,
+    );
+    const formattedLastName = this.getNameWithFiller(lastName);
+    const formattedFirstName = this.getNameWithFiller(firstName);
+    const expectedRecord = `7101${sin}    0020${formattedLastName}${formattedFirstName}${formattedBirthDate}${taxYear}                ${CRA_PROGRAM_AREA_CODE}${freeProjectArea}   0`;
+    return expectedRecord === this.record;
+  }
+
+  /**
+   * Recreates the header data from the provided {@link headerData} object
+   * and compares it with the record.
+   * @param headerData object containing the header data to be matched.
+   * @returns true if the header data matches the record, false otherwise.
+   */
+  matchHeaderData(headerData: {
+    fileDate: Date;
+    sequenceNumber: number;
+  }): boolean {
+    const date = dayjs(headerData.fileDate).format(DATE_FORMAT);
+    const sequence = headerData.sequenceNumber.toString().padStart(5, "0");
+    const expectedString = `7100                        ${date} ${CRA_PROGRAM_AREA_CODE}A${sequence}                                                                                                   0`;
+    return expectedString === this.record;
+  }
+
+  /**
+   * Recreates the footer data from the provided {@link footerData} object
+   * and compares it with the record.
+   * @param footerData object containing the footer data to be matched.
+   * @returns true if the footer data matches the record, false otherwise.
+   */
+  matchFooterData(footerData: {
+    fileDate: Date;
+    sequenceNumber: number;
+    totalRecords: number;
+  }): boolean {
+    const date = dayjs(footerData.fileDate).format(DATE_FORMAT);
+    const sequence = footerData.sequenceNumber.toString().padStart(5, "0");
+    const recordsCount = footerData.totalRecords.toString().padStart(8, "0");
+    const expectedString = `7102                        ${date} ${CRA_PROGRAM_AREA_CODE}A${sequence}      ${recordsCount}                                                                                     0`;
+    return expectedString === this.record;
+  }
+
+  /**
+   * Pads the provided name with spaces to ensure it meets the maximum length requirement
+   * in the same way it is expected to be presented in the CRA request record.
+   * @param name first or last name to be padded.
+   * @returns name is the expected format for CRA request record.
+   */
+  private getNameWithFiller(name?: string): string {
+    return (name ?? "")
+      .padEnd(MAX_NAME_LENGTH, SPACE_FILLER)
+      .substring(0, MAX_NAME_LENGTH);
+  }
+}

--- a/sources/packages/backend/libs/integrations/src/services/cra-income-verification/cra-income-verification.service.ts
+++ b/sources/packages/backend/libs/integrations/src/services/cra-income-verification/cra-income-verification.service.ts
@@ -38,8 +38,13 @@ export class CRAIncomeVerificationsService extends RecordDataModelService<CRAInc
       .innerJoin("student.sinValidation", "sinValidation")
       .innerJoin("student.user", "studentUser")
       .leftJoin("incomeVerification.supportingUser", "supportingUser")
-      .leftJoin("supportingUser.user", "supportingUserUser")
-      .where("incomeVerification.dateSent is null")
+      .leftJoin(
+        "supportingUser.user",
+        "supportingUserUser",
+        "supportingUser.sin IS NOT NULL",
+      )
+      .where("incomeVerification.dateSent IS NULL")
+      .orderBy("incomeVerification.id", "ASC")
       .getMany();
   }
 

--- a/sources/packages/backend/libs/integrations/src/services/cra-income-verification/cra-income-verification.service.ts
+++ b/sources/packages/backend/libs/integrations/src/services/cra-income-verification/cra-income-verification.service.ts
@@ -19,7 +19,8 @@ export class CRAIncomeVerificationsService extends RecordDataModelService<CRAInc
   }
 
   /**
-   * Gets income verifications that were never sent to CRA (dateSent is null).
+   * Gets income verifications that were never sent to CRA (dateSent is null),
+   * and there is an associated SIN (either student or supporting user).
    * Once sent, there is no mechanism in place for a retry logic.
    * @returns pending income verifications.
    */

--- a/sources/packages/backend/libs/test-utils/src/factories/supporting-user.ts
+++ b/sources/packages/backend/libs/test-utils/src/factories/supporting-user.ts
@@ -9,6 +9,7 @@ import {
  * Creates a fake supporting user.
  * @param relations dependencies:
  * - `application`: application that the supporting user is associated with.
+ * - `user`: user that the supporting user is associated with.
  * @param options student options.
  * - `initialValues` supporting user values.
  * @returns a fake supporting user.

--- a/sources/packages/backend/libs/test-utils/src/factories/supporting-user.ts
+++ b/sources/packages/backend/libs/test-utils/src/factories/supporting-user.ts
@@ -25,6 +25,7 @@ export function createFakeSupportingUser(
   const supportingUser = new SupportingUser();
   supportingUser.application = relations.application;
   supportingUser.sin = options?.initialValues?.sin;
+  supportingUser.birthDate = options?.initialValues?.birthDate;
   supportingUser.createdAt = new Date();
   supportingUser.updatedAt = new Date();
   supportingUser.supportingUserType =

--- a/sources/packages/backend/libs/test-utils/src/factories/supporting-user.ts
+++ b/sources/packages/backend/libs/test-utils/src/factories/supporting-user.ts
@@ -1,4 +1,9 @@
-import { Application, SupportingUser, SupportingUserType } from "@sims/sims-db";
+import {
+  Application,
+  SupportingUser,
+  SupportingUserType,
+  User,
+} from "@sims/sims-db";
 
 /**
  * Creates a fake supporting user.
@@ -11,6 +16,7 @@ import { Application, SupportingUser, SupportingUserType } from "@sims/sims-db";
 export function createFakeSupportingUser(
   relations: {
     application: Application;
+    user?: User;
   },
   options?: {
     initialValues: Partial<SupportingUser>;
@@ -18,6 +24,7 @@ export function createFakeSupportingUser(
 ): SupportingUser {
   const supportingUser = new SupportingUser();
   supportingUser.application = relations.application;
+  supportingUser.sin = options?.initialValues?.sin;
   supportingUser.createdAt = new Date();
   supportingUser.updatedAt = new Date();
   supportingUser.supportingUserType =
@@ -26,5 +33,6 @@ export function createFakeSupportingUser(
     options?.initialValues?.supportingData ?? null;
   supportingUser.isAbleToReport =
     options?.initialValues?.isAbleToReport ?? true;
+  supportingUser.user = relations?.user ?? null;
   return supportingUser;
 }


### PR DESCRIPTION
- Updated the CRA request query to skip supporting users without a SIN associated with it.
- Create E2E tests for the scheduler.
  - Should create one CRA file request with two income verification records when there are pending requests for a student and a parent and both have a SIN.
  - Should create one CRA file request with one income verification when there are pending requests for a student and a parent and only the student has a SIN.

_Note:_ The `CRARequestRecordParser` was created to follow the same idea from the existing `FullTimeCertRecordParser` and `PartTimeCertRecordParser`.