### PR TITLE
#5816 - Appeals/Forms history view, data connection, and institution view - Fix Institution Notes

### DIFF
--- a/sources/packages/backend/apps/api/src/route-controllers/form-submission/form-submission.aest.controller.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/form-submission/form-submission.aest.controller.ts
@@ -112,7 +112,6 @@ export class FormSubmissionAESTController extends BaseController {
     // the flag are not required to be returned by this endpoint.
     const submissions =
       await this.formSubmissionControllerService.getFormSubmissions(studentId, {
-        includeBasicDecisionDetails: false,
         keepPendingDecisionsWhilePendingFormSubmission: false,
       });
     return {

--- a/sources/packages/backend/apps/api/src/route-controllers/form-submission/form-submission.controller.service.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/form-submission/form-submission.controller.service.ts
@@ -134,12 +134,12 @@ export class FormSubmissionControllerService {
     const shouldRestrictDecisionDetails =
       keepPendingDecisionsWhilePendingFormSubmission &&
       submissionStatus === FormSubmissionStatus.Pending;
-    // Defined the status.
+    // Define the status.
     let decisionStatus = shouldRestrictDecisionDetails
       ? FormSubmissionDecisionStatus.Pending
       : submissionItem.currentDecision?.decisionStatus;
     decisionStatus = decisionStatus ?? FormSubmissionDecisionStatus.Pending;
-    // Defined the notes.
+    // Define the notes.
     const decisionNoteDescription =
       shouldRestrictDecisionDetails || !includeBasicDecisionDetails
         ? undefined


### PR DESCRIPTION
Fix the error introduced in the last refactor prior to merging the PR that prevents the final note decision from being displayed for institutions.

<img width="1061" height="1155" alt="image" src="https://github.com/user-attachments/assets/c2d2fc69-eb29-4b0e-98d2-baf4f526485c" />
