### PR TITLE
#5065 - Exceptions not repeat 25-26 backwards compatibility

### DIFF
--- a/sources/packages/forms/src/form-definitions/sfaa2025-26-pt.json
+++ b/sources/packages/forms/src/form-definitions/sfaa2025-26-pt.json
@@ -2787,7 +2787,7 @@
                       "label": "otherLivingSituation",
                       "calculateValue": "value = data[component.key];",
                       "calculateServer": true,
-                      "key": "bclivingSituation1",
+                      "key": "otherLivingSituation",
                       "type": "hidden",
                       "input": true,
                       "tableView": false


### PR DESCRIPTION
- Creating exception containers for the 2025-26 application to allow the hash generation using the same approach executed for full-time.
- The new containers follow the same names as the existing part-time exceptions, and they have hidden fields to allow the exception-specific data to be copied into the containers, replicating what was enabled for full-time.

<img width="703" height="1137" alt="image" src="https://github.com/user-attachments/assets/ac52bde3-03fe-4415-b6e6-920470e16c16" />

_Note:_ There was an issue with the dependants list explained in [this comment](https://github.com/bcgov/SIMS/issues/5065#issuecomment-3208474893) that would prevent the first submission of an existing application from creating the expected exception descriptions.