### PR TITLE
#4835 - BUG: PROD: Duplicate offerings (change under approval/new) allowed

### DIFF
--- a/sources/packages/backend/apps/db-migrations/src/migrations/1756934022742-UpdateOfferingDuplicateUniqueIndex.ts
+++ b/sources/packages/backend/apps/db-migrations/src/migrations/1756934022742-UpdateOfferingDuplicateUniqueIndex.ts
@@ -1,0 +1,24 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+import { getSQLFileData } from "../utilities/sqlLoader";
+
+export class UpdateOfferingDuplicateUniqueIndex1756934022742
+  implements MigrationInterface
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      getSQLFileData(
+        "Update-offering-request-unique-index.sql",
+        "EducationProgramsOfferings",
+      ),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      getSQLFileData(
+        "Rollback-update-offering-request-unique-index.sql",
+        "EducationProgramsOfferings",
+      ),
+    );
+  }
+}

--- a/sources/packages/backend/apps/db-migrations/src/sql/EducationProgramsOfferings/Rollback-update-offering-request-unique-index.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/EducationProgramsOfferings/Rollback-update-offering-request-unique-index.sql
@@ -1,0 +1,21 @@
+DROP INDEX sims.loc_id_prog_id_offer_name_study_dts_year_study_index;
+
+-- Create the unique index for the offering name, start, and end dates on the same program and location.
+-- The unique index is valid only for the offerings in "Approved" or "Creation pending",
+-- the others statuses can allow the duplication, for instance, during an "offering request a changed" process the offering can be "cloned".
+-- An unique index was used instead of a constraint to allow the creation of the unique "constraint" including the 
+-- where IN ('Approved', 'Creation pending').
+CREATE UNIQUE INDEX loc_id_prog_id_offer_name_study_dts_year_study_index ON sims.education_programs_offerings(
+    location_id,
+    program_id,
+    offering_name,
+    study_start_date,
+    study_end_date,
+    offering_status
+)
+WHERE
+    (
+        offering_status IN ('Approved', 'Creation pending')
+    );
+
+COMMENT ON INDEX sims.loc_id_prog_id_offer_name_study_dts_year_study_index IS 'Ensures offering in "Approved" or "Creation pending" statuses does not have the same name, study start, and study end dates.'

--- a/sources/packages/backend/apps/db-migrations/src/sql/EducationProgramsOfferings/Update-offering-request-unique-index.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/EducationProgramsOfferings/Update-offering-request-unique-index.sql
@@ -1,0 +1,23 @@
+-- Create the unique index for the offering name, start, and end dates on the same program and location.
+DROP INDEX sims.loc_id_prog_id_offer_name_study_dts_year_study_index;
+
+-- The unique index is valid only for the offerings in "Approved", "Creation pending" or "Change under review",
+-- the others statuses can allow the duplication, for instance, during an "offering request a changed" process the offering can be "cloned".
+-- A unique index was used instead of a constraint to allow the creation of the unique "constraint" including the 
+-- where IN ('Approved', 'Creation pending', 'Change under review').
+CREATE UNIQUE INDEX loc_id_prog_id_offer_name_study_dts_year_study_index ON sims.education_programs_offerings(
+  location_id,
+  program_id,
+  offering_name,
+  study_start_date,
+  study_end_date,
+  offering_status,
+  year_of_study
+)
+WHERE
+  (
+    offering_status IN ('Approved', 'Creation pending', 'Change under review')
+  )
+  AND offering_type IN ('Public', 'Private');
+
+COMMENT ON INDEX sims.loc_id_prog_id_offer_name_study_dts_year_study_index IS 'Ensures offering in "Approved", "Creation pending" or "Change under review" statuses does not have the same name, study start/end dates and year of study.Applied only to "Public" and "Private" offering types.'


### PR DESCRIPTION
**Bug Fix**
- Add `'Change under review'` status for `education_programs_offerings` table.

**Migration Run**
<img width="1766" height="416" alt="image" src="https://github.com/user-attachments/assets/5d972d50-3f5c-42b8-86c6-b13de27c2d21" />

**Migration Rollback**

<img width="1712" height="748" alt="image" src="https://github.com/user-attachments/assets/c22c8574-7700-4022-bcf6-6325f735e271" />
