### PR TITLE
#5216 - Hide label on FT25/26 question

### DIFF
--- a/sources/packages/forms/src/form-definitions/sfaa2025-26-ft.json
+++ b/sources/packages/forms/src/form-definitions/sfaa2025-26-ft.json
@@ -7748,6 +7748,7 @@
             {
               "title": "Merit-based scholarships panel",
               "collapsible": false,
+              "hideLabel": true,
               "key": "meritBasedScholarshipsPanel",
               "conditional": {
                 "show": true,


### PR DESCRIPTION
- Change to hide label on merit-based scholarship question for FT 25/26 app 

<img width="1083" height="283" alt="image" src="https://github.com/user-attachments/assets/6e18d889-f422-4496-885b-25cf317f03d8" />
