### PR TITLE
#5821 - Partner programs go to pending

### DIFF
--- a/sources/packages/forms/src/form-definitions/educationprogram.json
+++ b/sources/packages/forms/src/form-definitions/educationprogram.json
@@ -1160,7 +1160,7 @@
               "input": true
             },
             {
-              "label": "Are all institutions you partner with for this program designated with StudentAid BC?",
+              "label": "Are all institutions you partner with for this program designated by StudentAid BC?",
               "optionsLabelPosition": "right",
               "inline": false,
               "tableView": false,


### PR DESCRIPTION
## Overview
- Minor update to question content
- Add a new warning banner for designated
- Fixed double period typo in banner for non-designated
- Set status to pending for designated. Note, non-designated already went to Pending so logic was simplified to just use partnership question

## Screenshots
### Institution - Add Program
**Designated banner**
<img width="932" height="252" alt="image" src="https://github.com/user-attachments/assets/5bf750a9-6d05-4dff-a39c-c16c9e2ef872" />

**Non-designated banner**
<img width="761" height="204" alt="image" src="https://github.com/user-attachments/assets/c6489ce8-3d99-45cc-8328-d8cffb6b590b" />

### Institution - Programs
**Shows status on create**
<img width="1261" height="304" alt="image" src="https://github.com/user-attachments/assets/7007f815-73b8-4dfc-b610-f00feafc38b9" />
