### PR TITLE
#4886 - Convert to ASCII

### DIFF
--- a/sources/packages/backend/libs/utilities/src/_tests_/unit/string-utils.translateToASCII.spec.ts
+++ b/sources/packages/backend/libs/utilities/src/_tests_/unit/string-utils.translateToASCII.spec.ts
@@ -1,10 +1,9 @@
-import {
-  CARRIAGE_RETURN,
-  convertToASCIIString,
-  LINE_FEED,
-  NON_PRINTABLE_CHARACTERS_LIMIT,
-  UNEXPECTED_CHAR,
-} from "@sims/utilities/string-utils";
+import { convertToASCIIString } from "@sims/utilities/string-utils";
+
+const NON_PRINTABLE_CHARACTERS_LIMIT = 31;
+const CARRIAGE_RETURN = 13;
+const LINE_FEED = 10;
+const UNEXPECTED_CHAR = 63;
 
 describe("StringUtils-convertToASCII", () => {
   it("Should replace the special characters when equivalent ones are present.", () => {

--- a/sources/packages/backend/libs/utilities/src/_tests_/unit/string-utils.translateToASCII.spec.ts
+++ b/sources/packages/backend/libs/utilities/src/_tests_/unit/string-utils.translateToASCII.spec.ts
@@ -49,6 +49,6 @@ describe("StringUtils-convertToASCII", () => {
     // Act
     const translatedData = convertToASCIIString(controlChars);
     // Assert: all should be replaced by '?'
-    expect(translatedData).toBe("?".repeat(32));
+    expect(translatedData).toBe("?".repeat(controlChars.length));
   });
 });

--- a/sources/packages/backend/libs/utilities/src/_tests_/unit/string-utils.translateToASCII.spec.ts
+++ b/sources/packages/backend/libs/utilities/src/_tests_/unit/string-utils.translateToASCII.spec.ts
@@ -41,7 +41,10 @@ describe("StringUtils-convertToASCII", () => {
     // Arrange: create a string with characters from char code 0 to 31
     let controlChars = "";
     for (let i = 0; i <= 31; i++) {
-      controlChars += String.fromCharCode(i);
+      if (i !== 10 && i !== 13) {
+        // Exclude line feed (LF) and carriage return (CR) characters
+        controlChars += String.fromCharCode(i);
+      }
     }
     // Act
     const translatedData = convertToASCIIString(controlChars);

--- a/sources/packages/backend/libs/utilities/src/_tests_/unit/string-utils.translateToASCII.spec.ts
+++ b/sources/packages/backend/libs/utilities/src/_tests_/unit/string-utils.translateToASCII.spec.ts
@@ -1,4 +1,10 @@
-import { convertToASCIIString } from "@sims/utilities/string-utils";
+import {
+  CARRIAGE_RETURN,
+  convertToASCIIString,
+  LINE_FEED,
+  NON_PRINTABLE_CHARACTERS_LIMIT,
+  UNEXPECTED_CHAR,
+} from "@sims/utilities/string-utils";
 
 describe("StringUtils-convertToASCII", () => {
   it("Should replace the special characters when equivalent ones are present.", () => {
@@ -37,18 +43,22 @@ describe("StringUtils-convertToASCII", () => {
     expect(translatedData).toBeNull();
   });
 
-  it("Should replace ASCII control characters (0-31) with '?'", () => {
-    // Arrange: create a string with characters from char code 0 to 31
+  it("Should replace ASCII control characters (0-31) with '?' when they are not line feed or carriage return.", () => {
+    // Arrange
     let controlChars = "";
-    for (let i = 0; i <= 31; i++) {
-      if (i !== 10 && i !== 13) {
-        // Exclude line feed (LF) and carriage return (CR) characters
+    for (let i = 0; i <= NON_PRINTABLE_CHARACTERS_LIMIT; i++) {
+      if (i !== LINE_FEED && i !== CARRIAGE_RETURN) {
+        // Exclude line feed (LF) and carriage return (CR) characters.
         controlChars += String.fromCharCode(i);
       }
     }
+
     // Act
     const translatedData = convertToASCIIString(controlChars);
-    // Assert: all should be replaced by '?'
-    expect(translatedData).toBe("?".repeat(controlChars.length));
+
+    // Assert
+    expect(translatedData).toBe(
+      String.fromCharCode(UNEXPECTED_CHAR).repeat(controlChars.length),
+    );
   });
 });

--- a/sources/packages/backend/libs/utilities/src/_tests_/unit/string-utils.translateToASCII.spec.ts
+++ b/sources/packages/backend/libs/utilities/src/_tests_/unit/string-utils.translateToASCII.spec.ts
@@ -36,4 +36,16 @@ describe("StringUtils-convertToASCII", () => {
     // Assert
     expect(translatedData).toBeNull();
   });
+
+  it("Should replace ASCII control characters (0-31) with '?'", () => {
+    // Arrange: create a string with characters from char code 0 to 31
+    let controlChars = "";
+    for (let i = 0; i <= 31; i++) {
+      controlChars += String.fromCharCode(i);
+    }
+    // Act
+    const translatedData = convertToASCIIString(controlChars);
+    // Assert: all should be replaced by '?'
+    expect(translatedData).toBe("?".repeat(32));
+  });
 });

--- a/sources/packages/backend/libs/utilities/src/string-utils.ts
+++ b/sources/packages/backend/libs/utilities/src/string-utils.ts
@@ -49,7 +49,7 @@ export function convertToASCII(rawContent?: string): Buffer | null {
   });
   const content = Buffer.from(rawContent, FILE_DEFAULT_ENCODING);
   for (const [index, char] of content.entries()) {
-    if (char < 32) {
+    if (char < 32 && char !== 10 && char !== 13) {
       content[index] = 63; // Replace with ? for control characters.
     }
     if (char > 127) {

--- a/sources/packages/backend/libs/utilities/src/string-utils.ts
+++ b/sources/packages/backend/libs/utilities/src/string-utils.ts
@@ -49,6 +49,9 @@ export function convertToASCII(rawContent?: string): Buffer | null {
   });
   const content = Buffer.from(rawContent, FILE_DEFAULT_ENCODING);
   for (const [index, char] of content.entries()) {
+    if (char < 32) {
+      content[index] = 63; // Replace with ? for control characters.
+    }
     if (char > 127) {
       // If extended ascii.
       switch (char) {

--- a/sources/packages/backend/libs/utilities/src/string-utils.ts
+++ b/sources/packages/backend/libs/utilities/src/string-utils.ts
@@ -54,7 +54,7 @@ export function convertToASCII(rawContent?: string): Buffer | null {
   const content = Buffer.from(rawContent, FILE_DEFAULT_ENCODING);
   for (const [index, char] of content.entries()) {
     if (
-      char <= NONPRINTABLE_CHARACTERS_LIMIT &&
+      char <= NON_PRINTABLE_CHARACTERS_LIMIT &&
       char !== LINE_FEED &&
       char !== CARRIAGE_RETURN
     ) {

--- a/sources/packages/backend/libs/utilities/src/string-utils.ts
+++ b/sources/packages/backend/libs/utilities/src/string-utils.ts
@@ -146,7 +146,7 @@ export function convertToASCII(rawContent?: string): Buffer | null {
           content[index] = 121; // Replace with y.
           break;
         default:
-          content[index] = 63; // Replace with ? by default.
+          content[index] = UNEXPECTED_CHAR; // Replace with ? by default.
           break;
       }
     }

--- a/sources/packages/backend/libs/utilities/src/string-utils.ts
+++ b/sources/packages/backend/libs/utilities/src/string-utils.ts
@@ -1,6 +1,10 @@
 import { FILE_DEFAULT_ENCODING, UTF8_BYTE_ORDER_MARK } from "@sims/utilities";
 
 const REPLACE_LINE_BREAK_REGEX = /\r?\n|\r/g;
+export const NON_PRINTABLE_CHARACTERS_LIMIT = 31;
+export const CARRIAGE_RETURN = 13;
+export const LINE_FEED = 10;
+export const UNEXPECTED_CHAR = 63;
 
 /**
  * Replace the line breaks in the given text.
@@ -49,8 +53,12 @@ export function convertToASCII(rawContent?: string): Buffer | null {
   });
   const content = Buffer.from(rawContent, FILE_DEFAULT_ENCODING);
   for (const [index, char] of content.entries()) {
-    if (char < 32 && char !== 10 && char !== 13) {
-      content[index] = 63; // Replace with ? for control characters.
+    if (
+      char <= NONPRINTABLE_CHARACTERS_LIMIT &&
+      char !== LINE_FEED &&
+      char !== CARRIAGE_RETURN
+    ) {
+      content[index] = UNEXPECTED_CHAR; // Replace with ? for control characters.
     }
     if (char > 127) {
       // If extended ascii.

--- a/sources/packages/backend/libs/utilities/src/string-utils.ts
+++ b/sources/packages/backend/libs/utilities/src/string-utils.ts
@@ -1,10 +1,10 @@
 import { FILE_DEFAULT_ENCODING, UTF8_BYTE_ORDER_MARK } from "@sims/utilities";
 
 const REPLACE_LINE_BREAK_REGEX = /\r?\n|\r/g;
-export const NON_PRINTABLE_CHARACTERS_LIMIT = 31;
-export const CARRIAGE_RETURN = 13;
-export const LINE_FEED = 10;
-export const UNEXPECTED_CHAR = 63;
+const NON_PRINTABLE_CHARACTERS_LIMIT = 31;
+const CARRIAGE_RETURN = 13;
+const LINE_FEED = 10;
+const UNEXPECTED_CHAR = 63;
 
 /**
  * Replace the line breaks in the given text.


### PR DESCRIPTION
As a part of this PR, the following was added:

- Adapted the method `convertToASCII` to allow only printable characters from 0 to 127 (excluding newline and carriage return characters).
- Added a unit test to test it.