### PR TITLE
#5124 - Student debit subtraction bug

### DIFF
--- a/sources/packages/backend/libs/services/src/disbursement-schedule/disbursement-schedule-shared.service.ts
+++ b/sources/packages/backend/libs/services/src/disbursement-schedule/disbursement-schedule-shared.service.ts
@@ -616,7 +616,7 @@ export class DisbursementScheduleSharedService extends RecordDataModelService<Di
   ): number {
     let studentDebit = totalStudentDebit;
     for (const award of awards) {
-      if (award.valueAmount >= totalStudentDebit) {
+      if (award.valueAmount >= studentDebit) {
         // Current disbursement value is enough to pay the debit.
         // For instance:
         // - Award: $1000


### PR DESCRIPTION
## Bug Root cause

During the process of creating disbursement schedules(which happens in workers), besides saving the value amount for each award, we subtract the award value which was already sent for that particular award for the same application to eventually derive the effective amount. 

In a particular scenario where, an application has 2 disbursements where one of the disbursement is Sent and other disbursement is pending with 2nd disbursement amount different than first disbursement for the same award, and then the application gets re-assessed, then the issue that **_this particular award gets amount subtracted with value which was never sent_**.

Assessment 1 - Original Assessment

| Disbursement Schedule No | Disbursement status | Award Code | Award Value | Amount Subtracted |
|--------------------------|---------------------|------------|-------------|-------------------|
| 1                        | Sent                | CSPT       | 553         | 0                 |
| 2                        | Pending             | CSPT       | 552         | 0                 |


Assessment 2 - Re-Assessment

| Disbursement Schedule No | Disbursement status | Award Code | Award Value | Amount Subtracted |
|--------------------------|---------------------|------------|-------------|-------------------|
| 1 (Original Assessment)  | Sent                | CSPT       | 553         | 0                 |
| 2 (Original Assessment)  | Cancelled           | CSPT       | 552         | 0                 |
| 1 (Reassessment)         | Pending             | CSPT       | 553         | 553               |
| 2 (Reassessment)         | Pending             | CSPT       | 552         | 552               |

The disbursement `2 (Reassessment)` should have amount subtracted as 0 as disbursement 2 amount was never sent.

This is due to a bug in condition where we use the inital student debit(totalStudentDebit) instead of current student debit(studentDebit) here. 

https://github.com/bcgov/SIMS/blob/8a9c06a0757234c5625a4861ee699b78843a959d/sources/packages/backend/libs/services/src/disbursement-schedule/disbursement-schedule-shared.service.ts#L619

## Solution

Using the current student debit. 


## Manual testing 

Before fix 

Awards sent from assessment 1 - disbursement 1

<img width="1244" height="764" alt="image" src="https://github.com/user-attachments/assets/83a307e1-9c5d-43e0-9658-d5b3e848e3bb" />

Awards sent from assessment 2 - disbursement 2
<img width="1235" height="505" alt="image" src="https://github.com/user-attachments/assets/c8b198cc-da8d-4fa3-bb2b-918aafeb018b" />


Current assessment - award subtracted
<img width="1657" height="298" alt="image" src="https://github.com/user-attachments/assets/db1d625d-c01b-4553-bd87-8641b226381d" />


After Fix

Current assessment - award subtracted
<img width="1705" height="322" alt="image" src="https://github.com/user-attachments/assets/07624b4c-8eb3-4179-b3e9-1bb683fe4916" />
