### PR TITLE
#5919 - Release 3.5 - Upgrade Packages (DOCKER_REGISTRY centralization)

### DIFF
--- a/devops/openshift/docker-build.yml
+++ b/devops/openshift/docker-build.yml
@@ -39,7 +39,7 @@ objects:
           dockerfilePath: "${DOCKER_FILE_PATH}"
           buildArgs:
             - name: DOCKER_REGISTRY
-              value: "artifacts.developer.gov.bc.ca/docker-remote/"
+              value: "artifacts.developer.gov.bc.ca/docker-remote"
           pullSecret:
             name: artifactory-secret-credential
         type: Docker

--- a/devops/openshift/docker-build.yml
+++ b/devops/openshift/docker-build.yml
@@ -37,6 +37,9 @@ objects:
       strategy:
         dockerStrategy:
           dockerfilePath: "${DOCKER_FILE_PATH}"
+          buildArgs:
+            - name: DOCKER_REGISTRY
+              value: "artifacts.developer.gov.bc.ca/docker-remote/"
           pullSecret:
             name: artifactory-secret-credential
         type: Docker

--- a/sources/packages/backend/apps/api/Dockerfile
+++ b/sources/packages/backend/apps/api/Dockerfile
@@ -1,5 +1,7 @@
 # Base Image
-ARG DOCKER_REGISTRY=artifacts.developer.gov.bc.ca/docker-remote
+# Artifactory registry is passed as a build argument to avoid hardcoding it in the Dockerfile.
+# It allows dependabot to update the base image when an update is available.
+ARG DOCKER_REGISTRY
 FROM ${DOCKER_REGISTRY}/node:25.9.0-alpine3.22
 
 ENV npm_config_cache=/app/.npm

--- a/sources/packages/backend/apps/load-test-gateway/Dockerfile
+++ b/sources/packages/backend/apps/load-test-gateway/Dockerfile
@@ -1,5 +1,7 @@
 # Base Image
-ARG DOCKER_REGISTRY=artifacts.developer.gov.bc.ca/docker-remote
+# Artifactory registry is passed as a build argument to avoid hardcoding it in the Dockerfile.
+# It allows dependabot to update the base image when an update is available.
+ARG DOCKER_REGISTRY
 FROM ${DOCKER_REGISTRY}/node:25.9.0-alpine3.22
 
 ENV npm_config_cache=/app/.npm

--- a/sources/packages/backend/apps/queue-consumers/Dockerfile
+++ b/sources/packages/backend/apps/queue-consumers/Dockerfile
@@ -1,4 +1,5 @@
 # Base Image
+# Artifactory registry is passed as a build argument to avoid hardcoding it in the Dockerfile.
 # It allows dependabot to update the base image when an update is available.
 ARG DOCKER_REGISTRY
 FROM ${DOCKER_REGISTRY}/node:25.9.0-alpine3.22

--- a/sources/packages/backend/apps/queue-consumers/Dockerfile
+++ b/sources/packages/backend/apps/queue-consumers/Dockerfile
@@ -1,5 +1,6 @@
 # Base Image
-ARG DOCKER_REGISTRY=artifacts.developer.gov.bc.ca/docker-remote
+# It allows dependabot to update the base image when an update is available.
+ARG DOCKER_REGISTRY
 FROM ${DOCKER_REGISTRY}/node:25.9.0-alpine3.22
 
 ENV npm_config_cache=/app/.npm

--- a/sources/packages/backend/apps/workers/Dockerfile
+++ b/sources/packages/backend/apps/workers/Dockerfile
@@ -1,4 +1,5 @@
 # Base Image
+# Artifactory registry is passed as a build argument to avoid hardcoding it in the Dockerfile.
 # It allows dependabot to update the base image when an update is available.
 ARG DOCKER_REGISTRY
 FROM ${DOCKER_REGISTRY}/node:25.9.0-alpine3.22

--- a/sources/packages/backend/apps/workers/Dockerfile
+++ b/sources/packages/backend/apps/workers/Dockerfile
@@ -1,5 +1,6 @@
 # Base Image
-ARG DOCKER_REGISTRY=artifacts.developer.gov.bc.ca/docker-remote
+# It allows dependabot to update the base image when an update is available.
+ARG DOCKER_REGISTRY
 FROM ${DOCKER_REGISTRY}/node:25.9.0-alpine3.22
 
 ENV npm_config_cache=/app/.npm

--- a/sources/packages/backend/migrations/Dockerfile
+++ b/sources/packages/backend/migrations/Dockerfile
@@ -1,4 +1,5 @@
 # Base Image
+# Artifactory registry is passed as a build argument to avoid hardcoding it in the Dockerfile.
 # It allows dependabot to update the base image when an update is available.
 ARG DOCKER_REGISTRY
 FROM ${DOCKER_REGISTRY}/node:25.9.0-alpine3.22

--- a/sources/packages/backend/migrations/Dockerfile
+++ b/sources/packages/backend/migrations/Dockerfile
@@ -1,5 +1,6 @@
 # Base Image
-ARG DOCKER_REGISTRY=artifacts.developer.gov.bc.ca/docker-remote
+# It allows dependabot to update the base image when an update is available.
+ARG DOCKER_REGISTRY
 FROM ${DOCKER_REGISTRY}/node:25.9.0-alpine3.22
 
 ENV npm_config_cache=/app/.npm

--- a/sources/packages/web/Dockerfile
+++ b/sources/packages/web/Dockerfile
@@ -1,7 +1,10 @@
 # Base Image
 # "builder" stage, based on Node.js, to build and compile the frontend.
-ARG DOCKER_REGISTRY=artifacts.developer.gov.bc.ca/docker-remote/
-FROM ${DOCKER_REGISTRY}node:25.9.0-alpine3.22 AS builder
+
+# Artifactory registry is passed as a build argument to avoid hardcoding it in the Dockerfile.
+# It allows dependabot to update the base image when an update is available.
+ARG DOCKER_REGISTRY
+FROM ${DOCKER_REGISTRY}/node:25.9.0-alpine3.22 AS builder
 
 # Application Port.
 ENV PORT=3030
@@ -25,7 +28,7 @@ RUN sed 's/${PORT}/'"${PORT}"'/g' nginx/default.conf.template > default.conf
 RUN npm run build
 
 # dependabot: FROM nginx:1.29.3-alpine3.22
-FROM artifacts.developer.gov.bc.ca/docker-remote/nginx:1.29.3-alpine3.22 AS deployer
+FROM ${DOCKER_REGISTRY}/nginx:1.29.3-alpine3.22 AS deployer
 
 # Copy the app built on builder stage to the resulting container.
 COPY --from=builder /app/dist /usr/share/nginx/html


### PR DESCRIPTION
Centralization of the `DOCKER_REGISTRY` in an attempt to make dependabot indicate NodeJS versions to be updated for PROD containers.