### PR TITLE
#5919 - Release 3.5 - Upgrade Packages (Nodejs)

### DIFF
--- a/sources/packages/backend/apps/api/Dockerfile
+++ b/sources/packages/backend/apps/api/Dockerfile
@@ -1,7 +1,7 @@
 # Base Image
 # Artifactory registry is passed as a build argument to avoid hardcoding it in the Dockerfile.
-# It allows dependabot to update the base image when an update is available.
-ARG DOCKER_REGISTRY
+# The default value (docker.io) allows dependabot to resolve and update the base image when an update is available.
+ARG DOCKER_REGISTRY=docker.io
 FROM ${DOCKER_REGISTRY}/node:25.9.0-alpine3.22
 
 ENV npm_config_cache=/app/.npm

--- a/sources/packages/backend/apps/load-test-gateway/Dockerfile
+++ b/sources/packages/backend/apps/load-test-gateway/Dockerfile
@@ -1,7 +1,7 @@
 # Base Image
 # Artifactory registry is passed as a build argument to avoid hardcoding it in the Dockerfile.
-# It allows dependabot to update the base image when an update is available.
-ARG DOCKER_REGISTRY
+# The default value (docker.io) allows dependabot to resolve and update the base image when an update is available.
+ARG DOCKER_REGISTRY=docker.io
 FROM ${DOCKER_REGISTRY}/node:25.9.0-alpine3.22
 
 ENV npm_config_cache=/app/.npm

--- a/sources/packages/backend/apps/queue-consumers/Dockerfile
+++ b/sources/packages/backend/apps/queue-consumers/Dockerfile
@@ -1,7 +1,7 @@
 # Base Image
 # Artifactory registry is passed as a build argument to avoid hardcoding it in the Dockerfile.
-# It allows dependabot to update the base image when an update is available.
-ARG DOCKER_REGISTRY
+# The default value (docker.io) allows dependabot to resolve and update the base image when an update is available.
+ARG DOCKER_REGISTRY=docker.io
 FROM ${DOCKER_REGISTRY}/node:25.9.0-alpine3.22
 
 ENV npm_config_cache=/app/.npm

--- a/sources/packages/backend/apps/workers/Dockerfile
+++ b/sources/packages/backend/apps/workers/Dockerfile
@@ -1,7 +1,7 @@
 # Base Image
 # Artifactory registry is passed as a build argument to avoid hardcoding it in the Dockerfile.
-# It allows dependabot to update the base image when an update is available.
-ARG DOCKER_REGISTRY
+# The default value (docker.io) allows dependabot to resolve and update the base image when an update is available.
+ARG DOCKER_REGISTRY=docker.io
 FROM ${DOCKER_REGISTRY}/node:25.9.0-alpine3.22
 
 ENV npm_config_cache=/app/.npm

--- a/sources/packages/backend/migrations/Dockerfile
+++ b/sources/packages/backend/migrations/Dockerfile
@@ -1,7 +1,7 @@
 # Base Image
 # Artifactory registry is passed as a build argument to avoid hardcoding it in the Dockerfile.
-# It allows dependabot to update the base image when an update is available.
-ARG DOCKER_REGISTRY
+# The default value (docker.io) allows dependabot to resolve and update the base image when an update is available.
+ARG DOCKER_REGISTRY=docker.io
 FROM ${DOCKER_REGISTRY}/node:25.9.0-alpine3.22
 
 ENV npm_config_cache=/app/.npm

--- a/sources/packages/web/Dockerfile
+++ b/sources/packages/web/Dockerfile
@@ -2,8 +2,8 @@
 # "builder" stage, based on Node.js, to build and compile the frontend.
 
 # Artifactory registry is passed as a build argument to avoid hardcoding it in the Dockerfile.
-# It allows dependabot to update the base image when an update is available.
-ARG DOCKER_REGISTRY
+# The default value (docker.io) allows dependabot to resolve and update the base image when an update is available.
+ARG DOCKER_REGISTRY=docker.io
 FROM ${DOCKER_REGISTRY}/node:25.9.0-alpine3.22 AS builder
 
 # Application Port.
@@ -27,7 +27,6 @@ RUN sed 's/${PORT}/'"${PORT}"'/g' nginx/default.conf.template > default.conf
 # Building app
 RUN npm run build
 
-# dependabot: FROM nginx:1.29.3-alpine3.22
 FROM ${DOCKER_REGISTRY}/nginx:1.29.3-alpine3.22 AS deployer
 
 # Copy the app built on builder stage to the resulting container.


### PR DESCRIPTION
Added `docker.io` as a default value for the `DOCKER_REGISTRY` assuming dependabot will be able to inspect the version and it will be overwritten during the Opsnhift deployment.