### PR TITLE
#5144 - Ministry: Display badge is institution is restricted

### DIFF
--- a/sources/packages/backend/apps/api/src/route-controllers/institution/institution.aest.controller.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/institution/institution.aest.controller.ts
@@ -9,7 +9,10 @@ import {
   Post,
   Query,
 } from "@nestjs/common";
-import { InstitutionService } from "../../services";
+import {
+  InstitutionRestrictionService,
+  InstitutionService,
+} from "../../services";
 import { AddressInfo, Institution } from "@sims/sims-db";
 import { AuthorizedParties } from "../../auth/authorized-parties.enum";
 import {
@@ -49,6 +52,7 @@ import { Role } from "../../auth/roles.enum";
 export class InstitutionAESTController extends BaseController {
   constructor(
     private readonly institutionService: InstitutionService,
+    private readonly institutionRestrictionService: InstitutionRestrictionService,
     private readonly institutionControllerService: InstitutionControllerService,
     private readonly locationControllerService: InstitutionLocationControllerService,
   ) {
@@ -151,6 +155,13 @@ export class InstitutionAESTController extends BaseController {
       await this.institutionService.getBasicInstitutionDetailById(
         institutionId,
       );
+    const restrictions =
+      await this.institutionRestrictionService.getInstitutionRestrictions(
+        institutionId,
+        {
+          isActive: true,
+        },
+      );
     const designationStatus =
       await this.locationControllerService.getInstitutionDesignationStatus(
         institutionId,
@@ -159,6 +170,7 @@ export class InstitutionAESTController extends BaseController {
       operatingName: institutionDetail.operatingName,
       designationStatus: designationStatus,
       hasBusinessGuid: !!institutionDetail.businessGuid,
+      hasRestrictions: !!restrictions.length,
     };
   }
 

--- a/sources/packages/backend/apps/api/src/route-controllers/institution/models/institution.dto.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/institution/models/institution.dto.ts
@@ -148,6 +148,7 @@ export class InstitutionBasicAPIOutDTO {
    * associated with, if not it is a basic BCeID institution.
    */
   hasBusinessGuid: boolean;
+  hasRestrictions: boolean;
 }
 
 export class SearchInstitutionAPIOutDTO {

--- a/sources/packages/web/src/services/http/dto/Institution.dto.ts
+++ b/sources/packages/web/src/services/http/dto/Institution.dto.ts
@@ -102,6 +102,7 @@ export interface InstitutionBasicAPIOutDTO {
    * associated with, if not it is a basic BCeID institution.
    */
   hasBusinessGuid: boolean;
+  hasRestrictions: boolean;
 }
 
 export class CreateInstitution {

--- a/sources/packages/web/src/views/aest/institution/InstitutionDetails.vue
+++ b/sources/packages/web/src/views/aest/institution/InstitutionDetails.vue
@@ -11,6 +11,14 @@
             class="ml-4 mt-1"
             :status="institutionBasicDetail.designationStatus"
           />
+          <student-restriction-chip
+            class="ml-4 mt-1"
+            :status="
+              institutionBasicDetail.hasRestrictions
+                ? StudentRestrictionStatus.Restriction
+                : StudentRestrictionStatus.NoRestriction
+            "
+          />
         </template>
       </header-navigator>
     </template>
@@ -39,9 +47,11 @@ import { InstitutionService } from "@/services/InstitutionService";
 import { InstitutionBasicAPIOutDTO } from "@/services/http/dto";
 import { AESTRoutesConst } from "@/constants/routes/RouteConstants";
 import StatusChipDesignationAgreement from "@/components/generic/StatusChipDesignationAgreement.vue";
+import { StudentRestrictionStatus } from "@/types";
+import StudentRestrictionChip from "@/components/generic/StudentRestrictionChip.vue";
 
 export default defineComponent({
-  components: { StatusChipDesignationAgreement },
+  components: { StatusChipDesignationAgreement, StudentRestrictionChip },
   props: {
     institutionId: {
       type: Number,
@@ -128,6 +138,7 @@ export default defineComponent({
       AESTRoutesConst,
       items,
       tab,
+      StudentRestrictionStatus,
     };
   },
 });


### PR DESCRIPTION
### **As a part of this PR, the following were completed:**

- Used the existing `StudentRestrictionChip` to display the "Active restrictions" badge besides the "Designated" badge on Ministry site If institution has an active restriction.

**Screenshot:**

<img width="1919" height="1079" alt="image" src="https://github.com/user-attachments/assets/f1b9aa47-5530-4bdf-97de-fc9330e7cf52" />
