### PR TITLE
#4849 - Update Living Situation Questions 

### DIFF
--- a/sources/packages/forms/src/form-definitions/sfaa2025-26-ft.json
+++ b/sources/packages/forms/src/form-definitions/sfaa2025-26-ft.json
@@ -5554,34 +5554,6 @@
               "input": true
             },
             {
-              "label": "Will your partner be living with you during your study period?",
-              "optionsLabelPosition": "right",
-              "inline": false,
-              "tableView": false,
-              "values": [
-                {
-                  "label": "Yes",
-                  "value": "yes",
-                  "shortcut": ""
-                },
-                {
-                  "label": "No",
-                  "value": "no",
-                  "shortcut": ""
-                }
-              ],
-              "validate": {
-                "required": true,
-                "onlyAvailableItems": true
-              },
-              "key": "livingWithPartner",
-              "attributes": {
-                "data-cy": "livingWithPartner"
-              },
-              "type": "radio",
-              "input": true
-            },
-            {
               "label": "Will your partner be a full-time post-secondary student for some or all of your study period?",
               "optionsLabelPosition": "right",
               "inline": false,
@@ -7542,11 +7514,6 @@
           "collapsible": false,
           "hideLabel": true,
           "key": "livingSituationPanel",
-          "conditional": {
-            "show": false,
-            "when": "relationshipStatus",
-            "eq": "married"
-          },
           "type": "panel",
           "label": "Panel",
           "input": false,
@@ -7568,6 +7535,37 @@
               "type": "htmlelement",
               "input": false,
               "tableView": false
+            },
+            {
+              "label": "Will your partner be living with you during your study period?",
+              "optionsLabelPosition": "right",
+              "inline": false,
+              "tableView": false,
+              "values": [
+                {
+                  "label": "Yes",
+                  "value": "yes",
+                  "shortcut": ""
+                },
+                {
+                  "label": "No",
+                  "value": "no",
+                  "shortcut": ""
+                }
+              ],
+              "validate": {
+                "required": true,
+                "onlyAvailableItems": true
+              },
+              "validateWhenHidden": false,
+              "key": "livingWithPartner1",
+              "conditional": {
+                "show": true,
+                "when": "relationshipStatus",
+                "eq": "married"
+              },
+              "type": "radio",
+              "input": true
             },
             {
               "label": "Will you be living in a home paid for by your parent(s)/step-parent/sponsor/legal guardian during your study period?",
@@ -7593,6 +7591,11 @@
               "validateWhenHidden": false,
               "errorLabel": "Living with your parent/guardian",
               "key": "livingAtHome",
+              "conditional": {
+                "show": false,
+                "when": "relationshipStatus",
+                "eq": "married"
+              },
               "type": "radio",
               "input": true,
               "lockKey": true

--- a/sources/packages/forms/src/form-definitions/sfaa2025-26-ft.json
+++ b/sources/packages/forms/src/form-definitions/sfaa2025-26-ft.json
@@ -7558,7 +7558,7 @@
                 "onlyAvailableItems": true
               },
               "validateWhenHidden": false,
-              "key": "livingWithPartner1",
+              "key": "livingWithPartner",
               "conditional": {
                 "show": true,
                 "when": "relationshipStatus",

--- a/sources/packages/forms/src/form-definitions/supportinguserspartner2025-2026.json
+++ b/sources/packages/forms/src/form-definitions/supportinguserspartner2025-2026.json
@@ -735,36 +735,6 @@
                   "input": true
                 },
                 {
-                  "label": "Will you be living with your Partner during your Partner's study period?",
-                  "optionsLabelPosition": "right",
-                  "inline": false,
-                  "tableView": false,
-                  "values": [
-                    {
-                      "label": "Yes",
-                      "value": "yes",
-                      "shortcut": ""
-                    },
-                    {
-                      "label": "No",
-                      "value": "no",
-                      "shortcut": ""
-                    }
-                  ],
-                  "validate": {
-                    "required": true,
-                    "onlyAvailableItems": true
-                  },
-                  "key": "partnerLivingWithStudent",
-                  "type": "radio",
-                  "input": true,
-                  "conditional": {
-                    "show": "true",
-                    "when": "offeringIntensity",
-                    "eq": "Full Time"
-                  }
-                },
-                {
                   "label": "Will you be a full-time post-secondary student for some or all of your Partner's study period?",
                   "optionsLabelPosition": "right",
                   "inline": false,


### PR DESCRIPTION
Details for this PR: 
- [ ] moves partner living situation question from "Partner" tab to "Financial Information" tab, "Living Situation" section

<img width="1141" height="193" alt="image" src="https://github.com/user-attachments/assets/40452e3e-47f2-4b48-8ebd-df25ca857793" />

- [ ] removed conditional logic for the "Living Situation" panel and implemented logic on questions as the questions (self contained suite, partner living situation) are mutually exclusive
- [ ] no cleanup required for partner data as the removed question does not have anything mapped in consolidated data 