### PR TITLE
#4970 - Applications - application_status_updated_on

### DIFF
--- a/sources/packages/backend/apps/api/src/services/education-program-offering/education-program-offering.service.ts
+++ b/sources/packages/backend/apps/api/src/services/education-program-offering/education-program-offering.service.ts
@@ -1314,6 +1314,7 @@ export class EducationProgramOfferingService extends RecordDataModelService<Educ
         // then set the application as cancelled as it cannot be re-assessed.
         else {
           application.applicationStatus = ApplicationStatus.Cancelled;
+          application.applicationStatusUpdatedOn = currentDate;
 
           // Updates the current assessment status to cancellation required.
           application.currentAssessment.studentAssessmentStatus =

--- a/sources/packages/backend/apps/api/src/services/student-assessment/student-assessment.service.ts
+++ b/sources/packages/backend/apps/api/src/services/student-assessment/student-assessment.service.ts
@@ -210,6 +210,7 @@ export class StudentAssessmentService extends RecordDataModelService<StudentAsse
     const now = new Date();
     assessment.noaApprovalStatus = AssessmentStatus.completed;
     assessment.application.applicationStatus = ApplicationStatus.Enrolment;
+    assessment.application.applicationStatusUpdatedOn = now;
     // Populate the audit fields.
     assessment.application.modifier = auditUser;
     assessment.application.updatedAt = now;


### PR DESCRIPTION
PR Description: Application Status Updates

- Ensures data accuracy: This change consistently updates the application_status_updated_on field whenever an application's status is modified, providing an accurate timestamp for tracking its lifecycle.
- Fixes specific bug: It resolves an issue where the NOA Acceptance process failed to update the application_status_updated_on field when an application status changed from 'Assessment' to 'Enrolment'.

**Demo**
Step 1: Assessment Status
<img width="1186" height="244" alt="Screenshot 2025-08-25 at 3 19 02 PM" src="https://github.com/user-attachments/assets/aa3357a0-6c62-46a6-b7b3-dd99bcd4ae9a" />
Step 2: Enrollment Status
<img width="1272" height="234" alt="Screenshot 2025-08-25 at 3 19 33 PM" src="https://github.com/user-attachments/assets/30cea2a9-2535-4bdf-9ac4-cded2ae0ca0c" />
