### PR TITLE
#4504 - Ecert Feedback Error - Update to include new codes

### DIFF
--- a/sources/packages/backend/apps/db-migrations/src/migrations/1766424393193-UpdateEcertFeedbackErrorsFullTime.ts
+++ b/sources/packages/backend/apps/db-migrations/src/migrations/1766424393193-UpdateEcertFeedbackErrorsFullTime.ts
@@ -1,0 +1,24 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+import { getSQLFileData } from "../utilities/sqlLoader";
+
+export class UpdateEcertFeedbackErrorsFullTime1766424393193
+  implements MigrationInterface
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      getSQLFileData(
+        "Update-ecert-feedback-errors-full-time.sql",
+        "ECertFeedbackErrors",
+      ),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      getSQLFileData(
+        "Rollback-update-ecert-feedback-errors-full-time.sql",
+        "ECertFeedbackErrors",
+      ),
+    );
+  }
+}

--- a/sources/packages/backend/apps/db-migrations/src/migrations/1766424426427-AddNewEcertFeedbackErrors.ts
+++ b/sources/packages/backend/apps/db-migrations/src/migrations/1766424426427-AddNewEcertFeedbackErrors.ts
@@ -1,0 +1,24 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+import { getSQLFileData } from "../utilities/sqlLoader";
+
+export class AddNewEcertFeedbackErrors1766424426427
+  implements MigrationInterface
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      getSQLFileData(
+        "Add-new-ecert-feedback-errors.sql",
+        "ECertFeedbackErrors",
+      ),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      getSQLFileData(
+        "Rollback-add-new-ecert-feedback-errors.sql",
+        "ECertFeedbackErrors",
+      ),
+    );
+  }
+}

--- a/sources/packages/backend/apps/db-migrations/src/sql/ECertFeedbackErrors/Add-new-ecert-feedback-errors.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/ECertFeedbackErrors/Add-new-ecert-feedback-errors.sql
@@ -1,0 +1,38 @@
+INSERT INTO
+    sims.ecert_feedback_errors (
+        error_code,
+        error_description,
+        offering_intensity,
+        block_funding
+    )
+VALUES
+    (
+        'EDU-00077',
+        'ENTIL ISSUE DATE: MUST BE ON OR BEFORE PSED',
+        'Full Time',
+        TRUE
+    ),
+    (
+        'LNS-00716',
+        'CSG-PT AMOUNT CANNOT EXCEED LIMIT',
+        'Part Time',
+        TRUE
+    ),
+    (
+        'LNS-BR035',
+        'DATE OF ISSUE: MUST BE BEFORE PSED',
+        'Part Time',
+        TRUE
+    ),
+    (
+        'LNS-00684',
+        'PD AMT SHOULD NOT EXCEED $2000, FT & PT COMBINED',
+        'Full Time',
+        TRUE
+    ),
+    (
+        'LNS-00684',
+        'PD AMT SHOULD NOT EXCEED $2000, FT & PT COMBINED',
+        'Part Time',
+        TRUE
+    );

--- a/sources/packages/backend/apps/db-migrations/src/sql/ECertFeedbackErrors/Rollback-add-new-ecert-feedback-errors.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/ECertFeedbackErrors/Rollback-add-new-ecert-feedback-errors.sql
@@ -1,0 +1,10 @@
+DELETE FROM
+    sims.ecert_feedback_errors
+WHERE
+    (error_code, offering_intensity) IN (
+        ('EDU-00077', 'Full Time'),
+        ('LNS-00716', 'Part Time'),
+        ('LNS-BR035', 'Part Time'),
+        ('LNS-00684', 'Full Time'),
+        ('LNS-00684', 'Part Time')
+    );

--- a/sources/packages/backend/apps/db-migrations/src/sql/ECertFeedbackErrors/Rollback-update-ecert-feedback-errors-full-time.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/ECertFeedbackErrors/Rollback-update-ecert-feedback-errors-full-time.sql
@@ -1,0 +1,32 @@
+UPDATE
+  sims.ecert_feedback_errors
+SET
+  block_funding = TRUE
+WHERE
+  offering_intensity = 'Full Time'
+  AND error_code IN (
+    'EDU-00040',
+    'EDU-00041',
+    'EDU-00042',
+    'EDU-00043',
+    'EDU-00044',
+    'EDU-00045',
+    'EDU-00046',
+    'EDU-00047',
+    'EDU-00048',
+    'EDU-00049',
+    'EDU-00050',
+    'EDU-00051',
+    'EDU-00052',
+    'EDU-00070',
+    'EDU-00074',
+    'EDU-00095',
+    'EDU-00096',
+    'EDU-00097',
+    'EDU-00098',
+    'EDU-00099',
+    'EDU-00100',
+    'EDU-00101',
+    'EDU-00102',
+    'EDU-00111'
+  );

--- a/sources/packages/backend/apps/db-migrations/src/sql/ECertFeedbackErrors/Update-ecert-feedback-errors-full-time.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/ECertFeedbackErrors/Update-ecert-feedback-errors-full-time.sql
@@ -1,0 +1,32 @@
+UPDATE
+  sims.ecert_feedback_errors
+SET
+  block_funding = FALSE
+WHERE
+  offering_intensity = 'Full Time'
+  AND error_code IN (
+    'EDU-00040',
+    'EDU-00041',
+    'EDU-00042',
+    'EDU-00043',
+    'EDU-00044',
+    'EDU-00045',
+    'EDU-00046',
+    'EDU-00047',
+    'EDU-00048',
+    'EDU-00049',
+    'EDU-00050',
+    'EDU-00051',
+    'EDU-00052',
+    'EDU-00070',
+    'EDU-00074',
+    'EDU-00095',
+    'EDU-00096',
+    'EDU-00097',
+    'EDU-00098',
+    'EDU-00099',
+    'EDU-00100',
+    'EDU-00101',
+    'EDU-00102',
+    'EDU-00111'
+  );


### PR DESCRIPTION
### Two Migrations For `ecert_feedback_errors`
- One to update required FT ecert codes that exist to change effect (`block_funding`)
- One to add new codes not previously on the list.

#### Run Migrations
<img width="853" height="335" alt="image" src="https://github.com/user-attachments/assets/8f28a0d4-6de9-4656-a221-8ad60f70b604" />

#### Revert Migrations
<img width="928" height="508" alt="image" src="https://github.com/user-attachments/assets/f0d06dd6-ba9c-488c-bd76-a1c3a90b6d9d" />
<img width="951" height="500" alt="image" src="https://github.com/user-attachments/assets/87b684a4-1e57-4702-b966-de34c21b3cb7" />

#### Run Migrations Again
<img width="853" height="335" alt="image" src="https://github.com/user-attachments/assets/e7a4e720-77d9-4020-b6c7-7a5c664a5c7f" />
