### PR TITLE
#2429 - Update health controller to allow during maintenance mode

### DIFF
--- a/sources/packages/backend/apps/api/src/route-controllers/health-check/health.controller.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/health-check/health.controller.ts
@@ -5,8 +5,9 @@ import {
   HealthCheckService,
   TypeOrmHealthIndicator,
 } from "@nestjs/terminus";
-import { Public } from "../../auth/decorators";
+import { AllowDuringMaintenanceMode, Public } from "../../auth/decorators";
 
+@AllowDuringMaintenanceMode()
 @Controller("health")
 export class HealthController {
   constructor(


### PR DESCRIPTION
Allows /health endpoint to be hit while in maintenance mode is enabled by adding the custom decorator.