### PR TITLE
#4965 - Upgrade Packages - Configuring importHelpers and adding tslib

### DIFF
--- a/sources/packages/backend/package-lock.json
+++ b/sources/packages/backend/package-lock.json
@@ -54,6 +54,7 @@
         "soap": "^1.5.0",
         "ssh2-sftp-client": "^12.0.1",
         "swagger-ui-express": "^5.0.1",
+        "tslib": "^2.8.1",
         "typeorm": "^0.3.27",
         "uuid": "^13.0.0"
       },

--- a/sources/packages/backend/package.json
+++ b/sources/packages/backend/package.json
@@ -91,6 +91,7 @@
     "soap": "^1.5.0",
     "ssh2-sftp-client": "^12.0.1",
     "swagger-ui-express": "^5.0.1",
+    "tslib": "^2.8.1",
     "typeorm": "^0.3.27",
     "uuid": "^13.0.0"
   },

--- a/sources/packages/backend/tsconfig.json
+++ b/sources/packages/backend/tsconfig.json
@@ -6,6 +6,7 @@
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "allowSyntheticDefaultImports": true,
+    "importHelpers": true,
     "target": "ES2024",
     "lib": ["ES2024"],
     "sourceMap": true,

--- a/sources/packages/web/package-lock.json
+++ b/sources/packages/web/package-lock.json
@@ -25,6 +25,7 @@
         "primeflex": "^2.0.0",
         "primeicons": "^5.0.0",
         "primevue": "^3.8.2",
+        "tslib": "^2.8.1",
         "uuid": "^13.0.0",
         "vue": "^3.5.22",
         "vue-router": "^4.5.1",
@@ -4186,6 +4187,12 @@
       "peerDependencies": {
         "typescript": ">=4.8.4"
       }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/sources/packages/web/package.json
+++ b/sources/packages/web/package.json
@@ -29,6 +29,7 @@
     "primeflex": "^2.0.0",
     "primeicons": "^5.0.0",
     "primevue": "^3.8.2",
+    "tslib": "^2.8.1",
     "uuid": "^13.0.0",
     "vue": "^3.5.22",
     "vue-router": "^4.5.1",


### PR DESCRIPTION
- Ensured [importHelpers](https://www.typescriptlang.org/tsconfig/#importHelpers) is configured as `true` for web and backend.
- Added [tslib](https://www.npmjs.com/package/tslib) to support the `importHelpers`.