### PR TITLE
#5635 - Formio Spring Upgrade - Updated form.io definitions

### DIFF
--- a/sources/packages/forms/src/form-definitions/sfaa2022-23.json
+++ b/sources/packages/forms/src/form-definitions/sfaa2022-23.json
@@ -440,7 +440,7 @@
                       "refreshOnChange": false,
                       "customClass": "banner-info",
                       "key": "html12",
-                      "customConditional": "show = data.myProgramNotListed.programnotListed || (data.myStudyPeriodIsntListed && data.myStudyPeriodIsntListed.offeringnotListed);",
+                      "customConditional": "show = !!data.myProgramNotListed?.programnotListed || !!data.myStudyPeriodIsntListed?.offeringnotListed;",
                       "type": "htmlelement",
                       "input": false,
                       "tableView": false,
@@ -2729,7 +2729,6 @@
                 },
                 {
                   "label": "<h4 class='category-header-medium-small'></h4>",
-                  "conditionalAddButton": "show = data.roiInformation.length < 2;",
                   "reorder": false,
                   "addAnother": "Add another trusted contact",
                   "addAnotherPosition": "bottom",
@@ -2744,6 +2743,10 @@
                       "relationshipWithThisContact": ""
                     }
                   ],
+                  "validate": {
+                    "maxLength": "2"
+                  },
+                  "validateWhenHidden": false,
                   "key": "roiInformation",
                   "type": "datagrid",
                   "defaultOpen": false,
@@ -3305,11 +3308,7 @@
                           "collapsible": false,
                           "hideLabel": true,
                           "key": "uploadPanel",
-                          "conditional": {
-                            "show": true,
-                            "when": "dependants.declaredOnTaxes",
-                            "eq": "yes"
-                          },
+                          "customConditional": "show = row.declaredOnTaxes === 'yes';",
                           "type": "panel",
                           "label": "Upload panel",
                           "buttonSettings": {
@@ -3525,11 +3524,7 @@
               "collapsible": false,
               "hideLabel": true,
               "key": "dependentsThatYouSupportFinanciallyButDoNotHaveSoleCustody",
-              "conditional": {
-                "show": true,
-                "when": "supportnocustodyDependants",
-                "eq": "yes"
-              },
+              "customConditional": "show = row.supportnocustodyDependants === 'yes';",
               "type": "panel",
               "label": "Dependents that you support financially but do not have sole custody",
               "input": false,

--- a/sources/packages/forms/src/form-definitions/sfaa2023-24.json
+++ b/sources/packages/forms/src/form-definitions/sfaa2023-24.json
@@ -440,7 +440,7 @@
                       "refreshOnChange": false,
                       "customClass": "banner-info",
                       "key": "html12",
-                      "customConditional": "show = data.myProgramNotListed.programnotListed || (data.myStudyPeriodIsntListed && data.myStudyPeriodIsntListed.offeringnotListed);",
+                      "customConditional": "show = !!data.myProgramNotListed?.programnotListed || !!data.myStudyPeriodIsntListed?.offeringnotListed;",
                       "type": "htmlelement",
                       "input": false,
                       "tableView": false,
@@ -2729,7 +2729,6 @@
                 },
                 {
                   "label": "<h4 class='category-header-medium-small'></h4>",
-                  "conditionalAddButton": "show = data.roiInformation.length < 2;",
                   "reorder": false,
                   "addAnother": "Add another trusted contact",
                   "addAnotherPosition": "bottom",
@@ -2744,6 +2743,10 @@
                       "relationshipWithThisContact": ""
                     }
                   ],
+                  "validate": {
+                    "maxLength": "2"
+                  },
+                  "validateWhenHidden": false,
                   "key": "roiInformation",
                   "type": "datagrid",
                   "defaultOpen": false,
@@ -3305,11 +3308,7 @@
                           "collapsible": false,
                           "hideLabel": true,
                           "key": "uploadPanel",
-                          "conditional": {
-                            "show": true,
-                            "when": "dependants.declaredOnTaxes",
-                            "eq": "yes"
-                          },
+                          "customConditional": "show = row.declaredOnTaxes === 'yes';",
                           "type": "panel",
                           "label": "Upload panel",
                           "buttonSettings": {
@@ -3525,11 +3524,7 @@
               "collapsible": false,
               "hideLabel": true,
               "key": "dependentsThatYouSupportFinanciallyButDoNotHaveSoleCustody",
-              "conditional": {
-                "show": true,
-                "when": "supportnocustodyDependants",
-                "eq": "yes"
-              },
+              "customConditional": "show = row.supportnocustodyDependants === 'yes';",
               "type": "panel",
               "label": "Dependents that you support financially but do not have sole custody",
               "input": false,

--- a/sources/packages/forms/src/form-definitions/sfaa2024-25.json
+++ b/sources/packages/forms/src/form-definitions/sfaa2024-25.json
@@ -439,7 +439,7 @@
                       "refreshOnChange": false,
                       "customClass": "banner-info",
                       "key": "html12",
-                      "customConditional": "show = data.myProgramNotListed.programnotListed || (data.myStudyPeriodIsntListed && data.myStudyPeriodIsntListed.offeringnotListed);",
+                      "customConditional": "show = !!data.myProgramNotListed?.programnotListed || !!data.myStudyPeriodIsntListed?.offeringnotListed;",
                       "type": "htmlelement",
                       "input": false,
                       "tableView": false,
@@ -2728,7 +2728,6 @@
                 },
                 {
                   "label": "<h4 class='category-header-medium-small'></h4>",
-                  "conditionalAddButton": "show = data.roiInformation.length < 2;",
                   "reorder": false,
                   "addAnother": "Add another trusted contact",
                   "addAnotherPosition": "bottom",
@@ -2743,6 +2742,10 @@
                       "relationshipWithThisContact": ""
                     }
                   ],
+                  "validate": {
+                    "maxLength": "2"
+                  },
+                  "validateWhenHidden": false,
                   "key": "roiInformation",
                   "type": "datagrid",
                   "defaultOpen": false,
@@ -3304,11 +3307,7 @@
                           "collapsible": false,
                           "hideLabel": true,
                           "key": "uploadPanel",
-                          "conditional": {
-                            "show": true,
-                            "when": "dependants.declaredOnTaxes",
-                            "eq": "yes"
-                          },
+                          "customConditional": "show = row.declaredOnTaxes === 'yes';",
                           "type": "panel",
                           "label": "Upload panel",
                           "buttonSettings": {
@@ -3524,11 +3523,7 @@
               "collapsible": false,
               "hideLabel": true,
               "key": "dependentsThatYouSupportFinanciallyButDoNotHaveSoleCustody",
-              "conditional": {
-                "show": true,
-                "when": "supportnocustodyDependants",
-                "eq": "yes"
-              },
+              "customConditional": "show = row.supportnocustodyDependants === 'yes';",
               "type": "panel",
               "label": "Dependents that you support financially but do not have sole custody",
               "input": false,

--- a/sources/packages/forms/src/form-definitions/sfaa2025-26-ft.json
+++ b/sources/packages/forms/src/form-definitions/sfaa2025-26-ft.json
@@ -707,7 +707,7 @@
                       "refreshOnChange": false,
                       "customClass": "banner-info",
                       "key": "html12",
-                      "customConditional": "show = !data.allowBetaInstitutionsOnly && (data.myProgramNotListed.programnotListed || (data.myStudyPeriodIsntListed && data.myStudyPeriodIsntListed.offeringnotListed));",
+                      "customConditional": "show = !data.allowBetaInstitutionsOnly && (!!data.myProgramNotListed?.programnotListed || !!data.myStudyPeriodIsntListed?.offeringnotListed);",
                       "type": "htmlelement",
                       "input": false,
                       "tableView": false
@@ -3698,7 +3698,6 @@
                 },
                 {
                   "label": "<h4 class='category-header-medium-small'></h4>",
-                  "conditionalAddButton": "show = data.roiInformation.length < 2;",
                   "reorder": false,
                   "addAnother": "Add another trusted contact",
                   "addAnotherPosition": "bottom",
@@ -3713,6 +3712,10 @@
                       "relationshipWithThisContact": ""
                     }
                   ],
+                  "validate": {
+                    "maxLength": "2"
+                  },
+                  "validateWhenHidden": false,
                   "key": "roiInformation",
                   "type": "datagrid",
                   "defaultOpen": false,
@@ -4204,11 +4207,7 @@
                       "collapsible": false,
                       "hideLabel": true,
                       "key": "uploadPanel",
-                      "conditional": {
-                        "show": "true",
-                        "when": "declaredOnTaxes",
-                        "eq": "yes"
-                      },
+                      "customConditional": "show = row.declaredOnTaxes === 'yes';",
                       "type": "panel",
                       "label": "Upload panel",
                       "buttonSettings": {
@@ -4424,11 +4423,7 @@
                       },
                       "collapsible": false,
                       "key": "dependentsThatYouSupportFinanciallyButDoNotHaveSoleCustody",
-                      "conditional": {
-                        "show": "true",
-                        "when": "supportnocustodyDependants",
-                        "eq": "yes"
-                      },
+                      "customConditional": "show = row.supportnocustodyDependants === 'yes';",
                       "type": "panel",
                       "label": "Dependents that you support financially but do not have sole custody",
                       "input": false,

--- a/sources/packages/forms/src/form-definitions/sfaa2025-26-ft.json
+++ b/sources/packages/forms/src/form-definitions/sfaa2025-26-ft.json
@@ -4223,6 +4223,8 @@
                         {
                           "label": "dependantsIncomeTaxApplicationException",
                           "tableView": false,
+                          "calculateValue": "value = { ...value, fullName: row?.fullName };",
+                          "calculateServer": true,
                           "validateWhenHidden": false,
                           "key": "dependantsIncomeTaxApplicationException",
                           "type": "container",
@@ -4230,7 +4232,7 @@
                           "components": [
                             {
                               "label": "Exception Description - Dependant's income tax",
-                              "calculateValue": "value = `Dependant's income tax - ${data.dependants[rowIndex].fullName}`;",
+                              "calculateValue": "value = `Dependant's income tax - ${row?.fullName}`;",
                               "calculateServer": true,
                               "key": "exceptionDescription",
                               "type": "hidden",
@@ -4433,6 +4435,8 @@
                         {
                           "label": "dependantsSharedCustodyApplicationException",
                           "tableView": false,
+                          "calculateValue": "value = { ...value, fullName: row?.fullName };",
+                          "calculateServer": true,
                           "validateWhenHidden": false,
                           "key": "dependantsSharedCustodyApplicationException",
                           "type": "container",
@@ -4440,7 +4444,7 @@
                           "components": [
                             {
                               "label": "Exception Description - Dependant's shared custody",
-                              "calculateValue": "value = `Dependant's shared custody - ${data.dependants[rowIndex].fullName}`;",
+                              "calculateValue": "value = `Dependant's shared custody - ${row?.fullName}`;",
                               "calculateServer": true,
                               "key": "exceptionDescription",
                               "type": "hidden",
@@ -6159,11 +6163,7 @@
                           "collapsible": false,
                           "hideLabel": true,
                           "key": "parentCurrentYearIncomeExceptionConfirmPanel",
-                          "conditional": {
-                            "show": true,
-                            "when": "parents.hasCurrentYearParentIncome",
-                            "eq": "yes"
-                          },
+                          "customConditional": "show = row.hasCurrentYearParentIncome === 'yes';",
                           "type": "panel",
                           "label": "Panel",
                           "input": false,
@@ -6178,7 +6178,7 @@
                                   "attr": ""
                                 }
                               ],
-                              "content": "<strong> Please confirm that you match the criteria below and are eligible for this exception category.</strong>\n<br />\nYou are requesting additional financial aid due to your  parent/step-parent/sponsor/legal guardian having or anticipating a significant decrease in gross income for {{data.currentTaxYear}}, due to one of the following circumstances:\n<li>Medical illness or injury</li>\n<li>Family emergency (e.g., death or injury)</li>\n<li>Natural disaster</li>\n<li>Layoff, strike, lockout or other reduction in earnings beyond the family’s control</li>",
+                              "content": "<strong> Please confirm that you match the criteria below and are eligible for this exception category.</strong>\n<br />\nYou are requesting additional financial aid due to your  parent/step-parent/sponsor/legal guardian having or anticipating a significant decrease in gross income for {{data.currentTaxYear}}, due to one of the following circumstances:\n<ul>\n  <li>Medical illness or injury</li>\n  <li>Family emergency (e.g., death or injury)</li>\n  <li>Natural disaster</li>\n  <li>Layoff, strike, lockout or other reduction in earnings beyond the family’s control</li>\n</ul>",
                               "refreshOnChange": false,
                               "key": "estimatedCurrentYearIncomeParentExceptionPanelContent",
                               "type": "htmlelement",
@@ -6213,11 +6213,7 @@
                       "collapsible": false,
                       "hideLabel": true,
                       "key": "parentIncomePanel1",
-                      "conditional": {
-                        "show": true,
-                        "when": "parents.parentCurrentYearIncomeConfirmation",
-                        "eq": "true"
-                      },
+                      "customConditional": "show = row.parentCurrentYearIncomeConfirmation === true;",
                       "type": "panel",
                       "label": "Panel",
                       "input": false,
@@ -6226,6 +6222,8 @@
                         {
                           "label": "currentYearParentIncomeApplicationException",
                           "tableView": false,
+                          "calculateValue": "value = { ...value, parentFullName: row?.parentFullName };",
+                          "calculateServer": true,
                           "validateWhenHidden": false,
                           "key": "currentYearParentIncomeApplicationException",
                           "type": "container",
@@ -6233,7 +6231,7 @@
                           "components": [
                             {
                               "label": "Exception Description - Parent current year income",
-                              "calculateValue": "value = `Parent current year income - ${data.parents[rowIndex].parentFullName}`;",
+                              "calculateValue": "value = `Parent current year income - ${row?.parentFullName}`;",
                               "calculateServer": true,
                               "key": "exceptionDescription",
                               "type": "hidden",

--- a/sources/packages/forms/src/form-definitions/sfaa2025-26-pt.json
+++ b/sources/packages/forms/src/form-definitions/sfaa2025-26-pt.json
@@ -685,7 +685,7 @@
                       "refreshOnChange": false,
                       "customClass": "banner-info",
                       "key": "html12",
-                      "customConditional": "show = data.myProgramNotListed.programnotListed || (data.myStudyPeriodIsntListed && data.myStudyPeriodIsntListed.offeringnotListed);",
+                      "customConditional": "show = !!data.myProgramNotListed?.programnotListed || !!data.myStudyPeriodIsntListed?.offeringnotListed;",
                       "type": "htmlelement",
                       "input": false,
                       "tableView": false,
@@ -3281,7 +3281,6 @@
                 },
                 {
                   "label": "<h4 class='category-header-medium-small'></h4>",
-                  "conditionalAddButton": "show = data.roiInformation.length < 2;",
                   "reorder": false,
                   "addAnother": "Add another trusted contact",
                   "addAnotherPosition": "bottom",
@@ -3296,6 +3295,10 @@
                       "relationshipWithThisContact": ""
                     }
                   ],
+                  "validate": {
+                    "maxLength": "2"
+                  },
+                  "validateWhenHidden": false,
                   "key": "roiInformation",
                   "type": "datagrid",
                   "defaultOpen": false,
@@ -3775,11 +3778,7 @@
                       "collapsible": false,
                       "hideLabel": true,
                       "key": "uploadPanel",
-                      "conditional": {
-                        "show": "true",
-                        "when": "declaredOnTaxes",
-                        "eq": "yes"
-                      },
+                      "customConditional": "show = row.declaredOnTaxes === 'yes';",
                       "type": "panel",
                       "label": "Upload panel",
                       "buttonSettings": {
@@ -3988,11 +3987,7 @@
                       },
                       "collapsible": false,
                       "key": "dependentsThatYouSupportFinanciallyButDoNotHaveSoleCustody",
-                      "conditional": {
-                        "show": "true",
-                        "when": "supportnocustodyDependants",
-                        "eq": "yes"
-                      },
+                      "customConditional": "show = row.supportnocustodyDependants === 'yes';",
                       "type": "panel",
                       "label": "Dependents that you support financially but do not have sole custody",
                       "input": false,

--- a/sources/packages/forms/src/form-definitions/sfaa2025-26-pt.json
+++ b/sources/packages/forms/src/form-definitions/sfaa2025-26-pt.json
@@ -3793,7 +3793,7 @@
                       "components": [
                         {
                           "label": "dependantsIncomeTaxApplicationException",
-                          "calculateValue": "value = {\n exceptionDescription: `Dependant's income tax - ${data.dependants[rowIndex].fullName}`,\n pdDependentUpload: data.dependants[rowIndex][\"pdDependentUpload\"]\n}",
+                          "calculateValue": "value = {\n exceptionDescription: `Dependant's income tax - ${row?.fullName}`,\n pdDependentUpload: row?.pdDependentUpload\n}",
                           "calculateServer": true,
                           "key": "dependantsIncomeTaxApplicationException",
                           "type": "hidden",
@@ -3997,7 +3997,7 @@
                         {
                           "label": "dependantsSharedCustodyApplicationException",
                           "customDefaultValue": "value = [];",
-                          "calculateValue": "value = {\r\n  exceptionDescription: `Dependant's shared custody - ${data.dependants[rowIndex].fullName}`,\r\n  dependantCustodyFileUpload: data.dependants[rowIndex][\"dependantCustodyFileUpload\"]\r\n}",
+                          "calculateValue": "value = {\r\n  exceptionDescription: `Dependant's shared custody - ${row?.fullName}`,\r\n  dependantCustodyFileUpload: row?.dependantCustodyFileUpload\r\n}",
                           "calculateServer": true,
                           "key": "dependantsSharedCustodyApplicationException",
                           "type": "hidden",

--- a/sources/packages/forms/src/form-definitions/sfaa2026-27-ft.json
+++ b/sources/packages/forms/src/form-definitions/sfaa2026-27-ft.json
@@ -4332,6 +4332,8 @@
                         {
                           "label": "dependantsIncomeTaxApplicationException",
                           "tableView": false,
+                          "calculateValue": "value = { ...value, fullName: row?.fullName };",
+                          "calculateServer": true,
                           "validateWhenHidden": false,
                           "key": "dependantsIncomeTaxApplicationException",
                           "type": "container",
@@ -4339,7 +4341,7 @@
                           "components": [
                             {
                               "label": "Exception Description - Dependant's income tax",
-                              "calculateValue": "value = `Dependant's income tax - ${data.dependants[rowIndex].fullName}`;",
+                              "calculateValue": "value = `Dependant's income tax - ${row?.fullName}`;",
                               "calculateServer": true,
                               "key": "exceptionDescription",
                               "type": "hidden",
@@ -4542,6 +4544,8 @@
                         {
                           "label": "dependantsSharedCustodyApplicationException",
                           "tableView": false,
+                          "calculateValue": "value = { ...value, fullName: row?.fullName };",
+                          "calculateServer": true,
                           "validateWhenHidden": false,
                           "key": "dependantsSharedCustodyApplicationException",
                           "type": "container",
@@ -4549,7 +4553,7 @@
                           "components": [
                             {
                               "label": "Exception Description - Dependant's shared custody",
-                              "calculateValue": "value = `Dependant's shared custody - ${data.dependants[rowIndex].fullName}`;",
+                              "calculateValue": "value = `Dependant's shared custody - ${row?.fullName}`;",
                               "calculateServer": true,
                               "key": "exceptionDescription",
                               "type": "hidden",

--- a/sources/packages/forms/src/form-definitions/sfaa2026-27-ft.json
+++ b/sources/packages/forms/src/form-definitions/sfaa2026-27-ft.json
@@ -707,7 +707,7 @@
                       "refreshOnChange": false,
                       "customClass": "banner-info",
                       "key": "html12",
-                      "customConditional": "show = !data.allowBetaInstitutionsOnly && (data.myProgramNotListed.programnotListed || (data.myStudyPeriodIsntListed && data.myStudyPeriodIsntListed.offeringnotListed));",
+                      "customConditional": "show = !data.allowBetaInstitutionsOnly && (!!data.myProgramNotListed?.programnotListed || !!data.myStudyPeriodIsntListed?.offeringnotListed);",
                       "type": "htmlelement",
                       "input": false,
                       "tableView": false
@@ -3762,7 +3762,6 @@
                 },
                 {
                   "label": "<h4 class='category-header-medium-small'></h4>",
-                  "conditionalAddButton": "show = data.roiInformation.length < 2;",
                   "reorder": false,
                   "addAnother": "Add another trusted contact",
                   "addAnotherPosition": "bottom",
@@ -3777,6 +3776,10 @@
                       "relationshipWithThisContact": ""
                     }
                   ],
+                  "validate": {
+                    "maxLength": "2"
+                  },
+                  "validateWhenHidden": false,
                   "key": "roiInformation",
                   "type": "datagrid",
                   "defaultOpen": false,
@@ -4313,11 +4316,7 @@
                       "collapsible": false,
                       "hideLabel": true,
                       "key": "uploadPanel",
-                      "conditional": {
-                        "show": "true",
-                        "when": "declaredOnTaxes",
-                        "eq": "yes"
-                      },
+                      "customConditional": "show = row.declaredOnTaxes === 'yes';",
                       "type": "panel",
                       "label": "Upload panel",
                       "buttonSettings": {
@@ -4533,11 +4532,7 @@
                       },
                       "collapsible": false,
                       "key": "dependentsThatYouSupportFinanciallyButDoNotHaveSoleCustody",
-                      "conditional": {
-                        "show": "true",
-                        "when": "supportnocustodyDependants",
-                        "eq": "yes"
-                      },
+                      "customConditional": "show = row.supportnocustodyDependants === 'yes';",
                       "type": "panel",
                       "label": "Dependents that you support financially but do not have sole custody",
                       "input": false,

--- a/sources/packages/forms/src/form-definitions/sfaa2026-27-pt.json
+++ b/sources/packages/forms/src/form-definitions/sfaa2026-27-pt.json
@@ -3886,6 +3886,8 @@
                         {
                           "label": "dependantsIncomeTaxApplicationException",
                           "tableView": false,
+                          "calculateValue": "value = { ...value, fullName: row?.fullName };",
+                          "calculateServer": true,
                           "validateWhenHidden": false,
                           "key": "dependantsIncomeTaxApplicationException",
                           "type": "container",
@@ -3893,7 +3895,7 @@
                           "components": [
                             {
                               "label": "Exception Description - Dependant's income tax",
-                              "calculateValue": "value = `Dependant's income tax - ${data.dependants[rowIndex].fullName}`;",
+                              "calculateValue": "value = `Dependant's income tax - ${row?.fullName}`;",
                               "calculateServer": true,
                               "key": "exceptionDescription",
                               "type": "hidden",
@@ -4097,6 +4099,8 @@
                         {
                           "label": "dependantsSharedCustodyApplicationException",
                           "tableView": false,
+                          "calculateValue": "value = { ...value, fullName: row?.fullName };",
+                          "calculateServer": true,
                           "validateWhenHidden": false,
                           "key": "dependantsSharedCustodyApplicationException",
                           "type": "container",
@@ -4104,7 +4108,7 @@
                           "components": [
                             {
                               "label": "Exception Description - Dependant's shared custody",
-                              "calculateValue": "value = `Dependant's shared custody - ${data.dependants[rowIndex].fullName}`;",
+                              "calculateValue": "value = `Dependant's shared custody - ${row?.fullName}`;",
                               "calculateServer": true,
                               "key": "exceptionDescription",
                               "type": "hidden",

--- a/sources/packages/forms/src/form-definitions/sfaa2026-27-pt.json
+++ b/sources/packages/forms/src/form-definitions/sfaa2026-27-pt.json
@@ -685,7 +685,7 @@
                       "refreshOnChange": false,
                       "customClass": "banner-info",
                       "key": "html12",
-                      "customConditional": "show = data.myProgramNotListed.programnotListed || (data.myStudyPeriodIsntListed && data.myStudyPeriodIsntListed.offeringnotListed);",
+                      "customConditional": "show = !!data.myProgramNotListed?.programnotListed || !!data.myStudyPeriodIsntListed?.offeringnotListed;",
                       "type": "htmlelement",
                       "input": false,
                       "tableView": false,
@@ -3337,7 +3337,6 @@
                 },
                 {
                   "label": "<h4 class='category-header-medium-small'></h4>",
-                  "conditionalAddButton": "show = data.roiInformation.length < 2;",
                   "reorder": false,
                   "addAnother": "Add another trusted contact",
                   "addAnotherPosition": "bottom",
@@ -3352,6 +3351,10 @@
                       "relationshipWithThisContact": ""
                     }
                   ],
+                  "validate": {
+                    "maxLength": "2"
+                  },
+                  "validateWhenHidden": false,
                   "key": "roiInformation",
                   "type": "datagrid",
                   "defaultOpen": false,
@@ -3867,11 +3870,7 @@
                       "collapsible": false,
                       "hideLabel": true,
                       "key": "uploadPanel",
-                      "conditional": {
-                        "show": true,
-                        "when": "declaredOnTaxes",
-                        "eq": "yes"
-                      },
+                      "customConditional": "show = row.declaredOnTaxes === 'yes';",
                       "type": "panel",
                       "label": "Upload panel",
                       "breadcrumbClickable": true,
@@ -4079,24 +4078,21 @@
                     },
                     {
                       "title": "Dependents that you support financially but do not have sole custody",
+                      "collapsible": false,
+                      "hideLabel": true,
+                      "key": "dependentsThatYouSupportFinanciallyButDoNotHaveSoleCustody",
+                      "customConditional": "show = row.supportnocustodyDependants === 'yes';",
+                      "type": "panel",
+                      "label": "Dependents that you support financially but do not have sole custody",
                       "breadcrumbClickable": false,
+                      "allowPrevious": false,
                       "buttonSettings": {
                         "previous": false,
                         "cancel": false,
                         "next": false
                       },
-                      "collapsible": false,
-                      "key": "dependentsThatYouSupportFinanciallyButDoNotHaveSoleCustody",
-                      "conditional": {
-                        "show": "true",
-                        "when": "supportnocustodyDependants",
-                        "eq": "yes"
-                      },
-                      "type": "panel",
-                      "label": "Dependents that you support financially but do not have sole custody",
                       "input": false,
                       "tableView": false,
-                      "allowPrevious": false,
                       "components": [
                         {
                           "label": "dependantsSharedCustodyApplicationException",
@@ -4260,8 +4256,7 @@
                             }
                           ]
                         }
-                      ],
-                      "hideLabel": true
+                      ]
                     }
                   ],
                   "inDataGrid": true

--- a/sources/packages/forms/src/form-definitions/studentdependantsappeal.json
+++ b/sources/packages/forms/src/form-definitions/studentdependantsappeal.json
@@ -218,9 +218,14 @@
                       "customClass": "\"customClass\": \"label-bold\""
                     },
                     {
-                      "key": "addDependantsUploadPanel",
-                      "input": false,
                       "title": "Upload panel",
+                      "collapsible": false,
+                      "hideLabel": true,
+                      "key": "addDependantsUploadPanel",
+                      "customConditional": "shwow = row.declaredOnTaxes === 'yes';",
+                      "type": "panel",
+                      "label": "Panel",
+                      "input": false,
                       "tableView": false,
                       "components": [
                         {
@@ -361,15 +366,7 @@
                           "lockKey": true
                         }
                       ],
-                      "type": "panel",
-                      "hideLabel": true,
-                      "conditional": {
-                        "show": "true",
-                        "when": "declaredOnTaxes",
-                        "eq": "yes"
-                      },
-                      "lockKey": true,
-                      "label": "Panel"
+                      "lockKey": true
                     }
                   ],
                   "type": "fieldset",

--- a/sources/packages/forms/src/form-definitions/studentdependantsappeal.json
+++ b/sources/packages/forms/src/form-definitions/studentdependantsappeal.json
@@ -222,7 +222,7 @@
                       "collapsible": false,
                       "hideLabel": true,
                       "key": "addDependantsUploadPanel",
-                      "customConditional": "shwow = row.declaredOnTaxes === 'yes';",
+                      "customConditional": "show = row.declaredOnTaxes === 'yes';",
                       "type": "panel",
                       "label": "Panel",
                       "input": false,
@@ -294,27 +294,31 @@
                           "tableView": false
                         },
                         {
-                          "input": true,
-                          "tableView": false,
                           "label": "PD Dependent",
-                          "key": "pdDependentUpload",
-                          "multiple": true,
+                          "tableView": false,
+                          "storage": "url",
+                          "dir": "PD Dependent",
+                          "webcam": false,
+                          "capture": false,
+                          "fileTypes": [
+                            {
+                              "label": "",
+                              "value": ""
+                            }
+                          ],
                           "filePattern": ".pdf,.doc,.docx,.jpg,.png,.txt",
                           "fileMaxSize": "15MB",
-                          "type": "file",
-                          "conditional": {
-                            "show": "true",
-                            "when": "declaredOnTaxes",
-                            "eq": "yes"
-                          },
-                          "storage": "url",
-                          "url": "student/files",
-                          "dir": "PD Dependent",
+                          "multiple": true,
                           "validate": {
                             "required": true,
                             "customMessage": "You must upload at least one file, and the total number of uploaded files cannot exceed {{data.maxUploadedFiles}}.",
                             "custom": "const files = data[instance.key] || []; valid = files.length > data.maxUploadedFiles ? false : true;"
                           },
+                          "validateWhenHidden": false,
+                          "key": "pdDependentUpload",
+                          "type": "file",
+                          "url": "student/files",
+                          "input": true,
                           "lockKey": true
                         },
                         {


### PR DESCRIPTION
Fixed some issues for the upcoming form.io upgrade.

## Warning Issues

### Dependents

#### File Uploaders

- The conditional settings to display the uploaders were failing when using the reference for `dependants.declaredOnTaxes`, where, when two dependents were present, the answers for the first row would determine the condition for all rows. The condition was replaced by the `show = row.declaredOnTaxes === 'yes';` where `row` will have the right value for each dependent row, allowing the file uploader to work nicely.

<img width="824" height="744" alt="image" src="https://github.com/user-attachments/assets/13d2d922-bec2-4e2d-9f96-a5c9d89144f9" />


#### Dependents Exception Description Name

- The "description name" contains the dependent name that comes from outside the container, where it is critical to allow the trigger of a new exception, forcing its hash to be different. The `rowIndex` was failing at the server side, and it is now relaced but the `row.fullName`.

### Program selection

- There were a few points accessing the `programnotListed` property without ensuring the `data.myProgramNotListed` was defined. For simplicity, the checks were changed to use the syntax as follows, which should be equivalent.

```ts
!!data.myProgramNotListed?.programnotListed
```

<img width="1731" height="833" alt="image" src="https://github.com/user-attachments/assets/8f9f0784-d749-499b-840f-6b015c7372d3" />


### Share information with trusted contact

- Moved the validation to ensure a maximum of two contacts can be added from a custom validation for the out-of-box form.io validation.
- This was causing a "warning" looping once the `@formio/js` was upgraded.

<img width="1678" height="467" alt="image" src="https://github.com/user-attachments/assets/5da946c2-910d-4b74-9b31-a22504a955ff" />
