### PR TITLE
#5618 - Update sysdig teams and group deployed packages

### DIFF
--- a/devops/Makefile
+++ b/devops/Makefile
@@ -691,3 +691,12 @@ update-sysdig-team:
 	@echo "Updating Sysdig Team for license plate a6ef19.\n"
 	@oc project a6ef19-tools
 	@oc process -f openshift/sysdig-team.yml -p LICENSE_PLATE=a6ef19 | oc apply -f -
+
+# TODO: Rename to update-sysdig-team after the migration is complete in prod and the silver license plates are no longer in use.
+update-sysdig-team-gold:
+	@echo "Updating Sysdig Team for license plate e0a504.\n"
+	@oc project e0a504-tools
+	@oc process -f openshift/sysdig-team.yml -p LICENSE_PLATE=e0a504 | oc apply -f -
+	@echo "Updating Sysdig Team for license plate c85dee.\n"
+	@oc project c85dee-tools
+	@oc process -f openshift/sysdig-team.yml -p LICENSE_PLATE=c85dee | oc apply -f -

--- a/devops/openshift/api-deploy.yml
+++ b/devops/openshift/api-deploy.yml
@@ -9,8 +9,11 @@ objects:
   - apiVersion: apps/v1
     kind: Deployment
     metadata:
+      annotations:
+        app.openshift.io/connects-to: '[{ "apiVersion": "apps/v1", "kind": "StatefulSet", "name": "redis-cluster" }]'
       labels:
         app: ${NAME}
+        app.kubernetes.io/part-of: sims-packages-group
       name: ${NAME}
     spec:
       replicas: "${{REPLICAS}}"

--- a/devops/openshift/migrations-job.yml
+++ b/devops/openshift/migrations-job.yml
@@ -12,6 +12,8 @@ objects:
     kind: Job
     metadata:
       name: ${JOB_NAME}
+      labels:
+        app.kubernetes.io/part-of: sims-packages-group
     spec:
       activeDeadlineSeconds: ${{ACTIVE_DEADLINE_SECONDS}} # The maximum duration the job can run.
       backoffLimit: 5 # The number of retries for a job.

--- a/devops/openshift/queue-consumers-deploy.yml
+++ b/devops/openshift/queue-consumers-deploy.yml
@@ -9,8 +9,11 @@ objects:
   - apiVersion: apps/v1
     kind: Deployment
     metadata:
+      annotations:
+        app.openshift.io/connects-to: '[{ "apiVersion": "apps/v1", "kind": "StatefulSet", "name": "redis-cluster" }, { "apiVersion": "apps/v1", "kind": "StatefulSet", "name": "clamav" }]'
       labels:
         app: ${NAME}
+        app.kubernetes.io/part-of: sims-packages-group
       name: ${NAME}
     spec:
       replicas: "${{REPLICAS}}"

--- a/devops/openshift/web-deploy.yml
+++ b/devops/openshift/web-deploy.yml
@@ -11,6 +11,7 @@ objects:
     metadata:
       labels:
         app: ${NAME}
+        app.kubernetes.io/part-of: sims-packages-group
       name: ${NAME}
     spec:
       replicas: "${{REPLICAS}}"

--- a/devops/openshift/workers-deploy.yml
+++ b/devops/openshift/workers-deploy.yml
@@ -11,6 +11,7 @@ objects:
     metadata:
       labels:
         app: ${NAME}
+        app.kubernetes.io/part-of: sims-packages-group
       name: ${NAME}
     spec:
       replicas: "${{REPLICAS}}"


### PR DESCRIPTION
 - [x] Added a make command for sysdig teams to include new license plates (Separate command was used as the SA token for silver will not have access to deploy in gold cluster)
 - [x] The SIMS packages which are part of release(API, Web, Workers, Queue Consumers and Migrations) are added to a group in OC `sims-packages-group`
 - [x] Added visual connections on OC from sims-api to redis and queue consumers to redis and clamav.