### PR TITLE
#4248 - Adjusted allowed statuses to display assessment history

### DIFF
--- a/sources/packages/web/src/components/layouts/aest/AESTApplicationSideBar.vue
+++ b/sources/packages/web/src/components/layouts/aest/AESTApplicationSideBar.vue
@@ -32,6 +32,16 @@ import {
 } from "@/services/http/dto";
 import useEmitterEvents from "@/composables/useEmitterEvents";
 
+/**
+ * Applications edit statuses where the assessment history
+ * menu item should be displayed.
+ */
+const ALLOWED_ASSESSMENT_HISTORY_STATUSES = new Set([
+  ApplicationEditStatus.Original,
+  ApplicationEditStatus.Edited,
+  ApplicationEditStatus.ChangedWithApproval,
+]);
+
 export default defineComponent({
   props: {
     studentId: {
@@ -347,8 +357,7 @@ export default defineComponent({
         ];
         // Conditionally create the assessment menu.
         if (
-          version.applicationEditStatus !==
-          ApplicationEditStatus.ChangeCancelled
+          ALLOWED_ASSESSMENT_HISTORY_STATUSES.has(version.applicationEditStatus)
         ) {
           children.push({
             title: "Assessments",


### PR DESCRIPTION
Adjusted the logic to avoid displaying assessment history for `Chande declined` after a small AC adjustment.

<img width="1050" height="1095" alt="image" src="https://github.com/user-attachments/assets/ff13f8c8-c212-44de-9623-fb70176b3221" />
