### PR TITLE
#5146 - Fixes exception label for PT 25/26 

### DIFF
--- a/sources/packages/forms/src/form-definitions/sfaa2025-26-pt.json
+++ b/sources/packages/forms/src/form-definitions/sfaa2025-26-pt.json
@@ -2734,8 +2734,8 @@
                   "input": true,
                   "components": [
                     {
-                      "label": "Exception Description - Married/common-law domestic violence",
-                      "calculateValue": "value = \"Married/common-law domestic violence\";",
+                      "label": "Exception Description - Citizenship for B.C. residency",
+                      "calculateValue": "value = \"Citizenship for B.C. residency\";",
                       "calculateServer": true,
                       "key": "exceptionDescription",
                       "type": "hidden",


### PR DESCRIPTION
- minor fix for exception label for PT25/26. "BC residency" exception was incorrectly using label of "Married/Common-law" exception 