### PR TITLE
#5722 - Remove form header

### DIFF
--- a/sources/packages/forms/src/form-definitions/parentcurrentyearincomeappeal.json
+++ b/sources/packages/forms/src/form-definitions/parentcurrentyearincomeappeal.json
@@ -254,23 +254,6 @@
                   "requireDecimal": true
                 },
                 {
-                  "label": "HTML",
-                  "attrs": [
-                    {
-                      "attr": "",
-                      "value": ""
-                    }
-                  ],
-                  "content": "Reason for Significant Decrease in Gross Income",
-                  "refreshOnChange": false,
-                  "key": "html4",
-                  "type": "htmlelement",
-                  "input": false,
-                  "tableView": false,
-                  "hideLabel": true,
-                  "tag": "p"
-                },
-                {
                   "label": "Select the reason that best describes the decrease in your parent’s gross income:",
                   "optionsLabelPosition": "right",
                   "inline": false,


### PR DESCRIPTION
## Summary
- Header identified during demo wasn't styled correctly. Upon further review, the decision was made to remove it entirely to make it consistent with partner current year income appeal.

## Screenshots
<img width="1341" height="823" alt="image" src="https://github.com/user-attachments/assets/cf47a909-bb38-453c-b2b2-1dae791fe71c" />
