### PR TITLE
#5896 - Add configuration for health check timeout

### DIFF
--- a/configs/env-example
+++ b/configs/env-example
@@ -1,11 +1,9 @@
 # Set time zone for the same expected from Openshift.
-
 TZ=UTC
 
 VERSION=v0.0.1
 
 # Project Specific Env
-
 PROJECT_NAME=sims
 ENVIRONMENT=local
 BUILD_REF=dev
@@ -16,7 +14,6 @@ SWAGGER_ENABLED=true
 APPLICATION_ARCHIVE_DAYS=365
 
 # Database
-
 POSTGRES_USER=
 POSTGRES_PASSWORD=
 POSTGRES_DB=
@@ -27,7 +24,6 @@ DB_POOL_MAX_CONNECTIONS=10 # Example maximum number of connections in the databa
 DB_CONNECTION_REQUEST_TIMEOUT=120000 # Example timeout in milliseconds to wait for a database connection.
 
 # KeyCloak
-
 KEYCLOAK_AUTH_URL=
 KEYCLOAK_REALM=
 KEYCLOAK_CLIENT_STUDENT=
@@ -36,7 +32,6 @@ KEYCLOAK_CLIENT_AEST=
 KEYCLOAK_CLIENT_SUPPORTING_USERS=
 
 # E2E Test
-
 E2E_TEST_STUDENT_USERNAME=student_e2e_test
 E2E_TEST_STUDENT_PASSWORD=ADD_THE_PASSWORD_HERE_TO_RUN_LOCALLY
 
@@ -49,9 +44,7 @@ E2E_TEST_AEST_MOF_OPERATIONS_USER=ministry-user-mof-operations@e2e-tests
 E2E_TEST_AEST_READ_ONLY_USER=ministry-user-read-only@e2e-tests
 
 E2E_TEST_EXTERNAL_USER_CLIENT_SECRET=ADD_THE_PASSWORD_HERE_TO_RUN_LOCALLY
-
 # BCeID Web Service - These variables are used only to run the application locally.
-
 BCeID_WEB_SERVICE_WSDL=https://gws1.test.bceid.ca/webservices/Client/V10/BCeIDService.asmx?wsdl
 BCeID_WEB_SERVICE_ONLINE_SERVICE_ID=
 BCeID_WEB_SERVICE_REQUESTER_USER_GUID=
@@ -59,28 +52,22 @@ BCeID_WEB_SERVICE_AUTH_USER_NAME=
 BCeID_WEB_SERVICE_AUTH_USER_PASSWORD=
 
 # GC Notify Web Service - These variables are used to send Email notifications.
-
 GC_NOTIFY_URL=https://api.notification.canada.ca/v2/notifications/email
 GC_NOTIFY_API_KEY=
 
 # Devops/openshift Make init-zone-b-sftp-secret
-
 INIT_ZONE_B_SFTP_SERVER=
 INIT_ZONE_B_SFTP_SERVER_PORT=
 INIT_ZONE_B_SFTP_USER_NAME=
 INIT_ZONE_B_SFTP_PRIVATE_KEY_PASSPHRASE=
 
 # Forms Related
-
 FORMS_URL=
-
 # Service Account
-
 FORMS_SA_USER_NAME=
 FORMS_SA_PASSWORD=
 
 # Dummy BCeID account response
-
 DUMMY_BCeID_ACCOUNT_RESPONSE=no
 
 #CRA Integration
@@ -93,27 +80,16 @@ ZONE_B_SFTP_SERVER_PORT=
 ZONE_B_SFTP_USER_NAME=
 ZONE_B_SFTP_PRIVATE_KEY_PASSPHRASE=
 ZONE_B_SFTP_PRIVATE_KEY=
-
 # When defined as true, allows the simulation of a complete cycle of the
-
 # CRA send/response process that allows the workflow to proceed without
-
 # the need for the actual CRA verification happens. By default, it should be
-
 # disabled, and should be enabled only for DEV purposes on local developer
-
 # machine or on an environment where the CRA process is not enabled.
-
 BYPASS_CRA_INCOME_VERIFICATION=false
-
 # When defined as true, bypasses the MSFAA signing process.
-
 # The MSFAA process will execute all steps expected trying to
-
 # finding an available MSFAA to be reused.
-
 # If no MSFAA is available, a new one will be created and signed.
-
 BYPASS_MSFAA_SIGNING=false
 #ESDC Integration
 ESDC_REQUEST_FOLDER=
@@ -125,13 +101,10 @@ ATBC_LOGIN_ENDPOINT=
 ATBC_USERNAME=
 ATBC_PASSWORD=
 ATBC_APP=
-
-# add till /api
-
+# add till  /api
 ATBC_ENDPOINT=
 
 # File Upload Global Config
-
 FILE_UPLOAD_MAX_FILE_SIZE=15728640
 FILE_UPLOAD_ALLOWED_EXTENSIONS=.pdf,.doc,.docx,.jpg,.png
 
@@ -162,18 +135,14 @@ FILE_NAME= cypress.env.json
 FILE_PATH= SIMS\testing\functional\tests\cypress.env.json
 
 # Zeebe (only the 3 below are neeed for local development)
-
 ZEEBE_GRPC_ADDRESS=grpc://localhost:26500
 CAMUNDA_OAUTH_DISABLED=true
 ZEEBE_CLIENT_ID=
 ZEEBE_CLIENT_SECRET=
 CAMUNDA_OAUTH_URL=
 ZEEBE_GRPC_WORKER_LONGPOLL_SECONDS=45
-
 # Max retries ensures that if the grpc connection cannot be established within maximum
-
 # number of retry then the process with terminate.
-
 ZEEBE_CLIENT_MAX_RETRIES=20
 
 #Redis and queue properties
@@ -183,9 +152,7 @@ REDIS_PASSWORD=
 REDIS_STANDALONE_MODE=true
 QUEUE_CONSUMERS_PORT=3010
 QUEUE_PREFIX={sims-local}
-
 # The below secret should be set with any valid base 64 string for local development.
-
 QUEUE_DASHBOARD_TOKEN_SECRET=
 QUEUE_DASHBOARD_TOKEN_EXPIRATION_SECONDS=3600
 QUEUE_DASHBOARD_BASE_URL=http://localhost:3010
@@ -201,13 +168,11 @@ WORKERS_PORT=
 LOAD_TEST_API_PORT=
 
 # CAS integration configuration
-
 CAS_BASE_URL=
 CAS_CLIENT_ID=
 CAS_CLIENT_SECRET=
 
 # S3 Storage
-
 S3_ACCESS_KEY_ID=
 S3_SECRET_ACCESS_KEY=
 S3_ENDPOINT=
@@ -215,35 +180,27 @@ S3_DEFAULT_BUCKET=sims-local
 S3_REGION=
 
 # Logged Out due to inactivity, wait times in seconds.
-
 MAXIMUM_IDLE_TIME_FOR_WARNING_STUDENT =
 MAXIMUM_IDLE_TIME_FOR_WARNING_INSTITUTION =
 MAXIMUM_IDLE_TIME_FOR_WARNING_SUPPORTING_USER =
 MAXIMUM_IDLE_TIME_FOR_WARNING_AEST =
 
 # Application Submission Deadline in weeks.
-
 APPLICATION_SUBMISSION_DEADLINE_WEEKS=
 
 # Allow beta users only to access the system if true.
-
 ALLOW_BETA_USERS_ONLY=
 
 # Allow full-time application submissions only for beta institution locations if true.
-
 ALLOW_BETA_INSTITUTIONS_ONLY=
 
 # Throttling Configuration: time window in milliseconds (THROTTLE_TIME) and request limit per window (THROTTLE_LIMIT).
-
 THROTTLE_TIME=10000
 THROTTLE_LIMIT=30
 
 # App Environment
-
 APP_ENV=
 
 # A comma-separated list of feature toggles to enable specific features in the application.
-
 # For example: "SOME_FEATURE_TOGGLE,ANOTHER_FEATURE_TOGGLE".
-
 FEATURE_TOGGLES=

--- a/configs/env-example
+++ b/configs/env-example
@@ -22,6 +22,7 @@ DB_SCHEMA=sims
 DISABLE_ORM_CACHE=
 DB_POOL_MAX_CONNECTIONS=10 # Example maximum number of connections in the database pool.
 DB_CONNECTION_REQUEST_TIMEOUT=120000 # Example timeout in milliseconds to wait for a database connection.
+DB_HEALTH_CHECK_TIMEOUT=3000 # Example timeout in milliseconds for the database health check ping.
 
 # KeyCloak
 KEYCLOAK_AUTH_URL=

--- a/configs/env-example
+++ b/configs/env-example
@@ -1,9 +1,11 @@
 # Set time zone for the same expected from Openshift.
+
 TZ=UTC
 
 VERSION=v0.0.1
 
 # Project Specific Env
+
 PROJECT_NAME=sims
 ENVIRONMENT=local
 BUILD_REF=dev
@@ -14,6 +16,7 @@ SWAGGER_ENABLED=true
 APPLICATION_ARCHIVE_DAYS=365
 
 # Database
+
 POSTGRES_USER=
 POSTGRES_PASSWORD=
 POSTGRES_DB=
@@ -22,9 +25,9 @@ DB_SCHEMA=sims
 DISABLE_ORM_CACHE=
 DB_POOL_MAX_CONNECTIONS=10 # Example maximum number of connections in the database pool.
 DB_CONNECTION_REQUEST_TIMEOUT=120000 # Example timeout in milliseconds to wait for a database connection.
-DB_HEALTH_CHECK_TIMEOUT=3000 # Example timeout in milliseconds for the database health check ping.
 
 # KeyCloak
+
 KEYCLOAK_AUTH_URL=
 KEYCLOAK_REALM=
 KEYCLOAK_CLIENT_STUDENT=
@@ -33,6 +36,7 @@ KEYCLOAK_CLIENT_AEST=
 KEYCLOAK_CLIENT_SUPPORTING_USERS=
 
 # E2E Test
+
 E2E_TEST_STUDENT_USERNAME=student_e2e_test
 E2E_TEST_STUDENT_PASSWORD=ADD_THE_PASSWORD_HERE_TO_RUN_LOCALLY
 
@@ -45,7 +49,9 @@ E2E_TEST_AEST_MOF_OPERATIONS_USER=ministry-user-mof-operations@e2e-tests
 E2E_TEST_AEST_READ_ONLY_USER=ministry-user-read-only@e2e-tests
 
 E2E_TEST_EXTERNAL_USER_CLIENT_SECRET=ADD_THE_PASSWORD_HERE_TO_RUN_LOCALLY
+
 # BCeID Web Service - These variables are used only to run the application locally.
+
 BCeID_WEB_SERVICE_WSDL=https://gws1.test.bceid.ca/webservices/Client/V10/BCeIDService.asmx?wsdl
 BCeID_WEB_SERVICE_ONLINE_SERVICE_ID=
 BCeID_WEB_SERVICE_REQUESTER_USER_GUID=
@@ -53,22 +59,28 @@ BCeID_WEB_SERVICE_AUTH_USER_NAME=
 BCeID_WEB_SERVICE_AUTH_USER_PASSWORD=
 
 # GC Notify Web Service - These variables are used to send Email notifications.
+
 GC_NOTIFY_URL=https://api.notification.canada.ca/v2/notifications/email
 GC_NOTIFY_API_KEY=
 
 # Devops/openshift Make init-zone-b-sftp-secret
+
 INIT_ZONE_B_SFTP_SERVER=
 INIT_ZONE_B_SFTP_SERVER_PORT=
 INIT_ZONE_B_SFTP_USER_NAME=
 INIT_ZONE_B_SFTP_PRIVATE_KEY_PASSPHRASE=
 
 # Forms Related
+
 FORMS_URL=
+
 # Service Account
+
 FORMS_SA_USER_NAME=
 FORMS_SA_PASSWORD=
 
 # Dummy BCeID account response
+
 DUMMY_BCeID_ACCOUNT_RESPONSE=no
 
 #CRA Integration
@@ -81,16 +93,27 @@ ZONE_B_SFTP_SERVER_PORT=
 ZONE_B_SFTP_USER_NAME=
 ZONE_B_SFTP_PRIVATE_KEY_PASSPHRASE=
 ZONE_B_SFTP_PRIVATE_KEY=
+
 # When defined as true, allows the simulation of a complete cycle of the
+
 # CRA send/response process that allows the workflow to proceed without
+
 # the need for the actual CRA verification happens. By default, it should be
+
 # disabled, and should be enabled only for DEV purposes on local developer
+
 # machine or on an environment where the CRA process is not enabled.
+
 BYPASS_CRA_INCOME_VERIFICATION=false
+
 # When defined as true, bypasses the MSFAA signing process.
+
 # The MSFAA process will execute all steps expected trying to
+
 # finding an available MSFAA to be reused.
+
 # If no MSFAA is available, a new one will be created and signed.
+
 BYPASS_MSFAA_SIGNING=false
 #ESDC Integration
 ESDC_REQUEST_FOLDER=
@@ -102,10 +125,13 @@ ATBC_LOGIN_ENDPOINT=
 ATBC_USERNAME=
 ATBC_PASSWORD=
 ATBC_APP=
-# add till  /api
+
+# add till /api
+
 ATBC_ENDPOINT=
 
 # File Upload Global Config
+
 FILE_UPLOAD_MAX_FILE_SIZE=15728640
 FILE_UPLOAD_ALLOWED_EXTENSIONS=.pdf,.doc,.docx,.jpg,.png
 
@@ -136,14 +162,18 @@ FILE_NAME= cypress.env.json
 FILE_PATH= SIMS\testing\functional\tests\cypress.env.json
 
 # Zeebe (only the 3 below are neeed for local development)
+
 ZEEBE_GRPC_ADDRESS=grpc://localhost:26500
 CAMUNDA_OAUTH_DISABLED=true
 ZEEBE_CLIENT_ID=
 ZEEBE_CLIENT_SECRET=
 CAMUNDA_OAUTH_URL=
 ZEEBE_GRPC_WORKER_LONGPOLL_SECONDS=45
+
 # Max retries ensures that if the grpc connection cannot be established within maximum
+
 # number of retry then the process with terminate.
+
 ZEEBE_CLIENT_MAX_RETRIES=20
 
 #Redis and queue properties
@@ -153,7 +183,9 @@ REDIS_PASSWORD=
 REDIS_STANDALONE_MODE=true
 QUEUE_CONSUMERS_PORT=3010
 QUEUE_PREFIX={sims-local}
+
 # The below secret should be set with any valid base 64 string for local development.
+
 QUEUE_DASHBOARD_TOKEN_SECRET=
 QUEUE_DASHBOARD_TOKEN_EXPIRATION_SECONDS=3600
 QUEUE_DASHBOARD_BASE_URL=http://localhost:3010
@@ -169,11 +201,13 @@ WORKERS_PORT=
 LOAD_TEST_API_PORT=
 
 # CAS integration configuration
+
 CAS_BASE_URL=
 CAS_CLIENT_ID=
 CAS_CLIENT_SECRET=
 
 # S3 Storage
+
 S3_ACCESS_KEY_ID=
 S3_SECRET_ACCESS_KEY=
 S3_ENDPOINT=
@@ -181,27 +215,35 @@ S3_DEFAULT_BUCKET=sims-local
 S3_REGION=
 
 # Logged Out due to inactivity, wait times in seconds.
+
 MAXIMUM_IDLE_TIME_FOR_WARNING_STUDENT =
 MAXIMUM_IDLE_TIME_FOR_WARNING_INSTITUTION =
 MAXIMUM_IDLE_TIME_FOR_WARNING_SUPPORTING_USER =
 MAXIMUM_IDLE_TIME_FOR_WARNING_AEST =
 
 # Application Submission Deadline in weeks.
+
 APPLICATION_SUBMISSION_DEADLINE_WEEKS=
 
 # Allow beta users only to access the system if true.
+
 ALLOW_BETA_USERS_ONLY=
 
 # Allow full-time application submissions only for beta institution locations if true.
+
 ALLOW_BETA_INSTITUTIONS_ONLY=
 
 # Throttling Configuration: time window in milliseconds (THROTTLE_TIME) and request limit per window (THROTTLE_LIMIT).
+
 THROTTLE_TIME=10000
 THROTTLE_LIMIT=30
 
 # App Environment
+
 APP_ENV=
 
 # A comma-separated list of feature toggles to enable specific features in the application.
+
 # For example: "SOME_FEATURE_TOGGLE,ANOTHER_FEATURE_TOGGLE".
+
 FEATURE_TOGGLES=

--- a/devops/openshift/api-deploy.yml
+++ b/devops/openshift/api-deploy.yml
@@ -256,7 +256,7 @@ objects:
                 failureThreshold: 3
                 successThreshold: 1
                 httpGet:
-                  path: /health/
+                  path: /health/timeout/1500
                   port: "${{PORT}}"
                 initialDelaySeconds: 30
                 periodSeconds: 30
@@ -265,12 +265,12 @@ objects:
                 failureThreshold: 3
                 successThreshold: 1
                 httpGet:
-                  path: /health/
+                  path: /health/timeout/3000
                   port: "${{PORT}}"
                   scheme: HTTP
                 initialDelaySeconds: 30
                 periodSeconds: 30
-                timeoutSeconds: 3
+                timeoutSeconds: 5
   - apiVersion: v1
     kind: Service
     metadata:

--- a/devops/openshift/workers-deploy.yml
+++ b/devops/openshift/workers-deploy.yml
@@ -109,12 +109,12 @@ objects:
                 failureThreshold: 3
                 successThreshold: 1
                 httpGet:
-                  path: /health/
+                  path: /health/timeout/3000
                   port: "${{PORT}}"
                   scheme: HTTP
                 initialDelaySeconds: 30
                 periodSeconds: 30
-                timeoutSeconds: 3
+                timeoutSeconds: 5
   - apiVersion: autoscaling/v2
     kind: HorizontalPodAutoscaler
     metadata:

--- a/sources/packages/backend/apps/api/src/route-controllers/health-check/health.controller.spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/health-check/health.controller.spec.ts
@@ -18,7 +18,7 @@ describe.skip("HealthController", () => {
 
   describe("root", () => {
     it("should return a health check", () => {
-      expect(healthController.check()).toHaveBeenCalled();
+      expect(healthController.check(3000)).toHaveBeenCalled();
     });
   });
 });

--- a/sources/packages/backend/apps/api/src/route-controllers/health-check/health.controller.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/health-check/health.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get } from "@nestjs/common";
+import { Controller, Get, Param, ParseIntPipe } from "@nestjs/common";
 import { DataSource } from "typeorm";
 import {
   HealthCheck,
@@ -20,18 +20,18 @@ export class HealthController {
 
   /**
    * Check the health of the api.
+   * @param timeout amount of milliseconds for the health checks.
    * @returns the status of the health for api, with info or error and details.
    */
-  @Get()
+  @Get("timeout/:timeout")
   @HealthCheck()
   @Public()
-  async check() {
+  async check(@Param("timeout", ParseIntPipe) timeout: number) {
     return this.healthCheckService.check([
       () =>
         this.typeOrmHealthIndicator.pingCheck("sims-db", {
           connection: this.dataSource,
-          timeout:
-            Number.parseInt(process.env.DB_HEALTH_CHECK_TIMEOUT, 1000) || 3000,
+          timeout,
         }),
     ]);
   }

--- a/sources/packages/backend/apps/api/src/route-controllers/health-check/health.controller.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/health-check/health.controller.ts
@@ -30,6 +30,8 @@ export class HealthController {
       () =>
         this.typeOrmHealthIndicator.pingCheck("sims-db", {
           connection: this.dataSource,
+          timeout:
+            Number.parseInt(process.env.DB_HEALTH_CHECK_TIMEOUT, 1000) || 3000,
         }),
     ]);
   }

--- a/sources/packages/backend/apps/workers/src/controllers/health-check/health.controller.ts
+++ b/sources/packages/backend/apps/workers/src/controllers/health-check/health.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get } from "@nestjs/common";
+import { Controller, Get, Param, ParseIntPipe } from "@nestjs/common";
 import {
   HealthCheck,
   HealthCheckService,
@@ -22,17 +22,17 @@ export class HealthController {
 
   /**
    * Check the health of the workers.
+   * @param timeout amount of milliseconds for the health checks.
    * @returns the status of the health for workers, with info or error and details.
    */
-  @Get()
+  @Get("timeout/:timeout")
   @HealthCheck()
-  async check() {
+  async check(@Param("timeout", ParseIntPipe) timeout: number) {
     return this.healthCheckService.check([
       () =>
         this.typeOrmHealthIndicator.pingCheck("sims-db", {
           connection: this.dataSource,
-          timeout:
-            Number.parseInt(process.env.DB_HEALTH_CHECK_TIMEOUT, 1000) || 3000,
+          timeout,
         }),
       () => this.zeebeHealthIndicator.check("zeebe"),
     ]);

--- a/sources/packages/backend/apps/workers/src/controllers/health-check/health.controller.ts
+++ b/sources/packages/backend/apps/workers/src/controllers/health-check/health.controller.ts
@@ -31,6 +31,8 @@ export class HealthController {
       () =>
         this.typeOrmHealthIndicator.pingCheck("sims-db", {
           connection: this.dataSource,
+          timeout:
+            Number.parseInt(process.env.DB_HEALTH_CHECK_TIMEOUT, 1000) || 3000,
         }),
       () => this.zeebeHealthIndicator.check("zeebe"),
     ]);


### PR DESCRIPTION
### Summary

Makes the health check timeout configurable instead of always default (1000ms)

The healthcheck controller endpoint receives the timeout as a parameter /health/timeout/<timeoutInMS>, the docker configuration set its hardcoded timeouts to 1500ms for readiness (/health/timeout/1500) and 3000ms for liveness (/health/timeout/3000)