### PR TITLE
#5722 - Add parent id dry-run validation

### DIFF
--- a/sources/packages/forms/src/form-definitions/parentcurrentyearincomeappeal.json
+++ b/sources/packages/forms/src/form-definitions/parentcurrentyearincomeappeal.json
@@ -51,7 +51,6 @@
     },
     {
       "label": "Parents",
-      "persistent": false,
       "key": "parents",
       "tags": [
         "supplementary-data"
@@ -127,7 +126,7 @@
       "clearOnHide": false,
       "calculateValue": "value = data.parents;",
       "validate": {
-        "custom": "// Don't validate until required fields are entered\r\nif (data.parentsIncome.some(parent => !parent.hasCurrentYearParentIncome)) {\r\n  valid = true;\r\n} else {\r\n  const errorMessage = 'An income appeal must be submitted for at least one parent';\r\n  valid = data.parentsIncome.some(parent => parent.hasCurrentYearParentIncome === 'yes') ? true : errorMessage;    \r\n}"
+        "custom": "let errorMessage;\r\n\r\n// Only validate if all parents have a value selected\r\nif (data.parentsIncome.every(parent => parent.hasCurrentYearParentIncome)) {\r\n\r\n  // Get allowed values from injected property 'parents'.\r\n  const allowedValues = !!data.parents\r\n   ? data.parents.map((parent) => parent.id)\r\n   : [];\r\n\r\n  if (!data.parentsIncome.some(parent => parent.hasCurrentYearParentIncome === 'yes')) {\r\n    errorMessage = 'An income appeal must be submitted for at least one parent.';\r\n  } else if (!data.parentsIncome.every(parent => allowedValues.includes(parent.id))) {\r\n    errorMessage = 'Invalid value for parent(s).';\r\n  }\r\n}\r\nvalid = errorMessage || true;"
       },
       "validateWhenHidden": false,
       "key": "parentsIncome",


### PR DESCRIPTION
## Summary
- Adds custom validation to ensure invalid parent ids aren't submitted directly to the server.

<img width="978" height="777" alt="image" src="https://github.com/user-attachments/assets/f7ca87ab-cb9a-4f7c-8678-927c0e4b5583" />

<img width="1498" height="911" alt="image" src="https://github.com/user-attachments/assets/18c8a3e1-1539-473f-9501-d3cb2f2d404c" />