### PR TITLE
#4731 -  Formio-loader bug fix

### DIFF
--- a/sources/packages/web/src/components/common/StudentApplication.vue
+++ b/sources/packages/web/src/components/common/StudentApplication.vue
@@ -250,9 +250,8 @@ export default defineComponent({
       };
       formInstance.on("prevPage", prevNextNavigation);
       formInstance.on("nextPage", prevNextNavigation);
-
-      await loadFormDependencies();
       isFormLoaded.value = true;
+      await loadFormDependencies();
     };
 
     const getOfferingDetails = async (form: FormIOForm, locationId: number) => {

--- a/sources/packages/web/src/components/common/StudentApplication.vue
+++ b/sources/packages/web/src/components/common/StudentApplication.vue
@@ -1,7 +1,7 @@
 <template>
   <formio
     :formName="selectedForm"
-    :data="{ ...initialData, ...additionalFormData }"
+    :data="initialData"
     :readOnly="isReadOnly"
     @loaded="formLoaded"
     @changed="formChanged"
@@ -127,9 +127,6 @@ export default defineComponent({
     const isLastPage = ref(false);
     const showNav = ref(false);
     const isFormLoaded = ref(false);
-    const additionalFormData = ref(
-      {} as { howWillYouBeAttendingTheProgram: OfferingIntensity },
-    );
     let offeringIntensity: OfferingIntensity;
 
     const wizardPrimaryLabel = computed(() => {
@@ -158,8 +155,11 @@ export default defineComponent({
         // Program year forms older than 2025-26 required offering intensity to be injected to the form.
         // Check if the form has the offering intensity component and if so, inject the values.
         if (applicationIntensityComponent) {
-          additionalFormData.value.howWillYouBeAttendingTheProgram =
-            offeringIntensity;
+          formioUtils.setComponentValue(
+            formInstance,
+            OFFERING_INTENSITY_KEY,
+            offeringIntensity,
+          );
         }
         // When the form is editable, load locations and programs.
         if (!props.isReadOnly) {
@@ -395,7 +395,6 @@ export default defineComponent({
       customEvent,
       showNav,
       isSaveDraftAllowed,
-      additionalFormData,
       wizardPrimaryLabel,
       isFormLoaded,
     };

--- a/sources/packages/web/src/components/generic/formio.vue
+++ b/sources/packages/web/src/components/generic/formio.vue
@@ -25,6 +25,7 @@ import {
 } from "@/types";
 import { v4 as uuid } from "uuid";
 import { useFormatters, useFormioUtils, useOffering } from "@/composables";
+import { FORMIO_LOAD_DATA_PROCESSING_VIEW_DELAY } from "@/constants/system-constants";
 
 export default defineComponent({
   emits: {
@@ -183,7 +184,7 @@ export default defineComponent({
       setTimeout(() => {
         isFormCreated.value = true;
         context.emit("loaded", form);
-      }, 200);
+      }, FORMIO_LOAD_DATA_PROCESSING_VIEW_DELAY);
     };
 
     watchEffect(async () => {

--- a/sources/packages/web/src/components/generic/formio.vue
+++ b/sources/packages/web/src/components/generic/formio.vue
@@ -179,7 +179,7 @@ export default defineComponent({
       });
 
       // When the form submission data is set, the form is rendered again.
-      // To visually hide the form for the rendering to be completed, a delay is set.
+      // To visually hide the form until the rendering to be completed, a delay is set.
       setTimeout(() => {
         isFormCreated.value = true;
         context.emit("loaded", form);

--- a/sources/packages/web/src/components/generic/formio.vue
+++ b/sources/packages/web/src/components/generic/formio.vue
@@ -75,12 +75,6 @@ export default defineComponent({
     registerUtilsMethod("currencyFormatter", currencyFormatter);
     registerUtilsMethod("mapOfferingIntensity", mapOfferingIntensity);
     let formDefinition: FormIOComponent;
-    // Indicates if the form is being created.
-    let isFormCreationInProgress = false;
-    // If there is a change in initial data during the form creation
-    // the form data cannot be reloaded and this is an indicator to
-    // reload the initial data after the form is created.
-    let mustReloadInitialDataAfterCreation = false;
     const formioContainerRef = ref(null);
     // Indicates if the form definition is loaded.
     const isFormDefinitionLoaded = ref(false);
@@ -97,13 +91,6 @@ export default defineComponent({
     // display the correct label associated with the correct value
     // that was loaded into the submission data.
     const updateFormSubmissionData = () => {
-      if (isFormCreationInProgress) {
-        // At this point the form is not available yet to update the data.
-        // Hence, the flag is set to true and the data will be reloaded
-        // after the form is created.
-        mustReloadInitialDataAfterCreation = true;
-        return;
-      }
       if (form && props.data) {
         form.submission = {
           data: props.data,
@@ -164,23 +151,12 @@ export default defineComponent({
     };
 
     const createForm = async () => {
-      isFormCreationInProgress = true;
       form = await Formio.createForm(formioContainerRef.value, formDefinition, {
         fileService: new FormUploadService(),
         readOnly: props.readOnly,
-        submission: {
-          data: props.data ?? {},
-        },
       });
-      isFormCreationInProgress = false;
-      // If the initial data was changed while the form was being created,
-      // reload the initial data.
-      if (mustReloadInitialDataAfterCreation) {
-        mustReloadInitialDataAfterCreation = false;
-        updateFormSubmissionData();
-      }
+      updateFormSubmissionData();
       form.nosubmit = true;
-      context.emit("loaded", form);
 
       // Triggered when any component in the form is changed.
       form.on("change", (event: FormIOChangeEvent) => {
@@ -201,7 +177,13 @@ export default defineComponent({
       form.on("render", (event: HTMLElement) => {
         context.emit("render", form, event);
       });
-      isFormCreated.value = true;
+
+      // When the form submission data is set, the form is rendered again.
+      // To visually hide the form for the rendering to be completed, a delay is set.
+      setTimeout(() => {
+        isFormCreated.value = true;
+        context.emit("loaded", form);
+      }, 200);
     };
 
     watchEffect(async () => {

--- a/sources/packages/web/src/constants/system-constants.ts
+++ b/sources/packages/web/src/constants/system-constants.ts
@@ -22,3 +22,7 @@ export const MONEY_VALUE_FOR_UNKNOWN_MAX_VALUE = 100000000;
  * Canada country code.
  */
 export const CANADA_COUNTRY_CODE = "CA";
+/**
+ * Formio load data processing view delay.
+ */
+export const FORMIO_LOAD_DATA_PROCESSING_VIEW_DELAY = 200;


### PR DESCRIPTION
## Fomio Loader issues fix

- [x] Student application form initial data has been populated with spread operator which on every reactive change re-merges and creates the value again. Because of this action, form data is reset to inital data, whenever any reactive variable is modified at Vue component. Hence the spread operator is removed, and to update a component value in formio, the formio utils have been used.
<img width="1317" height="183" alt="image" src="https://github.com/user-attachments/assets/b58cf0d9-f4b9-4f0c-848b-a564cff07229" />

- [x] Due to the `submittedData` set at the create form operation, `Formio.createForm`  there are few impacts observed and we anticipate potentially more impacts. Hence we restored to the previous logic of setting form data after form create operation. 
But by doing this way, there is a visual re-rendering which is now hidden by forcefully using a timeout.