### PR TITLE
#6091 - Post production gold migration tasks - Upgrade Postgres to 18

### DIFF
--- a/sources/.docker/postgres/Dockerfile
+++ b/sources/.docker/postgres/Dockerfile
@@ -1,1 +1,1 @@
-FROM postgres:17
+FROM postgres:18


### PR DESCRIPTION
- Upgrade local PostgreSQL to version 18 to match PROD.
- The developer is repsonible to take a backup and restore if keeping its data is desirable.
- The volume `postgres-${PROJECT_NAME}-${BUILD_REF}-${BUILD_ID}` should be removed (after the backup, if required), to allow PostgreSQL data for 18 version to be created and then, if required, the backup to be restored.