### PR TITLE
#5896 - Increase database connection limits

### DIFF
--- a/devops/helm/crunchy-postgres/templates/PostgresCluster.yaml
+++ b/devops/helm/crunchy-postgres/templates/PostgresCluster.yaml
@@ -199,6 +199,7 @@ spec:
       config:
         global:
           client_tls_sslmode: disable
+          default_pool_size: "{{ .Values.proxy.pgBouncer.defaultPoolSize }}"
       {{ if .Values.proxy.pgBouncer.image }}
       image: {{ .Values.proxy.pgBouncer.image }}
       {{ end }}

--- a/devops/helm/crunchy-postgres/templates/PostgresCluster.yaml
+++ b/devops/helm/crunchy-postgres/templates/PostgresCluster.yaml
@@ -201,6 +201,7 @@ spec:
           client_tls_sslmode: disable
           default_pool_size: {{ .Values.proxy.pgBouncer.defaultPoolSize | quote }}
           max_client_conn: {{ .Values.proxy.pgBouncer.maxClientConnections | quote }}
+          pool_mode: {{ .Values.proxy.pgBouncer.poolMode }}
       {{ if .Values.proxy.pgBouncer.image }}
       image: {{ .Values.proxy.pgBouncer.image }}
       {{ end }}

--- a/devops/helm/crunchy-postgres/templates/PostgresCluster.yaml
+++ b/devops/helm/crunchy-postgres/templates/PostgresCluster.yaml
@@ -199,7 +199,7 @@ spec:
       config:
         global:
           client_tls_sslmode: disable
-          default_pool_size: "{{ .Values.proxy.pgBouncer.defaultPoolSize }}"
+          default_pool_size: {{ .Values.proxy.pgBouncer.defaultPoolSize | default 20 | quote }}
       {{ if .Values.proxy.pgBouncer.image }}
       image: {{ .Values.proxy.pgBouncer.image }}
       {{ end }}

--- a/devops/helm/crunchy-postgres/templates/PostgresCluster.yaml
+++ b/devops/helm/crunchy-postgres/templates/PostgresCluster.yaml
@@ -199,7 +199,8 @@ spec:
       config:
         global:
           client_tls_sslmode: disable
-          default_pool_size: {{ .Values.proxy.pgBouncer.defaultPoolSize | default 20 | quote }}
+          default_pool_size: {{ .Values.proxy.pgBouncer.defaultPoolSize | quote }}
+          max_client_conn: {{ .Values.proxy.pgBouncer.maxClientConnections | quote }}
       {{ if .Values.proxy.pgBouncer.image }}
       image: {{ .Values.proxy.pgBouncer.image }}
       {{ end }}

--- a/devops/helm/crunchy-postgres/values-e0a504-dev.yaml
+++ b/devops/helm/crunchy-postgres/values-e0a504-dev.yaml
@@ -93,6 +93,8 @@ proxy:
     image: # it's not necessary to specify an image as the images specified in the Crunchy Postgres Operator will be pulled by default
     replicas: 3
     defaultPoolSize: 30
+    maxClientConnections: 100
+    poolMode: transaction # session (default) | transaction | statement
     requests:
       cpu: 50m
       memory: 128Mi

--- a/devops/helm/crunchy-postgres/values-e0a504-dev.yaml
+++ b/devops/helm/crunchy-postgres/values-e0a504-dev.yaml
@@ -92,6 +92,7 @@ proxy:
   pgBouncer:
     image: # it's not necessary to specify an image as the images specified in the Crunchy Postgres Operator will be pulled by default
     replicas: 3
+    defaultPoolSize: 30
     requests:
       cpu: 50m
       memory: 128Mi

--- a/devops/helm/crunchy-postgres/values.yaml
+++ b/devops/helm/crunchy-postgres/values.yaml
@@ -127,6 +127,7 @@ proxy:
     replicas: 3
     defaultPoolSize: 20
     maxClientConnections: 100
+    poolMode: session # session (default) | transaction | statement
     requests:
       cpu: 50m
       memory: 128Mi

--- a/devops/helm/crunchy-postgres/values.yaml
+++ b/devops/helm/crunchy-postgres/values.yaml
@@ -125,6 +125,8 @@ proxy:
   pgBouncer:
     image: # it's not necessary to specify an image as the images specified in the Crunchy Postgres Operator will be pulled by default
     replicas: 3
+    defaultPoolSize: 20
+    maxClientConnections: 100
     requests:
       cpu: 50m
       memory: 128Mi


### PR DESCRIPTION
### Summary

Increases default pool size of pgBouncer from default (20) to 30. total connections now should be 90 instead of 60 (30 x 3 pods), still under the postgres default cap of 100.