### PR TITLE
#3653 - Fixes the scroll arrows not being displayed in the tab navigation

### DIFF
--- a/sources/packages/web/src/views/aest/student/StudentDetails.vue
+++ b/sources/packages/web/src/views/aest/student/StudentDetails.vue
@@ -14,7 +14,7 @@
       </header-navigator>
     </template>
     <template #tab-header>
-      <v-tabs stacked grow show-arrows="always">
+      <v-tabs color="primary" stacked grow show-arrows="always">
         <v-tab
           v-for="item in items"
           :text="item.label"

--- a/sources/packages/web/src/views/institution/student/InstitutionStudentDetails.vue
+++ b/sources/packages/web/src/views/institution/student/InstitutionStudentDetails.vue
@@ -7,7 +7,7 @@
       />
     </template>
     <template #tab-header>
-      <v-tabs stacked grow show-arrows="always">
+      <v-tabs color="primary" stacked grow show-arrows="always">
         <v-tab
           v-for="item in items"
           :text="item.label"


### PR DESCRIPTION
### Summary

Fixes the scroll arrows not being displayed in small screens.
Shrank the size of the tabs by refactoring the tab component to use builtin properties (prependicon, text) instead of custom layout/components
Fixed applied to BOTH ministry and Institution views.

<img width="1575" height="360" alt="image" src="https://github.com/user-attachments/assets/9f25306d-b50a-411b-a01e-62c052724357" />

<img width="679" height="261" alt="image" src="https://github.com/user-attachments/assets/52bc6c64-9a91-40f6-a862-7601a443109b" />
