### PR TITLE
#4879 - Reverse Scholastic Standing Reporting Tracker Card - Query Update

### DIFF
--- a/sources/packages/backend/apps/api/src/route-controllers/application/application.controller.service.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/application/application.controller.service.ts
@@ -68,7 +68,6 @@ import {
   ApplicationEditStatusInProgress,
   APPLICATION_EDIT_STATUS_IN_PROGRESS_VALUES,
   DynamicFormType,
-  StudentScholasticStandingChangeType,
 } from "@sims/sims-db";
 import { ApiProcessError } from "../../types";
 import { ACTIVE_STUDENT_RESTRICTION } from "../../constants";
@@ -291,12 +290,7 @@ export class ApplicationControllerService {
         application.currentAssessment.disbursementSchedules,
       );
     const hasActiveUnsuccessfulCompletionWeeks =
-      application.studentScholasticStandings.some(
-        (scholasticStanding) =>
-          scholasticStanding.changeType ===
-            StudentScholasticStandingChangeType.StudentDidNotCompleteProgram &&
-          !scholasticStanding.reversalDate,
-      );
+      !!application.studentScholasticStandings;
     const changeRequestInProgress =
       await this.getInProgressChangeRequestDetails(application.id, options);
     const eCertFailedValidations = eCertValidationResult.failedValidations.map(

--- a/sources/packages/backend/apps/api/src/route-controllers/application/application.controller.service.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/application/application.controller.service.ts
@@ -290,7 +290,7 @@ export class ApplicationControllerService {
         application.currentAssessment.disbursementSchedules,
       );
     const hasActiveUnsuccessfulCompletionWeeks =
-      !!application.studentScholasticStandings;
+      !!application.studentScholasticStandings.length;
     const changeRequestInProgress =
       await this.getInProgressChangeRequestDetails(application.id, options);
     const eCertFailedValidations = eCertValidationResult.failedValidations.map(


### PR DESCRIPTION
**As a part of this PR, the query is updated to filter and retrieve applications which have either no scholastic standings or scholastic standings of the type "Student did not complete the program".**

### **Screenshots:**

- Withdrawal type of scholastic change

<img width="1918" height="1012" alt="image" src="https://github.com/user-attachments/assets/8d347f7f-8c8d-4317-9943-ff00631994e8" />

--------------------------------------------------------------------------------------------------------------------------------------------

- Unsuccessful Completion type of scholastic change

<img width="1919" height="1016" alt="image" src="https://github.com/user-attachments/assets/5e5a08ca-7753-4659-b94f-5c54e0412342" />

