### PR TITLE
#4988 - Re-map B2D SFAS incoming restriction to B2D not B2

### DIFF
--- a/sources/packages/backend/apps/db-migrations/src/migrations/1757554863902-RemoveLegacyB2DMap.ts
+++ b/sources/packages/backend/apps/db-migrations/src/migrations/1757554863902-RemoveLegacyB2DMap.ts
@@ -1,0 +1,19 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+import { getSQLFileData } from "../utilities/sqlLoader";
+
+export class RemoveLegacyB2DMap1757554863902 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      getSQLFileData("Remove-legacy-B2D-map.sql", "SFASRestrictionMaps"),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      getSQLFileData(
+        "Rollback-remove-legacy-B2D-map.sql",
+        "SFASRestrictionMaps",
+      ),
+    );
+  }
+}

--- a/sources/packages/backend/apps/db-migrations/src/sql/SFASRestrictionMaps/Remove-legacy-B2D-map.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/SFASRestrictionMaps/Remove-legacy-B2D-map.sql
@@ -1,0 +1,5 @@
+-- Remove the legacy B2D restriction map that is incorrectly mapped to B2 in SIMS.
+DELETE FROM
+    sims.sfas_restriction_maps
+WHERE
+    legacy_code = 'B2D'

--- a/sources/packages/backend/apps/db-migrations/src/sql/SFASRestrictionMaps/Rollback-remove-legacy-B2D-map.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/SFASRestrictionMaps/Rollback-remove-legacy-B2D-map.sql
@@ -1,0 +1,4 @@
+INSERT INTO
+    sims.sfas_restriction_maps (legacy_code, code, is_legacy_only)
+VALUES
+    ('B2D', 'B2', false);


### PR DESCRIPTION
## Removal of the B2D to B2 legacy restriction mapping. 

### Migration
Local:
<img width="732" height="166" alt="image" src="https://github.com/user-attachments/assets/bc92dc87-2bdd-407e-9d23-054ce0a7e435" />

### Rollback
<img width="840" height="543" alt="image" src="https://github.com/user-attachments/assets/b464b899-ef02-4223-b652-acd14f76dd46" />

Local:

<img width="728" height="169" alt="image" src="https://github.com/user-attachments/assets/8440580e-3328-4d1e-bae1-f3518a8e7408" />
