### PR TITLE
#4820 - Parent Declare - Application History Menu - Part 1

### DIFF
--- a/sources/packages/backend/apps/api/src/route-controllers/application/_tests_/application.aest.controller.getApplicationOverallDetails.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/application/_tests_/application.aest.controller.getApplicationOverallDetails.e2e-spec.ts
@@ -194,6 +194,8 @@ describe("ApplicationAESTController(e2e)-getApplicationOverallDetails", () => {
               {
                 supportingUserId: partner.id,
                 supportingUserType: partner.supportingUserType,
+                supportingUserFullName: partner.fullName,
+                isAbleToReport: partner.isAbleToReport,
               },
             ],
           },
@@ -328,10 +330,14 @@ describe("ApplicationAESTController(e2e)-getApplicationOverallDetails", () => {
             {
               supportingUserId: parent1.id,
               supportingUserType: parent1.supportingUserType,
+              supportingUserFullName: parent1.fullName,
+              isAbleToReport: parent1.isAbleToReport,
             },
             {
               supportingUserId: parent2.id,
               supportingUserType: parent2.supportingUserType,
+              supportingUserFullName: parent2.fullName,
+              isAbleToReport: parent2.isAbleToReport,
             },
           ],
         },
@@ -345,6 +351,8 @@ describe("ApplicationAESTController(e2e)-getApplicationOverallDetails", () => {
               {
                 supportingUserId: partner.id,
                 supportingUserType: partner.supportingUserType,
+                supportingUserFullName: partner.fullName,
+                isAbleToReport: partner.isAbleToReport,
               },
             ],
           },

--- a/sources/packages/backend/apps/api/src/route-controllers/application/application.controller.service.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/application/application.controller.service.ts
@@ -892,6 +892,8 @@ export class ApplicationControllerService {
       supportingUsers: application.supportingUsers.map((user) => ({
         supportingUserId: user.id,
         supportingUserType: user.supportingUserType,
+        supportingUserFullName: user.fullName,
+        isAbleToReport: user.isAbleToReport,
       })),
     };
   }

--- a/sources/packages/backend/apps/api/src/route-controllers/application/models/application.dto.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/application/models/application.dto.ts
@@ -281,6 +281,8 @@ export class ApplicationWarningsAPIOutDTO {
 export class ApplicationSupportingUsersAPIOutDTO {
   supportingUserId: number;
   supportingUserType: SupportingUserType;
+  supportingUserFullName?: string;
+  isAbleToReport?: boolean;
 }
 
 /**

--- a/sources/packages/backend/apps/api/src/route-controllers/supporting-user/supporting-user.aest.controller.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/supporting-user/supporting-user.aest.controller.ts
@@ -79,9 +79,9 @@ export class SupportingUserAESTController {
       contactInfo: supportingUserForApplication.contactInfo,
       sin: supportingUserForApplication.sin,
       birthDate: supportingUserForApplication.birthDate,
-      email: supportingUserForApplication.user.email,
-      firstName: supportingUserForApplication.user.firstName,
-      lastName: supportingUserForApplication.user.lastName,
+      email: supportingUserForApplication.user?.email,
+      firstName: supportingUserForApplication.user?.firstName,
+      lastName: supportingUserForApplication.user?.lastName,
       hasValidSIN: supportingUserForApplication.personalInfo?.hasValidSIN,
     };
   }

--- a/sources/packages/backend/apps/api/src/services/application/application.service.ts
+++ b/sources/packages/backend/apps/api/src/services/application/application.service.ts
@@ -2217,8 +2217,12 @@ export class ApplicationService extends RecordDataModelService<Application> {
         "version.applicationEditStatus",
         "supportingUser.id",
         "supportingUser.supportingUserType",
+        "supportingUser.fullName",
+        "supportingUser.isAbleToReport",
         "versionSupportingUser.id",
         "versionSupportingUser.supportingUserType",
+        "versionSupportingUser.fullName",
+        "versionSupportingUser.isAbleToReport",
       ])
       .innerJoin("application.parentApplication", "parentApplication")
       .leftJoin("application.supportingUsers", "supportingUser")

--- a/sources/packages/backend/apps/api/src/services/supporting-user/supporting-user.service.ts
+++ b/sources/packages/backend/apps/api/src/services/supporting-user/supporting-user.service.ts
@@ -124,7 +124,7 @@ export class SupportingUserService extends RecordDataModelService<SupportingUser
         "application.id",
         "programYear.id",
       ])
-      .innerJoin("supportingUser.user", "user")
+      .leftJoin("supportingUser.user", "user")
       .innerJoin("supportingUser.application", "application")
       .innerJoin("application.programYear", "programYear")
       .where("supportingUser.id = :supportingUserId", {

--- a/sources/packages/web/src/components/layouts/aest/AESTApplicationSideBar.vue
+++ b/sources/packages/web/src/components/layouts/aest/AESTApplicationSideBar.vue
@@ -104,16 +104,12 @@ export default defineComponent({
         return "Partner";
       }
 
-      // For parents, use full name if available, otherwise default to Parent 1/Parent 2
+      // For parents, use full name if available, otherwise default to Parent 1/Parent 2.
       if (supportingUser.supportingUserFullName) {
-        const fullName = supportingUser.supportingUserFullName.trim();
-        // Truncate if name is longer than 36 characters
-        return fullName.length > 36
-          ? `${fullName.substring(0, 33)}...`
-          : fullName;
+        return supportingUser.supportingUserFullName.trim();
       }
 
-      // Fallback to Parent 1/Parent 2 when no name is available
+      // Fallback to Parent 1/Parent 2 when no name is available.
       return `Parent ${index + 1}`;
     };
 
@@ -128,12 +124,10 @@ export default defineComponent({
         return "";
       }
 
-      // For parents, determine if it was student declared or parent declared
-      if (supportingUser.isAbleToReport === false) {
-        return "Student Declared";
-      } else {
-        return "Parent Declared";
-      }
+      // For parents, determine if it was student declared or parent declared.
+      return supportingUser.isAbleToReport
+        ? "Parent declared"
+        : "Student declared";
     };
 
     /**

--- a/sources/packages/web/src/components/layouts/aest/AESTApplicationSideBar.vue
+++ b/sources/packages/web/src/components/layouts/aest/AESTApplicationSideBar.vue
@@ -24,7 +24,6 @@ import { useFormatters, useApplication } from "@/composables";
 import {
   ApplicationSupportingUsersAPIOutDTO,
   ApplicationVersionAPIOutDTO,
-  ParentDetails,
 } from "@/services/http/dto";
 import useEmitterEvents from "@/composables/useEmitterEvents";
 
@@ -53,20 +52,12 @@ export default defineComponent({
 
     // Function to load application data and update menu items.
     const loadApplicationData = async () => {
-      const [overallDetails, inProgressDetails] = await Promise.all([
-        ApplicationService.shared.getApplicationOverallDetails(
+      const overallDetails =
+        await ApplicationService.shared.getApplicationOverallDetails(
           props.applicationId,
-        ),
-        ApplicationService.shared.getInProgressApplicationDetails(
-          props.applicationId,
-        ).catch(() => ({ parentsInfo: [] })), // Fallback if not available
-      ]);
-      
+        );
       menuItems.value = [
-        ...createCurrentApplicationMenuItems(
-          overallDetails.currentApplication,
-          inProgressDetails.parentsInfo || [],
-        ),
+        ...createCurrentApplicationMenuItems(overallDetails.currentApplication),
         ...createChangeRequestMenuItems(overallDetails.inProgressChangeRequest),
         ...createVersionsMenuItems(overallDetails.previousVersions),
       ];
@@ -103,32 +94,19 @@ export default defineComponent({
     /**
      * Get display name for supporting user with truncation.
      * @param supportingUser supporting user information.
-     * @param parentsInfo parent details with full names.
      * @param index index for fallback naming.
-     * @param useFullNames whether to use full names (for active) or Parent 1/2 (for history).
      */
     const getSupportingUserDisplayName = (
       supportingUser: ApplicationSupportingUsersAPIOutDTO,
-      parentsInfo: ParentDetails[],
       index: number,
-      useFullNames = true,
     ): string => {
       if (supportingUser.supportingUserType === SupportingUserType.Partner) {
         return "Partner";
       }
 
-      // For history, always use Parent 1/Parent 2
-      if (!useFullNames) {
-        return `Parent ${index + 1}`;
-      }
-
-      // For active section, try to find the parent details
-      const parentDetail = parentsInfo.find(
-        (parent) => parent.supportingUserId === supportingUser.supportingUserId,
-      );
-
-      if (parentDetail?.parentFullName) {
-        const fullName = parentDetail.parentFullName.trim();
+      // For parents, use full name if available, otherwise default to Parent 1/Parent 2
+      if (supportingUser.supportingUserFullName) {
+        const fullName = supportingUser.supportingUserFullName.trim();
         // Truncate if name is longer than 36 characters
         return fullName.length > 36
           ? `${fullName.substring(0, 33)}...`
@@ -142,23 +120,16 @@ export default defineComponent({
     /**
      * Get subtitle for supporting user based on who declared the information.
      * @param supportingUser supporting user information.
-     * @param parentsInfo parent details with declaration info.
      */
     const getSupportingUserSubtitle = (
       supportingUser: ApplicationSupportingUsersAPIOutDTO,
-      parentsInfo: ParentDetails[],
     ): string => {
       if (supportingUser.supportingUserType === SupportingUserType.Partner) {
         return "";
       }
 
-      // Find the parent details
-      const parentDetail = parentsInfo.find(
-        (parent) => parent.supportingUserId === supportingUser.supportingUserId,
-      );
-
       // For parents, determine if it was student declared or parent declared
-      if (parentDetail?.isAbleToReport === false) {
+      if (supportingUser.isAbleToReport === false) {
         return "Student Declared";
       } else {
         return "Parent Declared";
@@ -168,27 +139,14 @@ export default defineComponent({
     /**
      * Create one or more menu items for one to two parents or one partner.
      * @param supportingUsers supporting users information.
-     * @param parentsInfo parent details with full names.
-     * @param includeSubtitle whether to include declaration subtitles.
-     * @param useFullNames whether to use full names (active) or Parent 1/2 (history).
      */
     const createSupportingUsersMenu = (
       supportingUsers: ApplicationSupportingUsersAPIOutDTO[],
-      parentsInfo: ParentDetails[] = [],
-      includeSubtitle = false,
-      useFullNames = true,
     ): MenuItemModel[] => {
       return (
         supportingUsers.map((supportingUser, index) => {
-          const title = getSupportingUserDisplayName(
-            supportingUser,
-            parentsInfo,
-            index,
-            useFullNames,
-          );
-          const subtitle = includeSubtitle
-            ? getSupportingUserSubtitle(supportingUser, parentsInfo)
-            : undefined;
+          const title = getSupportingUserDisplayName(supportingUser, index);
+          const subtitle = getSupportingUserSubtitle(supportingUser);
           return {
             title,
             props: {
@@ -238,17 +196,12 @@ export default defineComponent({
     /**
      * Create the menu for the current application (Active).
      * @param currentVersion application version information.
-     * @param parentsInfo parent details with full names.
      */
     const createCurrentApplicationMenuItems = (
       currentVersion: ApplicationVersionAPIOutDTO,
-      parentsInfo: ParentDetails[],
     ): MenuItemModel[] => {
       const supportingUsers = createSupportingUsersMenu(
         currentVersion.supportingUsers,
-        parentsInfo,
-        true, // Include subtitles for active section
-        true, // Use full names for active section
       );
       return [
         {
@@ -338,9 +291,6 @@ export default defineComponent({
       );
       const supportingUsersMenuItems = createSupportingUsersMenu(
         inProgressChangeRequest?.supportingUsers,
-        [], // No parent details available for change requests
-        false, // No subtitles for change requests
-        false, // Use Parent 1/2 for change requests
       );
       const menuItems = [
         DIVIDER_MENU_ITEM,
@@ -382,9 +332,6 @@ export default defineComponent({
       versions.forEach((version) => {
         const versionSupportingUsersMenuItems = createSupportingUsersMenu(
           version.supportingUsers,
-          [], // No parent details available for history
-          false, // No subtitles for application history
-          false, // Use Parent 1/2 for history
         );
         menuItems.push({
           title: `${getISODateHourMinuteString(version.submittedDate)}`,

--- a/sources/packages/web/src/components/layouts/aest/AESTApplicationSideBar.vue
+++ b/sources/packages/web/src/components/layouts/aest/AESTApplicationSideBar.vue
@@ -103,14 +103,7 @@ export default defineComponent({
       if (supportingUser.supportingUserType === SupportingUserType.Partner) {
         return "Partner";
       }
-
-      // For parents, use full name if available, otherwise default to Parent 1/Parent 2.
-      if (supportingUser.supportingUserFullName) {
-        return supportingUser.supportingUserFullName.trim();
-      }
-
-      // Fallback to Parent 1/Parent 2 when no name is available.
-      return `Parent ${index + 1}`;
+      return supportingUser.supportingUserFullName ?? `Parent ${index + 1}`;
     };
 
     /**
@@ -146,7 +139,7 @@ export default defineComponent({
             props: {
               prependIcon: "mdi-account-outline",
               slim: true,
-              subtitle: subtitle || undefined,
+              subtitle,
               to: {
                 name: AESTRoutesConst.SUPPORTING_USER_DETAILS,
                 params: {

--- a/sources/packages/web/src/services/http/dto/Application.dto.ts
+++ b/sources/packages/web/src/services/http/dto/Application.dto.ts
@@ -237,6 +237,8 @@ export interface ApplicationWarningsAPIOutDTO {
 export interface ApplicationSupportingUsersAPIOutDTO {
   supportingUserId: number;
   supportingUserType: SupportingUserType;
+  supportingUserFullName?: string;
+  isAbleToReport?: boolean;
 }
 
 /**

--- a/sources/packages/web/src/views/aest/SupportingUser.vue
+++ b/sources/packages/web/src/views/aest/SupportingUser.vue
@@ -10,7 +10,7 @@
   </header-navigator>
   <full-page-container class="my-2">
     <formio
-      v-if="formName"
+      v-if="formName && formData.supportingData"
       :formName="formName"
       :data="formData"
       :readOnly="true"


### PR DESCRIPTION
**AC**
- Update the application side menu to display the parent’s full name instead of "Parent 1/Parent 2" in all states (active, change request, history). If the name is longer than 36 characters, truncate it. If the name is missing, default to "Parent 1/Parent 2".

- Add a new subtitle for parent declarations in the application history section: "Student Declared" and "Parent Declared".

## Demo
<img width="414" height="916" alt="image" src="https://github.com/user-attachments/assets/08d4bce1-41cc-45de-97ab-e1f0cbbec9f4" />

