### PR TITLE
#5160 - BUG: 2.15: PT Exceptions NR: Container inconsistent red edit section highlighting

### DIFF
--- a/sources/packages/web/src/composables/useFormioUtils.ts
+++ b/sources/packages/web/src/composables/useFormioUtils.ts
@@ -6,6 +6,16 @@ import { AppConfigService } from "@/services/AppConfigService";
 const UTILS_COMMON_OBJECT_NAME = "custom";
 
 /**
+ * Hidden components and containers are not visible
+ * but they have their _visible property as true.
+ * Containers are visible if at least one of their children is visible.
+ */
+const NON_VISIBLE_COMPONENT_TYPES = [
+  FromIOComponentTypes.Hidden,
+  FromIOComponentTypes.Container,
+];
+
+/**
  * Properties that are not required to be saved.
  */
 const NON_REQUIRED_FORM_PROPERTIES = [
@@ -338,8 +348,7 @@ export function useFormioUtils() {
         component,
         (component) =>
           component._visible === true &&
-          // Hidden components are not visible but they have their _visible property as true.
-          component.type !== FromIOComponentTypes.Hidden,
+          !NON_VISIBLE_COMPONENT_TYPES.includes(component.type),
         { stopOnFirstMatch: true },
       );
       if (!visibleChildren.length) {

--- a/sources/packages/web/src/types/formio/formio.ts
+++ b/sources/packages/web/src/types/formio/formio.ts
@@ -97,6 +97,7 @@ export enum FromIOComponentTypes {
   EditGrid = "editgrid",
   Radio = "radio",
   Calendar = "calendar",
+  Container = "container",
 }
 
 export interface FormIOComponentInternal {

--- a/sources/packages/web/src/views/aest/StudentApplicationView.vue
+++ b/sources/packages/web/src/views/aest/StudentApplicationView.vue
@@ -81,7 +81,6 @@ import {
   ChangeTypes,
   FormIOComponent,
   FormIOForm,
-  FromIOComponentTypes,
   Role,
   StudentApplicationFormData,
 } from "@/types";
@@ -115,7 +114,7 @@ export default defineComponent({
   },
   setup(props) {
     const { emptyStringFiller } = useFormatters();
-    const { searchByKey } = useFormioUtils();
+    const { searchByKey, isComponentVisible } = useFormioUtils();
     const applicationDetail = ref({} as ApplicationSupplementalDataAPIOutDTO);
     const initialData = ref({} as StudentApplicationFormData);
     const selectedForm = ref();
@@ -247,10 +246,7 @@ export default defineComponent({
       component: FormIOComponent,
       changeType: ChangeTypes,
     ) {
-      if (
-        component.type === FromIOComponentTypes.Hidden ||
-        component._visible === false
-      ) {
+      if (!isComponentVisible(component)) {
         return;
       }
       let cssClass: string;


### PR DESCRIPTION
Prevent highlighting on a container with no visible elements.

## Before the fix

<img width="1188" height="728" alt="image" src="https://github.com/user-attachments/assets/fab7725d-a07a-4539-9c1e-4f26f5b766d7" />

## After the fix

<img width="1199" height="711" alt="image" src="https://github.com/user-attachments/assets/da4532a1-0238-4969-907c-2b51934938fc" />

