### PR TITLE
#2905 - Increase formio e2e container start time

### DIFF
--- a/sources/tests/docker-compose.yml
+++ b/sources/tests/docker-compose.yml
@@ -127,8 +127,8 @@ services:
       test: ["CMD-SHELL", "wget -qO- http://localhost:3001/access || exit 1"]
       interval: 15s
       timeout: 10s
-      retries: 15
-      start_period: 60s
+      retries: 20
+      start_period: 120s
   # Workers
   workers:
     image: workers-${PROJECT_NAME}:${BUILD_REF}-${BUILD_ID}


### PR DESCRIPTION
### Summary

E2E tests seem to be failing sometimes with formio container being marked as unhealthy. 
Update E2E Tests formio container to allow for more time during the initial setup. 