### PR TITLE
#4571 - Aviation Change Program Questions - Part 2

### DIFF
--- a/sources/packages/backend/apps/api/src/route-controllers/education-program/_tests_/e2e/education-program.institutions.controller.createEducationProgram.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/education-program/_tests_/e2e/education-program.institutions.controller.createEducationProgram.e2e-spec.ts
@@ -168,7 +168,7 @@ describe("EducationProgramInstitutionsController(e2e)-createEducationProgram", (
         programIntensity: payload.programIntensity,
         institutionProgramCode: payload.institutionProgramCode,
         minHoursWeek: null,
-        isAviationProgram: null,
+        isAviationProgram: "no",
         minHoursWeekAvi: null,
         hasMinimumAge: payload.entranceRequirements.hasMinimumAge,
         minHighSchool: payload.entranceRequirements.minHighSchool,

--- a/sources/packages/backend/apps/api/src/route-controllers/education-program/_tests_/e2e/education-program.institutions.controller.createEducationProgram.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/education-program/_tests_/e2e/education-program.institutions.controller.createEducationProgram.e2e-spec.ts
@@ -400,6 +400,7 @@ describe("EducationProgramInstitutionsController(e2e)-createEducationProgram", (
         requirementsByBCITA: true,
         noneOfTheAboveEntranceRequirements: false,
       },
+      isAviationProgram: "no",
       eslEligibility: "lessThan20",
       hasJointInstitution: "no",
       hasWILComponent: "no",

--- a/sources/packages/backend/apps/api/src/route-controllers/education-program/education-program.controller.service.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/education-program/education-program.controller.service.ts
@@ -214,6 +214,7 @@ export class EducationProgramControllerService {
       institutionProgramCode: program.institutionProgramCode,
       minHoursWeek: program.minHoursWeek,
       isAviationProgram: program.isAviationProgram,
+      credentialTypesAvi: program.credentialTypesAviation,
       minHoursWeekAvi: program.minHoursWeekAvi,
       entranceRequirements: {
         hasMinimumAge: program.hasMinimumAge,

--- a/sources/packages/backend/apps/api/src/route-controllers/education-program/education-program.controller.service.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/education-program/education-program.controller.service.ts
@@ -214,7 +214,7 @@ export class EducationProgramControllerService {
       institutionProgramCode: program.institutionProgramCode,
       minHoursWeek: program.minHoursWeek,
       isAviationProgram: program.isAviationProgram,
-      credentialTypesAvi: program.credentialTypesAviation,
+      credentialTypesAviation: program.credentialTypesAviation,
       minHoursWeekAvi: program.minHoursWeekAvi,
       entranceRequirements: {
         hasMinimumAge: program.hasMinimumAge,

--- a/sources/packages/backend/apps/api/src/route-controllers/education-program/models/education-program.dto.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/education-program/models/education-program.dto.ts
@@ -39,7 +39,7 @@ export class EducationProgramAPIOutDTO {
   institutionProgramCode?: string;
   minHoursWeek?: string;
   isAviationProgram?: string;
-  credentialTypesAvi?: AviationProgramCredentialTypes;
+  credentialTypesAviation?: AviationProgramCredentialTypes;
   minHoursWeekAvi?: string;
   entranceRequirements: EntranceRequirements;
   hasWILComponent: string;
@@ -137,7 +137,7 @@ export class EducationProgramAPIInDTO {
   @Allow()
   isAviationProgram?: string;
   @Allow()
-  credentialTypesAvi?: AviationProgramCredentialTypes;
+  credentialTypesAviation?: AviationProgramCredentialTypes;
   @Allow()
   minHoursWeekAvi?: string;
   @Allow()

--- a/sources/packages/backend/apps/api/src/route-controllers/education-program/models/education-program.dto.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/education-program/models/education-program.dto.ts
@@ -1,6 +1,5 @@
 import { Allow, IsDateString, IsNotEmpty, MaxLength } from "class-validator";
 import {
-  AviationProgramCredentialTypes,
   EntranceRequirements,
   ProgramDeliveryTypes,
 } from "../../../services/education-program/education-program.service.models";
@@ -8,6 +7,7 @@ import {
   NOTE_DESCRIPTION_MAX_LENGTH,
   ProgramStatus,
   ProgramIntensity,
+  AviationProgramCredentialTypes,
 } from "@sims/sims-db";
 
 /**
@@ -39,6 +39,7 @@ export class EducationProgramAPIOutDTO {
   institutionProgramCode?: string;
   minHoursWeek?: string;
   isAviationProgram?: string;
+  credentialTypesAvi?: AviationProgramCredentialTypes;
   minHoursWeekAvi?: string;
   entranceRequirements: EntranceRequirements;
   hasWILComponent: string;
@@ -136,6 +137,8 @@ export class EducationProgramAPIInDTO {
   @Allow()
   isAviationProgram?: string;
   @Allow()
+  credentialTypesAvi?: AviationProgramCredentialTypes;
+  @Allow()
   minHoursWeekAvi?: string;
   @Allow()
   entranceRequirements: EntranceRequirements;
@@ -157,8 +160,6 @@ export class EducationProgramAPIInDTO {
   programDeclaration: boolean;
   @Allow()
   fieldOfStudyCode: number;
-  @Allow()
-  credentialTypesAvi?: AviationProgramCredentialTypes;
   /**
    * Indicates the institution type as BC Private. isBCPrivate is part of the form and defines if the dynamic
    * area of the form.io definition will be visible or not. It will impact the validation using the dryrun.

--- a/sources/packages/backend/apps/api/src/services/education-program/education-program.service.models.ts
+++ b/sources/packages/backend/apps/api/src/services/education-program/education-program.service.models.ts
@@ -51,7 +51,7 @@ export interface SaveEducationProgram {
   programDeclaration: boolean;
   programStatus: ProgramStatus;
   fieldOfStudyCode: number;
-  credentialTypesAvi?: AviationProgramCredentialTypes;
+  credentialTypesAviation?: AviationProgramCredentialTypes;
 }
 
 export interface EducationProgramsSummary {

--- a/sources/packages/backend/apps/api/src/services/education-program/education-program.service.models.ts
+++ b/sources/packages/backend/apps/api/src/services/education-program/education-program.service.models.ts
@@ -1,4 +1,8 @@
-import { ProgramIntensity, ProgramStatus } from "@sims/sims-db";
+import {
+  AviationProgramCredentialTypes,
+  ProgramIntensity,
+  ProgramStatus,
+} from "@sims/sims-db";
 
 export interface ProgramDeliveryTypes {
   deliveredOnSite: boolean;
@@ -11,14 +15,6 @@ export interface EntranceRequirements {
   requirementsByInstitution: boolean;
   requirementsByBCITA: boolean;
   noneOfTheAboveEntranceRequirements: boolean;
-}
-
-export interface AviationProgramCredentialTypes {
-  commercialPilotTraining: boolean;
-  instructorsRating: boolean;
-  endorsements: boolean;
-  privatePilotTraining: boolean;
-  noneOfTheAbove: boolean;
 }
 
 export interface SaveEducationProgram {
@@ -55,6 +51,7 @@ export interface SaveEducationProgram {
   programDeclaration: boolean;
   programStatus: ProgramStatus;
   fieldOfStudyCode: number;
+  credentialTypesAvi?: AviationProgramCredentialTypes;
 }
 
 export interface EducationProgramsSummary {

--- a/sources/packages/backend/apps/api/src/services/education-program/education-program.service.ts
+++ b/sources/packages/backend/apps/api/src/services/education-program/education-program.service.ts
@@ -225,7 +225,8 @@ export class EducationProgramService extends RecordDataModelService<EducationPro
       program.institutionProgramCode = educationProgram.institutionProgramCode;
       program.minHoursWeek = educationProgram.minHoursWeek;
       program.isAviationProgram = educationProgram.isAviationProgram;
-      program.credentialTypesAviation = educationProgram.credentialTypesAvi;
+      program.credentialTypesAviation =
+        educationProgram.credentialTypesAviation;
       program.minHoursWeekAvi = educationProgram.minHoursWeekAvi;
       program.minHighSchool =
         educationProgram.entranceRequirements.minHighSchool;

--- a/sources/packages/backend/apps/api/src/services/education-program/education-program.service.ts
+++ b/sources/packages/backend/apps/api/src/services/education-program/education-program.service.ts
@@ -225,6 +225,7 @@ export class EducationProgramService extends RecordDataModelService<EducationPro
       program.institutionProgramCode = educationProgram.institutionProgramCode;
       program.minHoursWeek = educationProgram.minHoursWeek;
       program.isAviationProgram = educationProgram.isAviationProgram;
+      program.credentialTypesAviation = educationProgram.credentialTypesAvi;
       program.minHoursWeekAvi = educationProgram.minHoursWeekAvi;
       program.minHighSchool =
         educationProgram.entranceRequirements.minHighSchool;
@@ -538,6 +539,7 @@ export class EducationProgramService extends RecordDataModelService<EducationPro
         "programs.institutionProgramCode",
         "programs.minHoursWeek",
         "programs.isAviationProgram",
+        "programs.credentialTypesAviation",
         "programs.minHoursWeekAvi",
         "programs.hasMinimumAge",
         "programs.minHighSchool",

--- a/sources/packages/backend/apps/api/src/testHelpers/fake-entities/education-program-fake.ts
+++ b/sources/packages/backend/apps/api/src/testHelpers/fake-entities/education-program-fake.ts
@@ -50,6 +50,7 @@ export function createFakeEducationProgram(
   program.institution = relations?.institution ?? createFakeInstitution();
   program.programIntensity =
     options?.initialValue?.programIntensity ?? ProgramIntensity.fullTime;
+  program.isAviationProgram = options?.initialValue?.isAviationProgram ?? "no";
   program.submittedBy = relations?.user;
   program.fieldOfStudyCode = 1;
   program.isActive = options?.initialValue?.isActive ?? true;

--- a/sources/packages/backend/apps/db-migrations/src/migrations/1753136296375-AddCredentialTypesAviationColumn.ts
+++ b/sources/packages/backend/apps/db-migrations/src/migrations/1753136296375-AddCredentialTypesAviationColumn.ts
@@ -1,0 +1,24 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+import { getSQLFileData } from "../utilities/sqlLoader";
+
+export class AddCredentialTypesAviationColumn1753136296375
+  implements MigrationInterface
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      getSQLFileData(
+        "Add-credential-types-aviation-column.sql",
+        "EducationPrograms",
+      ),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      getSQLFileData(
+        "Rollback-add-credential-types-aviation-column.sql",
+        "EducationPrograms",
+      ),
+    );
+  }
+}

--- a/sources/packages/backend/apps/db-migrations/src/migrations/1753144314059-UpdateIsAviationProgramToNo.ts
+++ b/sources/packages/backend/apps/db-migrations/src/migrations/1753144314059-UpdateIsAviationProgramToNo.ts
@@ -1,0 +1,24 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+import { getSQLFileData } from "../utilities/sqlLoader";
+
+export class UpdateIsAviationProgramToNo1753144314059
+  implements MigrationInterface
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      getSQLFileData(
+        "Update-is-aviation-program-to-no.sql",
+        "EducationPrograms",
+      ),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      getSQLFileData(
+        "Rollback-update-is-aviation-program-to-no.sql",
+        "EducationPrograms",
+      ),
+    );
+  }
+}

--- a/sources/packages/backend/apps/db-migrations/src/sql/EducationPrograms/Add-credential-types-aviation-column.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/EducationPrograms/Add-credential-types-aviation-column.sql
@@ -1,0 +1,13 @@
+ALTER TABLE
+  sims.education_programs
+ADD
+  COLUMN credential_types_aviation jsonb;
+
+COMMENT ON COLUMN sims.education_programs.credential_types_aviation IS 'A jsonb column to store various credential types related to aviation programs.';
+
+ALTER TABLE
+  sims.education_programs_history
+ADD
+  COLUMN credential_types_aviation jsonb;
+
+COMMENT ON COLUMN sims.education_programs_history.credential_types_aviation IS 'A jsonb column to store various credential types related to aviation programs.';

--- a/sources/packages/backend/apps/db-migrations/src/sql/EducationPrograms/Add-credential-types-aviation-column.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/EducationPrograms/Add-credential-types-aviation-column.sql
@@ -3,11 +3,11 @@ ALTER TABLE
 ADD
   COLUMN credential_types_aviation jsonb;
 
-COMMENT ON COLUMN sims.education_programs.credential_types_aviation IS 'A jsonb column to store various credential types related to aviation programs.';
+COMMENT ON COLUMN sims.education_programs.credential_types_aviation IS 'Aviation program credential types.';
 
 ALTER TABLE
   sims.education_programs_history
 ADD
   COLUMN credential_types_aviation jsonb;
 
-COMMENT ON COLUMN sims.education_programs_history.credential_types_aviation IS 'A jsonb column to store various credential types related to aviation programs.';
+COMMENT ON COLUMN sims.education_programs_history.credential_types_aviation IS 'Aviation program credential types.';

--- a/sources/packages/backend/apps/db-migrations/src/sql/EducationPrograms/Add-credential-types-aviation-column.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/EducationPrograms/Add-credential-types-aviation-column.sql
@@ -10,4 +10,4 @@ ALTER TABLE
 ADD
   COLUMN credential_types_aviation jsonb;
 
-COMMENT ON COLUMN sims.education_programs_history.credential_types_aviation IS 'Aviation program credential types.';
+COMMENT ON COLUMN sims.education_programs_history.credential_types_aviation IS 'Historical data from the original table. See the original table comments for details.';

--- a/sources/packages/backend/apps/db-migrations/src/sql/EducationPrograms/Rollback-add-credential-types-aviation-column.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/EducationPrograms/Rollback-add-credential-types-aviation-column.sql
@@ -1,0 +1,5 @@
+ALTER TABLE
+  sims.education_programs DROP COLUMN credential_types_aviation;
+
+ALTER TABLE
+  sims.education_programs_history DROP COLUMN credential_types_aviation;

--- a/sources/packages/backend/apps/db-migrations/src/sql/EducationPrograms/Rollback-update-is-aviation-program-to-no.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/EducationPrograms/Rollback-update-is-aviation-program-to-no.sql
@@ -1,3 +1,8 @@
+ALTER TABLE
+  sims.education_programs
+ALTER COLUMN
+  is_aviation_program DROP NOT NULL;
+
 UPDATE
   sims.education_programs
 SET

--- a/sources/packages/backend/apps/db-migrations/src/sql/EducationPrograms/Rollback-update-is-aviation-program-to-no.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/EducationPrograms/Rollback-update-is-aviation-program-to-no.sql
@@ -3,7 +3,8 @@ UPDATE
 SET
   is_aviation_program = NULL
 WHERE
-  course_load_calculation = 'credit' || (
+  course_load_calculation = 'credit'
+  OR (
     course_load_calculation = 'hours'
     AND min_hours_week = 'yes'
   );

--- a/sources/packages/backend/apps/db-migrations/src/sql/EducationPrograms/Rollback-update-is-aviation-program-to-no.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/EducationPrograms/Rollback-update-is-aviation-program-to-no.sql
@@ -1,0 +1,9 @@
+UPDATE
+  sims.education_programs
+SET
+  is_aviation_program = NULL
+WHERE
+  course_load_calculation = 'credit' || (
+    course_load_calculation = 'hours'
+    AND min_hours_week = 'yes'
+  );

--- a/sources/packages/backend/apps/db-migrations/src/sql/EducationPrograms/Update-is-aviation-program-to-no.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/EducationPrograms/Update-is-aviation-program-to-no.sql
@@ -4,3 +4,10 @@ SET
   is_aviation_program = 'no'
 WHERE
   is_aviation_program IS NULL;
+
+ALTER TABLE
+  education_programs
+ALTER COLUMN
+  is_aviation_program
+SET
+  NOT NULL;

--- a/sources/packages/backend/apps/db-migrations/src/sql/EducationPrograms/Update-is-aviation-program-to-no.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/EducationPrograms/Update-is-aviation-program-to-no.sql
@@ -1,0 +1,6 @@
+UPDATE
+  education_programs
+SET
+  is_aviation_program = 'no'
+WHERE
+  is_aviation_program IS NULL;

--- a/sources/packages/backend/libs/sims-db/src/entities/education-program.model.ts
+++ b/sources/packages/backend/libs/sims-db/src/entities/education-program.model.ts
@@ -219,14 +219,13 @@ export class EducationProgram extends RecordDataModel {
   isAviationProgram?: string;
 
   /**
-   * A jsonb column to store various credential types related to aviation programs.
+   * Aviation program credential types.
    */
   @Column({
     name: "credential_types_aviation",
     type: "jsonb",
     nullable: true,
-    comment:
-      "A jsonb column to store various credential types related to aviation programs.",
+    comment: "Aviation program credential types.",
   })
   credentialTypesAviation?: AviationProgramCredentialTypes;
 

--- a/sources/packages/backend/libs/sims-db/src/entities/education-program.model.ts
+++ b/sources/packages/backend/libs/sims-db/src/entities/education-program.model.ts
@@ -219,6 +219,18 @@ export class EducationProgram extends RecordDataModel {
   isAviationProgram?: string;
 
   /**
+   * A jsonb column to store various credential types related to aviation programs.
+   */
+  @Column({
+    name: "credential_types_aviation",
+    type: "jsonb",
+    nullable: true,
+    comment:
+      "A jsonb column to store various credential types related to aviation programs.",
+  })
+  credentialTypesAviation?: AviationProgramCredentialTypes;
+
+  /**
    * Minimum hours check for a aviation program.
    */
   @Column({
@@ -430,4 +442,15 @@ export class EducationProgram extends RecordDataModel {
     nullable: true,
   })
   isActiveUpdatedOn?: Date;
+}
+
+/**
+ * Aviation program credential types.
+ */
+export interface AviationProgramCredentialTypes {
+  commercialPilotTraining: boolean;
+  instructorsRating: boolean;
+  endorsements: boolean;
+  privatePilotTraining: boolean;
+  noneOfTheAbove: boolean;
 }

--- a/sources/packages/backend/libs/sims-db/src/entities/education-program.model.ts
+++ b/sources/packages/backend/libs/sims-db/src/entities/education-program.model.ts
@@ -225,7 +225,6 @@ export class EducationProgram extends RecordDataModel {
     name: "credential_types_aviation",
     type: "jsonb",
     nullable: true,
-    comment: "Aviation program credential types.",
   })
   credentialTypesAviation?: AviationProgramCredentialTypes;
 

--- a/sources/packages/backend/libs/test-utils/src/factories/education-program.ts
+++ b/sources/packages/backend/libs/test-utils/src/factories/education-program.ts
@@ -38,6 +38,7 @@ export function createFakeEducationProgram(
   program.institution = relations?.institution ?? createFakeInstitution();
   program.programIntensity =
     options?.initialValues?.programIntensity ?? ProgramIntensity.fullTime;
+  program.isAviationProgram = options?.initialValues?.isAviationProgram ?? "no";
   program.submittedBy = relations.auditUser;
   program.isActive = options?.initialValues?.isActive ?? true;
   program.effectiveEndDate = options?.initialValues?.effectiveEndDate ?? null;

--- a/sources/packages/forms/src/form-definitions/educationprogram.json
+++ b/sources/packages/forms/src/form-definitions/educationprogram.json
@@ -1773,7 +1773,7 @@
                 "onlyAvailableItems": true
               },
               "validateWhenHidden": false,
-              "key": "credentialTypesAvi",
+              "key": "credentialTypesAviation",
               "conditional": {
                 "show": true,
                 "when": "isAviationProgram",
@@ -1799,7 +1799,7 @@
               "key": "html22",
               "conditional": {
                 "show": true,
-                "when": "credentialTypesAvi",
+                "when": "credentialTypesAviation",
                 "eq": "privatePilotTraining"
               },
               "type": "htmlelement",

--- a/sources/packages/web/src/services/http/dto/EducationProgram.dto.ts
+++ b/sources/packages/web/src/services/http/dto/EducationProgram.dto.ts
@@ -36,6 +36,7 @@ export interface EducationProgramAPIOutDTO {
   institutionProgramCode?: string;
   minHoursWeek?: string;
   isAviationProgram?: string;
+  credentialTypesAvi?: AviationProgramCredentialTypes;
   minHoursWeekAvi?: string;
   entranceRequirements: EntranceRequirements;
   hasWILComponent: string;

--- a/sources/packages/web/src/services/http/dto/EducationProgram.dto.ts
+++ b/sources/packages/web/src/services/http/dto/EducationProgram.dto.ts
@@ -36,7 +36,7 @@ export interface EducationProgramAPIOutDTO {
   institutionProgramCode?: string;
   minHoursWeek?: string;
   isAviationProgram?: string;
-  credentialTypesAvi?: AviationProgramCredentialTypes;
+  credentialTypesAviation?: AviationProgramCredentialTypes;
   minHoursWeekAvi?: string;
   entranceRequirements: EntranceRequirements;
   hasWILComponent: string;
@@ -151,7 +151,7 @@ export class EducationProgramAPIInDTO {
   @Expose()
   fieldOfStudyCode: number;
   @Expose()
-  credentialTypesAvi?: AviationProgramCredentialTypes;
+  credentialTypesAviation?: AviationProgramCredentialTypes;
   isBCPrivate: boolean;
   isBCPublic: boolean;
 }


### PR DESCRIPTION
### As a part of this PR, the following were completed:

- Added migrations for the following:

       1. Added the new `Credential Types Aviation` column
       2. Updated the `isAviationProgram` to `no` where `null` for existing records

- Updated the `api` and `web` code logic to save, update and retrieve the values in edit and read-only mode from this newly created column `Credential Types Aviation` to be displayed to the UI

### **Screenshots:**

**Read-only mode institutions program:**

<img width="1871" height="1052" alt="image" src="https://github.com/user-attachments/assets/970ef965-256c-4200-a2cf-4a2eaa27dc64" />

--------------------------------------------------------------------------------------------------------------------------------------------

**Migrations Rollback:**

<img width="788" height="451" alt="image" src="https://github.com/user-attachments/assets/13e7e956-de9b-4fe8-b65c-b641a8304523" />

--------------------------------------------------------------------------------------------------------------------------------------------

<img width="909" height="454" alt="image" src="https://github.com/user-attachments/assets/e88162e1-0fe2-4369-af9f-15fabced1e40" />