### PR TITLE
#4941 - Approved exception does not repeat - Save File Hash

### DIFF
--- a/sources/packages/backend/apps/api/src/services/student-file/student-file.service.ts
+++ b/sources/packages/backend/apps/api/src/services/student-file/student-file.service.ts
@@ -20,6 +20,7 @@ import { Queue } from "bull";
 import { VirusScanQueueInDTO } from "@sims/services/queue";
 import { FILE_SAVE_ERROR } from "../../constants";
 import { ObjectStorageService } from "@sims/integrations/object-storage";
+import { createHash } from "crypto";
 
 @Injectable()
 export class StudentFileService extends RecordDataModelService<StudentFile> {
@@ -72,6 +73,10 @@ export class StudentFileService extends RecordDataModelService<StudentFile> {
     newFile.student = { id: studentId } as Student;
     newFile.creator = { id: auditUserId } as User;
     newFile.virusScanStatus = VirusScanStatus.InProgress;
+    // Generate the file hash.
+    newFile.fileHash = createHash("sha256")
+      .update(createFile.fileContent)
+      .digest("hex");
 
     summary.info(`Saving the file ${createFile.fileName} to database.`);
     let savedFile: StudentFile;

--- a/sources/packages/backend/apps/db-migrations/src/migrations/1754086479996-AddStudentFileHash.ts
+++ b/sources/packages/backend/apps/db-migrations/src/migrations/1754086479996-AddStudentFileHash.ts
@@ -1,0 +1,16 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+import { getSQLFileData } from "../utilities/sqlLoader";
+
+export class AddStudentFileHash1754086479996 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      getSQLFileData("Add-file-hash-column.sql", "StudentFiles"),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      getSQLFileData("Rollback-add-file-hash-column.sql", "StudentFiles"),
+    );
+  }
+}

--- a/sources/packages/backend/apps/db-migrations/src/sql/StudentFiles/Add-file-hash-column.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/StudentFiles/Add-file-hash-column.sql
@@ -1,6 +1,12 @@
+-- Creates the new column with an empty default value to allow it to be defined as NOT NULL.
 ALTER TABLE
   sims.student_files
 ADD
-  COLUMN file_hash CHAR(64);
+  COLUMN file_hash CHAR(64) NOT NULL DEFAULT '';
 
-COMMENT ON COLUMN sims.student_files.file_hash IS 'SHA256 hash of the file contents.';
+ALTER TABLE
+  sims.student_files
+ALTER COLUMN
+  file_hash DROP DEFAULT;
+
+COMMENT ON COLUMN sims.student_files.file_hash IS 'SHA256 hash of the FILE contents converted to a hexadecimal string.';

--- a/sources/packages/backend/apps/db-migrations/src/sql/StudentFiles/Add-file-hash-column.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/StudentFiles/Add-file-hash-column.sql
@@ -1,0 +1,6 @@
+ALTER TABLE
+  sims.student_files
+ADD
+  COLUMN file_hash CHAR(64);
+
+COMMENT ON COLUMN sims.student_files.file_hash IS 'SHA256 hash of the file contents.';

--- a/sources/packages/backend/apps/db-migrations/src/sql/StudentFiles/Add-file-hash-column.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/StudentFiles/Add-file-hash-column.sql
@@ -9,4 +9,4 @@ ALTER TABLE
 ALTER COLUMN
   file_hash DROP DEFAULT;
 
-COMMENT ON COLUMN sims.student_files.file_hash IS 'SHA256 hash of the FILE contents converted to a hexadecimal string.';
+COMMENT ON COLUMN sims.student_files.file_hash IS 'SHA256 hash of the file contents converted to a hexadecimal string.';

--- a/sources/packages/backend/apps/db-migrations/src/sql/StudentFiles/Rollback-add-file-hash-column.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/StudentFiles/Rollback-add-file-hash-column.sql
@@ -1,0 +1,2 @@
+ALTER TABLE
+  sims.student_files DROP COLUMN file_hash;

--- a/sources/packages/backend/libs/integrations/src/object-storage/object-storage.service.ts
+++ b/sources/packages/backend/libs/integrations/src/object-storage/object-storage.service.ts
@@ -65,7 +65,7 @@ export class ObjectStorageService {
     return {
       contentLength: response.ContentLength,
       contentType: response.ContentType,
-      body: response.Body as NodeJS.ReadableStream,
+      body: response.Body,
     };
   }
 }

--- a/sources/packages/backend/libs/integrations/src/object-storage/object-storage.service.ts
+++ b/sources/packages/backend/libs/integrations/src/object-storage/object-storage.service.ts
@@ -65,7 +65,7 @@ export class ObjectStorageService {
     return {
       contentLength: response.ContentLength,
       contentType: response.ContentType,
-      body: response.Body,
+      body: response.Body as NodeJS.ReadableStream,
     };
   }
 }

--- a/sources/packages/backend/libs/sims-db/src/entities/student-file.model.ts
+++ b/sources/packages/backend/libs/sims-db/src/entities/student-file.model.ts
@@ -102,7 +102,7 @@ export class StudentFile extends RecordDataModel {
   })
   virusScanStatusUpdatedOn: Date;
   /**
-   * SHA256 hash of the FILE contents converted to a hexadecimal string.
+   * SHA256 hash of the file contents converted to a hexadecimal string.
    */
   @Column({
     name: "file_hash",

--- a/sources/packages/backend/libs/sims-db/src/entities/student-file.model.ts
+++ b/sources/packages/backend/libs/sims-db/src/entities/student-file.model.ts
@@ -102,7 +102,7 @@ export class StudentFile extends RecordDataModel {
   })
   virusScanStatusUpdatedOn: Date;
   /**
-   * Hash of the file content (SHA256).
+   * SHA256 hash of the FILE contents converted to a hexadecimal string.
    */
   @Column({
     name: "file_hash",

--- a/sources/packages/backend/libs/sims-db/src/entities/student-file.model.ts
+++ b/sources/packages/backend/libs/sims-db/src/entities/student-file.model.ts
@@ -101,4 +101,13 @@ export class StudentFile extends RecordDataModel {
     nullable: false,
   })
   virusScanStatusUpdatedOn: Date;
+  /**
+   * Hash of the file content (SHA256).
+   */
+  @Column({
+    name: "file_hash",
+    type: "char",
+    nullable: true,
+  })
+  fileHash?: string;
 }

--- a/sources/packages/backend/libs/sims-db/src/entities/student-file.model.ts
+++ b/sources/packages/backend/libs/sims-db/src/entities/student-file.model.ts
@@ -107,7 +107,6 @@ export class StudentFile extends RecordDataModel {
   @Column({
     name: "file_hash",
     type: "char",
-    nullable: true,
   })
-  fileHash?: string;
+  fileHash: string;
 }

--- a/sources/packages/backend/libs/test-utils/src/factories/student-file-uploads.ts
+++ b/sources/packages/backend/libs/test-utils/src/factories/student-file-uploads.ts
@@ -40,6 +40,7 @@ export function createFakeStudentFileUpload(
   studentFile.creator = relations?.creator;
   studentFile.fileOrigin = options?.fileOrigin ?? FileOriginType.Ministry;
   studentFile.virusScanStatus = VirusScanStatus.Pending;
+  studentFile.fileHash = "";
   return studentFile;
 }
 


### PR DESCRIPTION
Saving the file hash for student-uploaded files to allow future comparison of exception files.

## Migration rollback

<img width="803" height="156" alt="image" src="https://github.com/user-attachments/assets/eeca4462-4c32-4f71-aa5c-438e0ac20b5c" />
