### PR TITLE
#4823 - Parent declare: email notification (e2e tests)

### DIFF
--- a/sources/packages/backend/apps/workers/src/controllers/supporting-user/_test_/e2e/supporting-user.controller.createIdentifiableSupportingUsers.e2e-spec.ts
+++ b/sources/packages/backend/apps/workers/src/controllers/supporting-user/_test_/e2e/supporting-user.controller.createIdentifiableSupportingUsers.e2e-spec.ts
@@ -26,7 +26,7 @@ import {
   APPLICATION_NOT_FOUND,
   SUPPORTING_USER_FULL_NAME_NOT_RESOLVED,
 } from "@sims/services/constants";
-import { IsNull } from "typeorm";
+import { In, IsNull } from "typeorm";
 
 describe("SupportingUserController(e2e)-createIdentifiableSupportingUsers", () => {
   let db: E2EDataSources;
@@ -41,14 +41,22 @@ describe("SupportingUserController(e2e)-createIdentifiableSupportingUsers", () =
   beforeEach(async () => {
     // Update the date sent for the notifications to current date where the date sent is null.
     await db.notification.update(
-      { dateSent: IsNull() },
+      {
+        dateSent: IsNull(),
+        notificationMessage: {
+          id: In([
+            NotificationMessageType.ParentDeclarationRequiredParentCanReportNotification,
+            NotificationMessageType.ParentDeclarationRequiredParentCannotReportNotification,
+          ]),
+        },
+      },
       { dateSent: new Date() },
     );
   });
 
   it(
-    "Should create a supporting user for the first provided parent, save the associated full name and send a notification to the student " +
-      " indicating that the parent's declaration needs to be completed by the parent when one parent's information is added to the student application " +
+    "Should create a supporting user for the first provided parent, save the associated full name and send a notification to the student. " +
+      "The notification indicates that the parent's declaration needs to be completed by the parent when one parent's information is added to the student application, " +
       "with the parent being able to report their own information.",
     async () => {
       // Arrange
@@ -138,7 +146,7 @@ describe("SupportingUserController(e2e)-createIdentifiableSupportingUsers", () =
           },
         },
       });
-      expect(notification.dateSent).toBe(null);
+      expect(notification.dateSent).toBeNull();
       expect(notification.messagePayload).toStrictEqual({
         email_address: notification.user.email,
         template_id: notification.notificationMessage.templateId,
@@ -154,8 +162,8 @@ describe("SupportingUserController(e2e)-createIdentifiableSupportingUsers", () =
   );
 
   it(
-    "Should create supporting user for the second provided parent, save the associated full name and send a notification to the student" +
-      " indicating that the parent's declaration needs to be completed by the student when the parent's information is added to the student application" +
+    "Should create supporting user for the second provided parent, save the associated full name and send a notification to the student. " +
+      "The notification indicates that the parent's declaration needs to be completed by the student when the parent's information is added to the student application, " +
       " with the parent unable to report their information.",
     async () => {
       // Arrange
@@ -249,7 +257,7 @@ describe("SupportingUserController(e2e)-createIdentifiableSupportingUsers", () =
           },
         },
       });
-      expect(notification.dateSent).toBe(null);
+      expect(notification.dateSent).toBeNull();
       expect(notification.messagePayload).toStrictEqual({
         email_address: notification.user.email,
         template_id: notification.notificationMessage.templateId,

--- a/sources/packages/backend/apps/workers/src/controllers/supporting-user/_test_/e2e/supporting-user.controller.createIdentifiableSupportingUsers.e2e-spec.ts
+++ b/sources/packages/backend/apps/workers/src/controllers/supporting-user/_test_/e2e/supporting-user.controller.createIdentifiableSupportingUsers.e2e-spec.ts
@@ -1,4 +1,5 @@
 import {
+  Application,
   ApplicationData,
   NotificationMessageType,
   SupportingUserType,
@@ -358,7 +359,7 @@ describe("SupportingUserController(e2e)-createIdentifiableSupportingUsers", () =
    * @param notificationMessageType the notification message type to check.
    */
   async function notificationLookupAndAssertion(
-    savedApplication: any,
+    savedApplication: Application,
     parentFullName: string,
     notificationMessageType: NotificationMessageType,
   ): Promise<void> {

--- a/sources/packages/backend/apps/workers/src/controllers/supporting-user/_test_/e2e/supporting-user.controller.createIdentifiableSupportingUsers.e2e-spec.ts
+++ b/sources/packages/backend/apps/workers/src/controllers/supporting-user/_test_/e2e/supporting-user.controller.createIdentifiableSupportingUsers.e2e-spec.ts
@@ -164,7 +164,7 @@ describe("SupportingUserController(e2e)-createIdentifiableSupportingUsers", () =
   it(
     "Should create supporting user for the second provided parent, save the associated full name and send a notification to the student. " +
       "The notification indicates that the parent's declaration needs to be completed by the student when the parent's information is added to the student application, " +
-      " with the parent unable to report their information.",
+      "with the parent unable to report their information.",
     async () => {
       // Arrange
       const parentFullName1 = faker.datatype.uuid();

--- a/sources/packages/backend/libs/services/src/notifications/notification/notification-actions.service.ts
+++ b/sources/packages/backend/libs/services/src/notifications/notification/notification-actions.service.ts
@@ -1253,12 +1253,12 @@ export class NotificationActionsService {
     const auditUser = this.systemUsersService.systemUser;
     const { templateId } =
       await this.notificationMessageService.getNotificationMessageDetails(
-        NotificationMessageType.ParentDeclarationRequiredParentCanReportNotification,
+        NotificationMessageType.ParentInformationRequiredFromParentNotification,
       );
     const supportingUserInformationNotification = {
       userId: notification.userId,
       messageType:
-        NotificationMessageType.ParentDeclarationRequiredParentCanReportNotification,
+        NotificationMessageType.ParentInformationRequiredFromParentNotification,
       messagePayload: {
         email_address: notification.toAddress,
         template_id: templateId,
@@ -1291,12 +1291,12 @@ export class NotificationActionsService {
     const auditUser = this.systemUsersService.systemUser;
     const { templateId } =
       await this.notificationMessageService.getNotificationMessageDetails(
-        NotificationMessageType.ParentDeclarationRequiredParentCannotReportNotification,
+        NotificationMessageType.ParentInformationRequiredFromStudentNotification,
       );
     const supportingUserInformationNotification = {
       userId: notification.userId,
       messageType:
-        NotificationMessageType.ParentDeclarationRequiredParentCannotReportNotification,
+        NotificationMessageType.ParentInformationRequiredFromStudentNotification,
       messagePayload: {
         email_address: notification.toAddress,
         template_id: templateId,

--- a/sources/packages/backend/libs/sims-db/src/entities/notification.model.ts
+++ b/sources/packages/backend/libs/sims-db/src/entities/notification.model.ts
@@ -222,11 +222,11 @@ export enum NotificationMessageType {
    */
   StudentSecondDisbursementNotification = 31,
   /**
-   * Parent Declaration Required Parent Can Report Notification.
+   * Parent Information Required From Parent Notification.
    */
-  ParentDeclarationRequiredParentCanReportNotification = 32,
+  ParentInformationRequiredFromParentNotification = 32,
   /**
-   * Parent Declaration Required Parent Cannot Report Notification.
+   * Parent Information Required From Student Notification.
    */
-  ParentDeclarationRequiredParentCannotReportNotification = 33,
+  ParentInformationRequiredFromStudentNotification = 33,
 }


### PR DESCRIPTION
### As a part of this PR, the following e2e tests were updated to include the test of notifications:

**SupportingUserController(e2e)-createIdentifiableSupportingUsers**

**√** Should create supporting user for the first provided parent and save the associated full name when one parent's information is added to the student application and create a student notification for parent declaration uired by parent.
**√** Should create supporting user for the second provided parent and save the associated full name when the two parent's information is added to the student application and create a student notification for parent declaran required by student.

### **Screenshot:**

<img width="1484" height="236" alt="image" src="https://github.com/user-attachments/assets/cd2b19fe-e74a-4dd9-a756-884a94629921" />
