### PR TITLE
#4818 - Parent Declare - Supporting User Portal Update

### DIFF
--- a/sources/packages/backend/apps/api/src/route-controllers/supporting-user/supporting-user.supporting-users.controller.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/supporting-user/supporting-user.supporting-users.controller.ts
@@ -27,7 +27,6 @@ import {
   STUDENT_APPLICATION_NOT_FOUND,
   SUPPORTING_USER_ALREADY_PROVIDED_DATA,
   SUPPORTING_USER_IS_THE_STUDENT_FROM_APPLICATION,
-  SUPPORTING_USER_TYPE_ALREADY_PROVIDED_DATA,
 } from "../../services/supporting-user/constants";
 import { getSupportingUserFormType } from "../../utilities";
 import {
@@ -267,10 +266,7 @@ export class SupportingUserSupportingUsersController extends BaseController {
 
     if (updateResult.affected !== 1) {
       throw new UnprocessableEntityException(
-        new ApiProcessError(
-          `The application is not expecting supporting information from a ${payload.supportingUserType} to be provided at this time.`,
-          SUPPORTING_USER_TYPE_ALREADY_PROVIDED_DATA,
-        ),
+        `Error while updating the supporting user details for ${supportingUser.id}. Number of affected rows was ${updateResult.affected}, expected 1.`,
       );
     }
     // Send the message to the workflow to complete the supporting user process.

--- a/sources/packages/backend/apps/api/src/route-controllers/supporting-user/supporting-user.supporting-users.controller.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/supporting-user/supporting-user.supporting-users.controller.ts
@@ -252,23 +252,26 @@ export class SupportingUserSupportingUsersController extends BaseController {
         address: addressInfo,
       };
 
-      const updatedUser = await this.supportingUserService.updateSupportingUser(
-        supportingUser.application.id,
-        payload.supportingUserType,
-        user.id,
-        {
-          contactInfo,
-          sin: submissionResult.sin,
-          hasValidSIN: submissionResult.hasValidSIN,
-          birthDate: userToken.birthdate,
-          supportingData: submissionResult.supportingData,
-          userId: user.id,
-        },
-      );
+      const updateResult =
+        await this.supportingUserService.updateSupportingUserReportedData(
+          supportingUser.id,
+          payload.supportingUserType,
+          user.id,
+          {
+            contactInfo,
+            sin: submissionResult.sin,
+            hasValidSIN: submissionResult.hasValidSIN,
+            birthDate: userToken.birthdate,
+            supportingData: submissionResult.supportingData,
+            userId: user.id,
+          },
+        );
 
-      await this.workflowClientService.sendSupportingUsersCompletedMessage(
-        updatedUser.id,
-      );
+      if (updateResult.affected > 0) {
+        await this.workflowClientService.sendSupportingUsersCompletedMessage(
+          supportingUser.id,
+        );
+      }
     } catch (error) {
       if (error.name === SUPPORTING_USER_TYPE_ALREADY_PROVIDED_DATA) {
         throw new UnprocessableEntityException(

--- a/sources/packages/backend/apps/api/src/services/supporting-user/constants.ts
+++ b/sources/packages/backend/apps/api/src/services/supporting-user/constants.ts
@@ -8,10 +8,6 @@ export const STUDENT_APPLICATION_NOT_FOUND = "STUDENT_APPLICATION_NOT_FOUND";
 // Student Application.
 export const SUPPORTING_USER_ALREADY_PROVIDED_DATA =
   "SUPPORTING_USER_ALREADY_PROVIDED_DATA";
-// The same supporting user type (parent/partner) already provided supporting data for the
-// Student Application.
-export const SUPPORTING_USER_TYPE_ALREADY_PROVIDED_DATA =
-  "SUPPORTING_USER_TYPE_ALREADY_PROVIDED_DATA";
 // The user currently authenticated is the student and the student cannot provide supporting
 // data for his own application.
 export const SUPPORTING_USER_IS_THE_STUDENT_FROM_APPLICATION =

--- a/sources/packages/backend/apps/api/src/services/supporting-user/supporting-user.service.ts
+++ b/sources/packages/backend/apps/api/src/services/supporting-user/supporting-user.service.ts
@@ -10,10 +10,8 @@ import {
   SupportingUserPersonalInfo,
   SupportingUserType,
   User,
-  configureIdleTransactionSessionTimeout,
 } from "@sims/sims-db";
 import { removeWhiteSpaces } from "../../utilities/string-utils";
-import { SUPPORTING_USERS_TRANSACTION_IDLE_TIMEOUT_SECONDS } from "../../utilities";
 import { CustomNamedError } from "@sims/utilities";
 import { SUPPORTING_USER_TYPE_ALREADY_PROVIDED_DATA } from "./constants";
 import {
@@ -28,90 +26,48 @@ export class SupportingUserService extends RecordDataModelService<SupportingUser
   }
 
   /**
-   * Updates supporting user (e.g. parent/partner).
-   * @param applicationId application id to be used to search
-   * for the record to be update.
-   * @param supportingUserType type of the user to search
-   * to have the supporting information updated.
-   * @param auditUserId user who is making the changes.
-   * @param updateInfo information that must be updated
-   * altogether when a supporting user is providing
-   * the supporting data for a Student Application.
-   * @returns update result. Expected one and only one
-   * row to be updated. If no rows are updated it means that
-   * there is no supporting user record to be updated at
-   * this moment. These records must be created by the workflow
-   * and must exists prior of the supporting user logging to
-   * provide the information.
+   * Updates supporting user (e.g. parent/partner) data.
+   * @param supportingUserId The ID of the supporting user record to be updated.
+   * @param supportingUserType The type of the user, used for crafting the error message.
+   * @param auditUserId The user performing the update.
+   * @param updateInfo The information to be updated.
+   * @returns The result of the update operation.
    */
-  async updateSupportingUser(
-    applicationId: number,
+  async updateSupportingUserReportedData(
+    supportingUserId: number,
     supportingUserType: SupportingUserType,
     auditUserId: number,
     updateInfo: UpdateSupportingUserInfo,
-  ): Promise<SupportingUser> {
-    const queryRunner = this.dataSource.createQueryRunner();
-    await configureIdleTransactionSessionTimeout(
-      queryRunner,
-      SUPPORTING_USERS_TRANSACTION_IDLE_TIMEOUT_SECONDS,
+  ): Promise<UpdateResult> {
+    const sinWithNoSpaces = updateInfo.sin
+      ? removeWhiteSpaces(updateInfo.sin)
+      : null;
+    const personalInfo = updateInfo.hasValidSIN
+      ? { hasValidSIN: updateInfo.hasValidSIN }
+      : null;
+
+    const updateResult = await this.repo.update(
+      { id: supportingUserId, user: { id: IsNull() } },
+      {
+        contactInfo: updateInfo.contactInfo,
+        sin: sinWithNoSpaces,
+        birthDate: updateInfo.birthDate,
+        supportingData: updateInfo.supportingData,
+        user: { id: updateInfo.userId } as User,
+        personalInfo,
+        modifier: { id: auditUserId } as User,
+      },
     );
-
-    try {
-      await queryRunner.startTransaction();
-      // Query to select the supporting user to be update.
-      // The record must have the user id as null to ensure that it was never update before.
-      // The table could also contains more than one record for parents so while defining
-      // the record to be updated we must ensure that only one record will be updated.
-      // The below query will lock the specific records in the select for updates. Case
-      // two parents tries to update the record at the same time the second one will wait
-      // till the first one finishes it.
-      const transactionRepo = queryRunner.manager.getRepository(SupportingUser);
-      const possibleUsersToUpdate = await transactionRepo
-        .createQueryBuilder("supportingUser")
-        .setLock("pessimistic_write")
-        .select("supportingUser.id")
-        .innerJoin("supportingUser.application", "application")
-        .where("supportingUser.supportingUserType = :supportingUserType", {
-          supportingUserType,
-        })
-        .andWhere("supportingUser.user.id is null")
-        .andWhere("application.id = :applicationId", { applicationId })
-        .orderBy("supportingUser.id")
-        .getMany();
-
-      // Case there are more than one records (e.g. two parents), just selected one
-      // to execute the update.
-      const userToUpdate = possibleUsersToUpdate.shift();
-      if (!userToUpdate) {
-        throw new CustomNamedError(
-          `The application is not expecting supporting information from a ${supportingUserType.toLowerCase()} to be provided at this time.`,
-          SUPPORTING_USER_TYPE_ALREADY_PROVIDED_DATA,
-        );
-      }
-
-      // The SIN can be received with a few white spaces in the middle, so we need remove then
-      // before inserting it because the DB will accept only 9 characters.
-      const sinWithNoSpaces = updateInfo.sin
-        ? removeWhiteSpaces(updateInfo.sin)
-        : null;
-      userToUpdate.contactInfo = updateInfo.contactInfo;
-      userToUpdate.sin = sinWithNoSpaces;
-      userToUpdate.birthDate = updateInfo.birthDate;
-      userToUpdate.supportingData = updateInfo.supportingData;
-      userToUpdate.user = { id: updateInfo.userId } as User;
-      userToUpdate.modifier = { id: auditUserId } as User;
-      userToUpdate.personalInfo = updateInfo.hasValidSIN
-        ? { hasValidSIN: updateInfo.hasValidSIN }
-        : null;
-      const updatedUser = await transactionRepo.save(userToUpdate);
-      await queryRunner.commitTransaction();
-      return updatedUser;
-    } catch (error) {
-      await queryRunner.rollbackTransaction();
-      throw error;
-    } finally {
-      await queryRunner.release();
+    // If no records are updated, it means the supporting user record either
+    // did not exist or was already updated by another process.
+    if (updateResult.affected === 0) {
+      throw new CustomNamedError(
+        `The application is not expecting supporting information from a ${supportingUserType} to be provided at this time.`,
+        SUPPORTING_USER_TYPE_ALREADY_PROVIDED_DATA,
+      );
     }
+
+    return updateResult;
   }
 
   /**

--- a/sources/packages/backend/apps/api/src/services/supporting-user/supporting-user.service.ts
+++ b/sources/packages/backend/apps/api/src/services/supporting-user/supporting-user.service.ts
@@ -44,7 +44,7 @@ export class SupportingUserService extends RecordDataModelService<SupportingUser
 
     const auditUser = { id: auditUserId } as User;
     const user = { id: updateInfo.userId } as User;
-    const updateResult = await this.repo.update(
+    return this.repo.update(
       { id: supportingUserId, user: { id: IsNull() } },
       {
         contactInfo: updateInfo.contactInfo,
@@ -56,8 +56,6 @@ export class SupportingUserService extends RecordDataModelService<SupportingUser
         modifier: auditUser,
       },
     );
-
-    return updateResult;
   }
 
   /**

--- a/sources/packages/backend/apps/api/src/utilities/system-configurations-constants.ts
+++ b/sources/packages/backend/apps/api/src/utilities/system-configurations-constants.ts
@@ -1,9 +1,6 @@
 import { RestrictionCode } from "@sims/services";
 
 export const PIR_DENIED_REASON_OTHER_ID = 1;
-// Timeout to handle the worst-case scenario where the commit/rollback
-// was not executed due to a possible catastrophic failure.
-export const SUPPORTING_USERS_TRANSACTION_IDLE_TIMEOUT_SECONDS = 10;
 /**
  * For multipart forms, the max number of file fields.
  */

--- a/sources/packages/web/src/types/contracts/supporting-user/SupportingUserContracts.ts
+++ b/sources/packages/web/src/types/contracts/supporting-user/SupportingUserContracts.ts
@@ -7,10 +7,6 @@ export const STUDENT_APPLICATION_NOT_FOUND = "STUDENT_APPLICATION_NOT_FOUND";
 // Student Application.
 export const SUPPORTING_USER_ALREADY_PROVIDED_DATA =
   "SUPPORTING_USER_ALREADY_PROVIDED_DATA";
-// The same supporting user type (parent/partner) already provided supporting data for the
-// Student Application.
-export const SUPPORTING_USER_TYPE_ALREADY_PROVIDED_DATA =
-  "SUPPORTING_USER_TYPE_ALREADY_PROVIDED_DATA";
 // The user currently authenticated is the student and the student cannot provide supporting
 // data for his own application.
 export const SUPPORTING_USER_IS_THE_STUDENT_FROM_APPLICATION =

--- a/sources/packages/web/src/views/supporting-user/SupportingInformation.vue
+++ b/sources/packages/web/src/views/supporting-user/SupportingInformation.vue
@@ -120,7 +120,6 @@ import { PropType, ref, defineComponent } from "vue";
 import {
   STUDENT_APPLICATION_NOT_FOUND,
   SUPPORTING_USER_ALREADY_PROVIDED_DATA,
-  SUPPORTING_USER_TYPE_ALREADY_PROVIDED_DATA,
   SUPPORTING_USER_IS_THE_STUDENT_FROM_APPLICATION,
   WizardNavigationEvent,
   SupportingUserType,
@@ -285,13 +284,6 @@ export default defineComponent({
             case SUPPORTING_USER_ALREADY_PROVIDED_DATA:
               snackBar.warn(
                 `User already provided data.
-                ${error.message}`,
-                snackBar.EXTENDED_MESSAGE_DISPLAY_TIME,
-              );
-              break;
-            case SUPPORTING_USER_TYPE_ALREADY_PROVIDED_DATA:
-              snackBar.warn(
-                `Not expecting data for a ${props.supportingUserType}.
                 ${error.message}`,
                 snackBar.EXTENDED_MESSAGE_DISPLAY_TIME,
               );


### PR DESCRIPTION
### Refactor

- Made the workflow notification for supporting user data submission conditional and remove DB Lock.
- Ensured the completion message is sent only after the database update is successfully verified to prevent race conditions.