### PR TITLE
#5744 - Add Document Number to eCert error notification

### DIFF
--- a/sources/packages/backend/apps/db-migrations/src/migrations/1774208743866-UpdateECertFeedbackFileErrorTemplateId.ts
+++ b/sources/packages/backend/apps/db-migrations/src/migrations/1774208743866-UpdateECertFeedbackFileErrorTemplateId.ts
@@ -1,0 +1,22 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+import { getSQLFileData } from "../utilities/sqlLoader";
+
+export class UpdateECertFeedbackFileErrorTemplateId1774208743866 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      getSQLFileData(
+        "Update-ecert-feedback-file-error-template-id.sql",
+        "NotificationMessages",
+      ),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      getSQLFileData(
+        "Rollback-update-ecert-feedback-file-error-template-id.sql",
+        "NotificationMessages",
+      ),
+    );
+  }
+}

--- a/sources/packages/backend/apps/db-migrations/src/sql/NotificationMessages/Rollback-update-ecert-feedback-file-error-template-id.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/NotificationMessages/Rollback-update-ecert-feedback-file-error-template-id.sql
@@ -1,0 +1,6 @@
+UPDATE
+    sims.notification_messages
+SET
+    template_id = '1d8f7d12-3a5a-4961-840d-e1a2558ceb45'
+WHERE
+    id = 27;

--- a/sources/packages/backend/apps/db-migrations/src/sql/NotificationMessages/Update-ecert-feedback-file-error-template-id.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/NotificationMessages/Update-ecert-feedback-file-error-template-id.sql
@@ -1,0 +1,6 @@
+UPDATE
+    sims.notification_messages
+SET
+    template_id = '9ab7adce-354e-4645-9679-6ce531954a23'
+WHERE
+    id = 27;

--- a/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/esdc-integration/ecert-integration/_tests_/ecert-full-time-feedback-integration.scheduler.e2e-spec.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/esdc-integration/ecert-integration/_tests_/ecert-full-time-feedback-integration.scheduler.e2e-spec.ts
@@ -448,6 +448,7 @@ describe(
           lastName: application.student.user.lastName,
           givenNames: application.student.user.firstName,
           applicationNumber: application.applicationNumber,
+          documentNumber: SHARED_DOCUMENT_NUMBER,
           errorCodes: ["EDU-00033", "EDU-00034"],
         },
       });

--- a/sources/packages/backend/libs/integrations/src/services/disbursement-schedule-errors/disbursement-schedule-errors.service.ts
+++ b/sources/packages/backend/libs/integrations/src/services/disbursement-schedule-errors/disbursement-schedule-errors.service.ts
@@ -87,6 +87,7 @@ export class DisbursementScheduleErrorsService extends RecordDataModelService<Di
             applicationNumber:
               disbursementSchedule.studentAssessment.application
                 .applicationNumber,
+            documentNumber,
             errorCodes: blockingErrorCodes,
           };
           await this.notificationActionsService.saveECertFeedbackFileErrorNotification(

--- a/sources/packages/backend/libs/services/src/notifications/notification/notification-actions.service.ts
+++ b/sources/packages/backend/libs/services/src/notifications/notification/notification-actions.service.ts
@@ -1077,6 +1077,7 @@ export class NotificationActionsService {
           givenNames: notification.givenNames ?? "",
           lastName: notification.lastName,
           applicationNumber: notification.applicationNumber,
+          documentNumber: notification.documentNumber,
           errorCodes: notification.errorCodes,
         },
       },

--- a/sources/packages/backend/libs/services/src/notifications/notification/notification.model.ts
+++ b/sources/packages/backend/libs/services/src/notifications/notification/notification.model.ts
@@ -135,6 +135,7 @@ export interface ECertFeedbackFileErrorNotification {
   givenNames: string;
   lastName: string;
   applicationNumber: string;
+  documentNumber: number;
   errorCodes: string[];
 }
 


### PR DESCRIPTION
### Summary

Updates the eCert error notification to include the eCert document number.
Updates the notification message to use the new template id.

### Migration Test

<img width="729" height="340" alt="Screenshot 2026-03-23 at 13 37 54" src="https://github.com/user-attachments/assets/42293ebe-bfb4-4890-a383-5f5d91bdd46f" />

