### PR TITLE
#5111 - Fixes display of uploader 

### DIFF
--- a/sources/packages/forms/src/form-definitions/sfaa2025-26-ft.json
+++ b/sources/packages/forms/src/form-definitions/sfaa2025-26-ft.json
@@ -3512,13 +3512,12 @@
                       "input": true
                     },
                     {
-                      "label": "Upload supporting documents",
                       "title": "Upload supporting documents",
                       "collapsible": false,
                       "hideLabel": true,
                       "key": "uploadSupportingDocuments1",
-                      "customConditional": "show = data['bcParentLivingSituation'];",
                       "type": "panel",
+                      "label": "Upload supporting documents",
                       "input": false,
                       "tableView": false,
                       "components": [


### PR DESCRIPTION
- Fixes bug where uploader is not displayed for parent residency exception question on FT25/26 form
- Uploader is displayed when list of situations for parent residency exception is shown. 

<img width="1157" height="785" alt="image" src="https://github.com/user-attachments/assets/fffe994b-e0e3-4acd-b273-03e1899ac1c3" />
