### PR TITLE
#3059 - Software Package Updates (dependabot config update)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,6 +23,7 @@ updates:
       - dependency-name: "*"
         update-types:
           ["version-update:semver-patch", "version-update:semver-minor"]
+      - dependency-name: "@nestjs*"
   - package-ecosystem: "npm"
     directory: "/sources/packages/forms"
     schedule:
@@ -59,8 +60,6 @@ updates:
           - "*"
         update-types:
           - "minor"
-    ignore:
-      - dependency-name: "@nestjs*"
   - package-ecosystem: "npm"
     directory: "/sources/packages/backend"
     schedule:
@@ -89,8 +88,6 @@ updates:
           - "*"
         update-types:
           - "minor"
-    ignore:
-      - dependency-name: "@nestjs*"
   - package-ecosystem: "npm"
     directory: "/sources/packages/load-test"
     schedule:
@@ -104,8 +101,6 @@ updates:
           - "*"
         update-types:
           - "minor"
-    ignore:
-      - dependency-name: "@nestjs*"
   # Security updates for all npm packages (non-grouped).
   - package-ecosystem: "npm"
     directory: "/sources/packages/web"
@@ -121,8 +116,6 @@ updates:
           - "*"
         update-types:
           - "patch"
-    ignore:
-      - dependency-name: "@nestjs*"
   - package-ecosystem: "npm"
     directory: "/sources/packages/backend"
     schedule:
@@ -137,8 +130,6 @@ updates:
           - "*"
         update-types:
           - "patch"
-    ignore:
-      - dependency-name: "@nestjs*"
   - package-ecosystem: "npm"
     directory: "/sources/packages/forms"
     schedule:
@@ -153,24 +144,6 @@ updates:
           - "*"
         update-types:
           - "patch"
-    ignore:
-      - dependency-name: "@nestjs*"
-  - package-ecosystem: "npm"
-    directory: "/sources/packages/forms"
-    schedule:
-      interval: "weekly"
-    labels:
-      - "Dependencies"
-      - "Security-related"
-      - "npm"
-    groups:
-      patch-updates:
-        patterns:
-          - "*"
-        update-types:
-          - "patch"
-    ignore:
-      - dependency-name: "@nestjs*"
   - package-ecosystem: "npm"
     directory: "/sources/packages/load-test"
     schedule:
@@ -185,8 +158,6 @@ updates:
           - "*"
         update-types:
           - "patch"
-    ignore:
-      - dependency-name: "@nestjs*"
   # Nestjs packages updates monitored separately.
   - package-ecosystem: "npm"
     directory: "/sources/packages/backend"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,6 +23,7 @@ updates:
       - dependency-name: "*"
         update-types:
           ["version-update:semver-patch", "version-update:semver-minor"]
+      # NestJS packages are excluded from major updates to ensure compatibility with the framework's ecosystem.
       - dependency-name: "@nestjs*"
   - package-ecosystem: "npm"
     directory: "/sources/packages/forms"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,6 @@
 version: 2
 updates:
+  # Major versions updates for all npm packages (non-grouped).
   - package-ecosystem: "npm"
     directory: "/sources/packages/web"
     schedule:
@@ -7,8 +8,186 @@ updates:
     labels:
       - "Dependencies"
       - "npm"
-      - "Web portal"
-
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          ["version-update:semver-patch", "version-update:semver-minor"]
+  - package-ecosystem: "npm"
+    directory: "/sources/packages/backend"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "Dependencies"
+      - "npm"
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          ["version-update:semver-patch", "version-update:semver-minor"]
+  - package-ecosystem: "npm"
+    directory: "/sources/packages/forms"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "Dependencies"
+      - "npm"
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          ["version-update:semver-patch", "version-update:semver-minor"]
+  - package-ecosystem: "npm"
+    directory: "/sources/packages/load-test"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "Dependencies"
+      - "npm"
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          ["version-update:semver-patch", "version-update:semver-minor"]
+  # Minor version updates for all npm packages (grouped).
+  - package-ecosystem: "npm"
+    directory: "/sources/packages/web"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "Dependencies"
+      - "npm"
+    groups:
+      minor-updates:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+    ignore:
+      - dependency-name: "@nestjs*"
+  - package-ecosystem: "npm"
+    directory: "/sources/packages/backend"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "Dependencies"
+      - "npm"
+    groups:
+      minor-updates:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+    ignore:
+      - dependency-name: "@nestjs*"
+  - package-ecosystem: "npm"
+    directory: "/sources/packages/forms"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "Dependencies"
+      - "npm"
+    groups:
+      minor-updates:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+    ignore:
+      - dependency-name: "@nestjs*"
+  - package-ecosystem: "npm"
+    directory: "/sources/packages/load-test"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "Dependencies"
+      - "npm"
+    groups:
+      minor-updates:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+    ignore:
+      - dependency-name: "@nestjs*"
+  # Security updates for all npm packages (non-grouped).
+  - package-ecosystem: "npm"
+    directory: "/sources/packages/web"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "Dependencies"
+      - "Security-related"
+      - "npm"
+    groups:
+      patch-updates:
+        patterns:
+          - "*"
+        update-types:
+          - "patch"
+    ignore:
+      - dependency-name: "@nestjs*"
+  - package-ecosystem: "npm"
+    directory: "/sources/packages/backend"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "Dependencies"
+      - "Security-related"
+      - "npm"
+    groups:
+      patch-updates:
+        patterns:
+          - "*"
+        update-types:
+          - "patch"
+    ignore:
+      - dependency-name: "@nestjs*"
+  - package-ecosystem: "npm"
+    directory: "/sources/packages/forms"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "Dependencies"
+      - "Security-related"
+      - "npm"
+    groups:
+      patch-updates:
+        patterns:
+          - "*"
+        update-types:
+          - "patch"
+    ignore:
+      - dependency-name: "@nestjs*"
+  - package-ecosystem: "npm"
+    directory: "/sources/packages/forms"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "Dependencies"
+      - "Security-related"
+      - "npm"
+    groups:
+      patch-updates:
+        patterns:
+          - "*"
+        update-types:
+          - "patch"
+    ignore:
+      - dependency-name: "@nestjs*"
+  - package-ecosystem: "npm"
+    directory: "/sources/packages/load-test"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "Dependencies"
+      - "Security-related"
+      - "npm"
+    groups:
+      patch-updates:
+        patterns:
+          - "*"
+        update-types:
+          - "patch"
+    ignore:
+      - dependency-name: "@nestjs*"
+  # Nestjs packages updates monitored separately.
   - package-ecosystem: "npm"
     directory: "/sources/packages/backend"
     schedule:
@@ -21,25 +200,7 @@ updates:
       nestjs:
         patterns:
           - "@nestjs*"
-
-  - package-ecosystem: "npm"
-    directory: "/sources/packages/forms"
-    schedule:
-      interval: "weekly"
-    labels:
-      - "Dependencies"
-      - "npm"
-      - "Form.io"
-
-  - package-ecosystem: "npm"
-    directory: "/sources/packages/load-test"
-    schedule:
-      interval: "weekly"
-    labels:
-      - "Dependencies"
-      - "npm"
-      - "Load Test"
-
+  # GitHub Actions updates.
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,118 +1,25 @@
 version: 2
 updates:
-  # Major versions updates for all npm packages (non-grouped).
   - package-ecosystem: "npm"
     directory: "/sources/packages/web"
     schedule:
       interval: "weekly"
     labels:
       - "Dependencies"
-      - "npm"
-    ignore:
-      - dependency-name: "*"
-        update-types:
-          ["version-update:semver-patch", "version-update:semver-minor"]
-  - package-ecosystem: "npm"
-    directory: "/sources/packages/backend"
-    schedule:
-      interval: "weekly"
-    labels:
-      - "Dependencies"
-      - "npm"
-    ignore:
-      - dependency-name: "*"
-        update-types:
-          ["version-update:semver-patch", "version-update:semver-minor"]
-      # NestJS packages are excluded from major updates to ensure compatibility with the framework's ecosystem.
-      - dependency-name: "@nestjs*"
-  - package-ecosystem: "npm"
-    directory: "/sources/packages/forms"
-    schedule:
-      interval: "weekly"
-    labels:
-      - "Dependencies"
-      - "npm"
-    ignore:
-      - dependency-name: "*"
-        update-types:
-          ["version-update:semver-patch", "version-update:semver-minor"]
-  - package-ecosystem: "npm"
-    directory: "/sources/packages/load-test"
-    schedule:
-      interval: "weekly"
-    labels:
-      - "Dependencies"
-      - "npm"
-    ignore:
-      - dependency-name: "*"
-        update-types:
-          ["version-update:semver-patch", "version-update:semver-minor"]
-  # Minor version updates for all npm packages (grouped).
-  - package-ecosystem: "npm"
-    directory: "/sources/packages/web"
-    schedule:
-      interval: "weekly"
-    labels:
-      - "Dependencies"
+      - "Web portal"
       - "npm"
     groups:
+      major-updates:
+        patterns:
+          - "*"
+        update-types:
+          - "major"
       minor-updates:
         patterns:
           - "*"
         update-types:
           - "minor"
-  - package-ecosystem: "npm"
-    directory: "/sources/packages/backend"
-    schedule:
-      interval: "weekly"
-    labels:
-      - "Dependencies"
-      - "npm"
-    groups:
-      minor-updates:
-        patterns:
-          - "*"
-        update-types:
-          - "minor"
-    ignore:
-      - dependency-name: "@nestjs*"
-  - package-ecosystem: "npm"
-    directory: "/sources/packages/forms"
-    schedule:
-      interval: "weekly"
-    labels:
-      - "Dependencies"
-      - "npm"
-    groups:
-      minor-updates:
-        patterns:
-          - "*"
-        update-types:
-          - "minor"
-  - package-ecosystem: "npm"
-    directory: "/sources/packages/load-test"
-    schedule:
-      interval: "weekly"
-    labels:
-      - "Dependencies"
-      - "npm"
-    groups:
-      minor-updates:
-        patterns:
-          - "*"
-        update-types:
-          - "minor"
-  # Security updates for all npm packages (non-grouped).
-  - package-ecosystem: "npm"
-    directory: "/sources/packages/web"
-    schedule:
-      interval: "weekly"
-    labels:
-      - "Dependencies"
-      - "Security-related"
-      - "npm"
-    groups:
-      patch-updates:
+      patches-updates:
         patterns:
           - "*"
         update-types:
@@ -123,55 +30,72 @@ updates:
       interval: "weekly"
     labels:
       - "Dependencies"
-      - "Security-related"
-      - "npm"
-    groups:
-      patch-updates:
-        patterns:
-          - "*"
-        update-types:
-          - "patch"
-  - package-ecosystem: "npm"
-    directory: "/sources/packages/forms"
-    schedule:
-      interval: "weekly"
-    labels:
-      - "Dependencies"
-      - "Security-related"
-      - "npm"
-    groups:
-      patch-updates:
-        patterns:
-          - "*"
-        update-types:
-          - "patch"
-  - package-ecosystem: "npm"
-    directory: "/sources/packages/load-test"
-    schedule:
-      interval: "weekly"
-    labels:
-      - "Dependencies"
-      - "Security-related"
-      - "npm"
-    groups:
-      patch-updates:
-        patterns:
-          - "*"
-        update-types:
-          - "patch"
-  # Nestjs packages updates monitored separately.
-  - package-ecosystem: "npm"
-    directory: "/sources/packages/backend"
-    schedule:
-      interval: "weekly"
-    labels:
-      - "Dependencies"
-      - "npm"
       - "Backend"
+      - "npm"
     groups:
-      nestjs:
+      major-updates:
         patterns:
-          - "@nestjs*"
+          - "*"
+        update-types:
+          - "major"
+      minor-updates:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+      patches-updates:
+        patterns:
+          - "*"
+        update-types:
+          - "patch"
+  - package-ecosystem: "npm"
+    directory: "/sources/packages/forms"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "Dependencies"
+      - "Form.io"
+      - "npm"
+    groups:
+      major-updates:
+        patterns:
+          - "*"
+        update-types:
+          - "major"
+      minor-updates:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+      patches-updates:
+        patterns:
+          - "*"
+        update-types:
+          - "patch"
+  - package-ecosystem: "npm"
+    directory: "/sources/packages/load-test"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "Dependencies"
+      - "Load Test"
+      - "npm"
+    groups:
+      major-updates:
+        patterns:
+          - "*"
+        update-types:
+          - "major"
+      minor-updates:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+      patches-updates:
+        patterns:
+          - "*"
+        update-types:
+          - "patch"
   # GitHub Actions updates.
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -180,3 +104,7 @@ updates:
     labels:
       - "Dependencies"
       - "GitHub actions"
+    groups:
+      github-actions-updates:
+        patterns:
+          - "*"


### PR DESCRIPTION
Update the configuration for the dependabot PRs creation.
The PRs are still grouped per directory, but also grouped as agreed:
- major versions - individuals
- minor versions - grouped
- security patch security - grouped
_Note:_ kept Nestjs as a separate group for now.

It seems that there is a possible feature called [multi-ecosystem-groups](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/configuring-multi-ecosystem-updates) that can be explored later to group the PRs for the individual apps, but it seems new and it was causing validation issues in the file.

