### PR TITLE
#5117 - PY 26/27: Independent Student: Remove Parent Information Tab

### DIFF
--- a/sources/packages/forms/src/form-definitions/sfaa2026-27-ft.json
+++ b/sources/packages/forms/src/form-definitions/sfaa2026-27-ft.json
@@ -2765,9 +2765,18 @@
           "label": "Panel"
         },
         {
-          "key": "parentInformationPanel",
-          "input": false,
           "title": "Parent information panel",
+          "collapsible": false,
+          "hideLabel": true,
+          "key": "parentInformationPanel",
+          "conditional": {
+            "show": true,
+            "when": "dependantstatus",
+            "eq": "dependant"
+          },
+          "type": "panel",
+          "label": "Panel",
+          "input": false,
           "tableView": false,
           "components": [
             {
@@ -2884,10 +2893,7 @@
               "tableView": false,
               "hideLabel": true
             }
-          ],
-          "type": "panel",
-          "hideLabel": true,
-          "label": "Panel"
+          ]
         },
         {
           "title": "Disability information panel",
@@ -3986,8 +3992,18 @@
           "calculateServer": true
         },
         {
+          "label": "Is estranged from parents",
+          "calculateValue": "if (data.parentsDeceased === \"yes\") {\r\n  instance.setValue(\"no\");\r\n} else {\r\n  instance.setValue(data.estrangedFromParents ?? null);\r\n}",
+          "calculateServer": true,
+          "key": "isEstrangedFromParents",
+          "type": "hidden",
+          "input": true,
+          "tableView": false,
+          "lockKey": true
+        },
+        {
           "label": "Dependant Status",
-          "calculateValue": "const isStudentIndependant =\r\n  data.hasDependents === \"yes\" ||\r\n  [\"married\", \"other\", \"marriedUnable\"].includes(data.relationshipStatus) ||\r\n  data.outOfHighSchoolFor4Years === \"yes\" ||\r\n  data.fulltimelabourForce === \"yes\" ||\r\n  data.parentsDeceased === \"yes\" ||\r\n  data.estrangedFromParents === \"yes\" ||\r\n  data.custodyOfChildWelfare === \"yes\";\r\n// If the student is not independant, dependant status is calculated based on personal information answer inputs.\r\nif (!isStudentIndependant) {\r\n  const isPersonalInfoAnswered =\r\n    !!data.hasDependents &&\r\n    !!data.relationshipStatus &&\r\n    !!data.outOfHighSchoolFor4Years &&\r\n    !!data.fulltimelabourForce &&\r\n    !!data.parentsDeceased &&\r\n    !!data.estrangedFromParents && // Considered to be \"no\" at this moment.\r\n    !!data.youthInCare &&\r\n    (data.youthInCare === \"no\" || !!data.custodyOfChildWelfare);\r\n  // If the answers to required personal information inputs are not provided, set the dependant status to null.\r\n  // Otherwise, dependant status is calculated based on personal information answers.\r\n  const calculatedStatusFromPersonalInfo = isPersonalInfoAnswered\r\n    ? \"dependant\"\r\n    : null;\r\n  instance.setValue(calculatedStatusFromPersonalInfo);\r\n} else {\r\n  instance.setValue(\"independant\");\r\n}",
+          "calculateValue": "const isStudentIndependant =\r\n  data.hasDependents === \"yes\" ||\r\n  [\"married\", \"other\", \"marriedUnable\"].includes(data.relationshipStatus) ||\r\n  data.outOfHighSchoolFor4Years === \"yes\" ||\r\n  data.fulltimelabourForce === \"yes\" ||\r\n  data.parentsDeceased === \"yes\" ||\r\n  data.isEstrangedFromParents === \"yes\" ||\r\n  data.custodyOfChildWelfare === \"yes\";\r\n// If the student is not independant, dependant status is calculated based on personal information answer inputs.\r\nif (!isStudentIndependant) {\r\n  const isPersonalInfoAnswered =\r\n    !!data.hasDependents &&\r\n    !!data.relationshipStatus &&\r\n    !!data.outOfHighSchoolFor4Years &&\r\n    !!data.fulltimelabourForce &&\r\n    !!data.youthInCare &&\r\n    (data.youthInCare === \"no\" || !!data.custodyOfChildWelfare);\r\n  // If the answers to required personal information inputs are not provided, set the dependant status to null.\r\n  // Otherwise, dependant status is calculated based on personal information answers.\r\n  const calculatedStatusFromPersonalInfo = isPersonalInfoAnswered\r\n    ? \"dependant\"\r\n    : null;\r\n  instance.setValue(calculatedStatusFromPersonalInfo);\r\n} else {\r\n  instance.setValue(\"independant\");\r\n}",
           "calculateServer": true,
           "key": "dependantstatus",
           "type": "hidden",


### PR DESCRIPTION
**As a part of this PR, the following was completed:**

Changed the logic for the PY 26/27 FT form to display the Parent Information only if the student is dependant.