### PR TITLE
#2197 revise ft scholastic standing restriction logic

### DIFF
--- a/sims.code-workspace
+++ b/sims.code-workspace
@@ -208,6 +208,7 @@
       "timestamptz",
       "typeorm",
       "unparse",
+      "WTHD",
       "Zeebe"
     ],
     "[json]": {

--- a/sources/packages/backend/apps/api/src/services/application/application.service.ts
+++ b/sources/packages/backend/apps/api/src/services/application/application.service.ts
@@ -360,10 +360,13 @@ export class ApplicationService extends RecordDataModelService<Application> {
     }
     // Check if the student already has E2 or RB restriction.
     const hasE2orRBRestriction =
-      await this.studentRestrictionService.hasAnyActiveRestriction(
+      await this.studentRestrictionService.hasAnyRestriction(
         studentId,
         [RestrictionCode.E2, RestrictionCode.RB],
-        transactionalEntityManager,
+        {
+          isActive: true,
+          entityManager: transactionalEntityManager,
+        },
       );
     // If the student does not have E2 or RB restriction, add the E2 restriction.
     if (!hasE2orRBRestriction) {

--- a/sources/packages/backend/apps/api/src/services/restriction/student-restriction.service.ts
+++ b/sources/packages/backend/apps/api/src/services/restriction/student-restriction.service.ts
@@ -300,12 +300,21 @@ export class StudentRestrictionService extends RecordDataModelService<StudentRes
     return !!hasRestriction;
   }
 
+  /**
+   * Get student restrictions by their codes.
+   * @param studentId student ID.
+   * @param restrictionCodes restriction codes.
+   * @returns student restrictions.
+   */
   async getRestrictionByCodes(studentId: number, restrictionCodes: string[]) {
     return this.repo.find({
       select: {
         id: true,
         isActive: true,
         restriction: { id: true, restrictionCode: true },
+      },
+      relations: {
+        restriction: true,
       },
       where: {
         student: { id: studentId },

--- a/sources/packages/backend/apps/db-migrations/src/migrations/1750711964565-CreateMissingProvincialRestrictions.ts
+++ b/sources/packages/backend/apps/db-migrations/src/migrations/1750711964565-CreateMissingProvincialRestrictions.ts
@@ -1,0 +1,19 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+import { getSQLFileData } from "../utilities/sqlLoader";
+
+export class CreateMissingProvincialRestrictions1750711964565
+  implements MigrationInterface
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      getSQLFileData(
+        "Create-missing-provincial-restrictions.sql",
+        "Restrictions",
+      ),
+    );
+  }
+
+  public async down(): Promise<void> {
+    // No down migration planned.
+  }
+}

--- a/sources/packages/backend/apps/db-migrations/src/sql/Restrictions/Create-missing-provincial-restrictions.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/Restrictions/Create-missing-provincial-restrictions.sql
@@ -1,0 +1,79 @@
+-- Creates missing provincial restrictions that were directly converted on PROD
+-- and are missing in non-PROD environments DB seed.
+-- Z1
+INSERT INTO
+    sims.restrictions (
+        restriction_type,
+        restriction_code,
+        description,
+        modifier,
+        restriction_category,
+        action_type,
+        notification_type,
+        is_legacy
+    )
+SELECT
+    'Provincial',
+    'Z1',
+    'Grant overaward. Not eligible for BCSL. Eligible for CSL.',
+    (
+        SELECT
+            id
+        FROM
+            sims.users
+        WHERE
+            -- System user.
+            user_name = '8fb44f70-6ce6-11ed-b307-8743a2da47ef@system'
+    ),
+    'BCSL Delinquency',
+    '{"Stop full time BC funding"}',
+    'Error',
+    false
+WHERE
+    NOT EXISTS (
+        SELECT
+            1
+        FROM
+            sims.restrictions
+        WHERE
+            restriction_code = 'Z1'
+    );
+
+-- SSRN
+INSERT INTO
+    sims.restrictions (
+        restriction_type,
+        restriction_code,
+        description,
+        modifier,
+        restriction_category,
+        action_type,
+        notification_type,
+        is_legacy
+    )
+SELECT
+    'Provincial',
+    'SSRN',
+    'Poor Scholastic Standing.',
+    (
+        SELECT
+            id
+        FROM
+            sims.users
+        WHERE
+            -- System user.
+            user_name = '8fb44f70-6ce6-11ed-b307-8743a2da47ef@system'
+    ),
+    'Academic',
+    '{"Stop full time disbursement","Stop full time apply"}',
+    'Error',
+    false
+WHERE
+    NOT EXISTS (
+        SELECT
+            1
+        FROM
+            sims.restrictions
+        WHERE
+            restriction_code = 'SSRN'
+    );

--- a/sources/packages/backend/libs/services/src/restriction/model/restriction.model.ts
+++ b/sources/packages/backend/libs/services/src/restriction/model/restriction.model.ts
@@ -4,11 +4,8 @@
  */
 export enum RestrictionCode {
   /**
-   * When an institution report withdrawal for a FT course application,
-   * "WTHD" restriction is added to student account or when institution
-   * reports a change related to a FT application for unsuccessful
-   * completion and the total number of unsuccessful weeks hits minimum 68,
-   * the "SSR" restriction is added to the student account.
+   * When an institution report withdrawal for a full-time course application,
+   * "WTHD" restriction is added to student account if one is not already present.
    */
   WTHD = "WTHD",
   /**

--- a/sources/packages/backend/libs/services/src/restriction/model/restriction.model.ts
+++ b/sources/packages/backend/libs/services/src/restriction/model/restriction.model.ts
@@ -18,6 +18,12 @@ export enum RestrictionCode {
    */
   SSR = "SSR",
   /**
+   * When an institution report withdrawal for a FT course
+   * and the student already had or has a "SSR" restriction,
+   * an SSRN restriction is added to the student account.
+   */
+  SSRN = "SSRN",
+  /**
    * when an institution report withdrawal or unsuccessful weeks
    * for a PT course application, "PTSSR" restriction is added to the student account.
    */

--- a/sources/packages/backend/libs/test-utils/src/factories/education-program-offering.ts
+++ b/sources/packages/backend/libs/test-utils/src/factories/education-program-offering.ts
@@ -67,10 +67,12 @@ export function createFakeEducationProgramOffering(
   offering.studyEndDate =
     options?.initialValues?.studyEndDate ??
     getISODateOnlyString(faker.date.soon(30));
-  offering.studyBreaks = {
-    totalFundedWeeks: 16,
-    totalDays: 210, // 30 offering weeks * 7 days,
-  } as StudyBreaksAndWeeks;
+  offering.studyBreaks =
+    options?.initialValues?.studyBreaks ??
+    ({
+      totalFundedWeeks: 16,
+      totalDays: 210, // 30 offering weeks * 7 days,
+    } as StudyBreaksAndWeeks);
   offering.offeringStatus = OfferingStatus.Approved;
   offering.parentOffering = offering;
   return offering;

--- a/sources/packages/backend/libs/test-utils/src/models/common.model.ts
+++ b/sources/packages/backend/libs/test-utils/src/models/common.model.ts
@@ -65,6 +65,12 @@ export enum RestrictionCode {
    */
   SSR = "SSR",
   /**
+   * When an institution report withdrawal for a FT course
+   * and the student already had or has a "SSR" restriction,
+   * an SSRN restriction is added to the student account.
+   */
+  SSRN = "SSRN",
+  /**
    * Legacy Restriction.
    */
   LGCY = "LGCY",
@@ -80,6 +86,11 @@ export enum RestrictionCode {
    * Dual Funding.
    */
   AF4 = "AF4",
+  /**
+   * When an institution report withdrawal for a full-time course application,
+   * "WTHD" restriction is added to student account if one is not already present.
+   */
+  WTHD = "WTHD",
   /**
    * Part-time scholastic standing restrictions - Student withdrew or was unsuccesful from Part Time studies.
    */


### PR DESCRIPTION
## E2E Tests

Created two new categories for better grouping of the full-time scholastic standing restrictions.

- Full-time restrictions for 'Student did not complete program'.                                                                                                 
  - Should create an SSR restriction when the student exceeds the maximum number of unsuccessful weeks application.
  - Should create an SSRN restriction when the student already has an SSR.                   
  - Should create an SSRN restriction when the student already has an SSRN, but it is inactive.
- Full-time restrictions for 'Student withdrew from program'.                                                                                                    
  - Should create a WTHD restriction when the student withdrew and there is no active WTHD restriction.
  - Should create an SSR restriction when the student withdrew and there is an active WTHD restriction.
  - Should create a WTHD and an SSRN restriction when the student withdraws and there is an inactive SSR restriction.