### PR TITLE
#5345 - Modified Independent field to be hidden from Create Your Profile and Create student account pages

### DIFF
--- a/sources/packages/forms/src/form-definitions/studentprofile.json
+++ b/sources/packages/forms/src/form-definitions/studentprofile.json
@@ -400,7 +400,11 @@
           "persistent": false,
           "validateWhenHidden": false,
           "key": "modifiedIndependentStatus",
-          "customConditional": "show = data.mode === 'student-edit'",
+          "conditional": {
+            "show": true,
+            "when": "mode",
+            "eq": "student-edit"
+          },
           "type": "textfield",
           "input": true
         },


### PR DESCRIPTION
Added condition to student-profile form to display Modified Independent field only for Edit (student-edit) mode. Create Profile (student-create) and Create Student (aest-account-approval) are hidden as per the requirements.

The student-profile form is used in the following screens.

**Create Student Profile (Student)** - Now hidden

<img width="1068" height="655" alt="image" src="https://github.com/user-attachments/assets/294bf40b-afe6-4a82-be40-7a07914d94c1" />

**Edit Student Profile (Student)** - No change

<img width="1075" height="596" alt="image" src="https://github.com/user-attachments/assets/7fc4b6e7-78e5-49ba-a8fe-240048ef8dcf" />

**Pending accounts request - View Profile (Ministry)** - Now hidden

<img width="763" height="625" alt="image" src="https://github.com/user-attachments/assets/3117e60b-b5aa-4c15-9692-6f1930f86850" />
