### PR TITLE
#5616 - Current year income "other" placeholder text

### DIFF
--- a/sources/packages/forms/src/form-definitions/partnercurrentyearincomeappeal.json
+++ b/sources/packages/forms/src/form-definitions/partnercurrentyearincomeappeal.json
@@ -198,7 +198,7 @@
       "components": [
         {
           "label": "Please explain the situation:",
-          "placeholder": "Describe your situation",
+          "placeholder": "Type here",
           "applyMaskOn": "change",
           "autoExpand": false,
           "tableView": true,

--- a/sources/packages/forms/src/form-definitions/studentcurrentyearincomeappeal.json
+++ b/sources/packages/forms/src/form-definitions/studentcurrentyearincomeappeal.json
@@ -198,7 +198,7 @@
       "components": [
         {
           "label": "Please explain your situation:",
-          "placeholder": "Describe your situation",
+          "placeholder": "Type here",
           "applyMaskOn": "change",
           "autoExpand": false,
           "tableView": true,


### PR DESCRIPTION
Updated the placeholder text for the student and partner current year income free-form text field when "other" is selected:
<img width="498" height="123" alt="image" src="https://github.com/user-attachments/assets/f8ad0c04-4c6f-4ef2-9935-456b9cf30a65" />
