### PR TITLE
#2905 - Fix Formio CICD Container Unhealthy

### DIFF
--- a/sources/tests/Makefile
+++ b/sources/tests/Makefile
@@ -42,7 +42,7 @@ e2e-tests-api:
 	@echo "+\n++ Make: Deploying form definitions \n+"
 	@cd ../packages/forms && npm ci && npm run deploy
 	@echo "+\n++ Make: Running API E2E tests \n+"
-	@docker compose run --name api-e2e-$(BUILD_REF) api npm run test:e2e:api
+	@docker compose run --no-deps --name api-e2e-$(BUILD_REF) api npm run test:e2e:api
 	@mkdir -p coverage/api
 	@docker cp api-e2e-$(BUILD_REF):app/apps/api/coverage/clover.xml coverage/api
 	@docker rm api-e2e-$(BUILD_REF)


### PR DESCRIPTION
### Summary

Avoids a recreate/restart on the dependency containers since they were already running with the docker compose up command.