### PR TITLE
#5166 - Include previously approved exception requests in update script

### DIFF
--- a/sources/packages/backend/apps/db-migrations/src/sql/ApplicationExceptionRequests/Add-col-exception-request-status.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/ApplicationExceptionRequests/Add-col-exception-request-status.sql
@@ -30,6 +30,24 @@ WHERE
     exception_request.application_exception_id = exception.id
     AND exception.exception_status IN ('Approved', 'Declined');
 
+-- Update the status of previously approved exception requests to Approved.
+UPDATE
+    sims.application_exception_requests
+SET
+    exception_request_status = 'Approved',
+    modifier = (
+        SELECT
+            id
+        FROM
+            sims.users
+        WHERE
+            -- System user.
+            user_name = '8fb44f70-6ce6-11ed-b307-8743a2da47ef@system'
+    ),
+    updated_at = NOW()
+WHERE
+    approval_exception_request_id IS NOT NULL;
+
 -- Drop default value after updating existing records.
 ALTER TABLE
     sims.application_exception_requests


### PR DESCRIPTION
- [x] DB Migration has an update script to set the status of application exception requests based on the application exception status. **This update script was missing a scenario where an exception request could be approved when a exception is still pending because the exception request with same hash was previously approved**

**Note**: The DB migration is already deployed in DEV, so after this deployment, the particular migration with update script will be re-executed in DEV.