### PR TITLE
#5166 - Individual exception approval - DB migration and worker updates

### DIFF
--- a/sources/packages/backend/apps/db-migrations/src/migrations/1759531941797-CreateApplicationExceptionRequestStatus.ts
+++ b/sources/packages/backend/apps/db-migrations/src/migrations/1759531941797-CreateApplicationExceptionRequestStatus.ts
@@ -1,0 +1,24 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+import { getSQLFileData } from "../utilities/sqlLoader";
+
+export class CreateApplicationExceptionRequestStatus1759531941797
+  implements MigrationInterface
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      getSQLFileData(
+        "Create-application-exception-request-status.sql",
+        "Types",
+      ),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      getSQLFileData(
+        "Rollback-create-application-exception-request-status.sql",
+        "Types",
+      ),
+    );
+  }
+}

--- a/sources/packages/backend/apps/db-migrations/src/migrations/1759532829028-ApplicationExceptionRequestsAddStatusCol.ts
+++ b/sources/packages/backend/apps/db-migrations/src/migrations/1759532829028-ApplicationExceptionRequestsAddStatusCol.ts
@@ -1,0 +1,24 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+import { getSQLFileData } from "../utilities/sqlLoader";
+
+export class ApplicationExceptionRequestsAddStatusCol1759532829028
+  implements MigrationInterface
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      getSQLFileData(
+        "Add-col-exception-request-status.sql",
+        "ApplicationExceptionRequests",
+      ),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      getSQLFileData(
+        "Rollback-add-col-exception-request-status.sql",
+        "ApplicationExceptionRequests",
+      ),
+    );
+  }
+}

--- a/sources/packages/backend/apps/db-migrations/src/sql/ApplicationExceptionRequests/Add-col-exception-request-status.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/ApplicationExceptionRequests/Add-col-exception-request-status.sql
@@ -13,7 +13,17 @@ UPDATE
 SET
     -- The value for the statuses approved and declined are same between the types sims.application_exception_request_status and sims.application_exception_status
     -- and hence we can directly cast the text value from one type to another.
-    exception_request_status = (exception.exception_status :: text) :: sims.application_exception_request_status
+    exception_request_status = (exception.exception_status :: text) :: sims.application_exception_request_status,
+    modifier = (
+        SELECT
+            id
+        FROM
+            sims.users
+        WHERE
+            -- System user.
+            user_name = '8fb44f70-6ce6-11ed-b307-8743a2da47ef@system'
+    ),
+    updated_at = NOW()
 FROM
     sims.application_exceptions exception
 WHERE

--- a/sources/packages/backend/apps/db-migrations/src/sql/ApplicationExceptionRequests/Add-col-exception-request-status.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/ApplicationExceptionRequests/Add-col-exception-request-status.sql
@@ -1,0 +1,27 @@
+ALTER TABLE
+    sims.application_exception_requests
+ADD
+    COLUMN exception_request_status sims.application_exception_request_status NOT NULL DEFAULT 'Pending';
+
+COMMENT ON COLUMN sims.application_exception_requests.exception_request_status IS 'Status of the application exception request.';
+
+-- Update the status of existing exception requests which belong to completed exceptions(approved or declined).
+-- If the exception is approved then the status of all the associated exception requests should be set to approved.
+-- If the exception is declined then the status of all the associated exception requests should be set to declined.
+UPDATE
+    sims.application_exception_requests exception_request
+SET
+    -- The value for the statuses approved and declined are same between the types sims.application_exception_request_status and sims.application_exception_status
+    -- and hence we can directly cast the text value from one type to another.
+    exception_request_status = (exception.exception_status :: text) :: sims.application_exception_request_status
+FROM
+    sims.application_exceptions exception
+WHERE
+    exception_request.application_exception_id = exception.id
+    AND exception.exception_status IN ('Approved', 'Declined');
+
+-- Drop default value after updating existing records.
+ALTER TABLE
+    sims.application_exception_requests
+ALTER COLUMN
+    exception_request_status DROP DEFAULT;

--- a/sources/packages/backend/apps/db-migrations/src/sql/ApplicationExceptionRequests/Rollback-add-col-exception-request-status.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/ApplicationExceptionRequests/Rollback-add-col-exception-request-status.sql
@@ -1,0 +1,2 @@
+ALTER TABLE
+    sims.application_exception_requests DROP COLUMN exception_request_status;

--- a/sources/packages/backend/apps/db-migrations/src/sql/Types/Create-application-exception-request-status.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/Types/Create-application-exception-request-status.sql
@@ -1,0 +1,3 @@
+CREATE TYPE sims.application_exception_request_status AS ENUM ('Pending', 'Approved', 'Declined');
+
+COMMENT ON TYPE sims.application_exception_request_status IS 'Status values of an application exception request.';

--- a/sources/packages/backend/apps/db-migrations/src/sql/Types/Create-application-exception-request-status.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/Types/Create-application-exception-request-status.sql
@@ -1,3 +1,3 @@
 CREATE TYPE sims.application_exception_request_status AS ENUM ('Pending', 'Approved', 'Declined');
 
-COMMENT ON TYPE sims.application_exception_request_status IS 'Status values of an application exception request.';
+COMMENT ON TYPE sims.application_exception_request_status IS 'Represents the different status values of an application exception request.';

--- a/sources/packages/backend/apps/db-migrations/src/sql/Types/Rollback-create-application-exception-request-status.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/Types/Rollback-create-application-exception-request-status.sql
@@ -1,0 +1,1 @@
+DROP TYPE sims.application_exception_request_status;

--- a/sources/packages/backend/apps/workers/src/controllers/application/_tests_/e2e/application.controller-verifyUniqueApplicationExceptions.e2e-spec.ts
+++ b/sources/packages/backend/apps/workers/src/controllers/application/_tests_/e2e/application.controller-verifyUniqueApplicationExceptions.e2e-spec.ts
@@ -5,6 +5,7 @@ import {
 } from "@sims/services/constants";
 import {
   ApplicationData,
+  ApplicationExceptionRequestStatus,
   ApplicationExceptionStatus,
   EducationProgramOffering,
   ProgramInfoStatus,
@@ -157,6 +158,7 @@ describe("ApplicationController(e2e)-verifyUniqueApplicationExceptions", () => {
               exceptionName: true,
               exceptionDescription: true,
               exceptionHash: true,
+              exceptionRequestStatus: true,
             },
           },
         },
@@ -184,6 +186,7 @@ describe("ApplicationController(e2e)-verifyUniqueApplicationExceptions", () => {
               exceptionDescription: "Some Application Exception - 1",
               exceptionHash:
                 "96001142bc2a3cae09072fb3992b611016ae8c3a07c2b0cb78e1f6f2789b6169",
+              exceptionRequestStatus: ApplicationExceptionRequestStatus.Pending,
             },
             {
               id: expect.any(Number),
@@ -191,6 +194,7 @@ describe("ApplicationController(e2e)-verifyUniqueApplicationExceptions", () => {
               exceptionDescription: "Some Application Exception - 2",
               exceptionHash:
                 "f032fcc52cfa04d24fb5abcd5c208f5b63c1b7893f2beeab1f5704a8eed11f1a",
+              exceptionRequestStatus: ApplicationExceptionRequestStatus.Pending,
             },
             {
               id: expect.any(Number),
@@ -198,6 +202,7 @@ describe("ApplicationController(e2e)-verifyUniqueApplicationExceptions", () => {
               exceptionDescription: "Some Other Application Exception",
               exceptionHash:
                 "2fcd1a09f2f7e8e2a5a46880cc97a8c38ef0b7428b8d2ffbf3ed740921fc62cd",
+              exceptionRequestStatus: ApplicationExceptionRequestStatus.Pending,
             },
           ],
         },
@@ -223,6 +228,7 @@ describe("ApplicationController(e2e)-verifyUniqueApplicationExceptions", () => {
             exceptionName: "someApplicationException",
             exceptionHash:
               "b0e3a8697648475e79c33f61a41cb514715690094ab9acdaae2737c744fc42de",
+            exceptionRequestStatus: ApplicationExceptionRequestStatus.Approved,
           },
         },
       );
@@ -235,6 +241,7 @@ describe("ApplicationController(e2e)-verifyUniqueApplicationExceptions", () => {
             exceptionName: "someOtherApplicationException",
             exceptionHash:
               "58f52eef5c7049560ef87de8d7a8726c8ac1b8c9c6e4d034168c7a86762c2900",
+            exceptionRequestStatus: ApplicationExceptionRequestStatus.Approved,
           },
         },
       );
@@ -338,6 +345,7 @@ describe("ApplicationController(e2e)-verifyUniqueApplicationExceptions", () => {
               },
               creator: { id: true },
               createdAt: true,
+              exceptionRequestStatus: true,
             },
           },
         },
@@ -387,6 +395,8 @@ describe("ApplicationController(e2e)-verifyUniqueApplicationExceptions", () => {
               },
               creator: systemUsersService.systemUser,
               createdAt: now,
+              exceptionRequestStatus:
+                ApplicationExceptionRequestStatus.Approved,
             },
             {
               id: expect.any(Number),
@@ -399,6 +409,8 @@ describe("ApplicationController(e2e)-verifyUniqueApplicationExceptions", () => {
               },
               creator: systemUsersService.systemUser,
               createdAt: now,
+              exceptionRequestStatus:
+                ApplicationExceptionRequestStatus.Approved,
             },
           ],
         },
@@ -452,6 +464,7 @@ describe("ApplicationController(e2e)-verifyUniqueApplicationExceptions", () => {
             id: true,
             exceptionName: true,
             exceptionDescription: true,
+            exceptionRequestStatus: true,
           },
         },
       },
@@ -470,6 +483,7 @@ describe("ApplicationController(e2e)-verifyUniqueApplicationExceptions", () => {
             id: expect.any(Number),
             exceptionName: "studyEndDateIsPastApplicationException",
             exceptionDescription: "Study end date is past",
+            exceptionRequestStatus: ApplicationExceptionRequestStatus.Pending,
           },
         ],
       },

--- a/sources/packages/backend/apps/workers/src/services/application-exception/application-exception.service.ts
+++ b/sources/packages/backend/apps/workers/src/services/application-exception/application-exception.service.ts
@@ -113,7 +113,9 @@ export class ApplicationExceptionService extends RecordDataModelService<Applicat
     );
     // Check if all exceptions were already approved, to set the exception status.
     const allExceptionsApproved = newException.exceptionRequests.every(
-      (exceptionRequest) => !!exceptionRequest.approvalExceptionRequest?.id,
+      (exceptionRequest) =>
+        exceptionRequest.exceptionRequestStatus ===
+        ApplicationExceptionRequestStatus.Approved,
     );
     if (allExceptionsApproved) {
       newException.exceptionStatus = ApplicationExceptionStatus.Approved;
@@ -195,7 +197,10 @@ export class ApplicationExceptionService extends RecordDataModelService<Applicat
         parentApplication: {
           versions: {
             applicationException: {
-              exceptionStatus: ApplicationExceptionStatus.Approved,
+              exceptionRequests: {
+                exceptionRequestStatus:
+                  ApplicationExceptionRequestStatus.Approved,
+              },
             },
           },
         },

--- a/sources/packages/backend/apps/workers/src/services/application-exception/application-exception.service.ts
+++ b/sources/packages/backend/apps/workers/src/services/application-exception/application-exception.service.ts
@@ -97,7 +97,7 @@ export class ApplicationExceptionService extends RecordDataModelService<Applicat
         // If the exception request with the same name and hash was previously approved
         // then the status of the exception request will be set to approved.
         // Otherwise the status will be set to pending which requires ministry assessment.
-        const exceptionRequestStatus = approvalExceptionRequest?.id
+        const exceptionRequestStatus = approvalExceptionRequest
           ? ApplicationExceptionRequestStatus.Approved
           : ApplicationExceptionRequestStatus.Pending;
         return {

--- a/sources/packages/backend/libs/sims-db/src/entities/application-exception-request-status.type.ts
+++ b/sources/packages/backend/libs/sims-db/src/entities/application-exception-request-status.type.ts
@@ -1,0 +1,17 @@
+/**
+ * Represents the different status values of an application exception request.
+ */
+export enum ApplicationExceptionRequestStatus {
+  /**
+   * Application exception request is waiting for the ministry assessment.
+   */
+  Pending = "Pending",
+  /**
+   * Application exception request is approved by the ministry.
+   */
+  Approved = "Approved",
+  /**
+   * Application exception request is declined by the ministry.
+   */
+  Declined = "Declined",
+}

--- a/sources/packages/backend/libs/sims-db/src/entities/application-exception-requests.model.ts
+++ b/sources/packages/backend/libs/sims-db/src/entities/application-exception-requests.model.ts
@@ -8,7 +8,7 @@ import {
 import { ColumnNames, TableNames } from "../constant";
 import { RecordDataModel } from "./record.model";
 import { ApplicationException } from "./application-exceptions.model";
-import { ApplicationExceptionRequestStatus } from "@sims/sims-db/entities/application-exception-request-status.type";
+import { ApplicationExceptionRequestStatus } from "./application-exception-request-status.type";
 
 export const EXCEPTION_NAME_MAX_LENGTH = 100;
 

--- a/sources/packages/backend/libs/sims-db/src/entities/application-exception-requests.model.ts
+++ b/sources/packages/backend/libs/sims-db/src/entities/application-exception-requests.model.ts
@@ -72,7 +72,6 @@ export class ApplicationExceptionRequest extends RecordDataModel {
     nullable: true,
   })
   exceptionHash?: string;
-
   /**
    * Status of the application exception request.
    */
@@ -81,7 +80,6 @@ export class ApplicationExceptionRequest extends RecordDataModel {
     type: "enum",
     enum: ApplicationExceptionRequestStatus,
     enumName: "ApplicationExceptionRequestStatus",
-    nullable: false,
   })
   exceptionRequestStatus: ApplicationExceptionRequestStatus;
 }

--- a/sources/packages/backend/libs/sims-db/src/entities/application-exception-requests.model.ts
+++ b/sources/packages/backend/libs/sims-db/src/entities/application-exception-requests.model.ts
@@ -8,6 +8,7 @@ import {
 import { ColumnNames, TableNames } from "../constant";
 import { RecordDataModel } from "./record.model";
 import { ApplicationException } from "./application-exceptions.model";
+import { ApplicationExceptionRequestStatus } from "@sims/sims-db/entities/application-exception-request-status.type";
 
 export const EXCEPTION_NAME_MAX_LENGTH = 100;
 
@@ -71,4 +72,16 @@ export class ApplicationExceptionRequest extends RecordDataModel {
     nullable: true,
   })
   exceptionHash?: string;
+
+  /**
+   * Status of the application exception request.
+   */
+  @Column({
+    name: "exception_request_status",
+    type: "enum",
+    enum: ApplicationExceptionRequestStatus,
+    enumName: "ApplicationExceptionRequestStatus",
+    nullable: false,
+  })
+  exceptionRequestStatus: ApplicationExceptionRequestStatus;
 }

--- a/sources/packages/backend/libs/sims-db/src/entities/index.ts
+++ b/sources/packages/backend/libs/sims-db/src/entities/index.ts
@@ -67,6 +67,7 @@ export * from "./address.type";
 export * from "./reports-config.model";
 export * from "./student-file.type";
 export * from "./application-exception-status.type";
+export * from "./application-exception-request-status.type";
 export * from "./application-exception-requests.model";
 export * from "./application-exceptions.model";
 export * from "./disbursement-receipts.model";

--- a/sources/packages/backend/libs/test-utils/src/factories/application-exception-request.ts
+++ b/sources/packages/backend/libs/test-utils/src/factories/application-exception-request.ts
@@ -1,6 +1,7 @@
 import {
   ApplicationException,
   ApplicationExceptionRequest,
+  ApplicationExceptionRequestStatus,
   User,
 } from "@sims/sims-db";
 import { faker } from "@faker-js/faker";
@@ -42,5 +43,8 @@ export function createFakeApplicationExceptionRequest(
   applicationExceptionRequest.creator = relations?.creator;
   applicationExceptionRequest.exceptionHash =
     options?.initialData?.exceptionHash;
+  applicationExceptionRequest.exceptionRequestStatus =
+    options?.initialData?.exceptionRequestStatus ??
+    ApplicationExceptionRequestStatus.Pending;
   return applicationExceptionRequest;
 }


### PR DESCRIPTION
# Individual exception approval - DB migration and worker updates

## DB Migration

- [x] Created a new enum `sims.application_exception_request_status` in DB for exception request status.
- [x] Created a new column `exception_request_status` in `sims.application_exception_requests` to enable individual application exception requests to be Approved/Declined.
- [x] Update query to set the status of existing application exception requests which belong to exceptions which are completed(Approved/Declined). The individual exception requests will reflect the status of it's exception.

## Worker updates

- [x] The query to select previously approved exception requests is now based on the `exceptionRequestStatus` instead of it's exception status.
- [x] When a previous approved exception request was found, then the status of current exception request is set to `Approved`. If otherwise it stays as `Pending`.
- [x] The worker that supports exception creation for previous PY `verifyApplicationExceptions` updated to set the exception request status as `Pending` during exception creation.


## E2E Tests
- [x] Adjusted the E2E tests for the workers `verifyUniqueApplicationExceptions` and `verifyApplicationExceptions`. 
- [x] Added new E2E test for `verifyUniqueApplicationExceptions` to validate the created exception request status to be based on previous exception request status, and irrespective of it's previous exception status.

<img width="1679" height="326" alt="image" src="https://github.com/user-attachments/assets/c30ba8e6-447e-4f1a-b439-17cc72063b1b" />

