### PR TITLE
#6023 - Additional transportation for blended programs

### DIFF
--- a/sources/packages/backend/workflow/src/workflow-definitions/fulltime-assessment-2025-2026.bpmn
+++ b/sources/packages/backend/workflow/src/workflow-definitions/fulltime-assessment-2025-2026.bpmn
@@ -1661,7 +1661,7 @@ Priority to loan reported by partner directly, then by student. Otherwise will b
     <bpmn:sequenceFlow id="Flow_1ahpybi" sourceRef="Event_1prgnrg" targetRef="Event_0ad1kcw" />
     <bpmn:sequenceFlow id="Flow_1phv8s0" sourceRef="Event_1alhhyz" targetRef="Event_1prgnrg" />
     <bpmn:sequenceFlow id="Flow_19c3ckn" name="Eligible" sourceRef="Gateway_13yktch" targetRef="Event_1alhhyz">
-      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=studentDataAdditionalTransportRequested = "yes" and studentDataAdditionalTransportListedDriver ="yes" and offeringDelivered = "onsite"</bpmn:conditionExpression>
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=studentDataAdditionalTransportRequested = "yes" and studentDataAdditionalTransportListedDriver ="yes" and (offeringDelivered = "onsite" or offeringDelivered = "blended")</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
     <bpmn:sequenceFlow id="Flow_03tcdoz" sourceRef="Activity_0ka3ctt" targetRef="Event_1tgteeo" />
     <bpmn:sequenceFlow id="Flow_0jz0alp" sourceRef="Event_1tgteeo" targetRef="Gateway_0iex0qd" />

--- a/sources/packages/backend/workflow/src/workflow-definitions/fulltime-assessment-2026-2027.bpmn
+++ b/sources/packages/backend/workflow/src/workflow-definitions/fulltime-assessment-2026-2027.bpmn
@@ -771,7 +771,7 @@ If distance education/blended learning program or if married and claiming separa
       <bpmn:outgoing>Flow_0frefsk</bpmn:outgoing>
     </bpmn:intermediateThrowEvent>
     <bpmn:sequenceFlow id="Flow_19c3ckn" name="Eligible" sourceRef="Gateway_13yktch" targetRef="Event_1alhhyz">
-      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=studentDataAdditionalTransportRequested = "yes" and studentDataAdditionalTransportListedDriver ="yes" and offeringDelivered = "onsite"</bpmn:conditionExpression>
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=studentDataAdditionalTransportRequested = "yes" and studentDataAdditionalTransportListedDriver ="yes" and (offeringDelivered = "onsite" or offeringDelivered = "blended")</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
     <bpmn:intermediateThrowEvent id="Event_0n3kqyy" name="Exceptional Expense (Appeal)">
       <bpmn:extensionElements>

--- a/sources/packages/backend/workflow/test/2025-2026/fulltime-assessment/costs/fulltime-assessment-costs-transportation.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2025-2026/fulltime-assessment/costs/fulltime-assessment-costs-transportation.e2e-spec.ts
@@ -183,182 +183,186 @@ describe(`E2E Test Workflow fulltime-assessment-${PROGRAM_YEAR}-costs-transporta
       calculatedAssessment.variables.calculatedDataTotalTransportationCost,
     ).toBe(0);
   });
-});
 
-it("Should determine max return transportation cost for two round trips (<=26 weeks).", async () => {
-  // Arrange
-  const assessmentConsolidatedData =
-    createFakeConsolidatedFulltimeData(PROGRAM_YEAR);
-  assessmentConsolidatedData.offeringWeeks = 26;
-  assessmentConsolidatedData.studentDataReturnTripHomeCost = 452;
-  assessmentConsolidatedData.studentDataLivingAtHome = YesNoOptions.Yes;
-  assessmentConsolidatedData.studentDataSelfContainedSuite = YesNoOptions.Yes;
-  assessmentConsolidatedData.studentDataAdditionalTransportRequested =
-    YesNoOptions.No;
-  // Act
-  const calculatedAssessment = await executeFullTimeAssessmentForProgramYear(
-    PROGRAM_YEAR,
-    assessmentConsolidatedData,
+  it("Should determine max return transportation cost for two round trips (<=26 weeks).", async () => {
+    // Arrange
+    const assessmentConsolidatedData =
+      createFakeConsolidatedFulltimeData(PROGRAM_YEAR);
+    assessmentConsolidatedData.offeringWeeks = 26;
+    assessmentConsolidatedData.studentDataReturnTripHomeCost = 452;
+    assessmentConsolidatedData.studentDataLivingAtHome = YesNoOptions.Yes;
+    assessmentConsolidatedData.studentDataSelfContainedSuite = YesNoOptions.Yes;
+    assessmentConsolidatedData.studentDataAdditionalTransportRequested =
+      YesNoOptions.No;
+    // Act
+    const calculatedAssessment = await executeFullTimeAssessmentForProgramYear(
+      PROGRAM_YEAR,
+      assessmentConsolidatedData,
+    );
+    // Assert
+    // Expect the return transportation cost to be $900 as the max for offerings up to 26 weeks.
+    // Student declared cost would be $452 x 2 (allowable round trips) = $904.
+    // Max is $900 for offerings 26 weeks or less.
+    expect(
+      calculatedAssessment.variables.calculatedDataReturnTransportationCost,
+    ).toBe(900);
+    // Expect the additional transportation cost to be null or undefined.
+    expect(
+      calculatedAssessment.variables
+        .calculatedDataTotalAdditionalTransportationAllowance,
+    ).toBe(undefined);
+    // Expect the total transportation cost to be $900.
+    expect(
+      calculatedAssessment.variables.calculatedDataTotalTransportationCost,
+    ).toBe(900);
+  });
+
+  it("Should determine max return transportation cost for two round trips (>=27 weeks).", async () => {
+    // Arrange
+    const assessmentConsolidatedData =
+      createFakeConsolidatedFulltimeData(PROGRAM_YEAR);
+    assessmentConsolidatedData.offeringWeeks = 27;
+    assessmentConsolidatedData.studentDataReturnTripHomeCost = 1000;
+    assessmentConsolidatedData.studentDataLivingAtHome = YesNoOptions.Yes;
+    assessmentConsolidatedData.studentDataSelfContainedSuite = YesNoOptions.Yes;
+    assessmentConsolidatedData.studentDataAdditionalTransportRequested =
+      YesNoOptions.No;
+    // Act
+    const calculatedAssessment = await executeFullTimeAssessmentForProgramYear(
+      PROGRAM_YEAR,
+      assessmentConsolidatedData,
+    );
+    // Assert
+    // Expect the return transportation cost to be $1800.
+    // Student declared cost would be $1000 x 2 (allowable round trips) = $2,000.
+    // Max is $1,800 for offerings 27 weeks or longer.
+    expect(
+      calculatedAssessment.variables.calculatedDataReturnTransportationCost,
+    ).toBe(1800);
+    // Expect the additional transportation cost to be null or undefined.
+    expect(
+      calculatedAssessment.variables
+        .calculatedDataTotalAdditionalTransportationAllowance,
+    ).toBe(undefined);
+    // Expect the total transportation cost to be $1800.
+    expect(
+      calculatedAssessment.variables.calculatedDataTotalTransportationCost,
+    ).toBe(1800);
+  });
+
+  it("Should determine return transportation cost below the maximum for two round trips (>=27 weeks).", async () => {
+    // Arrange
+    const assessmentConsolidatedData =
+      createFakeConsolidatedFulltimeData(PROGRAM_YEAR);
+    assessmentConsolidatedData.offeringWeeks = 27;
+    assessmentConsolidatedData.studentDataReturnTripHomeCost = 600;
+    assessmentConsolidatedData.studentDataLivingAtHome = YesNoOptions.Yes;
+    assessmentConsolidatedData.studentDataSelfContainedSuite = YesNoOptions.Yes;
+    assessmentConsolidatedData.studentDataAdditionalTransportRequested =
+      YesNoOptions.No;
+    // Act
+    const calculatedAssessment = await executeFullTimeAssessmentForProgramYear(
+      PROGRAM_YEAR,
+      assessmentConsolidatedData,
+    );
+    // Assert
+    // Expect the return transportation cost to be $1200.
+    // Student declared cost would be $600 x 2 (allowable round trips) = $1200.
+    // Max is $1,800 for offerings 27 weeks or longer.
+    expect(
+      calculatedAssessment.variables.calculatedDataReturnTransportationCost,
+    ).toBe(1200);
+    // Expect the additional transportation cost to be null or undefined.
+    expect(
+      calculatedAssessment.variables
+        .calculatedDataTotalAdditionalTransportationAllowance,
+    ).toBe(undefined);
+    // Expect the total transportation cost to be $1200.
+    expect(
+      calculatedAssessment.variables.calculatedDataTotalTransportationCost,
+    ).toBe(1200);
+  });
+
+  it("Should determine return transportation cost below the maximum for two round trips with previously claimed costs (>=27 weeks).", async () => {
+    // Arrange
+    const assessmentConsolidatedData =
+      createFakeConsolidatedFulltimeData(PROGRAM_YEAR);
+    assessmentConsolidatedData.offeringWeeks = 27;
+    assessmentConsolidatedData.studentDataReturnTripHomeCost = 600;
+    assessmentConsolidatedData.programYearTotalFullTimeReturnTransportationCost = 1000;
+    assessmentConsolidatedData.studentDataLivingAtHome = YesNoOptions.Yes;
+    assessmentConsolidatedData.studentDataSelfContainedSuite = YesNoOptions.Yes;
+    assessmentConsolidatedData.studentDataAdditionalTransportRequested =
+      YesNoOptions.No;
+    // Act
+    const calculatedAssessment = await executeFullTimeAssessmentForProgramYear(
+      PROGRAM_YEAR,
+      assessmentConsolidatedData,
+    );
+    // Assert
+    // Max is $1,800 for the program year.
+    // 1800 - 1000 (previously claimed) = 800 (remaining return transportation).
+    expect(
+      calculatedAssessment.variables
+        .calculatedDataRemainingReturnTransportation,
+    ).toBe(800);
+    // Expect the return transportation cost to be lower of:
+    // Remaining return transportation cost ($800),
+    // application limit ($1800 for 27+ weeks), or
+    // Student declared cost ($600 x 2 allowable round trips = $1200).
+    expect(
+      calculatedAssessment.variables.calculatedDataReturnTransportationCost,
+    ).toBe(800);
+    // Expect the additional transportation cost to be null or undefined.
+    expect(
+      calculatedAssessment.variables
+        .calculatedDataTotalAdditionalTransportationAllowance,
+    ).toBe(undefined);
+    // Expect the total transportation cost to be $1200.
+    expect(
+      calculatedAssessment.variables.calculatedDataTotalTransportationCost,
+    ).toBe(800);
+  });
+
+  it.each([OfferingDeliveryOptions.Onsite, OfferingDeliveryOptions.Blended])(
+    "Should determine additional transportation cost for a %s offering.",
+    async (offeringDelivered) => {
+      // Arrange
+      const assessmentConsolidatedData =
+        createFakeConsolidatedFulltimeData(PROGRAM_YEAR);
+      assessmentConsolidatedData.offeringDelivered = offeringDelivered;
+      assessmentConsolidatedData.studentDataAdditionalTransportRequested =
+        YesNoOptions.Yes;
+      assessmentConsolidatedData.studentDataAdditionalTransportListedDriver =
+        YesNoOptions.Yes;
+      assessmentConsolidatedData.studentDataAdditionalTransportOwner =
+        YesNoOptions.Yes;
+      assessmentConsolidatedData.studentDataAdditionalTransportKm = 300;
+      assessmentConsolidatedData.studentDataAdditionalTransportWeeks = 10;
+      assessmentConsolidatedData.studentDataAdditionalTransportPlacement =
+        YesNoOptions.No;
+      // Act
+      const calculatedAssessment =
+        await executeFullTimeAssessmentForProgramYear(
+          PROGRAM_YEAR,
+          assessmentConsolidatedData,
+        );
+      // Assert
+      // 300 km * 0.34 = $102, capped at limit of $94 per week.
+      expect(
+        calculatedAssessment.variables
+          .calculatedDataNetWeeklyAdditionalTransportCost,
+      ).toBe(94);
+      // $94 per week * 10 weeks = $940.
+      expect(
+        calculatedAssessment.variables
+          .calculatedDataTotalAdditionalTransportationAllowance,
+      ).toBe(940);
+    },
   );
-  // Assert
-  // Expect the return transportation cost to be $900 as the max for offerings up to 26 weeks.
-  // Student declared cost would be $452 x 2 (allowable round trips) = $904.
-  // Max is $900 for offerings 26 weeks or less.
-  expect(
-    calculatedAssessment.variables.calculatedDataReturnTransportationCost,
-  ).toBe(900);
-  // Expect the additional transportation cost to be null or undefined.
-  expect(
-    calculatedAssessment.variables
-      .calculatedDataTotalAdditionalTransportationAllowance,
-  ).toBe(undefined);
-  // Expect the total transportation cost to be $900.
-  expect(
-    calculatedAssessment.variables.calculatedDataTotalTransportationCost,
-  ).toBe(900);
-});
 
-it("Should determine max return transportation cost for two round trips (>=27 weeks).", async () => {
-  // Arrange
-  const assessmentConsolidatedData =
-    createFakeConsolidatedFulltimeData(PROGRAM_YEAR);
-  assessmentConsolidatedData.offeringWeeks = 27;
-  assessmentConsolidatedData.studentDataReturnTripHomeCost = 1000;
-  assessmentConsolidatedData.studentDataLivingAtHome = YesNoOptions.Yes;
-  assessmentConsolidatedData.studentDataSelfContainedSuite = YesNoOptions.Yes;
-  assessmentConsolidatedData.studentDataAdditionalTransportRequested =
-    YesNoOptions.No;
-  // Act
-  const calculatedAssessment = await executeFullTimeAssessmentForProgramYear(
-    PROGRAM_YEAR,
-    assessmentConsolidatedData,
-  );
-  // Assert
-  // Expect the return transportation cost to be $1800.
-  // Student declared cost would be $1000 x 2 (allowable round trips) = $2,000.
-  // Max is $1,800 for offerings 27 weeks or longer.
-  expect(
-    calculatedAssessment.variables.calculatedDataReturnTransportationCost,
-  ).toBe(1800);
-  // Expect the additional transportation cost to be null or undefined.
-  expect(
-    calculatedAssessment.variables
-      .calculatedDataTotalAdditionalTransportationAllowance,
-  ).toBe(undefined);
-  // Expect the total transportation cost to be $1800.
-  expect(
-    calculatedAssessment.variables.calculatedDataTotalTransportationCost,
-  ).toBe(1800);
-});
-
-it("Should determine return transportation cost below the maximum for two round trips (>=27 weeks).", async () => {
-  // Arrange
-  const assessmentConsolidatedData =
-    createFakeConsolidatedFulltimeData(PROGRAM_YEAR);
-  assessmentConsolidatedData.offeringWeeks = 27;
-  assessmentConsolidatedData.studentDataReturnTripHomeCost = 600;
-  assessmentConsolidatedData.studentDataLivingAtHome = YesNoOptions.Yes;
-  assessmentConsolidatedData.studentDataSelfContainedSuite = YesNoOptions.Yes;
-  assessmentConsolidatedData.studentDataAdditionalTransportRequested =
-    YesNoOptions.No;
-  // Act
-  const calculatedAssessment = await executeFullTimeAssessmentForProgramYear(
-    PROGRAM_YEAR,
-    assessmentConsolidatedData,
-  );
-  // Assert
-  // Expect the return transportation cost to be $1200.
-  // Student declared cost would be $600 x 2 (allowable round trips) = $1200.
-  // Max is $1,800 for offerings 27 weeks or longer.
-  expect(
-    calculatedAssessment.variables.calculatedDataReturnTransportationCost,
-  ).toBe(1200);
-  // Expect the additional transportation cost to be null or undefined.
-  expect(
-    calculatedAssessment.variables
-      .calculatedDataTotalAdditionalTransportationAllowance,
-  ).toBe(undefined);
-  // Expect the total transportation cost to be $1200.
-  expect(
-    calculatedAssessment.variables.calculatedDataTotalTransportationCost,
-  ).toBe(1200);
-});
-
-it("Should determine return transportation cost below the maximum for two round trips with previously claimed costs (>=27 weeks).", async () => {
-  // Arrange
-  const assessmentConsolidatedData =
-    createFakeConsolidatedFulltimeData(PROGRAM_YEAR);
-  assessmentConsolidatedData.offeringWeeks = 27;
-  assessmentConsolidatedData.studentDataReturnTripHomeCost = 600;
-  assessmentConsolidatedData.programYearTotalFullTimeReturnTransportationCost = 1000;
-  assessmentConsolidatedData.studentDataLivingAtHome = YesNoOptions.Yes;
-  assessmentConsolidatedData.studentDataSelfContainedSuite = YesNoOptions.Yes;
-  assessmentConsolidatedData.studentDataAdditionalTransportRequested =
-    YesNoOptions.No;
-  // Act
-  const calculatedAssessment = await executeFullTimeAssessmentForProgramYear(
-    PROGRAM_YEAR,
-    assessmentConsolidatedData,
-  );
-  // Assert
-  // Max is $1,800 for the program year.
-  // 1800 - 1000 (previously claimed) = 800 (remaining return transportation).
-  expect(
-    calculatedAssessment.variables.calculatedDataRemainingReturnTransportation,
-  ).toBe(800);
-  // Expect the return transportation cost to be lower of:
-  // Remaining return transportation cost ($800),
-  // application limit ($1800 for 27+ weeks), or
-  // Student declared cost ($600 x 2 allowable round trips = $1200).
-  expect(
-    calculatedAssessment.variables.calculatedDataReturnTransportationCost,
-  ).toBe(800);
-  // Expect the additional transportation cost to be null or undefined.
-  expect(
-    calculatedAssessment.variables
-      .calculatedDataTotalAdditionalTransportationAllowance,
-  ).toBe(undefined);
-  // Expect the total transportation cost to be $1200.
-  expect(
-    calculatedAssessment.variables.calculatedDataTotalTransportationCost,
-  ).toBe(800);
-});
-
-it("Should determine additional transportation allowance for a blended offering.", async () => {
-  // Arrange
-  const assessmentConsolidatedData =
-    createFakeConsolidatedFulltimeData(PROGRAM_YEAR);
-  assessmentConsolidatedData.offeringDelivered =
-    OfferingDeliveryOptions.Blended;
-  assessmentConsolidatedData.studentDataAdditionalTransportRequested =
-    YesNoOptions.Yes;
-  assessmentConsolidatedData.studentDataAdditionalTransportListedDriver =
-    YesNoOptions.Yes;
-  assessmentConsolidatedData.studentDataAdditionalTransportOwner =
-    YesNoOptions.Yes;
-  assessmentConsolidatedData.studentDataAdditionalTransportKm = 300;
-  assessmentConsolidatedData.studentDataAdditionalTransportWeeks = 10;
-  assessmentConsolidatedData.studentDataAdditionalTransportPlacement =
-    YesNoOptions.No;
-  // Act
-  const calculatedAssessment = await executeFullTimeAssessmentForProgramYear(
-    PROGRAM_YEAR,
-    assessmentConsolidatedData,
-  );
-  // Assert
-  // 300 km * 0.34 = $102, capped at limit of $94 per week.
-  expect(
-    calculatedAssessment.variables
-      .calculatedDataNetWeeklyAdditionalTransportCost,
-  ).toBe(94);
-  // $94 per week * 10 weeks = $940.
-  expect(
-    calculatedAssessment.variables
-      .calculatedDataTotalAdditionalTransportationAllowance,
-  ).toBe(940);
-});
-
-afterAll(async () => {
-  // Closes the singleton instance created during test executions.
-  await ZeebeMockedClient.getMockedZeebeInstance().close();
+  afterAll(async () => {
+    // Closes the singleton instance created during test executions.
+    await ZeebeMockedClient.getMockedZeebeInstance().close();
+  });
 });

--- a/sources/packages/backend/workflow/test/2025-2026/fulltime-assessment/costs/fulltime-assessment-costs-transportation.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2025-2026/fulltime-assessment/costs/fulltime-assessment-costs-transportation.e2e-spec.ts
@@ -35,7 +35,7 @@ describe(`E2E Test Workflow fulltime-assessment-${PROGRAM_YEAR}-costs-transporta
     ).toBe(0);
   });
 
-  it("Should determine no transportation cost when ineligible for return transportation due to online delivery.", async () => {
+  it("Should determine no transportation cost when student does not request additional transportation and is ineligible for return transportation due to online delivery.", async () => {
     // Arrange
     const assessmentConsolidatedData =
       createFakeConsolidatedFulltimeData(PROGRAM_YEAR);
@@ -65,7 +65,7 @@ describe(`E2E Test Workflow fulltime-assessment-${PROGRAM_YEAR}-costs-transporta
     ).toBe(0);
   });
 
-  it("Should determine no transportation cost when ineligible for return transportation due to living with partner.", async () => {
+  it("Should determine no transportation cost when student does not request additional transportation and is ineligible for return transportation due to living with partner.", async () => {
     // Arrange
     const assessmentConsolidatedData =
       createFakeConsolidatedFulltimeData(PROGRAM_YEAR);
@@ -103,7 +103,7 @@ describe(`E2E Test Workflow fulltime-assessment-${PROGRAM_YEAR}-costs-transporta
     ).toBe(0);
   });
 
-  it("Should determine no transportation cost when ineligible for return transportation as single independent student at home.", async () => {
+  it("Should determine no transportation cost when student does not request additional transportation and is ineligible for return transportation as single independent student at home.", async () => {
     // Arrange
     const assessmentConsolidatedData =
       createFakeConsolidatedFulltimeData(PROGRAM_YEAR);
@@ -137,7 +137,7 @@ describe(`E2E Test Workflow fulltime-assessment-${PROGRAM_YEAR}-costs-transporta
     ).toBe(0);
   });
 
-  it("Should determine no transportation cost when ineligible for return transportation as single dependant at home.", async () => {
+  it("Should determine no transportation cost when student does not request additional transportation and is ineligible for return transportation as single dependant at home.", async () => {
     // Arrange
     const assessmentConsolidatedData =
       createFakeConsolidatedFulltimeData(PROGRAM_YEAR);
@@ -184,7 +184,7 @@ describe(`E2E Test Workflow fulltime-assessment-${PROGRAM_YEAR}-costs-transporta
     ).toBe(0);
   });
 
-  it("Should determine max return transportation cost for two round trips (<=26 weeks).", async () => {
+  it("Should determine max return transportation cost when student reported cost higher than two round trips (<=26 weeks).", async () => {
     // Arrange
     const assessmentConsolidatedData =
       createFakeConsolidatedFulltimeData(PROGRAM_YEAR);
@@ -217,7 +217,7 @@ describe(`E2E Test Workflow fulltime-assessment-${PROGRAM_YEAR}-costs-transporta
     ).toBe(900);
   });
 
-  it("Should determine max return transportation cost for two round trips (>=27 weeks).", async () => {
+  it("Should determine max return transportation cost when student reported cost higher than two round trips (>=27 weeks).", async () => {
     // Arrange
     const assessmentConsolidatedData =
       createFakeConsolidatedFulltimeData(PROGRAM_YEAR);
@@ -325,7 +325,7 @@ describe(`E2E Test Workflow fulltime-assessment-${PROGRAM_YEAR}-costs-transporta
   });
 
   it.each([OfferingDeliveryOptions.Onsite, OfferingDeliveryOptions.Blended])(
-    "Should determine additional transportation cost for a %s offering.",
+    "Should determine additional transportation cost when offering delivered is %s.",
     async (offeringDelivered) => {
       // Arrange
       const assessmentConsolidatedData =

--- a/sources/packages/backend/workflow/test/2025-2026/fulltime-assessment/costs/fulltime-assessment-costs-transportation.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2025-2026/fulltime-assessment/costs/fulltime-assessment-costs-transportation.e2e-spec.ts
@@ -35,190 +35,13 @@ describe(`E2E Test Workflow fulltime-assessment-${PROGRAM_YEAR}-costs-transporta
     ).toBe(0);
   });
 
-  it(
-    "Should determine no transportation cost when student does not request additional transportation and " +
-      "they are ineligible for return transportation due to online delivery.",
-    async () => {
-      // Arrange
-      const assessmentConsolidatedData =
-        createFakeConsolidatedFulltimeData(PROGRAM_YEAR);
-      assessmentConsolidatedData.studentDataReturnTripHomeCost = 1000;
-      assessmentConsolidatedData.offeringDelivered =
-        OfferingDeliveryOptions.Online;
-      assessmentConsolidatedData.studentDataAdditionalTransportRequested =
-        YesNoOptions.No;
-      // Act
-      const calculatedAssessment =
-        await executeFullTimeAssessmentForProgramYear(
-          PROGRAM_YEAR,
-          assessmentConsolidatedData,
-        );
-      // Assert
-      // Expect the return transportation cost to be 0.
-      expect(
-        calculatedAssessment.variables.calculatedDataReturnTransportationCost,
-      ).toBe(0);
-      // Expect the additional transportation cost to be null or undefined.
-      expect(
-        calculatedAssessment.variables
-          .calculatedDataTotalAdditionalTransportationAllowance,
-      ).toBe(undefined);
-      // Expect the total transportation cost to be 0.
-      expect(
-        calculatedAssessment.variables.calculatedDataTotalTransportationCost,
-      ).toBe(0);
-    },
-  );
-
-  it(
-    "Should determine no transportation cost when student does not request additional transportation and " +
-      "they are ineligible for return transportation due to living with partner.",
-    async () => {
-      // Arrange
-      const assessmentConsolidatedData =
-        createFakeConsolidatedFulltimeData(PROGRAM_YEAR);
-      assessmentConsolidatedData.studentDataAdditionalTransportRequested =
-        YesNoOptions.No;
-      assessmentConsolidatedData.studentDataReturnTripHomeCost = 1000;
-      assessmentConsolidatedData.studentDataLivingWithPartner =
-        YesNoOptions.Yes;
-      assessmentConsolidatedData.studentDataIsYourPartnerAbleToReport = false;
-      assessmentConsolidatedData.studentDataRelationshipStatus = "married";
-      assessmentConsolidatedData.studentDataPartnerHasEmploymentInsuranceBenefits =
-        YesNoOptions.No;
-      assessmentConsolidatedData.studentDataPartnerHasTotalIncomeAssistance =
-        YesNoOptions.No;
-      assessmentConsolidatedData.studentDataPartnerHasFedralProvincialPDReceipt =
-        YesNoOptions.No;
-      assessmentConsolidatedData.studentDataEstimatedSpouseIncome = 0;
-      // Act
-      const calculatedAssessment =
-        await executeFullTimeAssessmentForProgramYear(
-          PROGRAM_YEAR,
-          assessmentConsolidatedData,
-        );
-      // Assert
-      // Expect the return transportation cost to be 0.
-      expect(
-        calculatedAssessment.variables.calculatedDataReturnTransportationCost,
-      ).toBe(0);
-      // Expect the additional transportation cost to be null or undefined.
-      expect(
-        calculatedAssessment.variables
-          .calculatedDataTotalAdditionalTransportationAllowance,
-      ).toBe(undefined);
-      // Expect the total transportation cost to be 0.
-      expect(
-        calculatedAssessment.variables.calculatedDataTotalTransportationCost,
-      ).toBe(0);
-    },
-  );
-
-  it(
-    "Should determine no transportation cost when student does not request additional transportation and " +
-      "they are ineligible for return transportation due to being a Single independant student at home.",
-    async () => {
-      // Arrange
-      const assessmentConsolidatedData =
-        createFakeConsolidatedFulltimeData(PROGRAM_YEAR);
-      assessmentConsolidatedData.studentDataReturnTripHomeCost = 1000;
-      assessmentConsolidatedData.studentDataLivingAtHome = YesNoOptions.Yes;
-      assessmentConsolidatedData.studentDataSelfContainedSuite =
-        YesNoOptions.No;
-      assessmentConsolidatedData.studentDataAdditionalTransportRequested =
-        YesNoOptions.No;
-      // Act
-      const calculatedAssessment =
-        await executeFullTimeAssessmentForProgramYear(
-          PROGRAM_YEAR,
-          assessmentConsolidatedData,
-        );
-      // Assert
-      // Expect the Living Category to be at Home (H).
-      expect(calculatedAssessment.variables.dmnFullTimeLivingCategory).toBe(
-        "SIH",
-      );
-      // Expect the return transportation cost to be 0.
-      expect(
-        calculatedAssessment.variables.calculatedDataReturnTransportationCost,
-      ).toBe(0);
-      // Expect the additional transportation cost to be null or undefined.
-      expect(
-        calculatedAssessment.variables
-          .calculatedDataTotalAdditionalTransportationAllowance,
-      ).toBe(undefined);
-      // Expect the total transportation cost to be 0.
-      expect(
-        calculatedAssessment.variables.calculatedDataTotalTransportationCost,
-      ).toBe(0);
-    },
-  );
-
-  it(
-    "Should determine no transportation cost when student does not request additional transportation and " +
-      "they are ineligible for return transportation due to being a Single dependant living at home.",
-    async () => {
-      // Arrange
-      const assessmentConsolidatedData =
-        createFakeConsolidatedFulltimeData(PROGRAM_YEAR);
-      assessmentConsolidatedData.studentDataAdditionalTransportRequested =
-        YesNoOptions.No;
-      assessmentConsolidatedData.studentDataReturnTripHomeCost = 1000;
-      assessmentConsolidatedData.studentDataLivingAtHome = YesNoOptions.Yes;
-      assessmentConsolidatedData.studentDataSelfContainedSuite =
-        YesNoOptions.No;
-      assessmentConsolidatedData.studentDataDependantstatus = "dependant";
-      assessmentConsolidatedData.parent1TotalIncome = 0;
-      assessmentConsolidatedData.parent1CppEmployment = 0;
-      assessmentConsolidatedData.parent1CppSelfemploymentOther = 0;
-      assessmentConsolidatedData.parent1Ei = 0;
-      assessmentConsolidatedData.parent1Tax = 0;
-      assessmentConsolidatedData.parent1Contributions = 0;
-      assessmentConsolidatedData.studentDataVoluntaryContributions = 0;
-      assessmentConsolidatedData.studentDataParents = [
-        {
-          parentIsAbleToReport: YesNoOptions.Yes,
-        },
-      ];
-      // Act
-      const calculatedAssessment =
-        await executeFullTimeAssessmentForProgramYear(
-          PROGRAM_YEAR,
-          assessmentConsolidatedData,
-        );
-      // Assert
-      // Expect the Living Category to be at Home (H).
-      expect(calculatedAssessment.variables.dmnFullTimeLivingCategory).toBe(
-        "SDH",
-      );
-      // Expect the return transportation cost to be 0.
-      expect(
-        calculatedAssessment.variables.calculatedDataReturnTransportationCost,
-      ).toBe(0);
-      // Expect the additional transportation cost to be null or undefined.
-      expect(
-        calculatedAssessment.variables
-          .calculatedDataTotalAdditionalTransportationAllowance,
-      ).toBe(undefined);
-      // Expect the total transportation cost to be 0.
-      expect(
-        calculatedAssessment.variables.calculatedDataTotalTransportationCost,
-      ).toBe(0);
-    },
-  );
-});
-
-it(
-  "Should determine max return transportation cost when an eligible student " +
-    "reports costs that would be higher than that for two round trips. (<=26 weeks) ",
-  async () => {
+  it("Should determine no transportation cost when ineligible for return transportation due to online delivery.", async () => {
     // Arrange
     const assessmentConsolidatedData =
       createFakeConsolidatedFulltimeData(PROGRAM_YEAR);
-    assessmentConsolidatedData.offeringWeeks = 26;
-    assessmentConsolidatedData.studentDataReturnTripHomeCost = 452;
-    assessmentConsolidatedData.studentDataLivingAtHome = YesNoOptions.Yes;
-    assessmentConsolidatedData.studentDataSelfContainedSuite = YesNoOptions.Yes;
+    assessmentConsolidatedData.studentDataReturnTripHomeCost = 1000;
+    assessmentConsolidatedData.offeringDelivered =
+      OfferingDeliveryOptions.Online;
     assessmentConsolidatedData.studentDataAdditionalTransportRequested =
       YesNoOptions.No;
     // Act
@@ -227,35 +50,66 @@ it(
       assessmentConsolidatedData,
     );
     // Assert
-    // Expect the return transportation cost to be $900 as the max for offerings up to 26 weeks.
-    // Student declared cost would be $452 x 2 (allowable round trips) = $904.
-    // Max is $900 for offerings 26 weeks or less.
+    // Expect the return transportation cost to be 0.
     expect(
       calculatedAssessment.variables.calculatedDataReturnTransportationCost,
-    ).toBe(900);
+    ).toBe(0);
     // Expect the additional transportation cost to be null or undefined.
     expect(
       calculatedAssessment.variables
         .calculatedDataTotalAdditionalTransportationAllowance,
     ).toBe(undefined);
-    // Expect the total transportation cost to be $900.
+    // Expect the total transportation cost to be 0.
     expect(
       calculatedAssessment.variables.calculatedDataTotalTransportationCost,
-    ).toBe(900);
-  },
-);
+    ).toBe(0);
+  });
 
-it(
-  "Should determine max return transportation cost when an eligible student " +
-    "reports costs that would be higher than that for two round trips (>=27 weeks).",
-  async () => {
+  it("Should determine no transportation cost when ineligible for return transportation due to living with partner.", async () => {
     // Arrange
     const assessmentConsolidatedData =
       createFakeConsolidatedFulltimeData(PROGRAM_YEAR);
-    assessmentConsolidatedData.offeringWeeks = 27;
+    assessmentConsolidatedData.studentDataAdditionalTransportRequested =
+      YesNoOptions.No;
+    assessmentConsolidatedData.studentDataReturnTripHomeCost = 1000;
+    assessmentConsolidatedData.studentDataLivingWithPartner = YesNoOptions.Yes;
+    assessmentConsolidatedData.studentDataIsYourPartnerAbleToReport = false;
+    assessmentConsolidatedData.studentDataRelationshipStatus = "married";
+    assessmentConsolidatedData.studentDataPartnerHasEmploymentInsuranceBenefits =
+      YesNoOptions.No;
+    assessmentConsolidatedData.studentDataPartnerHasTotalIncomeAssistance =
+      YesNoOptions.No;
+    assessmentConsolidatedData.studentDataPartnerHasFedralProvincialPDReceipt =
+      YesNoOptions.No;
+    assessmentConsolidatedData.studentDataEstimatedSpouseIncome = 0;
+    // Act
+    const calculatedAssessment = await executeFullTimeAssessmentForProgramYear(
+      PROGRAM_YEAR,
+      assessmentConsolidatedData,
+    );
+    // Assert
+    // Expect the return transportation cost to be 0.
+    expect(
+      calculatedAssessment.variables.calculatedDataReturnTransportationCost,
+    ).toBe(0);
+    // Expect the additional transportation cost to be null or undefined.
+    expect(
+      calculatedAssessment.variables
+        .calculatedDataTotalAdditionalTransportationAllowance,
+    ).toBe(undefined);
+    // Expect the total transportation cost to be 0.
+    expect(
+      calculatedAssessment.variables.calculatedDataTotalTransportationCost,
+    ).toBe(0);
+  });
+
+  it("Should determine no transportation cost when ineligible for return transportation as single independent student at home.", async () => {
+    // Arrange
+    const assessmentConsolidatedData =
+      createFakeConsolidatedFulltimeData(PROGRAM_YEAR);
     assessmentConsolidatedData.studentDataReturnTripHomeCost = 1000;
     assessmentConsolidatedData.studentDataLivingAtHome = YesNoOptions.Yes;
-    assessmentConsolidatedData.studentDataSelfContainedSuite = YesNoOptions.Yes;
+    assessmentConsolidatedData.studentDataSelfContainedSuite = YesNoOptions.No;
     assessmentConsolidatedData.studentDataAdditionalTransportRequested =
       YesNoOptions.No;
     // Act
@@ -264,106 +118,245 @@ it(
       assessmentConsolidatedData,
     );
     // Assert
-    // Expect the return transportation cost to be $1800.
-    // Student declared cost would be $1000 x 2 (allowable round trips) = $2,000.
-    // Max is $1,800 for offerings 27 weeks or longer.
+    // Expect the Living Category to be at Home (H).
+    expect(calculatedAssessment.variables.dmnFullTimeLivingCategory).toBe(
+      "SIH",
+    );
+    // Expect the return transportation cost to be 0.
     expect(
       calculatedAssessment.variables.calculatedDataReturnTransportationCost,
-    ).toBe(1800);
+    ).toBe(0);
     // Expect the additional transportation cost to be null or undefined.
     expect(
       calculatedAssessment.variables
         .calculatedDataTotalAdditionalTransportationAllowance,
     ).toBe(undefined);
-    // Expect the total transportation cost to be $1800.
+    // Expect the total transportation cost to be 0.
     expect(
       calculatedAssessment.variables.calculatedDataTotalTransportationCost,
-    ).toBe(1800);
-  },
-);
+    ).toBe(0);
+  });
 
-it(
-  "Should determine return transportation cost when an eligible student " +
-    "reports costs that would be lower than the maximum for two round trips (>=27 weeks).",
-  async () => {
+  it("Should determine no transportation cost when ineligible for return transportation as single dependant at home.", async () => {
     // Arrange
     const assessmentConsolidatedData =
       createFakeConsolidatedFulltimeData(PROGRAM_YEAR);
-    assessmentConsolidatedData.offeringWeeks = 27;
-    assessmentConsolidatedData.studentDataReturnTripHomeCost = 600;
-    assessmentConsolidatedData.studentDataLivingAtHome = YesNoOptions.Yes;
-    assessmentConsolidatedData.studentDataSelfContainedSuite = YesNoOptions.Yes;
     assessmentConsolidatedData.studentDataAdditionalTransportRequested =
       YesNoOptions.No;
+    assessmentConsolidatedData.studentDataReturnTripHomeCost = 1000;
+    assessmentConsolidatedData.studentDataLivingAtHome = YesNoOptions.Yes;
+    assessmentConsolidatedData.studentDataSelfContainedSuite = YesNoOptions.No;
+    assessmentConsolidatedData.studentDataDependantstatus = "dependant";
+    assessmentConsolidatedData.parent1TotalIncome = 0;
+    assessmentConsolidatedData.parent1CppEmployment = 0;
+    assessmentConsolidatedData.parent1CppSelfemploymentOther = 0;
+    assessmentConsolidatedData.parent1Ei = 0;
+    assessmentConsolidatedData.parent1Tax = 0;
+    assessmentConsolidatedData.parent1Contributions = 0;
+    assessmentConsolidatedData.studentDataVoluntaryContributions = 0;
+    assessmentConsolidatedData.studentDataParents = [
+      {
+        parentIsAbleToReport: YesNoOptions.Yes,
+      },
+    ];
     // Act
     const calculatedAssessment = await executeFullTimeAssessmentForProgramYear(
       PROGRAM_YEAR,
       assessmentConsolidatedData,
     );
     // Assert
-    // Expect the return transportation cost to be $1200.
-    // Student declared cost would be $600 x 2 (allowable round trips) = $1200.
-    // Max is $1,800 for offerings 27 weeks or longer.
+    // Expect the Living Category to be at Home (H).
+    expect(calculatedAssessment.variables.dmnFullTimeLivingCategory).toBe(
+      "SDH",
+    );
+    // Expect the return transportation cost to be 0.
     expect(
       calculatedAssessment.variables.calculatedDataReturnTransportationCost,
-    ).toBe(1200);
+    ).toBe(0);
     // Expect the additional transportation cost to be null or undefined.
     expect(
       calculatedAssessment.variables
         .calculatedDataTotalAdditionalTransportationAllowance,
     ).toBe(undefined);
-    // Expect the total transportation cost to be $1200.
+    // Expect the total transportation cost to be 0.
     expect(
       calculatedAssessment.variables.calculatedDataTotalTransportationCost,
-    ).toBe(1200);
-  },
-);
+    ).toBe(0);
+  });
+});
 
-it(
-  "Should determine return transportation cost when an eligible student " +
-    "reports costs that would be lower than the maximum for two round trips (>=27 weeks) " +
-    "and has previously had return transportation costs.",
-  async () => {
-    // Arrange
-    const assessmentConsolidatedData =
-      createFakeConsolidatedFulltimeData(PROGRAM_YEAR);
-    assessmentConsolidatedData.offeringWeeks = 27;
-    assessmentConsolidatedData.studentDataReturnTripHomeCost = 600;
-    assessmentConsolidatedData.programYearTotalFullTimeReturnTransportationCost = 1000;
-    assessmentConsolidatedData.studentDataLivingAtHome = YesNoOptions.Yes;
-    assessmentConsolidatedData.studentDataSelfContainedSuite = YesNoOptions.Yes;
-    assessmentConsolidatedData.studentDataAdditionalTransportRequested =
-      YesNoOptions.No;
-    // Act
-    const calculatedAssessment = await executeFullTimeAssessmentForProgramYear(
-      PROGRAM_YEAR,
-      assessmentConsolidatedData,
-    );
-    // Assert
-    // Max is $1,800 for the program year.
-    // 1800 - 1000 (previously claimed) = 800 (remaining return transportation).
-    expect(
-      calculatedAssessment.variables
-        .calculatedDataRemainingReturnTransportation,
-    ).toBe(800);
-    // Expect the return transportation cost to be lower of:
-    // Remaining return transportation cost ($800),
-    // application limit ($1800 for 27+ weeks), or
-    // Student declared cost ($600 x 2 allowable round trips = $1200).
-    expect(
-      calculatedAssessment.variables.calculatedDataReturnTransportationCost,
-    ).toBe(800);
-    // Expect the additional transportation cost to be null or undefined.
-    expect(
-      calculatedAssessment.variables
-        .calculatedDataTotalAdditionalTransportationAllowance,
-    ).toBe(undefined);
-    // Expect the total transportation cost to be $1200.
-    expect(
-      calculatedAssessment.variables.calculatedDataTotalTransportationCost,
-    ).toBe(800);
-  },
-);
+it("Should determine max return transportation cost for two round trips (<=26 weeks).", async () => {
+  // Arrange
+  const assessmentConsolidatedData =
+    createFakeConsolidatedFulltimeData(PROGRAM_YEAR);
+  assessmentConsolidatedData.offeringWeeks = 26;
+  assessmentConsolidatedData.studentDataReturnTripHomeCost = 452;
+  assessmentConsolidatedData.studentDataLivingAtHome = YesNoOptions.Yes;
+  assessmentConsolidatedData.studentDataSelfContainedSuite = YesNoOptions.Yes;
+  assessmentConsolidatedData.studentDataAdditionalTransportRequested =
+    YesNoOptions.No;
+  // Act
+  const calculatedAssessment = await executeFullTimeAssessmentForProgramYear(
+    PROGRAM_YEAR,
+    assessmentConsolidatedData,
+  );
+  // Assert
+  // Expect the return transportation cost to be $900 as the max for offerings up to 26 weeks.
+  // Student declared cost would be $452 x 2 (allowable round trips) = $904.
+  // Max is $900 for offerings 26 weeks or less.
+  expect(
+    calculatedAssessment.variables.calculatedDataReturnTransportationCost,
+  ).toBe(900);
+  // Expect the additional transportation cost to be null or undefined.
+  expect(
+    calculatedAssessment.variables
+      .calculatedDataTotalAdditionalTransportationAllowance,
+  ).toBe(undefined);
+  // Expect the total transportation cost to be $900.
+  expect(
+    calculatedAssessment.variables.calculatedDataTotalTransportationCost,
+  ).toBe(900);
+});
+
+it("Should determine max return transportation cost for two round trips (>=27 weeks).", async () => {
+  // Arrange
+  const assessmentConsolidatedData =
+    createFakeConsolidatedFulltimeData(PROGRAM_YEAR);
+  assessmentConsolidatedData.offeringWeeks = 27;
+  assessmentConsolidatedData.studentDataReturnTripHomeCost = 1000;
+  assessmentConsolidatedData.studentDataLivingAtHome = YesNoOptions.Yes;
+  assessmentConsolidatedData.studentDataSelfContainedSuite = YesNoOptions.Yes;
+  assessmentConsolidatedData.studentDataAdditionalTransportRequested =
+    YesNoOptions.No;
+  // Act
+  const calculatedAssessment = await executeFullTimeAssessmentForProgramYear(
+    PROGRAM_YEAR,
+    assessmentConsolidatedData,
+  );
+  // Assert
+  // Expect the return transportation cost to be $1800.
+  // Student declared cost would be $1000 x 2 (allowable round trips) = $2,000.
+  // Max is $1,800 for offerings 27 weeks or longer.
+  expect(
+    calculatedAssessment.variables.calculatedDataReturnTransportationCost,
+  ).toBe(1800);
+  // Expect the additional transportation cost to be null or undefined.
+  expect(
+    calculatedAssessment.variables
+      .calculatedDataTotalAdditionalTransportationAllowance,
+  ).toBe(undefined);
+  // Expect the total transportation cost to be $1800.
+  expect(
+    calculatedAssessment.variables.calculatedDataTotalTransportationCost,
+  ).toBe(1800);
+});
+
+it("Should determine return transportation cost below the maximum for two round trips (>=27 weeks).", async () => {
+  // Arrange
+  const assessmentConsolidatedData =
+    createFakeConsolidatedFulltimeData(PROGRAM_YEAR);
+  assessmentConsolidatedData.offeringWeeks = 27;
+  assessmentConsolidatedData.studentDataReturnTripHomeCost = 600;
+  assessmentConsolidatedData.studentDataLivingAtHome = YesNoOptions.Yes;
+  assessmentConsolidatedData.studentDataSelfContainedSuite = YesNoOptions.Yes;
+  assessmentConsolidatedData.studentDataAdditionalTransportRequested =
+    YesNoOptions.No;
+  // Act
+  const calculatedAssessment = await executeFullTimeAssessmentForProgramYear(
+    PROGRAM_YEAR,
+    assessmentConsolidatedData,
+  );
+  // Assert
+  // Expect the return transportation cost to be $1200.
+  // Student declared cost would be $600 x 2 (allowable round trips) = $1200.
+  // Max is $1,800 for offerings 27 weeks or longer.
+  expect(
+    calculatedAssessment.variables.calculatedDataReturnTransportationCost,
+  ).toBe(1200);
+  // Expect the additional transportation cost to be null or undefined.
+  expect(
+    calculatedAssessment.variables
+      .calculatedDataTotalAdditionalTransportationAllowance,
+  ).toBe(undefined);
+  // Expect the total transportation cost to be $1200.
+  expect(
+    calculatedAssessment.variables.calculatedDataTotalTransportationCost,
+  ).toBe(1200);
+});
+
+it("Should determine return transportation cost below the maximum for two round trips with previously claimed costs (>=27 weeks).", async () => {
+  // Arrange
+  const assessmentConsolidatedData =
+    createFakeConsolidatedFulltimeData(PROGRAM_YEAR);
+  assessmentConsolidatedData.offeringWeeks = 27;
+  assessmentConsolidatedData.studentDataReturnTripHomeCost = 600;
+  assessmentConsolidatedData.programYearTotalFullTimeReturnTransportationCost = 1000;
+  assessmentConsolidatedData.studentDataLivingAtHome = YesNoOptions.Yes;
+  assessmentConsolidatedData.studentDataSelfContainedSuite = YesNoOptions.Yes;
+  assessmentConsolidatedData.studentDataAdditionalTransportRequested =
+    YesNoOptions.No;
+  // Act
+  const calculatedAssessment = await executeFullTimeAssessmentForProgramYear(
+    PROGRAM_YEAR,
+    assessmentConsolidatedData,
+  );
+  // Assert
+  // Max is $1,800 for the program year.
+  // 1800 - 1000 (previously claimed) = 800 (remaining return transportation).
+  expect(
+    calculatedAssessment.variables.calculatedDataRemainingReturnTransportation,
+  ).toBe(800);
+  // Expect the return transportation cost to be lower of:
+  // Remaining return transportation cost ($800),
+  // application limit ($1800 for 27+ weeks), or
+  // Student declared cost ($600 x 2 allowable round trips = $1200).
+  expect(
+    calculatedAssessment.variables.calculatedDataReturnTransportationCost,
+  ).toBe(800);
+  // Expect the additional transportation cost to be null or undefined.
+  expect(
+    calculatedAssessment.variables
+      .calculatedDataTotalAdditionalTransportationAllowance,
+  ).toBe(undefined);
+  // Expect the total transportation cost to be $1200.
+  expect(
+    calculatedAssessment.variables.calculatedDataTotalTransportationCost,
+  ).toBe(800);
+});
+
+it("Should determine additional transportation allowance for a blended offering.", async () => {
+  // Arrange
+  const assessmentConsolidatedData =
+    createFakeConsolidatedFulltimeData(PROGRAM_YEAR);
+  assessmentConsolidatedData.offeringDelivered =
+    OfferingDeliveryOptions.Blended;
+  assessmentConsolidatedData.studentDataAdditionalTransportRequested =
+    YesNoOptions.Yes;
+  assessmentConsolidatedData.studentDataAdditionalTransportListedDriver =
+    YesNoOptions.Yes;
+  assessmentConsolidatedData.studentDataAdditionalTransportOwner =
+    YesNoOptions.Yes;
+  assessmentConsolidatedData.studentDataAdditionalTransportKm = 300;
+  assessmentConsolidatedData.studentDataAdditionalTransportWeeks = 10;
+  assessmentConsolidatedData.studentDataAdditionalTransportPlacement =
+    YesNoOptions.No;
+  // Act
+  const calculatedAssessment = await executeFullTimeAssessmentForProgramYear(
+    PROGRAM_YEAR,
+    assessmentConsolidatedData,
+  );
+  // Assert
+  // 300 km * 0.34 = $102, capped at limit of $94 per week.
+  expect(
+    calculatedAssessment.variables
+      .calculatedDataNetWeeklyAdditionalTransportCost,
+  ).toBe(94);
+  // $94 per week * 10 weeks = $940.
+  expect(
+    calculatedAssessment.variables
+      .calculatedDataTotalAdditionalTransportationAllowance,
+  ).toBe(940);
+});
 
 afterAll(async () => {
   // Closes the singleton instance created during test executions.

--- a/sources/packages/backend/workflow/test/2026-2027/fulltime-assessment/costs/fulltime-assessment-costs-transportation.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2026-2027/fulltime-assessment/costs/fulltime-assessment-costs-transportation.e2e-spec.ts
@@ -324,7 +324,7 @@ describe(`E2E Test Workflow fulltime-assessment-${PROGRAM_YEAR}-costs-transporta
   });
 
   it.each([OfferingDeliveryOptions.Onsite, OfferingDeliveryOptions.Blended])(
-    "Should determine additional transportation cost for a %s offering.",
+    "Should determine additional transportation cost when offering delivered is %s.",
     async (offeringDelivered) => {
       // Arrange
       const assessmentConsolidatedData =

--- a/sources/packages/backend/workflow/test/2026-2027/fulltime-assessment/costs/fulltime-assessment-costs-transportation.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2026-2027/fulltime-assessment/costs/fulltime-assessment-costs-transportation.e2e-spec.ts
@@ -323,39 +323,42 @@ describe(`E2E Test Workflow fulltime-assessment-${PROGRAM_YEAR}-costs-transporta
     ).toBe(800);
   });
 
-  it("Should determine additional transportation allowance for a blended offering.", async () => {
-    // Arrange
-    const assessmentConsolidatedData =
-      createFakeConsolidatedFulltimeData(PROGRAM_YEAR);
-    assessmentConsolidatedData.offeringDelivered =
-      OfferingDeliveryOptions.Blended;
-    assessmentConsolidatedData.studentDataAdditionalTransportRequested =
-      YesNoOptions.Yes;
-    assessmentConsolidatedData.studentDataAdditionalTransportListedDriver =
-      YesNoOptions.Yes;
-    assessmentConsolidatedData.studentDataAdditionalTransportOwner =
-      YesNoOptions.Yes;
-    assessmentConsolidatedData.studentDataAdditionalTransportKm = 300;
-    assessmentConsolidatedData.studentDataAdditionalTransportWeeks = 10;
-    assessmentConsolidatedData.studentDataAdditionalTransportPlacement =
-      YesNoOptions.No;
-    // Act
-    const calculatedAssessment = await executeFullTimeAssessmentForProgramYear(
-      PROGRAM_YEAR,
-      assessmentConsolidatedData,
-    );
-    // Assert
-    // 300 km * 0.34 = $102, capped at limit of $94 per week.
-    expect(
-      calculatedAssessment.variables
-        .calculatedDataNetWeeklyAdditionalTransportCost,
-    ).toBe(94);
-    // $94 per week * 10 weeks = $940.
-    expect(
-      calculatedAssessment.variables
-        .calculatedDataTotalAdditionalTransportationAllowance,
-    ).toBe(940);
-  });
+  it.each([OfferingDeliveryOptions.Onsite, OfferingDeliveryOptions.Blended])(
+    "Should determine additional transportation cost for a %s offering.",
+    async (offeringDelivered) => {
+      // Arrange
+      const assessmentConsolidatedData =
+        createFakeConsolidatedFulltimeData(PROGRAM_YEAR);
+      assessmentConsolidatedData.offeringDelivered = offeringDelivered;
+      assessmentConsolidatedData.studentDataAdditionalTransportRequested =
+        YesNoOptions.Yes;
+      assessmentConsolidatedData.studentDataAdditionalTransportListedDriver =
+        YesNoOptions.Yes;
+      assessmentConsolidatedData.studentDataAdditionalTransportOwner =
+        YesNoOptions.Yes;
+      assessmentConsolidatedData.studentDataAdditionalTransportKm = 300;
+      assessmentConsolidatedData.studentDataAdditionalTransportWeeks = 10;
+      assessmentConsolidatedData.studentDataAdditionalTransportPlacement =
+        YesNoOptions.No;
+      // Act
+      const calculatedAssessment =
+        await executeFullTimeAssessmentForProgramYear(
+          PROGRAM_YEAR,
+          assessmentConsolidatedData,
+        );
+      // Assert
+      // 300 km * 0.34 = $102, capped at limit of $94 per week.
+      expect(
+        calculatedAssessment.variables
+          .calculatedDataNetWeeklyAdditionalTransportCost,
+      ).toBe(94);
+      // $94 per week * 10 weeks = $940.
+      expect(
+        calculatedAssessment.variables
+          .calculatedDataTotalAdditionalTransportationAllowance,
+      ).toBe(940);
+    },
+  );
 
   afterAll(async () => {
     // Closes the singleton instance created during test executions.

--- a/sources/packages/backend/workflow/test/2026-2027/fulltime-assessment/costs/fulltime-assessment-costs-transportation.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2026-2027/fulltime-assessment/costs/fulltime-assessment-costs-transportation.e2e-spec.ts
@@ -35,341 +35,327 @@ describe(`E2E Test Workflow fulltime-assessment-${PROGRAM_YEAR}-costs-transporta
     ).toBe(0);
   });
 
-  it(
-    "Should determine no transportation cost when student does not request additional transportation and " +
-      "they are ineligible for return transportation due to online delivery.",
-    async () => {
-      // Arrange
-      const assessmentConsolidatedData =
-        createFakeConsolidatedFulltimeData(PROGRAM_YEAR);
-      assessmentConsolidatedData.studentDataReturnTripHomeCost = 1000;
-      assessmentConsolidatedData.offeringDelivered =
-        OfferingDeliveryOptions.Online;
-      assessmentConsolidatedData.studentDataAdditionalTransportRequested =
-        YesNoOptions.No;
-      // Act
-      const calculatedAssessment =
-        await executeFullTimeAssessmentForProgramYear(
-          PROGRAM_YEAR,
-          assessmentConsolidatedData,
-        );
-      // Assert
-      // Expect the return transportation cost to be 0.
-      expect(
-        calculatedAssessment.variables.calculatedDataReturnTransportationCost,
-      ).toBe(0);
-      // Expect the additional transportation cost to be null or undefined.
-      expect(
-        calculatedAssessment.variables
-          .calculatedDataTotalAdditionalTransportationAllowance,
-      ).toBe(undefined);
-      // Expect the total transportation cost to be 0.
-      expect(
-        calculatedAssessment.variables.calculatedDataTotalTransportationCost,
-      ).toBe(0);
-    },
-  );
+  it("Should determine no transportation cost when ineligible for return transportation due to online delivery.", async () => {
+    // Arrange
+    const assessmentConsolidatedData =
+      createFakeConsolidatedFulltimeData(PROGRAM_YEAR);
+    assessmentConsolidatedData.studentDataReturnTripHomeCost = 1000;
+    assessmentConsolidatedData.offeringDelivered =
+      OfferingDeliveryOptions.Online;
+    assessmentConsolidatedData.studentDataAdditionalTransportRequested =
+      YesNoOptions.No;
+    // Act
+    const calculatedAssessment = await executeFullTimeAssessmentForProgramYear(
+      PROGRAM_YEAR,
+      assessmentConsolidatedData,
+    );
+    // Assert
+    // Expect the return transportation cost to be 0.
+    expect(
+      calculatedAssessment.variables.calculatedDataReturnTransportationCost,
+    ).toBe(0);
+    // Expect the additional transportation cost to be null or undefined.
+    expect(
+      calculatedAssessment.variables
+        .calculatedDataTotalAdditionalTransportationAllowance,
+    ).toBe(undefined);
+    // Expect the total transportation cost to be 0.
+    expect(
+      calculatedAssessment.variables.calculatedDataTotalTransportationCost,
+    ).toBe(0);
+  });
 
-  it(
-    "Should determine no transportation cost when student does not request additional transportation and " +
-      "they are ineligible for return transportation due to living with partner.",
-    async () => {
-      // Arrange
-      const assessmentConsolidatedData =
-        createFakeConsolidatedFulltimeData(PROGRAM_YEAR);
-      assessmentConsolidatedData.studentDataAdditionalTransportRequested =
-        YesNoOptions.No;
-      assessmentConsolidatedData.studentDataReturnTripHomeCost = 1000;
-      assessmentConsolidatedData.studentDataLivingWithPartner =
-        YesNoOptions.Yes;
-      assessmentConsolidatedData.studentDataRelationshipStatus = "married";
-      assessmentConsolidatedData.partner1HasEmploymentInsuranceBenefits =
-        YesNoOptions.No;
-      assessmentConsolidatedData.partner1HasTotalIncomeAssistance =
-        YesNoOptions.No;
-      assessmentConsolidatedData.partner1HasFedralProvincialPDReceipt =
-        YesNoOptions.No;
-      assessmentConsolidatedData.partner1TotalIncome = 0;
-      // Act
-      const calculatedAssessment =
-        await executeFullTimeAssessmentForProgramYear(
-          PROGRAM_YEAR,
-          assessmentConsolidatedData,
-        );
-      // Assert
-      // Expect the return transportation cost to be 0.
-      expect(
-        calculatedAssessment.variables.calculatedDataReturnTransportationCost,
-      ).toBe(0);
-      // Expect the additional transportation cost to be null or undefined.
-      expect(
-        calculatedAssessment.variables
-          .calculatedDataTotalAdditionalTransportationAllowance,
-      ).toBe(undefined);
-      // Expect the total transportation cost to be 0.
-      expect(
-        calculatedAssessment.variables.calculatedDataTotalTransportationCost,
-      ).toBe(0);
-    },
-  );
+  it("Should determine no transportation cost when ineligible for return transportation due to living with partner.", async () => {
+    // Arrange
+    const assessmentConsolidatedData =
+      createFakeConsolidatedFulltimeData(PROGRAM_YEAR);
+    assessmentConsolidatedData.studentDataAdditionalTransportRequested =
+      YesNoOptions.No;
+    assessmentConsolidatedData.studentDataReturnTripHomeCost = 1000;
+    assessmentConsolidatedData.studentDataLivingWithPartner = YesNoOptions.Yes;
+    assessmentConsolidatedData.studentDataRelationshipStatus = "married";
+    assessmentConsolidatedData.partner1HasEmploymentInsuranceBenefits =
+      YesNoOptions.No;
+    assessmentConsolidatedData.partner1HasTotalIncomeAssistance =
+      YesNoOptions.No;
+    assessmentConsolidatedData.partner1HasFedralProvincialPDReceipt =
+      YesNoOptions.No;
+    assessmentConsolidatedData.partner1TotalIncome = 0;
+    // Act
+    const calculatedAssessment = await executeFullTimeAssessmentForProgramYear(
+      PROGRAM_YEAR,
+      assessmentConsolidatedData,
+    );
+    // Assert
+    // Expect the return transportation cost to be 0.
+    expect(
+      calculatedAssessment.variables.calculatedDataReturnTransportationCost,
+    ).toBe(0);
+    // Expect the additional transportation cost to be null or undefined.
+    expect(
+      calculatedAssessment.variables
+        .calculatedDataTotalAdditionalTransportationAllowance,
+    ).toBe(undefined);
+    // Expect the total transportation cost to be 0.
+    expect(
+      calculatedAssessment.variables.calculatedDataTotalTransportationCost,
+    ).toBe(0);
+  });
 
-  it(
-    "Should determine no transportation cost when student does not request additional transportation and " +
-      "they are ineligible for return transportation due to being a Single independant student at home.",
-    async () => {
-      // Arrange
-      const assessmentConsolidatedData =
-        createFakeConsolidatedFulltimeData(PROGRAM_YEAR);
-      assessmentConsolidatedData.studentDataReturnTripHomeCost = 1000;
-      assessmentConsolidatedData.studentDataLivingAtHome = YesNoOptions.Yes;
-      assessmentConsolidatedData.studentDataSelfContainedSuite =
-        YesNoOptions.No;
-      assessmentConsolidatedData.studentDataAdditionalTransportRequested =
-        YesNoOptions.No;
-      // Act
-      const calculatedAssessment =
-        await executeFullTimeAssessmentForProgramYear(
-          PROGRAM_YEAR,
-          assessmentConsolidatedData,
-        );
-      // Assert
-      // Expect the Living Category to be at Home (H).
-      expect(calculatedAssessment.variables.dmnFullTimeLivingCategory).toBe(
-        "SIH",
-      );
-      // Expect the return transportation cost to be 0.
-      expect(
-        calculatedAssessment.variables.calculatedDataReturnTransportationCost,
-      ).toBe(0);
-      // Expect the additional transportation cost to be null or undefined.
-      expect(
-        calculatedAssessment.variables
-          .calculatedDataTotalAdditionalTransportationAllowance,
-      ).toBe(undefined);
-      // Expect the total transportation cost to be 0.
-      expect(
-        calculatedAssessment.variables.calculatedDataTotalTransportationCost,
-      ).toBe(0);
-    },
-  );
+  it("Should determine no transportation cost when ineligible for return transportation as single independent student at home.", async () => {
+    // Arrange
+    const assessmentConsolidatedData =
+      createFakeConsolidatedFulltimeData(PROGRAM_YEAR);
+    assessmentConsolidatedData.studentDataReturnTripHomeCost = 1000;
+    assessmentConsolidatedData.studentDataLivingAtHome = YesNoOptions.Yes;
+    assessmentConsolidatedData.studentDataSelfContainedSuite = YesNoOptions.No;
+    assessmentConsolidatedData.studentDataAdditionalTransportRequested =
+      YesNoOptions.No;
+    // Act
+    const calculatedAssessment = await executeFullTimeAssessmentForProgramYear(
+      PROGRAM_YEAR,
+      assessmentConsolidatedData,
+    );
+    // Assert
+    // Expect the Living Category to be at Home (H).
+    expect(calculatedAssessment.variables.dmnFullTimeLivingCategory).toBe(
+      "SIH",
+    );
+    // Expect the return transportation cost to be 0.
+    expect(
+      calculatedAssessment.variables.calculatedDataReturnTransportationCost,
+    ).toBe(0);
+    // Expect the additional transportation cost to be null or undefined.
+    expect(
+      calculatedAssessment.variables
+        .calculatedDataTotalAdditionalTransportationAllowance,
+    ).toBe(undefined);
+    // Expect the total transportation cost to be 0.
+    expect(
+      calculatedAssessment.variables.calculatedDataTotalTransportationCost,
+    ).toBe(0);
+  });
 
-  it(
-    "Should determine no transportation cost when student does not request additional transportation and " +
-      "they are ineligible for return transportation due to being a Single dependant living at home.",
-    async () => {
-      // Arrange
-      const assessmentConsolidatedData =
-        createFakeConsolidatedFulltimeData(PROGRAM_YEAR);
-      assessmentConsolidatedData.studentDataAdditionalTransportRequested =
-        YesNoOptions.No;
-      assessmentConsolidatedData.studentDataReturnTripHomeCost = 1000;
-      assessmentConsolidatedData.studentDataLivingAtHome = YesNoOptions.Yes;
-      assessmentConsolidatedData.studentDataSelfContainedSuite =
-        YesNoOptions.No;
-      assessmentConsolidatedData.studentDataDependantstatus = "dependant";
-      assessmentConsolidatedData.parent1TotalIncome = 0;
-      assessmentConsolidatedData.parent1CppEmployment = 0;
-      assessmentConsolidatedData.parent1CppSelfemploymentOther = 0;
-      assessmentConsolidatedData.parent1Ei = 0;
-      assessmentConsolidatedData.parent1Tax = 0;
-      assessmentConsolidatedData.parent1Contributions = 0;
-      assessmentConsolidatedData.studentDataVoluntaryContributions = 0;
-      assessmentConsolidatedData.studentDataParents = [
-        {
-          parentIsAbleToReport: YesNoOptions.Yes,
-        },
-      ];
-      // Act
-      const calculatedAssessment =
-        await executeFullTimeAssessmentForProgramYear(
-          PROGRAM_YEAR,
-          assessmentConsolidatedData,
-        );
-      // Assert
-      // Expect the Living Category to be at Home (H).
-      expect(calculatedAssessment.variables.dmnFullTimeLivingCategory).toBe(
-        "SDH",
-      );
-      // Expect the return transportation cost to be 0.
-      expect(
-        calculatedAssessment.variables.calculatedDataReturnTransportationCost,
-      ).toBe(0);
-      // Expect the additional transportation cost to be null or undefined.
-      expect(
-        calculatedAssessment.variables
-          .calculatedDataTotalAdditionalTransportationAllowance,
-      ).toBe(undefined);
-      // Expect the total transportation cost to be 0.
-      expect(
-        calculatedAssessment.variables.calculatedDataTotalTransportationCost,
-      ).toBe(0);
-    },
-  );
+  it("Should determine no transportation cost when ineligible for return transportation as single dependant at home.", async () => {
+    // Arrange
+    const assessmentConsolidatedData =
+      createFakeConsolidatedFulltimeData(PROGRAM_YEAR);
+    assessmentConsolidatedData.studentDataAdditionalTransportRequested =
+      YesNoOptions.No;
+    assessmentConsolidatedData.studentDataReturnTripHomeCost = 1000;
+    assessmentConsolidatedData.studentDataLivingAtHome = YesNoOptions.Yes;
+    assessmentConsolidatedData.studentDataSelfContainedSuite = YesNoOptions.No;
+    assessmentConsolidatedData.studentDataDependantstatus = "dependant";
+    assessmentConsolidatedData.parent1TotalIncome = 0;
+    assessmentConsolidatedData.parent1CppEmployment = 0;
+    assessmentConsolidatedData.parent1CppSelfemploymentOther = 0;
+    assessmentConsolidatedData.parent1Ei = 0;
+    assessmentConsolidatedData.parent1Tax = 0;
+    assessmentConsolidatedData.parent1Contributions = 0;
+    assessmentConsolidatedData.studentDataVoluntaryContributions = 0;
+    assessmentConsolidatedData.studentDataParents = [
+      {
+        parentIsAbleToReport: YesNoOptions.Yes,
+      },
+    ];
+    // Act
+    const calculatedAssessment = await executeFullTimeAssessmentForProgramYear(
+      PROGRAM_YEAR,
+      assessmentConsolidatedData,
+    );
+    // Assert
+    // Expect the Living Category to be at Home (H).
+    expect(calculatedAssessment.variables.dmnFullTimeLivingCategory).toBe(
+      "SDH",
+    );
+    // Expect the return transportation cost to be 0.
+    expect(
+      calculatedAssessment.variables.calculatedDataReturnTransportationCost,
+    ).toBe(0);
+    // Expect the additional transportation cost to be null or undefined.
+    expect(
+      calculatedAssessment.variables
+        .calculatedDataTotalAdditionalTransportationAllowance,
+    ).toBe(undefined);
+    // Expect the total transportation cost to be 0.
+    expect(
+      calculatedAssessment.variables.calculatedDataTotalTransportationCost,
+    ).toBe(0);
+  });
 
-  it(
-    "Should determine max return transportation cost when an eligible student " +
-      "reports costs that would be higher than that for two round trips. (<=26 weeks) ",
-    async () => {
-      // Arrange
-      const assessmentConsolidatedData =
-        createFakeConsolidatedFulltimeData(PROGRAM_YEAR);
-      assessmentConsolidatedData.offeringWeeks = 26;
-      assessmentConsolidatedData.studentDataReturnTripHomeCost = 452;
-      assessmentConsolidatedData.studentDataLivingAtHome = YesNoOptions.Yes;
-      assessmentConsolidatedData.studentDataSelfContainedSuite =
-        YesNoOptions.Yes;
-      assessmentConsolidatedData.studentDataAdditionalTransportRequested =
-        YesNoOptions.No;
-      // Act
-      const calculatedAssessment =
-        await executeFullTimeAssessmentForProgramYear(
-          PROGRAM_YEAR,
-          assessmentConsolidatedData,
-        );
-      // Assert
-      // Expect the return transportation cost to be $900 as the max for offerings up to 26 weeks.
-      // Student declared cost would be $452 x 2 (allowable round trips) = $904.
-      // Max is $900 for offerings 26 weeks or less.
-      expect(
-        calculatedAssessment.variables.calculatedDataReturnTransportationCost,
-      ).toBe(900);
-      // Expect the additional transportation cost to be null or undefined.
-      expect(
-        calculatedAssessment.variables
-          .calculatedDataTotalAdditionalTransportationAllowance,
-      ).toBe(undefined);
-      // Expect the total transportation cost to be $900.
-      expect(
-        calculatedAssessment.variables.calculatedDataTotalTransportationCost,
-      ).toBe(900);
-    },
-  );
+  it("Should determine max return transportation cost for two round trips (<=26 weeks).", async () => {
+    // Arrange
+    const assessmentConsolidatedData =
+      createFakeConsolidatedFulltimeData(PROGRAM_YEAR);
+    assessmentConsolidatedData.offeringWeeks = 26;
+    assessmentConsolidatedData.studentDataReturnTripHomeCost = 452;
+    assessmentConsolidatedData.studentDataLivingAtHome = YesNoOptions.Yes;
+    assessmentConsolidatedData.studentDataSelfContainedSuite = YesNoOptions.Yes;
+    assessmentConsolidatedData.studentDataAdditionalTransportRequested =
+      YesNoOptions.No;
+    // Act
+    const calculatedAssessment = await executeFullTimeAssessmentForProgramYear(
+      PROGRAM_YEAR,
+      assessmentConsolidatedData,
+    );
+    // Assert
+    // Expect the return transportation cost to be $900 as the max for offerings up to 26 weeks.
+    // Student declared cost would be $452 x 2 (allowable round trips) = $904.
+    // Max is $900 for offerings 26 weeks or less.
+    expect(
+      calculatedAssessment.variables.calculatedDataReturnTransportationCost,
+    ).toBe(900);
+    // Expect the additional transportation cost to be null or undefined.
+    expect(
+      calculatedAssessment.variables
+        .calculatedDataTotalAdditionalTransportationAllowance,
+    ).toBe(undefined);
+    // Expect the total transportation cost to be $900.
+    expect(
+      calculatedAssessment.variables.calculatedDataTotalTransportationCost,
+    ).toBe(900);
+  });
 
-  it(
-    "Should determine max return transportation cost when an eligible student " +
-      "reports costs that would be higher than that for two round trips (>=27 weeks).",
-    async () => {
-      // Arrange
-      const assessmentConsolidatedData =
-        createFakeConsolidatedFulltimeData(PROGRAM_YEAR);
-      assessmentConsolidatedData.offeringWeeks = 27;
-      assessmentConsolidatedData.studentDataReturnTripHomeCost = 1000;
-      assessmentConsolidatedData.studentDataLivingAtHome = YesNoOptions.Yes;
-      assessmentConsolidatedData.studentDataSelfContainedSuite =
-        YesNoOptions.Yes;
-      assessmentConsolidatedData.studentDataAdditionalTransportRequested =
-        YesNoOptions.No;
-      // Act
-      const calculatedAssessment =
-        await executeFullTimeAssessmentForProgramYear(
-          PROGRAM_YEAR,
-          assessmentConsolidatedData,
-        );
-      // Assert
-      // Expect the return transportation cost to be $1800.
-      // Student declared cost would be $1000 x 2 (allowable round trips) = $2,000.
-      // Max is $1,800 for offerings 27 weeks or longer.
-      expect(
-        calculatedAssessment.variables.calculatedDataReturnTransportationCost,
-      ).toBe(1800);
-      // Expect the additional transportation cost to be null or undefined.
-      expect(
-        calculatedAssessment.variables
-          .calculatedDataTotalAdditionalTransportationAllowance,
-      ).toBe(undefined);
-      // Expect the total transportation cost to be $1800.
-      expect(
-        calculatedAssessment.variables.calculatedDataTotalTransportationCost,
-      ).toBe(1800);
-    },
-  );
+  it("Should determine max return transportation cost for two round trips (>=27 weeks).", async () => {
+    // Arrange
+    const assessmentConsolidatedData =
+      createFakeConsolidatedFulltimeData(PROGRAM_YEAR);
+    assessmentConsolidatedData.offeringWeeks = 27;
+    assessmentConsolidatedData.studentDataReturnTripHomeCost = 1000;
+    assessmentConsolidatedData.studentDataLivingAtHome = YesNoOptions.Yes;
+    assessmentConsolidatedData.studentDataSelfContainedSuite = YesNoOptions.Yes;
+    assessmentConsolidatedData.studentDataAdditionalTransportRequested =
+      YesNoOptions.No;
+    // Act
+    const calculatedAssessment = await executeFullTimeAssessmentForProgramYear(
+      PROGRAM_YEAR,
+      assessmentConsolidatedData,
+    );
+    // Assert
+    // Expect the return transportation cost to be $1800.
+    // Student declared cost would be $1000 x 2 (allowable round trips) = $2,000.
+    // Max is $1,800 for offerings 27 weeks or longer.
+    expect(
+      calculatedAssessment.variables.calculatedDataReturnTransportationCost,
+    ).toBe(1800);
+    // Expect the additional transportation cost to be null or undefined.
+    expect(
+      calculatedAssessment.variables
+        .calculatedDataTotalAdditionalTransportationAllowance,
+    ).toBe(undefined);
+    // Expect the total transportation cost to be $1800.
+    expect(
+      calculatedAssessment.variables.calculatedDataTotalTransportationCost,
+    ).toBe(1800);
+  });
 
-  it(
-    "Should determine return transportation cost when an eligible student " +
-      "reports costs that would be lower than the maximum for two round trips (>=27 weeks).",
-    async () => {
-      // Arrange
-      const assessmentConsolidatedData =
-        createFakeConsolidatedFulltimeData(PROGRAM_YEAR);
-      assessmentConsolidatedData.offeringWeeks = 27;
-      assessmentConsolidatedData.studentDataReturnTripHomeCost = 600;
-      assessmentConsolidatedData.studentDataLivingAtHome = YesNoOptions.Yes;
-      assessmentConsolidatedData.studentDataSelfContainedSuite =
-        YesNoOptions.Yes;
-      assessmentConsolidatedData.studentDataAdditionalTransportRequested =
-        YesNoOptions.No;
-      // Act
-      const calculatedAssessment =
-        await executeFullTimeAssessmentForProgramYear(
-          PROGRAM_YEAR,
-          assessmentConsolidatedData,
-        );
-      // Assert
-      // Expect the return transportation cost to be $1200.
-      // Student declared cost would be $600 x 2 (allowable round trips) = $1200.
-      // Max is $1,800 for offerings 27 weeks or longer.
-      expect(
-        calculatedAssessment.variables.calculatedDataReturnTransportationCost,
-      ).toBe(1200);
-      // Expect the additional transportation cost to be null or undefined.
-      expect(
-        calculatedAssessment.variables
-          .calculatedDataTotalAdditionalTransportationAllowance,
-      ).toBe(undefined);
-      // Expect the total transportation cost to be $1200.
-      expect(
-        calculatedAssessment.variables.calculatedDataTotalTransportationCost,
-      ).toBe(1200);
-    },
-  );
+  it("Should determine return transportation cost below the maximum for two round trips (>=27 weeks).", async () => {
+    // Arrange
+    const assessmentConsolidatedData =
+      createFakeConsolidatedFulltimeData(PROGRAM_YEAR);
+    assessmentConsolidatedData.offeringWeeks = 27;
+    assessmentConsolidatedData.studentDataReturnTripHomeCost = 600;
+    assessmentConsolidatedData.studentDataLivingAtHome = YesNoOptions.Yes;
+    assessmentConsolidatedData.studentDataSelfContainedSuite = YesNoOptions.Yes;
+    assessmentConsolidatedData.studentDataAdditionalTransportRequested =
+      YesNoOptions.No;
+    // Act
+    const calculatedAssessment = await executeFullTimeAssessmentForProgramYear(
+      PROGRAM_YEAR,
+      assessmentConsolidatedData,
+    );
+    // Assert
+    // Expect the return transportation cost to be $1200.
+    // Student declared cost would be $600 x 2 (allowable round trips) = $1200.
+    // Max is $1,800 for offerings 27 weeks or longer.
+    expect(
+      calculatedAssessment.variables.calculatedDataReturnTransportationCost,
+    ).toBe(1200);
+    // Expect the additional transportation cost to be null or undefined.
+    expect(
+      calculatedAssessment.variables
+        .calculatedDataTotalAdditionalTransportationAllowance,
+    ).toBe(undefined);
+    // Expect the total transportation cost to be $1200.
+    expect(
+      calculatedAssessment.variables.calculatedDataTotalTransportationCost,
+    ).toBe(1200);
+  });
 
-  it(
-    "Should determine return transportation cost when an eligible student " +
-      "reports costs that would be lower than the maximum for two round trips (>=27 weeks) " +
-      "and has previously had return transportation costs.",
-    async () => {
-      // Arrange
-      const assessmentConsolidatedData =
-        createFakeConsolidatedFulltimeData(PROGRAM_YEAR);
-      assessmentConsolidatedData.offeringWeeks = 27;
-      assessmentConsolidatedData.studentDataReturnTripHomeCost = 600;
-      assessmentConsolidatedData.programYearTotalFullTimeReturnTransportationCost = 1000;
-      assessmentConsolidatedData.studentDataLivingAtHome = YesNoOptions.Yes;
-      assessmentConsolidatedData.studentDataSelfContainedSuite =
-        YesNoOptions.Yes;
-      assessmentConsolidatedData.studentDataAdditionalTransportRequested =
-        YesNoOptions.No;
-      // Act
-      const calculatedAssessment =
-        await executeFullTimeAssessmentForProgramYear(
-          PROGRAM_YEAR,
-          assessmentConsolidatedData,
-        );
-      // Assert
-      // Max is $1,800 for the program year.
-      // 1800 - 1000 (previously claimed) = 800 (remaining return transportation).
-      expect(
-        calculatedAssessment.variables
-          .calculatedDataRemainingReturnTransportation,
-      ).toBe(800);
-      // Expect the return transportation cost to be lower of:
-      // Remaining return transportation cost ($800),
-      // application limit ($1800 for 27+ weeks), or
-      // Student declared cost ($600 x 2 allowable round trips = $1200).
-      expect(
-        calculatedAssessment.variables.calculatedDataReturnTransportationCost,
-      ).toBe(800);
-      // Expect the additional transportation cost to be null or undefined.
-      expect(
-        calculatedAssessment.variables
-          .calculatedDataTotalAdditionalTransportationAllowance,
-      ).toBe(undefined);
-      // Expect the total transportation cost to be $1200.
-      expect(
-        calculatedAssessment.variables.calculatedDataTotalTransportationCost,
-      ).toBe(800);
-    },
-  );
+  it("Should determine return transportation cost below the maximum for two round trips with previously claimed costs (>=27 weeks).", async () => {
+    // Arrange
+    const assessmentConsolidatedData =
+      createFakeConsolidatedFulltimeData(PROGRAM_YEAR);
+    assessmentConsolidatedData.offeringWeeks = 27;
+    assessmentConsolidatedData.studentDataReturnTripHomeCost = 600;
+    assessmentConsolidatedData.programYearTotalFullTimeReturnTransportationCost = 1000;
+    assessmentConsolidatedData.studentDataLivingAtHome = YesNoOptions.Yes;
+    assessmentConsolidatedData.studentDataSelfContainedSuite = YesNoOptions.Yes;
+    assessmentConsolidatedData.studentDataAdditionalTransportRequested =
+      YesNoOptions.No;
+    // Act
+    const calculatedAssessment = await executeFullTimeAssessmentForProgramYear(
+      PROGRAM_YEAR,
+      assessmentConsolidatedData,
+    );
+    // Assert
+    // Max is $1,800 for the program year.
+    // 1800 - 1000 (previously claimed) = 800 (remaining return transportation).
+    expect(
+      calculatedAssessment.variables
+        .calculatedDataRemainingReturnTransportation,
+    ).toBe(800);
+    // Expect the return transportation cost to be lower of:
+    // Remaining return transportation cost ($800),
+    // application limit ($1800 for 27+ weeks), or
+    // Student declared cost ($600 x 2 allowable round trips = $1200).
+    expect(
+      calculatedAssessment.variables.calculatedDataReturnTransportationCost,
+    ).toBe(800);
+    // Expect the additional transportation cost to be null or undefined.
+    expect(
+      calculatedAssessment.variables
+        .calculatedDataTotalAdditionalTransportationAllowance,
+    ).toBe(undefined);
+    // Expect the total transportation cost to be $1200.
+    expect(
+      calculatedAssessment.variables.calculatedDataTotalTransportationCost,
+    ).toBe(800);
+  });
+
+  it("Should determine additional transportation allowance for a blended offering.", async () => {
+    // Arrange
+    const assessmentConsolidatedData =
+      createFakeConsolidatedFulltimeData(PROGRAM_YEAR);
+    assessmentConsolidatedData.offeringDelivered =
+      OfferingDeliveryOptions.Blended;
+    assessmentConsolidatedData.studentDataAdditionalTransportRequested =
+      YesNoOptions.Yes;
+    assessmentConsolidatedData.studentDataAdditionalTransportListedDriver =
+      YesNoOptions.Yes;
+    assessmentConsolidatedData.studentDataAdditionalTransportOwner =
+      YesNoOptions.Yes;
+    assessmentConsolidatedData.studentDataAdditionalTransportKm = 300;
+    assessmentConsolidatedData.studentDataAdditionalTransportWeeks = 10;
+    assessmentConsolidatedData.studentDataAdditionalTransportPlacement =
+      YesNoOptions.No;
+    // Act
+    const calculatedAssessment = await executeFullTimeAssessmentForProgramYear(
+      PROGRAM_YEAR,
+      assessmentConsolidatedData,
+    );
+    // Assert
+    // 300 km * 0.34 = $102, capped at limit of $94 per week.
+    expect(
+      calculatedAssessment.variables
+        .calculatedDataNetWeeklyAdditionalTransportCost,
+    ).toBe(94);
+    // $94 per week * 10 weeks = $940.
+    expect(
+      calculatedAssessment.variables
+        .calculatedDataTotalAdditionalTransportationAllowance,
+    ).toBe(940);
+  });
 
   afterAll(async () => {
     // Closes the singleton instance created during test executions.


### PR DESCRIPTION
### Summary

Add "blended" program option for additional transportation costs exception.
Added a E2E test to validate the scenario.
Updated ticket with SQL Query to return existing applications/students that need to be recalculated.

```sql
-- This report identifies all full-time (FT) students with a previously approved additional
-- transportation exception where the offering was blended for program years 2025-2026 and
-- 2026-2027.
SELECT
    apps.application_number,
    apps.id AS application_id,
    s.id AS student_id,
    u.first_name,
    u.last_name,
    u.email,
    py.program_year,
    apps.application_status,
    apps.offering_intensity,
    epo.offering_delivered,
    ae.exception_status,
    ae.assessed_date,
    aer.exception_name,
    aer.exception_request_status
FROM
    sims.applications apps
    INNER JOIN sims.students s ON s.id = apps.student_id
    INNER JOIN sims.users u ON u.id = s.user_id
    INNER JOIN sims.program_years py ON py.id = apps.program_year_id
    INNER JOIN sims.application_exceptions ae ON ae.id = apps.application_exception_id
    INNER JOIN sims.application_exception_requests aer ON aer.application_exception_id = ae.id
    INNER JOIN sims.student_assessments sa ON sa.id = apps.current_assessment_id
    INNER JOIN sims.education_programs_offerings epo ON epo.id = sa.offering_id
WHERE
    apps.offering_intensity = 'Full Time'
    AND py.program_year IN ('2025-2026', '2026-2027')
    AND aer.exception_name = 'transportationApplicationException'
    AND aer.exception_request_status = 'Approved'
    AND epo.offering_delivered = 'blended'
ORDER BY
    py.program_year,
    apps.application_number;
```