### PR TITLE
#3059 - Software Package Updates (local mongo update)

### DIFF
--- a/devops/openshift/forms-deploy.yml
+++ b/devops/openshift/forms-deploy.yml
@@ -19,6 +19,15 @@ objects:
   - apiVersion: apps/v1
     kind: Deployment
     metadata:
+      annotations:
+        app.openshift.io/connects-to:
+          [
+            {
+              "apiVersion": "apps/v1",
+              "kind": "StatefulSet",
+              "name": "mongo-ha",
+            },
+          ]
       labels:
         app: ${NAME}
       name: ${NAME}

--- a/devops/openshift/forms-deploy.yml
+++ b/devops/openshift/forms-deploy.yml
@@ -20,14 +20,7 @@ objects:
     kind: Deployment
     metadata:
       annotations:
-        app.openshift.io/connects-to:
-          [
-            {
-              "apiVersion": "apps/v1",
-              "kind": "StatefulSet",
-              "name": "mongo-ha",
-            },
-          ]
+        app.openshift.io/connects-to: '[{ "apiVersion": "apps/v1", "kind": "StatefulSet", "name": "mongo-ha" }]'
       labels:
         app: ${NAME}
       name: ${NAME}

--- a/sources/forms-docker-compose.yml
+++ b/sources/forms-docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   mongo:
-    image: mongo:4.1
+    image: mongo:8.0.11
     restart: always
     volumes:
       - mdb-data:/data/db
@@ -43,3 +43,4 @@ networks:
 
 volumes:
   mdb-data:
+    name: formio-mongo-data


### PR DESCRIPTION
- Updated the MongoDB local version to use the same version as recently updated on OpenShift.
- Named the MondoDB volume to force it to be recreated, making it easier to locate and making it easier to have the local upgraded.
  - To update its local environment, a developer needs to execute the `make forms` and redeploy the form.io definitions.

## Minor Visual Change

Added the visual connector between the MongoDB and Form.io server to prevent the MongoDB from being "alone" while displaying the topology.

<img width="332" height="484" alt="image" src="https://github.com/user-attachments/assets/fcfcf662-88a4-4bbd-b529-6bf9a9e760b9" />
