### PR TITLE
#4873 - Ministry: ability to delete restrictions - DB Migrations

### DIFF
--- a/sources/packages/backend/apps/db-migrations/src/migrations/1758065738801-StudentRestrictionsAddDeletedAndAuditColumns.ts
+++ b/sources/packages/backend/apps/db-migrations/src/migrations/1758065738801-StudentRestrictionsAddDeletedAndAuditColumns.ts
@@ -1,0 +1,24 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+import { getSQLFileData } from "../utilities/sqlLoader";
+
+export class StudentRestrictionsAddDeletedAndAuditColumns1758065738801
+  implements MigrationInterface
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      getSQLFileData(
+        "Add-cols-restriction-deleted-and-audit.sql",
+        "Restrictions",
+      ),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      getSQLFileData(
+        "Rollback-add-cols-restriction-deleted-and-audit.sql",
+        "Restrictions",
+      ),
+    );
+  }
+}

--- a/sources/packages/backend/apps/db-migrations/src/sql/Restrictions/Add-cols-restriction-deleted-and-audit.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/Restrictions/Add-cols-restriction-deleted-and-audit.sql
@@ -1,0 +1,32 @@
+ALTER TABLE
+    sims.student_restrictions
+ADD
+    COLUMN resolved_at TIMESTAMP WITH TIME ZONE,
+ADD
+    COLUMN resolved_by INT REFERENCES sims.users(id),
+ADD
+    COLUMN deletion_note_id INT REFERENCES sims.notes(id),
+ADD
+    COLUMN deleted_at TIMESTAMP WITH TIME ZONE,
+ADD
+    COLUMN deleted_by INT REFERENCES sims.users(id);
+
+COMMENT ON COLUMN sims.student_restrictions.resolved_at IS 'Date when the restriction was resolved.';
+
+COMMENT ON COLUMN sims.student_restrictions.resolved_by IS 'User who resolved the restriction.';
+
+COMMENT ON COLUMN sims.student_restrictions.deletion_note_id IS 'Note added during restriction deletion.';
+
+COMMENT ON COLUMN sims.student_restrictions.deleted_at IS 'Date when the restriction was deleted.';
+
+COMMENT ON COLUMN sims.student_restrictions.deleted_by IS 'User who deleted the restriction.';
+
+-- Update the resolved columns for inactive restrictions
+-- following the logic used to return the same from the API.
+UPDATE
+    sims.student_restrictions
+SET
+    resolved_at = updated_at,
+    resolved_by = modifier
+WHERE
+    is_active = FALSE;

--- a/sources/packages/backend/apps/db-migrations/src/sql/Restrictions/Rollback-add-cols-restriction-deleted-and-audit.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/Restrictions/Rollback-add-cols-restriction-deleted-and-audit.sql
@@ -1,0 +1,6 @@
+ALTER TABLE
+    sims.student_restrictions DROP COLUMN resolved_at,
+    DROP COLUMN resolved_by,
+    DROP COLUMN deletion_note_id,
+    DROP COLUMN deleted_at,
+    DROP COLUMN deleted_by;

--- a/sources/packages/backend/libs/sims-db/src/entities/student-restriction.model.ts
+++ b/sources/packages/backend/libs/sims-db/src/entities/student-restriction.model.ts
@@ -1,13 +1,22 @@
 import {
+  Column,
+  DeleteDateColumn,
   Entity,
   JoinColumn,
   ManyToOne,
   OneToMany,
+  OneToOne,
   PrimaryGeneratedColumn,
 } from "typeorm";
 import { ColumnNames, TableNames } from "../constant";
 import { BaseRestrictionModel } from "./base-restriction.model";
-import { Student, Application, ApplicationRestrictionBypass } from ".";
+import {
+  Student,
+  Application,
+  ApplicationRestrictionBypass,
+  Note,
+  User,
+} from ".";
 
 /**
  * Entity for student restrictions
@@ -48,4 +57,54 @@ export class StudentRestriction extends BaseRestrictionModel {
     },
   )
   applicationRestrictionBypasses?: ApplicationRestrictionBypass[];
+
+  /**
+   * Date when the restriction was resolved.
+   */
+  @Column({
+    name: "resolved_at",
+    type: "timestamptz",
+    nullable: true,
+  })
+  resolvedAt?: Date;
+
+  /**
+   * User who resolved the restriction.
+   */
+  @ManyToOne(() => User, { eager: false, cascade: false })
+  @JoinColumn({
+    name: "resolved_by",
+    referencedColumnName: "id",
+  })
+  resolvedBy?: User;
+
+  /**
+   * Note added during restriction deletion.
+   */
+  @OneToOne(() => Note, { nullable: true })
+  @JoinColumn({
+    name: "deletion_note_id",
+    referencedColumnName: "id",
+  })
+  deletionNote?: Note;
+
+  /**
+   * Date when the restriction was deleted.
+   */
+  @DeleteDateColumn({
+    name: "deleted_at",
+    type: "timestamptz",
+    nullable: true,
+  })
+  deletedAt?: Date;
+
+  /**
+   * User who deleted the restriction.
+   */
+  @ManyToOne(() => User, { nullable: true })
+  @JoinColumn({
+    name: "deleted_by",
+    referencedColumnName: "id",
+  })
+  deletedBy?: User;
 }


### PR DESCRIPTION
- Added `deleted_at` to `sims.student_restrictions` to allow soft delete.
- Created new columns to capture resolution and deletion audit. _Note:_ creation will still use the `creator` and `created_at` columns.
- The entity model was changed only for students, but it has a shared class with institutions that can be enhanced once the institution restrictions are worked on.

## Migration Rollback

<img width="794" height="162" alt="image" src="https://github.com/user-attachments/assets/656fe62c-a389-49fd-8e66-485b3a8a1f27" />
