### PR TITLE
#5079 - FT Assessment: BCAG max value rounding issues

### DIFF
--- a/sources/packages/backend/workflow/src/workflow-definitions/fulltime-assessment-decisions.dmn
+++ b/sources/packages/backend/workflow/src/workflow-definitions/fulltime-assessment-decisions.dmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" xmlns:modeler="http://camunda.org/schema/modeler/1.0" xmlns:camunda="http://camunda.org/schema/1.0/dmn" id="dmnFullTimeAssessmentDecisions" name="dmnFullTimeAssessmentDecisions" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="5.35.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.6.0" camunda:diagramRelationId="1a575ead-1e6d-468c-901a-766a35569b38">
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" xmlns:modeler="http://camunda.org/schema/modeler/1.0" xmlns:camunda="http://camunda.org/schema/1.0/dmn" id="dmnFullTimeAssessmentDecisions" name="dmnFullTimeAssessmentDecisions" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="5.38.1" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.6.0" camunda:diagramRelationId="1a575ead-1e6d-468c-901a-766a35569b38">
   <decision id="dmnFullTimeProgramYearMaximums" name="dmnFullTimeProgramYearMaximums">
     <decisionTable id="DecisionTable_1oyvbif">
       <input id="InputClause_02zjhj9" label="programYear">
@@ -2938,10 +2938,10 @@
           <text>100</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_05rn97y">
-          <text>round half up(1000 / 34,2)</text>
+          <text>round half up(1000 / 34,4)</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_0ifhr0i">
-          <text>round half up(4000 / 34,2)</text>
+          <text>round half up(4000 / 34,4)</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_1qcfwjx">
           <text>100</text>

--- a/sources/packages/backend/workflow/test/2025-2026/fulltime-assessment/awards/fulltime-assessment-awards-amount-BCAG.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2025-2026/fulltime-assessment/awards/fulltime-assessment-awards-amount-BCAG.e2e-spec.ts
@@ -1,0 +1,103 @@
+import { PROGRAM_YEAR } from "../../constants/program-year.constants";
+import {
+  ZeebeMockedClient,
+  createFakeAssessmentConsolidatedData,
+  executeFullTimeAssessmentForProgramYear,
+  executePartTimeAssessmentForProgramYear,
+} from "../../../test-utils";
+import { ProgramLengthOptions } from "../../../models";
+
+describe(`E2E Test Workflow fulltime-assessment-${PROGRAM_YEAR}-awards-amount-BCAG.`, () => {
+  it("Should determine $0 Weekly BCAG Max Amount when student is not eligible for BCAG or BCAG 2 Year.", async () => {
+    // Arrange
+    const assessmentConsolidatedData =
+      createFakeAssessmentConsolidatedData(PROGRAM_YEAR);
+    assessmentConsolidatedData.studentDataTaxReturnIncome = 79719; // Above the BCAG income cap for single student
+
+    // Act
+    const calculatedAssessment = await executeFullTimeAssessmentForProgramYear(
+      PROGRAM_YEAR,
+      assessmentConsolidatedData,
+    );
+    // Assert
+    expect(calculatedAssessment.variables.awardEligibilityBCAG).toBe(false);
+    expect(calculatedAssessment.variables.awardEligibilityBCAG2Year).toBe(
+      false,
+    );
+    expect(calculatedAssessment.variables.provincialAwardWeeklyBCAGMax).toBe(0);
+    expect(calculatedAssessment.variables.provincialAwardBCAGAmount).toBe(0);
+    expect(calculatedAssessment.variables.provincialAwardNetBCAGAmount).toBe(0);
+    expect(
+      calculatedAssessment.variables.finalProvincialAwardNetBCAGAmount,
+    ).toBe(0);
+  });
+
+  it("Should determine the correct weekly amount when student is eligible for BCAG (not 2 year) and is below income threshold.", async () => {
+    // Arrange
+    const assessmentConsolidatedData =
+      createFakeAssessmentConsolidatedData(PROGRAM_YEAR);
+    assessmentConsolidatedData.studentDataTaxReturnIncome = 36810; // Below the BCAG income threshold for single student
+    assessmentConsolidatedData.programLength =
+      ProgramLengthOptions.TwelveWeeksToFiftyTwoWeeks;
+
+    // Act
+    const calculatedAssessment = await executePartTimeAssessmentForProgramYear(
+      PROGRAM_YEAR,
+      assessmentConsolidatedData,
+    );
+    // Assert
+    expect(calculatedAssessment.variables.awardEligibilityBCAG).toBe(true);
+    expect(calculatedAssessment.variables.awardEligibilityBCAG2Year).toBe(
+      false,
+    );
+    expect(calculatedAssessment.variables.provincialAwardWeeklyBCAGMax).toBe(
+      29.4118,
+    );
+    // The provincialAwardBCAGAmount is calculated as: weekly amount * number of weeks.
+    // 29.4118 * 34 weeks = 1000
+    expect(calculatedAssessment.variables.provincialAwardBCAGAmount).toBe(1000);
+    // The provincialAwardNetBCAGAmount is calculated as the lesser of provincialAwardBCAGAmount or the minimum BCAG award amount.
+    expect(calculatedAssessment.variables.provincialAwardNetBCAGAmount).toBe(
+      calculatedAssessment.variables.provincialAwardBCAGAmount,
+    );
+    // Exact amount after other award amounts can impact the final BCAG amount.
+    expect(
+      calculatedAssessment.variables.finalProvincialAwardNetBCAGAmount,
+    ).toBeGreaterThan(0);
+  });
+
+  it("Should determine the correct weekly amount when student is eligible for BCAG 2 Year and is below income threshold.", async () => {
+    // Arrange
+    const assessmentConsolidatedData =
+      createFakeAssessmentConsolidatedData(PROGRAM_YEAR);
+    assessmentConsolidatedData.studentDataTaxReturnIncome = 36810; // Below the BCAG income threshold for single student
+
+    // Act
+    const calculatedAssessment = await executePartTimeAssessmentForProgramYear(
+      PROGRAM_YEAR,
+      assessmentConsolidatedData,
+    );
+    // Assert
+    expect(calculatedAssessment.variables.awardEligibilityBCAG).toBe(false);
+    expect(calculatedAssessment.variables.awardEligibilityBCAG2Year).toBe(true);
+    expect(calculatedAssessment.variables.provincialAwardWeeklyBCAGMax).toBe(
+      117.6471,
+    );
+    // The provincialAwardBCAGAmount is calculated as: weekly amount * number of weeks.
+    // 117.6471 * 34 weeks = 4000
+    expect(calculatedAssessment.variables.provincialAwardBCAGAmount).toBe(4000);
+    // The provincialAwardNetBCAGAmount is calculated as the lesser of provincialAwardBCAGAmount or the minimum BCAG award amount.
+    expect(calculatedAssessment.variables.provincialAwardNetBCAGAmount).toBe(
+      calculatedAssessment.variables.provincialAwardBCAGAmount,
+    );
+    // Exact amount after other award amounts can impact the final BCAG amount.
+    expect(
+      calculatedAssessment.variables.finalProvincialAwardNetBCAGAmount,
+    ).toBeGreaterThan(0);
+  });
+
+  afterAll(async () => {
+    // Closes the singleton instance created during test executions.
+    await ZeebeMockedClient.getMockedZeebeInstance().close();
+  });
+});

--- a/sources/packages/backend/workflow/test/models/assessment.model.ts
+++ b/sources/packages/backend/workflow/test/models/assessment.model.ts
@@ -388,6 +388,7 @@ export interface CalculatedAssessmentModel {
   provincialAwardNetCSGTAmount: number;
   // BCAG
   federalAwardNetBCAGAmount: number;
+  provincialAwardWeeklyBCAGMax: number;
   provincialAwardNetBCAGAmount: number;
   // BCAG2Year
   awardEligibilityBCAG2Year: number;


### PR DESCRIPTION
DMN Updated to round weekly amount:
<img width="405" height="300" alt="image" src="https://github.com/user-attachments/assets/35320649-2d60-41bd-818d-d2c84bfdbdd9" />

New BCAG Amount Test Cases:
- Should determine $0 Weekly BCAG Max Amount when student is not eligible for BCAG or BCAG 2 Year.
- Should determine the correct weekly amount when student is eligible for BCAG (not 2 year) and is below income threshold.
- Should determine the correct weekly amount when student is eligible for BCAG 2 Year and is below income threshold.