### PR TITLE
#4964 - Upgrade Packages - Faker

### DIFF
--- a/sources/packages/backend/apps/api/src/route-controllers/application-change-request/_tests_/e2e/application-change-request.aest.controller.assessApplicationChangeRequest.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/application-change-request/_tests_/e2e/application-change-request.aest.controller.assessApplicationChangeRequest.e2e-spec.ts
@@ -9,7 +9,7 @@ import {
   getAESTUser,
 } from "../../../../testHelpers";
 import { ApplicationEditStatus, ApplicationStatus, User } from "@sims/sims-db";
-import * as faker from "faker";
+import { faker } from "@faker-js/faker";
 import {
   createE2EDataSources,
   createFakeStudentAppeal,
@@ -475,7 +475,7 @@ describe("ApplicationChangeRequestAESTController(e2e)-assessApplicationChangeReq
    */
   function getPayload(applicationEditStatus: ApplicationEditStatus) {
     return {
-      note: faker.datatype.uuid(),
+      note: faker.string.uuid(),
       applicationEditStatus,
     };
   }

--- a/sources/packages/backend/apps/api/src/route-controllers/application-exception/_tests_/e2e/application-exception.aest.approveException.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/application-exception/_tests_/e2e/application-exception.aest.approveException.e2e-spec.ts
@@ -12,7 +12,7 @@ import {
   ApplicationExceptionStatus,
   ApplicationStatus,
 } from "@sims/sims-db";
-import * as faker from "faker";
+import { faker } from "@faker-js/faker";
 import { saveFakeApplicationWithApplicationException } from "../application-exception-helper";
 import { createE2EDataSources, E2EDataSources } from "@sims/test-utils";
 import { ZeebeGrpcClient } from "@camunda8/sdk/dist/zeebe";
@@ -42,7 +42,7 @@ describe("ApplicationExceptionAESTController(e2e)-approveException", () => {
     );
     const updateApplicationException = {
       exceptionStatus: ApplicationExceptionStatus.Approved,
-      noteDescription: faker.lorem.text(10),
+      noteDescription: faker.lorem.words(10),
     };
     const endpoint = `/aest/application-exception/${application.applicationException.id}`;
     const token = await getAESTToken(AESTGroups.BusinessAdministrators);
@@ -81,7 +81,7 @@ describe("ApplicationExceptionAESTController(e2e)-approveException", () => {
     );
     const updateApplicationException = {
       exceptionStatus: ApplicationExceptionStatus.Declined,
-      noteDescription: faker.lorem.text(10),
+      noteDescription: faker.lorem.words(10),
     };
     const endpoint = `/aest/application-exception/${application.applicationException.id}`;
     const token = await getAESTToken(AESTGroups.BusinessAdministrators);
@@ -115,7 +115,7 @@ describe("ApplicationExceptionAESTController(e2e)-approveException", () => {
     // Arrange
     const updateApplicationException = {
       exceptionStatus: ApplicationExceptionStatus.Approved,
-      noteDescription: faker.lorem.text(10),
+      noteDescription: faker.lorem.words(10),
     };
     const endpoint = "/aest/application-exception/9999999";
     const token = await getAESTToken(AESTGroups.BusinessAdministrators);
@@ -142,7 +142,7 @@ describe("ApplicationExceptionAESTController(e2e)-approveException", () => {
     );
     const updateApplicationException = {
       exceptionStatus: ApplicationExceptionStatus.Approved,
-      noteDescription: faker.lorem.text(10),
+      noteDescription: faker.lorem.words(10),
     };
     const endpoint = `/aest/application-exception/${application.applicationException.id}`;
     const token = await getAESTToken(AESTGroups.BusinessAdministrators);
@@ -172,7 +172,7 @@ describe("ApplicationExceptionAESTController(e2e)-approveException", () => {
     await db.application.save(application);
     const updateApplicationException = {
       exceptionStatus: ApplicationExceptionStatus.Approved,
-      noteDescription: faker.lorem.text(10),
+      noteDescription: faker.lorem.words(10),
     };
     const endpoint = `/aest/application-exception/${application.applicationException.id}`;
     const token = await getAESTToken(AESTGroups.BusinessAdministrators);
@@ -194,7 +194,7 @@ describe("ApplicationExceptionAESTController(e2e)-approveException", () => {
     // Arrange
     const updateApplicationException = {
       exceptionStatus: ApplicationExceptionStatus.Pending,
-      noteDescription: faker.lorem.text(10),
+      noteDescription: faker.lorem.words(10),
     };
     const endpoint = "/aest/application-exception/1";
     const token = await getAESTToken(AESTGroups.BusinessAdministrators);

--- a/sources/packages/backend/apps/api/src/route-controllers/education-program-offering/_tests_/e2e/education-program-offering.institutions.controller.createOffering.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/education-program-offering/_tests_/e2e/education-program-offering.institutions.controller.createOffering.e2e-spec.ts
@@ -158,7 +158,7 @@ describe("EducationProgramOfferingInstitutionsController(e2e)-createOffering", (
       user: collegeFUser,
     });
     fakeEducationProgram.sabcCode = faker.string.alpha({
-      length: 6,
+      length: 4,
       casing: "upper",
     });
     const savedFakeEducationProgram =

--- a/sources/packages/backend/apps/api/src/route-controllers/education-program-offering/_tests_/e2e/education-program-offering.institutions.controller.createOffering.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/education-program-offering/_tests_/e2e/education-program-offering.institutions.controller.createOffering.e2e-spec.ts
@@ -25,7 +25,7 @@ import {
   getAuthorizedLocation,
 } from "../../../../testHelpers";
 import * as request from "supertest";
-import * as faker from "faker";
+import { faker } from "@faker-js/faker";
 import {
   MAX_ALLOWED_OFFERING_AMOUNT,
   MONEY_VALUE_FOR_UNKNOWN_MAX_VALUE,
@@ -157,10 +157,12 @@ describe("EducationProgramOfferingInstitutionsController(e2e)-createOffering", (
       institution: collegeF,
       user: collegeFUser,
     });
-    fakeEducationProgram.sabcCode = faker.random.alpha({ count: 4 });
-    const savedFakeEducationProgram = await db.educationProgram.save(
-      fakeEducationProgram,
-    );
+    fakeEducationProgram.sabcCode = faker.string.alpha({
+      length: 6,
+      casing: "upper",
+    });
+    const savedFakeEducationProgram =
+      await db.educationProgram.save(fakeEducationProgram);
     const endpoint = `/institutions/education-program-offering/location/${collegeFLocation.id}/education-program/${savedFakeEducationProgram.id}`;
     const studyBreak = {
       breakStartDate: "2023-12-01",
@@ -277,9 +279,8 @@ describe("EducationProgramOfferingInstitutionsController(e2e)-createOffering", (
         institution: collegeF,
         user: collegeFUser,
       });
-      const savedFakeEducationProgram = await db.educationProgram.save(
-        fakeEducationProgram,
-      );
+      const savedFakeEducationProgram =
+        await db.educationProgram.save(fakeEducationProgram);
       const endpoint = `/institutions/education-program-offering/location/${collegeFLocation.id}/education-program/${savedFakeEducationProgram.id}`;
       const studyBreak = {
         breakStartDate: "2023-12-01",
@@ -400,9 +401,8 @@ describe("EducationProgramOfferingInstitutionsController(e2e)-createOffering", (
         institution: collegeF,
         user: collegeFUser,
       });
-      const savedFakeEducationProgram = await db.educationProgram.save(
-        fakeEducationProgram,
-      );
+      const savedFakeEducationProgram =
+        await db.educationProgram.save(fakeEducationProgram);
       const endpoint = `/institutions/education-program-offering/location/${collegeFLocation.id}/education-program/${savedFakeEducationProgram.id}`;
       const studyBreak = {
         breakStartDate: "2023-12-01",
@@ -460,9 +460,8 @@ describe("EducationProgramOfferingInstitutionsController(e2e)-createOffering", (
       institution: institutionCollegeC,
       user: institutionCollegeCUser,
     });
-    const savedFakeEducationProgram = await db.educationProgram.save(
-      fakeEducationProgram,
-    );
+    const savedFakeEducationProgram =
+      await db.educationProgram.save(fakeEducationProgram);
     const endpoint = `/institutions/education-program-offering/location/${collegeCLocation.id}/education-program/${savedFakeEducationProgram.id}`;
     const studyBreak = {
       breakStartDate: "2023-12-01",
@@ -582,9 +581,8 @@ describe("EducationProgramOfferingInstitutionsController(e2e)-createOffering", (
         institution: institutionCollegeC,
         user: institutionCollegeCUser,
       });
-      const savedFakeEducationProgram = await db.educationProgram.save(
-        fakeEducationProgram,
-      );
+      const savedFakeEducationProgram =
+        await db.educationProgram.save(fakeEducationProgram);
       const endpoint = `/institutions/education-program-offering/location/${collegeCLocation.id}/education-program/${savedFakeEducationProgram.id}`;
       const studyBreak = {
         breakStartDate: "2023-12-01",
@@ -708,9 +706,8 @@ describe("EducationProgramOfferingInstitutionsController(e2e)-createOffering", (
       institution: institutionCollegeC,
       user: institutionCollegeCUser,
     });
-    const savedFakeEducationProgram = await db.educationProgram.save(
-      fakeEducationProgram,
-    );
+    const savedFakeEducationProgram =
+      await db.educationProgram.save(fakeEducationProgram);
     const endpoint = `/institutions/education-program-offering/location/${collegeCLocation.id}/education-program/${savedFakeEducationProgram.id}`;
     const studyBreak = {
       breakStartDate: "2023-12-01",
@@ -766,10 +763,12 @@ describe("EducationProgramOfferingInstitutionsController(e2e)-createOffering", (
       institution: institutionCollegeD,
       user: institutionCollegeDUser,
     });
-    fakeEducationProgram.sabcCode = faker.random.alpha({ count: 4 });
-    const savedFakeEducationProgram = await db.educationProgram.save(
-      fakeEducationProgram,
-    );
+    fakeEducationProgram.sabcCode = faker.string.alpha({
+      length: 4,
+      casing: "upper",
+    });
+    const savedFakeEducationProgram =
+      await db.educationProgram.save(fakeEducationProgram);
     const endpoint = `/institutions/education-program-offering/location/${collegeDLocation.id}/education-program/${savedFakeEducationProgram.id}`;
     const studyBreak = {
       breakStartDate: "2023-12-01",
@@ -911,9 +910,8 @@ describe("EducationProgramOfferingInstitutionsController(e2e)-createOffering", (
         },
       },
     );
-    const savedFakeEducationProgram = await db.educationProgram.save(
-      fakeEducationProgram,
-    );
+    const savedFakeEducationProgram =
+      await db.educationProgram.save(fakeEducationProgram);
     const endpoint = `/institutions/education-program-offering/location/${collegeFLocation.id}/education-program/${savedFakeEducationProgram.id}`;
     const studyBreak = {
       breakStartDate: "2023-12-01",
@@ -971,10 +969,12 @@ describe("EducationProgramOfferingInstitutionsController(e2e)-createOffering", (
         institution: collegeF,
         user: collegeFUser,
       });
-      fakeEducationProgram.sabcCode = faker.random.alpha({ count: 4 });
-      const savedFakeEducationProgram = await db.educationProgram.save(
-        fakeEducationProgram,
-      );
+      fakeEducationProgram.sabcCode = faker.string.alpha({
+        length: 4,
+        casing: "upper",
+      });
+      const savedFakeEducationProgram =
+        await db.educationProgram.save(fakeEducationProgram);
       const existingOffering = createFakeEducationProgramOffering(
         savedFakeEducationProgram,
         collegeFLocation,
@@ -1040,10 +1040,12 @@ describe("EducationProgramOfferingInstitutionsController(e2e)-createOffering", (
         institution: collegeF,
         user: collegeFUser,
       });
-      fakeEducationProgram.sabcCode = faker.random.alpha({ count: 4 });
-      const savedFakeEducationProgram = await db.educationProgram.save(
-        fakeEducationProgram,
-      );
+      fakeEducationProgram.sabcCode = faker.string.alpha({
+        length: 4,
+        casing: "upper",
+      });
+      const savedFakeEducationProgram =
+        await db.educationProgram.save(fakeEducationProgram);
       const endpoint = `/institutions/education-program-offering/location/${collegeFLocation.id}/education-program/${savedFakeEducationProgram.id}`;
       payload.offeringName = "Offering 2";
       payload.actualTuitionCosts = 100001;
@@ -1125,9 +1127,8 @@ describe("EducationProgramOfferingInstitutionsController(e2e)-createOffering", (
         institution: collegeF,
         user: collegeFUser,
       });
-      const savedFakeEducationProgram = await db.educationProgram.save(
-        fakeEducationProgram,
-      );
+      const savedFakeEducationProgram =
+        await db.educationProgram.save(fakeEducationProgram);
       const endpoint = `/institutions/education-program-offering/location/${collegeFLocation.id}/education-program/${savedFakeEducationProgram.id}`;
       payload.studyStartDate = "2024-05-23";
       payload.studyEndDate = "2024-05-24";
@@ -1200,10 +1201,12 @@ describe("EducationProgramOfferingInstitutionsController(e2e)-createOffering", (
       institution: collegeF,
       user: collegeFUser,
     });
-    fakeEducationProgram.sabcCode = faker.random.alpha({ count: 4 });
-    const savedFakeEducationProgram = await db.educationProgram.save(
-      fakeEducationProgram,
-    );
+    fakeEducationProgram.sabcCode = faker.string.alpha({
+      length: 4,
+      casing: "upper",
+    });
+    const savedFakeEducationProgram =
+      await db.educationProgram.save(fakeEducationProgram);
     const endpoint = `/institutions/education-program-offering/location/${collegeFLocation.id}/education-program/${savedFakeEducationProgram.id}`;
     payload.offeringName = "Offering 3";
     payload.mandatoryFees = MONEY_VALUE_FOR_UNKNOWN_MAX_VALUE + 1;

--- a/sources/packages/backend/apps/api/src/route-controllers/education-program-offering/_tests_/e2e/education-program-offering.institutions.controller.updateProgramOffering.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/education-program-offering/_tests_/e2e/education-program-offering.institutions.controller.updateProgramOffering.e2e-spec.ts
@@ -25,7 +25,7 @@ import {
   getAuthorizedLocation,
 } from "../../../../testHelpers";
 import * as request from "supertest";
-import * as faker from "faker";
+import { faker } from "@faker-js/faker";
 import {
   MAX_ALLOWED_OFFERING_AMOUNT,
   MONEY_VALUE_FOR_UNKNOWN_MAX_VALUE,
@@ -93,10 +93,12 @@ describe("EducationProgramOfferingInstitutionsController(e2e)-updateProgramOffer
       institution: collegeF,
       user: collegeFUser,
     });
-    fakeEducationProgram.sabcCode = faker.random.alpha({ count: 4 });
-    const savedFakeEducationProgram = await db.educationProgram.save(
-      fakeEducationProgram,
-    );
+    fakeEducationProgram.sabcCode = faker.string.alpha({
+      length: 4,
+      casing: "upper",
+    });
+    const savedFakeEducationProgram =
+      await db.educationProgram.save(fakeEducationProgram);
     const newOffering = createFakeEducationProgramOffering(
       savedFakeEducationProgram,
       collegeFLocation,
@@ -202,9 +204,8 @@ describe("EducationProgramOfferingInstitutionsController(e2e)-updateProgramOffer
         institution: collegeF,
         user: collegeFUser,
       });
-      const savedFakeEducationProgram = await db.educationProgram.save(
-        fakeEducationProgram,
-      );
+      const savedFakeEducationProgram =
+        await db.educationProgram.save(fakeEducationProgram);
       const newOffering = createFakeEducationProgramOffering(
         savedFakeEducationProgram,
         collegeFLocation,
@@ -330,9 +331,8 @@ describe("EducationProgramOfferingInstitutionsController(e2e)-updateProgramOffer
         institution: institutionCollegeC,
         user: institutionCollegeCUser,
       });
-      const savedFakeEducationProgram = await db.educationProgram.save(
-        fakeEducationProgram,
-      );
+      const savedFakeEducationProgram =
+        await db.educationProgram.save(fakeEducationProgram);
       const newOffering = createFakeEducationProgramOffering(
         savedFakeEducationProgram,
         collegeCLocation,
@@ -491,9 +491,8 @@ describe("EducationProgramOfferingInstitutionsController(e2e)-updateProgramOffer
         },
       },
     );
-    const savedFakeEducationProgram = await db.educationProgram.save(
-      fakeEducationProgram,
-    );
+    const savedFakeEducationProgram =
+      await db.educationProgram.save(fakeEducationProgram);
     const newOffering = createFakeEducationProgramOffering(
       savedFakeEducationProgram,
       collegeFLocation,
@@ -558,10 +557,12 @@ describe("EducationProgramOfferingInstitutionsController(e2e)-updateProgramOffer
         institution: collegeF,
         user: collegeFUser,
       });
-      fakeEducationProgram.sabcCode = faker.random.alpha({ count: 4 });
-      const savedFakeEducationProgram = await db.educationProgram.save(
-        fakeEducationProgram,
-      );
+      fakeEducationProgram.sabcCode = faker.string.alpha({
+        length: 4,
+        casing: "upper",
+      });
+      const savedFakeEducationProgram =
+        await db.educationProgram.save(fakeEducationProgram);
       const newOffering = createFakeEducationProgramOffering(
         savedFakeEducationProgram,
         collegeFLocation,
@@ -634,10 +635,12 @@ describe("EducationProgramOfferingInstitutionsController(e2e)-updateProgramOffer
         institution: collegeF,
         user: collegeFUser,
       });
-      fakeEducationProgram.sabcCode = faker.random.alpha({ count: 4 });
-      const savedFakeEducationProgram = await db.educationProgram.save(
-        fakeEducationProgram,
-      );
+      fakeEducationProgram.sabcCode = faker.string.alpha({
+        length: 4,
+        casing: "upper",
+      });
+      const savedFakeEducationProgram =
+        await db.educationProgram.save(fakeEducationProgram);
       const newOffering = createFakeEducationProgramOffering(
         savedFakeEducationProgram,
         collegeFLocation,
@@ -753,9 +756,8 @@ describe("EducationProgramOfferingInstitutionsController(e2e)-updateProgramOffer
         institution: collegeF,
         user: collegeFUser,
       });
-      const savedFakeEducationProgram = await db.educationProgram.save(
-        fakeEducationProgram,
-      );
+      const savedFakeEducationProgram =
+        await db.educationProgram.save(fakeEducationProgram);
       const newOffering = createFakeEducationProgramOffering(
         savedFakeEducationProgram,
         collegeFLocation,
@@ -851,10 +853,12 @@ describe("EducationProgramOfferingInstitutionsController(e2e)-updateProgramOffer
       institution: collegeF,
       user: collegeFUser,
     });
-    fakeEducationProgram.sabcCode = faker.random.alpha({ count: 4 });
-    const savedFakeEducationProgram = await db.educationProgram.save(
-      fakeEducationProgram,
-    );
+    fakeEducationProgram.sabcCode = faker.string.alpha({
+      length: 4,
+      casing: "upper",
+    });
+    const savedFakeEducationProgram =
+      await db.educationProgram.save(fakeEducationProgram);
     const newOffering = createFakeEducationProgramOffering(
       savedFakeEducationProgram,
       collegeFLocation,

--- a/sources/packages/backend/apps/api/src/route-controllers/education-program-offering/_tests_/e2e/education-program-offering.institutions.controller.validateOffering.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/education-program-offering/_tests_/e2e/education-program-offering.institutions.controller.validateOffering.e2e-spec.ts
@@ -25,7 +25,7 @@ import {
   createFakeEducationProgram,
 } from "../../../../testHelpers";
 import * as request from "supertest";
-import * as faker from "faker";
+import { faker } from "@faker-js/faker";
 import {
   AviationCredentialTypeOptions,
   OfferingValidationInfos,
@@ -70,7 +70,7 @@ describe("EducationProgramOfferingInstitutionsController(e2e)-validateOffering",
       },
       {
         initialValue: {
-          sabcCode: faker.random.alpha({ count: 4 }),
+          sabcCode: faker.string.alpha({ length: 4, casing: "upper" }),
           deliveredOnline: true,
         },
       },

--- a/sources/packages/backend/apps/api/src/route-controllers/education-program/_tests_/e2e/education-program.aest.controller.getProgramsSummary.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/education-program/_tests_/e2e/education-program.aest.controller.getProgramsSummary.e2e-spec.ts
@@ -20,7 +20,7 @@ import {
   User,
 } from "@sims/sims-db";
 import * as request from "supertest";
-import * as faker from "faker";
+import { faker } from "@faker-js/faker";
 
 describe("EducationProgramAESTController(e2e)-getProgramsSummary", () => {
   let app: INestApplication;
@@ -425,7 +425,7 @@ describe("EducationProgramAESTController(e2e)-getProgramsSummary", () => {
         institution: institution,
         user: sharedUser,
       });
-      const programSearchString = faker.datatype.uuid();
+      const programSearchString = faker.string.uuid();
       firstApprovedProgram.name = programSearchString;
       const secondApprovedProgram = createFakeEducationProgram({
         institution: institution,
@@ -531,7 +531,7 @@ describe("EducationProgramAESTController(e2e)-getProgramsSummary", () => {
       "when the search for the programs is made and the declined program status is selected along with the inactive programs selected and the program name and location name search filter.",
     async () => {
       // Arrange
-      const locationSearchString = faker.datatype.uuid();
+      const locationSearchString = faker.string.uuid();
       institutionLocation.name = locationSearchString;
       const secondInstitutionLocation = createFakeInstitutionLocation({
         institution: institution,
@@ -552,7 +552,7 @@ describe("EducationProgramAESTController(e2e)-getProgramsSummary", () => {
           },
         },
       );
-      const programSearchString = faker.datatype.uuid();
+      const programSearchString = faker.string.uuid();
       declinedProgram.name = programSearchString;
       const pendingProgram = createFakeEducationProgram(
         {

--- a/sources/packages/backend/apps/api/src/route-controllers/education-program/_tests_/e2e/education-program.institutions.controller.createEducationProgram.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/education-program/_tests_/e2e/education-program.institutions.controller.createEducationProgram.e2e-spec.ts
@@ -25,7 +25,7 @@ import * as request from "supertest";
 import { FormService } from "../../../../services";
 import { TestingModule } from "@nestjs/testing";
 import { AppInstitutionsModule } from "../../../../app.institutions.module";
-import * as faker from "faker";
+import { faker } from "@faker-js/faker";
 import { addDays, getISODateOnlyString } from "@sims/utilities";
 
 describe("EducationProgramInstitutionsController(e2e)-createEducationProgram", () => {
@@ -58,7 +58,7 @@ describe("EducationProgramInstitutionsController(e2e)-createEducationProgram", (
 
   it("Should create an education program when valid data is passed.", async () => {
     // Arrange
-    const sabcCode = `${faker.random.alpha({ count: 3 })}1`;
+    const sabcCode = `${faker.string.alpha({ length: 3, casing: "upper" })}1`;
     const payload = getPayload(sabcCode);
     const formService = await getProviderInstanceForModule(
       testingModule,
@@ -383,7 +383,10 @@ describe("EducationProgramInstitutionsController(e2e)-createEducationProgram", (
       fieldOfStudyCode: "15",
       nocCode: "2174",
       sabcCode: sabcCode,
-      institutionProgramCode: faker.random.alpha({ count: 3 }),
+      institutionProgramCode: faker.string.alpha({
+        length: 3,
+        casing: "upper",
+      }),
       programIntensity: "Full Time and Part Time",
       programDeliveryTypes: {
         deliveredOnSite: true,

--- a/sources/packages/backend/apps/api/src/route-controllers/institution-user/_tests_/e2e/institution-user.institutions.controller.createInstitutionUserWithAuth.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/institution-user/_tests_/e2e/institution-user.institutions.controller.createInstitutionUserWithAuth.e2e-spec.ts
@@ -1,6 +1,6 @@
 import { HttpStatus, INestApplication } from "@nestjs/common";
 import * as request from "supertest";
-import * as faker from "faker";
+import { faker } from "@faker-js/faker";
 import {
   authorizeUserTokenForLocation,
   BEARER_AUTH_TYPE,
@@ -72,7 +72,7 @@ describe("InstitutionUserInstitutionsController(e2e)-createInstitutionUserWithAu
   it("Should throw an UnprocessableEntityException error when the user passed in the payload is not found on BCeID.", async () => {
     // Arrange
     const payload = {
-      bceidUserId: faker.random.alpha({ count: 5 }),
+      bceidUserId: faker.string.alpha({ length: 5 }),
       permissions: [
         {
           locationId: collegeFLocationA.id,
@@ -104,7 +104,7 @@ describe("InstitutionUserInstitutionsController(e2e)-createInstitutionUserWithAu
     // Arrange
     const user = createFakeUser();
     const payload = {
-      bceidUserId: faker.random.alpha({ count: 5 }),
+      bceidUserId: faker.string.alpha({ length: 5 }),
       permissions: [
         {
           locationId: collegeFLocationA.id,
@@ -153,7 +153,7 @@ describe("InstitutionUserInstitutionsController(e2e)-createInstitutionUserWithAu
     await db.user.save(user);
 
     const payload = {
-      bceidUserId: faker.random.alpha({ count: 5 }),
+      bceidUserId: faker.string.alpha({ length: 5 }),
       permissions: [
         {
           locationId: collegeFLocationA.id,
@@ -189,7 +189,7 @@ describe("InstitutionUserInstitutionsController(e2e)-createInstitutionUserWithAu
     // Arrange
     const user = createFakeUser();
     const payload = {
-      bceidUserId: faker.random.alpha({ count: 5 }),
+      bceidUserId: faker.string.alpha({ length: 5 }),
       permissions: [
         {
           locationId: collegeFLocationA.id,

--- a/sources/packages/backend/apps/api/src/route-controllers/institution/_tests_/e2e/institution.aest.controller.searchInstitutions.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/institution/_tests_/e2e/institution.aest.controller.searchInstitutions.e2e-spec.ts
@@ -1,6 +1,6 @@
 import { HttpStatus, INestApplication } from "@nestjs/common";
 import * as request from "supertest";
-import * as faker from "faker";
+import { faker } from "@faker-js/faker";
 import {
   AESTGroups,
   BEARER_AUTH_TYPE,
@@ -30,7 +30,7 @@ describe("InstitutionAESTController(e2e)-searchInstitutions", () => {
     const institution = createFakeInstitution();
     institution.operatingName = FAKE_INSTITUTION_NAME;
     // Using uuid to keep the legal operating name unique for institution.
-    institution.legalOperatingName = faker.datatype.uuid();
+    institution.legalOperatingName = faker.string.uuid();
     await db.institution.save(institution);
     // Modifying the text to uppercase to validate non case sensitive search.
     const legalNameSearchText = institution.legalOperatingName.toUpperCase();
@@ -67,7 +67,7 @@ describe("InstitutionAESTController(e2e)-searchInstitutions", () => {
     const institution = createFakeInstitution();
     institution.operatingName = FAKE_INSTITUTION_NAME;
     // Using uuid to keep the legal operating name unique for institution.
-    institution.legalOperatingName = faker.datatype.uuid();
+    institution.legalOperatingName = faker.string.uuid();
     await db.institution.save(institution);
     const operatingNameSearchText = "Search E2E Test institution";
     const legalNameSearchText = institution.legalOperatingName;

--- a/sources/packages/backend/apps/api/src/route-controllers/student-account-applications/_test_/e2e/student-account-application.aest.controller.approveStudentAccountApplication.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/student-account-applications/_test_/e2e/student-account-application.aest.controller.approveStudentAccountApplication.e2e-spec.ts
@@ -18,7 +18,7 @@ import { AppAESTModule } from "../../../../app.aest.module";
 import { FormNames, FormService } from "../../../../services";
 import { Notification, NotificationMessageType, User } from "@sims/sims-db";
 import { In, IsNull } from "typeorm";
-import * as faker from "faker";
+import { faker } from "@faker-js/faker";
 
 describe("StudentAccountApplicationAESTController(e2e)-approveStudentAccountApplication", () => {
   let app: INestApplication;
@@ -203,7 +203,7 @@ describe("StudentAccountApplicationAESTController(e2e)-approveStudentAccountAppl
 
     await saveFakeSFASIndividual(db.dataSource, {
       initialValues: {
-        lastName: faker.datatype.uuid(),
+        lastName: faker.string.uuid(),
         birthDate: TEST_BIRTH_DATE1,
         sin: TEST_SIN1,
       },

--- a/sources/packages/backend/apps/api/src/route-controllers/student/_tests_/e2e/student.aest.controller.associateLegacyStudent.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/student/_tests_/e2e/student.aest.controller.associateLegacyStudent.e2e-spec.ts
@@ -15,7 +15,7 @@ import {
   createFakeUser,
   createFakeSFASRestriction,
 } from "@sims/test-utils";
-import * as faker from "faker";
+import { faker } from "@faker-js/faker";
 import { getISODateOnlyString } from "@sims/utilities";
 import { NoteType } from "@sims/sims-db";
 
@@ -53,7 +53,7 @@ describe("StudentAESTController(e2e)-associateLegacyStudent", () => {
     async () => {
       // Arrange.
       const user = createFakeUser();
-      const userLastName = faker.datatype.uuid();
+      const userLastName = faker.string.uuid();
       user.lastName = userLastName;
       const birthDate = getISODateOnlyString(new Date());
       const student = await saveFakeStudent(
@@ -82,7 +82,7 @@ describe("StudentAESTController(e2e)-associateLegacyStudent", () => {
       );
       const payload = {
         individualId: legacyProfileMatch.id,
-        noteDescription: faker.datatype.uuid(),
+        noteDescription: faker.string.uuid(),
       };
       const endpoint = `/aest/student/${student.id}/legacy-match`;
 
@@ -161,7 +161,7 @@ describe("StudentAESTController(e2e)-associateLegacyStudent", () => {
     const aestUserToken = await getAESTToken(AESTGroups.BusinessAdministrators);
     const payload = {
       individualId: legacyProfileMatch.id,
-      noteDescription: faker.datatype.uuid(),
+      noteDescription: faker.string.uuid(),
     };
     const endpoint = `/aest/student/${student.id}/legacy-match`;
 
@@ -188,7 +188,7 @@ describe("StudentAESTController(e2e)-associateLegacyStudent", () => {
     const aestUserToken = await getAESTToken(AESTGroups.BusinessAdministrators);
     const payload = {
       individualId: legacyProfileMatch.id,
-      noteDescription: faker.datatype.uuid(),
+      noteDescription: faker.string.uuid(),
     };
     const endpoint = `/aest/student/${student.id}/legacy-match`;
 

--- a/sources/packages/backend/apps/api/src/route-controllers/student/_tests_/e2e/student.aest.controller.getStudentLegacyMatches.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/student/_tests_/e2e/student.aest.controller.getStudentLegacyMatches.e2e-spec.ts
@@ -13,7 +13,7 @@ import {
   createE2EDataSources,
   createFakeUser,
 } from "@sims/test-utils";
-import * as faker from "faker";
+import { faker } from "@faker-js/faker";
 import { getISODateOnlyString } from "@sims/utilities";
 
 /**
@@ -122,7 +122,7 @@ describe("StudentAESTController(e2e)-getStudentLegacyMatches", () => {
   it("Should get potential student matches from legacy when there is an exact last name (case insensitive) and DOB match.", async () => {
     // Arrange.
     const user = createFakeUser();
-    const userLastName = faker.datatype.uuid();
+    const userLastName = faker.string.uuid();
     user.lastName = userLastName.toLowerCase();
     const birthDate = getISODateOnlyString(new Date());
     const student = await saveFakeStudent(

--- a/sources/packages/backend/apps/api/src/route-controllers/student/_tests_/e2e/student.aest.controller.updateProfileInformation.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/student/_tests_/e2e/student.aest.controller.updateProfileInformation.e2e-spec.ts
@@ -12,7 +12,7 @@ import {
   saveFakeStudent,
 } from "@sims/test-utils";
 import { IdentityProviders } from "@sims/sims-db";
-import * as faker from "faker";
+import { faker } from "@faker-js/faker";
 
 interface StudentProfileUpdateInfo {
   givenNames: string;
@@ -32,11 +32,11 @@ describe("StudentAESTController(e2e)-updateProfileInformation", () => {
     app = nestApplication;
     db = createE2EDataSources(dataSource);
     studentProfileUpdateInfo = {
-      givenNames: faker.name.firstName(),
-      lastName: faker.name.lastName(),
+      givenNames: faker.person.firstName(),
+      lastName: faker.person.lastName(),
       birthdate: "1990-01-15",
       email: faker.internet.email(),
-      noteDescription: faker.datatype.uuid(),
+      noteDescription: faker.string.uuid(),
     };
   });
 
@@ -192,10 +192,10 @@ describe("StudentAESTController(e2e)-updateProfileInformation", () => {
     await request(app.getHttpServer())
       .patch(endpoint)
       .send({
-        givenNames: faker.name.firstName(),
+        givenNames: faker.person.firstName(),
         birthdate: "1990-01-15",
         email: faker.internet.email(),
-        noteDescription: faker.lorem.text(),
+        noteDescription: faker.lorem.words(10),
       })
       .auth(token, BEARER_AUTH_TYPE)
       .expect(HttpStatus.BAD_REQUEST)

--- a/sources/packages/backend/apps/api/src/route-controllers/supporting-user/_tests_/e2e/supporting-user.aest.controller.getIdentifiableSupportingUser.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/supporting-user/_tests_/e2e/supporting-user.aest.controller.getIdentifiableSupportingUser.e2e-spec.ts
@@ -1,6 +1,6 @@
 import { HttpStatus, INestApplication } from "@nestjs/common";
 import * as request from "supertest";
-import * as faker from "faker";
+import { faker } from "@faker-js/faker";
 import {
   AESTGroups,
   BEARER_AUTH_TYPE,
@@ -50,7 +50,7 @@ describe("SupportingUserAESTController(e2e)-getIdentifiableSupportingUser", () =
       programYear: recentPYParentForm.programYear,
     });
 
-    const parentFullName = faker.random.alpha({ count: 50 });
+    const parentFullName = faker.string.alpha({ length: 50 });
     const parent = createFakeSupportingUser(
       { application },
       {

--- a/sources/packages/backend/apps/api/src/route-controllers/supporting-user/_tests_/e2e/supporting-user.students.controller.getIdentifiableSupportingUser.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/supporting-user/_tests_/e2e/supporting-user.students.controller.getIdentifiableSupportingUser.e2e-spec.ts
@@ -1,7 +1,7 @@
 import { HttpStatus, INestApplication } from "@nestjs/common";
 import { TestingModule } from "@nestjs/testing";
 import * as request from "supertest";
-import * as faker from "faker";
+import { faker } from "@faker-js/faker";
 import {
   BEARER_AUTH_TYPE,
   createTestingAppModule,
@@ -60,7 +60,7 @@ describe("SupportingUserStudentsController(e2e)-getIdentifiableSupportingUser", 
       programYear: recentPYParentForm.programYear,
     });
     // Create fake supporting user parent.
-    const parentFullName = faker.random.alpha({ count: 50 });
+    const parentFullName = faker.string.alpha({ length: 50 });
     const parent = createFakeSupportingUser(
       { application },
       {
@@ -137,7 +137,7 @@ describe("SupportingUserStudentsController(e2e)-getIdentifiableSupportingUser", 
     });
     const student = application.student;
     // Create fake supporting user parent.
-    const parentFullName = faker.random.alpha({ count: 50 });
+    const parentFullName = faker.string.alpha({ length: 50 });
     const parent = createFakeSupportingUser(
       { application },
       {
@@ -202,7 +202,7 @@ describe("SupportingUserStudentsController(e2e)-getIdentifiableSupportingUser", 
       });
       const student = application.student;
       // Create fake supporting user parent.
-      const parentFullName = faker.random.alpha({ count: 50 });
+      const parentFullName = faker.string.alpha({ length: 50 });
       const parent = createFakeSupportingUser(
         { application },
         {

--- a/sources/packages/backend/apps/api/src/route-controllers/supporting-user/_tests_/e2e/supporting-user.students.controller.submitSupportingUserDetails.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/supporting-user/_tests_/e2e/supporting-user.students.controller.submitSupportingUserDetails.e2e-spec.ts
@@ -1,7 +1,7 @@
 import { HttpStatus, INestApplication } from "@nestjs/common";
 import { TestingModule } from "@nestjs/testing";
 import * as request from "supertest";
-import * as faker from "faker";
+import { faker } from "@faker-js/faker";
 import {
   BEARER_AUTH_TYPE,
   createTestingAppModule,
@@ -323,7 +323,7 @@ describe("SupportingUserStudentsController(e2e)-submitSupportingUserDetails", ()
       },
     );
     // Create fake supporting user parent.
-    const parentFullName = faker.random.alpha({ count: 50 });
+    const parentFullName = faker.string.alpha({ length: 50 });
     const supportingUser = createFakeSupportingUser(
       { application },
       {
@@ -345,14 +345,14 @@ describe("SupportingUserStudentsController(e2e)-submitSupportingUserDetails", ()
    */
   function createSupportingUserPayload(): ReportedSupportingUserAPIInDTO {
     return {
-      givenNames: faker.random.alpha({ count: 100 }),
-      lastName: faker.random.alpha({ count: 100 }),
-      addressLine1: faker.address.streetAddress(),
-      city: faker.address.city(),
+      givenNames: faker.string.alpha({ length: 100 }),
+      lastName: faker.string.alpha({ length: 100 }),
+      addressLine1: faker.location.streetAddress(),
+      city: faker.location.city(),
       country: "Canada",
-      phone: faker.phone.phoneNumber(),
-      postalCode: faker.address.zipCode(),
-      provinceState: faker.address.state(),
+      phone: faker.phone.number({ style: "national" }),
+      postalCode: faker.location.zipCode(),
+      provinceState: faker.location.state(),
       supportingData: { totalIncome: 1000 },
     };
   }

--- a/sources/packages/backend/apps/api/src/testHelpers/fake-entities/education-program-fake.ts
+++ b/sources/packages/backend/apps/api/src/testHelpers/fake-entities/education-program-fake.ts
@@ -1,4 +1,4 @@
-import * as faker from "faker";
+import { faker } from "@faker-js/faker";
 import {
   EducationProgram,
   Institution,
@@ -27,7 +27,7 @@ export function createFakeEducationProgram(
   },
 ): EducationProgram {
   const program = new EducationProgram();
-  program.name = faker.name.jobArea();
+  program.name = faker.person.jobArea();
   program.description = "description";
   program.credentialType = "credentialType";
   program.cipCode = "cipCode";

--- a/sources/packages/backend/apps/api/src/testHelpers/fake-entities/education-program-offering-fake.ts
+++ b/sources/packages/backend/apps/api/src/testHelpers/fake-entities/education-program-offering-fake.ts
@@ -1,4 +1,4 @@
-import * as faker from "faker";
+import { faker } from "@faker-js/faker";
 import { createFakeLocation } from ".";
 import {
   EducationProgram,
@@ -16,11 +16,11 @@ export function createFakeEducationProgramOffering(
   institutionLocation?: InstitutionLocation,
 ): EducationProgramOffering {
   const offering = new EducationProgramOffering();
-  offering.name = faker.random.word();
-  offering.actualTuitionCosts = faker.datatype.number(1000);
-  offering.programRelatedCosts = faker.datatype.number(1000);
-  offering.mandatoryFees = faker.datatype.number(1000);
-  offering.exceptionalExpenses = faker.datatype.number(1000);
+  offering.name = faker.lorem.word();
+  offering.actualTuitionCosts = faker.number.int(1000);
+  offering.programRelatedCosts = faker.number.int(1000);
+  offering.mandatoryFees = faker.number.int(1000);
+  offering.exceptionalExpenses = faker.number.int(1000);
   offering.offeringDelivered = "offeringDelivered";
   offering.lacksStudyBreaks = true;
   offering.educationProgram = program ?? createFakeEducationProgram();

--- a/sources/packages/backend/apps/api/src/testHelpers/fake-entities/location-fake.ts
+++ b/sources/packages/backend/apps/api/src/testHelpers/fake-entities/location-fake.ts
@@ -1,4 +1,4 @@
-import * as faker from "faker";
+import { faker } from "@faker-js/faker";
 import { Institution, InstitutionLocation } from "@sims/sims-db";
 import { createFakeInstitution } from "@sims/test-utils";
 
@@ -8,12 +8,12 @@ export function createFakeLocation(
   const location = new InstitutionLocation();
   location.data = {
     address: {
-      addressLine1: faker.address.streetAddress(),
-      addressLine2: faker.address.secondaryAddress(),
+      addressLine1: faker.location.streetAddress(),
+      addressLine2: faker.location.secondaryAddress(),
       provinceState: "BC",
       country: "CAN",
       city: "Victoria",
-      postalCode: faker.address.zipCode("A9A9A9"),
+      postalCode: faker.location.zipCode("A9A9A9"),
     },
   };
   location.primaryContact = {
@@ -22,7 +22,7 @@ export function createFakeLocation(
     email: "Email",
     phone: "Phone",
   };
-  location.name = faker.company.companyName();
+  location.name = faker.company.name();
   location.institution = institution ?? createFakeInstitution();
   return location;
 }

--- a/sources/packages/backend/apps/api/src/testHelpers/fake-entities/msfaa-number-fake.ts
+++ b/sources/packages/backend/apps/api/src/testHelpers/fake-entities/msfaa-number-fake.ts
@@ -1,12 +1,12 @@
 import { MSFAANumber, OfferingIntensity, Student } from "@sims/sims-db";
 import { createFakeStudent } from "./student-fake";
-import * as faker from "faker";
+import { faker } from "@faker-js/faker";
 
 export function createFakeMSFAANumber(student?: Student): MSFAANumber {
   const msfaaNumber = new MSFAANumber();
   msfaaNumber.student = student ?? createFakeStudent();
-  msfaaNumber.msfaaNumber = faker.datatype
-    .number({
+  msfaaNumber.msfaaNumber = faker.number
+    .int({
       min: 1111111111,
       max: 9999999999,
     })

--- a/sources/packages/backend/apps/api/src/testHelpers/fake-entities/student-fake.ts
+++ b/sources/packages/backend/apps/api/src/testHelpers/fake-entities/student-fake.ts
@@ -1,4 +1,4 @@
-import * as faker from "faker";
+import { faker } from "@faker-js/faker";
 import { Student, User } from "@sims/sims-db";
 import { createFakeUser } from "@sims/test-utils";
 
@@ -8,17 +8,17 @@ import { createFakeUser } from "@sims/test-utils";
 export function createFakeStudent(user?: User): Student {
   const student = new Student();
   student.user = user ?? createFakeUser();
-  student.birthDate = faker.date.past(18).toISOString();
+  student.birthDate = faker.date.past({ years: 99 }).toISOString();
   student.gender = "nonBinary";
   student.contactInfo = {
     address: {
-      addressLine1: faker.address.streetAddress(),
-      city: faker.address.city(),
+      addressLine1: faker.location.streetAddress(),
+      city: faker.location.city(),
       country: "CAN",
       provinceState: "BC",
-      postalCode: faker.address.zipCode(),
+      postalCode: faker.location.zipCode(),
     },
-    phone: faker.phone.phoneNumber(),
+    phone: faker.phone.number({ style: "national" }),
   };
   return student;
 }

--- a/sources/packages/backend/apps/api/test/jest-e2e.json
+++ b/sources/packages/backend/apps/api/test/jest-e2e.json
@@ -43,5 +43,8 @@
     ".dto.ts",
     "mock.ts",
     "index.ts"
+  ],
+  "transformIgnorePatterns": [
+    "/node_modules/(?!@faker-js|uuid)"
   ]
 }

--- a/sources/packages/backend/apps/queue-consumers/src/processors/assessment/_tests_/cancel-application-assessment.processor.e2e-spec.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/processors/assessment/_tests_/cancel-application-assessment.processor.e2e-spec.ts
@@ -30,7 +30,7 @@ import {
   StudentAssessment,
   StudentAssessmentStatus,
 } from "@sims/sims-db";
-import * as faker from "faker";
+import { faker } from "@faker-js/faker";
 import { AssessmentSequentialProcessingService } from "@sims/services";
 import { TestingModule } from "@nestjs/testing";
 import { QueueConsumersModule } from "../../../../src/queue-consumers.module";

--- a/sources/packages/backend/apps/queue-consumers/src/processors/assessment/_tests_/cancel-application-assessment.processor.e2e-spec.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/processors/assessment/_tests_/cancel-application-assessment.processor.e2e-spec.ts
@@ -72,8 +72,8 @@ describe(
 
     it("Should cancel the assessment pending disbursements and rollback overawards when the cancelled application has overawards and also one sent and one pending disbursements.", async () => {
       // Arrange
-      const workflowInstanceId = faker.datatype
-        .number({
+      const workflowInstanceId = faker.number
+        .int({
           min: 1000000000,
           max: 9999999999,
         })

--- a/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/esdc-integration/ecert-integration/_tests_/ecert-part-time-process-integration.scheduler.e2e-spec.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/esdc-integration/ecert-integration/_tests_/ecert-part-time-process-integration.scheduler.e2e-spec.ts
@@ -55,7 +55,7 @@ import {
   loadDisbursementSchedules,
 } from "./e-cert-utils";
 import { SystemUsersService } from "@sims/services";
-import * as faker from "faker";
+import { faker } from "@faker-js/faker";
 import { ECERT_PART_TIME_SENT_FILE_SEQUENCE_GROUP } from "@sims/integrations/esdc-integration";
 
 describe(
@@ -109,9 +109,8 @@ describe(
 
     it("Should create a notification for the ministry and student for a blocked disbursement when there are no previously existing notifications for the disbursement.", async () => {
       // Arrange
-      const { student, disbursement } = await createBlockedDisbursementTestData(
-        db,
-      );
+      const { student, disbursement } =
+        await createBlockedDisbursementTestData(db);
       // Queued job.
       const mockedJob = mockBullJob<void>();
 
@@ -235,9 +234,8 @@ describe(
 
     it("Should not create a notification for the student for a disbursement when there are already 3 notifications created.", async () => {
       // Arrange
-      const { student, disbursement } = await createBlockedDisbursementTestData(
-        db,
-      );
+      const { student, disbursement } =
+        await createBlockedDisbursementTestData(db);
       // Create pre-existing notificationsToCreate notifications for the student and ministry for the above created disbursement.
       const notificationsToCreate = 3;
       await saveNotifications(notificationsToCreate, student, disbursement.id);
@@ -270,9 +268,8 @@ describe(
 
     it("Should not create a notification for the student for a disbursement when an attempt is made to create the 2nd notification before 7 days from the first notification.", async () => {
       // Arrange
-      const { student, disbursement } = await createBlockedDisbursementTestData(
-        db,
-      );
+      const { student, disbursement } =
+        await createBlockedDisbursementTestData(db);
       // Create 1 pre-existing notification for the student and the ministry 6 days before the current date for the above created disbursement.
       await saveNotifications(1, student, disbursement.id, -6);
       // Queued job.
@@ -314,9 +311,8 @@ describe(
 
     it("Should create a notification for the student for a disbursement when an attempt is made to create the 2nd notification on or after 7 days from the first notification.", async () => {
       // Arrange
-      const { student, disbursement } = await createBlockedDisbursementTestData(
-        db,
-      );
+      const { student, disbursement } =
+        await createBlockedDisbursementTestData(db);
       // Create 1 pre-existing notification for the above created disbursement.
       await saveNotifications(1, student, disbursement.id, -7);
       // Queued job.

--- a/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/esdc-integration/student-loan-balances/_tests_/student-loan-balances-part-time-integration.scheduler.e2e-spec.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/esdc-integration/student-loan-balances/_tests_/student-loan-balances-part-time-integration.scheduler.e2e-spec.ts
@@ -17,7 +17,7 @@ import { mockDownloadFiles } from "@sims/test-utils/mocks";
 import * as Client from "ssh2-sftp-client";
 import * as path from "path";
 import { StudentLoanBalancesPartTimeIntegrationScheduler } from "../student-loan-balances-part-time-integration.scheduler";
-import * as faker from "faker";
+import { faker } from "@faker-js/faker";
 import { Student } from "@sims/sims-db";
 
 /**
@@ -66,7 +66,7 @@ describe(
       // last name to match the expected file records.
       await db.user.update(
         { lastName: RESERVED_USER_LAST_NAME },
-        { lastName: faker.datatype.uuid() },
+        { lastName: faker.string.uuid() },
       );
     });
 
@@ -337,7 +337,7 @@ describe(
       user.lastName =
         lastNameType === "reserved"
           ? RESERVED_USER_LAST_NAME
-          : faker.datatype.uuid();
+          : faker.string.uuid();
       return saveFakeStudent(
         db.dataSource,
         { user },

--- a/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/institution-integration/ece-response/_tests_/ece-response-helper.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/institution-integration/ece-response/_tests_/ece-response-helper.ts
@@ -9,7 +9,7 @@ import {
   createFakeInstitution,
   createFakeInstitutionLocation,
 } from "@sims/test-utils";
-import * as faker from "faker";
+import { faker } from "@faker-js/faker";
 import { IsNull } from "typeorm";
 
 export const CONR_008_CONF_FILE = "CONR-008-CONF-20250502-144027.TXT";

--- a/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/institution-integration/ier12-integration/_tests_/e2e/ier12-factory.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/institution-integration/ier12-integration/_tests_/e2e/ier12-factory.ts
@@ -33,7 +33,7 @@ import {
   IER12TestInputData,
 } from "./models/data-inputs";
 import { addDays, dateDifference, getISODateOnlyString } from "@sims/utilities";
-import * as faker from "faker";
+import { faker } from "@faker-js/faker";
 
 /**
  * Save all IER12 related records providing all data that

--- a/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/institution-integration/ier12-integration/_tests_/e2e/ier12-factory.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/institution-integration/ier12-integration/_tests_/e2e/ier12-factory.ts
@@ -171,7 +171,7 @@ async function saveIER12StudentFromTestInput(
       country: "canada",
       selectedCountry: "Canada",
     },
-    phone: faker.phone.phoneNumber(),
+    phone: faker.phone.number({ style: "national" }),
   };
   fakeStudent.disabilityStatus = testInputStudent.disabilityStatus;
   // SIN validation

--- a/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/sfas-integration/_tests_/sims-to-sfas-integration.scheduler.e2e-spec.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/sfas-integration/_tests_/sims-to-sfas-integration.scheduler.e2e-spec.ts
@@ -1,6 +1,6 @@
 import { DeepMocked } from "@golevelup/ts-jest";
 import MockDate from "mockdate";
-import * as faker from "faker";
+import { faker } from "@faker-js/faker";
 import { INestApplication } from "@nestjs/common";
 import {
   addDays,
@@ -727,8 +727,8 @@ describe(describeProcessorRootTest(QueueNames.SIMSToSFASIntegration), () => {
   }): Promise<Student> {
     const user = createFakeUser();
     // Name with fixed length will be easy to build the expected file data.
-    user.firstName = faker.random.alpha({ count: 15 });
-    user.lastName = faker.random.alpha({ count: 25 });
+    user.firstName = faker.string.alpha({ length: 15 });
+    user.lastName = faker.string.alpha({ length: 25 });
     // Create student with expected first name, last name and updated date.
     const student = await saveFakeStudent(db.dataSource, { user });
     // Create CAS supplier.

--- a/sources/packages/backend/apps/queue-consumers/test/helpers/mock-utils/cas-response.factory.ts
+++ b/sources/packages/backend/apps/queue-consumers/test/helpers/mock-utils/cas-response.factory.ts
@@ -92,9 +92,7 @@ export function createFakeCASNotFoundSupplierResponse(): CASSupplierResponse {
  */
 export function createFakePendingInvoicesResponse(): SendInvoicesResponse {
   return {
-    invoiceNumber: faker.datatype
-      .number({ min: 1000000, max: 9999999 })
-      .toString(),
+    invoiceNumber: faker.number.int({ min: 1000000, max: 9999999 }).toString(),
     casReturnedMessages: ["SUCCEEDED"],
   };
 }

--- a/sources/packages/backend/apps/queue-consumers/test/helpers/mock-utils/cas-response.factory.ts
+++ b/sources/packages/backend/apps/queue-consumers/test/helpers/mock-utils/cas-response.factory.ts
@@ -11,7 +11,7 @@ import {
   SendInvoicesResponse,
 } from "@sims/integrations/cas/models/cas-service.model";
 import { CASSupplierRecordStatus, SupplierAddress } from "@sims/sims-db";
-import * as faker from "faker";
+import { faker } from "@faker-js/faker";
 
 /**
  * Creates a fake CAS supplier response.
@@ -117,12 +117,12 @@ export function createFakeCASCreateSupplierAndSiteResponse(options?: {
     submittedData: {
       SupplierName: "DOE, JOHN",
       SubCategory: "Individual",
-      Sin: faker.datatype.number({ min: 100000000, max: 999999999 }).toString(),
+      Sin: faker.number.int({ min: 100000000, max: 999999999 }).toString(),
       SupplierAddress: [supplierAddress],
     },
     response: {
-      supplierNumber: faker.datatype
-        .number({ min: 1000000, max: 9999999 })
+      supplierNumber: faker.number
+        .int({ min: 1000000, max: 9999999 })
         .toString(),
       supplierSiteCode: "001",
     },
@@ -143,7 +143,7 @@ export function createFakeCASSiteForExistingSupplierResponse(options?: {
 }): CreateExistingSupplierSiteResponse {
   const supplierNumber =
     options?.initialValues?.supplierNumber ??
-    faker.datatype.number({ min: 1000000, max: 9999999 }).toString();
+    faker.number.int({ min: 1000000, max: 9999999 }).toString();
   const supplierAddress = createFakeCASSupplierAddress(
     options?.initialValues?.supplierAddress,
   );
@@ -165,7 +165,7 @@ export function createFakeCASSupplierAddress(
   return {
     AddressLine1: supplierAddress?.addressLine1
       ? formatAddress(supplierAddress?.addressLine1)
-      : faker.address.streetAddress(false).toUpperCase(),
+      : faker.location.streetAddress(false).toUpperCase(),
     City: supplierAddress?.city
       ? formatCity(supplierAddress?.city)
       : "Victoria",

--- a/sources/packages/backend/apps/queue-consumers/test/jest-e2e.json
+++ b/sources/packages/backend/apps/queue-consumers/test/jest-e2e.json
@@ -42,6 +42,6 @@
     "index.ts"
   ],
   "transformIgnorePatterns": [
-    "/node_modules/(?!uuid)"
+    "/node_modules/(?!@faker-js|uuid)"
   ]
 }

--- a/sources/packages/backend/apps/test-db-seeding/src/db-seeding/student/basic-seeding/create-student-users.model.ts
+++ b/sources/packages/backend/apps/test-db-seeding/src/db-seeding/student/basic-seeding/create-student-users.model.ts
@@ -1,4 +1,4 @@
-import * as faker from "faker";
+import { faker } from "@faker-js/faker";
 
 export interface FakeStudent {
   username: string;
@@ -18,7 +18,7 @@ export const STUDENTS_INITIAL_DATA = [
       sin: "706941291",
       isValidSIN: true,
       sinConsent: true,
-      birthDate: faker.date.past(18).toISOString(),
+      birthDate: faker.date.past({ years: 99 }).toISOString(),
       gender: "F",
     },
   },

--- a/sources/packages/backend/apps/test-db-seeding/src/db-seeding/student/basic-seeding/create-student-users.ts
+++ b/sources/packages/backend/apps/test-db-seeding/src/db-seeding/student/basic-seeding/create-student-users.ts
@@ -8,7 +8,7 @@ import {
   SeedPriorityOrder,
 } from "../../../seed-executors";
 import { Repository } from "typeorm";
-import * as faker from "faker";
+import { faker } from "@faker-js/faker";
 import { STUDENTS_INITIAL_DATA } from "./create-student-users.model";
 
 @Injectable()
@@ -56,13 +56,13 @@ export class CreateStudentUsers {
     fakeStudent.sinConsent = options.sinConsent ?? false;
     fakeStudent.contactInfo = {
       address: {
-        addressLine1: faker.address.streetAddress(),
-        city: faker.address.city(),
+        addressLine1: faker.location.streetAddress(),
+        city: faker.location.city(),
         country: "Canada",
         provinceState: "ON",
-        postalCode: faker.address.zipCode(),
+        postalCode: faker.location.zipCode(),
       },
-      phone: faker.phone.phoneNumber(),
+      phone: faker.phone.number({ style: "national" }),
     };
 
     await this.studentRepo.save(fakeStudent);

--- a/sources/packages/backend/apps/workers/src/controllers/assessment/_tests_/e2e/assessment.controller-verifyAssessmentCalculationOrder.e2e-spec.ts
+++ b/sources/packages/backend/apps/workers/src/controllers/assessment/_tests_/e2e/assessment.controller-verifyAssessmentCalculationOrder.e2e-spec.ts
@@ -402,16 +402,16 @@ describe("AssessmentController(e2e)-verifyAssessmentCalculationOrder", () => {
     const firstAssessmentDate =
       currentApplication.currentAssessment.assessmentDate;
     // The start date for the first SFAS and SFAS part-time application record is set to the date before the first assessment date of the current application.
-    const firstLegacyApplicationStartDate = faker.date.between(
-      programYear.startDate,
-      addDays(-1, firstAssessmentDate),
-    );
+    const firstLegacyApplicationStartDate = faker.date.between({
+      from: programYear.startDate,
+      to: addDays(-1, firstAssessmentDate),
+    });
     const firstLegacyApplicationEndDate = addDays(30, firstAssessmentDate);
     // The start date for the second SFAS and SFAS part-time application record is set to the date after the end date of the first SFAS application.
-    const secondLegacyApplicationStartDate = faker.date.between(
-      firstLegacyApplicationEndDate,
-      addDays(10, firstLegacyApplicationEndDate),
-    );
+    const secondLegacyApplicationStartDate = faker.date.between({
+      from: firstLegacyApplicationEndDate,
+      to: addDays(10, firstLegacyApplicationEndDate),
+    });
     const secondLegacyApplicationEndDate = addDays(
       40,
       firstLegacyApplicationEndDate,
@@ -866,16 +866,16 @@ describe("AssessmentController(e2e)-verifyAssessmentCalculationOrder", () => {
     const firstAssessmentDate =
       currentApplication.currentAssessment.assessmentDate;
     // The start date for the first SFAS and SFAS part-time application record is set to the date before the first assessment date of the current application.
-    const firstLegacyApplicationStartDate = faker.date.between(
-      programYear.startDate,
-      addDays(-1, firstAssessmentDate),
-    );
+    const firstLegacyApplicationStartDate = faker.date.between({
+      from: programYear.startDate,
+      to: addDays(-1, firstAssessmentDate),
+    });
     const firstLegacyApplicationEndDate = addDays(30, firstAssessmentDate);
     // The start date for the second SFAS and SFAS part-time application record is set to the date after the end date of the first SFAS application.
-    const secondLegacyApplicationStartDate = faker.date.between(
-      firstLegacyApplicationEndDate,
-      addDays(10, firstLegacyApplicationEndDate),
-    );
+    const secondLegacyApplicationStartDate = faker.date.between({
+      from: firstLegacyApplicationEndDate,
+      to: addDays(10, firstLegacyApplicationEndDate),
+    });
     const secondLegacyApplicationEndDate = addDays(
       40,
       firstLegacyApplicationEndDate,
@@ -1026,10 +1026,10 @@ describe("AssessmentController(e2e)-verifyAssessmentCalculationOrder", () => {
     const firstAssessmentDate =
       currentApplication.currentAssessment.assessmentDate;
     // The start date for the first SFAS and SFAS part-time application record is set to the date before the first assessment date of the current application.
-    const legacyApplicationStartDate = faker.date.between(
-      programYear.startDate,
-      addDays(-1, firstAssessmentDate),
-    );
+    const legacyApplicationStartDate = faker.date.between({
+      from: programYear.startDate,
+      to: addDays(-1, firstAssessmentDate),
+    });
     const legacyApplicationEndDate = addDays(30, firstAssessmentDate);
 
     // Create the second assessment for the current application with a different assessment date.

--- a/sources/packages/backend/apps/workers/src/controllers/assessment/_tests_/e2e/assessment.controller-verifyAssessmentCalculationOrder.e2e-spec.ts
+++ b/sources/packages/backend/apps/workers/src/controllers/assessment/_tests_/e2e/assessment.controller-verifyAssessmentCalculationOrder.e2e-spec.ts
@@ -32,7 +32,7 @@ import { addDays, getISODateOnlyString } from "@sims/utilities";
 import { createFakeVerifyAssessmentCalculationOrderPayload } from "./verify-assessment-calculation-order-factory";
 import { createFakeSFASApplication } from "@sims/test-utils/factories/sfas-application";
 import { createFakeSFASPartTimeApplication } from "@sims/test-utils/factories/sfas-part-time-application";
-import * as faker from "faker";
+import { faker } from "@faker-js/faker";
 import * as dayjs from "dayjs";
 
 describe("AssessmentController(e2e)-verifyAssessmentCalculationOrder", () => {

--- a/sources/packages/backend/apps/workers/src/controllers/supporting-user/_test_/e2e/supporting-user.controller.createIdentifiableSupportingUsers.e2e-spec.ts
+++ b/sources/packages/backend/apps/workers/src/controllers/supporting-user/_test_/e2e/supporting-user.controller.createIdentifiableSupportingUsers.e2e-spec.ts
@@ -22,7 +22,7 @@ import {
 } from "../../supporting-user.dto";
 import { createFakeCreateIdentifiableSupportingUsersPayload } from "./create-identifiable-supporting-user";
 import { ICustomHeaders } from "@camunda8/sdk/dist/zeebe/types";
-import * as faker from "faker";
+import { faker } from "@faker-js/faker";
 import {
   APPLICATION_NOT_FOUND,
   SUPPORTING_USER_FULL_NAME_NOT_RESOLVED,
@@ -43,7 +43,7 @@ describe("SupportingUserController(e2e)-createIdentifiableSupportingUsers", () =
       "and create a student notification for parent declaration required by parent.",
     async () => {
       // Arrange
-      const parentFullName = faker.datatype.uuid();
+      const parentFullName = faker.string.uuid();
       const savedApplication = await saveFakeApplication(
         db.dataSource,
         undefined,
@@ -122,8 +122,8 @@ describe("SupportingUserController(e2e)-createIdentifiableSupportingUsers", () =
       "and create a student notification for parent declaration required by student.",
     async () => {
       // Arrange
-      const parentFullName1 = faker.datatype.uuid();
-      const parentFullName2 = faker.datatype.uuid();
+      const parentFullName1 = faker.string.uuid();
+      const parentFullName2 = faker.string.uuid();
       const savedApplication = await saveFakeApplication(
         db.dataSource,
         undefined,
@@ -202,7 +202,7 @@ describe("SupportingUserController(e2e)-createIdentifiableSupportingUsers", () =
 
   it("Should not create a parent when the parent was already created.", async () => {
     // Arrange
-    const parentFullName = faker.datatype.uuid();
+    const parentFullName = faker.string.uuid();
     const savedApplication = await saveFakeApplication(
       db.dataSource,
       undefined,

--- a/sources/packages/backend/apps/workers/test/jest-e2e.json
+++ b/sources/packages/backend/apps/workers/test/jest-e2e.json
@@ -41,5 +41,8 @@
     ".dto.ts",
     "mock.ts",
     "index.ts"
+  ],
+  "transformIgnorePatterns": [
+    "/node_modules/(?!@faker-js|uuid)"
   ]
 }

--- a/sources/packages/backend/jest-unit-tests.json
+++ b/sources/packages/backend/jest-unit-tests.json
@@ -42,5 +42,8 @@
     "^@sims/test-utils(|/.*)$": "<rootDir>/libs/test-utils/src/$1",
     "^@sims/integrations(|/.*)$": "<rootDir>/libs/integrations/src/$1",
     "^@sims/auth(|/.*)$": "<rootDir>/libs/auth/src/$1"
-  }
+  },
+  "transformIgnorePatterns": [
+    "/node_modules/(?!@faker-js|uuid)"
+  ]
 }

--- a/sources/packages/backend/libs/test-utils/src/factories/announcement.ts
+++ b/sources/packages/backend/libs/test-utils/src/factories/announcement.ts
@@ -1,5 +1,5 @@
 import { Announcement } from "@sims/sims-db";
-import * as faker from "faker";
+import { faker } from "@faker-js/faker";
 
 /**
  * Creates an Announcement ready to be saved to the database.
@@ -12,9 +12,9 @@ export function createFakeAnnouncement(options?: {
 }): Announcement {
   const announcement = new Announcement();
   announcement.message =
-    options?.initialValues?.message ?? faker.random.alpha({ count: 200 });
+    options?.initialValues?.message ?? faker.string.alpha({ length: 200 });
   announcement.messageTitle =
-    options?.initialValues?.messageTitle ?? faker.random.alpha({ count: 50 });
+    options?.initialValues?.messageTitle ?? faker.string.alpha({ length: 50 });
   announcement.target = options?.initialValues?.target ?? [
     "student-dashboard",
     "institution-dashboard",

--- a/sources/packages/backend/libs/test-utils/src/factories/application-exception-request.ts
+++ b/sources/packages/backend/libs/test-utils/src/factories/application-exception-request.ts
@@ -3,7 +3,7 @@ import {
   ApplicationExceptionRequest,
   User,
 } from "@sims/sims-db";
-import * as faker from "faker";
+import { faker } from "@faker-js/faker";
 import { createFakeApplicationException } from "./application-exception";
 
 /**
@@ -35,7 +35,7 @@ export function createFakeApplicationExceptionRequest(
       });
   }
   applicationExceptionRequest.exceptionName =
-    options?.initialData?.exceptionName ?? faker.name.firstName();
+    options?.initialData?.exceptionName ?? faker.person.firstName();
   applicationExceptionRequest.exceptionDescription =
     options?.initialData?.exceptionDescription ??
     "Fake application exception description";

--- a/sources/packages/backend/libs/test-utils/src/factories/application-offering-change-request.ts
+++ b/sources/packages/backend/libs/test-utils/src/factories/application-offering-change-request.ts
@@ -8,7 +8,7 @@ import {
 import { saveFakeApplicationDisbursements } from "./application";
 import { createFakeEducationProgramOffering } from "./education-program-offering";
 import { createFakeUser } from "./user";
-import * as faker from "faker";
+import { faker } from "@faker-js/faker";
 import { E2EDataSources } from "../data-source/e2e-data-source";
 
 /**

--- a/sources/packages/backend/libs/test-utils/src/factories/application.ts
+++ b/sources/packages/backend/libs/test-utils/src/factories/application.ts
@@ -23,7 +23,7 @@ import {
   User,
 } from "@sims/sims-db";
 import { addDays, getISODateOnlyString } from "@sims/utilities";
-import * as faker from "faker";
+import { faker } from "@faker-js/faker";
 import { DataSource } from "typeorm";
 import {
   createFakeDisbursementSchedule,
@@ -71,7 +71,7 @@ export function createFakeApplication(
   // with fixed length of 10 characters.
   application.applicationNumber =
     options?.initialValue?.applicationNumber ??
-    faker.datatype.number({ max: 9999999999, min: 1000000000 }).toString();
+    faker.number.int({ max: 9999999999, min: 1000000000 }).toString();
   application.applicationException = relations?.applicationException;
   application.location = relations?.location ?? createFakeInstitutionLocation();
   application.pirProgram = relations?.pirProgram;

--- a/sources/packages/backend/libs/test-utils/src/factories/cas-invoice-batch.ts
+++ b/sources/packages/backend/libs/test-utils/src/factories/cas-invoice-batch.ts
@@ -9,7 +9,7 @@ import {
   SupplierStatus,
   User,
 } from "@sims/sims-db";
-import * as faker from "faker";
+import { faker } from "@faker-js/faker";
 import { saveFakeCASSupplier } from "./cas-supplier";
 import {
   E2EDataSources,
@@ -35,7 +35,7 @@ export function createFakeCASInvoiceBatch(
 ): CASInvoiceBatch {
   const now = new Date();
   const casInvoiceBatch = new CASInvoiceBatch();
-  casInvoiceBatch.batchName = `SIMS-BATCH-${faker.datatype.uuid()}}`;
+  casInvoiceBatch.batchName = `SIMS-BATCH-${faker.string.uuid()}}`;
   casInvoiceBatch.batchDate = options?.initialValue?.batchDate ?? now;
   casInvoiceBatch.approvalStatus =
     options?.initialValue?.approvalStatus ??

--- a/sources/packages/backend/libs/test-utils/src/factories/cas-invoice.ts
+++ b/sources/packages/backend/libs/test-utils/src/factories/cas-invoice.ts
@@ -7,7 +7,7 @@ import {
   DisbursementValueType,
   User,
 } from "@sims/sims-db";
-import * as faker from "faker";
+import { faker } from "@faker-js/faker";
 import { createFakeCASInvoiceDetail } from "./cas-invoice-detail";
 import { E2EDataSources } from "..";
 
@@ -38,7 +38,7 @@ export function createFakeCASInvoice(
   casInvoice.casInvoiceBatch = relations.casInvoiceBatch;
   casInvoice.disbursementReceipt = relations.disbursementReceipt;
   casInvoice.casSupplier = relations.casSupplier;
-  casInvoice.invoiceNumber = faker.datatype.uuid();
+  casInvoice.invoiceNumber = faker.string.uuid();
   casInvoice.invoiceStatus =
     options?.initialValue?.invoiceStatus ?? CASInvoiceStatus.Pending;
   casInvoice.invoiceStatusUpdatedOn =

--- a/sources/packages/backend/libs/test-utils/src/factories/cas-supplier.ts
+++ b/sources/packages/backend/libs/test-utils/src/factories/cas-supplier.ts
@@ -11,7 +11,7 @@ import {
   E2EDataSources,
   saveFakeStudent,
 } from "@sims/test-utils";
-import * as faker from "faker";
+import { faker } from "@faker-js/faker";
 
 /**
  * Saves a fake CAS supplier.
@@ -77,13 +77,13 @@ export function createFakeCASSupplier(
     casSupplier.isValid = options?.initialValues.isValid ?? true;
   } else {
     casSupplier.supplierAddress = {
-      supplierSiteCode: faker.datatype.number(999).toString(),
-      addressLine1: faker.address.streetAddress(),
-      addressLine2: faker.address.streetAddress(),
-      city: faker.address.city(),
-      provinceState: faker.address.state(),
-      country: faker.address.country(),
-      postalCode: faker.address.zipCode(),
+      supplierSiteCode: faker.number.int(999).toString(),
+      addressLine1: faker.location.streetAddress(),
+      addressLine2: faker.location.streetAddress(),
+      city: faker.location.city(),
+      provinceState: faker.location.state(),
+      country: faker.location.country(),
+      postalCode: faker.location.zipCode(),
       status: "ACTIVE",
       siteProtected: "YES",
       lastUpdated: new Date(),
@@ -91,12 +91,12 @@ export function createFakeCASSupplier(
     casSupplier.supplierProtected = true;
     casSupplier.isValid = options?.initialValues.isValid ?? false;
   }
-  casSupplier.supplierName = `${faker.name.lastName()}, ${faker.name.firstName()}`;
+  casSupplier.supplierName = `${faker.person.lastName()}, ${faker.person.firstName()}`;
   casSupplier.supplierNumber =
     options?.initialValues?.supplierNumber ??
-    faker.datatype.number({ min: 100000, max: 9999999999 }).toString();
-  casSupplier.supplierAddress.supplierSiteCode = faker.datatype
-    .number({ min: 100, max: 999 })
+    faker.number.int({ min: 100000, max: 9999999999 }).toString();
+  casSupplier.supplierAddress.supplierSiteCode = faker.number
+    .int({ min: 100, max: 999 })
     .toString();
   casSupplier.supplierStatusUpdatedOn = new Date();
   casSupplier.creator = relations.auditUser;

--- a/sources/packages/backend/libs/test-utils/src/factories/designation-agreement.ts
+++ b/sources/packages/backend/libs/test-utils/src/factories/designation-agreement.ts
@@ -8,7 +8,7 @@ import {
 } from "@sims/sims-db";
 import { INSTITUTION_TYPE_BC_PRIVATE } from "@sims/sims-db/constant";
 import { addDays, formatDate } from "@sims/utilities";
-import * as faker from "faker";
+import { faker } from "@faker-js/faker";
 
 /**
  * Create a fake designation agreement.
@@ -44,7 +44,7 @@ export function createFakeDesignationAgreement(
     fakeDesignationAgreement.institution.institutionType.id ===
     INSTITUTION_TYPE_BC_PRIVATE;
   fakeDesignationAgreement.submittedData = {
-    legalAuthorityName: faker.name.findName(),
+    legalAuthorityName: faker.person.fullName(),
     legalAuthorityEmailAddress: faker.internet.email(),
     scheduleA: isBCPrivate ? true : false,
     scheduleB: isBCPrivate ? true : false,
@@ -52,18 +52,18 @@ export function createFakeDesignationAgreement(
     agreementAccepted: isBCPrivate ? true : false,
     enrolmentOfficers: [
       {
-        name: isBCPrivate ? faker.name.findName() : "",
+        name: isBCPrivate ? faker.person.fullName() : "",
         email: isBCPrivate ? faker.internet.email() : "",
-        phone: isBCPrivate ? faker.phone.phoneNumber("##########") : "",
-        positionTitle: isBCPrivate ? faker.name.jobTitle() : "",
+        phone: isBCPrivate ? faker.phone.number({ style: "national" }) : "",
+        positionTitle: isBCPrivate ? faker.person.jobTitle() : "",
       },
     ],
     eligibilityOfficers: [
       {
-        name: isBCPrivate ? faker.name.findName() : "",
+        name: isBCPrivate ? faker.person.fullName() : "",
         email: isBCPrivate ? faker.internet.email() : "",
-        phone: isBCPrivate ? faker.phone.phoneNumber("##########") : "",
-        positionTitle: isBCPrivate ? faker.name.jobTitle() : "",
+        phone: isBCPrivate ? faker.phone.number({ style: "national" }) : "",
+        positionTitle: isBCPrivate ? faker.person.jobTitle() : "",
       },
     ],
   };

--- a/sources/packages/backend/libs/test-utils/src/factories/disbursement-overaward.ts
+++ b/sources/packages/backend/libs/test-utils/src/factories/disbursement-overaward.ts
@@ -7,7 +7,7 @@ import {
   StudentAssessment,
   User,
 } from "@sims/sims-db";
-import * as faker from "faker";
+import { faker } from "@faker-js/faker";
 
 export function createFakeDisbursementOveraward(relations?: {
   student?: Student;
@@ -20,15 +20,14 @@ export function createFakeDisbursementOveraward(relations?: {
   disbursementOveraward.student = relations?.student;
   disbursementOveraward.studentAssessment = relations?.studentAssessment;
   disbursementOveraward.disbursementSchedule = relations?.disbursementSchedule;
-  disbursementOveraward.overawardValue = faker.datatype.number({
+  disbursementOveraward.overawardValue = faker.number.int({
     min: 500,
     max: 50000,
   });
-  disbursementOveraward.disbursementValueCode = faker.random
-    .alpha({
-      count: 4,
-    })
-    .toUpperCase();
+  disbursementOveraward.disbursementValueCode = faker.string.alpha({
+    length: 4,
+    casing: "upper",
+  });
   disbursementOveraward.originType =
     DisbursementOverawardOriginType.ManualRecord;
   disbursementOveraward.deletedAt = null;

--- a/sources/packages/backend/libs/test-utils/src/factories/disbursement-receipt-value.ts
+++ b/sources/packages/backend/libs/test-utils/src/factories/disbursement-receipt-value.ts
@@ -1,5 +1,5 @@
 import { DisbursementReceipt, DisbursementReceiptValue } from "@sims/sims-db";
-import faker from "faker";
+import { faker } from "@faker-js/faker";
 
 /**
  * Create fake disbursement receipt value.
@@ -17,10 +17,10 @@ export function createFakeDisbursementReceiptValue(
 ): DisbursementReceiptValue {
   const disbursementReceiptValue = new DisbursementReceiptValue();
   disbursementReceiptValue.grantType =
-    initialValues.grantType ?? faker.random.alpha({ count: 4 });
+    initialValues.grantType ?? faker.string.alpha({ length: 4 });
   disbursementReceiptValue.grantAmount =
     initialValues.grantAmount ??
-    faker.datatype.number({
+    faker.number.int({
       min: 1000,
       max: 9999,
     });

--- a/sources/packages/backend/libs/test-utils/src/factories/disbursement-receipt.ts
+++ b/sources/packages/backend/libs/test-utils/src/factories/disbursement-receipt.ts
@@ -9,7 +9,7 @@ import {
   RECEIPT_FUNDING_TYPE_PROVINCIAL_FULL_TIME,
 } from "@sims/sims-db";
 import { getISODateOnlyString } from "@sims/utilities";
-import * as faker from "faker";
+import { faker } from "@faker-js/faker";
 import { createFakeDisbursementReceiptValue } from "./disbursement-receipt-value";
 import { E2EDataSources } from "../data-source/e2e-data-source";
 
@@ -28,20 +28,20 @@ export function createFakeDisbursementReceipt(relations: {
     relations.disbursementSchedule.studentAssessment.application.student;
   const now = new Date();
   const isoDateNow = getISODateOnlyString(new Date());
-  const randomAmount = faker.datatype.number({
+  const randomAmount = faker.number.int({
     min: 1000,
     max: 8999,
   });
   const receipt = new DisbursementReceipt();
   receipt.batchRunDate = isoDateNow;
   receipt.fileDate = isoDateNow;
-  receipt.sequenceNumber = faker.datatype.number({
+  receipt.sequenceNumber = faker.number.int({
     min: 1,
     max: 99999,
   });
   receipt.studentSIN =
     student?.sinValidation?.sin ??
-    faker.datatype.number({ min: 100000000, max: 899999999 }).toString();
+    faker.number.int({ min: 100000000, max: 899999999 }).toString();
   receipt.disbursementSchedule = relations.disbursementSchedule;
   receipt.fundingType = RECEIPT_FUNDING_TYPE_FEDERAL;
   receipt.totalEntitledDisbursedAmount = randomAmount;
@@ -52,10 +52,10 @@ export function createFakeDisbursementReceipt(relations: {
   receipt.dateSignedInstitution = isoDateNow;
   receipt.institutionCode =
     relations.institutionLocation?.institutionCode ??
-    faker.random.alpha({ count: 4, upcase: true });
-  receipt.disburseMethodStudent = faker.random.alpha({
-    count: 1,
-    upcase: true,
+    faker.string.alpha({ length: 4, casing: "upper" });
+  receipt.disburseMethodStudent = faker.string.alpha({
+    length: 1,
+    casing: "upper",
   });
   receipt.studyPeriodEndDate = isoDateNow;
   receipt.totalEntitledGrantAmount = randomAmount;

--- a/sources/packages/backend/libs/test-utils/src/factories/disbursement-schedule.ts
+++ b/sources/packages/backend/libs/test-utils/src/factories/disbursement-schedule.ts
@@ -7,7 +7,7 @@ import {
   MSFAANumber,
 } from "@sims/sims-db";
 import { getISODateOnlyString } from "@sims/utilities";
-import * as faker from "faker";
+import { faker } from "@faker-js/faker";
 
 /**
  * Creates a disbursement schedule.
@@ -36,7 +36,7 @@ export function createFakeDisbursementSchedule(
   // per e-Cert documentation. Numbers under 1000000 can still be used for E2E tests.
   schedule.documentNumber =
     options?.initialValues?.documentNumber ??
-    faker.datatype.number({ min: 1000000, max: 9999999 });
+    faker.number.int({ min: 1000000, max: 9999999 });
   schedule.disbursementDate =
     options?.initialValues?.disbursementDate ?? nowString;
   schedule.negotiatedExpiryDate = nowString;

--- a/sources/packages/backend/libs/test-utils/src/factories/dynamic-form-configuration.ts
+++ b/sources/packages/backend/libs/test-utils/src/factories/dynamic-form-configuration.ts
@@ -5,7 +5,7 @@ import {
   ProgramYear,
 } from "@sims/sims-db";
 import { E2EDataSources } from "@sims/test-utils/data-source/e2e-data-source";
-import * as faker from "faker";
+import { faker } from "@faker-js/faker";
 
 /**
  * Create a fake dynamic form configuration.
@@ -29,7 +29,7 @@ export function createFakeDynamicFormConfiguration(
   dynamicFormConfiguration.programYear = relations?.programYear;
   dynamicFormConfiguration.offeringIntensity = options?.offeringIntensity;
   dynamicFormConfiguration.formDefinitionName =
-    options?.formDefinitionName ?? faker.random.alphaNumeric(50);
+    options?.formDefinitionName ?? faker.string.alphanumeric({ length: 50 });
   return dynamicFormConfiguration;
 }
 

--- a/sources/packages/backend/libs/test-utils/src/factories/education-program-offering.ts
+++ b/sources/packages/backend/libs/test-utils/src/factories/education-program-offering.ts
@@ -1,4 +1,4 @@
-import * as faker from "faker";
+import { faker } from "@faker-js/faker";
 import { createFakeInstitutionLocation } from "./institution-location";
 import { createFakeEducationProgram } from "./education-program";
 import {
@@ -41,11 +41,11 @@ export function createFakeEducationProgramOffering(
   const institution =
     relations?.institutionLocation?.institution ?? relations.institution;
   const offering = new EducationProgramOffering();
-  offering.name = faker.random.word();
-  offering.actualTuitionCosts = faker.datatype.number(1000);
-  offering.programRelatedCosts = faker.datatype.number(1000);
-  offering.mandatoryFees = faker.datatype.number(1000);
-  offering.exceptionalExpenses = faker.datatype.number(1000);
+  offering.name = faker.lorem.word();
+  offering.actualTuitionCosts = faker.number.int(1000);
+  offering.programRelatedCosts = faker.number.int(1000);
+  offering.mandatoryFees = faker.number.int(1000);
+  offering.exceptionalExpenses = faker.number.int(1000);
   offering.offeringDelivered = "offeringDelivered";
   offering.lacksStudyBreaks = true;
   offering.educationProgram =
@@ -77,7 +77,7 @@ export function createFakeEducationProgramOffering(
   offering.offeringDeclaration = true;
   offering.studyStartDate =
     options?.initialValues?.studyStartDate ??
-    getISODateOnlyString(faker.date.recent(1));
+    getISODateOnlyString(faker.date.recent({ days: 1 }));
   offering.studyEndDate =
     options?.initialValues?.studyEndDate ??
     getISODateOnlyString(addDays(3, offering.studyStartDate));

--- a/sources/packages/backend/libs/test-utils/src/factories/education-program.ts
+++ b/sources/packages/backend/libs/test-utils/src/factories/education-program.ts
@@ -1,4 +1,4 @@
-import * as faker from "faker";
+import { faker } from "@faker-js/faker";
 import {
   EducationProgram,
   Institution,
@@ -16,7 +16,7 @@ export function createFakeEducationProgram(
   options?: { initialValues?: Partial<EducationProgram> },
 ): EducationProgram {
   const program = new EducationProgram();
-  program.name = faker.name.jobArea();
+  program.name = faker.person.jobArea();
   program.description = "description";
   program.credentialType = "credentialType";
   program.cipCode = "cipCode";

--- a/sources/packages/backend/libs/test-utils/src/factories/institution-location.ts
+++ b/sources/packages/backend/libs/test-utils/src/factories/institution-location.ts
@@ -1,5 +1,5 @@
 import { Institution, InstitutionLocation } from "@sims/sims-db";
-import * as faker from "faker";
+import { faker } from "@faker-js/faker";
 import { createFakeInstitution } from "./institution";
 
 /**
@@ -20,30 +20,30 @@ export function createFakeInstitutionLocation(
 ): InstitutionLocation {
   const institutionLocation = new InstitutionLocation();
 
-  institutionLocation.name = faker.company.companyName();
+  institutionLocation.name = faker.company.name();
   institutionLocation.institution =
     relations?.institution ?? createFakeInstitution();
   institutionLocation.data = {
     address: {
-      addressLine1: faker.address.streetAddress(),
+      addressLine1: faker.location.streetAddress(),
       city: "Victoria",
       provinceState: "BC",
       country: "canada",
       selectedCountry: "Canada",
-      postalCode: faker.address.zipCode("A9A9A9"),
+      postalCode: faker.location.zipCode("A9A9A9"),
     },
   };
   institutionLocation.primaryContact = {
-    firstName: faker.name.firstName(),
-    lastName: faker.name.lastName(),
+    firstName: faker.person.firstName(),
+    lastName: faker.person.lastName(),
     email: faker.internet.email(),
-    phone: faker.phone.phoneNumber("##########"),
+    phone: faker.phone.number({ style: "national" }),
   };
   institutionLocation.institutionCode =
     options?.initialValue?.institutionCode ??
-    faker.random.alpha({
-      count: 4,
-      upcase: true,
+    faker.string.alpha({
+      length: 4,
+      casing: "upper",
     });
   institutionLocation.hasIntegration = options?.initialValue?.hasIntegration;
   return institutionLocation;

--- a/sources/packages/backend/libs/test-utils/src/factories/institution.ts
+++ b/sources/packages/backend/libs/test-utils/src/factories/institution.ts
@@ -1,4 +1,4 @@
-import * as faker from "faker";
+import { faker } from "@faker-js/faker";
 import { Institution, InstitutionType } from "@sims/sims-db";
 import { INSTITUTION_TYPE_BC_PRIVATE } from "@sims/sims-db/constant";
 
@@ -12,34 +12,34 @@ export function createFakeInstitution(relations?: {
   institutionType?: InstitutionType;
 }): Institution {
   const institution = new Institution();
-  institution.businessGuid = faker.datatype.uuid();
-  institution.legalOperatingName = faker.company.companyName();
-  institution.operatingName = faker.company.companySuffix();
-  institution.primaryPhone = faker.phone.phoneNumber("##########");
+  institution.businessGuid = faker.string.uuid();
+  institution.legalOperatingName = faker.company.name();
+  institution.operatingName = faker.company.name();
+  institution.primaryPhone = faker.phone.number({ style: "national" });
   institution.primaryEmail = faker.internet.email();
   institution.website = faker.internet.url();
   institution.regulatingBody = "icbc";
-  institution.establishedDate = faker.date.past(20).toISOString();
+  institution.establishedDate = faker.date.past({ years: 20 }).toISOString();
   institution.institutionType =
     relations?.institutionType ??
     ({
       id: INSTITUTION_TYPE_BC_PRIVATE,
     } as InstitutionType);
   institution.institutionPrimaryContact = {
-    firstName: faker.name.firstName(),
-    lastName: faker.name.lastName(),
+    firstName: faker.person.firstName(),
+    lastName: faker.person.lastName(),
     email: faker.internet.email(),
-    phone: faker.phone.phoneNumber("##########"),
+    phone: faker.phone.number({ style: "national" }),
   };
   institution.institutionAddress = {
     mailingAddress: {
-      addressLine1: faker.address.streetAddress(),
-      addressLine2: faker.address.secondaryAddress(),
+      addressLine1: faker.location.streetAddress(),
+      addressLine2: faker.location.secondaryAddress(),
       provinceState: "BC",
       country: "canada",
       selectedCountry: "Canada",
       city: "Victoria",
-      postalCode: faker.address.zipCode("A9A9A9"),
+      postalCode: faker.location.zipCode("A9A9A9"),
     },
   };
   return institution;

--- a/sources/packages/backend/libs/test-utils/src/factories/msfaa-number.ts
+++ b/sources/packages/backend/libs/test-utils/src/factories/msfaa-number.ts
@@ -5,7 +5,7 @@ import {
   Student,
 } from "@sims/sims-db";
 import { getISODateOnlyString } from "@sims/utilities";
-import * as faker from "faker";
+import { faker } from "@faker-js/faker";
 
 /**
  * Represents the different MSFAA scenarios.
@@ -54,8 +54,8 @@ export function createFakeMSFAANumber(
   msfaaNumber.referenceApplication = relations?.referenceApplication;
   msfaaNumber.msfaaNumber =
     options?.msfaaInitialValues?.msfaaNumber ??
-    faker.datatype
-      .number({
+    faker.number
+      .int({
         min: 1000000000,
         max: 9999999999,
       })

--- a/sources/packages/backend/libs/test-utils/src/factories/note.ts
+++ b/sources/packages/backend/libs/test-utils/src/factories/note.ts
@@ -1,5 +1,5 @@
 import { Institution, Note, NoteType, Student, User } from "@sims/sims-db";
-import * as faker from "faker";
+import { faker } from "@faker-js/faker";
 import { DataSource } from "typeorm";
 import { createFakeUser } from "./user";
 
@@ -11,7 +11,7 @@ export function createFakeNote(
 ): Note {
   const note = new Note();
   note.noteType = noteType;
-  note.description = faker.random.words(10);
+  note.description = faker.lorem.words(10);
   note.creator = relations?.creator ?? createFakeUser();
   return note;
 }

--- a/sources/packages/backend/libs/test-utils/src/factories/notification.ts
+++ b/sources/packages/backend/libs/test-utils/src/factories/notification.ts
@@ -5,7 +5,7 @@ import {
   NotificationMessageType,
   User,
 } from "@sims/sims-db";
-import * as faker from "faker";
+import { faker } from "@faker-js/faker";
 
 /**
  * Creates a fake message payload.
@@ -14,10 +14,10 @@ import * as faker from "faker";
 function createDummyMessagePayload(): NotificationEmailMessage {
   return {
     email_address: faker.internet.email(),
-    template_id: faker.datatype.string(),
+    template_id: faker.string.uuid(),
     personalisation: {
-      givenNames: faker.name.firstName(),
-      lastName: faker.name.lastName(),
+      givenNames: faker.person.firstName(),
+      lastName: faker.person.lastName(),
     },
   };
 }

--- a/sources/packages/backend/libs/test-utils/src/factories/restriction.ts
+++ b/sources/packages/backend/libs/test-utils/src/factories/restriction.ts
@@ -4,7 +4,7 @@ import {
   RestrictionNotificationType,
   RestrictionType,
 } from "@sims/sims-db";
-import * as faker from "faker";
+import { faker } from "@faker-js/faker";
 
 /**
  * Creates a fake restriction to be persisted.
@@ -22,9 +22,9 @@ export function createFakeRestriction(options?: {
     options?.initialValues.restrictionCategory ?? "Other";
   restriction.restrictionCode =
     options?.initialValues.restrictionCode ??
-    faker.random.alpha({ count: 10, upcase: true });
+    faker.string.alpha({ length: 10, casing: "upper" });
   restriction.description =
-    options?.initialValues.description ?? faker.random.words(2);
+    options?.initialValues.description ?? faker.lorem.words(2);
   restriction.actionType = options?.initialValues.actionType ?? [
     RestrictionActionType.NoEffect,
   ];

--- a/sources/packages/backend/libs/test-utils/src/factories/sfas-application-dependant.ts
+++ b/sources/packages/backend/libs/test-utils/src/factories/sfas-application-dependant.ts
@@ -1,6 +1,6 @@
 import { SFASApplication, SFASApplicationDependant } from "@sims/sims-db";
 import { getISODateOnlyString } from "@sims/utilities";
-import * as faker from "faker";
+import { faker } from "@faker-js/faker";
 
 /**
  * Create fake SFAS application dependant.
@@ -16,16 +16,16 @@ export function createFakeSFASApplicationDependant(
   },
 ): SFASApplicationDependant {
   const sfasApplicationDependant = new SFASApplicationDependant();
-  sfasApplicationDependant.id = faker.datatype.number({
+  sfasApplicationDependant.id = faker.number.int({
     min: 100000000,
     max: 999999999,
   });
   sfasApplicationDependant.application = relations.sfasApplication;
   sfasApplicationDependant.dependantName =
-    options?.initialValues?.dependantName ?? faker.name.firstName();
+    options?.initialValues?.dependantName ?? faker.person.firstName();
   sfasApplicationDependant.dependantBirthDate =
     options?.initialValues?.dependantBirthDate ??
-    getISODateOnlyString(faker.date.past(18));
+    getISODateOnlyString(faker.date.past({ years: 18 }));
   sfasApplicationDependant.extractedAt = new Date();
   return sfasApplicationDependant;
 }

--- a/sources/packages/backend/libs/test-utils/src/factories/sfas-application-disbursement.ts
+++ b/sources/packages/backend/libs/test-utils/src/factories/sfas-application-disbursement.ts
@@ -1,6 +1,6 @@
 import { SFASApplication, SFASApplicationDisbursement } from "@sims/sims-db";
 import { getISODateOnlyString } from "@sims/utilities";
-import * as faker from "faker";
+import { faker } from "@faker-js/faker";
 
 /**
  * Create fake SFAS application disbursement.
@@ -16,7 +16,7 @@ export function createFakeSFASApplicationDisbursement(
   },
 ): SFASApplicationDisbursement {
   const sfasApplicationDependant = new SFASApplicationDisbursement();
-  sfasApplicationDependant.id = faker.datatype.number({
+  sfasApplicationDependant.id = faker.number.int({
     min: 100000000,
     max: 999999999,
   });
@@ -27,10 +27,10 @@ export function createFakeSFASApplicationDisbursement(
     options?.initialValues?.fundingAmount ?? 100;
   sfasApplicationDependant.fundingDate =
     options?.initialValues?.fundingDate ??
-    getISODateOnlyString(faker.date.past(18));
+    getISODateOnlyString(faker.date.recent({ days: 18 }));
   sfasApplicationDependant.dateIssued =
     options?.initialValues?.dateIssued ??
-    getISODateOnlyString(faker.date.past(18));
+    getISODateOnlyString(faker.date.recent({ days: 18 }));
   sfasApplicationDependant.extractedAt = new Date();
   return sfasApplicationDependant;
 }

--- a/sources/packages/backend/libs/test-utils/src/factories/sfas-application.ts
+++ b/sources/packages/backend/libs/test-utils/src/factories/sfas-application.ts
@@ -1,6 +1,6 @@
 import { SFASApplication, SFASIndividual } from "@sims/sims-db";
 import { getISODateOnlyString } from "@sims/utilities";
-import * as faker from "faker";
+import { faker } from "@faker-js/faker";
 
 /**
  * Create fake SFAS application.
@@ -19,16 +19,17 @@ export function createFakeSFASApplication(
   },
 ): SFASApplication {
   const sfasApplication = new SFASApplication();
-  sfasApplication.id = faker.datatype.number({
+  sfasApplication.id = faker.number.int({
     min: 100000000,
     max: 999999999,
   });
   sfasApplication.programYearId = options?.initialValues?.programYearId;
   sfasApplication.startDate =
     options?.initialValues.startDate ??
-    getISODateOnlyString(faker.date.past(18));
+    getISODateOnlyString(faker.date.past({ years: 18 }));
   sfasApplication.endDate =
-    options?.initialValues.endDate ?? getISODateOnlyString(faker.date.past(18));
+    options?.initialValues.endDate ??
+    getISODateOnlyString(faker.date.past({ years: 18 }));
   sfasApplication.individual = relations.individual;
   sfasApplication.bslAward = options?.initialValues.bslAward ?? 20;
   sfasApplication.cslAward = options?.initialValues.cslAward ?? 20;
@@ -39,20 +40,20 @@ export function createFakeSFASApplication(
   sfasApplication.csgdAward = options?.initialValues.csgdAward ?? 0;
   sfasApplication.csgpAward = options?.initialValues.csgpAward ?? 0;
   sfasApplication.sbsdAward = options?.initialValues.sbsdAward ?? 0;
-  sfasApplication.createdAt = faker.date.past(18);
-  sfasApplication.updatedAt = faker.date.past(18);
-  sfasApplication.extractedAt = faker.date.past(18);
+  sfasApplication.createdAt = faker.date.past({ years: 18 });
+  sfasApplication.updatedAt = faker.date.past({ years: 18 });
+  sfasApplication.extractedAt = faker.date.past({ years: 18 });
   sfasApplication.applicationCancelDate =
     options?.initialValues?.applicationCancelDate ?? null;
   sfasApplication.applicationNumber =
     options?.initialValues?.applicationNumber ??
-    faker.datatype.number({
+    faker.number.int({
       max: 9999999999,
       min: 1000000000,
     });
   sfasApplication.applicationStatusCode =
     options?.initialValues?.applicationStatusCode ??
-    faker.random.alpha({ count: 4, upcase: true });
+    faker.string.alpha({ length: 4, casing: "upper" });
   sfasApplication.withdrawalDate = options?.initialValues?.withdrawalDate;
   sfasApplication.withdrawalReason = options?.initialValues?.withdrawalReason;
   sfasApplication.withdrawalActiveFlag =
@@ -96,7 +97,7 @@ export function createFakeSFASApplication(
       options?.initialValues?.maritalStatus ?? "MA";
     sfasApplication.marriageDate =
       options?.initialValues?.marriageDate ??
-      getISODateOnlyString(faker.date.past(18));
+      getISODateOnlyString(faker.date.past({ years: 18 }));
   }
   return sfasApplication;
 }

--- a/sources/packages/backend/libs/test-utils/src/factories/sfas-individuals.ts
+++ b/sources/packages/backend/libs/test-utils/src/factories/sfas-individuals.ts
@@ -1,7 +1,7 @@
 import { SFASIndividual } from "@sims/sims-db";
 import { getISODateOnlyString } from "@sims/utilities";
 import { DataSource } from "typeorm";
-import * as faker from "faker";
+import { faker } from "@faker-js/faker";
 import { createFakeStudent } from "@sims/test-utils/factories/student";
 
 /**
@@ -15,30 +15,30 @@ export function createFakeSFASIndividual(options?: {
   initialValues?: Partial<SFASIndividual>;
   includeAddressLine2?: boolean;
 }) {
-  const fakeMSFAANumber = faker.datatype
-    .number({
+  const fakeMSFAANumber = faker.number
+    .int({
       min: 1000000000,
       max: 9999999999,
     })
     .toString();
-  const fakeId = faker.datatype.number({ min: 100000000, max: 999999999 });
-  const fakeSIN = faker.datatype
-    .number({ min: 100000000, max: 899999999 })
+  const fakeId = faker.number.int({ min: 100000000, max: 999999999 });
+  const fakeSIN = faker.number
+    .int({ min: 100000000, max: 899999999 })
     .toString();
 
   const sfasIndividual = new SFASIndividual();
   sfasIndividual.id = options?.initialValues?.id ?? fakeId;
   sfasIndividual.birthDate =
     options?.initialValues?.birthDate ??
-    getISODateOnlyString(faker.date.past(18));
+    getISODateOnlyString(faker.date.past({ years: 18 }));
   sfasIndividual.msfaaNumber =
     options?.initialValues?.msfaaNumber ?? fakeMSFAANumber;
   sfasIndividual.partTimeMSFAANumber =
     options?.initialValues?.partTimeMSFAANumber ?? fakeMSFAANumber;
   sfasIndividual.firstName =
-    options?.initialValues?.firstName ?? faker.name.firstName();
+    options?.initialValues?.firstName ?? faker.person.firstName();
   sfasIndividual.lastName =
-    options?.initialValues?.lastName ?? faker.name.lastName();
+    options?.initialValues?.lastName ?? faker.person.lastName();
   sfasIndividual.sin = options?.initialValues?.sin ?? fakeSIN;
   sfasIndividual.unsuccessfulCompletion =
     options?.initialValues?.unsuccessfulCompletion ?? 0;
@@ -55,17 +55,17 @@ export function createFakeSFASIndividual(options?: {
   sfasIndividual.student =
     options?.initialValues?.student ?? createFakeStudent();
   sfasIndividual.phoneNumber =
-    options?.initialValues?.phoneNumber ?? +faker.datatype.number(9999999999);
+    options?.initialValues?.phoneNumber ?? +faker.number.int(9999999999);
   sfasIndividual.addressLine1 =
-    options?.initialValues?.addressLine1 ?? faker.address.streetAddress();
-  sfasIndividual.city = options?.initialValues?.city ?? faker.address.city();
+    options?.initialValues?.addressLine1 ?? faker.location.streetAddress();
+  sfasIndividual.city = options?.initialValues?.city ?? faker.location.city();
   sfasIndividual.provinceState = options?.initialValues?.provinceState ?? "BC";
   sfasIndividual.country = options?.initialValues?.country ?? "CAN";
   sfasIndividual.postalZipCode =
     options?.initialValues?.postalZipCode ?? "A1A 1A1";
   if (options?.includeAddressLine2) {
     sfasIndividual.addressLine2 =
-      options?.initialValues?.addressLine2 ?? faker.address.secondaryAddress();
+      options?.initialValues?.addressLine2 ?? faker.location.secondaryAddress();
   }
   sfasIndividual.updatedAt = options?.initialValues?.updatedAt;
   return sfasIndividual;

--- a/sources/packages/backend/libs/test-utils/src/factories/sfas-individuals.ts
+++ b/sources/packages/backend/libs/test-utils/src/factories/sfas-individuals.ts
@@ -3,6 +3,10 @@ import { getISODateOnlyString } from "@sims/utilities";
 import { DataSource } from "typeorm";
 import { faker } from "@faker-js/faker";
 import { createFakeStudent } from "@sims/test-utils/factories/student";
+import { truncateString } from "@sims/test-utils/utils";
+
+const MAX_ADDRESS_LENGTH = 40;
+const MAX_CITY_LENGTH = 25;
 
 /**
  * Create fake sfas individual.
@@ -14,7 +18,7 @@ import { createFakeStudent } from "@sims/test-utils/factories/student";
 export function createFakeSFASIndividual(options?: {
   initialValues?: Partial<SFASIndividual>;
   includeAddressLine2?: boolean;
-}) {
+}): SFASIndividual {
   const fakeMSFAANumber = faker.number
     .int({
       min: 1000000000,
@@ -30,7 +34,7 @@ export function createFakeSFASIndividual(options?: {
   sfasIndividual.id = options?.initialValues?.id ?? fakeId;
   sfasIndividual.birthDate =
     options?.initialValues?.birthDate ??
-    getISODateOnlyString(faker.date.past({ years: 18 }));
+    getISODateOnlyString(faker.date.past({ years: 99 }));
   sfasIndividual.msfaaNumber =
     options?.initialValues?.msfaaNumber ?? fakeMSFAANumber;
   sfasIndividual.partTimeMSFAANumber =
@@ -57,15 +61,19 @@ export function createFakeSFASIndividual(options?: {
   sfasIndividual.phoneNumber =
     options?.initialValues?.phoneNumber ?? +faker.number.int(9999999999);
   sfasIndividual.addressLine1 =
-    options?.initialValues?.addressLine1 ?? faker.location.streetAddress();
-  sfasIndividual.city = options?.initialValues?.city ?? faker.location.city();
+    options?.initialValues?.addressLine1 ??
+    truncateString(faker.location.streetAddress(), MAX_ADDRESS_LENGTH);
+  sfasIndividual.city =
+    options?.initialValues?.city ??
+    truncateString(faker.location.city(), MAX_CITY_LENGTH);
   sfasIndividual.provinceState = options?.initialValues?.provinceState ?? "BC";
   sfasIndividual.country = options?.initialValues?.country ?? "CAN";
   sfasIndividual.postalZipCode =
     options?.initialValues?.postalZipCode ?? "A1A 1A1";
   if (options?.includeAddressLine2) {
     sfasIndividual.addressLine2 =
-      options?.initialValues?.addressLine2 ?? faker.location.secondaryAddress();
+      options?.initialValues?.addressLine2 ??
+      truncateString(faker.location.secondaryAddress(), MAX_ADDRESS_LENGTH);
   }
   sfasIndividual.updatedAt = options?.initialValues?.updatedAt;
   return sfasIndividual;

--- a/sources/packages/backend/libs/test-utils/src/factories/sfas-part-time-application.ts
+++ b/sources/packages/backend/libs/test-utils/src/factories/sfas-part-time-application.ts
@@ -1,6 +1,6 @@
 import { SFASIndividual, SFASPartTimeApplications } from "@sims/sims-db";
 import { getISODateOnlyString } from "@sims/utilities";
-import * as faker from "faker";
+import { faker } from "@faker-js/faker";
 
 /**
  * Create and save fake SFAS part time application.
@@ -18,30 +18,31 @@ export function createFakeSFASPartTimeApplication(
 ): SFASPartTimeApplications {
   const sfasPartTimeApplication = new SFASPartTimeApplications();
   sfasPartTimeApplication.id =
-    faker.datatype.number({
+    faker.number.int({
       min: 2000,
       max: 2999,
     }) +
     "P" +
-    faker.datatype.number({
+    faker.number.int({
       min: 2000,
       max: 29999,
     });
   sfasPartTimeApplication.individualId = relations.individual.id;
   sfasPartTimeApplication.startDate =
     options?.initialValues.startDate ??
-    getISODateOnlyString(faker.date.past(18));
+    getISODateOnlyString(faker.date.past({ years: 18 }));
   sfasPartTimeApplication.endDate =
-    options?.initialValues.endDate ?? getISODateOnlyString(faker.date.past(18));
+    options?.initialValues.endDate ??
+    getISODateOnlyString(faker.date.past({ years: 18 }));
   sfasPartTimeApplication.cslpAward = options?.initialValues.cslpAward ?? 0;
   sfasPartTimeApplication.csgpAward = options?.initialValues.csgpAward ?? 0;
   sfasPartTimeApplication.sbsdAward = options?.initialValues.sbsdAward ?? 0;
   sfasPartTimeApplication.csptAward = options?.initialValues.csptAward ?? 0;
   sfasPartTimeApplication.csgdAward = options?.initialValues.csgdAward ?? 0;
   sfasPartTimeApplication.bcagAward = options?.initialValues.bcagAward ?? 0;
-  sfasPartTimeApplication.createdAt = faker.date.past(18);
-  sfasPartTimeApplication.updatedAt = faker.date.past(18);
-  sfasPartTimeApplication.extractedAt = faker.date.past(18);
+  sfasPartTimeApplication.createdAt = faker.date.past({ years: 18 });
+  sfasPartTimeApplication.updatedAt = faker.date.past({ years: 18 });
+  sfasPartTimeApplication.extractedAt = faker.date.past({ years: 18 });
   sfasPartTimeApplication.applicationCancelDate =
     options?.initialValues?.applicationCancelDate;
   return sfasPartTimeApplication;

--- a/sources/packages/backend/libs/test-utils/src/factories/sfas-restriction.ts
+++ b/sources/packages/backend/libs/test-utils/src/factories/sfas-restriction.ts
@@ -1,6 +1,6 @@
 import { SFASRestriction } from "@sims/sims-db";
 import { getISODateOnlyString } from "@sims/utilities";
-import * as faker from "faker";
+import { faker } from "@faker-js/faker";
 
 /**
  * Create and save fake SFAS restriction.
@@ -17,7 +17,7 @@ export function createFakeSFASRestriction(options?: {
   restriction.individualId = options?.initialValues.individualId;
   restriction.code =
     options?.initialValues.code ??
-    faker.random.alpha({ count: 4, upcase: true });
+    faker.string.alpha({ length: 4, casing: "upper" });
   restriction.effectiveDate =
     options?.initialValues.effectiveDate ?? getISODateOnlyString(now);
   restriction.removalDate = options?.initialValues.removalDate;

--- a/sources/packages/backend/libs/test-utils/src/factories/sin-validation.ts
+++ b/sources/packages/backend/libs/test-utils/src/factories/sin-validation.ts
@@ -1,5 +1,5 @@
 import { SINValidation, Student } from "@sims/sims-db";
-import * as faker from "faker";
+import { faker } from "@faker-js/faker";
 
 /**
  * Creates a fake SINValidation.
@@ -21,7 +21,7 @@ export function createFakeSINValidation(
   // to the SIN be considered not temporary by default.
   sinValidation.sin =
     options?.initialValue?.sin ??
-    faker.datatype.number({ min: 100000000, max: 899999999 }).toString();
+    faker.number.int({ min: 100000000, max: 899999999 }).toString();
   sinValidation.dateSent = now;
   sinValidation.dateReceived =
     options?.initialValue?.dateReceived !== undefined

--- a/sources/packages/backend/libs/test-utils/src/factories/student-file-uploads.ts
+++ b/sources/packages/backend/libs/test-utils/src/factories/student-file-uploads.ts
@@ -1,4 +1,4 @@
-import * as faker from "faker";
+import { faker } from "@faker-js/faker";
 import {
   FileOriginType,
   Student,
@@ -36,16 +36,14 @@ export function createFakeStudentFileUpload(
   const studentFile = new StudentFile();
   studentFile.fileName = options?.fileName ?? faker.system.fileName();
   studentFile.uniqueFileName =
-    studentFile.fileName +
-    faker.datatype.uuid() +
-    "." +
-    faker.system.fileType();
+    studentFile.fileName + faker.string.uuid() + "." + faker.system.fileType();
   studentFile.groupName = options?.groupName ?? "Ministry communications";
   studentFile.student = relations?.student ?? createFakeStudent();
   studentFile.creator = relations?.creator;
   studentFile.fileOrigin = options?.fileOrigin ?? FileOriginType.Ministry;
   studentFile.virusScanStatus = VirusScanStatus.Pending;
-  studentFile.fileHash = options?.hash ?? faker.random.alphaNumeric(64);
+  studentFile.fileHash =
+    options?.hash ?? faker.string.alphanumeric({ length: 64 });
   return studentFile;
 }
 

--- a/sources/packages/backend/libs/test-utils/src/factories/student-loan-balance.ts
+++ b/sources/packages/backend/libs/test-utils/src/factories/student-loan-balance.ts
@@ -1,6 +1,6 @@
 import { Student, StudentLoanBalance, User } from "@sims/sims-db";
 import { addToDateOnlyString, getISODateOnlyString } from "@sims/utilities";
-import * as faker from "faker";
+import { faker } from "@faker-js/faker";
 
 /**
  * Create fake student loan balance.
@@ -23,7 +23,7 @@ export function createFakeStudentLoanBalance(
   studentLoanBalance.student = relations.student;
   studentLoanBalance.cslBalance =
     options?.initialValues?.cslBalance ??
-    faker.datatype.number({
+    faker.number.int({
       min: 500,
       max: 50000,
     });

--- a/sources/packages/backend/libs/test-utils/src/factories/student.ts
+++ b/sources/packages/backend/libs/test-utils/src/factories/student.ts
@@ -1,4 +1,4 @@
-import * as faker from "faker";
+import { faker } from "@faker-js/faker";
 import {
   CASSupplier,
   DisabilityStatus,
@@ -23,21 +23,22 @@ export function createFakeStudent(
   student.casSupplier = relations?.casSupplier;
   student.birthDate =
     options?.initialValue?.birthDate ??
-    getISODateOnlyString(faker.date.past(18));
+    getISODateOnlyString(faker.date.past({ years: 99 }));
   student.gender = options?.initialValue?.gender ?? "nonBinary";
   student.contactInfo = options?.initialValue?.contactInfo ?? {
     address: {
-      addressLine1: faker.address.streetAddress(),
-      city: faker.address.city(),
+      addressLine1: faker.location.streetAddress(),
+      city: faker.location.city(),
       country: "Canada",
       selectedCountry: COUNTRY_CANADA,
       provinceState: "BC",
-      postalCode: faker.address.zipCode(),
+      postalCode: faker.location.zipCode(),
     },
-    phone: faker.phone.phoneNumber(),
+    phone: faker.phone.number({ style: "national" }),
   };
   if (options?.includeAddressLine2) {
-    student.contactInfo.address.addressLine2 = faker.address.secondaryAddress();
+    student.contactInfo.address.addressLine2 =
+      faker.location.secondaryAddress();
   }
   student.sinConsent = true;
   student.disabilityStatus =

--- a/sources/packages/backend/libs/test-utils/src/factories/user.ts
+++ b/sources/packages/backend/libs/test-utils/src/factories/user.ts
@@ -1,13 +1,35 @@
 import { faker } from "@faker-js/faker";
 import { User } from "@sims/sims-db";
 
+/**
+ * Reasonable default max length for user first and last names
+ * that would be compatible with most tables in the DB.
+ */
+const MAX_USER_NAME_LENGTH = 50;
+
+/**
+ * Creates a fake user object.
+ * @param userName optional user name.
+ * @returns a User object with fake data.
+ */
 export function createFakeUser(userName?: string): User {
   // Creates a GUID to avoid conflicts in unique DB constraints.
   const uniqueId = faker.string.uuid();
   const user = new User();
   user.userName = userName ?? uniqueId;
   user.email = faker.internet.email();
-  user.firstName = `${faker.person.firstName()}_${uniqueId}`;
-  user.lastName = `${faker.person.lastName()}_${uniqueId}`;
+  user.firstName = createShortUniqueNames(faker.person.firstName(), uniqueId);
+  user.lastName = createShortUniqueNames(faker.person.lastName(), uniqueId);
   return user;
+}
+
+/**
+ * Creates a short unique name by truncating the original name and appending a unique ID.
+ * @param name original name.
+ * @param uniqueId unique ID to append.
+ * @returns a short unique name, up to a limit still keeping its uniqueness.
+ */
+function createShortUniqueNames(name: string, uniqueId: string): string {
+  const uniqueIdLength = uniqueId.length + 1; // +1 for the underscore.
+  return name.slice(0, MAX_USER_NAME_LENGTH - uniqueIdLength) + "_" + uniqueId;
 }

--- a/sources/packages/backend/libs/test-utils/src/factories/user.ts
+++ b/sources/packages/backend/libs/test-utils/src/factories/user.ts
@@ -1,13 +1,13 @@
-import * as faker from "faker";
+import { faker } from "@faker-js/faker";
 import { User } from "@sims/sims-db";
 
 export function createFakeUser(userName?: string): User {
   // Creates a GUID to avoid conflicts in unique DB constraints.
-  const uniqueId = faker.datatype.uuid();
+  const uniqueId = faker.string.uuid();
   const user = new User();
   user.userName = userName ?? uniqueId;
   user.email = faker.internet.email();
-  user.firstName = `${faker.name.firstName()}_${uniqueId}`;
-  user.lastName = `${faker.name.lastName()}_${uniqueId}`;
+  user.firstName = `${faker.person.firstName()}_${uniqueId}`;
+  user.lastName = `${faker.person.lastName()}_${uniqueId}`;
   return user;
 }

--- a/sources/packages/backend/libs/test-utils/src/utils/index.ts
+++ b/sources/packages/backend/libs/test-utils/src/utils/index.ts
@@ -1,1 +1,2 @@
 export * from "./date-utils";
+export * from "./string-utils";

--- a/sources/packages/backend/libs/test-utils/src/utils/string-utils.ts
+++ b/sources/packages/backend/libs/test-utils/src/utils/string-utils.ts
@@ -1,0 +1,11 @@
+/**
+ * Truncates a string to the specified maximum length.
+ * If the string is shorter than or equal to the maximum length, it is returned unchanged.
+ * @param value string to be truncated.
+ */
+export function truncateString(value: string, maxLength: number): string {
+  if (value.length <= maxLength) {
+    return value;
+  }
+  return value.slice(0, maxLength);
+}

--- a/sources/packages/backend/package-lock.json
+++ b/sources/packages/backend/package-lock.json
@@ -73,7 +73,7 @@
         "@types/find-config": "^1.0.4",
         "@types/jest": "^30.0.0",
         "@types/multer": "^2.0.0",
-        "@types/node": "^24.6.1",
+        "@types/node": "^24.6.2",
         "@types/papaparse": "^5.3.16",
         "@types/passport-jwt": "^4.0.1",
         "@types/pg": "^8.15.5",
@@ -5858,9 +5858,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "24.6.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.6.1.tgz",
-      "integrity": "sha512-ljvjjs3DNXummeIaooB4cLBKg2U6SPI6Hjra/9rRIy7CpM0HpLtG9HptkMKAb4HYWy5S7HUvJEuWgr/y0U8SHw==",
+      "version": "24.6.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.6.2.tgz",
+      "integrity": "sha512-d2L25Y4j+W3ZlNAeMKcy7yDsK425ibcAOO2t7aPTz6gNMH0z2GThtwENCDc0d/Pw9wgyRqE5Px1wkV7naz8ang==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.13.0"

--- a/sources/packages/backend/package-lock.json
+++ b/sources/packages/backend/package-lock.json
@@ -58,6 +58,7 @@
       },
       "devDependencies": {
         "@aws-sdk/types": "^3.901.0",
+        "@faker-js/faker": "^10.0.0",
         "@golevelup/ts-jest": "^0.7.0",
         "@nestjs/cli": "^11.0.10",
         "@nestjs/schematics": "^11.0.7",
@@ -69,7 +70,6 @@
         "@types/clamscan": "^2.4.1",
         "@types/cookie-parser": "^1.4.9",
         "@types/express": "^5.0.3",
-        "@types/faker": "^5.5.9",
         "@types/find-config": "^1.0.4",
         "@types/jest": "^30.0.0",
         "@types/multer": "^2.0.0",
@@ -83,7 +83,6 @@
         "eslint": "^9.36.0",
         "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-prettier": "^5.5.4",
-        "faker": "^5.5.3",
         "find-config": "^1.0.0",
         "jest": "^30.2.0",
         "jiti": "^2.6.1",
@@ -1948,6 +1947,23 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@faker-js/faker": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-10.0.0.tgz",
+      "integrity": "sha512-UollFEUkVXutsaP+Vndjxar40Gs5JL2HeLcl8xO1QAjJgOdhc3OmBFWyEylS+RddWaaBiAzH+5/17PLQJwDiLw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fakerjs"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || ^23.5.0 || >=24.0.0",
+        "npm": ">=10"
       }
     },
     "node_modules/@golevelup/nestjs-discovery": {
@@ -5725,13 +5741,6 @@
         "@types/send": "*"
       }
     },
-    "node_modules/@types/faker": {
-      "version": "5.5.9",
-      "resolved": "https://registry.npmjs.org/@types/faker/-/faker-5.5.9.tgz",
-      "integrity": "sha512-uCx6mP3UY5SIO14XlspxsGjgaemrxpssJI0Ol+GfhxtcKpv9pgRZYsS4eeKeHVLje6Qtc8lGszuBI461+gVZBA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/find-config": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@types/find-config/-/find-config-1.0.4.tgz",
@@ -9378,13 +9387,6 @@
       "engines": {
         "node": ">=6.6.0"
       }
-    },
-    "node_modules/faker": {
-      "version": "5.5.3",
-      "resolved": "https://registry.npmjs.org/faker/-/faker-5.5.3.tgz",
-      "integrity": "sha512-wLTv2a28wjUyWkbnX7u/ABZBkUkIF2fCd73V6P2oFqEGEktDfzWx4UxrSqtPRw0xPRAcjeAOIiJWqZm3pP4u3g==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",

--- a/sources/packages/backend/package.json
+++ b/sources/packages/backend/package.json
@@ -110,7 +110,7 @@
     "@types/find-config": "^1.0.4",
     "@types/jest": "^30.0.0",
     "@types/multer": "^2.0.0",
-    "@types/node": "^24.6.1",
+    "@types/node": "^24.6.2",
     "@types/papaparse": "^5.3.16",
     "@types/passport-jwt": "^4.0.1",
     "@types/pg": "^8.15.5",

--- a/sources/packages/backend/package.json
+++ b/sources/packages/backend/package.json
@@ -95,6 +95,7 @@
   },
   "devDependencies": {
     "@aws-sdk/types": "^3.901.0",
+    "@faker-js/faker": "^10.0.0",
     "@golevelup/ts-jest": "^0.7.0",
     "@nestjs/cli": "^11.0.10",
     "@nestjs/schematics": "^11.0.7",
@@ -106,7 +107,6 @@
     "@types/clamscan": "^2.4.1",
     "@types/cookie-parser": "^1.4.9",
     "@types/express": "^5.0.3",
-    "@types/faker": "^5.5.9",
     "@types/find-config": "^1.0.4",
     "@types/jest": "^30.0.0",
     "@types/multer": "^2.0.0",
@@ -120,7 +120,6 @@
     "eslint": "^9.36.0",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-prettier": "^5.5.4",
-    "faker": "^5.5.3",
     "find-config": "^1.0.0",
     "jest": "^30.2.0",
     "jiti": "^2.6.1",

--- a/sources/packages/backend/workflow/test/jest-e2e.json
+++ b/sources/packages/backend/workflow/test/jest-e2e.json
@@ -27,5 +27,8 @@
     "@sims/integrations": "<rootDir>/../libs/integrations/src",
     "@sims/auth/(.*)": "<rootDir>/../libs/auth/src/$1",
     "@sims/auth": "<rootDir>/../libs/auth/src"
-  }
+  },
+  "transformIgnorePatterns": [
+    "/node_modules/(?!@faker-js|uuid)"
+  ]
 }


### PR DESCRIPTION
- Replaced `faker` with `@faker-js/faker`.
  - Tried to use equivalent methods when available.
  - For SABC codes, added upper case in most cases.
  - Some birth dates were expanded to a maximum of 99 years in the past (previously, there was a maximum of 18, which would make every student too young). I believe there was a misunderstanding related to the `past` function.
- Added `uuid` and `@faker-js` to all `transformIgnorePatterns`. `uuid` would not be required unless consumed by the app package, but there was no harm in adding it.

_Note:_ possible improvement, if time allows, create a base e2e jest config.
