### PR TITLE
#5080 - Separate uploaders for proof of citizenship

### DIFF
--- a/sources/packages/forms/src/form-definitions/sfaa2026-27-pt.json
+++ b/sources/packages/forms/src/form-definitions/sfaa2026-27-pt.json
@@ -1961,7 +1961,7 @@
                       "hideLabel": true,
                       "tableView": false,
                       "storage": "url",
-                      "dir": "Proof of Citizenship",
+                      "dir": "Proof of Citizenship - Permanent resident",
                       "webcam": false,
                       "capture": false,
                       "fileTypes": [
@@ -2119,7 +2119,7 @@
                       "hideLabel": true,
                       "tableView": false,
                       "storage": "url",
-                      "dir": "Proof of Citizenship",
+                      "dir": "Proof of Citizenship - Protected person",
                       "webcam": false,
                       "capture": false,
                       "fileTypes": [


### PR DESCRIPTION
- This PR creates separate uploader components for PT 26/27 application. In PT25/26, a shared uploader is used for permanent residency and protected person uploaders. 

<img width="799" height="411" alt="image" src="https://github.com/user-attachments/assets/2b8ba148-d722-4d1f-a7f1-1c63acc832cd" />
