### PR TITLE
#5023 - FT Assessment Updates: CSG-FTDEP eligibility, negative need, BCSL

### DIFF
--- a/sources/packages/backend/workflow/src/workflow-definitions/fulltime-assessment-2025-2026.bpmn
+++ b/sources/packages/backend/workflow/src/workflow-definitions/fulltime-assessment-2025-2026.bpmn
@@ -1712,7 +1712,7 @@ The remaining limit in the program year is calculated with a floor of 0.</bpmn:d
     <bpmn:intermediateThrowEvent id="Event_1o1cgxp" name="Assessed Need">
       <bpmn:extensionElements>
         <zeebe:ioMapping>
-          <zeebe:output source="=max(calculatedDataTotalCosts - calculatedDataTotalProvincialContribution" target="calculatedDataProvincialAssessedNeed" />
+          <zeebe:output source="=max(calculatedDataTotalCosts - calculatedDataTotalProvincialContribution,0)" target="calculatedDataProvincialAssessedNeed" />
           <zeebe:output source="=max(calculatedDataTotalCosts - calculatedDataTotalFederalContribution,0)" target="calculatedDataFederalAssessedNeed" />
           <zeebe:output source="=max(calculatedDataFederalAssessedNeed, calculatedDataProvincialAssessedNeed)" target="calculatedDataTotalAssessedNeed" />
         </zeebe:ioMapping>
@@ -1804,7 +1804,8 @@ The remaining limit in the program year is calculated with a floor of 0.</bpmn:d
       <bpmn:extensionElements>
         <zeebe:ioMapping>
           <zeebe:output source="=min(dmnFullTimeContributionLimits.limitFederalFSCWeeklyAmount, dmnFullTimeContributionLimits.limitFederalLowIncomeWeeklyAmount + (dmnFullTimeContributionLimits.limitOverThresholdFSCProrate * (calculatedDataTotalFamilyIncome-dmnFullTimeIncomeThreshold.calculatedDataFederalFSCIncomeThreshold)))" target="calculatedDataWeeklyFederalFSC" />
-          <zeebe:output source="=min(calculatedDataWeeklyFederalFSC * min(offeringWeeks,dmnFullTimeContributionLimits.limitFederalContributionWeeks), dmnFullTimeContributionLimits.limitFederalFSCMax)" target="calculatedDataTotalFederalFSC" />
+          <zeebe:output source="=min(offeringWeeks,dmnFullTimeContributionLimits.limitFederalContributionWeeks)" target="calculatedDataFederalFSCWeeks" />
+          <zeebe:output source="=min(calculatedDataWeeklyFederalFSC * calculatedDataFederalFSCWeeks, dmnFullTimeContributionLimits.limitFederalFSCMax)" target="calculatedDataTotalFederalFSC" />
         </zeebe:ioMapping>
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_1u3sz5r</bpmn:incoming>

--- a/sources/packages/backend/workflow/src/workflow-definitions/fulltime-assessment-2025-2026.bpmn
+++ b/sources/packages/backend/workflow/src/workflow-definitions/fulltime-assessment-2025-2026.bpmn
@@ -1712,8 +1712,8 @@ The remaining limit in the program year is calculated with a floor of 0.</bpmn:d
     <bpmn:intermediateThrowEvent id="Event_1o1cgxp" name="Assessed Need">
       <bpmn:extensionElements>
         <zeebe:ioMapping>
-          <zeebe:output source="=calculatedDataTotalCosts - calculatedDataTotalProvincialContribution" target="calculatedDataProvincialAssessedNeed" />
-          <zeebe:output source="=calculatedDataTotalCosts - calculatedDataTotalFederalContribution" target="calculatedDataFederalAssessedNeed" />
+          <zeebe:output source="=max(calculatedDataTotalCosts - calculatedDataTotalProvincialContribution,0)" target="calculatedDataProvincialAssessedNeed" />
+          <zeebe:output source="=max(calculatedDataTotalCosts - calculatedDataTotalFederalContribution,0)" target="calculatedDataFederalAssessedNeed" />
           <zeebe:output source="=max(calculatedDataFederalAssessedNeed, calculatedDataProvincialAssessedNeed)" target="calculatedDataTotalAssessedNeed" />
         </zeebe:ioMapping>
       </bpmn:extensionElements>

--- a/sources/packages/backend/workflow/src/workflow-definitions/fulltime-assessment-2025-2026.bpmn
+++ b/sources/packages/backend/workflow/src/workflow-definitions/fulltime-assessment-2025-2026.bpmn
@@ -1206,7 +1206,7 @@ Federal Unmet Provincial Need = Provincial portion of Fed Need less Adjusted BCS
     <bpmn:intermediateThrowEvent id="Event_0fjl0zr" name="BCSL After Top Up">
       <bpmn:extensionElements>
         <zeebe:ioMapping>
-          <zeebe:output source="=(calculatedDataTotalCSG+federalAwardNetCSLFAmount+provincialAwardNetBCSLAmount)" target="calculatedDataPrelimAward" />
+          <zeebe:output source="=sum(calculatedDataTotalCSG,federalAwardNetCSLFAmount,calculatedDataRemainingBCSL1)" target="calculatedDataPrelimAward" />
           <zeebe:output source="=//remaining need and negative amounts will reduce BCSL&#10;calculatedDataProvincialAssessedNeed-calculatedDataPrelimAward" target="provincialAwardUnmetNeedAfterLoanAndCSG" />
           <zeebe:output source="=max(calculatedDataBCTopup-calculatedDataPrelimAward,0)" target="calculatedDataTopup" />
           <zeebe:output source="=min(calculatedDataTopup,provincialAwardUnmetNeedAfterLoanAndCSG)" target="calculatedDataNetTopup" />

--- a/sources/packages/backend/workflow/src/workflow-definitions/fulltime-assessment-2025-2026.bpmn
+++ b/sources/packages/backend/workflow/src/workflow-definitions/fulltime-assessment-2025-2026.bpmn
@@ -917,7 +917,7 @@ dmnFullTimeIncomeThreshold</bpmn:text>
     <bpmn:intermediateThrowEvent id="Event_1yndxhv" name="awardEligibilityCSGD">
       <bpmn:extensionElements>
         <zeebe:ioMapping>
-          <zeebe:output source="=if ((calculatedDataFederalAssessedNeed &#62;= 1) &#10;    and (calculatedDataTotalFamilyIncome &#60;= dmnFullTimeAwardFamilySizeVariables.limitAwardCSGDThresholdIncome) &#10;    and (calculatedDataTotalEligibleDependants &#62;= 1))&#10;then true else false" target="awardEligibilityCSGD" />
+          <zeebe:output source="=if ((calculatedDataFederalAssessedNeed &#62;= 1) &#10;    and (calculatedDataTotalFamilyIncome &#60;= dmnFullTimeAwardFamilySizeVariables.limitAwardCSGDThresholdIncome) &#10;    and (calculatedDataTotalChildcareDependants &#62;= 1))&#10;then true else false" target="awardEligibilityCSGD" />
         </zeebe:ioMapping>
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_0f51edb</bpmn:incoming>
@@ -1157,7 +1157,7 @@ Federal Unmet Provincial Need = Provincial portion of Fed Need less Adjusted BCS
       <bpmn:extensionElements>
         <zeebe:ioMapping>
           <zeebe:output source="=min(dmnFullTimeAwardAllowableLimits.limitAwardCSGDWeeklyRate,&#10;dmnFullTimeAwardAllowableLimits.limitAwardCSGDWeeklyRate - dmnFullTimeAwardFamilySizeVariables.limitAwardCSGDWeeklyPhaseoutSlope * (calculatedDataTotalFamilyIncome - dmnFullTimeAwardFamilySizeVariables.limitAwardCSGDIncomeCap))&#10;" target="federalAwardWeeklyCSGDAmount" />
-          <zeebe:output source="=//federal awards can only be requested in full dollar amounts. Rounding the weekly amount before transforming it to the full amount for the study period&#10;if (federalAwardWeeklyCSGDAmount &#62; 0) &#10;then&#10; round half up(federalAwardWeeklyCSGDAmount * offeringWeeks * calculatedDataTotalEligibleDependants,0)&#10;else 0" target="federalAwardCSGDAmount" />
+          <zeebe:output source="=//federal awards can only be requested in full dollar amounts. Rounding the weekly amount before transforming it to the full amount for the study period&#10;if (federalAwardWeeklyCSGDAmount &#62; 0) &#10;then&#10; round half up(federalAwardWeeklyCSGDAmount * offeringWeeks * calculatedDataTotalChildcareDependants,0)&#10;else 0" target="federalAwardCSGDAmount" />
           <zeebe:output source="=if (awardEligibilityCSGD = true) then&#10;max(dmnFullTimeAwardAllowableLimits.limitAwardCSGDMinAward, federalAwardCSGDAmount) &#10;else 0" target="federalAwardNetCSGDAmount" />
         </zeebe:ioMapping>
       </bpmn:extensionElements>

--- a/sources/packages/backend/workflow/src/workflow-definitions/fulltime-assessment-2025-2026.bpmn
+++ b/sources/packages/backend/workflow/src/workflow-definitions/fulltime-assessment-2025-2026.bpmn
@@ -1209,7 +1209,7 @@ Federal Unmet Provincial Need = Provincial portion of Fed Need less Adjusted BCS
           <zeebe:output source="=(calculatedDataTotalCSG+federalAwardNetCSLFAmount+provincialAwardNetBCSLAmount)" target="calculatedDataPrelimAward" />
           <zeebe:output source="=//remaining need and negative amounts will reduce BCSL&#10;calculatedDataProvincialAssessedNeed-calculatedDataPrelimAward" target="provincialAwardUnmetNeedAfterLoanAndCSG" />
           <zeebe:output source="=max(calculatedDataBCTopup-calculatedDataPrelimAward,0)" target="calculatedDataTopup" />
-          <zeebe:output source="=min(calculatedDataNetTopup,provincialAwardUnmetNeedAfterLoanAndCSG)" target="calculatedDataNetTopup" />
+          <zeebe:output source="=min(calculatedDataTopup,provincialAwardUnmetNeedAfterLoanAndCSG)" target="calculatedDataNetTopup" />
         </zeebe:ioMapping>
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_1p7o8v2</bpmn:incoming>

--- a/sources/packages/backend/workflow/src/workflow-definitions/fulltime-assessment-2025-2026.bpmn
+++ b/sources/packages/backend/workflow/src/workflow-definitions/fulltime-assessment-2025-2026.bpmn
@@ -1757,8 +1757,8 @@ The remaining limit in the program year is calculated with a floor of 0.</bpmn:d
     <bpmn:intermediateThrowEvent id="Event_1191le4" name="FSC Exemption">
       <bpmn:extensionElements>
         <zeebe:ioMapping>
-          <zeebe:output source="=if (studentDataIndigenousStatus = &#34;yes&#34; &#10;  or calculatedDataPDPPDStatus = true &#10;  or studentDataYouthInCare = &#34;yes&#34;)&#10;then true&#10;  else if studentDataDependantStatus = &#34;independant&#34; and (calculatedDataTotalEligibleDependants - calculatedDataDependantPostSecondaryQuantity &#62;0) &#10;  then true&#10;  else false" target="calculatedDataFederalFSCExempt" />
-          <zeebe:output source="=if (studentDataIndigenousStatus = &#34;yes&#34; &#10;  or calculatedDataPDPPDStatus = true &#10;  or studentDataYouthInCare = &#34;yes&#34;)&#10;then true&#10;  else if studentDataDependantStatus = &#34;independant&#34; and (calculatedDataTotalEligibleDependants - calculatedDataDependantPostSecondaryQuantity &#62;0) &#10;  then true&#10;  else false" target="calculatedDataProvincialFSCExempt" />
+          <zeebe:output source="=if (studentDataIndigenousStatus = &#34;yes&#34; &#10;  or calculatedDataPDPPDStatus = true &#10;  or studentDataYouthInCare = &#34;yes&#34;)&#10;  or (calculatedDataTotalEligibleDependants - calculatedDataDependantPostSecondaryQuantity &#62; 0)&#10;then true&#10;else false" target="calculatedDataFederalFSCExempt" />
+          <zeebe:output source="=if (studentDataIndigenousStatus = &#34;yes&#34; &#10;  or calculatedDataPDPPDStatus = true &#10;  or studentDataYouthInCare = &#34;yes&#34;)&#10;  or (calculatedDataTotalEligibleDependants - calculatedDataDependantPostSecondaryQuantity &#62; 0)&#10;then true&#10;else false" target="calculatedDataProvincialFSCExempt" />
         </zeebe:ioMapping>
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_1jtpb8r</bpmn:incoming>

--- a/sources/packages/backend/workflow/src/workflow-definitions/fulltime-assessment-2025-2026.bpmn
+++ b/sources/packages/backend/workflow/src/workflow-definitions/fulltime-assessment-2025-2026.bpmn
@@ -1712,7 +1712,7 @@ The remaining limit in the program year is calculated with a floor of 0.</bpmn:d
     <bpmn:intermediateThrowEvent id="Event_1o1cgxp" name="Assessed Need">
       <bpmn:extensionElements>
         <zeebe:ioMapping>
-          <zeebe:output source="=max(calculatedDataTotalCosts - calculatedDataTotalProvincialContribution,0)" target="calculatedDataProvincialAssessedNeed" />
+          <zeebe:output source="=max(calculatedDataTotalCosts - calculatedDataTotalProvincialContribution" target="calculatedDataProvincialAssessedNeed" />
           <zeebe:output source="=max(calculatedDataTotalCosts - calculatedDataTotalFederalContribution,0)" target="calculatedDataFederalAssessedNeed" />
           <zeebe:output source="=max(calculatedDataFederalAssessedNeed, calculatedDataProvincialAssessedNeed)" target="calculatedDataTotalAssessedNeed" />
         </zeebe:ioMapping>
@@ -1804,7 +1804,7 @@ The remaining limit in the program year is calculated with a floor of 0.</bpmn:d
       <bpmn:extensionElements>
         <zeebe:ioMapping>
           <zeebe:output source="=min(dmnFullTimeContributionLimits.limitFederalFSCWeeklyAmount, dmnFullTimeContributionLimits.limitFederalLowIncomeWeeklyAmount + (dmnFullTimeContributionLimits.limitOverThresholdFSCProrate * (calculatedDataTotalFamilyIncome-dmnFullTimeIncomeThreshold.calculatedDataFederalFSCIncomeThreshold)))" target="calculatedDataWeeklyFederalFSC" />
-          <zeebe:output source="=min(calculatedDataWeeklyFederalFSC * offeringWeeks, dmnFullTimeContributionLimits.limitFederalFSCMax)" target="calculatedDataTotalFederalFSC" />
+          <zeebe:output source="=min(calculatedDataWeeklyFederalFSC * min(offeringWeeks,dmnFullTimeContributionLimits.limitFederalContributionWeeks), dmnFullTimeContributionLimits.limitFederalFSCMax)" target="calculatedDataTotalFederalFSC" />
         </zeebe:ioMapping>
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_1u3sz5r</bpmn:incoming>

--- a/sources/packages/backend/workflow/test/2025-2026/fulltime-assessment/contribution/fulltime-assessment-spouse-contribution.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2025-2026/fulltime-assessment/contribution/fulltime-assessment-spouse-contribution.e2e-spec.ts
@@ -27,11 +27,11 @@ describe(`E2E Test Workflow fulltime-assessment-${PROGRAM_YEAR}-spouse-contribut
       assessmentConsolidatedData,
     );
     // Assert
-
+    // The spouse can be exempt from contribution if they are a full-time student at the same time.
+    // Or when they have a disability, or are receiving certain types of income assistance.
     expect(
       calculatedAssessment.variables.calculatedDataSpousalContributionExempt,
     ).toBe(false);
-
     // The federal and provincial fixed student contributions are based on family income and size when the student is not exempt.
     expect(calculatedAssessment.variables.calculatedDataTotalFederalFSC).toBe(
       1384.6153846153845,
@@ -39,7 +39,6 @@ describe(`E2E Test Workflow fulltime-assessment-${PROGRAM_YEAR}-spouse-contribut
     expect(
       calculatedAssessment.variables.calculatedDataTotalProvincialFSC,
     ).toBe(1847.2153846153847);
-    // The total spouse contribution is not calculated for single students.
     expect(
       calculatedAssessment.variables.calculatedDataTotalSpouseContribution,
     ).toBe(769.9384615384616);
@@ -54,26 +53,91 @@ describe(`E2E Test Workflow fulltime-assessment-${PROGRAM_YEAR}-spouse-contribut
     // Combination of federal fixed student contribution, spouse contribution, parental contribution, and targeted resources.
     expect(
       calculatedAssessment.variables.calculatedDataTotalFederalContribution,
-    ).toBe(2154.5538461538463);
-    // Combination of federal fixed student contribution, spouse contribution, parental contribution, and targeted resources.
+    ).toBe(
+      calculatedAssessment.variables.calculatedDataTotalSpouseContribution +
+        calculatedAssessment.variables.calculatedDataTotalFederalFSC,
+    );
+    // Combination of provincial fixed student contribution, spouse contribution, parental contribution, and targeted resources.
     expect(
       calculatedAssessment.variables.calculatedDataTotalProvincialContribution,
-    ).toBe(2617.153846153846);
+    ).toBe(
+      calculatedAssessment.variables.calculatedDataTotalSpouseContribution +
+        calculatedAssessment.variables.calculatedDataTotalProvincialFSC,
+    );
   });
 
-  it("Should calculate $0 fixed student contribution for a married independent student when both are exempt.", async () => {
+  it(
+    "Should calculate total fixed student contribution for a married independent student when the student is exempt " +
+      "and the partner is not exempt, is not a full time student, and has not already contributed in the program year.",
+    async () => {
+      // Arrange
+      const assessmentConsolidatedData =
+        createFakeConsolidatedFulltimeData(PROGRAM_YEAR);
+      assessmentConsolidatedData.studentDataHasDependents = YesNoOptions.No;
+      assessmentConsolidatedData.studentDataRelationshipStatus = "married";
+      assessmentConsolidatedData.studentDataPartnerHasEmploymentInsuranceBenefits =
+        YesNoOptions.No;
+      assessmentConsolidatedData.studentDataPartnerHasTotalIncomeAssistance =
+        YesNoOptions.No;
+      assessmentConsolidatedData.studentDataPartnerHasFedralProvincialPDReceipt =
+        YesNoOptions.No;
+      assessmentConsolidatedData.studentDataEstimatedSpouseIncome = 30000;
+      assessmentConsolidatedData.studentDataYouthInCare = YesNoOptions.Yes;
+
+      // Act
+      const calculatedAssessment =
+        await executeFullTimeAssessmentForProgramYear(
+          PROGRAM_YEAR,
+          assessmentConsolidatedData,
+        );
+      // Assert
+      // The spouse can be exempt from contribution if they are a full-time student at the same time.
+      // Or when they have a disability, or are receiving certain types of income assistance.
+      expect(
+        calculatedAssessment.variables.calculatedDataSpousalContributionExempt,
+      ).toBe(false);
+      // The federal and provincial fixed student contributions are based on family income and size when the student is not exempt.
+      expect(calculatedAssessment.variables.calculatedDataTotalFederalFSC).toBe(
+        1384.6153846153845,
+      );
+      expect(
+        calculatedAssessment.variables.calculatedDataTotalProvincialFSC,
+      ).toBe(1847.2153846153847);
+      expect(
+        calculatedAssessment.variables.calculatedDataTotalSpouseContribution,
+      ).toBe(769.9384615384616);
+      // Combination of federal fixed student contribution, spouse contribution, parental contribution, and targeted resources.
+      expect(
+        calculatedAssessment.variables.calculatedDataTotalFederalContribution,
+      ).toBe(
+        calculatedAssessment.variables.calculatedDataTotalSpouseContribution +
+          calculatedAssessment.variables.calculatedDataTotalFederalFSC,
+      );
+      // Combination of provincial fixed student contribution, spouse contribution, parental contribution, and targeted resources.
+      expect(
+        calculatedAssessment.variables
+          .calculatedDataTotalProvincialContribution,
+      ).toBe(
+        calculatedAssessment.variables.calculatedDataTotalSpouseContribution +
+          calculatedAssessment.variables.calculatedDataTotalProvincialFSC,
+      );
+    },
+  );
+
+  it("Should calculate $0 fixed student contribution for a married independent student when both are exempt ().", async () => {
     // Arrange
     const assessmentConsolidatedData =
       createFakeConsolidatedFulltimeData(PROGRAM_YEAR);
     assessmentConsolidatedData.studentDataHasDependents = YesNoOptions.No;
     assessmentConsolidatedData.studentDataRelationshipStatus = "married";
     assessmentConsolidatedData.studentDataPartnerHasEmploymentInsuranceBenefits =
-      YesNoOptions.No;
+      YesNoOptions.Yes;
     assessmentConsolidatedData.studentDataPartnerHasTotalIncomeAssistance =
       YesNoOptions.No;
     assessmentConsolidatedData.studentDataPartnerHasFedralProvincialPDReceipt =
       YesNoOptions.No;
     assessmentConsolidatedData.studentDataEstimatedSpouseIncome = 30000;
+    assessmentConsolidatedData.studentDataYouthInCare = YesNoOptions.Yes;
 
     // Act
     const calculatedAssessment = await executeFullTimeAssessmentForProgramYear(
@@ -81,17 +145,29 @@ describe(`E2E Test Workflow fulltime-assessment-${PROGRAM_YEAR}-spouse-contribut
       assessmentConsolidatedData,
     );
     // Assert
+    // If the student is indigenous, a former youth in care, or has a disability, they are exempt from the federal and provincial fixed student contributions.
+    expect(calculatedAssessment.variables.calculatedDataFederalFSCExempt).toBe(
+      true,
+    );
+    expect(
+      calculatedAssessment.variables.calculatedDataProvincialFSCExempt,
+    ).toBe(true);
+    // The spouse can be exempt from contribution if they are a full-time student at the same time.
+    // Or when they have a disability, or are receiving certain types of income assistance.
+    expect(
+      calculatedAssessment.variables.calculatedDataSpousalContributionExempt,
+    ).toBe(false);
     // The federal and provincial fixed student contributions are based on family income and size when the student is not exempt.
     expect(calculatedAssessment.variables.calculatedDataTotalFederalFSC).toBe(
-      1384.6153846153845,
+      0,
     );
     expect(
       calculatedAssessment.variables.calculatedDataTotalProvincialFSC,
-    ).toBe(1847.2153846153847);
+    ).toBe(0);
     // The total spouse contribution is not calculated for single students.
     expect(
       calculatedAssessment.variables.calculatedDataTotalSpouseContribution,
-    ).toBe(769.9384615384616);
+    ).toBe(0);
     // The total parental contribution is not calculated for independent students.
     expect(
       calculatedAssessment.variables.calculatedDataTotalParentalContribution,
@@ -103,11 +179,11 @@ describe(`E2E Test Workflow fulltime-assessment-${PROGRAM_YEAR}-spouse-contribut
     // Combination of federal fixed student contribution, spouse contribution, parental contribution, and targeted resources.
     expect(
       calculatedAssessment.variables.calculatedDataTotalFederalContribution,
-    ).toBe(2154.5538461538463);
-    // Combination of federal fixed student contribution, spouse contribution, parental contribution, and targeted resources.
+    ).toBe(0);
+    // Combination of provincial fixed student contribution, spouse contribution, parental contribution, and targeted resources.
     expect(
       calculatedAssessment.variables.calculatedDataTotalProvincialContribution,
-    ).toBe(2617.153846153846);
+    ).toBe(0);
   });
 
   afterAll(async () => {

--- a/sources/packages/backend/workflow/test/2025-2026/fulltime-assessment/contribution/fulltime-assessment-spouse-contribution.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2025-2026/fulltime-assessment/contribution/fulltime-assessment-spouse-contribution.e2e-spec.ts
@@ -124,6 +124,75 @@ describe(`E2E Test Workflow fulltime-assessment-${PROGRAM_YEAR}-spouse-contribut
     },
   );
 
+  it(
+    "Should calculate total fixed student contribution for a married independent student when the student is exempt " +
+      "and the partner is not exempt, is a full time student (12 wk), and has not already contributed in the program year.",
+    async () => {
+      // Arrange
+      const assessmentConsolidatedData =
+        createFakeConsolidatedFulltimeData(PROGRAM_YEAR);
+      assessmentConsolidatedData.studentDataHasDependents = YesNoOptions.No;
+      assessmentConsolidatedData.studentDataRelationshipStatus = "married";
+      assessmentConsolidatedData.studentDataPartnerHasEmploymentInsuranceBenefits =
+        YesNoOptions.No;
+      assessmentConsolidatedData.studentDataPartnerHasTotalIncomeAssistance =
+        YesNoOptions.No;
+      assessmentConsolidatedData.studentDataPartnerHasFedralProvincialPDReceipt =
+        YesNoOptions.No;
+      assessmentConsolidatedData.studentDataEstimatedSpouseIncome = 30000;
+      assessmentConsolidatedData.studentDataYouthInCare = YesNoOptions.Yes;
+      assessmentConsolidatedData.programYearSpouseContributionWeeks = 12; // Spouse contribution for 12 weeks have been calculated in the program year.
+
+      // Act
+      const calculatedAssessment =
+        await executeFullTimeAssessmentForProgramYear(
+          PROGRAM_YEAR,
+          assessmentConsolidatedData,
+        );
+      // Assert
+      // The spouse can be exempt from contribution if they are a full-time student at the same time.
+      // Or when they have a disability, or are receiving certain types of income assistance.
+      expect(
+        calculatedAssessment.variables.calculatedDataSpousalContributionExempt,
+      ).toBe(false);
+      // The federal and provincial fixed student contributions are based on family income and size when the student is not exempt.
+      expect(calculatedAssessment.variables.calculatedDataTotalFederalFSC).toBe(
+        0,
+      );
+      expect(
+        calculatedAssessment.variables.calculatedDataTotalProvincialFSC,
+      ).toBe(0);
+      // Spouse contribution weeks remaining is the max contribution weeks minus the weeks already contributed.
+      expect(
+        calculatedAssessment.variables
+          .calculatedDataRemainingSpouseContributionWeeks,
+      ).toBe(14.67);
+      // The spouse contribution weeks is the lower of remaining spouse contribution weeks and offering weeks (less any study overlap weeks).
+      expect(
+        calculatedAssessment.variables.calculatedDataSpouseContributionWeeks,
+      ).toBe(14.67);
+      // The total spouse contribution is calculated based on the spouse contribution weeks, spouse contribution rate, and family income.
+      expect(
+        calculatedAssessment.variables.calculatedDataTotalSpouseContribution,
+      ).toBe(705.937326923077);
+      // Combination of federal fixed student contribution, spouse contribution, parental contribution, and targeted resources.
+      expect(
+        calculatedAssessment.variables.calculatedDataTotalFederalContribution,
+      ).toBe(
+        calculatedAssessment.variables.calculatedDataTotalSpouseContribution +
+          calculatedAssessment.variables.calculatedDataTotalFederalFSC,
+      );
+      // Combination of provincial fixed student contribution, spouse contribution, parental contribution, and targeted resources.
+      expect(
+        calculatedAssessment.variables
+          .calculatedDataTotalProvincialContribution,
+      ).toBe(
+        calculatedAssessment.variables.calculatedDataTotalSpouseContribution +
+          calculatedAssessment.variables.calculatedDataTotalProvincialFSC,
+      );
+    },
+  );
+
   it("Should calculate $0 fixed student contribution for a married independent student when both are exempt ().", async () => {
     // Arrange
     const assessmentConsolidatedData =

--- a/sources/packages/backend/workflow/test/2025-2026/fulltime-assessment/contribution/fulltime-assessment-spouse-contribution.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2025-2026/fulltime-assessment/contribution/fulltime-assessment-spouse-contribution.e2e-spec.ts
@@ -68,7 +68,7 @@ describe(`E2E Test Workflow fulltime-assessment-${PROGRAM_YEAR}-spouse-contribut
 
   it(
     "Should calculate total fixed student contribution for a married independent student when the student is exempt " +
-      "and the partner is not exempt, is not a full time student, and has not already contributed in the program year.",
+      "and the partner is not exempt, is not a full-time student, and has not already contributed in the program year.",
     async () => {
       // Arrange
       const assessmentConsolidatedData =
@@ -126,7 +126,7 @@ describe(`E2E Test Workflow fulltime-assessment-${PROGRAM_YEAR}-spouse-contribut
 
   it(
     "Should calculate total fixed student contribution for a married independent student when the student is exempt " +
-      "and the partner is not exempt, is a full time student (12 wk), and has not already contributed in the program year.",
+      "and the partner is not exempt, is a full-time student (12 week overlap), and has not already contributed.",
     async () => {
       // Arrange
       const assessmentConsolidatedData =
@@ -141,7 +141,71 @@ describe(`E2E Test Workflow fulltime-assessment-${PROGRAM_YEAR}-spouse-contribut
         YesNoOptions.No;
       assessmentConsolidatedData.studentDataEstimatedSpouseIncome = 30000;
       assessmentConsolidatedData.studentDataYouthInCare = YesNoOptions.Yes;
-      assessmentConsolidatedData.programYearTotalFullTimeSpouseContributionWeeks = 12; // Spouse contribution for 12 weeks have been calculated in the program year.
+      assessmentConsolidatedData.studentDataPartnerStudyWeeks = 12;
+
+      // Act
+      const calculatedAssessment =
+        await executeFullTimeAssessmentForProgramYear(
+          PROGRAM_YEAR,
+          assessmentConsolidatedData,
+        );
+      // Assert
+      // The spouse can be exempt from contribution if they are a full-time student at the same time.
+      // Or when they have a disability, or are receiving certain types of income assistance.
+      expect(
+        calculatedAssessment.variables.calculatedDataSpousalContributionExempt,
+      ).toBe(false);
+      // The federal and provincial fixed student contributions are based on family income and size when the student is not exempt.
+      expect(calculatedAssessment.variables.calculatedDataTotalFederalFSC).toBe(
+        0,
+      );
+      expect(
+        calculatedAssessment.variables.calculatedDataTotalProvincialFSC,
+      ).toBe(0);
+      // The spouse contribution weeks is the lower of remaining spouse contribution weeks and offering weeks (less any study overlap weeks).
+      expect(
+        calculatedAssessment.variables.calculatedDataSpouseContributionWeeks,
+      ).toBe(4);
+      // The total spouse contribution is calculated based on the spouse contribution weeks, spouse contribution rate, and family income.
+      expect(
+        calculatedAssessment.variables.calculatedDataTotalSpouseContribution,
+      ).toBe(192.4846153846154);
+      // Combination of federal fixed student contribution, spouse contribution, parental contribution, and targeted resources.
+      expect(
+        calculatedAssessment.variables.calculatedDataTotalFederalContribution,
+      ).toBe(
+        calculatedAssessment.variables.calculatedDataTotalSpouseContribution +
+          calculatedAssessment.variables.calculatedDataTotalFederalFSC,
+      );
+      // Combination of provincial fixed student contribution, spouse contribution, parental contribution, and targeted resources.
+      expect(
+        calculatedAssessment.variables
+          .calculatedDataTotalProvincialContribution,
+      ).toBe(
+        calculatedAssessment.variables.calculatedDataTotalSpouseContribution +
+          calculatedAssessment.variables.calculatedDataTotalProvincialFSC,
+      );
+    },
+  );
+
+  it(
+    "Should calculate total fixed student contribution for a married independent student when the student is exempt " +
+      "and the partner is not exempt, is not a full-time student, and has already contributed in the program year (20 weeks).",
+    async () => {
+      // Arrange
+      const assessmentConsolidatedData =
+        createFakeConsolidatedFulltimeData(PROGRAM_YEAR);
+      assessmentConsolidatedData.studentDataHasDependents = YesNoOptions.No;
+      assessmentConsolidatedData.studentDataRelationshipStatus = "married";
+      assessmentConsolidatedData.studentDataPartnerHasEmploymentInsuranceBenefits =
+        YesNoOptions.No;
+      assessmentConsolidatedData.studentDataPartnerHasTotalIncomeAssistance =
+        YesNoOptions.No;
+      assessmentConsolidatedData.studentDataPartnerHasFedralProvincialPDReceipt =
+        YesNoOptions.No;
+      assessmentConsolidatedData.studentDataEstimatedSpouseIncome = 30000;
+      assessmentConsolidatedData.studentDataYouthInCare = YesNoOptions.Yes;
+      assessmentConsolidatedData.programYearTotalFullTimeSpouseContributionWeeks = 20; // Spouse contribution for 20 weeks have been calculated in the program year.
 
       // Act
       const calculatedAssessment =

--- a/sources/packages/backend/workflow/test/2025-2026/fulltime-assessment/contribution/fulltime-assessment-spouse-contribution.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2025-2026/fulltime-assessment/contribution/fulltime-assessment-spouse-contribution.e2e-spec.ts
@@ -27,17 +27,22 @@ describe(`E2E Test Workflow fulltime-assessment-${PROGRAM_YEAR}-spouse-contribut
       assessmentConsolidatedData,
     );
     // Assert
+
+    expect(
+      calculatedAssessment.variables.calculatedDataSpousalContributionExempt,
+    ).toBe(false);
+
     // The federal and provincial fixed student contributions are based on family income and size when the student is not exempt.
     expect(calculatedAssessment.variables.calculatedDataTotalFederalFSC).toBe(
-      1384.61538461538,
+      1384.6153846153845,
     );
     expect(
       calculatedAssessment.variables.calculatedDataTotalProvincialFSC,
-    ).toBe(1847.21538461538);
+    ).toBe(1847.2153846153847);
     // The total spouse contribution is not calculated for single students.
     expect(
       calculatedAssessment.variables.calculatedDataTotalSpouseContribution,
-    ).toBe(769.938461538462);
+    ).toBe(769.9384615384616);
     // The total parental contribution is not calculated for independent students.
     expect(
       calculatedAssessment.variables.calculatedDataTotalParentalContribution,
@@ -49,11 +54,60 @@ describe(`E2E Test Workflow fulltime-assessment-${PROGRAM_YEAR}-spouse-contribut
     // Combination of federal fixed student contribution, spouse contribution, parental contribution, and targeted resources.
     expect(
       calculatedAssessment.variables.calculatedDataTotalFederalContribution,
-    ).toBe(2154.553846153842);
+    ).toBe(2154.5538461538463);
     // Combination of federal fixed student contribution, spouse contribution, parental contribution, and targeted resources.
     expect(
       calculatedAssessment.variables.calculatedDataTotalProvincialContribution,
-    ).toBe(2617.153846153842);
+    ).toBe(2617.153846153846);
+  });
+
+  it("Should calculate $0 fixed student contribution for a married independent student when both are exempt.", async () => {
+    // Arrange
+    const assessmentConsolidatedData =
+      createFakeConsolidatedFulltimeData(PROGRAM_YEAR);
+    assessmentConsolidatedData.studentDataHasDependents = YesNoOptions.No;
+    assessmentConsolidatedData.studentDataRelationshipStatus = "married";
+    assessmentConsolidatedData.studentDataPartnerHasEmploymentInsuranceBenefits =
+      YesNoOptions.No;
+    assessmentConsolidatedData.studentDataPartnerHasTotalIncomeAssistance =
+      YesNoOptions.No;
+    assessmentConsolidatedData.studentDataPartnerHasFedralProvincialPDReceipt =
+      YesNoOptions.No;
+    assessmentConsolidatedData.studentDataEstimatedSpouseIncome = 30000;
+
+    // Act
+    const calculatedAssessment = await executeFullTimeAssessmentForProgramYear(
+      PROGRAM_YEAR,
+      assessmentConsolidatedData,
+    );
+    // Assert
+    // The federal and provincial fixed student contributions are based on family income and size when the student is not exempt.
+    expect(calculatedAssessment.variables.calculatedDataTotalFederalFSC).toBe(
+      1384.6153846153845,
+    );
+    expect(
+      calculatedAssessment.variables.calculatedDataTotalProvincialFSC,
+    ).toBe(1847.2153846153847);
+    // The total spouse contribution is not calculated for single students.
+    expect(
+      calculatedAssessment.variables.calculatedDataTotalSpouseContribution,
+    ).toBe(769.9384615384616);
+    // The total parental contribution is not calculated for independent students.
+    expect(
+      calculatedAssessment.variables.calculatedDataTotalParentalContribution,
+    ).toBe(undefined);
+    // Targeted resources are scholarships and bursaries, government funding, non-government funding and voluntary parental contributions.
+    expect(
+      calculatedAssessment.variables.calculatedDataTotalTargetedResources,
+    ).toBe(0);
+    // Combination of federal fixed student contribution, spouse contribution, parental contribution, and targeted resources.
+    expect(
+      calculatedAssessment.variables.calculatedDataTotalFederalContribution,
+    ).toBe(2154.5538461538463);
+    // Combination of federal fixed student contribution, spouse contribution, parental contribution, and targeted resources.
+    expect(
+      calculatedAssessment.variables.calculatedDataTotalProvincialContribution,
+    ).toBe(2617.153846153846);
   });
 
   afterAll(async () => {

--- a/sources/packages/backend/workflow/test/2025-2026/fulltime-assessment/contribution/fulltime-assessment-spouse-contribution.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2025-2026/fulltime-assessment/contribution/fulltime-assessment-spouse-contribution.e2e-spec.ts
@@ -98,11 +98,11 @@ describe(`E2E Test Workflow fulltime-assessment-${PROGRAM_YEAR}-spouse-contribut
       ).toBe(false);
       // The federal and provincial fixed student contributions are based on family income and size when the student is not exempt.
       expect(calculatedAssessment.variables.calculatedDataTotalFederalFSC).toBe(
-        1384.6153846153845,
+        0,
       );
       expect(
         calculatedAssessment.variables.calculatedDataTotalProvincialFSC,
-      ).toBe(1847.2153846153847);
+      ).toBe(0);
       expect(
         calculatedAssessment.variables.calculatedDataTotalSpouseContribution,
       ).toBe(769.9384615384616);
@@ -156,7 +156,7 @@ describe(`E2E Test Workflow fulltime-assessment-${PROGRAM_YEAR}-spouse-contribut
     // Or when they have a disability, or are receiving certain types of income assistance.
     expect(
       calculatedAssessment.variables.calculatedDataSpousalContributionExempt,
-    ).toBe(false);
+    ).toBe(true);
     // The federal and provincial fixed student contributions are based on family income and size when the student is not exempt.
     expect(calculatedAssessment.variables.calculatedDataTotalFederalFSC).toBe(
       0,

--- a/sources/packages/backend/workflow/test/2025-2026/fulltime-assessment/contribution/fulltime-assessment-spouse-contribution.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2025-2026/fulltime-assessment/contribution/fulltime-assessment-spouse-contribution.e2e-spec.ts
@@ -141,7 +141,7 @@ describe(`E2E Test Workflow fulltime-assessment-${PROGRAM_YEAR}-spouse-contribut
         YesNoOptions.No;
       assessmentConsolidatedData.studentDataEstimatedSpouseIncome = 30000;
       assessmentConsolidatedData.studentDataYouthInCare = YesNoOptions.Yes;
-      assessmentConsolidatedData.programYearSpouseContributionWeeks = 12; // Spouse contribution for 12 weeks have been calculated in the program year.
+      assessmentConsolidatedData.programYearTotalFullTimeSpouseContributionWeeks = 12; // Spouse contribution for 12 weeks have been calculated in the program year.
 
       // Act
       const calculatedAssessment =
@@ -193,7 +193,7 @@ describe(`E2E Test Workflow fulltime-assessment-${PROGRAM_YEAR}-spouse-contribut
     },
   );
 
-  it("Should calculate $0 fixed student contribution for a married independent student when both are exempt ().", async () => {
+  it("Should calculate $0 fixed student contribution for a married independent student when both are exempt (EI Benefits).", async () => {
     // Arrange
     const assessmentConsolidatedData =
       createFakeConsolidatedFulltimeData(PROGRAM_YEAR);
@@ -206,6 +206,68 @@ describe(`E2E Test Workflow fulltime-assessment-${PROGRAM_YEAR}-spouse-contribut
     assessmentConsolidatedData.studentDataPartnerHasFedralProvincialPDReceipt =
       YesNoOptions.No;
     assessmentConsolidatedData.studentDataEstimatedSpouseIncome = 30000;
+    assessmentConsolidatedData.studentDataYouthInCare = YesNoOptions.Yes;
+
+    // Act
+    const calculatedAssessment = await executeFullTimeAssessmentForProgramYear(
+      PROGRAM_YEAR,
+      assessmentConsolidatedData,
+    );
+    // Assert
+    // If the student is indigenous, a former youth in care, or has a disability, they are exempt from the federal and provincial fixed student contributions.
+    expect(calculatedAssessment.variables.calculatedDataFederalFSCExempt).toBe(
+      true,
+    );
+    expect(
+      calculatedAssessment.variables.calculatedDataProvincialFSCExempt,
+    ).toBe(true);
+    // The spouse can be exempt from contribution if they are a full-time student at the same time.
+    // Or when they have a disability, or are receiving certain types of income assistance.
+    expect(
+      calculatedAssessment.variables.calculatedDataSpousalContributionExempt,
+    ).toBe(true);
+    // The federal and provincial fixed student contributions are based on family income and size when the student is not exempt.
+    expect(calculatedAssessment.variables.calculatedDataTotalFederalFSC).toBe(
+      0,
+    );
+    expect(
+      calculatedAssessment.variables.calculatedDataTotalProvincialFSC,
+    ).toBe(0);
+    // The total spouse contribution is not calculated for single students.
+    expect(
+      calculatedAssessment.variables.calculatedDataTotalSpouseContribution,
+    ).toBe(0);
+    // The total parental contribution is not calculated for independent students.
+    expect(
+      calculatedAssessment.variables.calculatedDataTotalParentalContribution,
+    ).toBe(undefined);
+    // Targeted resources are scholarships and bursaries, government funding, non-government funding and voluntary parental contributions.
+    expect(
+      calculatedAssessment.variables.calculatedDataTotalTargetedResources,
+    ).toBe(0);
+    // Combination of federal fixed student contribution, spouse contribution, parental contribution, and targeted resources.
+    expect(
+      calculatedAssessment.variables.calculatedDataTotalFederalContribution,
+    ).toBe(0);
+    // Combination of provincial fixed student contribution, spouse contribution, parental contribution, and targeted resources.
+    expect(
+      calculatedAssessment.variables.calculatedDataTotalProvincialContribution,
+    ).toBe(0);
+  });
+
+  it("Should calculate $0 fixed student contribution for a married independent student when both are exempt (income).", async () => {
+    // Arrange
+    const assessmentConsolidatedData =
+      createFakeConsolidatedFulltimeData(PROGRAM_YEAR);
+    assessmentConsolidatedData.studentDataHasDependents = YesNoOptions.No;
+    assessmentConsolidatedData.studentDataRelationshipStatus = "married";
+    assessmentConsolidatedData.studentDataPartnerHasEmploymentInsuranceBenefits =
+      YesNoOptions.No;
+    assessmentConsolidatedData.studentDataPartnerHasTotalIncomeAssistance =
+      YesNoOptions.No;
+    assessmentConsolidatedData.studentDataPartnerHasFedralProvincialPDReceipt =
+      YesNoOptions.No;
+    assessmentConsolidatedData.studentDataEstimatedSpouseIncome = 10000;
     assessmentConsolidatedData.studentDataYouthInCare = YesNoOptions.Yes;
 
     // Act

--- a/sources/packages/backend/workflow/test/2025-2026/fulltime-assessment/contribution/fulltime-assessment-spouse-contribution.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2025-2026/fulltime-assessment/contribution/fulltime-assessment-spouse-contribution.e2e-spec.ts
@@ -1,0 +1,63 @@
+import { PROGRAM_YEAR } from "../../constants/program-year.constants";
+import {
+  ZeebeMockedClient,
+  createFakeConsolidatedFulltimeData,
+  executeFullTimeAssessmentForProgramYear,
+} from "../../../test-utils";
+import { YesNoOptions } from "@sims/test-utils";
+
+describe(`E2E Test Workflow fulltime-assessment-${PROGRAM_YEAR}-spouse-contribution.`, () => {
+  it("Should calculate total fixed student contribution for a married independent student when neither are exempt.", async () => {
+    // Arrange
+    const assessmentConsolidatedData =
+      createFakeConsolidatedFulltimeData(PROGRAM_YEAR);
+    assessmentConsolidatedData.studentDataHasDependents = YesNoOptions.No;
+    assessmentConsolidatedData.studentDataRelationshipStatus = "married";
+    assessmentConsolidatedData.studentDataPartnerHasEmploymentInsuranceBenefits =
+      YesNoOptions.No;
+    assessmentConsolidatedData.studentDataPartnerHasTotalIncomeAssistance =
+      YesNoOptions.No;
+    assessmentConsolidatedData.studentDataPartnerHasFedralProvincialPDReceipt =
+      YesNoOptions.No;
+    assessmentConsolidatedData.studentDataEstimatedSpouseIncome = 30000;
+
+    // Act
+    const calculatedAssessment = await executeFullTimeAssessmentForProgramYear(
+      PROGRAM_YEAR,
+      assessmentConsolidatedData,
+    );
+    // Assert
+    // The federal and provincial fixed student contributions are based on family income and size when the student is not exempt.
+    expect(calculatedAssessment.variables.calculatedDataTotalFederalFSC).toBe(
+      1384.61538461538,
+    );
+    expect(
+      calculatedAssessment.variables.calculatedDataTotalProvincialFSC,
+    ).toBe(1847.21538461538);
+    // The total spouse contribution is not calculated for single students.
+    expect(
+      calculatedAssessment.variables.calculatedDataTotalSpouseContribution,
+    ).toBe(769.938461538462);
+    // The total parental contribution is not calculated for independent students.
+    expect(
+      calculatedAssessment.variables.calculatedDataTotalParentalContribution,
+    ).toBe(undefined);
+    // Targeted resources are scholarships and bursaries, government funding, non-government funding and voluntary parental contributions.
+    expect(
+      calculatedAssessment.variables.calculatedDataTotalTargetedResources,
+    ).toBe(0);
+    // Combination of federal fixed student contribution, spouse contribution, parental contribution, and targeted resources.
+    expect(
+      calculatedAssessment.variables.calculatedDataTotalFederalContribution,
+    ).toBe(2154.553846153842);
+    // Combination of federal fixed student contribution, spouse contribution, parental contribution, and targeted resources.
+    expect(
+      calculatedAssessment.variables.calculatedDataTotalProvincialContribution,
+    ).toBe(2617.153846153842);
+  });
+
+  afterAll(async () => {
+    // Closes the singleton instance created during test executions.
+    await ZeebeMockedClient.getMockedZeebeInstance().close();
+  });
+});

--- a/sources/packages/backend/workflow/test/2025-2026/fulltime-assessment/contribution/fulltime-assessment-student-contribution.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2025-2026/fulltime-assessment/contribution/fulltime-assessment-student-contribution.e2e-spec.ts
@@ -60,7 +60,7 @@ describe(`E2E Test Workflow fulltime-assessment-${PROGRAM_YEAR}-student-contribu
       expect(
         calculatedAssessment.variables
           .calculatedDataTotalProvincialContribution,
-      ).toBe(calculatedAssessment.variables.calculatedDataProvincialFSCExempt);
+      ).toBe(calculatedAssessment.variables.calculatedDataTotalProvincialFSC);
     },
   );
 

--- a/sources/packages/backend/workflow/test/2025-2026/fulltime-assessment/contribution/fulltime-assessment-student-contribution.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2025-2026/fulltime-assessment/contribution/fulltime-assessment-student-contribution.e2e-spec.ts
@@ -1,0 +1,66 @@
+import { PROGRAM_YEAR } from "../../constants/program-year.constants";
+import {
+  ZeebeMockedClient,
+  createFakeConsolidatedFulltimeData,
+  executeFullTimeAssessmentForProgramYear,
+} from "../../../test-utils";
+
+describe(`E2E Test Workflow fulltime-assessment-${PROGRAM_YEAR}-student-contribution.`, () => {
+  it(
+    "Should calculate total fixed student contribution for a single independent student that is not exempt from contribution " +
+      " and has no dependants and no targeted resources.",
+    async () => {
+      // Arrange
+      const assessmentConsolidatedData =
+        createFakeConsolidatedFulltimeData(PROGRAM_YEAR);
+
+      // Act
+      const calculatedAssessment =
+        await executeFullTimeAssessmentForProgramYear(
+          PROGRAM_YEAR,
+          assessmentConsolidatedData,
+        );
+      // Assert
+      // If the student is indigenous, a former youth in care, or has a disability, they are exempt from the federal and provincial fixed student contributions.
+      expect(
+        calculatedAssessment.variables.calculatedDataFederalFSCExempt,
+      ).toBe(false);
+      expect(
+        calculatedAssessment.variables.calculatedDataProvincialFSCExempt,
+      ).toBe(false);
+      // The federal and provincial fixed student contributions are based on family income and size when the student is not exempt.
+      expect(calculatedAssessment.variables.calculatedDataTotalFederalFSC).toBe(
+        851,
+      );
+      expect(
+        calculatedAssessment.variables.calculatedDataTotalProvincialFSC,
+      ).toBe(851);
+      // The total spouse contribution is not calculated for single students.
+      expect(
+        calculatedAssessment.variables.calculatedDataTotalSpouseContribution,
+      ).toBe(undefined);
+      // The total parental contribution is not calculated for independent students.
+      expect(
+        calculatedAssessment.variables.calculatedDataTotalParentalContribution,
+      ).toBe(undefined);
+      // Targeted resources are scholarships and bursaries, government funding, non-government funding and voluntary parental contributions.
+      expect(
+        calculatedAssessment.variables.calculatedDataTotalTargetedResources,
+      ).toBe(0);
+      // Combination of federal fixed student contribution, spouse contribution, parental contribution, and targeted resources.
+      expect(
+        calculatedAssessment.variables.calculatedDataTotalFederalContribution,
+      ).toBe(851);
+      // Combination of federal fixed student contribution, spouse contribution, parental contribution, and targeted resources.
+      expect(
+        calculatedAssessment.variables
+          .calculatedDataTotalProvincialContribution,
+      ).toBe(851);
+    },
+  );
+
+  afterAll(async () => {
+    // Closes the singleton instance created during test executions.
+    await ZeebeMockedClient.getMockedZeebeInstance().close();
+  });
+});

--- a/sources/packages/backend/workflow/test/2025-2026/fulltime-assessment/contribution/fulltime-assessment-student-contribution.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2025-2026/fulltime-assessment/contribution/fulltime-assessment-student-contribution.e2e-spec.ts
@@ -6,14 +6,14 @@ import {
 } from "../../../test-utils";
 import { YesNoOptions } from "@sims/test-utils";
 import {
-  createFakeStudentDependentEligibleForChildcareCost,
-  DependentChildCareEligibility,
+  createFakeStudentDependentEligible,
+  DependentEligibility,
 } from "../../../test-utils/factories";
 
 describe(`E2E Test Workflow fulltime-assessment-${PROGRAM_YEAR}-student-contribution.`, () => {
   it(
     "Should calculate total fixed student contribution for a single independent student that is not exempt from contribution " +
-      " and has no dependants and no targeted resources.",
+      "and has no dependants and no targeted resources.",
     async () => {
       // Arrange
       const assessmentConsolidatedData =
@@ -66,7 +66,7 @@ describe(`E2E Test Workflow fulltime-assessment-${PROGRAM_YEAR}-student-contribu
 
   it(
     "Should calculate total fixed student contribution for a single independent student (low income) that is not exempt from contribution " +
-      " and has no dependants and no targeted resources.",
+      "and has no dependants and no targeted resources.",
     async () => {
       // Arrange
       const assessmentConsolidatedData =
@@ -89,11 +89,11 @@ describe(`E2E Test Workflow fulltime-assessment-${PROGRAM_YEAR}-student-contribu
       ).toBe(false);
       // The federal and provincial fixed student contributions are based on family income and size when the student is not exempt.
       expect(calculatedAssessment.variables.calculatedDataTotalFederalFSC).toBe(
-        692.307692307692,
+        692.3076923076923,
       );
       expect(
         calculatedAssessment.variables.calculatedDataTotalProvincialFSC,
-      ).toBe(692.307692307692);
+      ).toBe(692.3076923076923);
       // The total spouse contribution is not calculated for single students.
       expect(
         calculatedAssessment.variables.calculatedDataTotalSpouseContribution,
@@ -109,12 +109,12 @@ describe(`E2E Test Workflow fulltime-assessment-${PROGRAM_YEAR}-student-contribu
       // Combination of federal fixed student contribution, spouse contribution, parental contribution, and targeted resources.
       expect(
         calculatedAssessment.variables.calculatedDataTotalFederalContribution,
-      ).toBe(692.307692307692);
+      ).toBe(692.3076923076923);
       // Combination of federal fixed student contribution, spouse contribution, parental contribution, and targeted resources.
       expect(
         calculatedAssessment.variables
           .calculatedDataTotalProvincialContribution,
-      ).toBe(692.307692307692);
+      ).toBe(692.3076923076923);
     },
   );
 
@@ -175,7 +175,7 @@ describe(`E2E Test Workflow fulltime-assessment-${PROGRAM_YEAR}-student-contribu
 
   it(
     "Should calculate total fixed student contribution (long offering) for a single independent student that is not exempt from contribution " +
-      " and has no targeted resources.",
+      "and has no targeted resources.",
     async () => {
       // Arrange
       const assessmentConsolidatedData =
@@ -378,9 +378,8 @@ describe(`E2E Test Workflow fulltime-assessment-${PROGRAM_YEAR}-student-contribu
       createFakeConsolidatedFulltimeData(PROGRAM_YEAR);
     assessmentConsolidatedData.studentDataHasDependents = YesNoOptions.Yes;
     assessmentConsolidatedData.studentDataDependants = [
-      createFakeStudentDependentEligibleForChildcareCost(
-        DependentChildCareEligibility.Eligible0To11YearsOld,
-        assessmentConsolidatedData.offeringStudyStartDate,
+      createFakeStudentDependentEligible(
+        DependentEligibility.Eligible0To18YearsOld,
       ),
     ];
 

--- a/sources/packages/backend/workflow/test/2025-2026/fulltime-assessment/contribution/fulltime-assessment-student-contribution.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2025-2026/fulltime-assessment/contribution/fulltime-assessment-student-contribution.e2e-spec.ts
@@ -4,6 +4,7 @@ import {
   createFakeConsolidatedFulltimeData,
   executeFullTimeAssessmentForProgramYear,
 } from "../../../test-utils";
+import { YesNoOptions } from "@sims/test-utils";
 
 describe(`E2E Test Workflow fulltime-assessment-${PROGRAM_YEAR}-student-contribution.`, () => {
   it(
@@ -30,11 +31,11 @@ describe(`E2E Test Workflow fulltime-assessment-${PROGRAM_YEAR}-student-contribu
       ).toBe(false);
       // The federal and provincial fixed student contributions are based on family income and size when the student is not exempt.
       expect(calculatedAssessment.variables.calculatedDataTotalFederalFSC).toBe(
-        851,
+        851.4692307692308,
       );
       expect(
         calculatedAssessment.variables.calculatedDataTotalProvincialFSC,
-      ).toBe(851);
+      ).toBe(851.4692307692308);
       // The total spouse contribution is not calculated for single students.
       expect(
         calculatedAssessment.variables.calculatedDataTotalSpouseContribution,
@@ -50,15 +51,171 @@ describe(`E2E Test Workflow fulltime-assessment-${PROGRAM_YEAR}-student-contribu
       // Combination of federal fixed student contribution, spouse contribution, parental contribution, and targeted resources.
       expect(
         calculatedAssessment.variables.calculatedDataTotalFederalContribution,
-      ).toBe(851);
+      ).toBe(851.4692307692308);
       // Combination of federal fixed student contribution, spouse contribution, parental contribution, and targeted resources.
       expect(
         calculatedAssessment.variables
           .calculatedDataTotalProvincialContribution,
-      ).toBe(851);
+      ).toBe(851.4692307692308);
     },
   );
 
+  it(
+    "Should calculate total fixed student contribution for a single independent student that is not exempt from contribution " +
+      " and has no dependants and $1000 of targeted resources.",
+    async () => {
+      // Arrange
+      const assessmentConsolidatedData =
+        createFakeConsolidatedFulltimeData(PROGRAM_YEAR);
+      assessmentConsolidatedData.studentDataScholarshipAmount = 2800;
+
+      // Act
+      const calculatedAssessment =
+        await executeFullTimeAssessmentForProgramYear(
+          PROGRAM_YEAR,
+          assessmentConsolidatedData,
+        );
+      // Assert
+      // If the student is indigenous, a former youth in care, or has a disability, they are exempt from the federal and provincial fixed student contributions.
+      expect(
+        calculatedAssessment.variables.calculatedDataFederalFSCExempt,
+      ).toBe(false);
+      expect(
+        calculatedAssessment.variables.calculatedDataProvincialFSCExempt,
+      ).toBe(false);
+      // The federal and provincial fixed student contributions are based on family income and size when the student is not exempt.
+      expect(calculatedAssessment.variables.calculatedDataTotalFederalFSC).toBe(
+        851.4692307692308,
+      );
+      expect(
+        calculatedAssessment.variables.calculatedDataTotalProvincialFSC,
+      ).toBe(851.4692307692308);
+      // The total spouse contribution is not calculated for single students.
+      expect(
+        calculatedAssessment.variables.calculatedDataTotalSpouseContribution,
+      ).toBe(undefined);
+      // The total parental contribution is not calculated for independent students.
+      expect(
+        calculatedAssessment.variables.calculatedDataTotalParentalContribution,
+      ).toBe(undefined);
+      // Targeted resources are scholarships and bursaries, government funding, non-government funding and voluntary parental contributions.
+      // The first $1800 of scholarships and bursaries are exempt from contribution in a program year.
+      expect(
+        calculatedAssessment.variables.calculatedDataTotalTargetedResources,
+      ).toBe(1000);
+      // Combination of federal fixed student contribution, spouse contribution, parental contribution, and targeted resources.
+      expect(
+        calculatedAssessment.variables.calculatedDataTotalFederalContribution,
+      ).toBe(1851.4692307692308);
+      // Combination of federal fixed student contribution, spouse contribution, parental contribution, and targeted resources.
+      expect(
+        calculatedAssessment.variables
+          .calculatedDataTotalProvincialContribution,
+      ).toBe(1851.4692307692308);
+    },
+  );
+
+  it(
+    "Should calculate total fixed student contribution (long offering) for a single independent student that is not exempt from contribution " +
+      " and has no dependants and no targeted resources.",
+    async () => {
+      // Arrange
+      const assessmentConsolidatedData =
+        createFakeConsolidatedFulltimeData(PROGRAM_YEAR);
+      assessmentConsolidatedData.offeringWeeks = 52;
+
+      // Act
+      const calculatedAssessment =
+        await executeFullTimeAssessmentForProgramYear(
+          PROGRAM_YEAR,
+          assessmentConsolidatedData,
+        );
+      // Assert
+      // If the student is indigenous, a former youth in care, or has a disability, they are exempt from the federal and provincial fixed student contributions.
+      expect(
+        calculatedAssessment.variables.calculatedDataFederalFSCExempt,
+      ).toBe(false);
+      expect(
+        calculatedAssessment.variables.calculatedDataProvincialFSCExempt,
+      ).toBe(false);
+      // The federal and provincial fixed student contributions are based on family income and size when the student is not exempt.
+      expect(calculatedAssessment.variables.calculatedDataTotalFederalFSC).toBe(
+        2660.841346153845,
+      );
+      expect(
+        calculatedAssessment.variables.calculatedDataTotalProvincialFSC,
+      ).toBe(2660.841346153845);
+      // The total spouse contribution is not calculated for single students.
+      expect(
+        calculatedAssessment.variables.calculatedDataTotalSpouseContribution,
+      ).toBe(undefined);
+      // The total parental contribution is not calculated for independent students.
+      expect(
+        calculatedAssessment.variables.calculatedDataTotalParentalContribution,
+      ).toBe(undefined);
+      // Targeted resources are scholarships and bursaries, government funding, non-government funding and voluntary parental contributions.
+      expect(
+        calculatedAssessment.variables.calculatedDataTotalTargetedResources,
+      ).toBe(0);
+      // Combination of federal fixed student contribution, spouse contribution, parental contribution, and targeted resources.
+      expect(
+        calculatedAssessment.variables.calculatedDataTotalFederalContribution,
+      ).toBe(2660.841346153845);
+      // Combination of federal fixed student contribution, spouse contribution, parental contribution, and targeted resources.
+      expect(
+        calculatedAssessment.variables
+          .calculatedDataTotalProvincialContribution,
+      ).toBe(2660.841346153845);
+    },
+  );
+
+  it("Should calculate $0 for total fixed student contribution for a single independent student that is exempt from contribution (indigenous).", async () => {
+    // Arrange
+    const assessmentConsolidatedData =
+      createFakeConsolidatedFulltimeData(PROGRAM_YEAR);
+    assessmentConsolidatedData.studentDataIndigenousStatus = YesNoOptions.Yes;
+
+    // Act
+    const calculatedAssessment = await executeFullTimeAssessmentForProgramYear(
+      PROGRAM_YEAR,
+      assessmentConsolidatedData,
+    );
+    // Assert
+    // If the student is indigenous, a former youth in care, or has a disability, they are exempt from the federal and provincial fixed student contributions.
+    expect(calculatedAssessment.variables.calculatedDataFederalFSCExempt).toBe(
+      true,
+    );
+    expect(
+      calculatedAssessment.variables.calculatedDataProvincialFSCExempt,
+    ).toBe(true);
+    // The federal and provincial fixed student contributions are based on family income and size when the student is not exempt.
+    expect(calculatedAssessment.variables.calculatedDataTotalFederalFSC).toBe(
+      0,
+    );
+    expect(
+      calculatedAssessment.variables.calculatedDataTotalProvincialFSC,
+    ).toBe(0);
+    // The total spouse contribution is not calculated for single students.
+    expect(
+      calculatedAssessment.variables.calculatedDataTotalSpouseContribution,
+    ).toBe(undefined);
+    // The total parental contribution is not calculated for independent students.
+    expect(
+      calculatedAssessment.variables.calculatedDataTotalParentalContribution,
+    ).toBe(undefined);
+    // Targeted resources are scholarships and bursaries, government funding, non-government funding and voluntary parental contributions.
+    expect(
+      calculatedAssessment.variables.calculatedDataTotalTargetedResources,
+    ).toBe(0);
+    // Combination of federal fixed student contribution, spouse contribution, parental contribution, and targeted resources.
+    expect(
+      calculatedAssessment.variables.calculatedDataTotalFederalContribution,
+    ).toBe(0);
+    // Combination of federal fixed student contribution, spouse contribution, parental contribution, and targeted resources.
+    expect(
+      calculatedAssessment.variables.calculatedDataTotalProvincialContribution,
+    ).toBe(0);
+  });
   afterAll(async () => {
     // Closes the singleton instance created during test executions.
     await ZeebeMockedClient.getMockedZeebeInstance().close();

--- a/sources/packages/backend/workflow/test/2025-2026/fulltime-assessment/contribution/fulltime-assessment-student-contribution.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2025-2026/fulltime-assessment/contribution/fulltime-assessment-student-contribution.e2e-spec.ts
@@ -39,7 +39,7 @@ describe(`E2E Test Workflow fulltime-assessment-${PROGRAM_YEAR}-student-contribu
       );
       expect(
         calculatedAssessment.variables.calculatedDataTotalProvincialFSC,
-      ).toBe(851.4692307692308);
+      ).toBe(calculatedAssessment.variables.calculatedDataTotalFederalFSC);
       // The total spouse contribution is not calculated for single students.
       expect(
         calculatedAssessment.variables.calculatedDataTotalSpouseContribution,
@@ -55,12 +55,12 @@ describe(`E2E Test Workflow fulltime-assessment-${PROGRAM_YEAR}-student-contribu
       // Combination of federal fixed student contribution, spouse contribution, parental contribution, and targeted resources.
       expect(
         calculatedAssessment.variables.calculatedDataTotalFederalContribution,
-      ).toBe(851.4692307692308);
-      // Combination of federal fixed student contribution, spouse contribution, parental contribution, and targeted resources.
+      ).toBe(calculatedAssessment.variables.calculatedDataTotalFederalFSC);
+      // Combination of provincial fixed student contribution, spouse contribution, parental contribution, and targeted resources.
       expect(
         calculatedAssessment.variables
           .calculatedDataTotalProvincialContribution,
-      ).toBe(851.4692307692308);
+      ).toBe(calculatedAssessment.variables.calculatedDataProvincialFSCExempt);
     },
   );
 
@@ -93,7 +93,7 @@ describe(`E2E Test Workflow fulltime-assessment-${PROGRAM_YEAR}-student-contribu
       );
       expect(
         calculatedAssessment.variables.calculatedDataTotalProvincialFSC,
-      ).toBe(692.3076923076923);
+      ).toBe(calculatedAssessment.variables.calculatedDataTotalFederalFSC);
       // The total spouse contribution is not calculated for single students.
       expect(
         calculatedAssessment.variables.calculatedDataTotalSpouseContribution,
@@ -109,12 +109,12 @@ describe(`E2E Test Workflow fulltime-assessment-${PROGRAM_YEAR}-student-contribu
       // Combination of federal fixed student contribution, spouse contribution, parental contribution, and targeted resources.
       expect(
         calculatedAssessment.variables.calculatedDataTotalFederalContribution,
-      ).toBe(692.3076923076923);
-      // Combination of federal fixed student contribution, spouse contribution, parental contribution, and targeted resources.
+      ).toBe(calculatedAssessment.variables.calculatedDataTotalFederalFSC);
+      // Combination of provincial fixed student contribution, spouse contribution, parental contribution, and targeted resources.
       expect(
         calculatedAssessment.variables
           .calculatedDataTotalProvincialContribution,
-      ).toBe(692.3076923076923);
+      ).toBe(calculatedAssessment.variables.calculatedDataTotalProvincialFSC);
     },
   );
 
@@ -147,7 +147,7 @@ describe(`E2E Test Workflow fulltime-assessment-${PROGRAM_YEAR}-student-contribu
       );
       expect(
         calculatedAssessment.variables.calculatedDataTotalProvincialFSC,
-      ).toBe(851.4692307692308);
+      ).toBe(calculatedAssessment.variables.calculatedDataTotalFederalFSC);
       // The total spouse contribution is not calculated for single students.
       expect(
         calculatedAssessment.variables.calculatedDataTotalSpouseContribution,
@@ -164,12 +164,18 @@ describe(`E2E Test Workflow fulltime-assessment-${PROGRAM_YEAR}-student-contribu
       // Combination of federal fixed student contribution, spouse contribution, parental contribution, and targeted resources.
       expect(
         calculatedAssessment.variables.calculatedDataTotalFederalContribution,
-      ).toBe(1851.4692307692308);
-      // Combination of federal fixed student contribution, spouse contribution, parental contribution, and targeted resources.
+      ).toBe(
+        calculatedAssessment.variables.calculatedDataTotalFederalFSC +
+          calculatedAssessment.variables.calculatedDataTotalTargetedResources,
+      );
+      // Combination of provincial fixed student contribution, spouse contribution, parental contribution, and targeted resources.
       expect(
         calculatedAssessment.variables
           .calculatedDataTotalProvincialContribution,
-      ).toBe(1851.4692307692308);
+      ).toBe(
+        calculatedAssessment.variables.calculatedDataTotalProvincialFSC +
+          calculatedAssessment.variables.calculatedDataTotalTargetedResources,
+      );
     },
   );
 
@@ -218,12 +224,12 @@ describe(`E2E Test Workflow fulltime-assessment-${PROGRAM_YEAR}-student-contribu
       // Combination of federal fixed student contribution, spouse contribution, parental contribution, and targeted resources.
       expect(
         calculatedAssessment.variables.calculatedDataTotalFederalContribution,
-      ).toBe(1845.027389423077);
-      // Combination of federal fixed student contribution, spouse contribution, parental contribution, and targeted resources.
+      ).toBe(calculatedAssessment.variables.calculatedDataTotalFederalFSC);
+      // Combination of provincial fixed student contribution, spouse contribution, parental contribution, and targeted resources.
       expect(
         calculatedAssessment.variables
           .calculatedDataTotalProvincialContribution,
-      ).toBe(2767.275);
+      ).toBe(calculatedAssessment.variables.calculatedDataTotalProvincialFSC);
     },
   );
 
@@ -269,7 +275,7 @@ describe(`E2E Test Workflow fulltime-assessment-${PROGRAM_YEAR}-student-contribu
     expect(
       calculatedAssessment.variables.calculatedDataTotalFederalContribution,
     ).toBe(0);
-    // Combination of federal fixed student contribution, spouse contribution, parental contribution, and targeted resources.
+    // Combination of provincial fixed student contribution, spouse contribution, parental contribution, and targeted resources.
     expect(
       calculatedAssessment.variables.calculatedDataTotalProvincialContribution,
     ).toBe(0);
@@ -318,7 +324,7 @@ describe(`E2E Test Workflow fulltime-assessment-${PROGRAM_YEAR}-student-contribu
     expect(
       calculatedAssessment.variables.calculatedDataTotalFederalContribution,
     ).toBe(0);
-    // Combination of federal fixed student contribution, spouse contribution, parental contribution, and targeted resources.
+    // Combination of provincial fixed student contribution, spouse contribution, parental contribution, and targeted resources.
     expect(
       calculatedAssessment.variables.calculatedDataTotalProvincialContribution,
     ).toBe(0);
@@ -366,7 +372,7 @@ describe(`E2E Test Workflow fulltime-assessment-${PROGRAM_YEAR}-student-contribu
     expect(
       calculatedAssessment.variables.calculatedDataTotalFederalContribution,
     ).toBe(0);
-    // Combination of federal fixed student contribution, spouse contribution, parental contribution, and targeted resources.
+    // Combination of provincial fixed student contribution, spouse contribution, parental contribution, and targeted resources.
     expect(
       calculatedAssessment.variables.calculatedDataTotalProvincialContribution,
     ).toBe(0);
@@ -419,7 +425,7 @@ describe(`E2E Test Workflow fulltime-assessment-${PROGRAM_YEAR}-student-contribu
     expect(
       calculatedAssessment.variables.calculatedDataTotalFederalContribution,
     ).toBe(0);
-    // Combination of federal fixed student contribution, spouse contribution, parental contribution, and targeted resources.
+    // Combination of provincial fixed student contribution, spouse contribution, parental contribution, and targeted resources.
     expect(
       calculatedAssessment.variables.calculatedDataTotalProvincialContribution,
     ).toBe(0);

--- a/sources/packages/backend/workflow/test/2025-2026/fulltime-assessment/contribution/fulltime-assessment-student-contribution.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2025-2026/fulltime-assessment/contribution/fulltime-assessment-student-contribution.e2e-spec.ts
@@ -61,6 +61,60 @@ describe(`E2E Test Workflow fulltime-assessment-${PROGRAM_YEAR}-student-contribu
   );
 
   it(
+    "Should calculate total fixed student contribution for a single independent student (low income) that is not exempt from contribution " +
+      " and has no dependants and no targeted resources.",
+    async () => {
+      // Arrange
+      const assessmentConsolidatedData =
+        createFakeConsolidatedFulltimeData(PROGRAM_YEAR);
+      assessmentConsolidatedData.studentDataTaxReturnIncome = 20000;
+
+      // Act
+      const calculatedAssessment =
+        await executeFullTimeAssessmentForProgramYear(
+          PROGRAM_YEAR,
+          assessmentConsolidatedData,
+        );
+      // Assert
+      // If the student is indigenous, a former youth in care, or has a disability, they are exempt from the federal and provincial fixed student contributions.
+      expect(
+        calculatedAssessment.variables.calculatedDataFederalFSCExempt,
+      ).toBe(false);
+      expect(
+        calculatedAssessment.variables.calculatedDataProvincialFSCExempt,
+      ).toBe(false);
+      // The federal and provincial fixed student contributions are based on family income and size when the student is not exempt.
+      expect(calculatedAssessment.variables.calculatedDataTotalFederalFSC).toBe(
+        692.307692307692,
+      );
+      expect(
+        calculatedAssessment.variables.calculatedDataTotalProvincialFSC,
+      ).toBe(692.307692307692);
+      // The total spouse contribution is not calculated for single students.
+      expect(
+        calculatedAssessment.variables.calculatedDataTotalSpouseContribution,
+      ).toBe(undefined);
+      // The total parental contribution is not calculated for independent students.
+      expect(
+        calculatedAssessment.variables.calculatedDataTotalParentalContribution,
+      ).toBe(undefined);
+      // Targeted resources are scholarships and bursaries, government funding, non-government funding and voluntary parental contributions.
+      expect(
+        calculatedAssessment.variables.calculatedDataTotalTargetedResources,
+      ).toBe(0);
+      // Combination of federal fixed student contribution, spouse contribution, parental contribution, and targeted resources.
+      expect(
+        calculatedAssessment.variables.calculatedDataTotalFederalContribution,
+      ).toBe(692.307692307692);
+      // Combination of federal fixed student contribution, spouse contribution, parental contribution, and targeted resources.
+      expect(
+        calculatedAssessment.variables
+          .calculatedDataTotalProvincialContribution,
+      ).toBe(692.307692307692);
+    },
+  );
+
+  it(
     "Should calculate total fixed student contribution for a single independent student that is not exempt from contribution " +
       "and $1000 of targeted resources.",
     async () => {
@@ -216,6 +270,104 @@ describe(`E2E Test Workflow fulltime-assessment-${PROGRAM_YEAR}-student-contribu
       calculatedAssessment.variables.calculatedDataTotalProvincialContribution,
     ).toBe(0);
   });
+
+  it("Should calculate $0 for total fixed student contribution for a single independent student that is exempt from contribution (PD).", async () => {
+    // Arrange
+    const assessmentConsolidatedData =
+      createFakeConsolidatedFulltimeData(PROGRAM_YEAR);
+    assessmentConsolidatedData.studentDataApplicationPDPPDStatus =
+      YesNoOptions.Yes;
+
+    // Act
+    const calculatedAssessment = await executeFullTimeAssessmentForProgramYear(
+      PROGRAM_YEAR,
+      assessmentConsolidatedData,
+    );
+    // Assert
+    // If the student is indigenous, a former youth in care, or has a disability, they are exempt from the federal and provincial fixed student contributions.
+    expect(calculatedAssessment.variables.calculatedDataFederalFSCExempt).toBe(
+      true,
+    );
+    expect(
+      calculatedAssessment.variables.calculatedDataProvincialFSCExempt,
+    ).toBe(true);
+    // The federal and provincial fixed student contributions are based on family income and size when the student is not exempt.
+    expect(calculatedAssessment.variables.calculatedDataTotalFederalFSC).toBe(
+      0,
+    );
+    expect(
+      calculatedAssessment.variables.calculatedDataTotalProvincialFSC,
+    ).toBe(0);
+    // The total spouse contribution is not calculated for single students.
+    expect(
+      calculatedAssessment.variables.calculatedDataTotalSpouseContribution,
+    ).toBe(undefined);
+    // The total parental contribution is not calculated for independent students.
+    expect(
+      calculatedAssessment.variables.calculatedDataTotalParentalContribution,
+    ).toBe(undefined);
+    // Targeted resources are scholarships and bursaries, government funding, non-government funding and voluntary parental contributions.
+    expect(
+      calculatedAssessment.variables.calculatedDataTotalTargetedResources,
+    ).toBe(0);
+    // Combination of federal fixed student contribution, spouse contribution, parental contribution, and targeted resources.
+    expect(
+      calculatedAssessment.variables.calculatedDataTotalFederalContribution,
+    ).toBe(0);
+    // Combination of federal fixed student contribution, spouse contribution, parental contribution, and targeted resources.
+    expect(
+      calculatedAssessment.variables.calculatedDataTotalProvincialContribution,
+    ).toBe(0);
+  });
+
+  it("Should calculate $0 for total fixed student contribution for a single independent student that is exempt from contribution (Former YIC).", async () => {
+    // Arrange
+    const assessmentConsolidatedData =
+      createFakeConsolidatedFulltimeData(PROGRAM_YEAR);
+    assessmentConsolidatedData.studentDataYouthInCare = YesNoOptions.Yes;
+
+    // Act
+    const calculatedAssessment = await executeFullTimeAssessmentForProgramYear(
+      PROGRAM_YEAR,
+      assessmentConsolidatedData,
+    );
+    // Assert
+    // If the student is indigenous, a former youth in care, or has a disability, they are exempt from the federal and provincial fixed student contributions.
+    expect(calculatedAssessment.variables.calculatedDataFederalFSCExempt).toBe(
+      true,
+    );
+    expect(
+      calculatedAssessment.variables.calculatedDataProvincialFSCExempt,
+    ).toBe(true);
+    // The federal and provincial fixed student contributions are based on family income and size when the student is not exempt.
+    expect(calculatedAssessment.variables.calculatedDataTotalFederalFSC).toBe(
+      0,
+    );
+    expect(
+      calculatedAssessment.variables.calculatedDataTotalProvincialFSC,
+    ).toBe(0);
+    // The total spouse contribution is not calculated for single students.
+    expect(
+      calculatedAssessment.variables.calculatedDataTotalSpouseContribution,
+    ).toBe(undefined);
+    // The total parental contribution is not calculated for independent students.
+    expect(
+      calculatedAssessment.variables.calculatedDataTotalParentalContribution,
+    ).toBe(undefined);
+    // Targeted resources are scholarships and bursaries, government funding, non-government funding and voluntary parental contributions.
+    expect(
+      calculatedAssessment.variables.calculatedDataTotalTargetedResources,
+    ).toBe(0);
+    // Combination of federal fixed student contribution, spouse contribution, parental contribution, and targeted resources.
+    expect(
+      calculatedAssessment.variables.calculatedDataTotalFederalContribution,
+    ).toBe(0);
+    // Combination of federal fixed student contribution, spouse contribution, parental contribution, and targeted resources.
+    expect(
+      calculatedAssessment.variables.calculatedDataTotalProvincialContribution,
+    ).toBe(0);
+  });
+
   afterAll(async () => {
     // Closes the singleton instance created during test executions.
     await ZeebeMockedClient.getMockedZeebeInstance().close();

--- a/sources/packages/backend/workflow/test/2025-2026/fulltime-assessment/contribution/fulltime-assessment-student-contribution.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2025-2026/fulltime-assessment/contribution/fulltime-assessment-student-contribution.e2e-spec.ts
@@ -62,7 +62,7 @@ describe(`E2E Test Workflow fulltime-assessment-${PROGRAM_YEAR}-student-contribu
 
   it(
     "Should calculate total fixed student contribution for a single independent student that is not exempt from contribution " +
-      " and has no dependants and $1000 of targeted resources.",
+      "and $1000 of targeted resources.",
     async () => {
       // Arrange
       const assessmentConsolidatedData =
@@ -117,7 +117,7 @@ describe(`E2E Test Workflow fulltime-assessment-${PROGRAM_YEAR}-student-contribu
 
   it(
     "Should calculate total fixed student contribution (long offering) for a single independent student that is not exempt from contribution " +
-      " and has no dependants and no targeted resources.",
+      " and has no targeted resources.",
     async () => {
       // Arrange
       const assessmentConsolidatedData =
@@ -140,11 +140,11 @@ describe(`E2E Test Workflow fulltime-assessment-${PROGRAM_YEAR}-student-contribu
       ).toBe(false);
       // The federal and provincial fixed student contributions are based on family income and size when the student is not exempt.
       expect(calculatedAssessment.variables.calculatedDataTotalFederalFSC).toBe(
-        2660.841346153845,
+        1845.027389423077,
       );
       expect(
         calculatedAssessment.variables.calculatedDataTotalProvincialFSC,
-      ).toBe(2660.841346153845);
+      ).toBe(2767.275);
       // The total spouse contribution is not calculated for single students.
       expect(
         calculatedAssessment.variables.calculatedDataTotalSpouseContribution,
@@ -160,12 +160,12 @@ describe(`E2E Test Workflow fulltime-assessment-${PROGRAM_YEAR}-student-contribu
       // Combination of federal fixed student contribution, spouse contribution, parental contribution, and targeted resources.
       expect(
         calculatedAssessment.variables.calculatedDataTotalFederalContribution,
-      ).toBe(2660.841346153845);
+      ).toBe(1845.027389423077);
       // Combination of federal fixed student contribution, spouse contribution, parental contribution, and targeted resources.
       expect(
         calculatedAssessment.variables
           .calculatedDataTotalProvincialContribution,
-      ).toBe(2660.841346153845);
+      ).toBe(2767.275);
     },
   );
 

--- a/sources/packages/backend/workflow/test/2025-2026/fulltime-assessment/contribution/fulltime-assessment-student-contribution.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2025-2026/fulltime-assessment/contribution/fulltime-assessment-student-contribution.e2e-spec.ts
@@ -5,6 +5,10 @@ import {
   executeFullTimeAssessmentForProgramYear,
 } from "../../../test-utils";
 import { YesNoOptions } from "@sims/test-utils";
+import {
+  createFakeStudentDependentEligibleForChildcareCost,
+  DependentChildCareEligibility,
+} from "workflow/test/test-utils/factories";
 
 describe(`E2E Test Workflow fulltime-assessment-${PROGRAM_YEAR}-student-contribution.`, () => {
   it(
@@ -325,6 +329,60 @@ describe(`E2E Test Workflow fulltime-assessment-${PROGRAM_YEAR}-student-contribu
     const assessmentConsolidatedData =
       createFakeConsolidatedFulltimeData(PROGRAM_YEAR);
     assessmentConsolidatedData.studentDataYouthInCare = YesNoOptions.Yes;
+
+    // Act
+    const calculatedAssessment = await executeFullTimeAssessmentForProgramYear(
+      PROGRAM_YEAR,
+      assessmentConsolidatedData,
+    );
+    // Assert
+    // If the student is indigenous, a former youth in care, or has a disability, they are exempt from the federal and provincial fixed student contributions.
+    expect(calculatedAssessment.variables.calculatedDataFederalFSCExempt).toBe(
+      true,
+    );
+    expect(
+      calculatedAssessment.variables.calculatedDataProvincialFSCExempt,
+    ).toBe(true);
+    // The federal and provincial fixed student contributions are based on family income and size when the student is not exempt.
+    expect(calculatedAssessment.variables.calculatedDataTotalFederalFSC).toBe(
+      0,
+    );
+    expect(
+      calculatedAssessment.variables.calculatedDataTotalProvincialFSC,
+    ).toBe(0);
+    // The total spouse contribution is not calculated for single students.
+    expect(
+      calculatedAssessment.variables.calculatedDataTotalSpouseContribution,
+    ).toBe(undefined);
+    // The total parental contribution is not calculated for independent students.
+    expect(
+      calculatedAssessment.variables.calculatedDataTotalParentalContribution,
+    ).toBe(undefined);
+    // Targeted resources are scholarships and bursaries, government funding, non-government funding and voluntary parental contributions.
+    expect(
+      calculatedAssessment.variables.calculatedDataTotalTargetedResources,
+    ).toBe(0);
+    // Combination of federal fixed student contribution, spouse contribution, parental contribution, and targeted resources.
+    expect(
+      calculatedAssessment.variables.calculatedDataTotalFederalContribution,
+    ).toBe(0);
+    // Combination of federal fixed student contribution, spouse contribution, parental contribution, and targeted resources.
+    expect(
+      calculatedAssessment.variables.calculatedDataTotalProvincialContribution,
+    ).toBe(0);
+  });
+
+  it("Should calculate $0 for total fixed student contribution for a single independent student that is exempt from contribution (dependant).", async () => {
+    // Arrange
+    const assessmentConsolidatedData =
+      createFakeConsolidatedFulltimeData(PROGRAM_YEAR);
+    assessmentConsolidatedData.studentDataHasDependents = YesNoOptions.Yes;
+    assessmentConsolidatedData.studentDataDependants = [
+      createFakeStudentDependentEligibleForChildcareCost(
+        DependentChildCareEligibility.Eligible0To11YearsOld,
+        assessmentConsolidatedData.offeringStudyStartDate,
+      ),
+    ];
 
     // Act
     const calculatedAssessment = await executeFullTimeAssessmentForProgramYear(

--- a/sources/packages/backend/workflow/test/2025-2026/fulltime-assessment/contribution/fulltime-assessment-student-contribution.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2025-2026/fulltime-assessment/contribution/fulltime-assessment-student-contribution.e2e-spec.ts
@@ -8,7 +8,7 @@ import { YesNoOptions } from "@sims/test-utils";
 import {
   createFakeStudentDependentEligibleForChildcareCost,
   DependentChildCareEligibility,
-} from "workflow/test/test-utils/factories";
+} from "../../../test-utils/factories";
 
 describe(`E2E Test Workflow fulltime-assessment-${PROGRAM_YEAR}-student-contribution.`, () => {
   it(

--- a/sources/packages/backend/workflow/test/models/assessment.model.ts
+++ b/sources/packages/backend/workflow/test/models/assessment.model.ts
@@ -316,7 +316,9 @@ export interface CalculatedAssessmentModel {
   offeringExceptionalExpenses: number;
   calculatedDataProvincialAssessedNeed: number;
   calculatedDataTotalParentalContribution: number;
-  calculatedDataSpousalContributionExempt: boolean;
+  calculatedDataSpousalContributionExempt?: boolean;
+  calculatedDataSpouseContributionWeeks?: number;
+  calculatedDataRemainingSpouseContributionWeeks?: number;
   calculatedDataTotalSpouseContribution: number;
   calculatedDataProvincialFSCExempt: boolean;
   calculatedDataFederalFSCExempt: boolean;

--- a/sources/packages/backend/workflow/test/models/assessment.model.ts
+++ b/sources/packages/backend/workflow/test/models/assessment.model.ts
@@ -317,8 +317,13 @@ export interface CalculatedAssessmentModel {
   calculatedDataProvincialAssessedNeed: number;
   calculatedDataTotalParentalContribution: number;
   calculatedDataTotalSpouseContribution: number;
+  calculatedDataProvincialFSCExempt: boolean;
+  calculatedDataFederalFSCExempt: boolean;
   calculatedDataTotalFederalFSC: number;
   calculatedDataTotalProvincialFSC: number;
+  calculatedDataTotalFederalContribution: number;
+  calculatedDataTotalProvincialContribution: number;
+  calculatedDataTotalTargetedResources: number;
   calculatedDataTotalEligibleDependants: number;
   calculatedDataTotalScholarshipsBursaries: number;
   calculatedDataExemptScholarshipsBursaries: number;

--- a/sources/packages/backend/workflow/test/models/assessment.model.ts
+++ b/sources/packages/backend/workflow/test/models/assessment.model.ts
@@ -316,6 +316,7 @@ export interface CalculatedAssessmentModel {
   offeringExceptionalExpenses: number;
   calculatedDataProvincialAssessedNeed: number;
   calculatedDataTotalParentalContribution: number;
+  calculatedDataSpousalContributionExempt: boolean;
   calculatedDataTotalSpouseContribution: number;
   calculatedDataProvincialFSCExempt: boolean;
   calculatedDataFederalFSCExempt: boolean;


### PR DESCRIPTION
### BPMN Changes
- Max contribution weeks for federal student contribution made into it's own variable

<img width="668" height="206" alt="image" src="https://github.com/user-attachments/assets/2cea1262-91aa-4de1-a9b2-3700f5bfc036" />

- Provincial and Federal Assessed Need have a minimum of 0 (to prevent them from being negative).
- BCSL Remaining 2 fixed to "Net" top up
- Eligible dependants for CSG-FTDEP (CSGD) are <12 years old or 12+ on disability (childcare dependants). Updated eligibility and calculation dependant count to reflect this group.

### Test Cases Added (Student Contribution)
- Single Independant | $40k/16 week | No targeted resources
- Single Independant | $40k/16 week | $1000 targeted
- Single Independant | $40k/50 week | No targeted resources
- Single Independant | $20k/16 week | No targeted resources
- Single Independant | Exempt (Indigenous)
- Single Independant | Exempt (PD/PPD)
- Single Independant | Exempt (Former Youth In Care)
- Single Independant | Exempt (Eligible Dependant)

### Test Cases Added (Spouse Contribution)
- Student not exempt | Spouse not exempt | $70k / 16 wk | No Study overlap | Prev Weeks 0
- Student exempt | Spouse not exempt | $70k / 16 wk | No Study overlap | Prev Weeks 0
- Student exempt | Spouse not exempt | $70k / 16 wk | 12wk Study overlap | Prev Weeks 0
- Student exempt | Spouse not exempt | $70k / 16 wk | No Study overlap | Prev Weeks 20
- Student exempt | Spouse exempt (income)
- Student exempt | Spouse exempt (ei benefits)

//todo
- Student exempt | Spouse exempt (PD Receipt)
- Student exempt | Spouse exempt (Social Assistance)
- Student exempt | Spouse not exempt | $30k / 16 wk | No Study overlap | Prev Weeks 0
- Student exempt | Spouse not exempt | $60k / 50 wk | No Study overlap | Prev Weeks 
- CSGD eligibility test case for change in dependants