### PR TITLE
#5645 - Add institution type name back in Get institution details API

### DIFF
--- a/sources/packages/backend/apps/api/src/route-controllers/institution/_tests_/e2e/institution.aest.controller.getInstitutionDetailById.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/institution/_tests_/e2e/institution.aest.controller.getInstitutionDetailById.e2e-spec.ts
@@ -64,6 +64,7 @@ describe("InstitutionAESTController(e2e)-getInstitutionDetailById", () => {
       regulatingBody: institution.regulatingBody,
       otherRegulatingBody: institution.otherRegulatingBody ?? null,
       institutionType: institutionType.id,
+      institutionTypeName: institutionType.name,
       establishedDate: getISODateOnlyString(institution.establishedDate),
       primaryContactEmail: institution.institutionPrimaryContact.email,
       primaryContactFirstName: institution.institutionPrimaryContact.firstName,

--- a/sources/packages/backend/apps/api/src/route-controllers/institution/_tests_/e2e/institution.institutions.controller.getInstitutionDetail.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/institution/_tests_/e2e/institution.institutions.controller.getInstitutionDetail.e2e-spec.ts
@@ -71,6 +71,7 @@ describe("InstitutionInstitutionsController(e2e)-getInstitutionDetail", () => {
       regulatingBody: institution.regulatingBody,
       otherRegulatingBody: institution.otherRegulatingBody ?? null,
       institutionType: institutionType.id,
+      institutionTypeName: institutionType.name,
       establishedDate: getISODateOnlyString(institution.establishedDate),
       primaryContactEmail: institution.institutionPrimaryContact.email,
       primaryContactFirstName: institution.institutionPrimaryContact.firstName,

--- a/sources/packages/backend/apps/api/src/route-controllers/institution/institution.controller.service.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/institution/institution.controller.service.ts
@@ -71,6 +71,7 @@ export class InstitutionControllerService {
       regulatingBody: institutionDetail.regulatingBody,
       otherRegulatingBody: institutionDetail.otherRegulatingBody,
       institutionType: institutionDetail.institutionType.id,
+      institutionTypeName: institutionDetail.institutionType.name,
       establishedDate: institutionDetail.establishedDate,
       primaryContactEmail: institutionDetail.institutionPrimaryContact.email,
       primaryContactFirstName:

--- a/sources/packages/backend/apps/api/src/route-controllers/institution/models/institution.dto.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/institution/models/institution.dto.ts
@@ -129,6 +129,7 @@ export class InstitutionDetailAPIOutDTO {
   otherRegulatingBody?: string;
   establishedDate: string;
   institutionType: number;
+  institutionTypeName: string;
   legalOperatingName: string;
   isBCPrivate: boolean;
   isBCPublic: boolean;

--- a/sources/packages/web/src/services/http/dto/Institution.dto.ts
+++ b/sources/packages/web/src/services/http/dto/Institution.dto.ts
@@ -64,6 +64,7 @@ export interface InstitutionDetailAPIOutDTO {
   otherRegulatingBody?: string;
   establishedDate: string;
   institutionType: number;
+  institutionTypeName: string;
   legalOperatingName: string;
   isBCPrivate: boolean;
   isBCPublic: boolean;

--- a/sources/packages/web/src/store/modules/institution/actions.ts
+++ b/sources/packages/web/src/store/modules/institution/actions.ts
@@ -29,6 +29,7 @@ export const actions: ActionTree<InstitutionLocationState, RootState> = {
     context.commit("setInstitutionDetails", {
       legalOperatingName: response.legalOperatingName,
       operatingName: response.operatingName,
+      institutionType: response.institutionTypeName,
       isBCPrivate: response.isBCPrivate,
       isBCPublic: response.isBCPublic,
       hasBusinessGuid: response.hasBusinessGuid,


### PR DESCRIPTION
## Issue

When `institutionTypeName` was removed from the API which populates View profile page for ministry/institution
and it affected create designation agreement page. 

<img width="873" height="408" alt="image" src="https://github.com/user-attachments/assets/0d8840e6-b2d4-48a1-85aa-f2e078094f0d" />

This is because, the designation agreement page retrieves the  `institutionTypeName` from institution store which loads data from same API that populates profile which is now missing the `institutionTypeName` .

## Solution

Added the `institutionTypeName` back to API and E2E tests.