### PR TITLE
#4665 - Workflow Permissions - Fix Missing Permission

### DIFF
--- a/.github/workflows/release-build-all.yml
+++ b/.github/workflows/release-build-all.yml
@@ -1,7 +1,7 @@
 name: Release - Build All
 run-name: Release - Build all from ${{ github.ref_name }}(build ${{ github.run_number }})
 permissions:
-  contents: read
+  contents: write
   actions: read
 
 concurrency: release-build-all


### PR DESCRIPTION
Replace the `read` with the `write` permission to allow the tag creation (the write permission includes the `read` permission).