### PR TITLE
#4740 - Parent update first effort - New Worker E2E Tests

### DIFF
--- a/sources/packages/backend/apps/workers/src/controllers/supporting-user/_test_/e2e/create-identifiable-supporting-user.ts
+++ b/sources/packages/backend/apps/workers/src/controllers/supporting-user/_test_/e2e/create-identifiable-supporting-user.ts
@@ -1,0 +1,50 @@
+import { createFakeWorkerJob } from "../../../../../test/utils/worker-job-mock";
+import { SupportingUserType } from "@sims/sims-db";
+import {
+  CreateIdentifiableSupportingUsersJobInDTO,
+  CreateIdentifiableSupportingUsersJobOutDTO,
+} from "../../supporting-user.dto";
+import { ICustomHeaders, ZeebeJob } from "@camunda8/sdk/dist/zeebe/types";
+import { APPLICATION_ID } from "@sims/services/workflow/variables/assessment-gateway";
+import {
+  SUPPORTING_USER_TYPE,
+  FULL_NAME_PROPERTY_FILTER,
+  IS_ABLE_TO_REPORT,
+} from "@sims/services/workflow/variables/supporting-user-information-request";
+
+/**
+ * Creates a fake identifiable supporting users creation payload.
+ * @param options input variables for creating identifiable supporting user.
+ * - `applicationId`: ID of the application to which the supporting user belongs.
+ * - `supportingUserType`: type of the supporting user (Parent or Partner).
+ * - `parent`: indicates if the creation is for the first or second parent (1 for first parent, 2 for second parent).
+ * - `isAbleToReport`: indicates if the supporting user is able to report their data to the Ministry.
+ * @returns fake identifiable supporting users creation payload.
+ */
+export function createFakeCreateIdentifiableSupportingUsersPayload(options: {
+  applicationId: number;
+  supportingUserType: SupportingUserType;
+  parent: 1 | 2;
+  isAbleToReport: boolean;
+}): Readonly<
+  ZeebeJob<
+    CreateIdentifiableSupportingUsersJobInDTO,
+    ICustomHeaders,
+    CreateIdentifiableSupportingUsersJobOutDTO
+  >
+> {
+  return createFakeWorkerJob<
+    CreateIdentifiableSupportingUsersJobInDTO,
+    ICustomHeaders,
+    CreateIdentifiableSupportingUsersJobOutDTO
+  >({
+    variables: {
+      [APPLICATION_ID]: options.applicationId,
+      [SUPPORTING_USER_TYPE]: options.supportingUserType,
+      [FULL_NAME_PROPERTY_FILTER]: `$.parents[${
+        options.parent - 1
+      }].parentFullName`,
+      [IS_ABLE_TO_REPORT]: options.isAbleToReport,
+    },
+  });
+}

--- a/sources/packages/backend/apps/workers/src/controllers/supporting-user/_test_/e2e/create-identifiable-supporting-user.ts
+++ b/sources/packages/backend/apps/workers/src/controllers/supporting-user/_test_/e2e/create-identifiable-supporting-user.ts
@@ -13,7 +13,7 @@ import {
 } from "@sims/services/workflow/variables/supporting-user-information-request";
 
 /**
- * Creates a fake identifiable supporting users creation payload.
+ * Creates a fake identifiable supporting user creation payload.
  * @param options input variables for creating identifiable supporting user.
  * - `applicationId`: ID of the application to which the supporting user belongs.
  * - `supportingUserType`: type of the supporting user (Parent or Partner).

--- a/sources/packages/backend/apps/workers/src/controllers/supporting-user/_test_/e2e/supporting-user.controller.createIdentifiableSupportingUsers.e2e-spec.ts
+++ b/sources/packages/backend/apps/workers/src/controllers/supporting-user/_test_/e2e/supporting-user.controller.createIdentifiableSupportingUsers.e2e-spec.ts
@@ -1,0 +1,300 @@
+import { ApplicationData, SupportingUserType } from "@sims/sims-db";
+import {
+  createE2EDataSources,
+  createFakeSupportingUser,
+  E2EDataSources,
+  saveFakeApplication,
+} from "@sims/test-utils";
+import {
+  createFakeWorkerJob,
+  FAKE_WORKER_JOB_RESULT_PROPERTY,
+  MockedZeebeJobResult,
+} from "../../../../../test/utils/worker-job-mock";
+import { createTestingAppModule } from "../../../../../test/helpers";
+import { SupportingUserController } from "../../supporting-user.controller";
+import {
+  CreateIdentifiableSupportingUsersJobInDTO,
+  CreateIdentifiableSupportingUsersJobOutDTO,
+} from "../../supporting-user.dto";
+import { createFakeCreateIdentifiableSupportingUsersPayload } from "./create-identifiable-supporting-user";
+import { ICustomHeaders } from "@camunda8/sdk/dist/zeebe/types";
+import * as faker from "faker";
+import {
+  APPLICATION_NOT_FOUND,
+  SUPPORTING_USER_FULL_NAME_NOT_RESOLVED,
+} from "@sims/services/constants";
+
+describe("SupportingUserController(e2e)-createIdentifiableSupportingUsers", () => {
+  let db: E2EDataSources;
+  let supportingUserController: SupportingUserController;
+
+  beforeAll(async () => {
+    const { nestApplication, dataSource } = await createTestingAppModule();
+    db = createE2EDataSources(dataSource);
+    supportingUserController = nestApplication.get(SupportingUserController);
+  });
+
+  it("Should create one parent supporting user and save the associated full name when one information was added to the student application.", async () => {
+    // Arrange
+    const parentFullName = faker.datatype.uuid();
+    const savedApplication = await saveFakeApplication(
+      db.dataSource,
+      undefined,
+      {
+        applicationData: {
+          workflowName: "some-workflow",
+          parents: [
+            {
+              parentFullName,
+            },
+          ],
+        } as ApplicationData,
+      },
+    );
+    const fakePayload = createFakeCreateIdentifiableSupportingUsersPayload({
+      applicationId: savedApplication.id,
+      supportingUserType: SupportingUserType.Parent,
+      parent: 1,
+      isAbleToReport: true,
+    });
+
+    // Act
+    const result =
+      await supportingUserController.createIdentifiableSupportingUsers(
+        createFakeWorkerJob<
+          CreateIdentifiableSupportingUsersJobInDTO,
+          ICustomHeaders,
+          CreateIdentifiableSupportingUsersJobOutDTO
+        >(fakePayload),
+      );
+
+    // Asserts
+    expect(result).toHaveProperty(
+      FAKE_WORKER_JOB_RESULT_PROPERTY,
+      MockedZeebeJobResult.Complete,
+    );
+
+    // Validate DB creation.
+    const updatedApplication = await db.application.findOne({
+      select: {
+        id: true,
+        supportingUsers: {
+          id: true,
+          supportingUserType: true,
+          isAbleToReport: true,
+          fullName: true,
+        },
+      },
+      relations: { supportingUsers: true },
+      where: {
+        id: savedApplication.id,
+      },
+    });
+    expect(updatedApplication.supportingUsers).toHaveLength(1);
+    const [parent] = updatedApplication.supportingUsers;
+    expect(parent).toEqual({
+      id: expect.any(Number),
+      supportingUserType: SupportingUserType.Parent,
+      isAbleToReport: true,
+      fullName: parentFullName,
+    });
+  });
+
+  it("Should create the second parent supporting user and save the associated full name when two parent information was added to the student application.", async () => {
+    // Arrange
+    const parentFullName1 = faker.datatype.uuid();
+    const parentFullName2 = faker.datatype.uuid();
+    const savedApplication = await saveFakeApplication(
+      db.dataSource,
+      undefined,
+      {
+        applicationData: {
+          workflowName: "some-workflow",
+          parents: [
+            {
+              parentFullName: parentFullName1,
+            },
+            {
+              parentFullName: parentFullName2,
+            },
+          ],
+        } as ApplicationData,
+      },
+    );
+    const fakePayload = createFakeCreateIdentifiableSupportingUsersPayload({
+      applicationId: savedApplication.id,
+      supportingUserType: SupportingUserType.Parent,
+      parent: 2,
+      isAbleToReport: false,
+    });
+
+    // Act
+    const result =
+      await supportingUserController.createIdentifiableSupportingUsers(
+        createFakeWorkerJob<
+          CreateIdentifiableSupportingUsersJobInDTO,
+          ICustomHeaders,
+          CreateIdentifiableSupportingUsersJobOutDTO
+        >(fakePayload),
+      );
+
+    // Asserts
+    expect(result).toHaveProperty(
+      FAKE_WORKER_JOB_RESULT_PROPERTY,
+      MockedZeebeJobResult.Complete,
+    );
+
+    // Validate DB creation.
+    const updatedApplication = await db.application.findOne({
+      select: {
+        id: true,
+        supportingUsers: {
+          id: true,
+          supportingUserType: true,
+          isAbleToReport: true,
+          fullName: true,
+        },
+      },
+      relations: { supportingUsers: true },
+      where: {
+        id: savedApplication.id,
+      },
+    });
+    expect(updatedApplication.supportingUsers).toHaveLength(1);
+    const [parent] = updatedApplication.supportingUsers;
+    expect(parent).toEqual({
+      id: expect.any(Number),
+      supportingUserType: SupportingUserType.Parent,
+      isAbleToReport: false,
+      fullName: parentFullName2,
+    });
+  });
+
+  it("Should not create a parent when the parent was already created.", async () => {
+    // Arrange
+    const parentFullName = faker.datatype.uuid();
+    const savedApplication = await saveFakeApplication(
+      db.dataSource,
+      undefined,
+      {
+        applicationData: {
+          workflowName: "some-workflow",
+          parents: [
+            {
+              parentFullName,
+            },
+          ],
+        } as ApplicationData,
+      },
+    );
+    const parentSupportingUser = await db.supportingUser.save(
+      createFakeSupportingUser(
+        {
+          application: savedApplication,
+        },
+        {
+          initialValues: {
+            supportingUserType: SupportingUserType.Parent,
+            fullName: parentFullName,
+          },
+        },
+      ),
+    );
+    const fakePayload = createFakeCreateIdentifiableSupportingUsersPayload({
+      applicationId: savedApplication.id,
+      supportingUserType: SupportingUserType.Parent,
+      parent: 1,
+      isAbleToReport: true,
+    });
+
+    // Act
+    const result =
+      await supportingUserController.createIdentifiableSupportingUsers(
+        createFakeWorkerJob<
+          CreateIdentifiableSupportingUsersJobInDTO,
+          ICustomHeaders,
+          CreateIdentifiableSupportingUsersJobOutDTO
+        >(fakePayload),
+      );
+
+    // Asserts
+    expect(result).toHaveProperty(
+      FAKE_WORKER_JOB_RESULT_PROPERTY,
+      MockedZeebeJobResult.Complete,
+    );
+    // Validate DB creation.
+    const updatedApplication = await db.application.findOne({
+      select: {
+        id: true,
+        supportingUsers: {
+          id: true,
+        },
+      },
+      relations: { supportingUsers: true },
+      where: {
+        id: savedApplication.id,
+      },
+    });
+    // Ensures the application still has one supporting user.
+    expect(updatedApplication.supportingUsers).toHaveLength(1);
+    const [parent] = updatedApplication.supportingUsers;
+    // Ensures the parent supporting user is the same as the one created before.
+    expect(parent.id).toBe(parentSupportingUser.id);
+  });
+
+  it("Should throw an error when the full name is expected but it is not present in the application dynamic data.", async () => {
+    // Arrange
+    const savedApplication = await saveFakeApplication(db.dataSource);
+    const fakePayload = createFakeCreateIdentifiableSupportingUsersPayload({
+      applicationId: savedApplication.id,
+      supportingUserType: SupportingUserType.Parent,
+      parent: 1,
+      isAbleToReport: true,
+    });
+
+    // Act
+    const result =
+      await supportingUserController.createIdentifiableSupportingUsers(
+        createFakeWorkerJob<
+          CreateIdentifiableSupportingUsersJobInDTO,
+          ICustomHeaders,
+          CreateIdentifiableSupportingUsersJobOutDTO
+        >(fakePayload),
+      );
+
+    // Asserts
+    expect(result).toEqual({
+      errorCode: SUPPORTING_USER_FULL_NAME_NOT_RESOLVED,
+      errorMessage:
+        "Not able to extract the full name from the application dynamic data using filter '$.parents[0].parentFullName'.",
+      resultType: MockedZeebeJobResult.Error,
+    });
+  });
+
+  it("Should throw an error when the application does not exist.", async () => {
+    // Arrange
+    const fakePayload = createFakeCreateIdentifiableSupportingUsersPayload({
+      applicationId: 9999,
+      supportingUserType: SupportingUserType.Parent,
+      parent: 1,
+      isAbleToReport: true,
+    });
+
+    // Act
+    const result =
+      await supportingUserController.createIdentifiableSupportingUsers(
+        createFakeWorkerJob<
+          CreateIdentifiableSupportingUsersJobInDTO,
+          ICustomHeaders,
+          CreateIdentifiableSupportingUsersJobOutDTO
+        >(fakePayload),
+      );
+
+    // Asserts
+    expect(result).toEqual({
+      errorCode: APPLICATION_NOT_FOUND,
+      errorMessage: "Application ID not found.",
+      resultType: MockedZeebeJobResult.Error,
+    });
+  });
+});

--- a/sources/packages/backend/apps/workers/src/controllers/supporting-user/_test_/e2e/supporting-user.controller.createIdentifiableSupportingUsers.e2e-spec.ts
+++ b/sources/packages/backend/apps/workers/src/controllers/supporting-user/_test_/e2e/supporting-user.controller.createIdentifiableSupportingUsers.e2e-spec.ts
@@ -7,7 +7,6 @@ import {
 } from "@sims/test-utils";
 import {
   createFakeWorkerJob,
-  FAKE_WORKER_JOB_RESULT_PROPERTY,
   MockedZeebeJobResult,
 } from "../../../../../test/utils/worker-job-mock";
 import { createTestingAppModule } from "../../../../../test/helpers";
@@ -34,7 +33,7 @@ describe("SupportingUserController(e2e)-createIdentifiableSupportingUsers", () =
     supportingUserController = nestApplication.get(SupportingUserController);
   });
 
-  it("Should create one parent supporting user and save the associated full name when one information was added to the student application.", async () => {
+  it("Should create one parent supporting user and save the associated full name when one parent's information is added to the student application.", async () => {
     // Arrange
     const parentFullName = faker.datatype.uuid();
     const savedApplication = await saveFakeApplication(
@@ -69,11 +68,6 @@ describe("SupportingUserController(e2e)-createIdentifiableSupportingUsers", () =
       );
 
     // Asserts
-    expect(result).toHaveProperty(
-      FAKE_WORKER_JOB_RESULT_PROPERTY,
-      MockedZeebeJobResult.Complete,
-    );
-
     // Validate DB creation.
     const updatedApplication = await db.application.findOne({
       select: {
@@ -98,9 +92,16 @@ describe("SupportingUserController(e2e)-createIdentifiableSupportingUsers", () =
       isAbleToReport: true,
       fullName: parentFullName,
     });
+    // Validate job result.
+    expect(result).toEqual({
+      resultType: MockedZeebeJobResult.Complete,
+      outputVariables: {
+        createdSupportingUserId: parent.id,
+      },
+    });
   });
 
-  it("Should create the second parent supporting user and save the associated full name when two parent information was added to the student application.", async () => {
+  it("Should create the second parent supporting user and save the associated full name when the two parent's information is added to the student application.", async () => {
     // Arrange
     const parentFullName1 = faker.datatype.uuid();
     const parentFullName2 = faker.datatype.uuid();
@@ -139,11 +140,6 @@ describe("SupportingUserController(e2e)-createIdentifiableSupportingUsers", () =
       );
 
     // Asserts
-    expect(result).toHaveProperty(
-      FAKE_WORKER_JOB_RESULT_PROPERTY,
-      MockedZeebeJobResult.Complete,
-    );
-
     // Validate DB creation.
     const updatedApplication = await db.application.findOne({
       select: {
@@ -167,6 +163,13 @@ describe("SupportingUserController(e2e)-createIdentifiableSupportingUsers", () =
       supportingUserType: SupportingUserType.Parent,
       isAbleToReport: false,
       fullName: parentFullName2,
+    });
+    // Validate job result.
+    expect(result).toEqual({
+      resultType: MockedZeebeJobResult.Complete,
+      outputVariables: {
+        createdSupportingUserId: parent.id,
+      },
     });
   });
 
@@ -218,10 +221,6 @@ describe("SupportingUserController(e2e)-createIdentifiableSupportingUsers", () =
       );
 
     // Asserts
-    expect(result).toHaveProperty(
-      FAKE_WORKER_JOB_RESULT_PROPERTY,
-      MockedZeebeJobResult.Complete,
-    );
     // Validate DB creation.
     const updatedApplication = await db.application.findOne({
       select: {
@@ -240,6 +239,13 @@ describe("SupportingUserController(e2e)-createIdentifiableSupportingUsers", () =
     const [parent] = updatedApplication.supportingUsers;
     // Ensures the parent supporting user is the same as the one created before.
     expect(parent.id).toBe(parentSupportingUser.id);
+    // Validate job result.
+    expect(result).toEqual({
+      resultType: MockedZeebeJobResult.Complete,
+      outputVariables: {
+        createdSupportingUserId: parentSupportingUser.id,
+      },
+    });
   });
 
   it("Should throw an error when the full name is expected but it is not present in the application dynamic data.", async () => {

--- a/sources/packages/backend/apps/workers/src/controllers/supporting-user/_test_/e2e/supporting-user.controller.createIdentifiableSupportingUsers.e2e-spec.ts
+++ b/sources/packages/backend/apps/workers/src/controllers/supporting-user/_test_/e2e/supporting-user.controller.createIdentifiableSupportingUsers.e2e-spec.ts
@@ -33,7 +33,7 @@ describe("SupportingUserController(e2e)-createIdentifiableSupportingUsers", () =
     supportingUserController = nestApplication.get(SupportingUserController);
   });
 
-  it("Should create one parent supporting user and save the associated full name when one parent's information is added to the student application.", async () => {
+  it("Should create supporting user for the first provided parent and save the associated full name when one parent's information is added to the student application.", async () => {
     // Arrange
     const parentFullName = faker.datatype.uuid();
     const savedApplication = await saveFakeApplication(
@@ -101,7 +101,7 @@ describe("SupportingUserController(e2e)-createIdentifiableSupportingUsers", () =
     });
   });
 
-  it("Should create the second parent supporting user and save the associated full name when the two parent's information is added to the student application.", async () => {
+  it("Should create supporting user for the second provided parent and save the associated full name when the two parent's information is added to the student application.", async () => {
     // Arrange
     const parentFullName1 = faker.datatype.uuid();
     const parentFullName2 = faker.datatype.uuid();

--- a/sources/packages/backend/apps/workers/src/controllers/supporting-user/_test_/e2e/supporting-user.controller.createIdentifiableSupportingUsers.e2e-spec.ts
+++ b/sources/packages/backend/apps/workers/src/controllers/supporting-user/_test_/e2e/supporting-user.controller.createIdentifiableSupportingUsers.e2e-spec.ts
@@ -67,7 +67,7 @@ describe("SupportingUserController(e2e)-createIdentifiableSupportingUsers", () =
         >(fakePayload),
       );
 
-    // Asserts
+    // Assert
     // Validate DB creation.
     const updatedApplication = await db.application.findOne({
       select: {
@@ -139,7 +139,7 @@ describe("SupportingUserController(e2e)-createIdentifiableSupportingUsers", () =
         >(fakePayload),
       );
 
-    // Asserts
+    // Assert
     // Validate DB creation.
     const updatedApplication = await db.application.findOne({
       select: {
@@ -220,7 +220,7 @@ describe("SupportingUserController(e2e)-createIdentifiableSupportingUsers", () =
         >(fakePayload),
       );
 
-    // Asserts
+    // Assert
     // Validate DB creation.
     const updatedApplication = await db.application.findOne({
       select: {
@@ -268,7 +268,7 @@ describe("SupportingUserController(e2e)-createIdentifiableSupportingUsers", () =
         >(fakePayload),
       );
 
-    // Asserts
+    // Assert
     expect(result).toEqual({
       errorCode: SUPPORTING_USER_FULL_NAME_NOT_RESOLVED,
       errorMessage:
@@ -296,7 +296,7 @@ describe("SupportingUserController(e2e)-createIdentifiableSupportingUsers", () =
         >(fakePayload),
       );
 
-    // Asserts
+    // Assert
     expect(result).toEqual({
       errorCode: APPLICATION_NOT_FOUND,
       errorMessage: "Application ID not found.",

--- a/sources/packages/backend/apps/workers/src/controllers/supporting-user/supporting-user.dto.ts
+++ b/sources/packages/backend/apps/workers/src/controllers/supporting-user/supporting-user.dto.ts
@@ -23,7 +23,7 @@ export interface CheckSupportingUserResponseJobInDTO {
 export interface CreateIdentifiableSupportingUsersJobInDTO {
   [APPLICATION_ID]: number;
   [SUPPORTING_USER_TYPE]: SupportingUserType;
-  [FULL_NAME_PROPERTY_FILTER]: string;
+  [FULL_NAME_PROPERTY_FILTER]?: string;
   [IS_ABLE_TO_REPORT]: boolean;
 }
 

--- a/sources/packages/backend/libs/test-utils/src/factories/supporting-user.ts
+++ b/sources/packages/backend/libs/test-utils/src/factories/supporting-user.ts
@@ -33,6 +33,7 @@ export function createFakeSupportingUser(
     options?.initialValues?.supportingUserType ?? SupportingUserType.Parent;
   supportingUser.supportingData =
     options?.initialValues?.supportingData ?? null;
+  supportingUser.fullName = options?.initialValues?.fullName;
   supportingUser.isAbleToReport =
     options?.initialValues?.isAbleToReport ?? true;
   supportingUser.user = relations?.user ?? null;


### PR DESCRIPTION
Created E2E tests for the new worker `createIdentifiableSupportingUsers`.
- Should create one parent supporting user and save the associated full name when one parent's information is added to the student application.
- Should create the second parent supporting user and save the associated full name when the two parents' information is added to the student application.
- Should not create a parent when the parent was already created.
- Should throw an error when the full name is expected but it is not present in the application's dynamic data.
- Should throw an error when the application does not exist.