### PR TITLE
#5860 - Fix Location Programs Status Filter

### DIFF
--- a/sources/packages/backend/apps/api/src/services/education-program/education-program.service.ts
+++ b/sources/packages/backend/apps/api/src/services/education-program/education-program.service.ts
@@ -965,9 +965,12 @@ export class EducationProgramService extends RecordDataModelService<EducationPro
         ...paginationOptions.statusSearch,
         !paginationOptions.inactiveProgramSearch,
       );
+
+      return;
     }
+
     // Fetching only the active programs with the provided program status.
-    else if (paginationOptions.statusSearch) {
+    if (paginationOptions.statusSearch) {
       programQuery.andWhere(
         "programs.programStatus IN (:...programStatusSearchCriteria) and programs.isActive = true and (programs.effectiveEndDate is null OR programs.effectiveEndDate > CURRENT_DATE)",
         {
@@ -975,9 +978,11 @@ export class EducationProgramService extends RecordDataModelService<EducationPro
         },
       );
       queryParams.push(...paginationOptions.statusSearch);
+      return;
     }
+
     // Fetching only the inactive status programs.
-    else if (paginationOptions.inactiveProgramSearch) {
+    if (paginationOptions.inactiveProgramSearch) {
       programQuery.andWhere(
         new Brackets((qb) => {
           qb.where("programs.isActive = :programIsActiveSearchCriteria", {


### PR DESCRIPTION
### Summary

This fix resolves related bugs in the institution programs summary list.
The fix refactors the status filtering logic in getProgramsSummary and getProgramsSummaryForLocation into a shared private method, which correctly handles all four filter combinations: no filter (returns everything), inactive only, status only (returns active programs matching the status), and status + inactive (returns active programs matching the status OR any inactive program).

### Actual
When "All" was selected, inactive programs were being excluded from the results. 
When "Inactive" was selected, all status + inactive were being returned.

### Expected
When "All" is selected, all programs (active + inactive) records are returned 
When "Inactive" is selected, only inactive records are returned.
When "Approved" and "Inactive" are selected, only approved OR inactive records are returned.