### PR TITLE
#4743 - Validate offering intensity for appeal in API

### DIFF
--- a/sources/packages/backend/apps/api/src/route-controllers/student-appeal/_tests_/e2e/student-appeal.students.controller.submitStudentAppeal.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/student-appeal/_tests_/e2e/student-appeal.students.controller.submitStudentAppeal.e2e-spec.ts
@@ -26,6 +26,7 @@ import {
   Application,
   ApplicationStatus,
   FileOriginType,
+  OfferingIntensity,
   ProgramYear,
   StudentAppealRequest,
   StudentAppealStatus,
@@ -627,7 +628,10 @@ describe("StudentAppealStudentsController(e2e)-submitStudentAppeal", () => {
           student,
           programYear: recentActiveProgramYear,
         },
-        { applicationStatus: ApplicationStatus.Completed },
+        {
+          offeringIntensity: OfferingIntensity.fullTime,
+          applicationStatus: ApplicationStatus.Completed,
+        },
       );
       // Create a temporary file for room and board costs appeal.
       const roomAndBoardFile = await saveFakeStudentFileUpload(
@@ -741,7 +745,10 @@ describe("StudentAppealStudentsController(e2e)-submitStudentAppeal", () => {
           student,
           programYear: recentActiveProgramYear,
         },
-        { applicationStatus: ApplicationStatus.Completed },
+        {
+          offeringIntensity: OfferingIntensity.fullTime,
+          applicationStatus: ApplicationStatus.Completed,
+        },
       );
       // Prepare the data to request a change of financial information which is not an eligible appeal.
       const financialInformationData = {

--- a/sources/packages/backend/apps/api/src/route-controllers/student-appeal/student-appeal.students.controller.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/student-appeal/student-appeal.students.controller.ts
@@ -78,7 +78,8 @@ export class StudentAppealStudentsController extends BaseController {
     description:
       "Only one change request/appeal can be submitted at a time for each application. " +
       "When your current request is approved or denied by StudentAid BC, you will be able to submit a new one or " +
-      "one or more forms submitted are not valid for appeal submission.",
+      "one or more forms submitted are not valid for appeal submission or " +
+      "appeals cannot be submitted for part-time applications.",
   })
   @ApiBadRequestResponse({
     description:

--- a/sources/packages/backend/apps/api/src/route-controllers/student-appeal/student-appeal.students.controller.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/student-appeal/student-appeal.students.controller.ts
@@ -48,6 +48,7 @@ import { StudentAppealRequestModel } from "../../services/student-appeal/student
 import { StudentAppealControllerService } from "./student-appeal.controller.service";
 import { StudentAppealServerSideSubmissionData } from "./models/student-appeal.model";
 import { allowApplicationChangeRequest } from "../../utilities";
+import { OfferingIntensity } from "@sims/sims-db";
 
 @AllowAuthorizedParty(AuthorizedParties.student)
 @RequiresStudentAccount()
@@ -106,6 +107,16 @@ export class StudentAppealStudentsController extends BaseController {
     // If the submission is for new appeal process, then set the operation name as appeal.
     // Otherwise, set it to change request.
     const operation = isProgramYearForNewProcess ? "appeal" : "change request";
+
+    // Validate the application offering intensity for the operation.
+    if (
+      operation === "appeal" &&
+      application.offeringIntensity === OfferingIntensity.partTime
+    ) {
+      throw new UnprocessableEntityException(
+        "Appeals cannot be submitted for part-time applications.",
+      );
+    }
 
     // Validate the submitted form names for the operation.
     this.studentAppealControllerService.validateSubmittedFormNames(

--- a/sources/packages/backend/apps/api/src/services/application/application.service.ts
+++ b/sources/packages/backend/apps/api/src/services/application/application.service.ts
@@ -1777,6 +1777,7 @@ export class ApplicationService extends RecordDataModelService<Application> {
         id: true,
         applicationNumber: true,
         isArchived: true,
+        offeringIntensity: true,
         programYear: { id: true, programYear: true },
       },
       relations: { programYear: true },


### PR DESCRIPTION
- [x] Validate in API that the appeal submission happens only for full-time as there is no appeals yet for `Part-time`.