### PR TITLE
#5059 - When a partial match exists add hold restriction

### DIFF
--- a/sources/packages/backend/apps/api/src/app.external.module.ts
+++ b/sources/packages/backend/apps/api/src/app.external.module.ts
@@ -4,11 +4,17 @@ import {
   StudentExternalControllerService,
 } from "./route-controllers";
 import { AuthModule } from "./auth/auth.module";
-import { StudentInformationService, StudentService } from "./services";
+import {
+  StudentInformationService,
+  StudentRestrictionService,
+  StudentService,
+} from "./services";
 import {
   DisbursementOverawardService,
   NoteSharedService,
+  RestrictionSharedService,
   SFASIndividualService,
+  StudentRestrictionSharedService,
 } from "@sims/services";
 
 @Module({
@@ -21,6 +27,9 @@ import {
     NoteSharedService,
     StudentInformationService,
     StudentExternalControllerService,
+    StudentRestrictionSharedService,
+    StudentRestrictionService,
+    RestrictionSharedService,
   ],
 })
 export class AppExternalModule {}

--- a/sources/packages/backend/apps/api/src/auth/auth.module.ts
+++ b/sources/packages/backend/apps/api/src/auth/auth.module.ts
@@ -11,6 +11,7 @@ import {
   DesignationAgreementLocationService,
   InstitutionService,
   BCeIDService,
+  StudentRestrictionService,
 } from "../services";
 import { JwtAuthGuard } from "./guards/jwt-auth.guard";
 import { JwtStrategy } from "./jwt.strategy";
@@ -32,6 +33,8 @@ import { SFASIndividualService } from "@sims/services/sfas";
 import {
   DisbursementOverawardService,
   NoteSharedService,
+  StudentRestrictionSharedService,
+  RestrictionSharedService,
 } from "@sims/services";
 import { KeycloakService } from "@sims/auth/services";
 import { KeycloakConfig } from "@sims/auth/config";
@@ -56,6 +59,9 @@ const jwtModule = JwtModule.register({
     NoteSharedService,
     InstitutionService,
     BCeIDService,
+    RestrictionSharedService,
+    StudentRestrictionService,
+    StudentRestrictionSharedService,
     {
       provide: APP_GUARD,
       useClass: JwtAuthGuard,

--- a/sources/packages/backend/apps/api/src/services/student/student.service.ts
+++ b/sources/packages/backend/apps/api/src/services/student/student.service.ts
@@ -420,7 +420,7 @@ export class StudentService extends RecordDataModelService<Student> {
             student.id,
             RestrictionCode.HOLD,
             auditUserId,
-            undefined, // applicationId is null for this case
+            undefined, // applicationId is undefined for this case
             externalEntityManager,
           );
         holdRestriction.restrictionNote = holdNote;

--- a/sources/packages/backend/libs/services/src/restriction/model/restriction.model.ts
+++ b/sources/packages/backend/libs/services/src/restriction/model/restriction.model.ts
@@ -49,4 +49,9 @@ export enum RestrictionCode {
    * Bankruptcy has been filed and there is a hold on federal and BC funding.
    */
   RB = "RB",
+  /**
+   * Application processing hold restriction to prevent application completion while
+   * potential partial match exists.
+   */
+  HOLD = "HOLD",
 }

--- a/sources/packages/backend/libs/services/src/restriction/student-restriction-shared.service.ts
+++ b/sources/packages/backend/libs/services/src/restriction/student-restriction-shared.service.ts
@@ -189,7 +189,7 @@ export class StudentRestrictionSharedService extends RecordDataModelService<Stud
     studentId: number,
     restrictionCode: RestrictionCode,
     auditUserId: number,
-    applicationId: number,
+    applicationId?: number,
     entityManager?: EntityManager,
   ): Promise<StudentRestriction> {
     const restriction =
@@ -207,7 +207,9 @@ export class StudentRestrictionSharedService extends RecordDataModelService<Stud
       id: restriction.id,
     } as Restriction;
     studentRestriction.student = { id: studentId } as Student;
-    studentRestriction.application = { id: applicationId } as Application;
+    studentRestriction.application = applicationId
+      ? ({ id: applicationId } as Application)
+      : undefined;
     studentRestriction.creator = { id: auditUserId } as User;
     return studentRestriction;
   }


### PR DESCRIPTION
  ### AC
  Implements automatic addition of HOLD restrictions when partial matches are detected during student account creation. This ensures that students with potential data conflicts are prevented from completing applications until the matches are resolved manually.

### Demo 
- 2 partial data (Last name, DOB)
1. Restriction Added.
<img width="1588" height="602" alt="image" src="https://github.com/user-attachments/assets/43623e2b-a5dc-4db7-b471-7cba39e94ef9" />
2.Notes Added
<img width="1570" height="604" alt="image" src="https://github.com/user-attachments/assets/5622e161-1c92-4b95-af58-c1c31a47e1bc" />
