### PR TITLE
#6091 - Postgres upgrade task

### DIFF
--- a/sources/docker-compose.yml
+++ b/sources/docker-compose.yml
@@ -297,7 +297,6 @@ services:
       - POSTGRES_DB=${POSTGRES_DB}
       - POSTGRES_USER=${POSTGRES_USER}
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
-      - PGDATA=/var/lib/postgresql/data
     expose:
       - ${POSTGRES_PORT}
     ports:

--- a/sources/docker-compose.yml
+++ b/sources/docker-compose.yml
@@ -302,7 +302,7 @@ services:
     ports:
       - ${POSTGRES_PORT}:${POSTGRES_PORT}
     volumes:
-      - postgres:/var/lib/postgresql/data
+      - postgres:/var/lib/postgresql
     command: -p ${POSTGRES_PORT}
     networks:
       - local-network

--- a/sources/docker-compose.yml
+++ b/sources/docker-compose.yml
@@ -297,6 +297,7 @@ services:
       - POSTGRES_DB=${POSTGRES_DB}
       - POSTGRES_USER=${POSTGRES_USER}
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
+      - PGDATA=/var/lib/postgresql/data
     expose:
       - ${POSTGRES_PORT}
     ports:


### PR DESCRIPTION
As a part of this PR, the following was fixed:

- Postgres volume originally mounted at `/var/lib/postgresql/data` is incompatible with the Postgres 18 image. Changed it to `postgres:/var/lib/postgresql` for the upgrade to postgres 18.