### PR TITLE
#4664 - PSI Integration Changes - Filename and Folders - Part 3

### DIFF
--- a/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/institution-integration/ier12-integration/_tests_/e2e/utils/string-utils.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/institution-integration/ier12-integration/_tests_/e2e/utils/string-utils.ts
@@ -39,9 +39,7 @@ export function getSuccessSummaryMessages(
     expectedRecords?: number;
   },
 ): string {
-  return `Uploaded file ${
-    process.env.INSTITUTION_REQUEST_FOLDER
-  }\\${`${options.institutionCode}-IER12-${timestamp}.txt`}, with ${
-    options.expectedRecords ?? 1
-  } record(s).`;
+  return `Uploaded file ${process.env.INSTITUTION_REQUEST_FOLDER}\\${
+    options.institutionCode
+  }-IER12-${timestamp}.txt, with ${options.expectedRecords ?? 1} record(s).`;
 }

--- a/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/institution-integration/ier12-integration/_tests_/e2e/utils/string-utils.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/institution-integration/ier12-integration/_tests_/e2e/utils/string-utils.ts
@@ -39,9 +39,9 @@ export function getSuccessSummaryMessages(
     expectedRecords?: number;
   },
 ): string {
-  return `Uploaded file ${process.env.INSTITUTION_REQUEST_FOLDER}\\${
-    options.institutionCode
-  }\\${options.institutionCode}-IER12-${timestamp}.txt, with ${
+  return `Uploaded file ${
+    process.env.INSTITUTION_REQUEST_FOLDER
+  }\\${`${options.institutionCode}-IER12-${timestamp}.txt`}, with ${
     options.expectedRecords ?? 1
   } record(s).`;
 }

--- a/sources/packages/backend/libs/integrations/src/institution-integration/ier12-integration/ier12.processing.service.ts
+++ b/sources/packages/backend/libs/integrations/src/institution-integration/ier12-integration/ier12.processing.service.ts
@@ -156,7 +156,7 @@ export class IER12ProcessingService {
   } {
     const timestamp = getFileNameAsExtendedCurrentTimestamp();
     const fileName = `${institutionCode}-IER12-${timestamp}.txt`;
-    const filePath = `${this.institutionIntegrationConfig.ftpRequestFolder}\\${institutionCode}\\${fileName}`;
+    const filePath = `${this.institutionIntegrationConfig.ftpRequestFolder}\\${fileName}`;
     return {
       fileName,
       filePath,


### PR DESCRIPTION
- [x] Changes the file path for IER so that files are generated in the OUT folder instead of institution specific folders

**Demo**
![image](https://github.com/user-attachments/assets/fcb12eee-4496-4770-bbe2-e258bc634136)
