### PR TITLE
#5896 - Load Test - Formio/Application Submit - Fix health endpoint

### DIFF
--- a/sources/packages/backend/apps/api/src/main.ts
+++ b/sources/packages/backend/apps/api/src/main.ts
@@ -28,7 +28,7 @@ async function bootstrap() {
   await systemUsersService.loadSystemUser();
 
   // Setting global prefix
-  app.setGlobalPrefix("api", { exclude: ["health"] });
+  app.setGlobalPrefix("api", { exclude: ["health/(.*)"] });
 
   // Using helmet.
   app.use(helmet());


### PR DESCRIPTION
Adjusted the `health` endpoint to keep ignoring the API prefix that is no longer working as expected because of the new parameter provided for the timeout.

<img width="1051" height="231" alt="image" src="https://github.com/user-attachments/assets/1712aef4-64a2-43aa-8384-a63584230086" />
