### PR TITLE
#5612 - Increases CPU for pgbackrest

### DIFF
--- a/devops/helm/crunchy-postgres/values-0c27fb-prod.yaml
+++ b/devops/helm/crunchy-postgres/values-0c27fb-prod.yaml
@@ -61,10 +61,10 @@ pgBackRest:
   sidecars:
     pgbackrest:
       requests:
-        cpu: 50m
+        cpu: 100m
         memory: 256Mi
       limits:
-        cpu: 50m
+        cpu: 100m
         memory: 512Mi
     pgbackrestConfig:
       requests:


### PR DESCRIPTION
Following the increase of memory for pgbackrest, alerts started firing for cpu usage on pgbackrest. As such, an increase is required. 

- this PR increases the CPU in PROD for pgbackrest 