### PR TITLE
#4378 - Ecert Cancellation - UI & Ministry Access (2/2)

### DIFF
--- a/sources/packages/backend/apps/api/src/app.aest.module.ts
+++ b/sources/packages/backend/apps/api/src/app.aest.module.ts
@@ -87,6 +87,7 @@ import {
   CASInvoiceAESTController,
   ApplicationChangeRequestAESTController,
   DynamicFormAESTController,
+  DisbursementScheduleAESTController,
 } from "./route-controllers";
 import { AuthModule } from "./auth/auth.module";
 import {
@@ -106,6 +107,7 @@ import {
   MSFAANumberSharedService,
   AssessmentSequentialProcessingService,
   CASSupplierSharedService,
+  DisbursementScheduleSharedService,
 } from "@sims/services";
 import { ECertIntegrationModule } from "@sims/integrations/esdc-integration";
 
@@ -140,6 +142,7 @@ import { ECertIntegrationModule } from "@sims/integrations/esdc-integration";
     ApplicationRestrictionBypassAESTController,
     ApplicationChangeRequestAESTController,
     DynamicFormAESTController,
+    DisbursementScheduleAESTController,
   ],
   providers: [
     ApplicationExceptionControllerService,
@@ -214,6 +217,7 @@ import { ECertIntegrationModule } from "@sims/integrations/esdc-integration";
     CASInvoiceService,
     CASInvoiceBatchReportService,
     ApplicationChangeRequestService,
+    DisbursementScheduleSharedService,
   ],
 })
 export class AppAESTModule {}

--- a/sources/packages/backend/apps/api/src/auth/roles.enum.ts
+++ b/sources/packages/backend/apps/api/src/auth/roles.enum.ts
@@ -26,6 +26,7 @@ export enum Role {
   StudentAddNewSIN = "student-add-new-sin",
   StudentCreateNote = "student-create-note",
   StudentConfirmEnrolment = "student-confirm-enrolment",
+  StudentCancelDisbursementSchedule = "student-cancel-disbursement-schedule",
   StudentAddOverawardManual = "student-add-overaward-manual",
   InstitutionEditProfile = "institution-edit-profile",
   InstitutionApproveDeclineProgram = "institution-approve-decline-program",

--- a/sources/packages/backend/apps/api/src/route-controllers/assessment/_tests_/e2e/assessment.aest.controller.getAssessmentAwardDetails.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/assessment/_tests_/e2e/assessment.aest.controller.getAssessmentAwardDetails.e2e-spec.ts
@@ -179,8 +179,7 @@ describe("AssessmentAESTController(e2e)-getAssessmentAwardDetails", () => {
           disbursement1DateSent: dateSent1.toISOString(),
           disbursement1DocumentNumber: firstSchedule.documentNumber,
           disbursement1Id: firstSchedule.id,
-          disbursement1DisbursementScheduleStatusUpdatedOn:
-            dateSent1.toISOString(),
+          disbursement1StatusUpdatedOn: dateSent1.toISOString(),
           disbursement1cslf: 1,
           disbursement1csgp: 2,
           disbursement1csgd: 3,
@@ -205,8 +204,7 @@ describe("AssessmentAESTController(e2e)-getAssessmentAwardDetails", () => {
           disbursement2DateSent: dateSent2.toISOString(),
           disbursement2DocumentNumber: secondSchedule.documentNumber,
           disbursement2Id: secondSchedule.id,
-          disbursement2DisbursementScheduleStatusUpdatedOn:
-            dateSent2.toISOString(),
+          disbursement2StatusUpdatedOn: dateSent2.toISOString(),
           disbursement2cslf: 100,
           disbursement2csgp: 200,
           disbursement2csgd: 300,
@@ -219,9 +217,10 @@ describe("AssessmentAESTController(e2e)-getAssessmentAwardDetails", () => {
           disbursement2EnrolmentDate: enrolmentDate2.toISOString(),
         },
         finalAward: {
-          receivedDisbursementReceipt1: true,
-          receivedDisbursementReceipt2: true,
+          disbursementReceipt1Received: true,
+          disbursementReceipt2Received: true,
           // First disbursement schedule receipt dynamic properties.
+          disbursementReceipt1HasAwards: true,
           disbursementReceipt1cslf: 1,
           disbursementReceipt1csgp: 2,
           disbursementReceipt1csgd: 3,
@@ -232,6 +231,7 @@ describe("AssessmentAESTController(e2e)-getAssessmentAwardDetails", () => {
           disbursementReceipt1bgpd: 8,
           disbursementReceipt1sbsd: 9,
           // Second disbursement schedule receipt dynamic properties.
+          disbursementReceipt2HasAwards: true,
           disbursementReceipt2cslf: 100,
           disbursementReceipt2csgp: 200,
           disbursementReceipt2csgd: 300,
@@ -398,8 +398,7 @@ describe("AssessmentAESTController(e2e)-getAssessmentAwardDetails", () => {
           disbursement1DateSent: dateSent1.toISOString(),
           disbursement1DocumentNumber: firstSchedule.documentNumber,
           disbursement1Id: firstSchedule.id,
-          disbursement1DisbursementScheduleStatusUpdatedOn:
-            dateSent1.toISOString(),
+          disbursement1StatusUpdatedOn: dateSent1.toISOString(),
           disbursement1cslp: 111,
           disbursement1csgp: 222,
           disbursement1cspt: 333,
@@ -421,8 +420,7 @@ describe("AssessmentAESTController(e2e)-getAssessmentAwardDetails", () => {
           disbursement2DateSent: dateSent2.toISOString(),
           disbursement2DocumentNumber: secondSchedule.documentNumber,
           disbursement2Id: secondSchedule.id,
-          disbursement2DisbursementScheduleStatusUpdatedOn:
-            dateSent2.toISOString(),
+          disbursement2StatusUpdatedOn: dateSent2.toISOString(),
           disbursement2cslp: 9999,
           disbursement2csgp: 1010,
           disbursement2cspt: 1111,
@@ -432,9 +430,10 @@ describe("AssessmentAESTController(e2e)-getAssessmentAwardDetails", () => {
           disbursement2EnrolmentDate: enrolmentDate2.toISOString(),
         },
         finalAward: {
-          receivedDisbursementReceipt1: true,
-          receivedDisbursementReceipt2: true,
+          disbursementReceipt1Received: true,
+          disbursementReceipt2Received: true,
           // First disbursement schedule receipt dynamic properties.
+          disbursementReceipt1HasAwards: true,
           disbursementReceipt1cslp: 110,
           disbursementReceipt1csgp: 220,
           disbursementReceipt1cspt: 330,
@@ -442,6 +441,7 @@ describe("AssessmentAESTController(e2e)-getAssessmentAwardDetails", () => {
           disbursementReceipt1bcag: 550,
           disbursementReceipt1sbsd: 660,
           // Second disbursement schedule receipt dynamic properties.
+          disbursementReceipt2HasAwards: true,
           disbursementReceipt2cslp: 9990,
           disbursementReceipt2csgp: 1010,
           disbursementReceipt2cspt: 1110,

--- a/sources/packages/backend/apps/api/src/route-controllers/assessment/_tests_/e2e/assessment.aest.controller.getAssessmentAwardDetails.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/assessment/_tests_/e2e/assessment.aest.controller.getAssessmentAwardDetails.e2e-spec.ts
@@ -128,12 +128,14 @@ describe("AssessmentAESTController(e2e)-getAssessmentAwardDetails", () => {
           dateSent: dateSent1,
           tuitionRemittanceRequestedAmount: 1099,
           coeUpdatedAt: enrolmentDate1,
+          disbursementScheduleStatusUpdatedOn: dateSent1,
         },
         secondDisbursementInitialValues: {
           disbursementScheduleStatus: DisbursementScheduleStatus.Sent,
           coeStatus: COEStatus.completed,
           dateSent: dateSent2,
           coeUpdatedAt: enrolmentDate2,
+          disbursementScheduleStatusUpdatedOn: dateSent2,
         },
       },
     );
@@ -177,6 +179,8 @@ describe("AssessmentAESTController(e2e)-getAssessmentAwardDetails", () => {
           disbursement1DateSent: dateSent1.toISOString(),
           disbursement1DocumentNumber: firstSchedule.documentNumber,
           disbursement1Id: firstSchedule.id,
+          disbursement1DisbursementScheduleStatusUpdatedOn:
+            dateSent1.toISOString(),
           disbursement1cslf: 1,
           disbursement1csgp: 2,
           disbursement1csgd: 3,
@@ -201,6 +205,8 @@ describe("AssessmentAESTController(e2e)-getAssessmentAwardDetails", () => {
           disbursement2DateSent: dateSent2.toISOString(),
           disbursement2DocumentNumber: secondSchedule.documentNumber,
           disbursement2Id: secondSchedule.id,
+          disbursement2DisbursementScheduleStatusUpdatedOn:
+            dateSent2.toISOString(),
           disbursement2cslf: 100,
           disbursement2csgp: 200,
           disbursement2csgd: 300,
@@ -213,6 +219,8 @@ describe("AssessmentAESTController(e2e)-getAssessmentAwardDetails", () => {
           disbursement2EnrolmentDate: enrolmentDate2.toISOString(),
         },
         finalAward: {
+          receivedDisbursementReceipt1: true,
+          receivedDisbursementReceipt2: true,
           // First disbursement schedule receipt dynamic properties.
           disbursementReceipt1cslf: 1,
           disbursementReceipt1csgp: 2,
@@ -338,6 +346,7 @@ describe("AssessmentAESTController(e2e)-getAssessmentAwardDetails", () => {
           disbursementScheduleStatus: DisbursementScheduleStatus.Sent,
           dateSent: dateSent1,
           coeUpdatedAt: enrolmentDate1,
+          disbursementScheduleStatusUpdatedOn: dateSent1,
         },
         secondDisbursementInitialValues: {
           disbursementScheduleStatus: DisbursementScheduleStatus.Sent,
@@ -345,6 +354,7 @@ describe("AssessmentAESTController(e2e)-getAssessmentAwardDetails", () => {
           tuitionRemittanceRequestedAmount: 9876,
           dateSent: dateSent2,
           coeUpdatedAt: enrolmentDate2,
+          disbursementScheduleStatusUpdatedOn: dateSent2,
         },
       },
     );
@@ -388,6 +398,8 @@ describe("AssessmentAESTController(e2e)-getAssessmentAwardDetails", () => {
           disbursement1DateSent: dateSent1.toISOString(),
           disbursement1DocumentNumber: firstSchedule.documentNumber,
           disbursement1Id: firstSchedule.id,
+          disbursement1DisbursementScheduleStatusUpdatedOn:
+            dateSent1.toISOString(),
           disbursement1cslp: 111,
           disbursement1csgp: 222,
           disbursement1cspt: 333,
@@ -409,6 +421,8 @@ describe("AssessmentAESTController(e2e)-getAssessmentAwardDetails", () => {
           disbursement2DateSent: dateSent2.toISOString(),
           disbursement2DocumentNumber: secondSchedule.documentNumber,
           disbursement2Id: secondSchedule.id,
+          disbursement2DisbursementScheduleStatusUpdatedOn:
+            dateSent2.toISOString(),
           disbursement2cslp: 9999,
           disbursement2csgp: 1010,
           disbursement2cspt: 1111,
@@ -418,6 +432,8 @@ describe("AssessmentAESTController(e2e)-getAssessmentAwardDetails", () => {
           disbursement2EnrolmentDate: enrolmentDate2.toISOString(),
         },
         finalAward: {
+          receivedDisbursementReceipt1: true,
+          receivedDisbursementReceipt2: true,
           // First disbursement schedule receipt dynamic properties.
           disbursementReceipt1cslp: 110,
           disbursementReceipt1csgp: 220,

--- a/sources/packages/backend/apps/api/src/route-controllers/assessment/_tests_/e2e/assessment.institutions.controller.getAssessmentAwardDetails.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/assessment/_tests_/e2e/assessment.institutions.controller.getAssessmentAwardDetails.e2e-spec.ts
@@ -61,8 +61,8 @@ describe("AssessmentInstitutionsController(e2e)-getAssessmentAwardDetails", () =
 
   it("Should get the student award details for an eligible application when an eligible public institution user tries to access it.", async () => {
     // Arrange
-    const now = new Date();
     const enrolmentDate1 = addDays(1);
+    const statusUpdatedOn = new Date();
     // Student has an application to the institution with award details.
     const student = await saveFakeStudent(db.dataSource);
 
@@ -86,7 +86,7 @@ describe("AssessmentInstitutionsController(e2e)-getAssessmentAwardDetails", () =
         firstDisbursementInitialValues: {
           disbursementScheduleStatus: DisbursementScheduleStatus.Sent,
           coeUpdatedAt: enrolmentDate1,
-          disbursementScheduleStatusUpdatedOn: now,
+          disbursementScheduleStatusUpdatedOn: statusUpdatedOn,
         },
       },
     );
@@ -165,7 +165,7 @@ describe("AssessmentInstitutionsController(e2e)-getAssessmentAwardDetails", () =
           disbursement1Id: firstDisbursementSchedule.id,
           disbursement1DocumentNumber: firstDisbursementSchedule.documentNumber,
           disbursement1EnrolmentDate: enrolmentDate1.toISOString(),
-          disbursement1DisbursementScheduleStatusUpdatedOn: now.toISOString(),
+          disbursement1StatusUpdatedOn: statusUpdatedOn.toISOString(),
           ...awards,
         },
         finalAward: finalAwards,

--- a/sources/packages/backend/apps/api/src/route-controllers/assessment/_tests_/e2e/assessment.institutions.controller.getAssessmentAwardDetails.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/assessment/_tests_/e2e/assessment.institutions.controller.getAssessmentAwardDetails.e2e-spec.ts
@@ -117,7 +117,10 @@ describe("AssessmentInstitutionsController(e2e)-getAssessmentAwardDetails", () =
     });
     await db.disbursementReceiptValue.save(disbursementReceiptsValues);
 
-    const finalAwards = { receivedDisbursementReceipt1: true };
+    const finalAwards = {
+      disbursementReceipt1Received: true,
+      disbursementReceipt1HasAwards: true,
+    };
 
     disbursementReceiptsValues.forEach((disbursementReceiptsValue) => {
       finalAwards[

--- a/sources/packages/backend/apps/api/src/route-controllers/assessment/_tests_/e2e/assessment.institutions.controller.getAssessmentAwardDetails.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/assessment/_tests_/e2e/assessment.institutions.controller.getAssessmentAwardDetails.e2e-spec.ts
@@ -61,6 +61,7 @@ describe("AssessmentInstitutionsController(e2e)-getAssessmentAwardDetails", () =
 
   it("Should get the student award details for an eligible application when an eligible public institution user tries to access it.", async () => {
     // Arrange
+    const now = new Date();
     const enrolmentDate1 = addDays(1);
     // Student has an application to the institution with award details.
     const student = await saveFakeStudent(db.dataSource);
@@ -85,6 +86,7 @@ describe("AssessmentInstitutionsController(e2e)-getAssessmentAwardDetails", () =
         firstDisbursementInitialValues: {
           disbursementScheduleStatus: DisbursementScheduleStatus.Sent,
           coeUpdatedAt: enrolmentDate1,
+          disbursementScheduleStatusUpdatedOn: now,
         },
       },
     );
@@ -115,7 +117,7 @@ describe("AssessmentInstitutionsController(e2e)-getAssessmentAwardDetails", () =
     });
     await db.disbursementReceiptValue.save(disbursementReceiptsValues);
 
-    const finalAwards = {};
+    const finalAwards = { receivedDisbursementReceipt1: true };
 
     disbursementReceiptsValues.forEach((disbursementReceiptsValue) => {
       finalAwards[
@@ -163,6 +165,7 @@ describe("AssessmentInstitutionsController(e2e)-getAssessmentAwardDetails", () =
           disbursement1Id: firstDisbursementSchedule.id,
           disbursement1DocumentNumber: firstDisbursementSchedule.documentNumber,
           disbursement1EnrolmentDate: enrolmentDate1.toISOString(),
+          disbursement1DisbursementScheduleStatusUpdatedOn: now.toISOString(),
           ...awards,
         },
         finalAward: finalAwards,

--- a/sources/packages/backend/apps/api/src/route-controllers/assessment/_tests_/e2e/assessment.institutions.controller.getAssessmentNOA.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/assessment/_tests_/e2e/assessment.institutions.controller.getAssessmentNOA.e2e-spec.ts
@@ -127,8 +127,7 @@ describe("AssessmentInstitutionsController(e2e)-getAssessmentNOA", () => {
             firstDisbursementSchedule.disbursementDate,
           ),
           disbursement1Id: firstDisbursementSchedule.id,
-          disbursement1DisbursementScheduleStatusUpdatedOn:
-            statusUpdatedOn1.toISOString(),
+          disbursement1StatusUpdatedOn: statusUpdatedOn1.toISOString(),
           disbursement1MSFAACancelledDate:
             firstDisbursementSchedule.msfaaNumber?.cancelledDate,
           disbursement1MSFAADateSigned:
@@ -146,8 +145,7 @@ describe("AssessmentInstitutionsController(e2e)-getAssessmentNOA", () => {
             secondDisbursementSchedule.disbursementDate,
           ),
           disbursement2Id: secondDisbursementSchedule.id,
-          disbursement2DisbursementScheduleStatusUpdatedOn:
-            statusUpdatedOn2.toISOString(),
+          disbursement2StatusUpdatedOn: statusUpdatedOn2.toISOString(),
           disbursement2MSFAACancelledDate:
             secondDisbursementSchedule.msfaaNumber?.cancelledDate,
           disbursement2MSFAADateSigned:
@@ -251,8 +249,7 @@ describe("AssessmentInstitutionsController(e2e)-getAssessmentNOA", () => {
             firstDisbursementSchedule.disbursementDate,
           ),
           disbursement1Id: firstDisbursementSchedule.id,
-          disbursement1DisbursementScheduleStatusUpdatedOn:
-            statusUpdatedOn1.toISOString(),
+          disbursement1StatusUpdatedOn: statusUpdatedOn1.toISOString(),
           disbursement1MSFAACancelledDate:
             firstDisbursementSchedule.msfaaNumber?.cancelledDate,
           disbursement1MSFAADateSigned:
@@ -270,8 +267,7 @@ describe("AssessmentInstitutionsController(e2e)-getAssessmentNOA", () => {
             secondDisbursementSchedule.disbursementDate,
           ),
           disbursement2Id: secondDisbursementSchedule.id,
-          disbursement2DisbursementScheduleStatusUpdatedOn:
-            statusUpdatedOn2.toISOString(),
+          disbursement2StatusUpdatedOn: statusUpdatedOn2.toISOString(),
           disbursement2MSFAACancelledDate:
             secondDisbursementSchedule.msfaaNumber?.cancelledDate,
           disbursement2MSFAADateSigned:

--- a/sources/packages/backend/apps/api/src/route-controllers/assessment/_tests_/e2e/assessment.institutions.controller.getAssessmentNOA.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/assessment/_tests_/e2e/assessment.institutions.controller.getAssessmentNOA.e2e-spec.ts
@@ -57,6 +57,7 @@ describe("AssessmentInstitutionsController(e2e)-getAssessmentNOA", () => {
   it("Should get the student noa details for an eligible full time application when an eligible public institution user tries to access it.", async () => {
     // Arrange
     const [enrolmentDate1, enrolmentDate2] = [addDays(1), addDays(30)];
+    const [statusUpdatedOn1, statusUpdatedOn2] = [addDays(2), addDays(31)];
     // Student has an application to the institution eligible for NOA.
     const student = await saveFakeStudent(db.dataSource);
 
@@ -78,8 +79,14 @@ describe("AssessmentInstitutionsController(e2e)-getAssessmentNOA", () => {
       {
         offeringIntensity: OfferingIntensity.fullTime,
         createSecondDisbursement: true,
-        firstDisbursementInitialValues: { coeUpdatedAt: enrolmentDate1 },
-        secondDisbursementInitialValues: { coeUpdatedAt: enrolmentDate2 },
+        firstDisbursementInitialValues: {
+          coeUpdatedAt: enrolmentDate1,
+          disbursementScheduleStatusUpdatedOn: statusUpdatedOn1,
+        },
+        secondDisbursementInitialValues: {
+          coeUpdatedAt: enrolmentDate2,
+          disbursementScheduleStatusUpdatedOn: statusUpdatedOn2,
+        },
       },
     );
     const assessment = application.currentAssessment;
@@ -120,6 +127,8 @@ describe("AssessmentInstitutionsController(e2e)-getAssessmentNOA", () => {
             firstDisbursementSchedule.disbursementDate,
           ),
           disbursement1Id: firstDisbursementSchedule.id,
+          disbursement1DisbursementScheduleStatusUpdatedOn:
+            statusUpdatedOn1.toISOString(),
           disbursement1MSFAACancelledDate:
             firstDisbursementSchedule.msfaaNumber?.cancelledDate,
           disbursement1MSFAADateSigned:
@@ -137,6 +146,8 @@ describe("AssessmentInstitutionsController(e2e)-getAssessmentNOA", () => {
             secondDisbursementSchedule.disbursementDate,
           ),
           disbursement2Id: secondDisbursementSchedule.id,
+          disbursement2DisbursementScheduleStatusUpdatedOn:
+            statusUpdatedOn2.toISOString(),
           disbursement2MSFAACancelledDate:
             secondDisbursementSchedule.msfaaNumber?.cancelledDate,
           disbursement2MSFAADateSigned:
@@ -170,6 +181,7 @@ describe("AssessmentInstitutionsController(e2e)-getAssessmentNOA", () => {
   it("Should get the student noa details for an eligible part time application when an eligible public institution user tries to access it.", async () => {
     // Arrange
     const [enrolmentDate1, enrolmentDate2] = [addDays(1), addDays(30)];
+    const [statusUpdatedOn1, statusUpdatedOn2] = [addDays(2), addDays(31)];
     // Student has an application to the institution eligible for NOA.
     const student = await saveFakeStudent(db.dataSource);
 
@@ -191,8 +203,14 @@ describe("AssessmentInstitutionsController(e2e)-getAssessmentNOA", () => {
       {
         offeringIntensity: OfferingIntensity.partTime,
         createSecondDisbursement: true,
-        firstDisbursementInitialValues: { coeUpdatedAt: enrolmentDate1 },
-        secondDisbursementInitialValues: { coeUpdatedAt: enrolmentDate2 },
+        firstDisbursementInitialValues: {
+          coeUpdatedAt: enrolmentDate1,
+          disbursementScheduleStatusUpdatedOn: statusUpdatedOn1,
+        },
+        secondDisbursementInitialValues: {
+          coeUpdatedAt: enrolmentDate2,
+          disbursementScheduleStatusUpdatedOn: statusUpdatedOn2,
+        },
       },
     );
     const assessment = application.currentAssessment;
@@ -233,6 +251,8 @@ describe("AssessmentInstitutionsController(e2e)-getAssessmentNOA", () => {
             firstDisbursementSchedule.disbursementDate,
           ),
           disbursement1Id: firstDisbursementSchedule.id,
+          disbursement1DisbursementScheduleStatusUpdatedOn:
+            statusUpdatedOn1.toISOString(),
           disbursement1MSFAACancelledDate:
             firstDisbursementSchedule.msfaaNumber?.cancelledDate,
           disbursement1MSFAADateSigned:
@@ -250,6 +270,8 @@ describe("AssessmentInstitutionsController(e2e)-getAssessmentNOA", () => {
             secondDisbursementSchedule.disbursementDate,
           ),
           disbursement2Id: secondDisbursementSchedule.id,
+          disbursement2DisbursementScheduleStatusUpdatedOn:
+            statusUpdatedOn2.toISOString(),
           disbursement2MSFAACancelledDate:
             secondDisbursementSchedule.msfaaNumber?.cancelledDate,
           disbursement2MSFAADateSigned:

--- a/sources/packages/backend/apps/api/src/route-controllers/assessment/_tests_/e2e/assessment.students.controller.getAssessmentAwardDetails.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/assessment/_tests_/e2e/assessment.students.controller.getAssessmentAwardDetails.e2e-spec.ts
@@ -58,8 +58,8 @@ describe("AssessmentStudentsController(e2e)-getAssessmentAwardDetails", () => {
 
   it("Should get the student assessment summary containing loan and all grants values from e-Cert effective amount for a part-time application with a single disbursement.", async () => {
     // Arrange
-    const dateStatusUpdatedOn = new Date();
     const enrolmentDate1 = addDays(1);
+    const statusUpdatedOn = new Date();
     // First disbursement values.
     const firstDisbursementValues = [
       createFakeDisbursementValue(
@@ -116,7 +116,7 @@ describe("AssessmentStudentsController(e2e)-getAssessmentAwardDetails", () => {
           // Adding date sent to ensure that will not be returned by the API (students should not receive it).
           dateSent: new Date(),
           coeUpdatedAt: enrolmentDate1,
-          disbursementScheduleStatusUpdatedOn: dateStatusUpdatedOn,
+          disbursementScheduleStatusUpdatedOn: statusUpdatedOn,
         },
         secondDisbursementInitialValues: {
           disbursementScheduleStatus: DisbursementScheduleStatus.Sent,
@@ -158,8 +158,7 @@ describe("AssessmentStudentsController(e2e)-getAssessmentAwardDetails", () => {
           disbursement1EnrolmentDate: enrolmentDate1.toISOString(),
           disbursement1TuitionRemittance: 0,
           disbursement1Id: firstSchedule.id,
-          disbursement1DisbursementScheduleStatusUpdatedOn:
-            dateStatusUpdatedOn.toISOString(),
+          disbursement1StatusUpdatedOn: statusUpdatedOn.toISOString(),
           disbursement1cslp: 111,
           disbursement1csgp: 222,
           disbursement1cspt: 333,
@@ -168,7 +167,7 @@ describe("AssessmentStudentsController(e2e)-getAssessmentAwardDetails", () => {
           disbursement1sbsd: 666,
         },
         finalAward: {
-          receivedDisbursementReceipt1: false,
+          disbursementReceipt1Received: false,
           disbursementReceipt1cslp: 110,
           disbursementReceipt1csgp: 220,
           disbursementReceipt1cspt: 330,
@@ -330,8 +329,7 @@ describe("AssessmentStudentsController(e2e)-getAssessmentAwardDetails", () => {
           disbursement1MSFAADateSigned: sharedMSFAANumber.dateSigned,
           disbursement1TuitionRemittance: 0,
           disbursement1Id: firstSchedule.id,
-          disbursement1DisbursementScheduleStatusUpdatedOn:
-            statusUpdatedOn1.toISOString(),
+          disbursement1StatusUpdatedOn: statusUpdatedOn1.toISOString(),
           disbursement1cslp: 111,
           disbursement1csgp: 222,
           disbursement1cspt: 333,
@@ -351,8 +349,7 @@ describe("AssessmentStudentsController(e2e)-getAssessmentAwardDetails", () => {
           disbursement2MSFAADateSigned: sharedMSFAANumber.dateSigned,
           disbursement2TuitionRemittance: 9876,
           disbursement2Id: secondSchedule.id,
-          disbursement2DisbursementScheduleStatusUpdatedOn:
-            statusUpdatedOn2.toISOString(),
+          disbursement2StatusUpdatedOn: statusUpdatedOn2.toISOString(),
           disbursement2cslp: 9999,
           disbursement2csgp: 1010,
           disbursement2cspt: 1111,
@@ -362,9 +359,9 @@ describe("AssessmentStudentsController(e2e)-getAssessmentAwardDetails", () => {
           disbursement2EnrolmentDate: enrolmentDate2.toISOString(),
         },
         finalAward: {
-          receivedDisbursementReceipt1: true,
-          receivedDisbursementReceipt2: true,
           // First disbursement schedule receipt dynamic properties.
+          disbursementReceipt1Received: true,
+          disbursementReceipt1HasAwards: true,
           disbursementReceipt1cslp: 110,
           disbursementReceipt1csgp: 220,
           disbursementReceipt1cspt: 330,
@@ -372,6 +369,8 @@ describe("AssessmentStudentsController(e2e)-getAssessmentAwardDetails", () => {
           disbursementReceipt1bcag: 550,
           disbursementReceipt1sbsd: 660,
           // Second disbursement schedule receipt dynamic properties.
+          disbursementReceipt2Received: true,
+          disbursementReceipt2HasAwards: true,
           disbursementReceipt2cslp: 9990,
           disbursementReceipt2csgp: 1010,
           disbursementReceipt2cspt: 1110,
@@ -443,8 +442,7 @@ describe("AssessmentStudentsController(e2e)-getAssessmentAwardDetails", () => {
           disbursement1MSFAADateSigned: sharedMSFAANumber.dateSigned,
           disbursement1TuitionRemittance: 0,
           disbursement1Id: firstSchedule.id,
-          disbursement1DisbursementScheduleStatusUpdatedOn:
-            statusUpdatedOn.toISOString(),
+          disbursement1StatusUpdatedOn: statusUpdatedOn.toISOString(),
           disbursement1cslp: 111,
           disbursement1EnrolmentDate: enrolmentDate1.toISOString(),
         },
@@ -597,8 +595,7 @@ describe("AssessmentStudentsController(e2e)-getAssessmentAwardDetails", () => {
           disbursement1MSFAADateSigned: sharedMSFAANumber.dateSigned,
           disbursement1TuitionRemittance: 1099,
           disbursement1Id: firstSchedule.id,
-          disbursement1DisbursementScheduleStatusUpdatedOn:
-            statusUpdatedOn1.toISOString(),
+          disbursement1StatusUpdatedOn: statusUpdatedOn1.toISOString(),
           disbursement1cslf: 1000,
           disbursement1csgp: 10001,
           disbursement1csgd: 1002,
@@ -621,8 +618,7 @@ describe("AssessmentStudentsController(e2e)-getAssessmentAwardDetails", () => {
           disbursement2MSFAADateSigned: sharedMSFAANumber.dateSigned,
           disbursement2TuitionRemittance: 0,
           disbursement2Id: secondSchedule.id,
-          disbursement2DisbursementScheduleStatusUpdatedOn:
-            statusUpdatedOn2.toISOString(),
+          disbursement2StatusUpdatedOn: statusUpdatedOn2.toISOString(),
           disbursement2cslf: 10010,
           disbursement2csgp: 10011,
           disbursement2csgd: 10012,
@@ -635,8 +631,8 @@ describe("AssessmentStudentsController(e2e)-getAssessmentAwardDetails", () => {
           disbursement2EnrolmentDate: enrolmentDate2.toISOString(),
         },
         finalAward: {
-          receivedDisbursementReceipt1: true,
-          receivedDisbursementReceipt2: true,
+          disbursementReceipt1Received: true,
+          disbursementReceipt2Received: true,
           // First disbursement schedule receipt dynamic properties.
           disbursementReceipt1cslf: 1000,
           disbursementReceipt1csgp: 10001,
@@ -663,8 +659,8 @@ describe("AssessmentStudentsController(e2e)-getAssessmentAwardDetails", () => {
 
   it("Should get the student assessment summary containing federal, provincial loan, all federal grants and no provincial grants values for a full-time application when the BCSG does not match.", async () => {
     // Arrange
-    const statusUpdatedOn = new Date();
     const enrolmentDate1 = addDays(1);
+    const statusUpdatedOn = new Date();
     // First disbursement values.
     const firstDisbursementValues = [
       createFakeDisbursementValue(DisbursementValueType.CanadaLoan, "CSLF", 1),
@@ -740,8 +736,7 @@ describe("AssessmentStudentsController(e2e)-getAssessmentAwardDetails", () => {
           disbursement1MSFAADateSigned: sharedMSFAANumber.dateSigned,
           disbursement1TuitionRemittance: 0,
           disbursement1Id: firstSchedule.id,
-          disbursement1DisbursementScheduleStatusUpdatedOn:
-            statusUpdatedOn.toISOString(),
+          disbursement1StatusUpdatedOn: statusUpdatedOn.toISOString(),
           disbursement1cslf: 1,
           disbursement1csgp: 2,
           disbursement1bcsl: 3,
@@ -750,7 +745,7 @@ describe("AssessmentStudentsController(e2e)-getAssessmentAwardDetails", () => {
           disbursement1EnrolmentDate: enrolmentDate1.toISOString(),
         },
         finalAward: {
-          receivedDisbursementReceipt1: true,
+          disbursementReceipt1Received: true,
           disbursementReceipt1cslf: 1,
           disbursementReceipt1csgp: 2,
           disbursementReceipt1bcsl: 3,

--- a/sources/packages/backend/apps/api/src/route-controllers/assessment/_tests_/e2e/assessment.students.controller.getAssessmentAwardDetails.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/assessment/_tests_/e2e/assessment.students.controller.getAssessmentAwardDetails.e2e-spec.ts
@@ -57,6 +57,8 @@ describe("AssessmentStudentsController(e2e)-getAssessmentAwardDetails", () => {
   });
 
   it("Should get the student assessment summary containing loan and all grants values from e-Cert effective amount for a part-time application with a single disbursement.", async () => {
+    // Arrange
+    const dateStatusUpdatedOn = new Date();
     const enrolmentDate1 = addDays(1);
     // First disbursement values.
     const firstDisbursementValues = [
@@ -114,6 +116,7 @@ describe("AssessmentStudentsController(e2e)-getAssessmentAwardDetails", () => {
           // Adding date sent to ensure that will not be returned by the API (students should not receive it).
           dateSent: new Date(),
           coeUpdatedAt: enrolmentDate1,
+          disbursementScheduleStatusUpdatedOn: dateStatusUpdatedOn,
         },
         secondDisbursementInitialValues: {
           disbursementScheduleStatus: DisbursementScheduleStatus.Sent,
@@ -155,6 +158,8 @@ describe("AssessmentStudentsController(e2e)-getAssessmentAwardDetails", () => {
           disbursement1EnrolmentDate: enrolmentDate1.toISOString(),
           disbursement1TuitionRemittance: 0,
           disbursement1Id: firstSchedule.id,
+          disbursement1DisbursementScheduleStatusUpdatedOn:
+            dateStatusUpdatedOn.toISOString(),
           disbursement1cslp: 111,
           disbursement1csgp: 222,
           disbursement1cspt: 333,
@@ -163,6 +168,7 @@ describe("AssessmentStudentsController(e2e)-getAssessmentAwardDetails", () => {
           disbursement1sbsd: 666,
         },
         finalAward: {
+          receivedDisbursementReceipt1: false,
           disbursementReceipt1cslp: 110,
           disbursementReceipt1csgp: 220,
           disbursementReceipt1cspt: 330,
@@ -174,7 +180,9 @@ describe("AssessmentStudentsController(e2e)-getAssessmentAwardDetails", () => {
   });
 
   it("Should get the student assessment summary containing loan and all grants values from e-Cert effective amount for a part-time application with two disbursements.", async () => {
+    // Arrange
     const [enrolmentDate1, enrolmentDate2] = [addDays(1), addDays(30)];
+    const [statusUpdatedOn1, statusUpdatedOn2] = [addDays(2), addDays(31)];
     // First disbursement values.
     const firstDisbursementValues = [
       createFakeDisbursementValue(
@@ -271,12 +279,14 @@ describe("AssessmentStudentsController(e2e)-getAssessmentAwardDetails", () => {
         firstDisbursementInitialValues: {
           disbursementScheduleStatus: DisbursementScheduleStatus.Sent,
           coeUpdatedAt: enrolmentDate1,
+          disbursementScheduleStatusUpdatedOn: statusUpdatedOn1,
         },
         secondDisbursementInitialValues: {
           disbursementScheduleStatus: DisbursementScheduleStatus.Sent,
           coeStatus: COEStatus.completed,
           tuitionRemittanceRequestedAmount: 9876,
           coeUpdatedAt: enrolmentDate2,
+          disbursementScheduleStatusUpdatedOn: statusUpdatedOn2,
         },
       },
     );
@@ -320,6 +330,8 @@ describe("AssessmentStudentsController(e2e)-getAssessmentAwardDetails", () => {
           disbursement1MSFAADateSigned: sharedMSFAANumber.dateSigned,
           disbursement1TuitionRemittance: 0,
           disbursement1Id: firstSchedule.id,
+          disbursement1DisbursementScheduleStatusUpdatedOn:
+            statusUpdatedOn1.toISOString(),
           disbursement1cslp: 111,
           disbursement1csgp: 222,
           disbursement1cspt: 333,
@@ -339,6 +351,8 @@ describe("AssessmentStudentsController(e2e)-getAssessmentAwardDetails", () => {
           disbursement2MSFAADateSigned: sharedMSFAANumber.dateSigned,
           disbursement2TuitionRemittance: 9876,
           disbursement2Id: secondSchedule.id,
+          disbursement2DisbursementScheduleStatusUpdatedOn:
+            statusUpdatedOn2.toISOString(),
           disbursement2cslp: 9999,
           disbursement2csgp: 1010,
           disbursement2cspt: 1111,
@@ -348,6 +362,8 @@ describe("AssessmentStudentsController(e2e)-getAssessmentAwardDetails", () => {
           disbursement2EnrolmentDate: enrolmentDate2.toISOString(),
         },
         finalAward: {
+          receivedDisbursementReceipt1: true,
+          receivedDisbursementReceipt2: true,
           // First disbursement schedule receipt dynamic properties.
           disbursementReceipt1cslp: 110,
           disbursementReceipt1csgp: 220,
@@ -367,6 +383,8 @@ describe("AssessmentStudentsController(e2e)-getAssessmentAwardDetails", () => {
   });
 
   it("Should not generate final award values for a part-time application when the disbursement has not been sent yet.", async () => {
+    // Arrange
+    const statusUpdatedOn = new Date();
     const enrolmentDate1 = addDays(1);
     const firstDisbursementValues = [
       createFakeDisbursementValue(
@@ -389,6 +407,7 @@ describe("AssessmentStudentsController(e2e)-getAssessmentAwardDetails", () => {
         firstDisbursementInitialValues: {
           disbursementScheduleStatus: DisbursementScheduleStatus.Pending,
           coeUpdatedAt: enrolmentDate1,
+          disbursementScheduleStatusUpdatedOn: statusUpdatedOn,
         },
       },
     );
@@ -424,6 +443,8 @@ describe("AssessmentStudentsController(e2e)-getAssessmentAwardDetails", () => {
           disbursement1MSFAADateSigned: sharedMSFAANumber.dateSigned,
           disbursement1TuitionRemittance: 0,
           disbursement1Id: firstSchedule.id,
+          disbursement1DisbursementScheduleStatusUpdatedOn:
+            statusUpdatedOn.toISOString(),
           disbursement1cslp: 111,
           disbursement1EnrolmentDate: enrolmentDate1.toISOString(),
         },
@@ -432,6 +453,7 @@ describe("AssessmentStudentsController(e2e)-getAssessmentAwardDetails", () => {
 
   it("Should get the student assessment summary containing federal and provincial loans and all grants for a full-time application with two disbursements.", async () => {
     const [enrolmentDate1, enrolmentDate2] = [addDays(1), addDays(30)];
+    const [statusUpdatedOn1, statusUpdatedOn2] = [addDays(2), addDays(31)];
     // First disbursement values.
     const firstDisbursementValues = [
       createFakeDisbursementValue(
@@ -525,11 +547,13 @@ describe("AssessmentStudentsController(e2e)-getAssessmentAwardDetails", () => {
           // Adding date sent to ensure that will not be returned by the API (students should not receive it).
           dateSent: new Date(),
           coeUpdatedAt: enrolmentDate1,
+          disbursementScheduleStatusUpdatedOn: statusUpdatedOn1,
         },
         secondDisbursementInitialValues: {
           disbursementScheduleStatus: DisbursementScheduleStatus.Sent,
           coeStatus: COEStatus.completed,
           coeUpdatedAt: enrolmentDate2,
+          disbursementScheduleStatusUpdatedOn: statusUpdatedOn2,
         },
       },
     );
@@ -573,6 +597,8 @@ describe("AssessmentStudentsController(e2e)-getAssessmentAwardDetails", () => {
           disbursement1MSFAADateSigned: sharedMSFAANumber.dateSigned,
           disbursement1TuitionRemittance: 1099,
           disbursement1Id: firstSchedule.id,
+          disbursement1DisbursementScheduleStatusUpdatedOn:
+            statusUpdatedOn1.toISOString(),
           disbursement1cslf: 1000,
           disbursement1csgp: 10001,
           disbursement1csgd: 1002,
@@ -595,6 +621,8 @@ describe("AssessmentStudentsController(e2e)-getAssessmentAwardDetails", () => {
           disbursement2MSFAADateSigned: sharedMSFAANumber.dateSigned,
           disbursement2TuitionRemittance: 0,
           disbursement2Id: secondSchedule.id,
+          disbursement2DisbursementScheduleStatusUpdatedOn:
+            statusUpdatedOn2.toISOString(),
           disbursement2cslf: 10010,
           disbursement2csgp: 10011,
           disbursement2csgd: 10012,
@@ -607,6 +635,8 @@ describe("AssessmentStudentsController(e2e)-getAssessmentAwardDetails", () => {
           disbursement2EnrolmentDate: enrolmentDate2.toISOString(),
         },
         finalAward: {
+          receivedDisbursementReceipt1: true,
+          receivedDisbursementReceipt2: true,
           // First disbursement schedule receipt dynamic properties.
           disbursementReceipt1cslf: 1000,
           disbursementReceipt1csgp: 10001,
@@ -632,6 +662,8 @@ describe("AssessmentStudentsController(e2e)-getAssessmentAwardDetails", () => {
   });
 
   it("Should get the student assessment summary containing federal, provincial loan, all federal grants and no provincial grants values for a full-time application when the BCSG does not match.", async () => {
+    // Arrange
+    const statusUpdatedOn = new Date();
     const enrolmentDate1 = addDays(1);
     // First disbursement values.
     const firstDisbursementValues = [
@@ -660,6 +692,7 @@ describe("AssessmentStudentsController(e2e)-getAssessmentAwardDetails", () => {
         firstDisbursementInitialValues: {
           disbursementScheduleStatus: DisbursementScheduleStatus.Sent,
           coeUpdatedAt: enrolmentDate1,
+          disbursementScheduleStatusUpdatedOn: statusUpdatedOn,
         },
       },
     );
@@ -707,6 +740,8 @@ describe("AssessmentStudentsController(e2e)-getAssessmentAwardDetails", () => {
           disbursement1MSFAADateSigned: sharedMSFAANumber.dateSigned,
           disbursement1TuitionRemittance: 0,
           disbursement1Id: firstSchedule.id,
+          disbursement1DisbursementScheduleStatusUpdatedOn:
+            statusUpdatedOn.toISOString(),
           disbursement1cslf: 1,
           disbursement1csgp: 2,
           disbursement1bcsl: 3,
@@ -715,6 +750,7 @@ describe("AssessmentStudentsController(e2e)-getAssessmentAwardDetails", () => {
           disbursement1EnrolmentDate: enrolmentDate1.toISOString(),
         },
         finalAward: {
+          receivedDisbursementReceipt1: true,
           disbursementReceipt1cslf: 1,
           disbursementReceipt1csgp: 2,
           disbursementReceipt1bcsl: 3,

--- a/sources/packages/backend/apps/api/src/route-controllers/assessment/_tests_/e2e/assessment.students.controller.getAssessmentAwardDetails.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/assessment/_tests_/e2e/assessment.students.controller.getAssessmentAwardDetails.e2e-spec.ts
@@ -168,6 +168,7 @@ describe("AssessmentStudentsController(e2e)-getAssessmentAwardDetails", () => {
         },
         finalAward: {
           disbursementReceipt1Received: false,
+          disbursementReceipt1HasAwards: true,
           disbursementReceipt1cslp: 110,
           disbursementReceipt1csgp: 220,
           disbursementReceipt1cspt: 330,
@@ -359,8 +360,9 @@ describe("AssessmentStudentsController(e2e)-getAssessmentAwardDetails", () => {
           disbursement2EnrolmentDate: enrolmentDate2.toISOString(),
         },
         finalAward: {
-          // First disbursement schedule receipt dynamic properties.
           disbursementReceipt1Received: true,
+          disbursementReceipt2Received: true,
+          // First disbursement schedule receipt dynamic properties.
           disbursementReceipt1HasAwards: true,
           disbursementReceipt1cslp: 110,
           disbursementReceipt1csgp: 220,
@@ -369,7 +371,6 @@ describe("AssessmentStudentsController(e2e)-getAssessmentAwardDetails", () => {
           disbursementReceipt1bcag: 550,
           disbursementReceipt1sbsd: 660,
           // Second disbursement schedule receipt dynamic properties.
-          disbursementReceipt2Received: true,
           disbursementReceipt2HasAwards: true,
           disbursementReceipt2cslp: 9990,
           disbursementReceipt2csgp: 1010,
@@ -634,6 +635,7 @@ describe("AssessmentStudentsController(e2e)-getAssessmentAwardDetails", () => {
           disbursementReceipt1Received: true,
           disbursementReceipt2Received: true,
           // First disbursement schedule receipt dynamic properties.
+          disbursementReceipt1HasAwards: true,
           disbursementReceipt1cslf: 1000,
           disbursementReceipt1csgp: 10001,
           disbursementReceipt1csgd: 1002,
@@ -644,6 +646,7 @@ describe("AssessmentStudentsController(e2e)-getAssessmentAwardDetails", () => {
           disbursementReceipt1bgpd: 1007,
           disbursementReceipt1sbsd: 1008,
           // Second disbursement schedule receipt dynamic properties.
+          disbursementReceipt2HasAwards: true,
           disbursementReceipt2cslf: 10010,
           disbursementReceipt2csgp: 10011,
           disbursementReceipt2csgd: 10012,
@@ -746,6 +749,7 @@ describe("AssessmentStudentsController(e2e)-getAssessmentAwardDetails", () => {
         },
         finalAward: {
           disbursementReceipt1Received: true,
+          disbursementReceipt1HasAwards: true,
           disbursementReceipt1cslf: 1,
           disbursementReceipt1csgp: 2,
           disbursementReceipt1bcsl: 3,

--- a/sources/packages/backend/apps/api/src/route-controllers/assessment/_tests_/e2e/assessment.students.controller.getAssessmentNOA.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/assessment/_tests_/e2e/assessment.students.controller.getAssessmentNOA.e2e-spec.ts
@@ -45,6 +45,7 @@ describe("AssessmentStudentsController(e2e)-getAssessmentNOA", () => {
   it("Should get the student NOA details for an eligible part-time application when the student tries to access it.", async () => {
     // Arrange
     const enrolmentDate1 = addDays(1);
+    const statusUpdatedOn = addDays(2);
     // Create the new student to be mocked as the authenticated one.
     const student = await saveFakeStudent(db.dataSource);
     // Mock user services to return the saved student.
@@ -118,7 +119,12 @@ describe("AssessmentStudentsController(e2e)-getAssessmentNOA", () => {
           ),
         ],
       },
-      { initialValues: { coeUpdatedAt: enrolmentDate1 } },
+      {
+        initialValues: {
+          coeUpdatedAt: enrolmentDate1,
+          disbursementScheduleStatusUpdatedOn: statusUpdatedOn,
+        },
+      },
     );
     await db.disbursementSchedule.save(newAssessmentDisbursement);
 
@@ -161,6 +167,8 @@ describe("AssessmentStudentsController(e2e)-getAssessmentNOA", () => {
           newAssessmentDisbursement.disbursementDate,
         ),
         disbursement1Id: newAssessmentDisbursement.id,
+        disbursement1DisbursementScheduleStatusUpdatedOn:
+          statusUpdatedOn.toISOString(),
         disbursement1MSFAACancelledDate:
           newAssessmentDisbursement.msfaaNumber?.cancelledDate,
         disbursement1MSFAADateSigned:
@@ -188,6 +196,7 @@ describe("AssessmentStudentsController(e2e)-getAssessmentNOA", () => {
   it("Should get the student NOA details for a full-time application when the application assessment is created.", async () => {
     // Arrange
     const enrolmentDate1 = addDays(1);
+    const statusUpdatedOn = addDays(2);
     // Create the new student to be mocked as the authenticated one.
     const student = await saveFakeStudent(db.dataSource);
     // Mock user services to return the saved student.
@@ -273,7 +282,12 @@ describe("AssessmentStudentsController(e2e)-getAssessmentNOA", () => {
           ),
         ],
       },
-      { initialValues: { coeUpdatedAt: enrolmentDate1 } },
+      {
+        initialValues: {
+          coeUpdatedAt: enrolmentDate1,
+          disbursementScheduleStatusUpdatedOn: statusUpdatedOn,
+        },
+      },
     );
     await db.disbursementSchedule.save(newAssessmentDisbursement);
 
@@ -318,6 +332,8 @@ describe("AssessmentStudentsController(e2e)-getAssessmentNOA", () => {
           newAssessmentDisbursement.disbursementDate,
         ),
         disbursement1Id: newAssessmentDisbursement.id,
+        disbursement1DisbursementScheduleStatusUpdatedOn:
+          statusUpdatedOn.toISOString(),
         disbursement1MSFAACancelledDate:
           newAssessmentDisbursement.msfaaNumber.cancelledDate,
         disbursement1MSFAADateSigned:
@@ -345,6 +361,7 @@ describe("AssessmentStudentsController(e2e)-getAssessmentNOA", () => {
   it("Should exclude BC Total Grant from eligible amount calculation when getting NOA details", async () => {
     // Arrange
     const enrolmentDate1 = addDays(1);
+    const statusUpdatedOn = addDays(2);
     const student = await saveFakeStudent(db.dataSource);
     await mockUserLoginInfo(appModule, student);
 
@@ -400,7 +417,10 @@ describe("AssessmentStudentsController(e2e)-getAssessmentNOA", () => {
       },
       {
         offeringIntensity: OfferingIntensity.fullTime,
-        firstDisbursementInitialValues: { coeUpdatedAt: enrolmentDate1 },
+        firstDisbursementInitialValues: {
+          coeUpdatedAt: enrolmentDate1,
+          disbursementScheduleStatusUpdatedOn: statusUpdatedOn,
+        },
       },
     );
 
@@ -441,6 +461,8 @@ describe("AssessmentStudentsController(e2e)-getAssessmentNOA", () => {
           disbursement.disbursementDate,
         ),
         disbursement1Id: disbursement.id,
+        disbursement1DisbursementScheduleStatusUpdatedOn:
+          statusUpdatedOn.toISOString(),
         disbursement1MSFAACancelledDate:
           disbursement.msfaaNumber?.cancelledDate,
         disbursement1MSFAADateSigned: disbursement.msfaaNumber?.dateSigned,

--- a/sources/packages/backend/apps/api/src/route-controllers/assessment/_tests_/e2e/assessment.students.controller.getAssessmentNOA.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/assessment/_tests_/e2e/assessment.students.controller.getAssessmentNOA.e2e-spec.ts
@@ -167,8 +167,7 @@ describe("AssessmentStudentsController(e2e)-getAssessmentNOA", () => {
           newAssessmentDisbursement.disbursementDate,
         ),
         disbursement1Id: newAssessmentDisbursement.id,
-        disbursement1DisbursementScheduleStatusUpdatedOn:
-          statusUpdatedOn.toISOString(),
+        disbursement1StatusUpdatedOn: statusUpdatedOn.toISOString(),
         disbursement1MSFAACancelledDate:
           newAssessmentDisbursement.msfaaNumber?.cancelledDate,
         disbursement1MSFAADateSigned:
@@ -332,8 +331,7 @@ describe("AssessmentStudentsController(e2e)-getAssessmentNOA", () => {
           newAssessmentDisbursement.disbursementDate,
         ),
         disbursement1Id: newAssessmentDisbursement.id,
-        disbursement1DisbursementScheduleStatusUpdatedOn:
-          statusUpdatedOn.toISOString(),
+        disbursement1StatusUpdatedOn: statusUpdatedOn.toISOString(),
         disbursement1MSFAACancelledDate:
           newAssessmentDisbursement.msfaaNumber.cancelledDate,
         disbursement1MSFAADateSigned:
@@ -461,8 +459,7 @@ describe("AssessmentStudentsController(e2e)-getAssessmentNOA", () => {
           disbursement.disbursementDate,
         ),
         disbursement1Id: disbursement.id,
-        disbursement1DisbursementScheduleStatusUpdatedOn:
-          statusUpdatedOn.toISOString(),
+        disbursement1StatusUpdatedOn: statusUpdatedOn.toISOString(),
         disbursement1MSFAACancelledDate:
           disbursement.msfaaNumber?.cancelledDate,
         disbursement1MSFAADateSigned: disbursement.msfaaNumber?.dateSigned,

--- a/sources/packages/backend/apps/api/src/route-controllers/assessment/assessment.controller.service.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/assessment/assessment.controller.service.ts
@@ -322,7 +322,8 @@ export class AssessmentControllerService {
     // Populate the hasDisbursementReceipts flags for each disbursement schedule.
     assessment.disbursementSchedules.forEach((_, index) => {
       const hasReceipt = disbursementReceipts.some(
-        (receipt) => receipt.disbursementSchedule.id === assessment.id,
+        (receipt) =>
+          receipt.disbursementSchedule.studentAssessment.id === assessment.id,
       );
       finalAward[`receivedDisbursementReceipt${++index}`] = hasReceipt;
     });

--- a/sources/packages/backend/apps/api/src/route-controllers/assessment/assessment.controller.service.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/assessment/assessment.controller.service.ts
@@ -324,7 +324,7 @@ export class AssessmentControllerService {
       const hasReceipt = disbursementReceipts.some(
         (receipt) => receipt.disbursementSchedule.id === assessment.id,
       );
-      finalAward[`ReceivedDisbursementReceipt${++index}`] = hasReceipt;
+      finalAward[`receivedDisbursementReceipt${++index}`] = hasReceipt;
     });
 
     if (assessment.offering.offeringIntensity === OfferingIntensity.fullTime) {

--- a/sources/packages/backend/apps/api/src/route-controllers/assessment/assessment.controller.service.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/assessment/assessment.controller.service.ts
@@ -49,6 +49,14 @@ import { BC_TOTAL_GRANT_AWARD_CODE } from "@sims/services/constants";
  * Final award value dynamic identifier prefix.
  */
 const DISBURSEMENT_RECEIPT_PREFIX = "disbursementReceipt";
+/**
+ * Indicates which disbursement schedule statuses have
+ * the potential to generate a receipt.
+ */
+const HAS_POTENTIAL_RECEIPT_STATUSES = [
+  DisbursementScheduleStatus.Sent,
+  DisbursementScheduleStatus.Rejected,
+];
 
 @Injectable()
 export class AssessmentControllerService {
@@ -193,6 +201,9 @@ export class AssessmentControllerService {
       disbursementDetails[`${disbursementIdentifier}EnrolmentDate`] =
         schedule.coeUpdatedAt;
       disbursementDetails[`${disbursementIdentifier}Id`] = schedule.id;
+      disbursementDetails[
+        `${disbursementIdentifier}DisbursementScheduleStatusUpdatedOn`
+      ] = schedule.disbursementScheduleStatusUpdatedOn;
       if (includeDateSent) {
         disbursementDetails[`${disbursementIdentifier}DateSent`] =
           schedule.dateSent;
@@ -290,8 +301,9 @@ export class AssessmentControllerService {
   ): Promise<DynamicAwardValue | undefined> {
     const [firstDisbursement] = assessment.disbursementSchedules;
     if (
-      firstDisbursement.disbursementScheduleStatus !==
-      DisbursementScheduleStatus.Sent
+      !HAS_POTENTIAL_RECEIPT_STATUSES.includes(
+        firstDisbursement.disbursementScheduleStatus,
+      )
     ) {
       // If a e-Cert was never generated no additional processing is needed.
       return undefined;
@@ -327,8 +339,9 @@ export class AssessmentControllerService {
       }
       for (const schedule of assessment.disbursementSchedules) {
         if (
-          schedule.disbursementScheduleStatus !==
-          DisbursementScheduleStatus.Sent
+          !HAS_POTENTIAL_RECEIPT_STATUSES.includes(
+            schedule.disbursementScheduleStatus,
+          )
         ) {
           break;
         }
@@ -346,7 +359,9 @@ export class AssessmentControllerService {
     let index = 1;
     for (const schedule of assessment.disbursementSchedules) {
       if (
-        schedule.disbursementScheduleStatus !== DisbursementScheduleStatus.Sent
+        !HAS_POTENTIAL_RECEIPT_STATUSES.includes(
+          schedule.disbursementScheduleStatus,
+        )
       ) {
         break;
       }

--- a/sources/packages/backend/apps/api/src/route-controllers/assessment/assessment.controller.service.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/assessment/assessment.controller.service.ts
@@ -313,7 +313,7 @@ export class AssessmentControllerService {
     // but specific BC grants. Receipts should be used as a source of the information for full-time application.
     // Part-time receipts will not contain all the awards value hence the e-Cert effective
     // values are used instead to provide the best information as possible, but the existence of the part-time
-    // receipts are useful, for instance, to determine if a student disbursed can be cancelled.
+    // receipts are useful, for instance, to determine if a student disbursement can be cancelled.
     const disbursementReceipts =
       await this.disbursementReceiptService.getDisbursementReceiptByAssessment(
         assessment.id,
@@ -321,14 +321,10 @@ export class AssessmentControllerService {
       );
     // Populate the hasDisbursementReceipts flags for each disbursement schedule.
     assessment.disbursementSchedules.forEach((_, index) => {
-      const hasDisbursementReceiptsValueKey = this.createReceiptFullIdentifier(
-        "receivedDisbursementReceipt",
-        `${++index}`,
-      );
       const hasReceipt = disbursementReceipts.some(
         (receipt) => receipt.disbursementSchedule.id === assessment.id,
       );
-      finalAward[hasDisbursementReceiptsValueKey] = hasReceipt;
+      finalAward[`ReceivedDisbursementReceipt${++index}`] = hasReceipt;
     });
 
     if (assessment.offering.offeringIntensity === OfferingIntensity.fullTime) {

--- a/sources/packages/backend/apps/api/src/route-controllers/assessment/assessment.controller.service.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/assessment/assessment.controller.service.ts
@@ -319,10 +319,9 @@ export class AssessmentControllerService {
         options,
       );
     // Populate the disbursementReceipt[n]Received flags for each disbursement schedule.
-    assessment.disbursementSchedules.forEach((_, index) => {
+    assessment.disbursementSchedules.forEach((schedule, index) => {
       const hasReceipt = disbursementReceipts.some(
-        (receipt) =>
-          receipt.disbursementSchedule.studentAssessment.id === assessment.id,
+        (receipt) => receipt.disbursementSchedule.id === schedule.id,
       );
       this.setReceiptReceivedFlag(finalAward, index + 1, hasReceipt);
     });
@@ -342,11 +341,10 @@ export class AssessmentControllerService {
         ) {
           break;
         }
-        this.setHasAwardsFlag(finalAward, index, true);
         const awards = this.populateDisbursementReceiptAwardValues(
           disbursementReceipts,
           schedule,
-          `${DISBURSEMENT_RECEIPT_PREFIX}${index}`,
+          index,
         );
         finalAward = { ...finalAward, ...awards };
         index++;
@@ -412,7 +410,7 @@ export class AssessmentControllerService {
   }
 
   /**
-   * Populate final awards values from disbursements receipts.
+   * Populate final awards values from disbursements receipts for full-time.
    * @param disbursementReceipts disbursement receipts.
    * @param disbursementSchedule disbursement schedules.
    * @param identifier identifier which is used to create dynamic data by appending award code to it.
@@ -421,9 +419,15 @@ export class AssessmentControllerService {
   private populateDisbursementReceiptAwardValues(
     disbursementReceipts: DisbursementReceipt[],
     disbursementSchedule: DisbursementSchedule,
-    identifier: string,
+    index: number,
   ): DynamicAwardValue {
+    const identifier = `${DISBURSEMENT_RECEIPT_PREFIX}${index}`;
     const finalAward: DynamicAwardValue = {};
+    // Check if a receipt was received for the disbursement schedule.
+    const hasReceipt = disbursementReceipts.some(
+      (receipt) => receipt.disbursementSchedule.id === disbursementSchedule.id,
+    );
+    this.setHasAwardsFlag(finalAward, index, hasReceipt);
     // Add all estimated awards to the list of receipts returned.
     // Ensure that every estimated disbursement will be part of the summary.
     disbursementSchedule.disbursementValues.forEach((award) => {

--- a/sources/packages/backend/apps/api/src/route-controllers/assessment/assessment.controller.service.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/assessment/assessment.controller.service.ts
@@ -50,8 +50,10 @@ import { BC_TOTAL_GRANT_AWARD_CODE } from "@sims/services/constants";
  */
 const DISBURSEMENT_RECEIPT_PREFIX = "disbursementReceipt";
 /**
- * Indicates which disbursement schedule statuses have
- * the potential to generate a receipt.
+ * Indicates which disbursement schedule statuses are expected to have receipts generated.
+ * When 'Sent' and later 'Rejected', the receipt should not be received in a usual situation.
+ * Either way, both status are considered as subjected to check for receipts since an
+ * e-Cert was produced.
  */
 const HAS_POTENTIAL_RECEIPT_STATUSES = [
   DisbursementScheduleStatus.Sent,

--- a/sources/packages/backend/apps/api/src/route-controllers/assessment/models/assessment.dto.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/assessment/models/assessment.dto.ts
@@ -32,7 +32,10 @@ import { IsNotEmpty, MaxLength } from "class-validator";
  *    disbursementReceipt2sbsd: 1008,
  *   }
  */
-export type DynamicAwardValue = Record<string, string | number | Date>;
+export type DynamicAwardValue = Record<
+  string,
+  string | number | Date | boolean
+>;
 
 export enum RequestAssessmentTypeAPIOutDTO {
   StudentException = "Student exceptions",

--- a/sources/packages/backend/apps/api/src/route-controllers/disbursement-schedule/disbursement-schedule.aest.controller.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/disbursement-schedule/disbursement-schedule.aest.controller.ts
@@ -30,10 +30,5 @@ export class DisbursementScheduleAESTController extends BaseController {
     @UserToken() userToken: IUserToken,
   ): Promise<void> {
     // TODO: To be implemented.
-    console.log(
-      "Cancelling disbursement schedule:",
-      disbursementScheduleId,
-      payload,
-    );
   }
 }

--- a/sources/packages/backend/apps/api/src/route-controllers/disbursement-schedule/disbursement-schedule.aest.controller.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/disbursement-schedule/disbursement-schedule.aest.controller.ts
@@ -1,13 +1,5 @@
-import {
-  Body,
-  Controller,
-  NotFoundException,
-  Param,
-  ParseIntPipe,
-  Patch,
-  UnprocessableEntityException,
-} from "@nestjs/common";
-import { ApiNotFoundResponse, ApiTags } from "@nestjs/swagger";
+import { Body, Controller, Param, ParseIntPipe, Patch } from "@nestjs/common";
+import { ApiTags } from "@nestjs/swagger";
 import BaseController from "../BaseController";
 import {
   AllowAuthorizedParty,
@@ -17,9 +9,6 @@ import {
 } from "../../auth/decorators";
 import { ClientTypeBaseRoute } from "../../types";
 import { AuthorizedParties, IUserToken, Role, UserGroups } from "../../auth";
-import { DisbursementScheduleSharedService } from "@sims/services";
-import { DisbursementScheduleService } from "../../services";
-import { DisbursementScheduleStatus } from "@sims/sims-db";
 import { CancelDisbursementScheduleAPIInDTO } from "../../route-controllers";
 
 @AllowAuthorizedParty(AuthorizedParties.aest)
@@ -27,21 +16,11 @@ import { CancelDisbursementScheduleAPIInDTO } from "../../route-controllers";
 @Controller("disbursement-schedule")
 @ApiTags(`${ClientTypeBaseRoute.AEST}-disbursement-schedule`)
 export class DisbursementScheduleAESTController extends BaseController {
-  constructor(
-    private readonly disbursementScheduleService: DisbursementScheduleService,
-    private readonly disbursementScheduleSharedService: DisbursementScheduleSharedService,
-  ) {
-    super();
-  }
-
   /**
    * Cancels a disbursement schedule.
    * @param disbursementScheduleId disbursement schedule ID.
    * @param payload payload with the cancellation info.
    */
-  @ApiNotFoundResponse({
-    description: "To be added",
-  })
   @Roles(Role.StudentCancelDisbursementSchedule)
   @Patch(":disbursementScheduleId/cancel")
   async cancelDisbursementSchedule(
@@ -50,34 +29,11 @@ export class DisbursementScheduleAESTController extends BaseController {
     @Body() payload: CancelDisbursementScheduleAPIInDTO,
     @UserToken() userToken: IUserToken,
   ): Promise<void> {
-    const disbursement =
-      await this.disbursementScheduleService.getDisbursementById(
-        disbursementScheduleId,
-      );
-    if (!disbursement) {
-      throw new NotFoundException("Disbursement schedule not found.");
-    }
-    if (
-      disbursement.disbursementScheduleStatus !==
-      DisbursementScheduleStatus.Sent
-    ) {
-      throw new UnprocessableEntityException(
-        "Disbursement schedule is expected to be sent to allow its cancellation.",
-      );
-    }
-    if (disbursement.disbursementReceipts?.length) {
-      throw new UnprocessableEntityException(
-        "Disbursement receipts were already received for this disbursement schedule.",
-      );
-    }
-    try {
-      await this.disbursementScheduleSharedService.rejectDisbursement(
-        disbursementScheduleId,
-        userToken.userId,
-        true,
-      );
-    } catch (error: unknown) {
-      // TODO: to be added.
-    }
+    // TODO: To be implemented.
+    console.log(
+      "Cancelling disbursement schedule:",
+      disbursementScheduleId,
+      payload,
+    );
   }
 }

--- a/sources/packages/backend/apps/api/src/route-controllers/disbursement-schedule/disbursement-schedule.aest.controller.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/disbursement-schedule/disbursement-schedule.aest.controller.ts
@@ -1,0 +1,83 @@
+import {
+  Body,
+  Controller,
+  NotFoundException,
+  Param,
+  ParseIntPipe,
+  Patch,
+  UnprocessableEntityException,
+} from "@nestjs/common";
+import { ApiNotFoundResponse, ApiTags } from "@nestjs/swagger";
+import BaseController from "../BaseController";
+import {
+  AllowAuthorizedParty,
+  Groups,
+  Roles,
+  UserToken,
+} from "../../auth/decorators";
+import { ClientTypeBaseRoute } from "../../types";
+import { AuthorizedParties, IUserToken, Role, UserGroups } from "../../auth";
+import { DisbursementScheduleSharedService } from "@sims/services";
+import { DisbursementScheduleService } from "../../services";
+import { DisbursementScheduleStatus } from "@sims/sims-db";
+import { CancelDisbursementScheduleAPIInDTO } from "apps/api/src/route-controllers/disbursement-schedule/models/disbursement-schedule.dto";
+
+@AllowAuthorizedParty(AuthorizedParties.aest)
+@Groups(UserGroups.AESTUser)
+@Controller("disbursement-schedule")
+@ApiTags(`${ClientTypeBaseRoute.AEST}-disbursement-schedule`)
+export class DisbursementScheduleAESTController extends BaseController {
+  constructor(
+    private readonly disbursementScheduleService: DisbursementScheduleService,
+    private readonly disbursementScheduleSharedService: DisbursementScheduleSharedService,
+  ) {
+    super();
+  }
+
+  /**
+   * Cancels a disbursement schedule.
+   * @param disbursementScheduleId disbursement schedule ID.
+   * @param payload payload with the cancellation info.
+   */
+  @ApiNotFoundResponse({
+    description: "To be added",
+  })
+  @Roles(Role.StudentCancelDisbursementSchedule)
+  @Patch(":disbursementScheduleId/cancel")
+  async cancelDisbursementSchedule(
+    @Param("disbursementScheduleId", ParseIntPipe)
+    disbursementScheduleId: number,
+    @Body() payload: CancelDisbursementScheduleAPIInDTO,
+    @UserToken() userToken: IUserToken,
+  ): Promise<void> {
+    const disbursement =
+      await this.disbursementScheduleService.getDisbursementById(
+        disbursementScheduleId,
+      );
+    if (!disbursement) {
+      throw new NotFoundException("Disbursement schedule not found.");
+    }
+    if (
+      disbursement.disbursementScheduleStatus !==
+      DisbursementScheduleStatus.Sent
+    ) {
+      throw new UnprocessableEntityException(
+        "Disbursement schedule is expected to be sent to allow its cancellation.",
+      );
+    }
+    if (disbursement.disbursementReceipts?.length) {
+      throw new UnprocessableEntityException(
+        "Disbursement receipts were already received for this disbursement schedule.",
+      );
+    }
+    try {
+      await this.disbursementScheduleSharedService.rejectDisbursement(
+        disbursementScheduleId,
+        userToken.userId,
+        true,
+      );
+    } catch (error: unknown) {
+      // TODO: to be added.
+    }
+  }
+}

--- a/sources/packages/backend/apps/api/src/route-controllers/disbursement-schedule/disbursement-schedule.aest.controller.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/disbursement-schedule/disbursement-schedule.aest.controller.ts
@@ -20,7 +20,7 @@ import { AuthorizedParties, IUserToken, Role, UserGroups } from "../../auth";
 import { DisbursementScheduleSharedService } from "@sims/services";
 import { DisbursementScheduleService } from "../../services";
 import { DisbursementScheduleStatus } from "@sims/sims-db";
-import { CancelDisbursementScheduleAPIInDTO } from "apps/api/src/route-controllers/disbursement-schedule/models/disbursement-schedule.dto";
+import { CancelDisbursementScheduleAPIInDTO } from "../../route-controllers";
 
 @AllowAuthorizedParty(AuthorizedParties.aest)
 @Groups(UserGroups.AESTUser)

--- a/sources/packages/backend/apps/api/src/route-controllers/disbursement-schedule/models/disbursement-schedule.dto.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/disbursement-schedule/models/disbursement-schedule.dto.ts
@@ -1,0 +1,8 @@
+import { IsNotEmpty, MaxLength } from "class-validator";
+import { NOTE_DESCRIPTION_MAX_LENGTH } from "@sims/sims-db";
+
+export class CancelDisbursementScheduleAPIInDTO {
+  @IsNotEmpty()
+  @MaxLength(NOTE_DESCRIPTION_MAX_LENGTH)
+  note: string;
+}

--- a/sources/packages/backend/apps/api/src/route-controllers/index.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/index.ts
@@ -98,3 +98,5 @@ export * from "./dynamic-form-configuration/dynamic-form-configuration.controlle
 export * from "./application-change-request/models/application-change-request.dto";
 export * from "./application-change-request/application-change-request.aest.controller";
 export * from "./supporting-user/supporting-user.students.controller";
+export * from "./disbursement-schedule/disbursement-schedule.aest.controller";
+export * from "./disbursement-schedule/models/disbursement-schedule.dto";

--- a/sources/packages/backend/apps/api/src/services/disbursement-schedule/disbursement-schedule-service.ts
+++ b/sources/packages/backend/apps/api/src/services/disbursement-schedule/disbursement-schedule-service.ts
@@ -178,22 +178,4 @@ export class DisbursementScheduleService extends RecordDataModelService<Disburse
     orderByCondition[dbColumnName] = sortOrder;
     return orderByCondition;
   }
-
-  async getDisbursementById(
-    disbursementId: number,
-  ): Promise<DisbursementSchedule> {
-    return this.repo.findOne({
-      select: {
-        id: true,
-        disbursementScheduleStatus: true,
-        disbursementReceipts: {
-          id: true,
-        },
-      },
-      relations: {
-        disbursementReceipts: true,
-      },
-      where: { id: disbursementId },
-    });
-  }
 }

--- a/sources/packages/backend/apps/api/src/services/disbursement-schedule/disbursement-schedule-service.ts
+++ b/sources/packages/backend/apps/api/src/services/disbursement-schedule/disbursement-schedule-service.ts
@@ -178,4 +178,22 @@ export class DisbursementScheduleService extends RecordDataModelService<Disburse
     orderByCondition[dbColumnName] = sortOrder;
     return orderByCondition;
   }
+
+  async getDisbursementById(
+    disbursementId: number,
+  ): Promise<DisbursementSchedule> {
+    return this.repo.findOne({
+      select: {
+        id: true,
+        disbursementScheduleStatus: true,
+        disbursementReceipts: {
+          id: true,
+        },
+      },
+      relations: {
+        disbursementReceipts: true,
+      },
+      where: { id: disbursementId },
+    });
+  }
 }

--- a/sources/packages/backend/apps/api/src/services/student-assessment/student-assessment.service.ts
+++ b/sources/packages/backend/apps/api/src/services/student-assessment/student-assessment.service.ts
@@ -85,6 +85,7 @@ export class StudentAssessmentService extends RecordDataModelService<StudentAsse
         "disbursementSchedule.tuitionRemittanceRequestedAmount",
         "disbursementSchedule.dateSent",
         "disbursementSchedule.coeUpdatedAt",
+        "disbursementSchedule.disbursementScheduleStatusUpdatedOn",
         "msfaaNumber.id",
         "msfaaNumber.msfaaNumber",
         "msfaaNumber.dateSigned",

--- a/sources/packages/backend/libs/test-utils/src/factories/disbursement-schedule.ts
+++ b/sources/packages/backend/libs/test-utils/src/factories/disbursement-schedule.ts
@@ -59,5 +59,7 @@ export function createFakeDisbursementSchedule(
   schedule.hasEstimatedAwards =
     options?.initialValues?.hasEstimatedAwards ??
     relations?.disbursementValues?.length > 0;
+  schedule.disbursementScheduleStatusUpdatedOn =
+    options?.initialValues?.disbursementScheduleStatusUpdatedOn;
   return schedule;
 }

--- a/sources/packages/web/src/components/common/AssessmentAwardDetails.vue
+++ b/sources/packages/web/src/components/common/AssessmentAwardDetails.vue
@@ -58,7 +58,12 @@
               "
               @confirmEnrolment="$emit('confirmEnrolment', $event)"
             />
-            <cancel-disbursement-schedule v-if="canCancelFirstDisbursement" />
+            <cancel-disbursement-schedule
+              v-if="canCancelFirstDisbursement"
+              :disbursement-id="
+                assessmentAwardData.estimatedAward.disbursement1Id as number
+              "
+            />
           </div>
           <div
             class="my-3"
@@ -199,7 +204,12 @@
               "
               @confirmEnrolment="$emit('confirmEnrolment', $event)"
             />
-            <cancel-disbursement-schedule v-if="canCancelSecondDisbursement" />
+            <cancel-disbursement-schedule
+              v-if="canCancelSecondDisbursement"
+              :disbursement-id="
+                assessmentAwardData.estimatedAward.disbursement2Id as number
+              "
+            />
           </div>
           <div
             class="my-3"

--- a/sources/packages/web/src/components/common/AssessmentAwardDetails.vue
+++ b/sources/packages/web/src/components/common/AssessmentAwardDetails.vue
@@ -58,13 +58,6 @@
               "
               @confirmEnrolment="$emit('confirmEnrolment', $event)"
             />
-            <cancel-disbursement-schedule
-              v-if="canCancelFirstDisbursement"
-              :disbursement-id="
-                assessmentAwardData.estimatedAward.disbursement1Id as number
-              "
-              @disbursement-schedule-cancelled="disbursementScheduleCancelled"
-            />
           </div>
           <div
             class="my-3"
@@ -98,23 +91,6 @@
               :offeringIntensity="assessmentAwardData.offeringIntensity"
               identifier="disbursementReceipt1"
             />
-            <content-group-info v-if="allowFinalAwardExtendedInformation">
-              <div>
-                <span class="label-bold">Date eCert sent: </span>
-                <span>{{
-                  dateOnlyLongString(
-                    assessmentAwardData.estimatedAward
-                      .disbursement1DateSent as Date,
-                  )
-                }}</span>
-              </div>
-              <div>
-                <span class="label-bold">Certificate number: </span>
-                <span>{{
-                  assessmentAwardData.estimatedAward.disbursement1DocumentNumber
-                }}</span>
-              </div>
-            </content-group-info>
             <!-- Part-time final awards are retrieved from e-Cert generated values and requires further explanation.  -->
             <p
               v-if="
@@ -145,13 +121,36 @@
               )
             }}
           </p>
-          <div
+          <content-group-info
             v-if="
-              assessmentAwardData.estimatedAward.disbursement1Status ===
-              DisbursementScheduleStatus.Rejected
+              allowFinalAwardExtendedInformation &&
+              !!assessmentAwardData.estimatedAward.disbursement1DateSent
             "
-            class="mt-3"
           >
+            <div>
+              <span class="label-bold">Date eCert sent: </span>
+              <span>{{
+                dateOnlyLongString(
+                  assessmentAwardData.estimatedAward
+                    .disbursement1DateSent as Date,
+                )
+              }}</span>
+            </div>
+            <div>
+              <span class="label-bold">Certificate number: </span>
+              <span>{{
+                assessmentAwardData.estimatedAward.disbursement1DocumentNumber
+              }}</span>
+            </div>
+          </content-group-info>
+          <div class="mt-3">
+            <cancel-disbursement-schedule
+              v-if="canCancelFirstDisbursement"
+              :disbursement-id="
+                assessmentAwardData.estimatedAward.disbursement1Id as number
+              "
+              @disbursement-schedule-cancelled="disbursementScheduleCancelled"
+            />
             <status-info-disbursement-cancellation
               v-if="
                 assessmentAwardData.estimatedAward.disbursement1Status ===
@@ -235,13 +234,6 @@
                   .disbursement2StatusUpdatedOn as Date
               "
             />
-            <cancel-disbursement-schedule
-              v-if="canCancelSecondDisbursement"
-              :disbursement-id="
-                assessmentAwardData.estimatedAward.disbursement2Id as number
-              "
-              @disbursement-schedule-cancelled="disbursementScheduleCancelled"
-            />
           </div>
           <div
             class="my-3"
@@ -277,23 +269,6 @@
               :offeringIntensity="assessmentAwardData.offeringIntensity"
               identifier="disbursementReceipt2"
             />
-            <content-group-info v-if="allowFinalAwardExtendedInformation">
-              <div>
-                <span class="label-bold">Date eCert sent: </span>
-                <span>{{
-                  dateOnlyLongString(
-                    assessmentAwardData.estimatedAward
-                      .disbursement2DateSent as Date,
-                  )
-                }}</span>
-              </div>
-              <div>
-                <span class="label-bold">Certificate number: </span>
-                <span>{{
-                  assessmentAwardData.estimatedAward.disbursement2DocumentNumber
-                }}</span>
-              </div>
-            </content-group-info>
             <!-- Part-time final awards are retrieved from e-Cert generated values and requires further explanation.  -->
             <p
               v-if="
@@ -324,14 +299,41 @@
               )
             }}
           </p>
-          <div
+          <content-group-info
             v-if="
-              assessmentAwardData.estimatedAward.disbursement2Status ===
-              DisbursementScheduleStatus.Rejected
+              allowFinalAwardExtendedInformation &&
+              !!assessmentAwardData.estimatedAward.disbursement2DateSent
             "
-            class="mt-3"
           >
+            <div>
+              <span class="label-bold">Date eCert sent: </span>
+              <span>{{
+                dateOnlyLongString(
+                  assessmentAwardData.estimatedAward
+                    .disbursement2DateSent as Date,
+                )
+              }}</span>
+            </div>
+            <div>
+              <span class="label-bold">Certificate number: </span>
+              <span>{{
+                assessmentAwardData.estimatedAward.disbursement2DocumentNumber
+              }}</span>
+            </div>
+          </content-group-info>
+          <div class="mt-3">
+            <cancel-disbursement-schedule
+              v-if="canCancelSecondDisbursement"
+              :disbursement-id="
+                assessmentAwardData.estimatedAward.disbursement2Id as number
+              "
+              @disbursement-schedule-cancelled="disbursementScheduleCancelled"
+            />
             <status-info-disbursement-cancellation
+              v-if="
+                assessmentAwardData.estimatedAward.disbursement2Status ===
+                DisbursementScheduleStatus.Rejected
+              "
               :cancellation-date="
                 assessmentAwardData.estimatedAward
                   .disbursement1StatusUpdatedOn as Date
@@ -383,6 +385,11 @@ export default defineComponent({
     allowConfirmEnrolment: {
       type: Boolean,
       required: false,
+    },
+    allowDisbursementCancellation: {
+      type: Boolean,
+      required: false,
+      default: false,
     },
     allowFinalAwardExtendedInformation: {
       type: Boolean,
@@ -471,15 +478,18 @@ export default defineComponent({
       return undefined;
     };
 
-    const canCancelFirstDisbursement = computed<boolean>(
-      () =>
+    const canCancelFirstDisbursement = computed<boolean>(() => {
+      debugger;
+      return (
+        props.allowDisbursementCancellation &&
         props.assessmentAwardData.estimatedAward["disbursement1Status"] ===
           DisbursementScheduleStatus.Sent &&
         !receivedDisbursementReceipt(
           "first",
           props.assessmentAwardData.finalAward,
-        ),
-    );
+        )
+      );
+    });
 
     const canCancelSecondDisbursement = computed<boolean>(
       () =>

--- a/sources/packages/web/src/components/common/AssessmentAwardDetails.vue
+++ b/sources/packages/web/src/components/common/AssessmentAwardDetails.vue
@@ -418,29 +418,6 @@ export default defineComponent({
           : "disbursementReceipt2HasAwards";
       return !!finalAward[hasAwardsIdentifier];
     };
-    /**
-     * Indicates if a receipt was received for a disbursement.
-     * Final awards can be rendered from a receipt or directly from the
-     * awards for part-time where the receipts are incomplete or may never be
-     * received. This checks the flags that indicates if a receipt was ever received,
-     * not if the final awards can be rendered.
-     * @param disbursement first or second disbursement.
-     * @param finalAward dynamic object with the flag to be checked.
-     * @returns true if a receipt was received, otherwise, false.
-     */
-    const receivedDisbursementReceipt = (
-      disbursement: "first" | "second",
-      finalAward?: DynamicAwardValue,
-    ): boolean => {
-      if (!finalAward) {
-        return false;
-      }
-      const identifier =
-        disbursement === "first"
-          ? "disbursementReceipt1Received"
-          : "disbursementReceipt2Received";
-      return !!finalAward[identifier];
-    };
     const isFirstDisbursementCompleted = computed<boolean>(
       () =>
         props.assessmentAwardData.estimatedAward?.disbursement1COEStatus ===
@@ -479,31 +456,24 @@ export default defineComponent({
     };
 
     const canCancelFirstDisbursement = computed<boolean>(() => {
-      debugger;
       return (
         props.allowDisbursementCancellation &&
-        props.assessmentAwardData.estimatedAward["disbursement1Status"] ===
+        props.assessmentAwardData.estimatedAward.disbursement1Status ===
           DisbursementScheduleStatus.Sent &&
-        !receivedDisbursementReceipt(
-          "first",
-          props.assessmentAwardData.finalAward,
-        )
+        !props.assessmentAwardData.finalAward?.disbursementReceipt1Received
       );
     });
 
     const canCancelSecondDisbursement = computed<boolean>(
       () =>
-        props.assessmentAwardData.estimatedAward["disbursement2Status"] ===
+        props.allowDisbursementCancellation &&
+        props.assessmentAwardData.estimatedAward.disbursement2Status ===
           DisbursementScheduleStatus.Sent &&
-        !receivedDisbursementReceipt(
-          "second",
-          props.assessmentAwardData.finalAward,
-        ),
+        !props.assessmentAwardData.finalAward?.disbursementReceipt2Received,
     );
 
     const disbursementScheduleCancelled = () => {
       // TODO: To be implemented to refresh data.
-      console.log("Disbursement schedule cancelled, data will be refreshed.");
     };
 
     return {

--- a/sources/packages/web/src/components/common/AssessmentAwardDetails.vue
+++ b/sources/packages/web/src/components/common/AssessmentAwardDetails.vue
@@ -144,6 +144,24 @@
               )
             }}
           </p>
+          <div
+            v-if="
+              assessmentAwardData.estimatedAward.disbursement1Status ===
+              DisbursementScheduleStatus.Rejected
+            "
+            class="mt-3"
+          >
+            <status-info-disbursement-cancellation
+              v-if="
+                assessmentAwardData.estimatedAward.disbursement1Status ===
+                DisbursementScheduleStatus.Rejected
+              "
+              :cancellation-date="
+                assessmentAwardData.estimatedAward
+                  .disbursement1DisbursementScheduleStatusUpdatedOn as Date
+              "
+            />
+          </div>
         </content-group>
       </v-col>
     </v-row>
@@ -203,6 +221,18 @@
                 assessmentAwardData.estimatedAward.disbursement2Id as number
               "
               @confirmEnrolment="$emit('confirmEnrolment', $event)"
+            />
+          </div>
+          <div class="my-3">
+            <status-info-disbursement-cancellation
+              v-if="
+                assessmentAwardData.estimatedAward.disbursement2Status ===
+                DisbursementScheduleStatus.Rejected
+              "
+              :cancellation-date="
+                assessmentAwardData.estimatedAward
+                  .disbursement2DisbursementScheduleStatusUpdatedOn as Date
+              "
             />
             <cancel-disbursement-schedule
               v-if="canCancelSecondDisbursement"
@@ -292,6 +322,20 @@
               )
             }}
           </p>
+          <div
+            v-if="
+              assessmentAwardData.estimatedAward.disbursement2Status ===
+              DisbursementScheduleStatus.Rejected
+            "
+            class="mt-3"
+          >
+            <status-info-disbursement-cancellation
+              :cancellation-date="
+                assessmentAwardData.estimatedAward
+                  .disbursement1DisbursementScheduleStatusUpdatedOn as Date
+              "
+            />
+          </div>
         </content-group>
       </v-col>
     </v-row>
@@ -311,6 +355,7 @@ import AwardTable from "@/components/common/AwardTable.vue";
 import StatusInfoEnrolment from "@/components/common/StatusInfoEnrolment.vue";
 import ConfirmEnrolment from "@/components/common/ConfirmEnrolment.vue";
 import CancelDisbursementSchedule from "@/components/common/CancelDisbursementSchedule.vue";
+import StatusInfoDisbursementCancellation from "@/components/common/StatusInfoDisbursementCancellation.vue";
 
 import { useFormatters } from "@/composables";
 
@@ -322,9 +367,10 @@ export default defineComponent({
   },
   components: {
     AwardTable,
-    CancelDisbursementSchedule,
     ConfirmEnrolment,
     StatusInfoEnrolment,
+    CancelDisbursementSchedule,
+    StatusInfoDisbursementCancellation,
   },
   props: {
     assessmentAwardData: {

--- a/sources/packages/web/src/components/common/AssessmentAwardDetails.vue
+++ b/sources/packages/web/src/components/common/AssessmentAwardDetails.vue
@@ -58,6 +58,7 @@
               "
               @confirmEnrolment="$emit('confirmEnrolment', $event)"
             />
+            <cancel-disbursement-schedule v-if="canCancelFirstDisbursement" />
           </div>
           <div
             class="my-3"
@@ -198,6 +199,7 @@
               "
               @confirmEnrolment="$emit('confirmEnrolment', $event)"
             />
+            <cancel-disbursement-schedule v-if="canCancelSecondDisbursement" />
           </div>
           <div
             class="my-3"
@@ -298,6 +300,8 @@ import { PropType, computed, defineComponent } from "vue";
 import AwardTable from "@/components/common/AwardTable.vue";
 import StatusInfoEnrolment from "@/components/common/StatusInfoEnrolment.vue";
 import ConfirmEnrolment from "@/components/common/ConfirmEnrolment.vue";
+import CancelDisbursementSchedule from "@/components/common/CancelDisbursementSchedule.vue";
+
 import { useFormatters } from "@/composables";
 
 export default defineComponent({
@@ -308,6 +312,7 @@ export default defineComponent({
   },
   components: {
     AwardTable,
+    CancelDisbursementSchedule,
     ConfirmEnrolment,
     StatusInfoEnrolment,
   },
@@ -350,6 +355,19 @@ export default defineComponent({
         propName.startsWith(identifier),
       );
     };
+    const receivedDisbursementReceipt = (
+      disbursement: "first" | "second",
+      finalAward?: DynamicAwardValue,
+    ) => {
+      if (!finalAward) {
+        return false;
+      }
+      const identifier =
+        disbursement === "first"
+          ? "receivedDisbursementReceipt1"
+          : "receivedDisbursementReceipt2";
+      return !!finalAward[identifier];
+    };
     const isFirstDisbursementCompleted = computed<boolean>(
       () =>
         props.assessmentAwardData.estimatedAward?.disbursement1COEStatus ===
@@ -387,6 +405,26 @@ export default defineComponent({
       return undefined;
     };
 
+    const canCancelFirstDisbursement = computed<boolean>(
+      () =>
+        props.assessmentAwardData.estimatedAward["disbursement1Status"] ===
+          DisbursementScheduleStatus.Sent &&
+        !receivedDisbursementReceipt(
+          "first",
+          props.assessmentAwardData.finalAward,
+        ),
+    );
+
+    const canCancelSecondDisbursement = computed<boolean>(
+      () =>
+        props.assessmentAwardData.estimatedAward["disbursement2Status"] ===
+          DisbursementScheduleStatus.Sent &&
+        !receivedDisbursementReceipt(
+          "second",
+          props.assessmentAwardData.finalAward,
+        ),
+    );
+
     return {
       dateOnlyLongString,
       AESTRoutesConst,
@@ -399,6 +437,8 @@ export default defineComponent({
       StatusInfo,
       OfferingIntensity,
       DisbursementScheduleStatus,
+      canCancelFirstDisbursement,
+      canCancelSecondDisbursement,
     };
   },
 });

--- a/sources/packages/web/src/components/common/AssessmentAwardDetails.vue
+++ b/sources/packages/web/src/components/common/AssessmentAwardDetails.vue
@@ -63,6 +63,7 @@
               :disbursement-id="
                 assessmentAwardData.estimatedAward.disbursement1Id as number
               "
+              @disbursement-schedule-cancelled="disbursementScheduleCancelled"
             />
           </div>
           <div
@@ -239,6 +240,7 @@
               :disbursement-id="
                 assessmentAwardData.estimatedAward.disbursement2Id as number
               "
+              @disbursement-schedule-cancelled="disbursementScheduleCancelled"
             />
           </div>
           <div
@@ -396,7 +398,7 @@ export default defineComponent({
      * @param disbursement indicates the "first" or "second" disbursement.
      * @param finalAward dynamic final award object.
      */
-    const hasDisbursementReceipt = (
+    const hasDisbursementAwards = (
       disbursement: "first" | "second",
       finalAward?: DynamicAwardValue,
     ) => {
@@ -411,17 +413,27 @@ export default defineComponent({
         propName.startsWith(identifier),
       );
     };
+    /**
+     * Indicates if a receipt was received for a disbursement.
+     * Final awards can be rendered from a receipt or directly from the
+     * awards for part-time where the receipts are incomplete or may never be
+     * received. This checks the flags that indicates if a receipt was ever received,
+     * not if the final awards can be rendered.
+     * @param disbursement first or second disbursement.
+     * @param finalAward dynamic object with the flag to be checked.
+     * @returns true if a receipt was received, otherwise, false.
+     */
     const receivedDisbursementReceipt = (
       disbursement: "first" | "second",
       finalAward?: DynamicAwardValue,
-    ) => {
+    ): boolean => {
       if (!finalAward) {
         return false;
       }
       const identifier =
         disbursement === "first"
-          ? "receivedDisbursementReceipt1"
-          : "receivedDisbursementReceipt2";
+          ? "ReceivedDisbursementReceipt1"
+          : "ReceivedDisbursementReceipt2";
       return !!finalAward[identifier];
     };
     const isFirstDisbursementCompleted = computed<boolean>(
@@ -438,10 +450,10 @@ export default defineComponent({
         COEStatus.completed,
     );
     const showFirstFinalAward = computed<boolean>(() =>
-      hasDisbursementReceipt("first", props.assessmentAwardData.finalAward),
+      hasDisbursementAwards("first", props.assessmentAwardData.finalAward),
     );
     const showSecondFinalAward = computed<boolean>(() =>
-      hasDisbursementReceipt("second", props.assessmentAwardData.finalAward),
+      hasDisbursementAwards("second", props.assessmentAwardData.finalAward),
     );
     const getFinalAwardNotAvailableMessage = (
       coeStatus: COEStatus,
@@ -481,6 +493,11 @@ export default defineComponent({
         ),
     );
 
+    const disbursementScheduleCancelled = () => {
+      // TODO: To be implemented to refresh data.
+      console.log("Disbursement schedule cancelled, data will be refreshed.");
+    };
+
     return {
       dateOnlyLongString,
       AESTRoutesConst,
@@ -495,6 +512,7 @@ export default defineComponent({
       DisbursementScheduleStatus,
       canCancelFirstDisbursement,
       canCancelSecondDisbursement,
+      disbursementScheduleCancelled,
     };
   },
 });

--- a/sources/packages/web/src/components/common/AssessmentAwardDetails.vue
+++ b/sources/packages/web/src/components/common/AssessmentAwardDetails.vue
@@ -159,7 +159,7 @@
               "
               :cancellation-date="
                 assessmentAwardData.estimatedAward
-                  .disbursement1DisbursementScheduleStatusUpdatedOn as Date
+                  .disbursement1StatusUpdatedOn as Date
               "
             />
           </div>
@@ -232,7 +232,7 @@
               "
               :cancellation-date="
                 assessmentAwardData.estimatedAward
-                  .disbursement2DisbursementScheduleStatusUpdatedOn as Date
+                  .disbursement2StatusUpdatedOn as Date
               "
             />
             <cancel-disbursement-schedule
@@ -334,7 +334,7 @@
             <status-info-disbursement-cancellation
               :cancellation-date="
                 assessmentAwardData.estimatedAward
-                  .disbursement1DisbursementScheduleStatusUpdatedOn as Date
+                  .disbursement1StatusUpdatedOn as Date
               "
             />
           </div>
@@ -393,8 +393,8 @@ export default defineComponent({
   setup(props) {
     const { dateOnlyLongString } = useFormatters();
     /**
-     * Checks of the dynamic object with the final awards contains at least one property
-     * related to first or second disbursements.
+     * Checks if the dynamic object with the final awards contains a flag that
+     * indicates that awards values were added.
      * @param disbursement indicates the "first" or "second" disbursement.
      * @param finalAward dynamic final award object.
      */
@@ -405,13 +405,11 @@ export default defineComponent({
       if (!finalAward) {
         return false;
       }
-      const identifier =
+      const hasAwardsIdentifier =
         disbursement === "first"
-          ? "disbursementReceipt1"
-          : "disbursementReceipt2";
-      return Object.keys(finalAward).some((propName) =>
-        propName.startsWith(identifier),
-      );
+          ? "disbursementReceipt1HasAwards"
+          : "disbursementReceipt2HasAwards";
+      return !!finalAward[hasAwardsIdentifier];
     };
     /**
      * Indicates if a receipt was received for a disbursement.
@@ -432,8 +430,8 @@ export default defineComponent({
       }
       const identifier =
         disbursement === "first"
-          ? "receivedDisbursementReceipt1"
-          : "receivedDisbursementReceipt2";
+          ? "disbursementReceipt1Received"
+          : "disbursementReceipt2Received";
       return !!finalAward[identifier];
     };
     const isFirstDisbursementCompleted = computed<boolean>(

--- a/sources/packages/web/src/components/common/AssessmentAwardDetails.vue
+++ b/sources/packages/web/src/components/common/AssessmentAwardDetails.vue
@@ -432,8 +432,8 @@ export default defineComponent({
       }
       const identifier =
         disbursement === "first"
-          ? "ReceivedDisbursementReceipt1"
-          : "ReceivedDisbursementReceipt2";
+          ? "receivedDisbursementReceipt1"
+          : "receivedDisbursementReceipt2";
       return !!finalAward[identifier];
     };
     const isFirstDisbursementCompleted = computed<boolean>(

--- a/sources/packages/web/src/components/common/CancelDisbursementSchedule.vue
+++ b/sources/packages/web/src/components/common/CancelDisbursementSchedule.vue
@@ -4,7 +4,7 @@
       <v-btn
         variant="outlined"
         color="primary"
-        prependIcon="mdi-close-circle-outline"
+        prepend-icon="fa:fa fa-xmark"
         @click="cancelDisbursementSchedule"
         :disabled="notAllowed"
         ><span class="text-decoration-underline font-bold"

--- a/sources/packages/web/src/components/common/CancelDisbursementSchedule.vue
+++ b/sources/packages/web/src/components/common/CancelDisbursementSchedule.vue
@@ -1,0 +1,67 @@
+<template>
+  <check-permission-role :role="Role.StudentCancelDisbursementSchedule">
+    <template #="{ notAllowed }">
+      <v-btn
+        class="d-block"
+        variant="text"
+        color="primary"
+        @click="cancelDisbursementSchedule"
+        :disabled="notAllowed"
+        ><span class="text-decoration-underline font-bold"
+          >Cancel certificate</span
+        ></v-btn
+      >
+    </template>
+  </check-permission-role>
+  <confirm-modal
+    title="Confirm enrolment"
+    ref="confirmEnrolmentModal"
+    okLabel="Confirm enrolment now"
+    cancelLabel="Cancel"
+    ><template #content
+      ><span class="font-bold"
+        >Are you sure you want to confirm enrolment for this application?</span
+      >
+      <p class="mt-5">
+        Confirming enrolment verifies this applicant is attending your
+        institution and will allow funding to be disbursed.
+      </p>
+    </template></confirm-modal
+  >
+</template>
+
+<script lang="ts">
+import { defineComponent, ref } from "vue";
+import { Role } from "@/types";
+import { ModalDialog } from "@/composables";
+import ConfirmModal from "@/components/common/modals/ConfirmModal.vue";
+import CheckPermissionRole from "@/components/generic/CheckPermissionRole.vue";
+
+export default defineComponent({
+  emits: {
+    confirmEnrolment: (disbursementId: number) => {
+      return !!disbursementId;
+    },
+  },
+  components: { ConfirmModal, CheckPermissionRole },
+  props: {
+    disbursementId: {
+      type: Number,
+      required: false,
+    },
+  },
+  setup() {
+    const confirmEnrolmentModal = ref({} as ModalDialog<boolean>);
+
+    const cancelDisbursementSchedule = () => {
+      console.log("Cancel");
+    };
+
+    return {
+      cancelDisbursementSchedule,
+      confirmEnrolmentModal,
+      Role,
+    };
+  },
+});
+</script>

--- a/sources/packages/web/src/components/common/CancelDisbursementSchedule.vue
+++ b/sources/packages/web/src/components/common/CancelDisbursementSchedule.vue
@@ -85,12 +85,12 @@ export default defineComponent({
           userNoteModalResult.showParameter,
           { note: userNoteModalResult.note },
         );
-        snackBar.success("e-Cert cancelled.");
+        snackBar.success("eCert cancelled.");
         emit("disbursementScheduleCancelled");
         return true;
       } catch {
         snackBar.error(
-          "An unexpected error happened while cancelling the e-Cert.",
+          "An unexpected error happened while cancelling the eCert.",
         );
       }
       return false;

--- a/sources/packages/web/src/components/common/CancelDisbursementSchedule.vue
+++ b/sources/packages/web/src/components/common/CancelDisbursementSchedule.vue
@@ -2,8 +2,9 @@
   <check-permission-role :role="Role.StudentCancelDisbursementSchedule">
     <template #="{ notAllowed }">
       <v-btn
-        variant="text"
+        variant="outlined"
         color="primary"
+        prependIcon="mdi-close-circle-outline"
         @click="cancelDisbursementSchedule"
         :disabled="notAllowed"
         ><span class="text-decoration-underline font-bold"

--- a/sources/packages/web/src/components/common/CancelDisbursementSchedule.vue
+++ b/sources/packages/web/src/components/common/CancelDisbursementSchedule.vue
@@ -2,25 +2,42 @@
   <check-permission-role :role="Role.StudentCancelDisbursementSchedule">
     <template #="{ notAllowed }">
       <v-btn
-        class="d-block"
         variant="text"
         color="primary"
         @click="cancelDisbursementSchedule"
         :disabled="notAllowed"
         ><span class="text-decoration-underline font-bold"
-          >Cancel certificate</span
+          >Cancel eCert</span
         ></v-btn
       >
     </template>
   </check-permission-role>
   <user-note-confirm-modal
-    title="Confirm cancellation"
+    title="Cancel eCert"
     ref="confirmCancellationModal"
-    okLabel="Cancel e-Cert now"
+    okLabel="Confirm"
     cancelLabel="Cancel"
   >
     <template #content>
-      <p>Are you sure you would like to have the e-Cert cancelled?</p>
+      <p>
+        You are requesting the cancellation of an eCert. This action should be
+        communicated to the NSLSC prior to proceeding.
+      </p>
+      <p>Note:</p>
+      <ul>
+        <li>
+          Cancelling the eCert does not stop any future pending disbursements.
+        </li>
+        <li>It does not trigger a reassessment of the application.</li>
+        <li>
+          Please ensure all necessary changes are made before initiating a
+          reassessment to generate new disbursements.
+        </li>
+        <li>
+          Any overawards created or deducted as a result of this eCert will also
+          be reversed as part of this action.
+        </li>
+      </ul>
     </template>
     ></user-note-confirm-modal
   >

--- a/sources/packages/web/src/components/common/ConfirmEnrolment.vue
+++ b/sources/packages/web/src/components/common/ConfirmEnrolment.vue
@@ -3,8 +3,9 @@
     <template #="{ notAllowed }">
       <v-btn
         v-if="isConfirmCOEEnabled"
-        variant="text"
+        variant="outlined"
         color="primary"
+        prepend-icon="fa:fa fa-check"
         @click="submitConfirmEnrolment"
         :disabled="notAllowed"
         ><span class="text-decoration-underline font-bold"

--- a/sources/packages/web/src/components/common/StatusInfoDisbursementCancellation.vue
+++ b/sources/packages/web/src/components/common/StatusInfoDisbursementCancellation.vue
@@ -1,0 +1,38 @@
+<template>
+  <status-info-label :status="StatusInfo.Rejected"
+    >Certificate cancelled on {{ formattedDate }}</status-info-label
+  >
+  <p class="mt-3">
+    This final award was cancelled and no awards will be disbursed. Please
+    contact
+    <a href="mailto:StudentAidBC@gov.bc.ca" rel="noopener" target="_blank"
+      >StudentAid BC</a
+    >
+    to understand more about the next steps.
+  </p>
+</template>
+
+<script lang="ts">
+import { computed, defineComponent } from "vue";
+import { StatusInfo } from "@/types";
+import { useFormatters } from "@/composables";
+
+export default defineComponent({
+  props: {
+    cancellationDate: {
+      type: Date,
+      required: true,
+    },
+  },
+  setup(props) {
+    const { dateOnlyLongString } = useFormatters();
+    const formattedDate = computed(() =>
+      dateOnlyLongString(props.cancellationDate),
+    );
+    return {
+      formattedDate,
+      StatusInfo,
+    };
+  },
+});
+</script>

--- a/sources/packages/web/src/components/common/modals/UserNoteConfirmModal.vue
+++ b/sources/packages/web/src/components/common/modals/UserNoteConfirmModal.vue
@@ -1,0 +1,133 @@
+<template>
+  <v-form ref="modalNotesForm">
+    <modal-dialog-base
+      :title="title"
+      :showDialog="showDialog"
+      :maxWidth="maxWidth"
+    >
+      <template #content>
+        <error-summary :errors="modalNotesForm.errors" />
+        <slot name="content">{{ text }}</slot>
+        <v-textarea
+          label="Notes"
+          variant="outlined"
+          hide-details="auto"
+          v-model="note"
+          :rules="[checkNotesLengthRule]"
+          required
+        />
+      </template>
+      <template #footer>
+        <footer-buttons
+          :primaryLabel="okLabel"
+          :secondaryLabel="cancelLabel"
+          @primaryClick="resolvePromise(true)"
+          @secondaryClick="resolvePromise(false)"
+          :disablePrimaryButton="disablePrimaryButton"
+          :showSecondaryButton="showSecondaryButton"
+          :processing="loading"
+        />
+      </template>
+    </modal-dialog-base>
+  </v-form>
+</template>
+
+<script lang="ts">
+import { defineComponent, ref } from "vue";
+import ModalDialogBase from "@/components/generic/ModalDialogBase.vue";
+import { useModalDialog, useRules } from "@/composables";
+import { VForm } from "@/types";
+
+export interface UserNoteModal<T> {
+  showParameter: T;
+  note: string;
+}
+
+export default defineComponent({
+  components: {
+    ModalDialogBase,
+  },
+  props: {
+    title: {
+      type: String,
+      required: true,
+    },
+    text: {
+      type: String,
+      required: false,
+    },
+    okLabel: {
+      type: String,
+      required: true,
+      default: "Ok",
+    },
+    cancelLabel: {
+      type: String,
+      required: true,
+      default: "Cancel",
+    },
+    maxWidth: {
+      type: Number,
+      required: false,
+    },
+    disablePrimaryButton: {
+      type: Boolean,
+      required: false,
+      default: false,
+    },
+    showSecondaryButton: {
+      type: Boolean,
+      required: false,
+      default: true,
+    },
+    loading: {
+      type: Boolean,
+      default: false,
+    },
+  },
+  setup() {
+    const { checkNotesLengthRule } = useRules();
+    const {
+      showDialog,
+      resolvePromise: internalResolvePromise,
+      showModal,
+      showParameter,
+    } = useModalDialog<UserNoteModal<unknown> | false>();
+    const modalNotesForm = ref({} as VForm);
+    const note = ref("");
+
+    const resolvePromise = async (value: boolean) => {
+      if (!value) {
+        // Resets the form and closes the modal.
+        modalNotesForm.value.reset();
+        await internalResolvePromise(false);
+        return;
+      }
+      // Validates the form.
+      const validationResult = await modalNotesForm.value.validate();
+      if (!validationResult.valid) {
+        // Keeps the form open to allow the user to fix the validation.
+        return;
+      }
+      debugger;
+      const resolved = await internalResolvePromise({
+        showParameter: showParameter.value,
+        note: note.value,
+      });
+      if (resolved) {
+        // Reset the form if the promise was resolved.
+        modalNotesForm.value.reset();
+      }
+    };
+
+    return {
+      checkNotesLengthRule,
+      modalNotesForm,
+      note,
+      showDialog,
+      showModal,
+      resolvePromise,
+    };
+  },
+});
+</script>

--- a/sources/packages/web/src/components/common/modals/UserNoteConfirmModal.vue
+++ b/sources/packages/web/src/components/common/modals/UserNoteConfirmModal.vue
@@ -109,7 +109,6 @@ export default defineComponent({
         // Keeps the form open to allow the user to fix the validation.
         return;
       }
-      debugger;
       const resolved = await internalResolvePromise({
         showParameter: showParameter.value,
         note: note.value,

--- a/sources/packages/web/src/components/common/students/applicationDetails/AssessmentAward.vue
+++ b/sources/packages/web/src/components/common/students/applicationDetails/AssessmentAward.vue
@@ -14,10 +14,11 @@
     </template>
   </body-header>
   <assessment-award-details
-    :assessmentAwardData="assessmentAwardData"
-    :allowConfirmEnrolment="allowConfirmEnrolment"
+    :assessment-award-data="assessmentAwardData"
+    :allow-confirm-enrolment="allowConfirmEnrolment"
+    :allow-disbursement-cancellation="allowDisbursementCancellation"
     :allow-final-award-extended-information="allowFinalAwardExtendedInformation"
-    @confirmEnrolment="$emit('confirmEnrolment', $event)"
+    @confirm-enrolment="$emit('confirmEnrolment', $event)"
   />
 </template>
 <script lang="ts">
@@ -45,6 +46,11 @@ export default defineComponent({
       required: true,
     },
     allowConfirmEnrolment: {
+      type: Boolean,
+      required: false,
+      default: false,
+    },
+    allowDisbursementCancellation: {
       type: Boolean,
       required: false,
       default: false,

--- a/sources/packages/web/src/composables/useModalDialog.ts
+++ b/sources/packages/web/src/composables/useModalDialog.ts
@@ -1,16 +1,24 @@
 import { Ref, ref } from "vue";
 
-export function useModalDialog<T, TParameter = any>() {
+export function useModalDialog<T, TParameter = unknown>() {
   const showDialog = ref(false);
   const loading = ref(false);
   const showParameter = ref<TParameter>();
   let promise: (value: T) => void;
   let beforeResolvePromise: ((value: T) => Promise<boolean>) | undefined;
 
+  /**
+   * Resolves the promise returned by showModal.
+   * If {@see beforeResolvePromise} is provided, it will be called before resolving the promise,
+   * and if it returns false, the promise will not be resolved and the modal will remain open.
+   * @param value value to used to resolve the promise (also provided as a parameter to {@see beforeResolvePromise}).
+   * @param options options to control the modal behavior.
+   * @returns true if the promise was resolved, false otherwise.
+   */
   const resolvePromise = async (
     value: T,
     options?: { keepModalOpen?: boolean },
-  ) => {
+  ): Promise<boolean> => {
     // Check if a truthy value was returned.
     // value as false would indicate the modal was canceled.
     if (value && beforeResolvePromise) {
@@ -20,11 +28,13 @@ export function useModalDialog<T, TParameter = any>() {
       if (!success) {
         // Abort the promise resolution if the beforeResolvePromise
         // is present and did not return true.
-        return;
+        return false;
       }
     }
     showDialog.value = options?.keepModalOpen ?? false;
     promise(value);
+    // Indicate the promise was resolved.
+    return true;
   };
 
   const showModal = async (

--- a/sources/packages/web/src/services/DisbursementScheduleService.ts
+++ b/sources/packages/web/src/services/DisbursementScheduleService.ts
@@ -1,0 +1,26 @@
+import ApiClient from "@/services/http/ApiClient";
+import { CancelDisbursementScheduleAPIInDTO } from "@/services/http/dto";
+
+export class DisbursementScheduleService {
+  // Share Instance
+  private static instance: DisbursementScheduleService;
+
+  public static get shared(): DisbursementScheduleService {
+    return this.instance || (this.instance = new this());
+  }
+
+  /**
+   * Cancels a disbursement schedule.
+   * @param disbursementScheduleId disbursement schedule ID.
+   * @param payload payload with the cancellation info.
+   */
+  async cancelDisbursementSchedule(
+    disbursementScheduleId: number,
+    payload: CancelDisbursementScheduleAPIInDTO,
+  ): Promise<void> {
+    return ApiClient.DisbursementSchedule.cancelDisbursementSchedule(
+      disbursementScheduleId,
+      payload,
+    );
+  }
+}

--- a/sources/packages/web/src/services/DisbursementScheduleService.ts
+++ b/sources/packages/web/src/services/DisbursementScheduleService.ts
@@ -5,7 +5,7 @@ export class DisbursementScheduleService {
   // Share Instance
   private static instance: DisbursementScheduleService;
 
-  public static get shared(): DisbursementScheduleService {
+  static get shared(): DisbursementScheduleService {
     return this.instance || (this.instance = new this());
   }
 

--- a/sources/packages/web/src/services/http/ApiClient.ts
+++ b/sources/packages/web/src/services/http/ApiClient.ts
@@ -33,6 +33,7 @@ import { CASInvoiceBatchApi } from "@/services/http/CASInvoiceBatchApi";
 import { CASInvoiceApi } from "@/services/http/CASInvoiceApi";
 import { DynamicFormConfigurationApi } from "@/services/http/DynamicFormConfigurationApi";
 import { ApplicationChangeRequestApi } from "@/services/http/ApplicationChangeRequestApi";
+import { DisbursementScheduleApi } from "@/services/http/DisbursementScheduleApi";
 
 const ApiClient = {
   AuditApi: new AuditApi(),
@@ -71,6 +72,7 @@ const ApiClient = {
   CASInvoiceApi: new CASInvoiceApi(),
   DynamicFormConfigurationApi: new DynamicFormConfigurationApi(),
   ApplicationChangeRequestApi: new ApplicationChangeRequestApi(),
+  DisbursementSchedule: new DisbursementScheduleApi(),
 };
 
 export default ApiClient;

--- a/sources/packages/web/src/services/http/DisbursementScheduleApi.ts
+++ b/sources/packages/web/src/services/http/DisbursementScheduleApi.ts
@@ -1,0 +1,24 @@
+import HttpBaseClient from "./common/HttpBaseClient";
+import { CancelDisbursementScheduleAPIInDTO } from "@/services/http/dto";
+
+/**
+ * Http API client for disbursement schedules.
+ */
+export class DisbursementScheduleApi extends HttpBaseClient {
+  /**
+   * Cancels a disbursement schedule.
+   * @param disbursementScheduleId disbursement schedule ID.
+   * @param payload payload with the cancellation info.
+   */
+  async cancelDisbursementSchedule(
+    disbursementScheduleId: number,
+    payload: CancelDisbursementScheduleAPIInDTO,
+  ): Promise<void> {
+    return this.patchCall(
+      this.addClientRoot(
+        `disbursement-schedule/${disbursementScheduleId}/cancel`,
+      ),
+      payload,
+    );
+  }
+}

--- a/sources/packages/web/src/services/http/dto/Assessment.dto.ts
+++ b/sources/packages/web/src/services/http/dto/Assessment.dto.ts
@@ -82,7 +82,10 @@ export interface AssessmentNOAAPIOutDTO {
  *    disbursementReceipt2sbsd: 1008,
  *   }
  */
-export type DynamicAwardValue = Record<string, string | number | Date>;
+export type DynamicAwardValue = Record<
+  string,
+  string | number | Date | boolean
+>;
 
 export interface AwardDetailsAPIOutDTO {
   applicationNumber: string;

--- a/sources/packages/web/src/services/http/dto/DisbursementSchedule.dto.ts
+++ b/sources/packages/web/src/services/http/dto/DisbursementSchedule.dto.ts
@@ -1,0 +1,3 @@
+export interface CancelDisbursementScheduleAPIInDTO {
+  note: string;
+}

--- a/sources/packages/web/src/services/http/dto/index.ts
+++ b/sources/packages/web/src/services/http/dto/index.ts
@@ -34,3 +34,4 @@ export * from "@/services/http/dto/DynamicFormConfiguration.dto";
 export * from "@/services/http/dto/Announcement.dto";
 export * from "@/services/http/dto/Form.dto";
 export * from "@/services/http/dto/ApplicationChangeRequest.dto";
+export * from "@/services/http/dto/DisbursementSchedule.dto";

--- a/sources/packages/web/src/types/contracts/aest/roles.ts
+++ b/sources/packages/web/src/types/contracts/aest/roles.ts
@@ -26,6 +26,7 @@ export enum Role {
   StudentAddNewSIN = "student-add-new-sin",
   StudentCreateNote = "student-create-note",
   StudentConfirmEnrolment = "student-confirm-enrolment",
+  StudentCancelDisbursementSchedule = "student-cancel-disbursement-schedule",
   StudentAddOverawardManual = "student-add-overaward-manual",
   InstitutionEditProfile = "institution-edit-profile",
   InstitutionApproveDeclineProgram = "institution-approve-decline-program",

--- a/sources/packages/web/src/views/aest/student/applicationDetails/AssessmentAward.vue
+++ b/sources/packages/web/src/views/aest/student/applicationDetails/AssessmentAward.vue
@@ -15,6 +15,7 @@
       :assessment-award-data="assessmentAwardData"
       :notice-of-assessment-route="noticeOfAssessmentRoute"
       :allow-confirm-enrolment="true"
+      :allow-disbursement-cancellation="true"
       :allow-final-award-extended-information="true"
       @confirm-enrolment="confirmEnrolment"
     />


### PR DESCRIPTION
- Created new role `student-cancel-disbursement-schedule`.
- Created new API endpoint for disbursement schedules (placeholder for upcoming PR).
- Included in the assessment summary API payload the below new values:
  -  `disbursementReceipt[n]Received`: indicates if a receipt was received. _Note:_ full-time final awards are retrieved when a receipt is received, and part-time are displayed upon e-Cert creation. This new variable indicates when a receipt was received, not when a final award was returned.
  - `disbursementReceipt[n]HasAwards`: added to indicate when an award is present in the payload. Previously, only awards were present in this payload, and they were dynamically created. Adding the boolean makes it easier to identify when awards are present, avoiding inspecting the object structure as was done before. The examples for the payloads with the new variables were updated and can be seen across many E2E tests.
- Created a new component `StatusInfoDisbursementCancellation` to display the information when a disbursement is cancelled, following a similar idea from the `StatusInfoEnrolment`.
- Created a new component `CancelDisbursementSchedule` following the same idea from `ConfirmEnrolment`.
- Created the generic modal `user-note-confirm-modal` to allow modal confirmation, including a user note. Its usage can be checked in the `CancelDisbursementSchedule.vue`.

### Please note
_1. Changes executed in the methods retrieving the data for the summary page were executed, trying to keep the current dynamic behavior. Additional changes can be made to make a hybrid object model between dynamic and non-dynamic properties, but it was not considered worthwhile as part of this effort.
2. Some UI changes are pending decision, but no major adaptations are expected._

## Ministry View

### Full-time, Final award, e-Cert `Sent`, no receipts

<img width="1211" height="512" alt="image" src="https://github.com/user-attachments/assets/7be21978-f04f-49a8-9ad9-938833b69a42" />

### Full-time, Final award, e-Cert `Rejected`, no receipts

<img width="1205" height="499" alt="image" src="https://github.com/user-attachments/assets/c8b32e54-83bf-4d6e-a945-361df58ac4f0" />

### Full-time, Final award, e-Cert `Pending`, no receipts

<img width="1212" height="405" alt="image" src="https://github.com/user-attachments/assets/eb89d053-f881-4feb-9490-3a9131a58f33" />

### Full-time, Final award, e-Cert `Pending`, with receipts

<img width="1205" height="811" alt="image" src="https://github.com/user-attachments/assets/88e8a7d4-7275-4337-8e8a-c642af2aed4e" />

### Cancel eCert modal

<img width="752" height="620" alt="image" src="https://github.com/user-attachments/assets/e66b3f40-d61c-4f3f-8162-db5042f3bf39" />

### Buttons and icons adjustments

<img width="1211" height="778" alt="image" src="https://github.com/user-attachments/assets/82915ee0-9c0d-4ef3-9267-cbfabc949894" />





