### PR TITLE
#4941 - Approved exception does not repeat - DB Migrations Fixes

### DIFF
--- a/sources/packages/backend/apps/db-migrations/src/sql/ApplicationExceptionRequests/Add-hash-and-other-columns.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/ApplicationExceptionRequests/Add-hash-and-other-columns.sql
@@ -1,16 +1,11 @@
 ALTER TABLE
   sims.application_exception_requests
 ADD
-  -- Keeping the default to 0 to avoid nulls and simplify uniqueness enforcement.
-  COLUMN exception_index SMALLINT DEFAULT 0,
-ADD
   COLUMN exception_description VARCHAR(500) NOT NULL DEFAULT '',
 ADD
   COLUMN approval_exception_request_id INT REFERENCES sims.application_exception_requests(id),
 ADD
   COLUMN exception_hash CHAR(64);
-
-COMMENT ON COLUMN sims.application_exception_requests.exception_index IS 'Index used for exceptions that can happen multiple times, for instance, dependents list or parents list.';
 
 COMMENT ON COLUMN sims.application_exception_requests.exception_description IS 'Description of the application exception. Critical for exceptions that happen multiple times to allow its individual identification.';
 
@@ -18,15 +13,18 @@ COMMENT ON COLUMN sims.application_exception_requests.approval_exception_request
 
 COMMENT ON COLUMN sims.application_exception_requests.exception_hash IS 'Hash of the application exception data, which also include files names and content hashes.';
 
--- Create unique index on application_exception_id, exception_name, and exception_index.
-CREATE UNIQUE INDEX application_exception_id_exception_name_exception_index_unique ON sims.application_exception_requests (
-  application_exception_id,
-  exception_name,
-  exception_index
-);
+-- Create unique constraint on application_exception_id, exception_name, and exception_description.
+ALTER TABLE
+  sims.application_exception_requests
+ADD
+  CONSTRAINT application_exception_id_exception_name_exception_description_unique UNIQUE (
+    application_exception_id,
+    exception_name,
+    exception_description
+  );
 
--- No need to drop the index in the rollback as the columns will be dropped and the index will be removed automatically.
-COMMENT ON INDEX sims.application_exception_id_exception_name_exception_index_unique IS 'Ensures that for a given application exception request, the combination of exception name and index is unique. This prevents duplicate entries for the same exception type within a single application exception request.';
+-- No need to drop the constraint in the rollback as the columns will be dropped and the constraint will be removed automatically.
+COMMENT ON CONSTRAINT application_exception_id_exception_name_exception_description_unique ON sims.application_exception_requests IS 'Ensures that for a given application exception request, the combination of exception name and description is unique. This prevents duplicate entries for the same exception type within a single application exception request.';
 
 -- Update exception_description based on existing exception_name values
 UPDATE
@@ -57,3 +55,7 @@ ALTER TABLE
   sims.application_exception_requests
 ALTER COLUMN
   exception_description DROP DEFAULT;
+
+-- Drop the constraint
+ALTER TABLE
+  sims.application_exception_requests DROP CONSTRAINT application_exception_request_application_exception_id_exce_key;

--- a/sources/packages/backend/apps/db-migrations/src/sql/ApplicationExceptionRequests/Add-hash-and-other-columns.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/ApplicationExceptionRequests/Add-hash-and-other-columns.sql
@@ -13,19 +13,6 @@ COMMENT ON COLUMN sims.application_exception_requests.approval_exception_request
 
 COMMENT ON COLUMN sims.application_exception_requests.exception_hash IS 'Hash of the application exception data, which also include files names and content hashes.';
 
--- Create unique constraint on application_exception_id, exception_name, and exception_description.
-ALTER TABLE
-  sims.application_exception_requests
-ADD
-  CONSTRAINT application_exception_id_exception_name_exception_description_unique UNIQUE (
-    application_exception_id,
-    exception_name,
-    exception_description
-  );
-
--- No need to drop the constraint in the rollback as the columns will be dropped and the constraint will be removed automatically.
-COMMENT ON CONSTRAINT application_exception_id_exception_name_exception_description_unique ON sims.application_exception_requests IS 'Ensures that for a given application exception request, the combination of exception name and description is unique. This prevents duplicate entries for the same exception type within a single application exception request.';
-
 -- Update exception_description based on existing exception_name values
 UPDATE
   sims.application_exception_requests

--- a/sources/packages/backend/apps/db-migrations/src/sql/ApplicationExceptionRequests/Add-hash-and-other-columns.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/ApplicationExceptionRequests/Add-hash-and-other-columns.sql
@@ -43,6 +43,6 @@ ALTER TABLE
 ALTER COLUMN
   exception_description DROP DEFAULT;
 
--- Drop the constraint
+-- Drop the constraint.
 ALTER TABLE
   sims.application_exception_requests DROP CONSTRAINT application_exception_request_application_exception_id_exce_key;

--- a/sources/packages/backend/apps/db-migrations/src/sql/ApplicationExceptionRequests/Rollback-add-hash-and-other-columns.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/ApplicationExceptionRequests/Rollback-add-hash-and-other-columns.sql
@@ -1,5 +1,10 @@
 ALTER TABLE
-    sims.application_exception_requests DROP COLUMN exception_index,
-    DROP COLUMN exception_description,
+    sims.application_exception_requests DROP COLUMN exception_description,
     DROP COLUMN approval_exception_request_id,
     DROP COLUMN exception_hash;
+
+-- Recreate the original unique constraint on application_exception_id and exception_name.
+ALTER TABLE
+    sims.application_exception_requests
+ADD
+    CONSTRAINT application_exception_request_application_exception_id_exce_key UNIQUE (application_exception_id, exception_name);

--- a/sources/packages/backend/libs/sims-db/src/entities/application-exception-requests.model.ts
+++ b/sources/packages/backend/libs/sims-db/src/entities/application-exception-requests.model.ts
@@ -42,15 +42,6 @@ export class ApplicationExceptionRequest extends RecordDataModel {
   })
   exceptionName: string;
   /**
-   * Index used for exceptions that can happen multiple times, for instance,
-   * dependents list or parents list.
-   */
-  @Column({
-    name: "exception_index",
-    type: "smallint",
-  })
-  exceptionIndex: number;
-  /**
    * Description of the application exception. Critical for exceptions that
    * happens multiple times to allow its individual identification.
    */


### PR DESCRIPTION
- Adjusting the previously DB migration to remove the `exception_index` column.
- Removed the already existing unique constraint that prevents an exception name from being repeated, which must happen now that multiple exceptions with the same name will be saved for dependents and parents.
- Removed the recently added constraint, as discussed with @dheepak-aot, there is not a great benefit and it may cause an issue depending on how the descriptions are defined.

## Migration Rollback

<img width="813" height="160" alt="image" src="https://github.com/user-attachments/assets/c29d03a4-e1eb-4aa2-b8f6-41903e00c560" />
