### PR TITLE
#5023 - FT Assessment Updates: CSG-FTDEP eligibility, negative need, BCSL

### DIFF
--- a/sources/packages/backend/workflow/src/workflow-definitions/fulltime-assessment-2025-2026.bpmn
+++ b/sources/packages/backend/workflow/src/workflow-definitions/fulltime-assessment-2025-2026.bpmn
@@ -890,7 +890,7 @@ dmnFullTimeIncomeThreshold</bpmn:text>
     <bpmn:intermediateThrowEvent id="Event_0agg2gq" name="BC Top Up Eligibility">
       <bpmn:extensionElements>
         <zeebe:ioMapping>
-          <zeebe:output source="=if calculatedDataTotalEligibleDependants &#62;0&#10;then true&#10;else false" target="awardEligiblityBCTopUp" />
+          <zeebe:output source="=if calculatedDataTotalEligibleDependants &#62;0&#10;then true&#10;else false" target="awardEligibilityBCTopUp" />
         </zeebe:ioMapping>
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_06x3mce</bpmn:incoming>
@@ -1126,7 +1126,7 @@ Federal Unmet Provincial Need = Provincial portion of Fed Need less Adjusted BCS
     <bpmn:intermediateThrowEvent id="Event_0tml7mg" name="Calculate Max Potential BCSL">
       <bpmn:extensionElements>
         <zeebe:ioMapping>
-          <zeebe:output source="=if (awardEligibilityBCSL = true) &#10;then&#10;  if (awardEligiblityBCTopUp = true) then (dmnFullTimeAwardAllowableLimits.limitAwardBCSLRateWithDependents * offeringWeeks)&#10;   else  (dmnFullTimeAwardAllowableLimits.limitAwardBCSLRateWithoutDependents * offeringWeeks)&#10;else &#10;  0" target="calculatedDataPotentialBCSL" />
+          <zeebe:output source="=if (awardEligibilityBCSL = true) &#10;then&#10;  if (awardEligibilityBCTopUp = true) then (dmnFullTimeAwardAllowableLimits.limitAwardBCSLRateWithDependents * offeringWeeks)&#10;   else  (dmnFullTimeAwardAllowableLimits.limitAwardBCSLRateWithoutDependents * offeringWeeks)&#10;else &#10;  0" target="calculatedDataPotentialBCSL" />
         </zeebe:ioMapping>
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_16npkhr</bpmn:incoming>
@@ -1188,7 +1188,7 @@ Federal Unmet Provincial Need = Provincial portion of Fed Need less Adjusted BCS
     <bpmn:intermediateThrowEvent id="Event_15gw653" name="Calculate Max BC Top-Up">
       <bpmn:extensionElements>
         <zeebe:ioMapping>
-          <zeebe:output source="=if(awardEligiblityBCTopUp = true)&#10;  then&#10;  dmnFullTimeAwardAllowableLimits.limitAwardWeeklyMaximumTopup * offeringWeeks&#10;else&#10;  0" target="calculatedDataBCTopup" />
+          <zeebe:output source="=if(awardEligibilityBCTopUp = true)&#10;  then&#10;  dmnFullTimeAwardAllowableLimits.limitAwardWeeklyMaximumTopup * offeringWeeks&#10;else&#10;  0" target="calculatedDataBCTopup" />
         </zeebe:ioMapping>
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_18b447c</bpmn:incoming>
@@ -1262,7 +1262,7 @@ Federal Unmet Provincial Need = Provincial portion of Fed Need less Adjusted BCS
     <bpmn:sequenceFlow id="Flow_1y66wfs" sourceRef="Event_0k61284" targetRef="Event_02b62pr" />
     <bpmn:sequenceFlow id="Flow_1bp8xjk" sourceRef="Event_0wsaq9c" targetRef="Event_1b397cd" />
     <bpmn:sequenceFlow id="Flow_15cawt4" name="No" sourceRef="Gateway_1ou1gl5" targetRef="Event_00nf274">
-      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=awardEligiblityBCTopUp = false</bpmn:conditionExpression>
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=awardEligibilityBCTopUp = false</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
     <bpmn:sequenceFlow id="Flow_1bwo33x" sourceRef="Event_00nf274" targetRef="Gateway_14udst9" />
     <bpmn:sequenceFlow id="Flow_1papkhu" sourceRef="Event_0fjl0zr" targetRef="Gateway_14udst9" />
@@ -1279,7 +1279,7 @@ Federal Unmet Provincial Need = Provincial portion of Fed Need less Adjusted BCS
     <bpmn:sequenceFlow id="Flow_0tsq896" sourceRef="Event_0j44ttl" targetRef="Event_0wsaq9c" />
     <bpmn:sequenceFlow id="Flow_002wks7" sourceRef="Event_02b62pr" targetRef="Gateway_1ou1gl5" />
     <bpmn:sequenceFlow id="Flow_1p7o8v2" name="Yes" sourceRef="Gateway_1ou1gl5" targetRef="Event_0fjl0zr">
-      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=awardEligiblityBCTopUp = true</bpmn:conditionExpression>
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=awardEligibilityBCTopUp = true</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
     <bpmn:sequenceFlow id="Flow_0b8daly" sourceRef="Event_07f5bxc" targetRef="Event_0o9cj80" />
     <bpmn:sequenceFlow id="Flow_18b447c" sourceRef="Event_07ht20d" targetRef="Event_15gw653" />
@@ -3718,7 +3718,7 @@ If the appeal was submitted, the calculated amount will be the</bpmn:documentati
         <di:waypoint x="11380" y="3375" />
         <di:waypoint x="11452" y="3375" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="11412" y="3358" width="17" height="14" />
+          <dc:Bounds x="11412" y="3358" width="18" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0b8daly_di" bpmnElement="Flow_0b8daly">

--- a/sources/packages/backend/workflow/test/2025-2026/fulltime-assessment/contribution/fulltime-assessment-spouse-contribution.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2025-2026/fulltime-assessment/contribution/fulltime-assessment-spouse-contribution.e2e-spec.ts
@@ -394,7 +394,6 @@ describe(`E2E Test Workflow fulltime-assessment-${PROGRAM_YEAR}-spouse-contribut
     assessmentConsolidatedData.studentDataPartnerHasFedralProvincialPDReceipt =
       YesNoOptions.Yes;
     assessmentConsolidatedData.studentDataEstimatedSpouseIncome = 30000;
-
     assessmentConsolidatedData.studentDataYouthInCare = YesNoOptions.Yes;
 
     // Act
@@ -507,7 +506,7 @@ describe(`E2E Test Workflow fulltime-assessment-${PROGRAM_YEAR}-spouse-contribut
     ).toBe(0);
   });
 
-  it("Should calculate $0 fixed student contribution for a married independent student when both are exempt (FT Student for >= offering weeks).", async () => {
+  it("Should calculate $0 fixed student contribution for a married independent student when both are exempt (Spouse FT Student Weeks > Offering Weeks).", async () => {
     // Arrange
     const assessmentConsolidatedData =
       createFakeConsolidatedFulltimeData(PROGRAM_YEAR);
@@ -521,6 +520,7 @@ describe(`E2E Test Workflow fulltime-assessment-${PROGRAM_YEAR}-spouse-contribut
       YesNoOptions.No;
     assessmentConsolidatedData.studentDataEstimatedSpouseIncome = 30000;
     assessmentConsolidatedData.studentDataYouthInCare = YesNoOptions.Yes;
+    // The spouse is a full-time student for more weeks than the student's offering weeks (16).
     assessmentConsolidatedData.studentDataPartnerStudyWeeks = 20;
 
     // Act

--- a/sources/packages/backend/workflow/test/2025-2026/fulltime-assessment/contribution/fulltime-assessment-spouse-contribution.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2025-2026/fulltime-assessment/contribution/fulltime-assessment-spouse-contribution.e2e-spec.ts
@@ -506,7 +506,7 @@ describe(`E2E Test Workflow fulltime-assessment-${PROGRAM_YEAR}-spouse-contribut
     ).toBe(0);
   });
 
-  it("Should calculate $0 fixed student contribution for a married independent student when both are exempt (Spouse FT Student Weeks > Offering Weeks).", async () => {
+  it("Should calculate $0 fixed student contribution for a married independent student when both are exempt (Partner FT Study Weeks more than Offering Weeks).", async () => {
     // Arrange
     const assessmentConsolidatedData =
       createFakeConsolidatedFulltimeData(PROGRAM_YEAR);

--- a/sources/packages/backend/workflow/test/2025-2026/fulltime-assessment/contribution/fulltime-assessment-spouse-contribution.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2025-2026/fulltime-assessment/contribution/fulltime-assessment-spouse-contribution.e2e-spec.ts
@@ -190,6 +190,70 @@ describe(`E2E Test Workflow fulltime-assessment-${PROGRAM_YEAR}-spouse-contribut
 
   it(
     "Should calculate total fixed student contribution for a married independent student when the student is exempt " +
+      "and the partner is not exempt, is a full-time student (study weeks greater than offering), and has not already contributed.",
+    async () => {
+      // Arrange
+      const assessmentConsolidatedData =
+        createFakeConsolidatedFulltimeData(PROGRAM_YEAR);
+      assessmentConsolidatedData.studentDataHasDependents = YesNoOptions.No;
+      assessmentConsolidatedData.studentDataRelationshipStatus = "married";
+      assessmentConsolidatedData.studentDataPartnerHasEmploymentInsuranceBenefits =
+        YesNoOptions.No;
+      assessmentConsolidatedData.studentDataPartnerHasTotalIncomeAssistance =
+        YesNoOptions.No;
+      assessmentConsolidatedData.studentDataPartnerHasFedralProvincialPDReceipt =
+        YesNoOptions.No;
+      assessmentConsolidatedData.studentDataEstimatedSpouseIncome = 30000;
+      assessmentConsolidatedData.studentDataYouthInCare = YesNoOptions.Yes;
+      assessmentConsolidatedData.studentDataPartnerStudyWeeks = 20;
+
+      // Act
+      const calculatedAssessment =
+        await executeFullTimeAssessmentForProgramYear(
+          PROGRAM_YEAR,
+          assessmentConsolidatedData,
+        );
+      // Assert
+      // The spouse can be exempt from contribution if they are a full-time student at the same time.
+      // Or when they have a disability, or are receiving certain types of income assistance.
+      expect(
+        calculatedAssessment.variables.calculatedDataSpousalContributionExempt,
+      ).toBe(false);
+      // The federal and provincial fixed student contributions are based on family income and size when the student is not exempt.
+      expect(calculatedAssessment.variables.calculatedDataTotalFederalFSC).toBe(
+        0,
+      );
+      expect(
+        calculatedAssessment.variables.calculatedDataTotalProvincialFSC,
+      ).toBe(0);
+      // The spouse contribution weeks is the lower of remaining spouse contribution weeks and offering weeks (less any study overlap weeks).
+      expect(
+        calculatedAssessment.variables.calculatedDataSpouseContributionWeeks,
+      ).toBe(16);
+      // The total spouse contribution is calculated based on the spouse contribution weeks, spouse contribution rate, and family income.
+      expect(
+        calculatedAssessment.variables.calculatedDataTotalSpouseContribution,
+      ).toBe(769.9384615384616);
+      // Combination of federal fixed student contribution, spouse contribution, parental contribution, and targeted resources.
+      expect(
+        calculatedAssessment.variables.calculatedDataTotalFederalContribution,
+      ).toBe(
+        calculatedAssessment.variables.calculatedDataTotalSpouseContribution +
+          calculatedAssessment.variables.calculatedDataTotalFederalFSC,
+      );
+      // Combination of provincial fixed student contribution, spouse contribution, parental contribution, and targeted resources.
+      expect(
+        calculatedAssessment.variables
+          .calculatedDataTotalProvincialContribution,
+      ).toBe(
+        calculatedAssessment.variables.calculatedDataTotalSpouseContribution +
+          calculatedAssessment.variables.calculatedDataTotalProvincialFSC,
+      );
+    },
+  );
+
+  it(
+    "Should calculate total fixed student contribution for a married independent student when the student is exempt " +
       "and the partner is not exempt, is not a full-time student, and has already contributed in the program year (20 weeks).",
     async () => {
       // Arrange

--- a/sources/packages/backend/workflow/test/2025-2026/fulltime-assessment/contribution/fulltime-assessment-spouse-contribution.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2025-2026/fulltime-assessment/contribution/fulltime-assessment-spouse-contribution.e2e-spec.ts
@@ -190,71 +190,6 @@ describe(`E2E Test Workflow fulltime-assessment-${PROGRAM_YEAR}-spouse-contribut
 
   it(
     "Should calculate total fixed student contribution for a married independent student when the student is exempt " +
-      "and the partner is not exempt, is a full-time student (study weeks greater than offering), and has not already contributed.",
-    async () => {
-      // Arrange
-      const assessmentConsolidatedData =
-        createFakeConsolidatedFulltimeData(PROGRAM_YEAR);
-      assessmentConsolidatedData.studentDataHasDependents = YesNoOptions.No;
-      assessmentConsolidatedData.studentDataRelationshipStatus = "married";
-      assessmentConsolidatedData.studentDataPartnerHasEmploymentInsuranceBenefits =
-        YesNoOptions.No;
-      assessmentConsolidatedData.studentDataPartnerHasTotalIncomeAssistance =
-        YesNoOptions.No;
-      assessmentConsolidatedData.studentDataPartnerHasFedralProvincialPDReceipt =
-        YesNoOptions.No;
-      assessmentConsolidatedData.studentDataEstimatedSpouseIncome = 30000;
-      assessmentConsolidatedData.studentDataYouthInCare = YesNoOptions.Yes;
-      assessmentConsolidatedData.studentDataPartnerStudyWeeks = 20;
-
-      // Act
-      const calculatedAssessment =
-        await executeFullTimeAssessmentForProgramYear(
-          PROGRAM_YEAR,
-          assessmentConsolidatedData,
-        );
-      // Assert
-      // The spouse can be exempt from contribution if they are a full-time student at the same time.
-      // Or when they have a disability, or are receiving certain types of income assistance.
-      expect(
-        calculatedAssessment.variables.calculatedDataSpousalContributionExempt,
-      ).toBe(false);
-      // The federal and provincial fixed student contributions are based on family income and size when the student is not exempt.
-      expect(calculatedAssessment.variables.calculatedDataTotalFederalFSC).toBe(
-        0,
-      );
-      expect(
-        calculatedAssessment.variables.calculatedDataTotalProvincialFSC,
-      ).toBe(0);
-      // The spouse contribution weeks is the lower of remaining spouse contribution weeks and offering weeks (less any study overlap weeks).
-      // If the study weeks are greater than or equal to the offering weeks, the spouse contribution weeks is 0.
-      expect(
-        calculatedAssessment.variables.calculatedDataSpouseContributionWeeks,
-      ).toBe(0);
-      // The total spouse contribution is calculated based on the spouse contribution weeks, spouse contribution rate, and family income.
-      expect(
-        calculatedAssessment.variables.calculatedDataTotalSpouseContribution,
-      ).toBe(0);
-      // Combination of federal fixed student contribution, spouse contribution, parental contribution, and targeted resources.
-      expect(
-        calculatedAssessment.variables.calculatedDataTotalFederalContribution,
-      ).toBe(
-        calculatedAssessment.variables.calculatedDataTotalSpouseContribution +
-          calculatedAssessment.variables.calculatedDataTotalFederalFSC,
-      );
-      // Combination of provincial fixed student contribution, spouse contribution, parental contribution, and targeted resources.
-      expect(
-        calculatedAssessment.variables
-          .calculatedDataTotalProvincialContribution,
-      ).toBe(
-        calculatedAssessment.variables.calculatedDataTotalSpouseContribution +
-          calculatedAssessment.variables.calculatedDataTotalProvincialFSC,
-      );
-    },
-  );
-
-  it(
-    "Should calculate total fixed student contribution for a married independent student when the student is exempt " +
       "and the partner is not exempt, is not a full-time student, and has already contributed in the program year (20 weeks).",
     async () => {
       // Arrange
@@ -570,6 +505,65 @@ describe(`E2E Test Workflow fulltime-assessment-${PROGRAM_YEAR}-spouse-contribut
     expect(
       calculatedAssessment.variables.calculatedDataTotalProvincialContribution,
     ).toBe(0);
+  });
+
+  it("Should calculate $0 fixed student contribution for a married independent student when both are exempt (FT Student for >= offering weeks).", async () => {
+    // Arrange
+    const assessmentConsolidatedData =
+      createFakeConsolidatedFulltimeData(PROGRAM_YEAR);
+    assessmentConsolidatedData.studentDataHasDependents = YesNoOptions.No;
+    assessmentConsolidatedData.studentDataRelationshipStatus = "married";
+    assessmentConsolidatedData.studentDataPartnerHasEmploymentInsuranceBenefits =
+      YesNoOptions.No;
+    assessmentConsolidatedData.studentDataPartnerHasTotalIncomeAssistance =
+      YesNoOptions.No;
+    assessmentConsolidatedData.studentDataPartnerHasFedralProvincialPDReceipt =
+      YesNoOptions.No;
+    assessmentConsolidatedData.studentDataEstimatedSpouseIncome = 30000;
+    assessmentConsolidatedData.studentDataYouthInCare = YesNoOptions.Yes;
+    assessmentConsolidatedData.studentDataPartnerStudyWeeks = 20;
+
+    // Act
+    const calculatedAssessment = await executeFullTimeAssessmentForProgramYear(
+      PROGRAM_YEAR,
+      assessmentConsolidatedData,
+    );
+    // Assert
+    // The spouse can be exempt from contribution if they are a full-time student during the entire length of study.
+    // Or when they have a disability, or are receiving certain types of income assistance.
+    expect(
+      calculatedAssessment.variables.calculatedDataSpousalContributionExempt,
+    ).toBe(true);
+    // The federal and provincial fixed student contributions are based on family income and size when the student is not exempt.
+    expect(calculatedAssessment.variables.calculatedDataTotalFederalFSC).toBe(
+      0,
+    );
+    expect(
+      calculatedAssessment.variables.calculatedDataTotalProvincialFSC,
+    ).toBe(0);
+    // The spouse contribution weeks is the lower of remaining spouse contribution weeks and offering weeks (less any study overlap weeks).
+    // If the study weeks are greater than or equal to the offering weeks, the spouse contribution weeks is 0.
+    expect(
+      calculatedAssessment.variables.calculatedDataSpouseContributionWeeks,
+    ).toBe(0);
+    // The total spouse contribution is calculated based on the spouse contribution weeks, spouse contribution rate, and family income.
+    expect(
+      calculatedAssessment.variables.calculatedDataTotalSpouseContribution,
+    ).toBe(0);
+    // Combination of federal fixed student contribution, spouse contribution, parental contribution, and targeted resources.
+    expect(
+      calculatedAssessment.variables.calculatedDataTotalFederalContribution,
+    ).toBe(
+      calculatedAssessment.variables.calculatedDataTotalSpouseContribution +
+        calculatedAssessment.variables.calculatedDataTotalFederalFSC,
+    );
+    // Combination of provincial fixed student contribution, spouse contribution, parental contribution, and targeted resources.
+    expect(
+      calculatedAssessment.variables.calculatedDataTotalProvincialContribution,
+    ).toBe(
+      calculatedAssessment.variables.calculatedDataTotalSpouseContribution +
+        calculatedAssessment.variables.calculatedDataTotalProvincialFSC,
+    );
   });
 
   afterAll(async () => {

--- a/sources/packages/backend/workflow/test/2025-2026/fulltime-assessment/eligibility/fulltime-assessment-eligibility-BCSL.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2025-2026/fulltime-assessment/eligibility/fulltime-assessment-eligibility-BCSL.e2e-spec.ts
@@ -9,6 +9,7 @@ import {
   createFakeStudentDependentEligible,
   createFakeStudentDependentNotEligible,
 } from "../../../test-utils/factories";
+import { YesNoOptions } from "@sims/test-utils";
 
 describe(`E2E Test Workflow fulltime-assessment-${PROGRAM_YEAR}-eligibility-BCSL.`, () => {
   it("Should determine BCSL as eligible when provincial need is at least $1.", async () => {
@@ -53,8 +54,8 @@ describe(`E2E Test Workflow fulltime-assessment-${PROGRAM_YEAR}-eligibility-BCSL
     // Arrange
     const assessmentConsolidatedData =
       createFakeConsolidatedFulltimeData(PROGRAM_YEAR);
-    // Eligible dependants  include dependants 18-22 attending post-secondary school, 0-18 years old and >22 if declared on taxes.
-    // Dependants eligible for CSGD must be either 0-11 years old or 12+ with a disability.
+    assessmentConsolidatedData.studentDataHasDependents = YesNoOptions.Yes;
+    // Eligible dependants include dependants 18-22 attending post-secondary school, 0-18 years old and >22 if declared on taxes.
     assessmentConsolidatedData.studentDataDependants = [
       createFakeStudentDependentEligible(
         DependentEligibility.Eligible0To18YearsOld,
@@ -72,12 +73,12 @@ describe(`E2E Test Workflow fulltime-assessment-${PROGRAM_YEAR}-eligibility-BCSL
     expect(calculatedAssessment.variables.awardEligibilityBCTopUp).toBe(true);
   });
 
-  it("Should determine BC(SL) Top Up as eligible when eligible dependants is 0.", async () => {
+  it("Should determine BC(SL) Top Up as not eligible when eligible dependants is 0.", async () => {
     // Arrange
     const assessmentConsolidatedData =
       createFakeConsolidatedFulltimeData(PROGRAM_YEAR);
-    // Eligible dependants  include dependants 18-22 attending post-secondary school, 0-18 years old and >22 if declared on taxes.
-    // Dependants eligible for CSGD must be either 0-11 years old or 12+ with a disability.
+    assessmentConsolidatedData.studentDataHasDependents = YesNoOptions.Yes;
+    // Eligible dependants include dependants 18-22 attending post-secondary school, 0-18 years old and >22 if declared on taxes.
     assessmentConsolidatedData.studentDataDependants = [
       createFakeStudentDependentNotEligible(
         DependentEligibility.EligibleOver22YearsOld,

--- a/sources/packages/backend/workflow/test/2025-2026/fulltime-assessment/eligibility/fulltime-assessment-eligibility-BCSL.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2025-2026/fulltime-assessment/eligibility/fulltime-assessment-eligibility-BCSL.e2e-spec.ts
@@ -66,6 +66,9 @@ describe(`E2E Test Workflow fulltime-assessment-${PROGRAM_YEAR}-eligibility-BCSL
       assessmentConsolidatedData,
     );
     // Assert
+    expect(
+      calculatedAssessment.variables.calculatedDataTotalEligibleDependants,
+    ).toBe(1);
     expect(calculatedAssessment.variables.awardEligibilityBCTopUp).toBe(true);
   });
 
@@ -87,6 +90,9 @@ describe(`E2E Test Workflow fulltime-assessment-${PROGRAM_YEAR}-eligibility-BCSL
       assessmentConsolidatedData,
     );
     // Assert
+    expect(
+      calculatedAssessment.variables.calculatedDataTotalEligibleDependants,
+    ).toBe(0);
     expect(calculatedAssessment.variables.awardEligibilityBCTopUp).toBe(false);
   });
 

--- a/sources/packages/backend/workflow/test/2025-2026/fulltime-assessment/eligibility/fulltime-assessment-eligibility-BCSL.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2025-2026/fulltime-assessment/eligibility/fulltime-assessment-eligibility-BCSL.e2e-spec.ts
@@ -1,0 +1,74 @@
+import {
+  ZeebeMockedClient,
+  createFakeConsolidatedFulltimeData,
+  executeFullTimeAssessmentForProgramYear,
+} from "../../../test-utils";
+import { PROGRAM_YEAR } from "../../constants/program-year.constants";
+import {
+  DependentEligibility,
+  createFakeStudentDependentEligible,
+} from "../../../test-utils/factories";
+
+describe(`E2E Test Workflow fulltime-assessment-${PROGRAM_YEAR}-eligibility-BCSL.`, () => {
+  it("Should determine BCSL as eligible when provincial need is at least $1.", async () => {
+    // Arrange
+    const assessmentConsolidatedData =
+      createFakeConsolidatedFulltimeData(PROGRAM_YEAR);
+
+    // Act
+    const calculatedAssessment = await executeFullTimeAssessmentForProgramYear(
+      PROGRAM_YEAR,
+      assessmentConsolidatedData,
+    );
+    // Assert
+    expect(
+      calculatedAssessment.variables.calculatedDataProvincialAssessedNeed,
+    ).toBeGreaterThan(0);
+    expect(calculatedAssessment.variables.awardEligibilityBCSL).toBe(true);
+  });
+
+  it("Should determine BCSL as not eligible when provincial need is less than $1.", async () => {
+    // Arrange
+    const assessmentConsolidatedData =
+      createFakeConsolidatedFulltimeData(PROGRAM_YEAR);
+    // Ensures that the income is high enough to eliminate any provincial need.
+    assessmentConsolidatedData.studentDataTaxReturnIncome = 150000;
+    // Act
+    const calculatedAssessment = await executeFullTimeAssessmentForProgramYear(
+      PROGRAM_YEAR,
+      assessmentConsolidatedData,
+    );
+    // Assert
+    expect(calculatedAssessment.variables.awardEligibilityBCSL).toBe(false);
+    expect(
+      calculatedAssessment.variables.finalProvincialAwardNetBCSLAmount,
+    ).toBe(0);
+  });
+
+  it("Should determine CSGD as not eligible when financial need is at least $1 and total family income is below the threshold and eligible dependents is 0.", async () => {
+    // Arrange
+    const assessmentConsolidatedData =
+      createFakeConsolidatedFulltimeData(PROGRAM_YEAR);
+    // Ensures that the income is below any threshold to force enforce the "at least one eligible dependants" rule to fail.
+    assessmentConsolidatedData.studentDataTaxReturnIncome = 1000;
+    // Eligible dependants for family size include dependants 18-22 attending post-secondary school.
+    // Dependants eligible for CSGD must be either 0-11 years old or 12+ with a disability.
+    assessmentConsolidatedData.studentDataDependants = [
+      createFakeStudentDependentEligible(
+        DependentEligibility.Eligible18To22YearsOldAttendingHighSchool,
+      ),
+    ];
+    // Act
+    const calculatedAssessment = await executeFullTimeAssessmentForProgramYear(
+      PROGRAM_YEAR,
+      assessmentConsolidatedData,
+    );
+    // Assert
+    expect(calculatedAssessment.variables.awardEligibilityCSGD).toBe(false);
+  });
+
+  afterAll(async () => {
+    // Closes the singleton instance created during test executions.
+    await ZeebeMockedClient.getMockedZeebeInstance().close();
+  });
+});

--- a/sources/packages/backend/workflow/test/2025-2026/fulltime-assessment/eligibility/fulltime-assessment-eligibility-BCSL.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2025-2026/fulltime-assessment/eligibility/fulltime-assessment-eligibility-BCSL.e2e-spec.ts
@@ -32,13 +32,16 @@ describe(`E2E Test Workflow fulltime-assessment-${PROGRAM_YEAR}-eligibility-BCSL
     const assessmentConsolidatedData =
       createFakeConsolidatedFulltimeData(PROGRAM_YEAR);
     // Ensures that the income is high enough to eliminate any provincial need.
-    assessmentConsolidatedData.studentDataTaxReturnIncome = 150000;
+    assessmentConsolidatedData.studentDataTaxReturnIncome = 500000;
     // Act
     const calculatedAssessment = await executeFullTimeAssessmentForProgramYear(
       PROGRAM_YEAR,
       assessmentConsolidatedData,
     );
     // Assert
+    expect(
+      calculatedAssessment.variables.calculatedDataProvincialAssessedNeed,
+    ).toBeLessThan(1);
     expect(calculatedAssessment.variables.awardEligibilityBCSL).toBe(false);
     expect(
       calculatedAssessment.variables.finalProvincialAwardNetBCSLAmount,

--- a/sources/packages/backend/workflow/test/2025-2026/fulltime-assessment/eligibility/fulltime-assessment-eligibility-CSGD.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2025-2026/fulltime-assessment/eligibility/fulltime-assessment-eligibility-CSGD.e2e-spec.ts
@@ -63,8 +63,7 @@ describe(`E2E Test Workflow fulltime-assessment-${PROGRAM_YEAR}-eligibility-CSGD
     // Family size is calculated as the number of eligible dependants (6) plus the student.
     expect(calculatedAssessment.variables.calculatedDataFamilySize).toBe(7);
     expect(
-      calculatedAssessment.variables
-        .calculatedDataTotalEligibleDependentsForChildCare,
+      calculatedAssessment.variables.calculatedDataTotalChildcareDependants,
     ).toBe(4);
     expect(calculatedAssessment.variables.awardEligibilityCSGD).toBe(true);
     expect(

--- a/sources/packages/backend/workflow/test/2025-2026/fulltime-assessment/eligibility/fulltime-assessment-eligibility-CSGD.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2025-2026/fulltime-assessment/eligibility/fulltime-assessment-eligibility-CSGD.e2e-spec.ts
@@ -5,9 +5,11 @@ import {
 } from "../../../test-utils";
 import { PROGRAM_YEAR } from "../../constants/program-year.constants";
 import {
+  DependentChildCareEligibility,
   DependentEligibility,
   createFakeStudentDependentEligible,
-  createFakeStudentDependentNotEligible,
+  createFakeStudentDependentEligibleForChildcareCost,
+  createFakeStudentDependentNotEligibleForChildcareCost,
 } from "../../../test-utils/factories";
 
 describe(`E2E Test Workflow fulltime-assessment-${PROGRAM_YEAR}-eligibility-CSGD.`, () => {
@@ -18,37 +20,33 @@ describe(`E2E Test Workflow fulltime-assessment-${PROGRAM_YEAR}-eligibility-CSGD
     assessmentConsolidatedData.studentDataTaxReturnIncome = 32999;
     // Creates 4 eligible and 4 not eligible dependents.
     assessmentConsolidatedData.studentDataDependants = [
-      createFakeStudentDependentEligible(
-        DependentEligibility.Eligible0To18YearsOld,
-        { referenceDate: assessmentConsolidatedData.offeringStudyStartDate },
+      createFakeStudentDependentEligibleForChildcareCost(
+        DependentChildCareEligibility.Eligible0To11YearsOld,
+        assessmentConsolidatedData.offeringStudyStartDate,
       ),
-      createFakeStudentDependentEligible(
-        DependentEligibility.Eligible18To22YearsOldAttendingHighSchool,
-        { referenceDate: assessmentConsolidatedData.offeringStudyStartDate },
+      createFakeStudentDependentEligibleForChildcareCost(
+        DependentChildCareEligibility.Eligible0To11YearsOld,
+        assessmentConsolidatedData.offeringStudyStartDate,
       ),
-      createFakeStudentDependentEligible(
-        DependentEligibility.Eligible18To22YearsOldDeclaredOnTaxes,
-        { referenceDate: assessmentConsolidatedData.offeringStudyStartDate },
+      createFakeStudentDependentEligibleForChildcareCost(
+        DependentChildCareEligibility.Eligible12YearsAndOver,
+        assessmentConsolidatedData.offeringStudyStartDate,
       ),
-      createFakeStudentDependentEligible(
-        DependentEligibility.EligibleOver22YearsOld,
-        { referenceDate: assessmentConsolidatedData.offeringStudyStartDate },
+      createFakeStudentDependentEligibleForChildcareCost(
+        DependentChildCareEligibility.Eligible12YearsAndOver,
+        assessmentConsolidatedData.offeringStudyStartDate,
       ),
-      createFakeStudentDependentNotEligible(
-        DependentEligibility.Eligible0To18YearsOld,
-        { referenceDate: assessmentConsolidatedData.offeringStudyStartDate },
+      createFakeStudentDependentNotEligibleForChildcareCost(
+        assessmentConsolidatedData.offeringStudyStartDate,
       ),
-      createFakeStudentDependentNotEligible(
-        DependentEligibility.Eligible18To22YearsOldAttendingHighSchool,
-        { referenceDate: assessmentConsolidatedData.offeringStudyStartDate },
+      createFakeStudentDependentNotEligibleForChildcareCost(
+        assessmentConsolidatedData.offeringStudyStartDate,
       ),
-      createFakeStudentDependentNotEligible(
-        DependentEligibility.Eligible18To22YearsOldDeclaredOnTaxes,
-        { referenceDate: assessmentConsolidatedData.offeringStudyStartDate },
+      createFakeStudentDependentNotEligibleForChildcareCost(
+        assessmentConsolidatedData.offeringStudyStartDate,
       ),
-      createFakeStudentDependentNotEligible(
-        DependentEligibility.EligibleOver22YearsOld,
-        { referenceDate: assessmentConsolidatedData.offeringStudyStartDate },
+      createFakeStudentDependentNotEligibleForChildcareCost(
+        assessmentConsolidatedData.offeringStudyStartDate,
       ),
     ];
     // Act
@@ -76,8 +74,9 @@ describe(`E2E Test Workflow fulltime-assessment-${PROGRAM_YEAR}-eligibility-CSGD
     // Ensures that the income is above the threshold to force it to fail.
     assessmentConsolidatedData.studentDataTaxReturnIncome = 100000;
     assessmentConsolidatedData.studentDataDependants = [
-      createFakeStudentDependentEligible(
-        DependentEligibility.EligibleOver22YearsOld,
+      createFakeStudentDependentEligibleForChildcareCost(
+        DependentChildCareEligibility.Eligible0To11YearsOld,
+        assessmentConsolidatedData.offeringStudyStartDate,
       ),
     ];
     // Act
@@ -87,6 +86,7 @@ describe(`E2E Test Workflow fulltime-assessment-${PROGRAM_YEAR}-eligibility-CSGD
     );
     // Assert
     expect(calculatedAssessment.variables.awardEligibilityCSGD).toBe(false);
+    expect(calculatedAssessment.variables.federalAwardNetCSGDAmount).toBe(0);
   });
 
   it("Should determine CSGD as not eligible when financial need is at least $1 and total family income is below the threshold and eligible dependents is 0.", async () => {
@@ -95,9 +95,11 @@ describe(`E2E Test Workflow fulltime-assessment-${PROGRAM_YEAR}-eligibility-CSGD
       createFakeConsolidatedFulltimeData(PROGRAM_YEAR);
     // Ensures that the income is below any threshold to force enforce the "at least one eligible dependants" rule to fail.
     assessmentConsolidatedData.studentDataTaxReturnIncome = 1000;
+    // Eligible dependants for family size include dependants 18-22 attending post-secondary school.
+    // Dependants eligible for CSGD must be either 0-11 years old or 12+ with a disability.
     assessmentConsolidatedData.studentDataDependants = [
-      createFakeStudentDependentNotEligible(
-        DependentEligibility.Eligible0To18YearsOld,
+      createFakeStudentDependentEligible(
+        DependentEligibility.Eligible18To22YearsOldAttendingHighSchool,
       ),
     ];
     // Act

--- a/sources/packages/backend/workflow/test/2025-2026/fulltime-assessment/eligibility/fulltime-assessment-eligibility-CSGD.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2025-2026/fulltime-assessment/eligibility/fulltime-assessment-eligibility-CSGD.e2e-spec.ts
@@ -9,7 +9,7 @@ import {
   DependentEligibility,
   createFakeStudentDependentEligible,
   createFakeStudentDependentEligibleForChildcareCost,
-  createFakeStudentDependentNotEligibleForChildcareCost,
+  createFakeStudentDependentNotEligible,
 } from "../../../test-utils/factories";
 
 describe(`E2E Test Workflow fulltime-assessment-${PROGRAM_YEAR}-eligibility-CSGD.`, () => {
@@ -18,7 +18,7 @@ describe(`E2E Test Workflow fulltime-assessment-${PROGRAM_YEAR}-eligibility-CSGD
     const assessmentConsolidatedData =
       createFakeConsolidatedFulltimeData(PROGRAM_YEAR);
     assessmentConsolidatedData.studentDataTaxReturnIncome = 32999;
-    // Creates 4 eligible and 4 not eligible dependents.
+    // Creates 4 eligible childcare (CSGD) dependants, 2 family-size eligible dependants, 1 fully ineligible dependant.
     assessmentConsolidatedData.studentDataDependants = [
       createFakeStudentDependentEligibleForChildcareCost(
         DependentChildCareEligibility.Eligible0To11YearsOld,
@@ -36,17 +36,17 @@ describe(`E2E Test Workflow fulltime-assessment-${PROGRAM_YEAR}-eligibility-CSGD
         DependentChildCareEligibility.Eligible12YearsAndOver,
         assessmentConsolidatedData.offeringStudyStartDate,
       ),
-      createFakeStudentDependentNotEligibleForChildcareCost(
-        assessmentConsolidatedData.offeringStudyStartDate,
+      createFakeStudentDependentEligible(
+        DependentEligibility.Eligible18To22YearsOldAttendingHighSchool,
+        { referenceDate: assessmentConsolidatedData.offeringStudyStartDate },
       ),
-      createFakeStudentDependentNotEligibleForChildcareCost(
-        assessmentConsolidatedData.offeringStudyStartDate,
+      createFakeStudentDependentEligible(
+        DependentEligibility.Eligible18To22YearsOldAttendingHighSchool,
+        { referenceDate: assessmentConsolidatedData.offeringStudyStartDate },
       ),
-      createFakeStudentDependentNotEligibleForChildcareCost(
-        assessmentConsolidatedData.offeringStudyStartDate,
-      ),
-      createFakeStudentDependentNotEligibleForChildcareCost(
-        assessmentConsolidatedData.offeringStudyStartDate,
+      createFakeStudentDependentNotEligible(
+        DependentEligibility.EligibleOver22YearsOld,
+        { referenceDate: assessmentConsolidatedData.offeringStudyStartDate },
       ),
     ];
     // Act
@@ -60,7 +60,12 @@ describe(`E2E Test Workflow fulltime-assessment-${PROGRAM_YEAR}-eligibility-CSGD
     expect(calculatedAssessment.variables.calculatedDataTotalFamilyIncome).toBe(
       assessmentConsolidatedData.studentDataTaxReturnIncome,
     );
-    expect(calculatedAssessment.variables.calculatedDataFamilySize).toBe(5);
+    // Family size is calculated as the number of eligible dependants (6) plus the student.
+    expect(calculatedAssessment.variables.calculatedDataFamilySize).toBe(7);
+    expect(
+      calculatedAssessment.variables
+        .calculatedDataTotalEligibleDependentsForChildCare,
+    ).toBe(4);
     expect(calculatedAssessment.variables.awardEligibilityCSGD).toBe(true);
     expect(
       calculatedAssessment.variables.federalAwardNetCSGDAmount,

--- a/sources/packages/backend/workflow/test/2025-2026/fulltime-assessment/eligibility/fulltime-assessment-eligibility-CSGD.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2025-2026/fulltime-assessment/eligibility/fulltime-assessment-eligibility-CSGD.e2e-spec.ts
@@ -11,6 +11,7 @@ import {
   createFakeStudentDependentEligibleForChildcareCost,
   createFakeStudentDependentNotEligible,
 } from "../../../test-utils/factories";
+import { YesNoOptions } from "@sims/test-utils";
 
 describe(`E2E Test Workflow fulltime-assessment-${PROGRAM_YEAR}-eligibility-CSGD.`, () => {
   it("Should determine CSGD as eligible when financial need is at least $1 and total family income is under the threshold and there is at least 1 eligible dependent.", async () => {
@@ -18,6 +19,7 @@ describe(`E2E Test Workflow fulltime-assessment-${PROGRAM_YEAR}-eligibility-CSGD
     const assessmentConsolidatedData =
       createFakeConsolidatedFulltimeData(PROGRAM_YEAR);
     assessmentConsolidatedData.studentDataTaxReturnIncome = 32999;
+    assessmentConsolidatedData.studentDataHasDependents = YesNoOptions.Yes;
     // Creates 4 eligible childcare (CSGD) dependants, 2 family-size eligible dependants, 1 fully ineligible dependant.
     assessmentConsolidatedData.studentDataDependants = [
       createFakeStudentDependentEligibleForChildcareCost(
@@ -101,6 +103,7 @@ describe(`E2E Test Workflow fulltime-assessment-${PROGRAM_YEAR}-eligibility-CSGD
     assessmentConsolidatedData.studentDataTaxReturnIncome = 1000;
     // Eligible dependants for family size include dependants 18-22 attending post-secondary school.
     // Dependants eligible for CSGD must be either 0-11 years old or 12+ with a disability.
+    assessmentConsolidatedData.studentDataHasDependents = YesNoOptions.Yes;
     assessmentConsolidatedData.studentDataDependants = [
       createFakeStudentDependentEligible(
         DependentEligibility.Eligible18To22YearsOldAttendingHighSchool,

--- a/sources/packages/backend/workflow/test/models/assessment.model.ts
+++ b/sources/packages/backend/workflow/test/models/assessment.model.ts
@@ -365,8 +365,6 @@ export interface CalculatedAssessmentModel {
   awardEligibilityBCAG: boolean;
   // SBSD
   awardEligibilitySBSD: boolean;
-  // CSLP
-  awardEligibilityCSLP: boolean;
 
   // Full time.
   // CSGP
@@ -399,9 +397,20 @@ export interface CalculatedAssessmentModel {
   programYearTotalSBSD: number;
   federalAwardNetSBSDAmount: number;
   provincialAwardNetSBSDAmount: number;
+  // Loans
+  awardEligibilityBCSL: boolean;
+  finalProvincialAwardNetBCSLAmount: number;
+  awardEligibilityBCTopUp: boolean;
+  awardEligibilityCSLF: boolean;
+  federalAwardNetCSLFAmount: number;
+  // Calculated Data / Intermediate Award Variables
+  calculatedDataPotentialBCSL: number;
+  calculatedDataBCTopup: number;
+  calculatedDataPotentialCSLF: number;
 
   // Part time.
   // CSLP
+  awardEligibilityCSLP: boolean;
   federalAwardNetCSLPAmount: number;
   limitAwardCSLPRemaining: number;
   latestCSLPBalance: number;

--- a/sources/packages/backend/workflow/test/models/assessment.model.ts
+++ b/sources/packages/backend/workflow/test/models/assessment.model.ts
@@ -332,7 +332,7 @@ export interface CalculatedAssessmentModel {
   calculatedDataExemptScholarshipsBursaries: number;
   calculatedDataDependants11YearsOrUnder: number;
   calculatedDataDependants12YearsOverOnTaxes: number;
-  calculatedDataTotalEligibleDependentsForChildCare: number;
+  calculatedDataTotalChildcareDependants: number;
   calculatedDataTotalRoomAndBoardAmount: number;
   calculatedDataFamilySize: number;
   totalFederalContribution: number;

--- a/sources/packages/backend/workflow/test/models/assessment.model.ts
+++ b/sources/packages/backend/workflow/test/models/assessment.model.ts
@@ -332,6 +332,7 @@ export interface CalculatedAssessmentModel {
   calculatedDataExemptScholarshipsBursaries: number;
   calculatedDataDependants11YearsOrUnder: number;
   calculatedDataDependants12YearsOverOnTaxes: number;
+  calculatedDataTotalEligibleDependentsForChildCare: number;
   calculatedDataTotalChildcareDependants: number;
   calculatedDataTotalRoomAndBoardAmount: number;
   calculatedDataFamilySize: number;


### PR DESCRIPTION
### Test Cases

**Spouse Contribution**
Student exempt | Spouse not exempt | $60k / 16 wk | 20 wk overlap | Prev Weeks 0
Student exempt | Spouse exempt (PD Receipt)
Student exempt | Spouse exempt (Social Assistance)

**CSGD Eligibility**
Updated eligibility test cases to align more with the childcare eligible dependants. These are the ones that make students eligible and count towards CSGD eligibility/calculation.

**BCSL & Top Up Eligibility**
Top up eligibility is determined independently of BCSL eligibility. It contributes to the max BCSL amount, so only has an end impact on BCSL if the student is already eligible for BCSL.

### Assessment model
Moved some award values and added some additional award amount values.
Updated award eligibility for BC Top Up name.

