### PR TITLE
#4378 - Ecert Cancellation - UI & Ministry Access (2/2) - Content adjustment

### DIFF
--- a/sources/packages/web/src/components/common/AssessmentAwardDetails.vue
+++ b/sources/packages/web/src/components/common/AssessmentAwardDetails.vue
@@ -448,9 +448,6 @@ export default defineComponent({
       coeStatus: COEStatus,
       disbursementStatus: DisbursementScheduleStatus,
     ): string | undefined => {
-      if (disbursementStatus === DisbursementScheduleStatus.Rejected) {
-        return undefined;
-      }
       if (coeStatus === COEStatus.declined) {
         return "The final award is no longer applicable due to a change. Any scheduled disbursements will be cancelled.";
       }


### PR DESCRIPTION
Adjusted content to avoid displaying no longer required messages once the e-Cert is cancelled, mainly affecting part-time but with a minor potential to affect full-time.

## Part-time before cancellation

<img width="788" height="802" alt="image" src="https://github.com/user-attachments/assets/f9748e37-b024-47ea-bae3-667f782673d5" />

## Part-time after cancellation

<img width="795" height="747" alt="image" src="https://github.com/user-attachments/assets/bd0e7747-beda-4d27-abba-cf4e67b8c289" />

## Full-time after cancellation

<img width="1492" height="583" alt="image" src="https://github.com/user-attachments/assets/400e44e8-6af5-46d3-a5ea-c69e25870f5e" />






