### PR TITLE
#5335 - Formio Spring Upgrade - Divider Fix

### DIFF
--- a/sources/packages/web/src/plugins/vuetify.ts
+++ b/sources/packages/web/src/plugins/vuetify.ts
@@ -33,7 +33,7 @@ export default createVuetify({
     VDividerInsetOpaque: {
       thickness: 2,
       color: "secondary",
-      inset: true,
+      style: "margin-inline: 16px;",
     },
     VDividerVerticalOpaque: {
       thickness: 2,


### PR DESCRIPTION
Minor fix for the v-divider, removing the `inset` and keeping some spacing as it was before.

### Before

<img width="859" height="483" alt="image" src="https://github.com/user-attachments/assets/c8199c39-2861-4637-9c20-f97e8cbd7aed" />

<img width="729" height="466" alt="image" src="https://github.com/user-attachments/assets/6e59a2d7-4b53-42ff-bf08-25da8255a76b" />

### After

<img width="825" height="477" alt="image" src="https://github.com/user-attachments/assets/66bed294-76da-4f2c-8d6a-02bd7d6ad24a" />

<img width="727" height="462" alt="image" src="https://github.com/user-attachments/assets/988dcd7c-c258-4f5d-8644-66a793c436ed" />





