### PR TITLE
#5089 - Mask required instead of blank: Institution student total income

### DIFF
--- a/sources/packages/forms/src/form-definitions/noticeofassessment.json
+++ b/sources/packages/forms/src/form-definitions/noticeofassessment.json
@@ -424,7 +424,7 @@
               "value": ""
             }
           ],
-          "content": "Total income used for assessment purposes: <span class=\"label-bold\">{{ utils.custom.currencyFormatter(data.assessment?.totalFamilyIncome, \"XXXXX\") }}</span>",
+          "content": "Total income used for assessment purposes: <span class=\"label-bold\">{{ utils.custom.currencyFormatter(data.assessment?.totalFamilyIncome) }}</span>",
           "refreshOnChange": true,
           "key": "html7",
           "type": "htmlelement",

--- a/sources/packages/web/src/composables/useFormatters.ts
+++ b/sources/packages/web/src/composables/useFormatters.ts
@@ -22,6 +22,7 @@ dayjs.extend(utc);
 const DEFAULT_EMPTY_VALUE = "-";
 export const DATE_ONLY_ISO_FORMAT = "YYYY-MM-DD";
 export const DATE_HOUR_MINUTE_ISO_FORMAT = "MMM DD YYYY HH:mm";
+const DEFAULT_MASKED_CHAR_REGEX = /^X+$/;
 
 /**
  * Helpers to adjust how values are shown in the UI.
@@ -447,6 +448,9 @@ export function useFormatters() {
         currency: "CAD",
         roundingMode: "trunc",
       }).format(value);
+    }
+    if (typeof value === "string" && DEFAULT_MASKED_CHAR_REGEX.test(value)) {
+      return value;
     }
     return placeholder;
   };


### PR DESCRIPTION
**As a part of this PR, passed the required 2nd argument mask *XXXXX* to the `currencyFormatter` utils method ensuring that the empty is replaced by the *XXXXX* mask.**

### **Screenshot:**

<img width="1558" height="1049" alt="image" src="https://github.com/user-attachments/assets/0c5c73e8-1cb2-4238-b7d2-742772574bfa" />
