### PR TITLE
#4665 - Workflow Permissions

### DIFF
--- a/.github/workflows/clamav.yml
+++ b/.github/workflows/clamav.yml
@@ -1,5 +1,7 @@
 name: ClamAV - Install/Upgrade/Remove
 run-name: ClamAV -  ${{ inputs.environment }} ClamAV in ${{ inputs.environment }} using ${{ github.ref_name }}
+permissions:
+  contents: read
 
 on:
   workflow_dispatch:

--- a/.github/workflows/crunchy-db.yml
+++ b/.github/workflows/crunchy-db.yml
@@ -1,5 +1,7 @@
 name: Crunchy DB - Install/Upgrade
 run-name: Crunchy DB - ${{ inputs.environment }} Crunchy DB in ${{ inputs.environment }} using ${{ github.ref_name }}
+permissions:
+  contents: read
 
 on:
   workflow_dispatch:

--- a/.github/workflows/env-setup-build-forms-server.yml
+++ b/.github/workflows/env-setup-build-forms-server.yml
@@ -1,5 +1,7 @@
 name: Env Setup - Build Forms Server
 run-name: Env Setup - Build forms server from ${{ github.ref_name }}(form.io tag ${{ inputs.formioTag }})
+permissions:
+  contents: read
 
 on:
   workflow_dispatch:

--- a/.github/workflows/env-setup-deploy-forms-server.yml
+++ b/.github/workflows/env-setup-deploy-forms-server.yml
@@ -1,5 +1,7 @@
 name: Env Setup - Deploy Forms Server
 run-name: Env Setup - Deploy forms server from ${{ github.ref_name }}(form.io tag ${{ inputs.formioTag }}) to ${{ inputs.environment }}
+permissions:
+  contents: read
 
 on:
   workflow_dispatch:

--- a/.github/workflows/env-setup-deploy-mongo.yml
+++ b/.github/workflows/env-setup-deploy-mongo.yml
@@ -2,6 +2,8 @@
 # If the helm is present, it updates the existing deployment; otherwise, it installs a new one.
 name: Env Setup - Deploy Mongo HA in Openshift for Formio
 run-name: Env Setup - Deploy Mongo HA in Openshift from ${{ github.ref_name }} to ${{ inputs.environment }}
+permissions:
+  contents: read
 
 concurrency: mongo-ha-setup
 

--- a/.github/workflows/env-setup-deploy-secrets.yml
+++ b/.github/workflows/env-setup-deploy-secrets.yml
@@ -1,5 +1,7 @@
 name: Env Setup - Deploy SIMS Secrets to Openshift
 run-name: Env Setup - Deploy SIMS secrets to Openshift from ${{ inputs.gitRef }} to ${{ inputs.environment }}
+permissions:
+  contents: read
 
 on:
   workflow_dispatch:

--- a/.github/workflows/env-setup-redis-cluster-recovery.yml
+++ b/.github/workflows/env-setup-redis-cluster-recovery.yml
@@ -1,5 +1,7 @@
 name: Env Setup - Redis-cluster recovery in Openshift
 run-name: Env Setup - Redis-cluster recovery in Openshift from ${{ inputs.gitRef }} to ${{ inputs.environment }}
+permissions:
+  contents: read
 
 concurrency: redis-setup
 

--- a/.github/workflows/env-setup-sysdig-teams.yml
+++ b/.github/workflows/env-setup-sysdig-teams.yml
@@ -1,5 +1,7 @@
 name: Env Setup - Update Sysdig Team in Openshift
 run-name: Env Setup - Update Sysdig Team in Openshift using ${{ github.ref_name }}
+permissions:
+  contents: read
 
 concurrency: update-sysdig-team
 

--- a/.github/workflows/prune-images.yml
+++ b/.github/workflows/prune-images.yml
@@ -1,5 +1,7 @@
 name: Prune Images
 run-name: Pruning all but the most recent ${{ inputs.minTags }} tags prior to what is deployed in ${{ inputs.environment }}
+permissions:
+  contents: read
 
 on:
   workflow_dispatch:

--- a/.github/workflows/redis-cluster.yml
+++ b/.github/workflows/redis-cluster.yml
@@ -1,5 +1,7 @@
 name: Redis Cluster - Install/Upgrade
 run-name: Redis Cluster - ${{ inputs.environment }} Redis Cluster in ${{ inputs.environment }} using ${{ github.ref_name }}
+permissions:
+  contents: read
 
 on:
   workflow_dispatch:

--- a/.github/workflows/release-build-all.yml
+++ b/.github/workflows/release-build-all.yml
@@ -1,5 +1,8 @@
 name: Release - Build All
 run-name: Release - Build all from ${{ github.ref_name }}(build ${{ github.run_number }})
+permissions:
+  contents: read
+  actions: read
 
 concurrency: release-build-all
 

--- a/.github/workflows/release-create-branch.yml
+++ b/.github/workflows/release-create-branch.yml
@@ -1,5 +1,7 @@
 name: Release - Create Branch
 run-name: Release - Create ${{ inputs.releaseType }} branch version ${{ inputs.versionName }}
+permissions:
+  contents: write
 
 on:
   workflow_dispatch:

--- a/.github/workflows/release-deploy-all.yml
+++ b/.github/workflows/release-deploy-all.yml
@@ -1,5 +1,8 @@
 name: Release - Deploy All
 run-name: Release - Deploy all from ${{ github.ref_name }} to ${{ inputs.environment }}
+permissions:
+  contents: read
+  actions: read
 
 on:
   workflow_dispatch:

--- a/.github/workflows/release-deploy-camunda-definitions.yml
+++ b/.github/workflows/release-deploy-camunda-definitions.yml
@@ -1,5 +1,7 @@
 name: Release - Deploy Camunda Resources
 run-name: Release - Deploy Camunda resources from ${{ inputs.gitRef }} to ${{ inputs.environment }}
+permissions:
+  contents: read
 
 on:
   workflow_dispatch:

--- a/.github/workflows/release-deploy-db-migrations-repl.yml
+++ b/.github/workflows/release-deploy-db-migrations-repl.yml
@@ -1,5 +1,7 @@
 name: Release - Deploy DB Migrations REPL
 run-name: Release - Deploy DB Migrations REPL ${{ github.ref_name }} to ${{ inputs.environment }}
+permissions:
+  contents: read
 
 on:
   workflow_dispatch:

--- a/.github/workflows/release-deploy-formio-definitions.yml
+++ b/.github/workflows/release-deploy-formio-definitions.yml
@@ -1,5 +1,7 @@
 name: Release - Deploy Form.io resources
 run-name: Release - Deploy Form.io resources from ${{ inputs.gitRef }} to ${{ inputs.environment }}
+permissions:
+  contents: read
 
 on:
   workflow_dispatch:

--- a/.github/workflows/repo-checks-tests.yml
+++ b/.github/workflows/repo-checks-tests.yml
@@ -7,9 +7,7 @@
 name: Repo Checks - Tests
 permissions:
   contents: read
-  actions: read
   checks: write
-  pull-requests: write
   statuses: write
 
 on: [pull_request]

--- a/.github/workflows/repo-checks-tests.yml
+++ b/.github/workflows/repo-checks-tests.yml
@@ -7,7 +7,9 @@
 name: Repo Checks - Tests
 permissions:
   contents: read
+  actions: read
   checks: write
+  pull-requests: write
   statuses: write
 
 on: [pull_request]

--- a/.github/workflows/repo-checks-tests.yml
+++ b/.github/workflows/repo-checks-tests.yml
@@ -10,6 +10,7 @@ permissions:
   actions: read
   checks: write
   pull-requests: write
+  statuses: write
 
 on: [pull_request]
 

--- a/.github/workflows/repo-checks-tests.yml
+++ b/.github/workflows/repo-checks-tests.yml
@@ -5,6 +5,11 @@
 # To allow access to the secrets in both cases, the test users' passwords (or any other secret) are defined at the
 # repository level and also at the `dependabot` secrets for now.
 name: Repo Checks - Tests
+permissions:
+  contents: read
+  actions: read
+  checks: write
+  pull-requests: write
 
 on: [pull_request]
 


### PR DESCRIPTION
- Explicitly added the `read` permission for almost all workflows.
- Workflows invoking another workflow require the `actions: read` permission.
- Repo tests required additional permissions.