### PR TITLE
#5049 - BUG: History of Bypassed restrictions

### DIFF
--- a/sources/packages/web/src/components/aest/students/bypassedRestrictions/HistoryBypassedRestrictions.vue
+++ b/sources/packages/web/src/components/aest/students/bypassedRestrictions/HistoryBypassedRestrictions.vue
@@ -131,13 +131,6 @@ export default defineComponent({
       bypasses: [],
     } as ApplicationRestrictionBypassHistoryAPIOutDTO);
 
-    // Adding watch effect instead of onMounted because
-    // applicationId may not be not available on load.
-    watchEffect(
-      async () =>
-        props.applicationId && (await reloadBypassedRestrictionsHistory()),
-    );
-
     const getRemoveBypassLabel = (isBypassActive: boolean): string => {
       return isBypassActive ? "Remove Bypass" : "Bypass Removed";
     };
@@ -183,6 +176,13 @@ export default defineComponent({
           props.applicationId,
         );
     };
+
+    // Adding watch effect instead of onMounted because
+    // applicationId may not be not available on load.
+    watchEffect(
+      async () =>
+        props.applicationId && (await reloadBypassedRestrictionsHistory()),
+    );
 
     return {
       DEFAULT_PAGE_LIMIT,


### PR DESCRIPTION
**Bug Fix**
- Moved `WatchEffect` code block to end.
- but the reason is, reloadBypassedRestrictionsHistory  is not accessible from watch effect as it is defined after watch effect.
- When Ministry User adds bypass, Ministry user can go back and see the history of Bypass at any time.

**Error**
<img width="3730" height="300" alt="image" src="https://github.com/user-attachments/assets/67274fa5-57c6-46c1-9e87-0a7a623a7c6f" />

**Demo**
<img width="3324" height="1414" alt="image" src="https://github.com/user-attachments/assets/c7f04968-607f-4ccc-9215-35487a3a6316" />

