### PR TITLE
#4886 - Converting to ASCII [Encode URL]

### DIFF
--- a/sources/packages/backend/libs/integrations/src/cas/_tests_/unit/cas.service.getSupplierInfoFromCAS.spec.ts
+++ b/sources/packages/backend/libs/integrations/src/cas/_tests_/unit/cas.service.getSupplierInfoFromCAS.spec.ts
@@ -31,7 +31,7 @@ describe("CASService-getSupplierInfoFromCAS", () => {
 
     // Assert
     expect(httpService.axiosRef.get).toHaveBeenCalledWith(
-      "cas-url/cfs/supplier/LAST NAME WITH SPECIAL CHARACTERS: AEIOU-AEIOU/lastname/dummy_sin_value/sin",
+      "cas-url/cfs/supplier/LAST%20NAME%20WITH%20SPECIAL%20CHARACTERS%3A%20AEIOU-AEIOU/lastname/dummy_sin_value/sin",
       DEFAULT_CAS_AXIOS_AUTH_HEADER,
     );
   });

--- a/sources/packages/backend/libs/integrations/src/cas/cas.service.ts
+++ b/sources/packages/backend/libs/integrations/src/cas/cas.service.ts
@@ -112,7 +112,9 @@ export class CASService {
     sin: string,
     lastName: string,
   ): Promise<CASSupplierResponse> {
-    const convertedLastName = convertToASCIIString(lastName).toUpperCase();
+    const convertedLastName = encodeURIComponent(
+      convertToASCIIString(lastName).toUpperCase(),
+    );
     const url = `${this.casIntegrationConfig.baseUrl}/cfs/supplier/${convertedLastName}/lastname/${sin}/sin`;
     let response: { data: CASSupplierResponse };
     try {


### PR DESCRIPTION
**As a part of this PR, the URL in the `getSupplierInfoFromCAS` is encoded to ensure a valid URL is formed for the CAS api call.**