### PR TITLE
#4389 - ECE - Multiple Disbursements / Disbursement IDs - Notification Fix

### DIFF
--- a/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/institution-integration/ece-response/_tests_/ece-response-integration.scheduler.e2e-spec.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/institution-integration/ece-response/_tests_/ece-response-integration.scheduler.e2e-spec.ts
@@ -201,12 +201,14 @@ describe(
       expect(sftpClientMock.rename).toHaveBeenCalled();
       // Expect the notifications to be created.
       const notifications = await getUnsentECEResponseNotifications(db);
+      const [emailAddress] = locationCONF.integrationContacts;
       expect(notifications).toEqual([
         {
           id: expect.any(Number),
           messagePayload: {
-            email_address: locationCONF.integrationContacts[0],
+            email_address: emailAddress,
             personalisation: {
+              institutionCode: locationCONF.institutionCode,
               fileParsingErrors: 0,
               totalRecords: 2,
               totalRecordsSkipped: 1,

--- a/sources/packages/backend/libs/integrations/src/services/institution-location/institution-location.service.ts
+++ b/sources/packages/backend/libs/integrations/src/services/institution-location/institution-location.service.ts
@@ -25,6 +25,7 @@ export class InstitutionLocationService {
       select: {
         id: true,
         integrationContacts: true,
+        institutionCode: true,
       },
       where: {
         hasIntegration: true,


### PR DESCRIPTION
Missing `institutionCode` in the GC Noty template was causing the notification to fail with the below error:
```json
[
    {
        "error": "BadRequestError",
        "message": "Missing personalisation for template ID a662979f-07d4-44c0-a38f-ab9fda5671fe: institutionCode"
    }
]
```