### PR TITLE
#2429 - Update api-deploy to use maintenance mode values as string

### DIFF
--- a/devops/openshift/api-deploy.yml
+++ b/devops/openshift/api-deploy.yml
@@ -532,17 +532,17 @@ parameters:
   - name: IS_FULLTIME_ALLOWED
     required: true
   - name: MAINTENANCE_MODE
-    value: false
+    value: "false"
   - name: MAINTENANCE_MODE_STUDENT
-    value: false
+    value: "false"
   - name: MAINTENANCE_MODE_INSTITUTION
-    value: false
+    value: "false"
   - name: MAINTENANCE_MODE_MINISTRY
-    value: false
+    value: "false"
   - name: MAINTENANCE_MODE_SUPPORTING_USER
-    value: false
+    value: "false"
   - name: MAINTENANCE_MODE_EXTERNAL
-    value: false
+    value: "false"
   - name: FILE_UPLOAD_MAX_FILE_SIZE
     value: "15728640"
   - name: FILE_UPLOAD_ALLOWED_EXTENSIONS


### PR DESCRIPTION
Fixes the current deployment issue:

`error: failed to read input object (not a Template?): unable to decode "openshift/api-deploy.yml": json: cannot unmarshal bool into Go struct field Parameter.parameters.value of type string`

likely caused by a default value not being set as string