### PR TITLE
#2905 - Testing mongo readiness

### DIFF
--- a/sources/tests/docker-compose.yml
+++ b/sources/tests/docker-compose.yml
@@ -99,6 +99,12 @@ services:
     container_name: mongo-${PROJECT_NAME}-${BUILD_REF}-${BUILD_ID}
     networks:
       - local-network-tests
+    healthcheck:
+      test: ["CMD", "mongosh", "--eval", "db.adminCommand('ping')"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
   # - MongoDB
   # Form.io
   formio:
@@ -122,13 +128,14 @@ services:
     networks:
       - local-network-tests
     depends_on:
-      - mongo
+      mongo:
+        condition: service_healthy
     healthcheck:
       test: ["CMD-SHELL", "wget -qO- http://localhost:3001/access || exit 1"]
       interval: 15s
       timeout: 10s
-      retries: 20
-      start_period: 120s
+      retries: 15
+      start_period: 60s
   # Workers
   workers:
     image: workers-${PROJECT_NAME}:${BUILD_REF}-${BUILD_ID}

--- a/sources/tests/docker-compose.yml
+++ b/sources/tests/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3"
-
 # Services
 services:
   # API
@@ -101,10 +99,10 @@ services:
       - local-network-tests
     healthcheck:
       test: ["CMD", "mongosh", "--eval", "db.adminCommand('ping')"]
-      interval: 10s
-      timeout: 5s
-      retries: 5
-      start_period: 10s
+      interval: 5s
+      timeout: 3s
+      retries: 50
+      start_period: 15s
   # - MongoDB
   # Form.io
   formio:
@@ -132,10 +130,10 @@ services:
         condition: service_healthy
     healthcheck:
       test: ["CMD-SHELL", "wget -qO- http://localhost:3001/access || exit 1"]
-      interval: 15s
-      timeout: 10s
-      retries: 15
-      start_period: 60s
+      interval: 5s
+      timeout: 3s
+      retries: 50
+      start_period: 30s
   # Workers
   workers:
     image: workers-${PROJECT_NAME}:${BUILD_REF}-${BUILD_ID}


### PR DESCRIPTION
- Added healthcheck to mongo to enforce fom.io will wait before trying to reach the DB for the first time.
- Increased the allowed time for the healthcheck to be performed (5x50s) and reduced the time between the attempts from 10s to 5s to allow the readiness sooner than later.