### PR TITLE
#4471 - BCSC - Enable using the address from BCSC in SIMS profile

### DIFF
--- a/sources/packages/web/src/constants/system-constants.ts
+++ b/sources/packages/web/src/constants/system-constants.ts
@@ -18,3 +18,7 @@ export const COUNT_DOWN_TIMER_FOR_LOGOUT = 30;
  * High estimated value to defined a max money amount for inputs that does not have a constrain defined.
  */
 export const MONEY_VALUE_FOR_UNKNOWN_MAX_VALUE = 100000000;
+/**
+ * Canada country code.
+ */
+export const CANADA_COUNTRY_CODE = "CA";

--- a/sources/packages/web/src/types/ApplicationToken.ts
+++ b/sources/packages/web/src/types/ApplicationToken.ts
@@ -71,6 +71,13 @@ export interface BCSCParsedToken extends ApplicationToken {
   familyName: string;
   gender: string;
   givenName: string;
+  address?: {
+    locality?: string;
+    region?: string;
+    postal_code?: string;
+    country?: string;
+    street_address?: string;
+  };
 }
 
 export interface BCeIDParsedToken extends ApplicationToken {

--- a/sources/packages/web/src/types/ApplicationToken.ts
+++ b/sources/packages/web/src/types/ApplicationToken.ts
@@ -71,12 +71,12 @@ export interface BCSCParsedToken extends ApplicationToken {
   familyName: string;
   gender: string;
   givenName: string;
-  address?: {
-    locality?: string;
-    region?: string;
-    postal_code?: string;
-    country?: string;
-    street_address?: string;
+  address: {
+    locality: string;
+    region: string;
+    postal_code: string;
+    country: string;
+    street_address: string;
   };
 }
 

--- a/sources/packages/web/src/views/student/StudentProfileCreate.vue
+++ b/sources/packages/web/src/views/student/StudentProfileCreate.vue
@@ -54,46 +54,27 @@ export default defineComponent({
     const studentStore = useStudentStore();
     const processing = ref(false);
 
-    const populateBcscAddressFields = (data: StudentProfileFormModel) => {
+    const populateBCSCAddressFields = (data: StudentProfileFormModel) => {
       if (!bcscParsedToken.address) return;
-
-      if (bcscParsedToken.address.street_address) {
-        const normalizedAddress =
-          bcscParsedToken.address.street_address.replace(/\\n/g, "\n");
-        const addressParts = normalizedAddress.split("\n");
-        data.addressLine1 = addressParts[0];
-        if (addressParts.length > 1) {
-          data.addressLine2 = addressParts.slice(1).join("\n");
-        }
-      }
-      if (bcscParsedToken.address.locality) {
-        data.city = bcscParsedToken.address.locality;
-      }
-      if (bcscParsedToken.address.region) {
-        data.provinceState = bcscParsedToken.address.region;
-      }
-      if (bcscParsedToken.address.postal_code) {
-        data.canadaPostalCode = bcscParsedToken.address.postal_code;
-      }
-      if (bcscParsedToken.address.country) {
-        data.country = bcscParsedToken.address.country;
-        data.selectedCountry =
-          bcscParsedToken.address.country.toLowerCase() === "ca" ||
-          bcscParsedToken.address.country.toLowerCase() === "canada"
-            ? "Canada"
-            : "other";
-      }
+      // BCSC users address fields to StudentProfileFormModel.
+      data.addressLine1 = bcscParsedToken.address.street_address;
+      data.city = bcscParsedToken.address.locality;
+      data.provinceState = bcscParsedToken.address.region;
+      data.canadaPostalCode = bcscParsedToken.address.postal_code;
+      data.country = bcscParsedToken.address.country;
+      data.selectedCountry =
+        bcscParsedToken.address.country === "CA" ? "Canada" : "other";
     };
 
-    const populateBcscUserData = (data: StudentProfileFormModel) => {
+    const populateBCSCUserData = (data: StudentProfileFormModel) => {
       data.firstName = bcscParsedToken.givenNames;
       data.lastName = bcscParsedToken.lastName;
       data.email = bcscParsedToken.email;
       data.dateOfBirth = dateOnlyLongString(bcscParsedToken.birthdate);
-      populateBcscAddressFields(data);
+      populateBCSCAddressFields(data);
     };
 
-    const populateBasicUserData = (data: StudentProfileFormModel) => {
+    const populateBCeIDBothUserData = (data: StudentProfileFormModel) => {
       data.email = bceidParsedToken.email;
     };
 
@@ -106,9 +87,9 @@ export default defineComponent({
       const identityProvider = AuthService.shared.userToken?.identityProvider;
 
       if (identityProvider === IdentityProviders.BCSC) {
-        populateBcscUserData(data);
+        populateBCSCUserData(data);
       } else if (identityProvider === IdentityProviders.BCeIDBoth) {
-        populateBasicUserData(data);
+        populateBCeIDBothUserData(data);
       }
 
       initialData.value = data;

--- a/sources/packages/web/src/views/student/StudentProfileCreate.vue
+++ b/sources/packages/web/src/views/student/StudentProfileCreate.vue
@@ -71,7 +71,13 @@ export default defineComponent({
         // Populate address fields from BCSC if available.
         if (bcscParsedToken.address) {
           if (bcscParsedToken.address.street_address) {
-            data.addressLine1 = bcscParsedToken.address.street_address;
+            const normalizedAddress =
+              bcscParsedToken.address.street_address.replace(/\\n/g, "\n");
+            const addressParts = normalizedAddress.split("\n");
+            data.addressLine1 = addressParts[0];
+            if (addressParts.length > 1) {
+              data.addressLine2 = addressParts.slice(1).join("\n");
+            }
           }
           if (bcscParsedToken.address.locality) {
             data.city = bcscParsedToken.address.locality;
@@ -80,7 +86,7 @@ export default defineComponent({
             data.provinceState = bcscParsedToken.address.region;
           }
           if (bcscParsedToken.address.postal_code) {
-            data.postalCode = bcscParsedToken.address.postal_code;
+            data.canadaPostalCode = bcscParsedToken.address.postal_code;
           }
           if (bcscParsedToken.address.country) {
             data.country = bcscParsedToken.address.country;

--- a/sources/packages/web/src/views/student/StudentProfileCreate.vue
+++ b/sources/packages/web/src/views/student/StudentProfileCreate.vue
@@ -37,7 +37,10 @@ import {
 } from "@/types";
 import { AuthService } from "@/services/AuthService";
 import StudentProfileForm from "@/components/common/StudentProfileForm.vue";
-import { STUDENT_ACCOUNT_APPLICATION_USER_ALREADY_EXISTS } from "@/constants";
+import {
+  STUDENT_ACCOUNT_APPLICATION_USER_ALREADY_EXISTS,
+  CANADA_COUNTRY_CODE,
+} from "@/constants";
 
 export default defineComponent({
   components: {
@@ -55,15 +58,23 @@ export default defineComponent({
     const processing = ref(false);
 
     const populateBCSCAddressFields = (data: StudentProfileFormModel) => {
-      if (!bcscParsedToken.address) return;
       // BCSC users address fields to StudentProfileFormModel.
-      data.addressLine1 = bcscParsedToken.address.street_address;
+      if (bcscParsedToken.address.street_address) {
+        data.addressLine1 = bcscParsedToken.address.street_address.replace(
+          /\r\n|\n/g,
+          " ",
+        );
+      }
       data.city = bcscParsedToken.address.locality;
-      data.provinceState = bcscParsedToken.address.region;
-      data.canadaPostalCode = bcscParsedToken.address.postal_code;
+      if (bcscParsedToken.address.country === CANADA_COUNTRY_CODE) {
+        data.provinceState = bcscParsedToken.address.region;
+        data.canadaPostalCode = bcscParsedToken.address.postal_code;
+      }
       data.country = bcscParsedToken.address.country;
       data.selectedCountry =
-        bcscParsedToken.address.country === "CA" ? "Canada" : "other";
+        bcscParsedToken.address.country === CANADA_COUNTRY_CODE
+          ? "Canada"
+          : "other";
     };
 
     const populateBCSCUserData = (data: StudentProfileFormModel) => {

--- a/sources/packages/web/src/views/student/StudentProfileCreate.vue
+++ b/sources/packages/web/src/views/student/StudentProfileCreate.vue
@@ -67,6 +67,30 @@ export default defineComponent({
         data.lastName = bcscParsedToken.lastName;
         data.email = bcscParsedToken.email;
         data.dateOfBirth = dateOnlyLongString(bcscParsedToken.birthdate);
+
+        // Populate address fields from BCSC if available.
+        if (bcscParsedToken.address) {
+          if (bcscParsedToken.address.street_address) {
+            data.addressLine1 = bcscParsedToken.address.street_address;
+          }
+          if (bcscParsedToken.address.locality) {
+            data.city = bcscParsedToken.address.locality;
+          }
+          if (bcscParsedToken.address.region) {
+            data.provinceState = bcscParsedToken.address.region;
+          }
+          if (bcscParsedToken.address.postal_code) {
+            data.postalCode = bcscParsedToken.address.postal_code;
+          }
+          if (bcscParsedToken.address.country) {
+            data.country = bcscParsedToken.address.country;
+            data.selectedCountry =
+              bcscParsedToken.address.country.toLowerCase() === "ca" ||
+              bcscParsedToken.address.country.toLowerCase() === "canada"
+                ? "Canada"
+                : "other";
+          }
+        }
       } else if (
         AuthService.shared.userToken?.identityProvider ===
         IdentityProviders.BCeIDBoth


### PR DESCRIPTION
## AC
Update keycloak to accept new fields from BCSC logins (BCSC in DEV/TEST are currently configured to send these fields)

## Keycloak
Dev Done ✅

**Pending**:
Test/Staging
Prod

#### Demo
<img width="2470" height="1070" alt="image" src="https://github.com/user-attachments/assets/b1552876-1260-429f-86c2-b590ff0562da" />

#### Keycloack Demo
<img width="1908" height="858" alt="image" src="https://github.com/user-attachments/assets/631402f5-f5ee-4023-9af7-8c090b4fcea4" />
