### PR TITLE
#4384 - Fix Request For Designation Validation

### DIFF
--- a/sources/packages/forms/src/form-definitions/designationagreementdetails.json
+++ b/sources/packages/forms/src/form-definitions/designationagreementdetails.json
@@ -273,8 +273,7 @@
       ],
       "validate": {
         "required": true,
-        "customMessage": "at least one location must be selected",
-        "custom": "valid = data.locations.filter(row => row.requestForDesignation).length > 0;"
+        "customMessage": "At least one location must be selected for designation"
       },
       "key": "locations",
       "type": "datagrid",
@@ -347,6 +346,19 @@
         }
       ],
       "persistent": ""
+    },
+    {
+      "label": "",
+      "key": "locationsValidation",
+      "type": "hidden",
+      "input": true,
+      "tableView": false,
+      "hideLabel": true,
+      "calculateValue": "hasRequestedDesignationSelected = data.locations && data.locations.some(row => row.requestForDesignation);",
+      "validate": {
+        "custom": "valid = hasRequestedDesignationSelected;",
+        "customMessage": "At least one location must be selected for designation"
+      }
     },
     {
       "label": "HTML",


### PR DESCRIPTION
Fix Designation Agreement Location Selection Validation

Added validation to ensure at least one location is selected for designation when submitting a designation agreement. Implemented custom validation on the [requestForDesignation](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) checkbox within the locations datagrid that checks if any location in the array has been selected. This prevents form submission when no locations are requested for designation.

<img width="1170" height="691" alt="image" src="https://github.com/user-attachments/assets/feda02df-5478-45a9-b8f7-d0f248333b5e" />
