### PR TITLE
#4964 - Upgrade Packages - Layout fix and dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,8 @@ version: 2
 updates:
   - package-ecosystem: "npm"
     directory: "/sources/packages/web"
+    commit-message:
+      prefix: "npm-frontend"
     schedule:
       interval: "weekly"
     labels:
@@ -28,8 +30,19 @@ updates:
           - "*"
         update-types:
           - "patch"
+      formio:
+        patterns:
+          - "formio*"
+          - "bootstrap*"
+          - "@fortawesome/fontawesome-free"
+        update-types:
+          - "major"
+          - "minor"
+          - "patch"
   - package-ecosystem: "npm"
     directory: "/sources/packages/backend"
+    commit-message:
+      prefix: "npm-backend"
     schedule:
       interval: "weekly"
     labels:
@@ -54,6 +67,8 @@ updates:
           - "patch"
   - package-ecosystem: "npm"
     directory: "/sources/packages/forms"
+    commit-message:
+      prefix: "npm-forms-deployment"
     schedule:
       interval: "weekly"
     labels:
@@ -78,6 +93,8 @@ updates:
           - "patch"
   - package-ecosystem: "npm"
     directory: "/sources/packages/load-test"
+    commit-message:
+      prefix: "npm-load-test"
     schedule:
       interval: "weekly"
     labels:
@@ -102,6 +119,8 @@ updates:
           - "patch"
   # GitHub Actions updates.
   - package-ecosystem: "github-actions"
+    commit-message:
+      prefix: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
@@ -110,5 +129,19 @@ updates:
       - "GitHub actions"
     groups:
       github-actions-updates:
+        patterns:
+          - "*"
+    # Docker updates.
+  - package-ecosystem: "docker"
+    commit-message:
+      prefix: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "Dependencies"
+      - "Docker"
+    groups:
+      docker-updates:
         patterns:
           - "*"

--- a/sources/packages/web/package-lock.json
+++ b/sources/packages/web/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "studentaid-bc",
+  "name": "studentaid-frontend",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "studentaid-bc",
+      "name": "studentaid-frontend",
       "version": "0.1.0",
       "dependencies": {
         "@bcgov/bc-sans": "^2.1.0",
@@ -32,7 +32,7 @@
         "vuex": "^4.1.0"
       },
       "devDependencies": {
-        "@fortawesome/fontawesome-free": "^7.1.0",
+        "@fortawesome/fontawesome-free": "^6.5.2",
         "@types/node": "^24.6.2",
         "@vitejs/plugin-vue": "^6.0.1",
         "@vue/eslint-config-typescript": "^14.6.0",
@@ -764,10 +764,11 @@
       "license": "Unlicense"
     },
     "node_modules/@fortawesome/fontawesome-free": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-7.1.0.tgz",
-      "integrity": "sha512-+WxNld5ZCJHvPQCr/GnzCTVREyStrAJjisUPtUxG5ngDA8TMlPnKp6dddlTpai4+1GNmltAeuk1hJEkBohwZYA==",
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-6.5.2.tgz",
+      "integrity": "sha512-hRILoInAx8GNT5IMkrtIt9blOdrqHOnPBH+k70aWUAqPZPgopb9G5EQJFpaBx/S8zp2fC+mPW349Bziuk1o28Q==",
       "dev": true,
+      "hasInstallScript": true,
       "license": "(CC-BY-4.0 AND OFL-1.1 AND MIT)",
       "engines": {
         "node": ">=6"

--- a/sources/packages/web/package.json
+++ b/sources/packages/web/package.json
@@ -36,7 +36,7 @@
     "vuex": "^4.1.0"
   },
   "devDependencies": {
-    "@fortawesome/fontawesome-free": "^7.1.0",
+    "@fortawesome/fontawesome-free": "^6.5.2",
     "@types/node": "^24.6.2",
     "@vitejs/plugin-vue": "^6.0.1",
     "@vue/eslint-config-typescript": "^14.6.0",


### PR DESCRIPTION
- Fixed banners that were not displayed correctly after the `@fortawesome/fontawesome-free` upgrade.

<img width="1186" height="407" alt="image" src="https://github.com/user-attachments/assets/c4dbffe1-5479-486d-870c-9ffb6d4d9be1" />

<img width="790" height="407" alt="image" src="https://github.com/user-attachments/assets/08f84c9d-dd32-4918-b2eb-18ff5cc1bfaa" />

<img width="1185" height="561" alt="image" src="https://github.com/user-attachments/assets/b33bd4d3-2434-40f0-8e88-8eb15ac5f28d" />

- Grouped form. io-related packages for dependabot PRs.
- Added monitoring of upgrades for Docker versions.
- Added a "commit-message" that should be the prefix for the PR titles, trying to make it clear where they are. We can remove it later if it does not achieve the goal.