### PR TITLE
#5687 - Disable View assessment when assessment data not available

### DIFF
--- a/sources/packages/web/src/components/common/students/assessment/History.vue
+++ b/sources/packages/web/src/components/common/students/assessment/History.vue
@@ -55,7 +55,7 @@
             <template #[`item.assessment`]="{ item }">
               <v-btn
                 v-if="!item.hasUnsuccessfulWeeks"
-                :disabled="disableViewButton(item)"
+                :disabled="!item.assessmentDate"
                 @click="$emit('viewAssessment', item.assessmentId)"
                 color="primary"
               >
@@ -192,10 +192,6 @@ export default defineComponent({
       return "View request";
     };
 
-    const disableViewButton = (data: AssessmentHistorySummaryAPIOutDTO) => {
-      return !data.assessmentDate;
-    };
-
     return {
       DEFAULT_PAGE_LIMIT,
       ITEMS_PER_PAGE,
@@ -209,7 +205,6 @@ export default defineComponent({
       CompletedChangesHeaders,
       isMobile,
       StudentScholasticStandingChangeType,
-      disableViewButton,
     };
   },
 });


### PR DESCRIPTION
## Overview
- Update View logic in Assessment to disable **View** button when the assessment data isn't available (e.g. when supporting user info is pending). Note, the View Assessment screen already handles missing assessment data gracefully.
- Updated button styling
## Screenshots
### Ministry - Supporting User declaration pending (View disabled)
<img width="1357" height="528" alt="image" src="https://github.com/user-attachments/assets/c97b1215-f551-445a-8a9e-77ce32911dad" />
<img width="1355" height="420" alt="image" src="https://github.com/user-attachments/assets/d2d15ec4-84b6-47f4-b66e-834a0f21b25a" />

### Ministry - Unsuccessful Completion (View hidden - existing logic)
<img width="1312" height="357" alt="image" src="https://github.com/user-attachments/assets/2067cdfe-aa60-4ae5-aa5d-47f72f381017" />

### Ministry - View enabled
<img width="1292" height="336" alt="image" src="https://github.com/user-attachments/assets/c599b6c6-7a37-4060-8899-7f08ca63958c" />

### Student - View enabled
<img width="1352" height="470" alt="image" src="https://github.com/user-attachments/assets/cf86eeef-45fc-47b2-988e-b839b9df986c" />

### Institution - View enabled
<img width="1270" height="466" alt="image" src="https://github.com/user-attachments/assets/129e3cd5-d44b-495c-845f-d5ac5159dcca" />
