### PR TITLE
#3625 - Create Program not loading correctly

### DIFF
--- a/sources/packages/web/src/views/institution/locations/programs/LocationProgramAddEdit.vue
+++ b/sources/packages/web/src/views/institution/locations/programs/LocationProgramAddEdit.vue
@@ -53,7 +53,7 @@ import {
   InstitutionRoutesConst,
   AESTRoutesConst,
 } from "@/constants/routes/RouteConstants";
-import { ref, computed, defineComponent, isReadonly, onMounted } from "vue";
+import { ref, computed, defineComponent, isReadonly, watchEffect } from "vue";
 import { ApiProcessError, ClientIdType, FormIOForm } from "@/types";
 import { useFormioUtils, useInstitutionAuth, useSnackBar } from "@/composables";
 import { AuthService } from "@/services/AuthService";
@@ -128,7 +128,7 @@ export default defineComponent({
       }
     };
 
-    onMounted(async () => {
+    watchEffect(async () => {
       await loadFormData();
     });
 


### PR DESCRIPTION
### Overview
- **[Create program]** wasn't loading correctly when navigated to from Edit Program since it's the same component
- Switched from `onMounted()` to `watchEffect()` which nicely handles initial component creation as well as subsequent navigation without program id

### Screenshots
<img width="1169" height="646" alt="image" src="https://github.com/user-attachments/assets/b2280347-06ef-4fbe-96b0-10752a3e210b" />

<img width="1156" height="691" alt="image" src="https://github.com/user-attachments/assets/9640d2e7-45c3-47f5-a406-1dffaf45b293" />
