### PR TITLE
#5844 - Resubmit PIR

### DIFF
--- a/sources/packages/backend/apps/api/src/route-controllers/application/_tests_/e2e/application.students.controller.getApplication.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/application/_tests_/e2e/application.students.controller.getApplication.e2e-spec.ts
@@ -287,9 +287,7 @@ describe("ApplicationStudentsController(e2e)-getApplication", () => {
           isArchived: false,
           assessmentId: currentApplication.currentAssessment?.id,
           data: {
-            programName: "My Program",
             workflowName: "",
-            programDescription: "This is my program.",
           },
           applicationStatus: currentApplication.applicationStatus,
           applicationEditStatus: currentApplication.applicationEditStatus,
@@ -304,7 +302,7 @@ describe("ApplicationStudentsController(e2e)-getApplication", () => {
             currentApplication.currentAssessment?.offering?.studyEndDate,
           ),
           applicationInstitutionName: currentApplication.location.name,
-          applicationPIRStatus: null,
+          applicationPIRStatus: ProgramInfoStatus.notRequired,
           applicationAssessmentStatus: null,
           applicationFormName: "SFAA2022-23",
           applicationProgramYearID: currentApplication.programYear.id,

--- a/sources/packages/backend/apps/api/src/route-controllers/application/_tests_/e2e/application.students.controller.getApplication.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/application/_tests_/e2e/application.students.controller.getApplication.e2e-spec.ts
@@ -56,7 +56,7 @@ describe("ApplicationStudentsController(e2e)-getApplication", () => {
       .expect(HttpStatus.NOT_FOUND);
   });
 
-  it("Should get the student application details when the application status is 'Draft'.", async () => {
+  it("Should get the student application details when the application status is Draft.", async () => {
     // Arrange
     const application = await saveFakeApplication(
       db.dataSource,
@@ -109,216 +109,204 @@ describe("ApplicationStudentsController(e2e)-getApplication", () => {
       });
   });
 
-  it(
-    "Should get the student application details when the application status is 'In-Progress'" +
-      " and the PIR has status Required.",
-    async () => {
-      // Arrange
-      const application = await saveFakeApplication(
-        db.dataSource,
-        { student },
-        {
-          applicationStatus: ApplicationStatus.InProgress,
-          offeringIntensity: OfferingIntensity.partTime,
-          applicationData: {
-            programName: "My Program",
-            programDescription: "This is my program.",
-            workflowName: "",
-          },
-          pirStatus: ProgramInfoStatus.required,
+  it("Should get the student application details when the application status is In-Progress and the PIR has status Required.", async () => {
+    // Arrange
+    const application = await saveFakeApplication(
+      db.dataSource,
+      { student },
+      {
+        applicationStatus: ApplicationStatus.InProgress,
+        offeringIntensity: OfferingIntensity.partTime,
+        applicationData: {
+          programName: "My Program",
+          programDescription: "This is my program.",
+          workflowName: "",
         },
-      );
+        pirStatus: ProgramInfoStatus.required,
+      },
+    );
 
-      await db.application.save(application);
-      const endpoint = `/students/application/${application.id}`;
-      const token = await getStudentToken(
-        FakeStudentUsersTypes.FakeStudentUserType1,
-      );
-      await mockJWTUserInfo(appModule, application.student.user);
+    await db.application.save(application);
+    const endpoint = `/students/application/${application.id}`;
+    const token = await getStudentToken(
+      FakeStudentUsersTypes.FakeStudentUserType1,
+    );
+    await mockJWTUserInfo(appModule, application.student.user);
 
-      // Act/Assert
-      await request(app.getHttpServer())
-        .get(endpoint)
-        .auth(token, BEARER_AUTH_TYPE)
-        .expect(HttpStatus.OK)
-        .expect({
-          id: application.id,
-          isArchived: false,
-          assessmentId: application.currentAssessment?.id,
-          data: {
-            programName: "My Program",
-            workflowName: "",
-            programDescription: "This is my program.",
-          },
-          applicationStatus: application.applicationStatus,
-          applicationEditStatus: application.applicationEditStatus,
-          applicationStatusUpdatedOn:
-            application.applicationStatusUpdatedOn.toISOString(),
-          applicationNumber: application.applicationNumber,
-          applicationOfferingIntensity: application.offeringIntensity,
-          applicationInstitutionName: application.location.name,
-          applicationPIRStatus: application.pirStatus,
-          applicationAssessmentStatus: null,
-          applicationFormName: "SFAA2022-23",
-          applicationProgramYearID: application.programYear.id,
-          programYearStartDate: application.programYear.startDate,
-          programYearEndDate: application.programYear.endDate,
-          submittedDate: application.submittedDate?.toISOString(),
-          isChangeRequestAllowedForPY: false,
-          hasPreviouslyCompletedPIR: false,
-        });
-    },
-  );
-
-  it(
-    "Should get the student application details when the application status is 'Assessment'" +
-      " and the PIR has status Completed.",
-    async () => {
-      // Arrange
-      const application = await saveFakeApplication(
-        db.dataSource,
-        { student },
-        {
-          applicationStatus: ApplicationStatus.Assessment,
-          offeringIntensity: OfferingIntensity.partTime,
-          applicationData: {
-            programName: "My Program",
-            programDescription: "This is my program.",
-            workflowName: "",
-          },
-          pirStatus: ProgramInfoStatus.completed,
+    // Act/Assert
+    await request(app.getHttpServer())
+      .get(endpoint)
+      .auth(token, BEARER_AUTH_TYPE)
+      .expect(HttpStatus.OK)
+      .expect({
+        id: application.id,
+        isArchived: false,
+        assessmentId: application.currentAssessment?.id,
+        data: {
+          programName: "My Program",
+          workflowName: "",
+          programDescription: "This is my program.",
         },
-      );
+        applicationStatus: application.applicationStatus,
+        applicationEditStatus: application.applicationEditStatus,
+        applicationStatusUpdatedOn:
+          application.applicationStatusUpdatedOn.toISOString(),
+        applicationNumber: application.applicationNumber,
+        applicationOfferingIntensity: application.offeringIntensity,
+        applicationInstitutionName: application.location.name,
+        applicationPIRStatus: application.pirStatus,
+        applicationAssessmentStatus: null,
+        applicationFormName: "SFAA2022-23",
+        applicationProgramYearID: application.programYear.id,
+        programYearStartDate: application.programYear.startDate,
+        programYearEndDate: application.programYear.endDate,
+        submittedDate: application.submittedDate?.toISOString(),
+        isChangeRequestAllowedForPY: false,
+        hasPreviouslyCompletedPIR: false,
+      });
+  });
 
-      await db.application.save(application);
-      const endpoint = `/students/application/${application.id}`;
-      const token = await getStudentToken(
-        FakeStudentUsersTypes.FakeStudentUserType1,
-      );
-      await mockJWTUserInfo(appModule, application.student.user);
-
-      // Act/Assert
-      await request(app.getHttpServer())
-        .get(endpoint)
-        .auth(token, BEARER_AUTH_TYPE)
-        .expect(HttpStatus.OK)
-        .expect({
-          id: application.id,
-          isArchived: false,
-          assessmentId: application.currentAssessment?.id,
-          data: {
-            programName: "My Program",
-            workflowName: "",
-            programDescription: "This is my program.",
-          },
-          applicationStatus: application.applicationStatus,
-          applicationEditStatus: application.applicationEditStatus,
-          applicationStatusUpdatedOn:
-            application.applicationStatusUpdatedOn.toISOString(),
-          applicationNumber: application.applicationNumber,
-          applicationOfferingIntensity: application.offeringIntensity,
-          applicationStartDate: getDateOnlyFormat(
-            application.currentAssessment?.offering?.studyStartDate,
-          ),
-          applicationEndDate: getDateOnlyFormat(
-            application.currentAssessment?.offering?.studyEndDate,
-          ),
-          applicationInstitutionName: application.location.name,
-          applicationPIRStatus: application.pirStatus,
-          applicationAssessmentStatus: null,
-          applicationFormName: "SFAA2022-23",
-          applicationProgramYearID: application.programYear.id,
-          programYearStartDate: application.programYear.startDate,
-          programYearEndDate: application.programYear.endDate,
-          submittedDate: application.submittedDate?.toISOString(),
-          isChangeRequestAllowedForPY: false,
-          hasPreviouslyCompletedPIR: true,
-        });
-    },
-  );
-
-  it(
-    "Should get the student application details when the application status is 'Assessment'" +
-      " and it has a previous version with PIR in 'Completed' status.",
-    async () => {
-      // Arrange
-      // First application with 'Completed' PIR status.
-      const firstApplication = await saveFakeApplication(
-        db.dataSource,
-        { student },
-        {
-          applicationStatus: ApplicationStatus.Edited,
-          offeringIntensity: OfferingIntensity.fullTime,
-          applicationData: {
-            programName: "My Program",
-            programDescription: "This is my program.",
-            workflowName: "",
-          },
-          pirStatus: ProgramInfoStatus.completed,
+  it("Should get the student application details when the application status is Assessment and the PIR has status Completed.", async () => {
+    // Arrange
+    const application = await saveFakeApplication(
+      db.dataSource,
+      { student },
+      {
+        applicationStatus: ApplicationStatus.Assessment,
+        offeringIntensity: OfferingIntensity.partTime,
+        applicationData: {
+          programName: "My Program",
+          programDescription: "This is my program.",
+          workflowName: "",
         },
-      );
-      // Current application with PIR 'Not Required' status.
-      const currentApplication = await saveFakeApplication(
-        db.dataSource,
-        {
-          student,
-          parentApplication: { id: firstApplication.id } as Application,
-          precedingApplication: { id: firstApplication.id } as Application,
-        },
-        {
-          applicationStatus: ApplicationStatus.Assessment,
-          offeringIntensity: OfferingIntensity.partTime,
-          applicationNumber: firstApplication.applicationNumber,
-          applicationData: {
-            workflowName: "",
-          },
-          pirStatus: ProgramInfoStatus.notRequired,
-        },
-      );
+        pirStatus: ProgramInfoStatus.completed,
+      },
+    );
 
-      const endpoint = `/students/application/${currentApplication.id}`;
-      const token = await getStudentToken(
-        FakeStudentUsersTypes.FakeStudentUserType1,
-      );
-      await mockJWTUserInfo(appModule, currentApplication.student.user);
+    await db.application.save(application);
+    const endpoint = `/students/application/${application.id}`;
+    const token = await getStudentToken(
+      FakeStudentUsersTypes.FakeStudentUserType1,
+    );
+    await mockJWTUserInfo(appModule, application.student.user);
 
-      // Act/Assert
-      await request(app.getHttpServer())
-        .get(endpoint)
-        .auth(token, BEARER_AUTH_TYPE)
-        .expect(HttpStatus.OK)
-        .expect({
-          id: currentApplication.id,
-          isArchived: false,
-          assessmentId: currentApplication.currentAssessment?.id,
-          data: {
-            workflowName: "",
-          },
-          applicationStatus: currentApplication.applicationStatus,
-          applicationEditStatus: currentApplication.applicationEditStatus,
-          applicationStatusUpdatedOn:
-            currentApplication.applicationStatusUpdatedOn.toISOString(),
-          applicationNumber: currentApplication.applicationNumber,
-          applicationOfferingIntensity: currentApplication.offeringIntensity,
-          applicationStartDate: getDateOnlyFormat(
-            currentApplication.currentAssessment?.offering?.studyStartDate,
-          ),
-          applicationEndDate: getDateOnlyFormat(
-            currentApplication.currentAssessment?.offering?.studyEndDate,
-          ),
-          applicationInstitutionName: currentApplication.location.name,
-          applicationPIRStatus: ProgramInfoStatus.notRequired,
-          applicationAssessmentStatus: null,
-          applicationFormName: "SFAA2022-23",
-          applicationProgramYearID: currentApplication.programYear.id,
-          programYearStartDate: currentApplication.programYear.startDate,
-          programYearEndDate: currentApplication.programYear.endDate,
-          submittedDate: currentApplication.submittedDate?.toISOString(),
-          isChangeRequestAllowedForPY: false,
-          hasPreviouslyCompletedPIR: true,
-        });
-    },
-  );
+    // Act/Assert
+    await request(app.getHttpServer())
+      .get(endpoint)
+      .auth(token, BEARER_AUTH_TYPE)
+      .expect(HttpStatus.OK)
+      .expect({
+        id: application.id,
+        isArchived: false,
+        assessmentId: application.currentAssessment?.id,
+        data: {
+          programName: "My Program",
+          workflowName: "",
+          programDescription: "This is my program.",
+        },
+        applicationStatus: application.applicationStatus,
+        applicationEditStatus: application.applicationEditStatus,
+        applicationStatusUpdatedOn:
+          application.applicationStatusUpdatedOn.toISOString(),
+        applicationNumber: application.applicationNumber,
+        applicationOfferingIntensity: application.offeringIntensity,
+        applicationStartDate: getDateOnlyFormat(
+          application.currentAssessment?.offering?.studyStartDate,
+        ),
+        applicationEndDate: getDateOnlyFormat(
+          application.currentAssessment?.offering?.studyEndDate,
+        ),
+        applicationInstitutionName: application.location.name,
+        applicationPIRStatus: application.pirStatus,
+        applicationAssessmentStatus: null,
+        applicationFormName: "SFAA2022-23",
+        applicationProgramYearID: application.programYear.id,
+        programYearStartDate: application.programYear.startDate,
+        programYearEndDate: application.programYear.endDate,
+        submittedDate: application.submittedDate?.toISOString(),
+        isChangeRequestAllowedForPY: false,
+        hasPreviouslyCompletedPIR: true,
+      });
+  });
+
+  it("Should get the student application details when the application status is Assessment and it has a previous version with PIR in Completed status.", async () => {
+    // Arrange
+    // First application with 'Completed' PIR status.
+    const firstApplication = await saveFakeApplication(
+      db.dataSource,
+      { student },
+      {
+        applicationStatus: ApplicationStatus.Edited,
+        offeringIntensity: OfferingIntensity.fullTime,
+        applicationData: {
+          programName: "My Program",
+          programDescription: "This is my program.",
+          workflowName: "",
+        },
+        pirStatus: ProgramInfoStatus.completed,
+      },
+    );
+    // Current application with PIR 'Not Required' status.
+    const currentApplication = await saveFakeApplication(
+      db.dataSource,
+      {
+        student,
+        parentApplication: { id: firstApplication.id } as Application,
+        precedingApplication: { id: firstApplication.id } as Application,
+      },
+      {
+        applicationStatus: ApplicationStatus.Assessment,
+        offeringIntensity: OfferingIntensity.partTime,
+        applicationNumber: firstApplication.applicationNumber,
+        applicationData: {
+          workflowName: "",
+        },
+        pirStatus: ProgramInfoStatus.notRequired,
+      },
+    );
+
+    const endpoint = `/students/application/${currentApplication.id}`;
+    const token = await getStudentToken(
+      FakeStudentUsersTypes.FakeStudentUserType1,
+    );
+    await mockJWTUserInfo(appModule, currentApplication.student.user);
+
+    // Act/Assert
+    await request(app.getHttpServer())
+      .get(endpoint)
+      .auth(token, BEARER_AUTH_TYPE)
+      .expect(HttpStatus.OK)
+      .expect({
+        id: currentApplication.id,
+        isArchived: false,
+        assessmentId: currentApplication.currentAssessment?.id,
+        data: {
+          workflowName: "",
+        },
+        applicationStatus: currentApplication.applicationStatus,
+        applicationEditStatus: currentApplication.applicationEditStatus,
+        applicationStatusUpdatedOn:
+          currentApplication.applicationStatusUpdatedOn.toISOString(),
+        applicationNumber: currentApplication.applicationNumber,
+        applicationOfferingIntensity: currentApplication.offeringIntensity,
+        applicationStartDate: getDateOnlyFormat(
+          currentApplication.currentAssessment?.offering?.studyStartDate,
+        ),
+        applicationEndDate: getDateOnlyFormat(
+          currentApplication.currentAssessment?.offering?.studyEndDate,
+        ),
+        applicationInstitutionName: currentApplication.location.name,
+        applicationPIRStatus: ProgramInfoStatus.notRequired,
+        applicationAssessmentStatus: null,
+        applicationFormName: "SFAA2022-23",
+        applicationProgramYearID: currentApplication.programYear.id,
+        programYearStartDate: currentApplication.programYear.startDate,
+        programYearEndDate: currentApplication.programYear.endDate,
+        submittedDate: currentApplication.submittedDate?.toISOString(),
+        isChangeRequestAllowedForPY: false,
+        hasPreviouslyCompletedPIR: true,
+      });
+  });
 
   afterAll(async () => {
     await app?.close();

--- a/sources/packages/backend/apps/api/src/route-controllers/application/_tests_/e2e/application.students.controller.getApplication.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/application/_tests_/e2e/application.students.controller.getApplication.e2e-spec.ts
@@ -1,0 +1,324 @@
+import { HttpStatus, INestApplication } from "@nestjs/common";
+import * as request from "supertest";
+import {
+  BEARER_AUTH_TYPE,
+  createTestingAppModule,
+  FakeStudentUsersTypes,
+  getStudentToken,
+  mockUserLoginInfo,
+} from "../../../../testHelpers";
+import {
+  createE2EDataSources,
+  E2EDataSources,
+  saveFakeApplication,
+  saveFakeStudent,
+} from "@sims/test-utils";
+import {
+  Application,
+  ApplicationStatus,
+  OfferingIntensity,
+  ProgramInfoStatus,
+  Student,
+} from "@sims/sims-db";
+import { getDateOnlyFormat } from "@sims/utilities";
+import { TestingModule } from "@nestjs/testing";
+
+describe("ApplicationStudentsController(e2e)-getApplication", () => {
+  let app: INestApplication;
+  let db: E2EDataSources;
+  let appModule: TestingModule;
+  let student: Student;
+
+  beforeAll(async () => {
+    const { nestApplication, module, dataSource } =
+      await createTestingAppModule();
+    app = nestApplication;
+    db = createE2EDataSources(dataSource);
+    appModule = module;
+    student = await saveFakeStudent(db.dataSource);
+  });
+
+  beforeEach(async () => {
+    await mockUserLoginInfo(appModule, student);
+  });
+
+  it("Should throw not found error when application is not found.", async () => {
+    const endpoint = `/students/application/99999999`;
+    const token = await getStudentToken(
+      FakeStudentUsersTypes.FakeStudentUserType1,
+    );
+
+    // Act/Assert
+    await request(app.getHttpServer())
+      .get(endpoint)
+      .auth(token, BEARER_AUTH_TYPE)
+      .expect(HttpStatus.NOT_FOUND);
+  });
+
+  it("Should get the student application details when the application status is 'Draft'.", async () => {
+    // Arrange
+    const application = await saveFakeApplication(
+      db.dataSource,
+      { student },
+      {
+        applicationStatus: ApplicationStatus.Draft,
+        offeringIntensity: OfferingIntensity.partTime,
+        applicationData: {
+          programName: "My Program",
+          programDescription: "This is my program.",
+          workflowName: "",
+        },
+      },
+    );
+
+    await db.application.save(application);
+    const endpoint = `/students/application/${application.id}`;
+    const token = await getStudentToken(
+      FakeStudentUsersTypes.FakeStudentUserType1,
+    );
+
+    // Act/Assert
+    await request(app.getHttpServer())
+      .get(endpoint)
+      .auth(token, BEARER_AUTH_TYPE)
+      .expect(HttpStatus.OK)
+      .expect({
+        id: application.id,
+        isArchived: false,
+        data: {
+          programName: "My Program",
+          workflowName: "",
+          programDescription: "This is my program.",
+        },
+        applicationStatus: application.applicationStatus,
+        applicationEditStatus: application.applicationEditStatus,
+        applicationStatusUpdatedOn:
+          application.applicationStatusUpdatedOn.toISOString(),
+        applicationNumber: application.applicationNumber,
+        applicationOfferingIntensity: application.offeringIntensity,
+        applicationPIRStatus: null,
+        applicationFormName: "SFAA2022-23",
+        applicationProgramYearID: application.programYear.id,
+        programYearStartDate: application.programYear.startDate,
+        programYearEndDate: application.programYear.endDate,
+        submittedDate: null,
+        isChangeRequestAllowedForPY: false,
+        hasPreviouslyCompletedPIR: false,
+      });
+  });
+
+  it(
+    "Should get the student application details when the application status is 'In-Progress'" +
+      " and the PIR has status Required.",
+    async () => {
+      // Arrange
+      const application = await saveFakeApplication(
+        db.dataSource,
+        { student },
+        {
+          applicationStatus: ApplicationStatus.InProgress,
+          offeringIntensity: OfferingIntensity.partTime,
+          applicationData: {
+            programName: "My Program",
+            programDescription: "This is my program.",
+            workflowName: "",
+          },
+          pirStatus: ProgramInfoStatus.required,
+        },
+      );
+
+      await db.application.save(application);
+      const endpoint = `/students/application/${application.id}`;
+      const token = await getStudentToken(
+        FakeStudentUsersTypes.FakeStudentUserType1,
+      );
+
+      // Act/Assert
+      await request(app.getHttpServer())
+        .get(endpoint)
+        .auth(token, BEARER_AUTH_TYPE)
+        .expect(HttpStatus.OK)
+        .expect({
+          id: application.id,
+          isArchived: false,
+          assessmentId: application.currentAssessment?.id,
+          data: {
+            programName: "My Program",
+            workflowName: "",
+            programDescription: "This is my program.",
+          },
+          applicationStatus: application.applicationStatus,
+          applicationEditStatus: application.applicationEditStatus,
+          applicationStatusUpdatedOn:
+            application.applicationStatusUpdatedOn.toISOString(),
+          applicationNumber: application.applicationNumber,
+          applicationOfferingIntensity: application.offeringIntensity,
+          applicationInstitutionName: application.location.name,
+          applicationPIRStatus: application.pirStatus,
+          applicationAssessmentStatus: null,
+          applicationFormName: "SFAA2022-23",
+          applicationProgramYearID: application.programYear.id,
+          programYearStartDate: application.programYear.startDate,
+          programYearEndDate: application.programYear.endDate,
+          submittedDate: application.submittedDate?.toISOString(),
+          isChangeRequestAllowedForPY: false,
+          hasPreviouslyCompletedPIR: false,
+        });
+    },
+  );
+
+  it(
+    "Should get the student application details when the application status is 'Assessment'" +
+      " and the PIR has status Completed.",
+    async () => {
+      // Arrange
+      const application = await saveFakeApplication(
+        db.dataSource,
+        { student },
+        {
+          applicationStatus: ApplicationStatus.Assessment,
+          offeringIntensity: OfferingIntensity.partTime,
+          applicationData: {
+            programName: "My Program",
+            programDescription: "This is my program.",
+            workflowName: "",
+          },
+          pirStatus: ProgramInfoStatus.completed,
+        },
+      );
+
+      await db.application.save(application);
+      const endpoint = `/students/application/${application.id}`;
+      const token = await getStudentToken(
+        FakeStudentUsersTypes.FakeStudentUserType1,
+      );
+
+      // Act/Assert
+      await request(app.getHttpServer())
+        .get(endpoint)
+        .auth(token, BEARER_AUTH_TYPE)
+        .expect(HttpStatus.OK)
+        .expect({
+          id: application.id,
+          isArchived: false,
+          assessmentId: application.currentAssessment?.id,
+          data: {
+            programName: "My Program",
+            workflowName: "",
+            programDescription: "This is my program.",
+          },
+          applicationStatus: application.applicationStatus,
+          applicationEditStatus: application.applicationEditStatus,
+          applicationStatusUpdatedOn:
+            application.applicationStatusUpdatedOn.toISOString(),
+          applicationNumber: application.applicationNumber,
+          applicationOfferingIntensity: application.offeringIntensity,
+          applicationStartDate: getDateOnlyFormat(
+            application.currentAssessment?.offering?.studyStartDate,
+          ),
+          applicationEndDate: getDateOnlyFormat(
+            application.currentAssessment?.offering?.studyEndDate,
+          ),
+          applicationInstitutionName: application.location.name,
+          applicationPIRStatus: application.pirStatus,
+          applicationAssessmentStatus: null,
+          applicationFormName: "SFAA2022-23",
+          applicationProgramYearID: application.programYear.id,
+          programYearStartDate: application.programYear.startDate,
+          programYearEndDate: application.programYear.endDate,
+          submittedDate: application.submittedDate?.toISOString(),
+          isChangeRequestAllowedForPY: false,
+          hasPreviouslyCompletedPIR: true,
+        });
+    },
+  );
+
+  it(
+    "Should get the student application details when the application status is 'In Progress'" +
+      " and it has a previous version with PIR in 'Completed' status.",
+    async () => {
+      // Arrange
+      // First application with 'Completed' PIR status.
+      const firstApplication = await saveFakeApplication(
+        db.dataSource,
+        { student },
+        {
+          applicationStatus: ApplicationStatus.Edited,
+          offeringIntensity: OfferingIntensity.partTime,
+          applicationData: {
+            programName: "My Program",
+            programDescription: "This is my program.",
+            workflowName: "",
+          },
+          pirStatus: ProgramInfoStatus.completed,
+        },
+      );
+      // Current application in PIR 'Not Required' required status to be edited by entering PIR data
+      const currentApplication = await saveFakeApplication(
+        db.dataSource,
+        {
+          student,
+          parentApplication: { id: firstApplication.id } as Application,
+          precedingApplication: { id: firstApplication.id } as Application,
+        },
+        {
+          applicationStatus: ApplicationStatus.Assessment,
+          offeringIntensity: OfferingIntensity.partTime,
+          applicationNumber: firstApplication.applicationNumber,
+          applicationData: {
+            programName: "My Program",
+            programDescription: "This is my program.",
+            workflowName: "",
+          },
+        },
+      );
+
+      const endpoint = `/students/application/${currentApplication.id}`;
+      const token = await getStudentToken(
+        FakeStudentUsersTypes.FakeStudentUserType1,
+      );
+
+      // Act/Assert
+      await request(app.getHttpServer())
+        .get(endpoint)
+        .auth(token, BEARER_AUTH_TYPE)
+        .expect(HttpStatus.OK)
+        .expect({
+          id: currentApplication.id,
+          isArchived: false,
+          assessmentId: currentApplication.currentAssessment?.id,
+          data: {
+            programName: "My Program",
+            workflowName: "",
+            programDescription: "This is my program.",
+          },
+          applicationStatus: currentApplication.applicationStatus,
+          applicationEditStatus: currentApplication.applicationEditStatus,
+          applicationStatusUpdatedOn:
+            currentApplication.applicationStatusUpdatedOn.toISOString(),
+          applicationNumber: currentApplication.applicationNumber,
+          applicationOfferingIntensity: currentApplication.offeringIntensity,
+          applicationStartDate: getDateOnlyFormat(
+            currentApplication.currentAssessment?.offering?.studyStartDate,
+          ),
+          applicationEndDate: getDateOnlyFormat(
+            currentApplication.currentAssessment?.offering?.studyEndDate,
+          ),
+          applicationInstitutionName: currentApplication.location.name,
+          applicationPIRStatus: null,
+          applicationAssessmentStatus: null,
+          applicationFormName: "SFAA2022-23",
+          applicationProgramYearID: currentApplication.programYear.id,
+          programYearStartDate: currentApplication.programYear.startDate,
+          programYearEndDate: currentApplication.programYear.endDate,
+          submittedDate: currentApplication.submittedDate?.toISOString(),
+          isChangeRequestAllowedForPY: false,
+          hasPreviouslyCompletedPIR: true,
+        });
+    },
+  );
+
+  afterAll(async () => {
+    await app?.close();
+  });
+});

--- a/sources/packages/backend/apps/api/src/route-controllers/application/_tests_/e2e/application.students.controller.getApplication.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/application/_tests_/e2e/application.students.controller.getApplication.e2e-spec.ts
@@ -234,7 +234,7 @@ describe("ApplicationStudentsController(e2e)-getApplication", () => {
   );
 
   it(
-    "Should get the student application details when the application status is 'In Progress'" +
+    "Should get the student application details when the application status is 'Assessment'" +
       " and it has a previous version with PIR in 'Completed' status.",
     async () => {
       // Arrange
@@ -244,7 +244,7 @@ describe("ApplicationStudentsController(e2e)-getApplication", () => {
         { student },
         {
           applicationStatus: ApplicationStatus.Edited,
-          offeringIntensity: OfferingIntensity.partTime,
+          offeringIntensity: OfferingIntensity.fullTime,
           applicationData: {
             programName: "My Program",
             programDescription: "This is my program.",
@@ -253,7 +253,7 @@ describe("ApplicationStudentsController(e2e)-getApplication", () => {
           pirStatus: ProgramInfoStatus.completed,
         },
       );
-      // Current application in PIR 'Not Required' required status to be edited by entering PIR data
+      // Current application with PIR 'Not Required' status.
       const currentApplication = await saveFakeApplication(
         db.dataSource,
         {
@@ -266,10 +266,9 @@ describe("ApplicationStudentsController(e2e)-getApplication", () => {
           offeringIntensity: OfferingIntensity.partTime,
           applicationNumber: firstApplication.applicationNumber,
           applicationData: {
-            programName: "My Program",
-            programDescription: "This is my program.",
             workflowName: "",
           },
+          pirStatus: ProgramInfoStatus.notRequired,
         },
       );
 

--- a/sources/packages/backend/apps/api/src/route-controllers/application/_tests_/e2e/application.students.controller.getApplication.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/application/_tests_/e2e/application.students.controller.getApplication.e2e-spec.ts
@@ -5,7 +5,8 @@ import {
   createTestingAppModule,
   FakeStudentUsersTypes,
   getStudentToken,
-  mockUserLoginInfo,
+  mockJWTUserInfo,
+  resetMockJWTUserInfo,
 } from "../../../../testHelpers";
 import {
   createE2EDataSources,
@@ -39,7 +40,7 @@ describe("ApplicationStudentsController(e2e)-getApplication", () => {
   });
 
   beforeEach(async () => {
-    await mockUserLoginInfo(appModule, student);
+    await resetMockJWTUserInfo(appModule);
   });
 
   it("Should throw not found error when application is not found.", async () => {
@@ -76,6 +77,7 @@ describe("ApplicationStudentsController(e2e)-getApplication", () => {
     const token = await getStudentToken(
       FakeStudentUsersTypes.FakeStudentUserType1,
     );
+    await mockJWTUserInfo(appModule, application.student.user);
 
     // Act/Assert
     await request(app.getHttpServer())
@@ -132,6 +134,7 @@ describe("ApplicationStudentsController(e2e)-getApplication", () => {
       const token = await getStudentToken(
         FakeStudentUsersTypes.FakeStudentUserType1,
       );
+      await mockJWTUserInfo(appModule, application.student.user);
 
       // Act/Assert
       await request(app.getHttpServer())
@@ -192,6 +195,7 @@ describe("ApplicationStudentsController(e2e)-getApplication", () => {
       const token = await getStudentToken(
         FakeStudentUsersTypes.FakeStudentUserType1,
       );
+      await mockJWTUserInfo(appModule, application.student.user);
 
       // Act/Assert
       await request(app.getHttpServer())
@@ -276,6 +280,7 @@ describe("ApplicationStudentsController(e2e)-getApplication", () => {
       const token = await getStudentToken(
         FakeStudentUsersTypes.FakeStudentUserType1,
       );
+      await mockJWTUserInfo(appModule, currentApplication.student.user);
 
       // Act/Assert
       await request(app.getHttpServer())

--- a/sources/packages/backend/apps/api/src/route-controllers/application/application.controller.service.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/application/application.controller.service.ts
@@ -673,8 +673,9 @@ export class ApplicationControllerService {
 
   /**
    * Transformation util for Application.
-   * @param applicationDetail
-   * @param disbursement
+   * @param applicationDetail the application.
+   * @param disbursement the disbursement schedule for the application..
+   * @param hasPreviouslyCompletedPIR true if PIR has been previously completed for the application.
    * @returns Application DTO
    */
   transformToApplicationDetailForStudentDTO(

--- a/sources/packages/backend/apps/api/src/route-controllers/application/application.controller.service.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/application/application.controller.service.ts
@@ -680,6 +680,7 @@ export class ApplicationControllerService {
   transformToApplicationDetailForStudentDTO(
     applicationDetail: Application,
     disbursement: DisbursementSchedule,
+    hasPreviouslyCompletedPIR: boolean,
   ): ApplicationDataAPIOutDTO {
     const offering = applicationDetail.currentAssessment?.offering;
     const applicationFormName = this.getStudentApplicationFormName(
@@ -715,6 +716,7 @@ export class ApplicationControllerService {
       isChangeRequestAllowedForPY: allowApplicationChangeRequest(
         applicationDetail.programYear,
       ),
+      hasPreviouslyCompletedPIR,
     };
   }
 

--- a/sources/packages/backend/apps/api/src/route-controllers/application/application.students.controller.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/application/application.students.controller.ts
@@ -92,15 +92,15 @@ export class ApplicationStudentsController extends BaseController {
 
   /**
    * Get application details by id.
-   * @param id for the application to be retrieved.
+   * @param applicationId Id of the application to be retrieved.
    * @returns application details.
    */
-  @Get(":id")
+  @Get(":applicationId")
   @ApiNotFoundResponse({
     description: "Application id not found.",
   })
-  async getByApplicationId(
-    @Param("id", ParseIntPipe) applicationId: number,
+  async getApplication(
+    @Param("applicationId", ParseIntPipe) applicationId: number,
     @UserToken() userToken: StudentUserToken,
   ): Promise<ApplicationDataAPIOutDTO> {
     const application = await this.applicationService.getApplicationById(

--- a/sources/packages/backend/apps/api/src/route-controllers/application/application.students.controller.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/application/application.students.controller.ts
@@ -125,15 +125,21 @@ export class ApplicationStudentsController extends BaseController {
       this.confirmationOfEnrollmentService.getFirstDisbursementScheduleByApplication(
         applicationId,
       );
-    const [applicationData, firstCOE] = await Promise.all([
-      applicationDataPromise,
-      firstCOEPromise,
-    ]);
+
+    const hasPreviouslyCompletedPIRPromise =
+      this.applicationService.hasPreviouslyCompletedPIR(application.id);
+    const [applicationData, firstCOE, hasPreviouslyCompletedPIR] =
+      await Promise.all([
+        applicationDataPromise,
+        firstCOEPromise,
+        hasPreviouslyCompletedPIRPromise,
+      ]);
 
     application.data = applicationData;
     return this.applicationControllerService.transformToApplicationDetailForStudentDTO(
       application,
       firstCOE,
+      hasPreviouslyCompletedPIR,
     );
   }
 

--- a/sources/packages/backend/apps/api/src/route-controllers/application/models/application.dto.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/application/models/application.dto.ts
@@ -158,6 +158,7 @@ export class ApplicationDataAPIOutDTO extends ApplicationBaseAPIOutDTO {
   programYearStartDate: string;
   programYearEndDate: string;
   submittedDate?: Date;
+  hasPreviouslyCompletedPIR: boolean;
 }
 
 export class ApplicationDataChangeAPIOutDTO {

--- a/sources/packages/backend/apps/api/src/services/application/application.service.ts
+++ b/sources/packages/backend/apps/api/src/services/application/application.service.ts
@@ -2456,6 +2456,30 @@ export class ApplicationService extends RecordDataModelService<Application> {
   }
 
   /**
+   * Checks if any of the previous versions of the application has completed PIR status.
+   * @param parentApplicationId parent application id.
+   * @returns boolean indicating if any previous version has completed PIR status.
+   */
+  async hasPreviouslyCompletedPIR(applicationId: number): Promise<boolean> {
+    return this.repo
+      .createQueryBuilder("application")
+      .where("application.pirStatus = :pirStatus", {
+        pirStatus: ProgramInfoStatus.completed,
+      })
+      .andWhere((qb) => {
+        const subQuery = qb
+          .subQuery()
+          .select("currentApp.parentApplication")
+          .from(Application, "currentApp")
+          .where("currentApp.id = :applicationId")
+          .getQuery();
+        return `application.parentApplication = ${subQuery}`;
+      })
+      .setParameter("applicationId", applicationId)
+      .getExists();
+  }
+
+  /**
    * Copy program data from a source application to a target application.
    * @param sourceApplicationData source application data to copy from.
    * @param targetApplicationData target application data to copy to.

--- a/sources/packages/backend/apps/api/src/services/application/application.service.ts
+++ b/sources/packages/backend/apps/api/src/services/application/application.service.ts
@@ -2461,22 +2461,16 @@ export class ApplicationService extends RecordDataModelService<Application> {
    * @returns boolean indicating if any version has completed PIR status.
    */
   async hasPreviouslyCompletedPIR(applicationId: number): Promise<boolean> {
-    return this.repo
-      .createQueryBuilder("application")
-      .where("application.pirStatus = :pirStatus", {
-        pirStatus: ProgramInfoStatus.completed,
-      })
-      .andWhere((qb) => {
-        const subQuery = qb
-          .subQuery()
-          .select("currentApp.parentApplication")
-          .from(Application, "currentApp")
-          .where("currentApp.id = :applicationId")
-          .getQuery();
-        return `application.parentApplication = ${subQuery}`;
-      })
-      .setParameter("applicationId", applicationId)
-      .getExists();
+    return this.repo.exists({
+      where: {
+        id: applicationId,
+        parentApplication: {
+          versions: {
+            pirStatus: ProgramInfoStatus.completed,
+          },
+        },
+      },
+    });
   }
 
   /**

--- a/sources/packages/backend/apps/api/src/services/application/application.service.ts
+++ b/sources/packages/backend/apps/api/src/services/application/application.service.ts
@@ -2456,9 +2456,9 @@ export class ApplicationService extends RecordDataModelService<Application> {
   }
 
   /**
-   * Checks if any of the previous versions of the application has completed PIR status.
-   * @param parentApplicationId parent application id.
-   * @returns boolean indicating if any previous version has completed PIR status.
+   * Checks if any version of the application has completed PIR status.
+   * @param applicationId application id.
+   * @returns boolean indicating if any version has completed PIR status.
    */
   async hasPreviouslyCompletedPIR(applicationId: number): Promise<boolean> {
     return this.repo

--- a/sources/packages/backend/tsconfig.json
+++ b/sources/packages/backend/tsconfig.json
@@ -17,6 +17,7 @@
     "forceConsistentCasingInFileNames": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
+    "strictPropertyInitialization": false,
     "paths": {
       "@sims/sims-db": ["libs/sims-db/src"],
       "@sims/sims-db/*": ["libs/sims-db/src/*"],

--- a/sources/packages/forms/src/form-definitions/sfaa2025-26-ft.json
+++ b/sources/packages/forms/src/form-definitions/sfaa2025-26-ft.json
@@ -1178,6 +1178,47 @@
                   "lockKey": true
                 },
                 {
+                  "title": "PIR Resubmission",
+                  "collapsible": false,
+                  "hideLabel": true,
+                  "key": "panel5",
+                  "customConditional": "// The box and area should only appear if the student previously approved/positively completed PIR\n// The check box question should disappear if the student attaches a program and offering and is no longer on the PIR path\n// The checkbox is not displayed during initial application submission\n// The check box question is only accessible by students during an edit and does not appear during a change request\nconst programOrStudyPeriodNotListed = (data.myProgramNotListed ? data.myProgramNotListed.programnotListed : false) ||\n        (data.myStudyPeriodIsntListed ? data.myStudyPeriodIsntListed.offeringnotListed : false);\nshow = !data.isReadOnly && data.hasPreviouslyCompletedPIR && programOrStudyPeriodNotListed &&  !data.isChangeRequestApplication;",
+                  "type": "panel",
+                  "label": "Panel",
+                  "input": false,
+                  "tableView": false,
+                  "components": [
+                    {
+                      "label": "HTML",
+                      "tag": "p",
+                      "className": "alert alert-info fa fa-info-circle",
+                      "attrs": [
+                        {
+                          "attr": "",
+                          "value": ""
+                        }
+                      ],
+                      "content": " <strong>Info!</strong><br />If you need your institution to review or update your program information, you can request a new program information request. Select the checkbox below to send a new request.",
+                      "refreshOnChange": false,
+                      "customClass": "banner-info",
+                      "key": "html2",
+                      "type": "htmlelement",
+                      "input": false,
+                      "tableView": false
+                    },
+                    {
+                      "label": "Request resubmission of program information request.",
+                      "tableView": false,
+                      "persistent": "client-only",
+                      "validateWhenHidden": false,
+                      "key": "requestPIRResubmission",
+                      "type": "checkbox",
+                      "input": true,
+                      "defaultValue": false
+                    }
+                  ]
+                },
+                {
                   "label": "Study period end date warning",
                   "tag": "p",
                   "className": "alert alert-warning fa fa-exclamation-triangle w-100",
@@ -1348,7 +1389,7 @@
         },
         {
           "label": "Program persistent properties",
-          "calculateValue": "value = [\r\n  \"selectedLocation\",\r\n  \"mySchoolIsNotListed\",\r\n  \"selectedProgram\",\r\n  \"myProgramNotListed\",\r\n  \"programName\",\r\n  \"programDescription\",\r\n  \"studystartDate\",\r\n  \"studyendDate\",\r\n  \"selectedOffering\",\r\n  \"myStudyPeriodIsntListed\",\r\n  \"studentNumber\",\r\n];",
+          "calculateValue": "value = [\r\n  \"selectedLocation\",\r\n  \"mySchoolIsNotListed\",\r\n  \"selectedProgram\",\r\n  \"myProgramNotListed\",\r\n  \"programName\",\r\n  \"programDescription\",\r\n  \"studystartDate\",\r\n  \"studyendDate\",\r\n  \"selectedOffering\",\r\n  \"myStudyPeriodIsntListed\",\r\n  \"studentNumber\",\r\n  \"pirResubmissionDate\",\r\n];",
           "calculateServer": true,
           "key": "programPersistentProperties",
           "type": "hidden",
@@ -1367,6 +1408,21 @@
           "persistent": false,
           "calculateValue": "const selectedLocationProgramRestrictions =  data.selectedLocationProgramRestrictions || [];\n\nvalue = selectedLocationProgramRestrictions.some((restriction) =>\n  restriction.restrictionActions.includes(\"Stop full time disbursement\")\n);",
           "key": "isSelectedLocationProgramRestricted",
+          "type": "hidden",
+          "input": true,
+          "tableView": false
+        },
+        {
+          "label": "PIR resubmission date",
+          "key": "pirResubmissionDate",
+          "type": "hidden",
+          "input": true,
+          "tableView": false
+        },
+        {
+          "label": "Has previously completed PIR",
+          "persistent": "client-only",
+          "key": "hasPreviouslyCompletedPIR",
           "type": "hidden",
           "input": true,
           "tableView": false

--- a/sources/packages/forms/src/form-definitions/sfaa2025-26-ft.json
+++ b/sources/packages/forms/src/form-definitions/sfaa2025-26-ft.json
@@ -1179,6 +1179,7 @@
                 },
                 {
                   "title": "PIR Resubmission",
+                  "customClass": "panel-border-none",
                   "collapsible": false,
                   "hideLabel": true,
                   "key": "panel5",

--- a/sources/packages/forms/src/form-definitions/sfaa2025-26-pt.json
+++ b/sources/packages/forms/src/form-definitions/sfaa2025-26-pt.json
@@ -895,47 +895,6 @@
                   "allowPrevious": false
                 },
                 {
-                  "title": "PIR Resubmission",
-                  "collapsible": false,
-                  "hideLabel": true,
-                  "key": "panel5",
-                  "customConditional": "// The box and area should only appear if the student previously approved/positively completed PIR\n// The check box question should disappear if the student attaches a program and offering and is no longer on the PIR path\n// The checkbox is not displayed during initial application submission\n// The check box question is only accessible by students during an edit and does not appear during a change request\nconst programOrStudyPeriodNotListed = (data.myProgramNotListed ? data.myProgramNotListed.programnotListed : false) ||\n        (data.myStudyPeriodIsntListed ? data.myStudyPeriodIsntListed.offeringnotListed : false);\nshow = !data.isReadOnly && data.hasPreviouslyCompletedPIR && programOrStudyPeriodNotListed &&  !data.isChangeRequestApplication;",
-                  "type": "panel",
-                  "label": "Panel",
-                  "input": false,
-                  "tableView": false,
-                  "components": [
-                    {
-                      "label": "HTML",
-                      "tag": "p",
-                      "className": "alert alert-info fa fa-info-circle",
-                      "attrs": [
-                        {
-                          "attr": "",
-                          "value": ""
-                        }
-                      ],
-                      "content": " <strong>Info!</strong><br />If you need your institution to review or update your program information, you can request a new program information request. Select the checkbox below to send a new request.",
-                      "refreshOnChange": false,
-                      "customClass": "banner-info",
-                      "key": "html2",
-                      "type": "htmlelement",
-                      "input": false,
-                      "tableView": false
-                    },
-                    {
-                      "label": "Request resubmission of program information request.",
-                      "tableView": false,
-                      "persistent": "client-only",
-                      "validateWhenHidden": false,
-                      "key": "requestPIRResubmission",
-                      "type": "checkbox",
-                      "input": true,
-                      "defaultValue": false
-                    }
-                  ]
-                },
-                {
                   "title": "programDesc",
                   "collapsible": false,
                   "hideLabel": true,
@@ -1174,6 +1133,47 @@
                     "offeringnotListed": false
                   },
                   "lockKey": true
+                },
+                {
+                  "title": "PIR Resubmission",
+                  "collapsible": false,
+                  "hideLabel": true,
+                  "key": "panel5",
+                  "customConditional": "// The box and area should only appear if the student previously approved/positively completed PIR\n// The check box question should disappear if the student attaches a program and offering and is no longer on the PIR path\n// The checkbox is not displayed during initial application submission\n// The check box question is only accessible by students during an edit and does not appear during a change request\nconst programOrStudyPeriodNotListed = (data.myProgramNotListed ? data.myProgramNotListed.programnotListed : false) ||\n        (data.myStudyPeriodIsntListed ? data.myStudyPeriodIsntListed.offeringnotListed : false);\nshow = !data.isReadOnly && data.hasPreviouslyCompletedPIR && programOrStudyPeriodNotListed &&  !data.isChangeRequestApplication;",
+                  "type": "panel",
+                  "label": "Panel",
+                  "input": false,
+                  "tableView": false,
+                  "components": [
+                    {
+                      "label": "HTML",
+                      "tag": "p",
+                      "className": "alert alert-info fa fa-info-circle",
+                      "attrs": [
+                        {
+                          "attr": "",
+                          "value": ""
+                        }
+                      ],
+                      "content": " <strong>Info!</strong><br />If you need your institution to review or update your program information, you can request a new program information request. Select the checkbox below to send a new request.",
+                      "refreshOnChange": false,
+                      "customClass": "banner-info",
+                      "key": "html2",
+                      "type": "htmlelement",
+                      "input": false,
+                      "tableView": false
+                    },
+                    {
+                      "label": "Request resubmission of program information request.",
+                      "tableView": false,
+                      "persistent": "client-only",
+                      "validateWhenHidden": false,
+                      "key": "requestPIRResubmission",
+                      "type": "checkbox",
+                      "input": true,
+                      "defaultValue": false
+                    }
+                  ]
                 },
                 {
                   "label": "Study period end date warning",

--- a/sources/packages/forms/src/form-definitions/sfaa2025-26-pt.json
+++ b/sources/packages/forms/src/form-definitions/sfaa2025-26-pt.json
@@ -895,6 +895,47 @@
                   "allowPrevious": false
                 },
                 {
+                  "title": "PIR Resubmission",
+                  "collapsible": false,
+                  "hideLabel": true,
+                  "key": "panel5",
+                  "customConditional": "// The box and area should only appear if the student previously approved/positively completed PIR\n// The check box question should disappear if the student attaches a program and offering and is no longer on the PIR path\n// The checkbox is not displayed during initial application submission\n// The check box question is only accessible by students during an edit and does not appear during a change request\nconst programOrStudyPeriodNotListed = (data.myProgramNotListed ? data.myProgramNotListed.programnotListed : false) ||\n        (data.myStudyPeriodIsntListed ? data.myStudyPeriodIsntListed.offeringnotListed : false);\nshow = !data.isReadOnly && data.hasPreviouslyCompletedPIR && programOrStudyPeriodNotListed &&  !data.isChangeRequestApplication;",
+                  "type": "panel",
+                  "label": "Panel",
+                  "input": false,
+                  "tableView": false,
+                  "components": [
+                    {
+                      "label": "HTML",
+                      "tag": "p",
+                      "className": "alert alert-info fa fa-info-circle",
+                      "attrs": [
+                        {
+                          "attr": "",
+                          "value": ""
+                        }
+                      ],
+                      "content": " <strong>Info!</strong><br />If you need your institution to review or update your program information, you can request a new program information request. Select the checkbox below to send a new request.",
+                      "refreshOnChange": false,
+                      "customClass": "banner-info",
+                      "key": "html2",
+                      "type": "htmlelement",
+                      "input": false,
+                      "tableView": false
+                    },
+                    {
+                      "label": "Request resubmission of program information request.",
+                      "tableView": false,
+                      "persistent": "client-only",
+                      "validateWhenHidden": false,
+                      "key": "requestPIRResubmission",
+                      "type": "checkbox",
+                      "input": true,
+                      "defaultValue": false
+                    }
+                  ]
+                },
+                {
                   "title": "programDesc",
                   "collapsible": false,
                   "hideLabel": true,
@@ -1527,7 +1568,7 @@
         },
         {
           "label": "Program persistent properties",
-          "calculateValue": "value = [\r\n  \"selectedLocation\",\r\n  \"mySchoolIsNotListed\",\r\n  \"selectedProgram\",\r\n  \"myProgramNotListed\",\r\n  \"programName\",\r\n  \"programDescription\",\r\n  \"studystartDate\",\r\n  \"studyendDate\",\r\n  \"selectedOffering\",\r\n  \"myStudyPeriodIsntListed\",\r\n  \"courseDetails\",\r\n  \"studentNumber\",\r\n];",
+          "calculateValue": "value = [\r\n  \"selectedLocation\",\r\n  \"mySchoolIsNotListed\",\r\n  \"selectedProgram\",\r\n  \"myProgramNotListed\",\r\n  \"programName\",\r\n  \"programDescription\",\r\n  \"studystartDate\",\r\n  \"studyendDate\",\r\n  \"selectedOffering\",\r\n  \"myStudyPeriodIsntListed\",\r\n  \"courseDetails\",\r\n  \"studentNumber\",\r\n  \"pirResubmissionDate\",\r\n];",
           "calculateServer": true,
           "key": "programPersistentProperties",
           "type": "hidden",
@@ -1546,6 +1587,21 @@
           "persistent": false,
           "calculateValue": "const selectedLocationProgramRestrictions =  data.selectedLocationProgramRestrictions || [];\n\nvalue = selectedLocationProgramRestrictions.some((restriction) =>\n  restriction.restrictionActions.includes(\"Stop part time disbursement\")\n);",
           "key": "isSelectedLocationProgramRestricted",
+          "type": "hidden",
+          "input": true,
+          "tableView": false
+        },
+        {
+          "label": "PIR resubmission date",
+          "key": "pirResubmissionDate",
+          "type": "hidden",
+          "input": true,
+          "tableView": false
+        },
+        {
+          "label": "Has previously completed PIR",
+          "persistent": "client-only",
+          "key": "hasPreviouslyCompletedPIR",
           "type": "hidden",
           "input": true,
           "tableView": false

--- a/sources/packages/forms/src/form-definitions/sfaa2025-26-pt.json
+++ b/sources/packages/forms/src/form-definitions/sfaa2025-26-pt.json
@@ -1136,6 +1136,7 @@
                 },
                 {
                   "title": "PIR Resubmission",
+                  "customClass": "panel-border-none",
                   "collapsible": false,
                   "hideLabel": true,
                   "key": "panel5",

--- a/sources/packages/forms/src/form-definitions/sfaa2026-27-ft.json
+++ b/sources/packages/forms/src/form-definitions/sfaa2026-27-ft.json
@@ -1178,6 +1178,47 @@
                   "lockKey": true
                 },
                 {
+                  "title": "PIR Resubmission",
+                  "collapsible": false,
+                  "hideLabel": true,
+                  "key": "panel5",
+                  "customConditional": "// The box and area should only appear if the student previously approved/positively completed PIR\n// The check box question should disappear if the student attaches a program and offering and is no longer on the PIR path\n// The checkbox is not displayed during initial application submission\n// The check box question is only accessible by students during an edit and does not appear during a change request\nconst programOrStudyPeriodNotListed = (data.myProgramNotListed ? data.myProgramNotListed.programnotListed : false) ||\n        (data.myStudyPeriodIsntListed ? data.myStudyPeriodIsntListed.offeringnotListed : false);\nshow = !data.isReadOnly && data.hasPreviouslyCompletedPIR && programOrStudyPeriodNotListed &&  !data.isChangeRequestApplication;",
+                  "type": "panel",
+                  "label": "Panel",
+                  "input": false,
+                  "tableView": false,
+                  "components": [
+                    {
+                      "label": "HTML",
+                      "tag": "p",
+                      "className": "alert alert-info fa fa-info-circle",
+                      "attrs": [
+                        {
+                          "attr": "",
+                          "value": ""
+                        }
+                      ],
+                      "content": " <strong>Info!</strong><br />If you need your institution to review or update your program information, you can request a new program information request. Select the checkbox below to send a new request.",
+                      "refreshOnChange": false,
+                      "customClass": "banner-info",
+                      "key": "html2",
+                      "type": "htmlelement",
+                      "input": false,
+                      "tableView": false
+                    },
+                    {
+                      "label": "Request resubmission of program information request.",
+                      "tableView": false,
+                      "persistent": "client-only",
+                      "validateWhenHidden": false,
+                      "key": "requestPIRResubmission",
+                      "type": "checkbox",
+                      "input": true,
+                      "defaultValue": false
+                    }
+                  ]
+                },
+                {
                   "label": "Study period end date warning",
                   "tag": "p",
                   "className": "alert alert-warning fa fa-exclamation-triangle w-100",
@@ -1348,7 +1389,7 @@
         },
         {
           "label": "Program persistent properties",
-          "calculateValue": "value = [\r\n  \"selectedLocation\",\r\n  \"mySchoolIsNotListed\",\r\n  \"selectedProgram\",\r\n  \"myProgramNotListed\",\r\n  \"programName\",\r\n  \"programDescription\",\r\n  \"studystartDate\",\r\n  \"studyendDate\",\r\n  \"selectedOffering\",\r\n  \"myStudyPeriodIsntListed\",\r\n  \"studentNumber\",\r\n];",
+          "calculateValue": "value = [\r\n  \"selectedLocation\",\r\n  \"mySchoolIsNotListed\",\r\n  \"selectedProgram\",\r\n  \"myProgramNotListed\",\r\n  \"programName\",\r\n  \"programDescription\",\r\n  \"studystartDate\",\r\n  \"studyendDate\",\r\n  \"selectedOffering\",\r\n  \"myStudyPeriodIsntListed\",\r\n  \"studentNumber\",\r\n  \"pirResubmissionDate\",\r\n];",
           "calculateServer": true,
           "key": "programPersistentProperties",
           "type": "hidden",
@@ -1367,6 +1408,21 @@
           "persistent": false,
           "calculateValue": "const selectedLocationProgramRestrictions =  data.selectedLocationProgramRestrictions || [];\n\nvalue = selectedLocationProgramRestrictions.some((restriction) =>\n  restriction.restrictionActions.includes(\"Stop full time disbursement\")\n);",
           "key": "isSelectedLocationProgramRestricted",
+          "type": "hidden",
+          "input": true,
+          "tableView": false
+        },
+        {
+          "label": "PIR resubmission date",
+          "key": "pirResubmissionDate",
+          "type": "hidden",
+          "input": true,
+          "tableView": false
+        },
+        {
+          "label": "Has previously completed PIR",
+          "persistent": "client-only",
+          "key": "hasPreviouslyCompletedPIR",
           "type": "hidden",
           "input": true,
           "tableView": false

--- a/sources/packages/forms/src/form-definitions/sfaa2026-27-ft.json
+++ b/sources/packages/forms/src/form-definitions/sfaa2026-27-ft.json
@@ -1179,6 +1179,7 @@
                 },
                 {
                   "title": "PIR Resubmission",
+                  "customClass": "panel-border-none",
                   "collapsible": false,
                   "hideLabel": true,
                   "key": "panel5",

--- a/sources/packages/forms/src/form-definitions/sfaa2026-27-pt.json
+++ b/sources/packages/forms/src/form-definitions/sfaa2026-27-pt.json
@@ -1135,6 +1135,47 @@
                   "lockKey": true
                 },
                 {
+                  "title": "PIR Resubmission",
+                  "collapsible": false,
+                  "hideLabel": true,
+                  "key": "panel5",
+                  "customConditional": "// The box and area should only appear if the student previously approved/positively completed PIR\n// The check box question should disappear if the student attaches a program and offering and is no longer on the PIR path\n// The checkbox is not displayed during initial application submission\n// The check box question is only accessible by students during an edit and does not appear during a change request\nconst programOrStudyPeriodNotListed = (data.myProgramNotListed ? data.myProgramNotListed.programnotListed : false) ||\n        (data.myStudyPeriodIsntListed ? data.myStudyPeriodIsntListed.offeringnotListed : false);\nshow = !data.isReadOnly && data.hasPreviouslyCompletedPIR && programOrStudyPeriodNotListed &&  !data.isChangeRequestApplication;",
+                  "type": "panel",
+                  "label": "Panel",
+                  "input": false,
+                  "tableView": false,
+                  "components": [
+                    {
+                      "label": "HTML",
+                      "tag": "p",
+                      "className": "alert alert-info fa fa-info-circle",
+                      "attrs": [
+                        {
+                          "attr": "",
+                          "value": ""
+                        }
+                      ],
+                      "content": " <strong>Info!</strong><br />If you need your institution to review or update your program information, you can request a new program information request. Select the checkbox below to send a new request.",
+                      "refreshOnChange": false,
+                      "customClass": "banner-info",
+                      "key": "html2",
+                      "type": "htmlelement",
+                      "input": false,
+                      "tableView": false
+                    },
+                    {
+                      "label": "Request resubmission of program information request.",
+                      "tableView": false,
+                      "persistent": "client-only",
+                      "validateWhenHidden": false,
+                      "key": "requestPIRResubmission",
+                      "type": "checkbox",
+                      "input": true,
+                      "defaultValue": false
+                    }
+                  ]
+                },
+                {
                   "label": "Study period end date warning",
                   "tag": "p",
                   "className": "alert alert-warning fa fa-exclamation-triangle w-100",
@@ -1527,7 +1568,7 @@
         },
         {
           "label": "Program persistent properties",
-          "calculateValue": "value = [\r\n  \"selectedLocation\",\r\n  \"mySchoolIsNotListed\",\r\n  \"selectedProgram\",\r\n  \"myProgramNotListed\",\r\n  \"programName\",\r\n  \"programDescription\",\r\n  \"studystartDate\",\r\n  \"studyendDate\",\r\n  \"selectedOffering\",\r\n  \"myStudyPeriodIsntListed\",\r\n  \"courseDetails\",\r\n  \"studentNumber\",\r\n];",
+          "calculateValue": "value = [\r\n  \"selectedLocation\",\r\n  \"mySchoolIsNotListed\",\r\n  \"selectedProgram\",\r\n  \"myProgramNotListed\",\r\n  \"programName\",\r\n  \"programDescription\",\r\n  \"studystartDate\",\r\n  \"studyendDate\",\r\n  \"selectedOffering\",\r\n  \"myStudyPeriodIsntListed\",\r\n  \"courseDetails\",\r\n  \"studentNumber\",\r\n  \"pirResubmissionDate\",\r\n];",
           "calculateServer": true,
           "key": "programPersistentProperties",
           "type": "hidden",
@@ -1546,6 +1587,21 @@
           "persistent": false,
           "calculateValue": "const selectedLocationProgramRestrictions =  data.selectedLocationProgramRestrictions || [];\n\nvalue = selectedLocationProgramRestrictions.some((restriction) =>\n  restriction.restrictionActions.includes(\"Stop part time disbursement\")\n);",
           "key": "isSelectedLocationProgramRestricted",
+          "type": "hidden",
+          "input": true,
+          "tableView": false
+        },
+        {
+          "label": "PIR resubmission date",
+          "key": "pirResubmissionDate",
+          "type": "hidden",
+          "input": true,
+          "tableView": false
+        },
+        {
+          "label": "Has previously completed PIR",
+          "persistent": "client-only",
+          "key": "hasPreviouslyCompletedPIR",
           "type": "hidden",
           "input": true,
           "tableView": false

--- a/sources/packages/forms/src/form-definitions/sfaa2026-27-pt.json
+++ b/sources/packages/forms/src/form-definitions/sfaa2026-27-pt.json
@@ -1136,6 +1136,7 @@
                 },
                 {
                   "title": "PIR Resubmission",
+                  "customClass": "panel-border-none",
                   "collapsible": false,
                   "hideLabel": true,
                   "key": "panel5",

--- a/sources/packages/web/src/components/common/StudentApplication.vue
+++ b/sources/packages/web/src/components/common/StudentApplication.vue
@@ -59,6 +59,7 @@ import {
 } from "@/types";
 import { ref, watch, defineComponent, computed, PropType } from "vue";
 import {
+  useFormatters,
   useFormioComponentLoader,
   useFormioDropdownLoader,
   useFormioUtils,
@@ -121,6 +122,8 @@ export default defineComponent({
     const OFFERING_NOT_LISTED = "myStudyPeriodIsntListed";
     const SELECTED_LOCATION_PROGRAM_RESTRICTIONS_KEY =
       "selectedLocationProgramRestrictions";
+    const REQUEST_PIR_RESUBMISSION_KEY = "requestPIRResubmission";
+    const PIR_RESUBMISSION_DATE_KEY = "pirResubmissionDate";
     let formInstance: any;
     const formioUtils = useFormioUtils();
     const formioDataLoader = useFormioDropdownLoader();
@@ -129,6 +132,7 @@ export default defineComponent({
     const isLastPage = ref(false);
     const showNav = ref(false);
     const isFormLoaded = ref(false);
+    const { getISODateHourMinuteString } = useFormatters();
     let offeringIntensity: OfferingIntensity;
 
     const wizardPrimaryLabel = computed(() => {
@@ -387,6 +391,29 @@ export default defineComponent({
         event.changed.value?.programnotListed
       ) {
         resetSelectedOfferingDetails(form);
+      }
+
+      // Handle updates to 'Request resubmission of program information request.'
+      if (event.changed?.component.key === REQUEST_PIR_RESUBMISSION_KEY) {
+        if (event.changed.value) {
+          // When selected, set pirResubmissionDate to the current date/time to force a new value for the pirHash.
+          // TODO Confirm date format
+          const currentDateTime = getISODateHourMinuteString(new Date());
+          formioUtils.setComponentValue(
+            form,
+            PIR_RESUBMISSION_DATE_KEY,
+            currentDateTime,
+          );
+        } else {
+          // When deselected, reset pirResubmissionDate to the persisted date/time so the pirHash isn't erroneously updated.
+          const initialPirResubmissionDate =
+            props.initialData[PIR_RESUBMISSION_DATE_KEY];
+          formioUtils.setComponentValue(
+            form,
+            PIR_RESUBMISSION_DATE_KEY,
+            initialPirResubmissionDate,
+          );
+        }
       }
     };
 

--- a/sources/packages/web/src/components/common/StudentApplication.vue
+++ b/sources/packages/web/src/components/common/StudentApplication.vue
@@ -59,7 +59,6 @@ import {
 } from "@/types";
 import { ref, watch, defineComponent, computed, PropType } from "vue";
 import {
-  useFormatters,
   useFormioComponentLoader,
   useFormioDropdownLoader,
   useFormioUtils,
@@ -132,7 +131,6 @@ export default defineComponent({
     const isLastPage = ref(false);
     const showNav = ref(false);
     const isFormLoaded = ref(false);
-    const { getISODateHourMinuteString } = useFormatters();
     let offeringIntensity: OfferingIntensity;
 
     const wizardPrimaryLabel = computed(() => {
@@ -371,50 +369,58 @@ export default defineComponent({
           SELECTED_OFFERING_END_DATE_KEY,
         );
       }
-      // If the user after selecting a study period finds that
-      // they need to check my study period not listed, then
-      // the details of previously selected
-      // study period must be cleared.
-      if (
-        event.changed?.component.key === OFFERING_NOT_LISTED &&
-        event.changed.value?.offeringnotListed
-      ) {
-        resetSelectedOfferingDetails(form);
-      }
 
-      // If the user after selecting a study period finds that
-      // they need to check my program not listed, then
-      // the details of previously selected
-      // study period must be cleared.
-      if (
-        event.changed?.component.key === PROGRAM_NOT_LISTED &&
-        event.changed.value?.programnotListed
-      ) {
-        resetSelectedOfferingDetails(form);
-      }
-
-      // Handle updates to 'Request resubmission of program information request.'
-      if (event.changed?.component.key === REQUEST_PIR_RESUBMISSION_KEY) {
-        if (event.changed.value) {
-          // When selected, set pirResubmissionDate to the current date/time to force a new value for the pirHash.
-          // TODO Confirm date format
-          const currentDateTime = getISODateHourMinuteString(new Date());
-          formioUtils.setComponentValue(
-            form,
-            PIR_RESUBMISSION_DATE_KEY,
-            currentDateTime,
-          );
+      if (event.changed?.component.key === OFFERING_NOT_LISTED) {
+        // If the user after selecting a study period finds that
+        // they need to check my study period not listed, then
+        // the details of previously selected
+        // study period must be cleared.
+        if (event.changed.value?.offeringnotListed) {
+          resetSelectedOfferingDetails(form);
         } else {
-          // When deselected, reset pirResubmissionDate to the persisted date/time so the pirHash isn't erroneously updated.
-          const initialPirResubmissionDate =
-            props.initialData[PIR_RESUBMISSION_DATE_KEY];
-          formioUtils.setComponentValue(
-            form,
-            PIR_RESUBMISSION_DATE_KEY,
-            initialPirResubmissionDate,
-          );
+          // If the user unchecks 'Your study dates are not listed.'
+          // then the pirResubmissionDate must be reset to avoid an erroneous update to the pirHash.
+          resetResubmissionDate(form);
         }
       }
+
+      if (event.changed?.component.key === PROGRAM_NOT_LISTED) {
+        // If the user after selecting a study period finds that
+        // they need to check my program not listed, then
+        // the details of previously selected
+        // study period must be cleared.
+        if (event.changed.value?.programnotListed) {
+          resetSelectedOfferingDetails(form);
+        } else {
+          // If the user unchecks 'Your program is not listed.'
+          // then the pirResubmissionDate must be reset to avoid an erroneous update to the pirHash.
+          resetResubmissionDate(form);
+        }
+      }
+
+      if (event.changed?.component.key === REQUEST_PIR_RESUBMISSION_KEY) {
+        // If the user selects 'Request resubmission...',
+        // set pirResubmissionDate to the current date/time to force a new value for the pirHash.
+        if (event.changed.value) {
+          formioUtils.setComponentValue(
+            form,
+            PIR_RESUBMISSION_DATE_KEY,
+            new Date(),
+          );
+        } else {
+          // If the user unselects 'Request resubmission...',
+          // then the pirResubmissionDate must be reset to avoid an erroneous update to the pirHash.
+          resetResubmissionDate(form);
+        }
+      }
+    };
+
+    const resetResubmissionDate = (form: FormIOForm) => {
+      formioUtils.setComponentValue(
+        form,
+        PIR_RESUBMISSION_DATE_KEY,
+        props.initialData[PIR_RESUBMISSION_DATE_KEY],
+      );
     };
 
     const resetSelectedOfferingDetails = (form: FormIOForm) => {

--- a/sources/packages/web/src/components/common/StudentApplication.vue
+++ b/sources/packages/web/src/components/common/StudentApplication.vue
@@ -416,11 +416,13 @@ export default defineComponent({
     };
 
     const resetResubmissionDate = (form: FormIOForm) => {
-      formioUtils.setComponentValue(
-        form,
-        PIR_RESUBMISSION_DATE_KEY,
-        props.initialData[PIR_RESUBMISSION_DATE_KEY],
-      );
+      if (formioUtils.getComponent(form, PIR_RESUBMISSION_DATE_KEY)) {
+        formioUtils.setComponentValue(
+          form,
+          PIR_RESUBMISSION_DATE_KEY,
+          props.initialData[PIR_RESUBMISSION_DATE_KEY],
+        );
+      }
     };
 
     const resetSelectedOfferingDetails = (form: FormIOForm) => {

--- a/sources/packages/web/src/services/http/dto/Application.dto.ts
+++ b/sources/packages/web/src/services/http/dto/Application.dto.ts
@@ -126,7 +126,7 @@ export interface ApplicationDataAPIOutDTO extends ApplicationBaseAPIOutDTO {
   programYearStartDate: string;
   programYearEndDate: string;
   submittedDate?: Date;
-  hasPreviouslyCompletedPIR?: boolean;
+  hasPreviouslyCompletedPIR: boolean;
 }
 
 export interface ApplicationDataChangeAPIOutDTO {

--- a/sources/packages/web/src/services/http/dto/Application.dto.ts
+++ b/sources/packages/web/src/services/http/dto/Application.dto.ts
@@ -126,6 +126,7 @@ export interface ApplicationDataAPIOutDTO extends ApplicationBaseAPIOutDTO {
   programYearStartDate: string;
   programYearEndDate: string;
   submittedDate?: Date;
+  hasPreviouslyCompletedPIR?: boolean;
 }
 
 export interface ApplicationDataChangeAPIOutDTO {

--- a/sources/packages/web/src/views/student/financial-aid-application/FullTimeApplication.vue
+++ b/sources/packages/web/src/views/student/financial-aid-application/FullTimeApplication.vue
@@ -272,6 +272,7 @@ export default defineComponent({
         isFulltimeAllowed,
         allowBetaInstitutionsOnly,
         applicationSubmissionDeadlineWeeks,
+        hasPreviouslyCompletedPIR: applicationData.hasPreviouslyCompletedPIR,
       };
       existingApplication.value = applicationData;
       isDataReady.value = true;


### PR DESCRIPTION
## Summary
- Adds the ability to resubmit a PIR when the PIR program/offering details have not changed
- At least one previously **Completed** PIR must be present
- Renamed existing service method to match standards
- Added missing E2E tests with specific scenarios assertions for new PIR flag
- Updated tsconfig.js to supress class initialization errors

### Technical Decisions
- As proposed a new hidden, persisted field `pirResubmissionDate` was used to track the latest date of resubmission in order to force a new `pirHash` and therefore Required PIR
- UI logic for the checkbox is implemented in the component as there is an existing `formChanged` handler
- Logic to determine whether resubsmission is allowed is determined flag populated by a backend query. Because the flag is only required for Students and it would add complexity to the shared `ApplicationService.getApplicationById` method, a separate query was used.

## Screenshots
### Program Not Listed
<img width="1256" height="869" alt="image" src="https://github.com/user-attachments/assets/b6946ba0-5969-4a4b-ab4d-462e5081ed23" />

### Offering Not Listed
<img width="1284" height="988" alt="image" src="https://github.com/user-attachments/assets/fe64373a-a79f-4194-92ea-f3d8b2196fe8" />

## E2E Tests
### ApplicationStudentsController(e2e)-getApplication
<img width="1405" height="331" alt="image" src="https://github.com/user-attachments/assets/52641830-bc64-44fd-935e-dadb955d95d3" />
