### PR TITLE
#5896 - Configure Horizontal Pod Scalers

### DIFF
--- a/devops/openshift/queue-consumers-deploy.yml
+++ b/devops/openshift/queue-consumers-deploy.yml
@@ -347,7 +347,7 @@ objects:
         kind: Deployment
         name: ${NAME}
       minReplicas: "${{REPLICAS}}"
-      maxReplicas: 10
+      maxReplicas: 4
       metrics:
         - type: Resource
           resource:

--- a/devops/openshift/workers-deploy.yml
+++ b/devops/openshift/workers-deploy.yml
@@ -125,7 +125,7 @@ objects:
         kind: Deployment
         name: ${NAME}
       minReplicas: "${{REPLICAS}}"
-      maxReplicas: 10
+      maxReplicas: 3
       metrics:
         - type: Resource
           resource:


### PR DESCRIPTION
### Summary

Reduces the number of max pods of queue-consumers and worker deployments.