### PR TITLE
#4324 - Added shared preloaded libraries option

### DIFF
--- a/devops/helm/crunchy-postgres/templates/PostgresCluster.yaml
+++ b/devops/helm/crunchy-postgres/templates/PostgresCluster.yaml
@@ -194,6 +194,7 @@ spec:
           max_wal_size: {{ .Values.patroni.postgresql.parameters.max_wal_size }}
           max_slot_wal_keep_size: {{ .Values.patroni.postgresql.parameters.max_slot_wal_keep_size }}
           max_connections: {{ .Values.patroni.postgresql.parameters.max_connections }}
+          shared_preload_libraries: {{ .Values.patroni.postgresql.parameters.shared_preload_libraries }}
   
   proxy:
     pgBouncer:

--- a/devops/helm/crunchy-postgres/values.yaml
+++ b/devops/helm/crunchy-postgres/values.yaml
@@ -121,7 +121,7 @@ patroni:
       max_wal_size: 1GB # default is 1GB
       max_slot_wal_keep_size: 128MB # default is -1, allowing unlimited wal growth when replicas fall behind
       max_connections: 125 # default is 100
-      shared_preload_libraries: "pg_stat_statements" # specify any libraries that need to be preloaded. Separate multiple libraries with a comma. For example: "pg_stat_statements,auto_explain"
+      shared_preload_libraries: "pg_stat_statements" # Specify any libraries that need to be preloaded. Separate multiple libraries with a comma. For example: "pg_stat_statements,auto_explain"
 
 proxy:
   pgBouncer:

--- a/devops/helm/crunchy-postgres/values.yaml
+++ b/devops/helm/crunchy-postgres/values.yaml
@@ -121,6 +121,7 @@ patroni:
       max_wal_size: 1GB # default is 1GB
       max_slot_wal_keep_size: 128MB # default is -1, allowing unlimited wal growth when replicas fall behind
       max_connections: 125 # default is 100
+      shared_preload_libraries: "pg_stat_statements" # specify any libraries that need to be preloaded. Separate multiple libraries with a comma. For example: "pg_stat_statements,auto_explain"
 
 proxy:
   pgBouncer:


### PR DESCRIPTION
Updated crunchy postgres to receive `shared_preload_libraries` and added `pg_stat_statements` to the list.