### PR TITLE
#5569 - Fix defect when viewing empty assessment

### DIFF
--- a/sources/packages/web/src/components/common/students/applicationDetails/AssessmentAward.vue
+++ b/sources/packages/web/src/components/common/students/applicationDetails/AssessmentAward.vue
@@ -53,6 +53,7 @@ export default defineComponent({
     assessmentAwardData: {
       type: Object as PropType<AwardDetailsAPIOutDTO>,
       required: true,
+      default: undefined,
     },
     noticeOfAssessmentRoute: {
       type: Object as PropType<RouteLocationRaw>,


### PR DESCRIPTION
### Overview
Fixed issue where clicking View when no assessment has been created shows a blank screen. Recent update to toggled logic did not take into account that there is a prop default of `{}`. Changed default to undefined so existing logic works as expected. Note, there will be a future fix to disable or hide the View button in this scenario.

<img width="1042" height="282" alt="image" src="https://github.com/user-attachments/assets/74b49be0-d366-430e-9f8c-0a27160b3837" />

<img width="1452" height="467" alt="image" src="https://github.com/user-attachments/assets/b294e9b3-45cb-4ea3-bd8e-4a4e8f1ae5a7" />



