### PR TITLE
#5629 - Increase resources for pgbackrest

### DIFF
--- a/devops/helm/crunchy-postgres/values-0c27fb-prod.yaml
+++ b/devops/helm/crunchy-postgres/values-0c27fb-prod.yaml
@@ -62,7 +62,7 @@ pgBackRest:
     pgbackrest:
       requests:
         cpu: 500m
-        memory: 524Mi
+        memory: 550Mi
       limits:
         cpu: 500m
         memory: 768Mi


### PR DESCRIPTION
- This PR increases cpu and memory resources for pgbackrest to appropriate amounts to minimize alerts being triggered 

Following these changes, the following approximate cpu/memory quota will remain. 

- 2.45 cores CPU
- 33GiB memory