### PR TITLE
#5012 - Institution beta - form updates

### DIFF
--- a/sources/packages/forms/src/form-definitions/sfaa2025-26-ft.json
+++ b/sources/packages/forms/src/form-definitions/sfaa2025-26-ft.json
@@ -692,7 +692,7 @@
                           "value": "font-size: 2.5rem;padding: 2rem 2rem;background: #ffeaea;color: #b71c1c;border: 4px solid #b71c1c;border-radius: 8px;text-align: left;white-space: normal;line-height: 1.2;"
                         }
                       ],
-                      "content": "<strong>We are currently accepting limited full-time applications</strong> \n<br><br>\n<span>If your institution is not listed here you are not eligible to complete a full-time application in SIMS. Please cancel this application draft and go to the <a href=\"https://studentaidbc.ca/dashboard\" target=\"_blank\" rel=\"noopener noreferrer\">SFAS student dashboard</a> to complete a full-time application.</span>",
+                      "content": "<strong>We are currently accepting limited full-time applications</strong> \n<br><br>\n<span>Only programs that appear in the programs list can be applied for in SIMS. If your program does not appear in this list please cancel this application draft and go to the <a href=\"https://studentaidbc.ca/dashboard\" target=\"_blank\" rel=\"noopener noreferrer\">SFAS student dashboard</a> to complete a full-time application.</span>",
                       "refreshOnChange": false,
                       "key": "html15",
                       "customConditional": "show = !!data.myProgramNotListed && !!data.allowBetaInstitutionsOnly;",


### PR DESCRIPTION
- Adds a new obvious banner to SFAA 25/26 when "allowBetaInstitutions" is true AND 

    - "institution not listed" is selected
    
<img width="862" height="740" alt="image" src="https://github.com/user-attachments/assets/95b88bd4-f45b-41f9-a8b6-c7632511af13" />

   - "program not listed" is selected  

<img width="800" height="559" alt="image" src="https://github.com/user-attachments/assets/c1da267b-8f3d-4905-af4b-7175d3c0b1e8" />

- Updated logic for existing "institution not listed" and "program not listed" banners to only display if "allowBetaInstitutions" is false, and checkbox is selected.  

<img width="1092" height="331" alt="image" src="https://github.com/user-attachments/assets/b76afeee-4122-4ce5-ab74-15a10d61471f" />

<img width="1062" height="220" alt="image" src="https://github.com/user-attachments/assets/1d64f686-dff3-4050-9f7c-c4ba9652e327" />


