### PR TITLE
#6165 - IER2 Manual Resend

### DIFF
--- a/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/institution-integration/ier12-integration/_tests_/e2e/ier12-factory.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/institution-integration/ier12-integration/_tests_/e2e/ier12-factory.ts
@@ -102,7 +102,7 @@ export async function saveIER12TestInputData(
     programYear,
     createSecondDisbursement,
     referenceSubmission,
-    program!,
+    program ?? undefined,
     testInputData.offering.offeringIntensity,
   );
   // Assessment and its awards.

--- a/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/institution-integration/ier12-integration/_tests_/e2e/ier12-factory.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/institution-integration/ier12-integration/_tests_/e2e/ier12-factory.ts
@@ -102,14 +102,14 @@ export async function saveIER12TestInputData(
     programYear,
     createSecondDisbursement,
     referenceSubmission,
-    program,
+    program!,
     testInputData.offering.offeringIntensity,
   );
   // Assessment and its awards.
   const assessment = await saveIER12AssessmentFromTestInput(
     db,
     testInputData.assessment,
-    application.currentAssessment,
+    application.currentAssessment!,
     studyStartDate,
     studyEndDate,
     referenceSubmission,
@@ -117,17 +117,20 @@ export async function saveIER12TestInputData(
   // Program
   await updateIER12ProgramFromTestInput(
     db,
-    assessment.offering.educationProgram.id,
+    assessment.offering!.educationProgram.id,
     testInputData.educationProgram,
   );
+  const updatedProgram = await db.educationProgram.findOneByOrFail({
+    id: assessment.offering!.educationProgram.id,
+  });
 
   // Parent offering, if needed.
   const parentOffering = testInputData.parentOfferingAvailable
     ? await db.educationProgramOffering.save(
         createFakeEducationProgramOffering({
-          institutionLocation: assessment.offering.institutionLocation,
-          auditUser: assessment.offering.submittedBy,
-          program: assessment.offering.educationProgram,
+          institutionLocation: assessment.offering!.institutionLocation,
+          auditUser: assessment.offering!.submittedBy,
+          program: updatedProgram,
         }),
       )
     : undefined;
@@ -135,7 +138,7 @@ export async function saveIER12TestInputData(
   // Offering
   await updateIER12OfferingFromTestInput(
     db,
-    assessment.offering.id,
+    assessment.offering!.id,
     testInputData.offering,
     studyStartDate,
     studyEndDate,
@@ -271,7 +274,7 @@ async function saveIER12AssessmentFromTestInput(
   assessment.workflowData = testInputAssessment.workflowData as WorkflowData;
   // Schedules and awards mapping.
   const [firstDisbursement, secondDisbursement] =
-    assessment.disbursementSchedules;
+    assessment.disbursementSchedules || [];
   const [firstDisbursementTestInput, secondDisbursementTestInput] =
     testInputAssessment.disbursementSchedules;
   mapTestInputToDisbursementAndAwards(
@@ -374,7 +377,7 @@ async function updateIER12OfferingFromTestInput(
   studyStartDate: string,
   studyEndDate: string,
   relations?: {
-    parentOffering: EducationProgramOffering;
+    parentOffering?: EducationProgramOffering;
   },
 ): Promise<void> {
   const offeringUpdate = {

--- a/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/institution-integration/ier12-integration/_tests_/e2e/ier12-integration.scheduler.e2e-spec.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/institution-integration/ier12-integration/_tests_/e2e/ier12-integration.scheduler.e2e-spec.ts
@@ -502,9 +502,9 @@ describe(describeProcessorRootTest(QueueNames.IER12Integration), () => {
       );
 
       // Queued job.
-      const mockedJob = createIER12SchedulerJobMock(
-        application.currentAssessment.assessmentDate,
-      );
+      const mockedJob = createIER12SchedulerJobMock({
+        modifiedSince: application.currentAssessment!.assessmentDate,
+      });
 
       // Act
       const ier12Results = await processor.processQueue(mockedJob.job);
@@ -588,9 +588,9 @@ describe(describeProcessorRootTest(QueueNames.IER12Integration), () => {
     );
 
     // Queued job.
-    const mockedJob = createIER12SchedulerJobMock(
-      application.currentAssessment.assessmentDate,
-    );
+    const mockedJob = createIER12SchedulerJobMock({
+      modifiedSince: application.currentAssessment!.assessmentDate,
+    });
 
     // Act
     const ier12Results = await processor.processQueue(mockedJob.job);
@@ -687,9 +687,9 @@ describe(describeProcessorRootTest(QueueNames.IER12Integration), () => {
     });
 
     // Queued job.
-    const mockedJob = createIER12SchedulerJobMock(
-      application.currentAssessment!.assessmentDate,
-    );
+    const mockedJob = createIER12SchedulerJobMock({
+      modifiedSince: application.currentAssessment!.assessmentDate,
+    });
 
     // Act
     const ier12Results = await processor.processQueue(mockedJob.job);
@@ -783,9 +783,9 @@ describe(describeProcessorRootTest(QueueNames.IER12Integration), () => {
     });
 
     // Queued job.
-    const mockedJob = createIER12SchedulerJobMock(
-      application.currentAssessment!.assessmentDate,
-    );
+    const mockedJob = createIER12SchedulerJobMock({
+      modifiedSince: application.currentAssessment!.assessmentDate,
+    });
 
     // Act
     const ier12Results = await processor.processQueue(mockedJob.job);
@@ -974,9 +974,9 @@ describe(describeProcessorRootTest(QueueNames.IER12Integration), () => {
     );
 
     // Queued job.
-    const mockedJob = createIER12SchedulerJobMock(
-      application.currentAssessment!.assessmentDate,
-    );
+    const mockedJob = createIER12SchedulerJobMock({
+      modifiedSince: application.currentAssessment!.assessmentDate,
+    });
 
     // Act
     const ier12Results = await processor.processQueue(mockedJob.job);
@@ -1116,7 +1116,9 @@ describe(describeProcessorRootTest(QueueNames.IER12Integration), () => {
     );
 
     // Queued job.
-    const mockedJob = createIER12SchedulerJobMock(referenceSubmissionDate);
+    const mockedJob = createIER12SchedulerJobMock({
+      modifiedSince: referenceSubmissionDate,
+    });
 
     // Act
     const ier12Results = await processor.processQueue(mockedJob.job);
@@ -1236,9 +1238,9 @@ describe(describeProcessorRootTest(QueueNames.IER12Integration), () => {
     );
 
     // Queued job.
-    const mockedJob = createIER12SchedulerJobMock(
-      application.currentAssessment!.assessmentDate,
-    );
+    const mockedJob = createIER12SchedulerJobMock({
+      modifiedSince: application.currentAssessment!.assessmentDate,
+    });
 
     // Act
     const ier12Results = await processor.processQueue(mockedJob.job);
@@ -1329,9 +1331,9 @@ describe(describeProcessorRootTest(QueueNames.IER12Integration), () => {
     );
 
     // Queued job.
-    const mockedJob = createIER12SchedulerJobMock(
-      application.currentAssessment!.assessmentDate,
-    );
+    const mockedJob = createIER12SchedulerJobMock({
+      modifiedSince: application.currentAssessment!.assessmentDate,
+    });
 
     // Act
     const ier12Results = await processor.processQueue(mockedJob.job);
@@ -1428,7 +1430,6 @@ describe(describeProcessorRootTest(QueueNames.IER12Integration), () => {
       },
       assessment: {
         triggerType: AssessmentTriggerType.OriginalAssessment,
-
         assessmentDate: assessmentJaneDate,
         workflowData: WORKFLOW_DATA_MARRIED_WITH_DEPENDENTS,
         assessmentData: ASSESSMENT_DATA_MARRIED,
@@ -1460,7 +1461,7 @@ describe(describeProcessorRootTest(QueueNames.IER12Integration), () => {
     // Get one month's worth of data
     const modifiedSince = dateUtils.addDays(-31);
     // Queued job.
-    const mockedJob = createIER12SchedulerJobMock(modifiedSince);
+    const mockedJob = createIER12SchedulerJobMock({ modifiedSince });
 
     // Act
     const ier12Results = await processor.processQueue(mockedJob.job);
@@ -1560,10 +1561,10 @@ describe(describeProcessorRootTest(QueueNames.IER12Integration), () => {
     );
 
     // Queued job.
-    const mockedJob = createIER12SchedulerJobMock(
-      referenceSubmissionDate,
-      locationA.institutionCode,
-    );
+    const mockedJob = createIER12SchedulerJobMock({
+      modifiedSince: referenceSubmissionDate,
+      institutionCode: locationA.institutionCode,
+    });
 
     // Act
     const ier12Results = await processor.processQueue(mockedJob.job);
@@ -1571,6 +1572,7 @@ describe(describeProcessorRootTest(QueueNames.IER12Integration), () => {
     // Assert
     // Assert process result.
     expect(ier12Results).toBeDefined();
+
     // File timestamp.
     const [firstTimestampResult] =
       getFileNameAsCurrentTimestampMock.mock.results;
@@ -1649,7 +1651,7 @@ describe(describeProcessorRootTest(QueueNames.IER12Integration), () => {
 
     // Queued job.
     const institutionCode = "ABCD";
-    const mockedJob = createIER12SchedulerJobMock(undefined, institutionCode);
+    const mockedJob = createIER12SchedulerJobMock({ institutionCode });
 
     // Act
     const ier12Results = await processor.processQueue(mockedJob.job);
@@ -1659,9 +1661,10 @@ describe(describeProcessorRootTest(QueueNames.IER12Integration), () => {
     const modifiedSince = dateUtils.addDays(-1, today);
     expect(
       mockedJob.containLogMessages([
-        `Retrieving application current assessment details for IER 12 with institution code ${institutionCode}.`,
-        `Retrieving data related to IER 12 created or modified between ${modifiedSince} and ${today} with institution code ${institutionCode}.`,
-        `No assessments found for IER 12 with institution code ${institutionCode}.`,
+        `Retrieving application current assessment details for IER 12.`,
+        `Filtering assessments for institution code: ${institutionCode}`,
+        `Retrieving data related to IER 12 created or modified between ${modifiedSince} and ${today}.`,
+        `No assessments found for IER 12.`,
       ]),
     ).toBe(true);
 
@@ -1672,7 +1675,7 @@ describe(describeProcessorRootTest(QueueNames.IER12Integration), () => {
   it("Should not generate an IER12 file for a specific location when the institution code is invalid.", async () => {
     // Queued job.
     const institutionCode = "ABCDE";
-    const mockedJob = createIER12SchedulerJobMock(undefined, institutionCode);
+    const mockedJob = createIER12SchedulerJobMock({ institutionCode });
 
     // Act
     const ier12Results = await processor.processQueue(mockedJob.job);
@@ -1685,13 +1688,13 @@ describe(describeProcessorRootTest(QueueNames.IER12Integration), () => {
     ).toBe(true);
 
     // Assert process result.
-    assertEmptyResults(ier12Results);
+    assertEmptyResults(ier12Results, "Invalid job data.");
   });
 
   it("Should not generate an IER12 file when the modified since date is not a valid date.", async () => {
     // Queued job.
-    const modifiedSinceDate = "ABC-12-3456";
-    const mockedJob = createIER12SchedulerJobMock(modifiedSinceDate);
+    const modifiedSince = "ABC-12-3456";
+    const mockedJob = createIER12SchedulerJobMock({ modifiedSince });
 
     // Act
     const ier12Results = await processor.processQueue(mockedJob.job);
@@ -1704,16 +1707,16 @@ describe(describeProcessorRootTest(QueueNames.IER12Integration), () => {
     ).toBe(true);
 
     // Assert process result.
-    assertEmptyResults(ier12Results);
+    assertEmptyResults(ier12Results, "Invalid job data.");
   });
 
   it("Should not generate an IER12 file when the modified since date is over 1 year in the past.", async () => {
     // Queued job.
-    const modifiedSinceDate = dayjs()
+    const modifiedSince = dayjs()
       .subtract(1, "year")
       .subtract(1, "day")
       .toDate();
-    const mockedJob = createIER12SchedulerJobMock(modifiedSinceDate);
+    const mockedJob = createIER12SchedulerJobMock({ modifiedSince });
 
     // Act
     const ier12Results = await processor.processQueue(mockedJob.job);
@@ -1726,7 +1729,7 @@ describe(describeProcessorRootTest(QueueNames.IER12Integration), () => {
     ).toBe(true);
 
     // Assert process result.
-    assertEmptyResults(ier12Results);
+    assertEmptyResults(ier12Results, "Invalid job data.");
   });
 
   afterAll(async () => {
@@ -1734,13 +1737,26 @@ describe(describeProcessorRootTest(QueueNames.IER12Integration), () => {
   });
 });
 
-function assertEmptyResults(ier12Results: string | string[]) {
+/**
+ * Asserts that the IER12 results indicate that no files were generated.
+ * @param ier12Results The results of the IER12 processing.
+ * @param expectedMessage The expected message to assert.
+ */
+function assertEmptyResults(
+  ier12Results: string | string[],
+  expectedMessage = "No IER12 files were generated.",
+) {
   const results = Array.isArray(ier12Results) ? ier12Results : [ier12Results];
   expect(results).toBeDefined();
   expect(results).toHaveLength(1);
-  expect(results[0]).toBe("No IER12 files were generated.");
+  expect(results[0]).toBe(expectedMessage);
 }
 
+/**
+ * Formats a date in the IER12 required format of YYYYMMDD.
+ * @param date The date to format.
+ * @returns The formatted date string.
+ */
 function formatIER12Date(date: Date) {
   return dayjs(date).format("YYYYMMDD");
 }

--- a/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/institution-integration/ier12-integration/_tests_/e2e/ier12-integration.scheduler.e2e-spec.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/institution-integration/ier12-integration/_tests_/e2e/ier12-integration.scheduler.e2e-spec.ts
@@ -930,8 +930,7 @@ describe(describeProcessorRootTest(QueueNames.IER12Integration), () => {
     );
   });
 
-  // TODO Fix this test.
-  it.skip("Should generate an IER12 file with one record for a student when there is one sent disbursement that had some funds withheld due to a restriction (DISW).", async () => {
+  it("Should generate an IER12 file with one record for a student when there is one sent disbursement that had some funds withheld due to a restriction (DISW).", async () => {
     // Arrange
     const testInputData = {
       student: JOHN_DOE_FROM_CANADA,
@@ -1020,10 +1019,14 @@ describe(describeProcessorRootTest(QueueNames.IER12Integration), () => {
 
     const parentOfferingId = numberToText(offering!.parentOffering!.id);
     // Line 1 validations.
+    const expectedAssessmentDate = dateUtils.addDays(
+      1,
+      referenceSubmissionDate,
+    );
     const firstDisbursementId = numberToText(firstDisbursement.id);
     expect(line1.length).toBe(IER_RECORD_EXPECTED_LENGTH);
     expect(line1).toBe(
-      `${assessmentId}${firstDisbursementId}${defaultApplicationNumber}            242963189Doe                      John           19980113B   MA  NONENAddress Line 1           Address Line 2           Victoria                 BC  Z1Z1Z1          Program name                                                               undergraduateCertificate 0001    8   0512123401234ADR1                         6${currentOfferingId}${parentOfferingId}                              2000081620001010000033330000004444000000555500000066660019100F2000060120002001COMP20000601000010000000006598000000032400NNNNN            20000602        000002850000000000000000400000006002001003000003005NNY000000000000000000000000000000000000000000000000000000000000NY0000000000000144430000000000000000000000000000000000007777000000150056000000000000000000000000000000000000000000003000000000050000000065430000001700000000792200N0000000000000000000000000000000000000000000000000000000000000000000000DISW2000081520000815Completed Sent      20000816                        CSLF0000100000BCSL0000659800CSGP0000000000CSGD0000000000CSGF0000000000CSGT0000000000BCAG0000032400SBSD0000000000BGPD0000000000    0000000000`,
+      `${assessmentId}${firstDisbursementId}${defaultApplicationNumber}            242963189Doe                      John           19980113B   MA  NONENAddress Line 1           Address Line 2           Victoria                 BC  Z1Z1Z1          Program name                                                               undergraduateCertificate 0001    8   0512123401234ADR1                         6${currentOfferingId}${parentOfferingId}                              2025081620251010000033330000004444000000555500000066660019100F${formatIER12Date(referenceSubmissionDate)}20252026COMP${formatIER12Date(referenceSubmissionDate)}000010000000006598000000032400NNNNN            ${formatIER12Date(expectedAssessmentDate)}        000002850000000000000000400000006002001003000003005NNY000000000000000000000000000000000000000000000000000000000000NY0000000000000144430000000000000000000000000000000000007777000000150056000000000000000000000000000000000000000000003000000000050000000065430000001700000000792200N0000000000000000000000000000000000000000000000000000000000000000000000DISW2025081520250815Completed Sent      20250816                        CSLF0000100000BCSL0000659800CSGP0000000000CSGD0000000000CSGF0000000000CSGT0000000000BCAG0000032400SBSD0000000000BGPD0000000000    0000000000`,
     );
   });
 

--- a/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/institution-integration/ier12-integration/_tests_/e2e/ier12-integration.scheduler.e2e-spec.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/institution-integration/ier12-integration/_tests_/e2e/ier12-integration.scheduler.e2e-spec.ts
@@ -68,15 +68,21 @@ describe(describeProcessorRootTest(QueueNames.IER12Integration), () => {
   /**
    * Default program year prefix.
    */
-  const sharedProgramYearPrefix = 2000;
+  const sharedProgramYearPrefix = 2025;
   /**
    * Default application submission date.
    */
-  const referenceSubmissionDate = new Date("2000-06-01");
+  const referenceSubmissionDate = dateUtils.addDays(-7);
   /**
    * An old date to fall outside the default IER file generation range matching the shared program year prefix.
    */
-  const dateOutsideDefaultIERFileGenerationRange = new Date("2000-08-01");
+  const dateOutsideDefaultIERFileGenerationRange = dateUtils.addDays(-3);
+  /**
+   * Default IER file generation start date which is the start of the previous day.
+   */
+  const defaultIERFileGenerationStartDate = new Date(
+    dateUtils.getISODateOnlyString(dateUtils.addDays(-1)),
+  );
   /**
    * Default application number.
    */
@@ -146,10 +152,11 @@ describe(describeProcessorRootTest(QueueNames.IER12Integration), () => {
     "Should generate IER12 record for only one disbursement but the application award totals must be the sum of the awards from both the disbursements of the current assessment of the application" +
       " when there are two disbursements for the application but only one disbursement update is within the default IER generation range.",
     async () => {
-      // Arrange
-      const defaultIERFileGenerationStartDate = new Date(
-        dateUtils.getISODateOnlyString(dateUtils.addDays(-1)),
+      const secondDisbursementUpdatedAt = dateUtils.addHours(
+        1,
+        defaultIERFileGenerationStartDate,
       );
+      // Arrange
       const testInputData = {
         student: {
           ...JOHN_DOE_FROM_CANADA,
@@ -181,10 +188,7 @@ describe(describeProcessorRootTest(QueueNames.IER12Integration), () => {
               disbursementScheduleStatus: DisbursementScheduleStatus.Pending,
               disbursementDate: undefined,
               // Only one disbursement update is within the default IER generation range.
-              updatedAt: dateUtils.addHours(
-                1,
-                defaultIERFileGenerationStartDate,
-              ),
+              updatedAt: secondDisbursementUpdatedAt,
               dateSent: undefined,
               disbursementValues: AWARDS_TWO_OF_TWO_DISBURSEMENT,
             },
@@ -221,7 +225,7 @@ describe(describeProcessorRootTest(QueueNames.IER12Integration), () => {
       expect(isValidFileTimestamp(timestampResult.value)).toBe(true);
       expect(ier12Results).toStrictEqual([
         getSuccessSummaryMessages(timestampResult.value, {
-          institutionCode: locationA.institutionCode,
+          institutionCode: locationA.institutionCode!,
           expectedRecords: 1,
         }),
       ]);
@@ -230,22 +234,19 @@ describe(describeProcessorRootTest(QueueNames.IER12Integration), () => {
       expect(uploadedFile.fileLines?.length).toBe(1);
       const [line1] = uploadedFile.fileLines;
       const [, secondDisbursement] =
-        application.currentAssessment.disbursementSchedules;
-      const assessmentId = numberToText(application.currentAssessment.id);
+        application.currentAssessment!.disbursementSchedules ?? [];
+      const assessmentId = numberToText(application.currentAssessment!.id);
       const currentOfferingId = numberToText(
-        application.currentAssessment.offering.id,
+        application.currentAssessment!.offering!.id,
       );
       const parentOfferingId = numberToText(
-        application.currentAssessment.offering.parentOffering.id,
+        application.currentAssessment!.offering!.parentOffering!.id,
       );
 
       const secondDisbursementId = numberToText(secondDisbursement.id);
-      const expectedApplicationEventDate = dayjs(
-        dateUtils.addHours(1, defaultIERFileGenerationStartDate),
-      ).format("YYYYMMDD");
       expect(line1.length).toBe(IER_RECORD_EXPECTED_LENGTH);
       expect(line1).toBe(
-        `${assessmentId}${secondDisbursementId}${defaultApplicationNumber}A1B2C3D4    242963189Doe                      John           19980113B   SI  NONENAddress Line 1           Address Line 2           Victoria                 BC  Z1Z1Z1          Program name                                                               undergraduateCertificate 0001    8   0512123401234ADR1                         6${currentOfferingId}${parentOfferingId}                              2000081620001205000033330000004444000000555500000066660050100F2000060120002001COMP20000601000010000000015161000008040500NNNNN            20000801        000002100000000000000000200000000000000000000000001NNN000000000000000000000000000000000000000000000000000000000000NN0000000000000144430000000115000000000000000000000000007777000000336667000009874600000000000000017500000000000000000000000000002200000120000100001500000009656600N0000000000000000000000000000000000000000000000000000000000000000000000COER${expectedApplicationEventDate}        Required  Pending   20001011                        CSLF0000000000BCSL0001516100CSGP0000123400CSGD0000597800CSGF0000910100CSGT0001213100BCAG0000181900SBSD0000002200BGPD0000202100    0000000000`,
+        `${assessmentId}${secondDisbursementId}${defaultApplicationNumber}A1B2C3D4    242963189Doe                      John           19980113B   SI  NONENAddress Line 1           Address Line 2           Victoria                 BC  Z1Z1Z1          Program name                                                               undergraduateCertificate 0001    8   0512123401234ADR1                         6${currentOfferingId}${parentOfferingId}                              2025081620251205000033330000004444000000555500000066660050100F${formatIER12Date(referenceSubmissionDate)}20252026COMP${formatIER12Date(referenceSubmissionDate)}000010000000015161000008040500NNNNN            ${formatIER12Date(dateOutsideDefaultIERFileGenerationRange)}        000002100000000000000000200000000000000000000000001NNN000000000000000000000000000000000000000000000000000000000000NN0000000000000144430000000115000000000000000000000000007777000000336667000009874600000000000000017500000000000000000000000000002200000120000100001500000009656600N0000000000000000000000000000000000000000000000000000000000000000000000COER${formatIER12Date(secondDisbursementUpdatedAt)}        Required  Pending   20251011                        CSLF0000000000BCSL0001516100CSGP0000123400CSGD0000597800CSGF0000910100CSGT0001213100BCAG0000181900SBSD0000002200BGPD0000202100    0000000000`,
       );
     },
   );
@@ -255,9 +256,6 @@ describe(describeProcessorRootTest(QueueNames.IER12Integration), () => {
       " when the student application has two disbursements, one sent and one pending.",
     async () => {
       // Arrange
-      const defaultIERFileGenerationStartDate = new Date(
-        dateUtils.getISODateOnlyString(dateUtils.addDays(-1)),
-      );
       const testInputData = {
         student: {
           ...JOHN_DOE_FROM_CANADA,
@@ -323,7 +321,7 @@ describe(describeProcessorRootTest(QueueNames.IER12Integration), () => {
       expect(isValidFileTimestamp(timestampResult.value)).toBe(true);
       expect(ier12Results).toStrictEqual([
         getSuccessSummaryMessages(timestampResult.value, {
-          institutionCode: locationA.institutionCode,
+          institutionCode: locationA.institutionCode!,
           expectedRecords: 2,
         }),
       ]);
@@ -332,25 +330,25 @@ describe(describeProcessorRootTest(QueueNames.IER12Integration), () => {
       expect(uploadedFile.fileLines?.length).toBe(2);
       const [line1, line2] = uploadedFile.fileLines;
       const [firstDisbursement, secondDisbursement] =
-        application.currentAssessment.disbursementSchedules;
-      const assessmentId = numberToText(application.currentAssessment.id);
+        application.currentAssessment!.disbursementSchedules || [];
+      const assessmentId = numberToText(application.currentAssessment!.id);
       const currentOfferingId = numberToText(
-        application.currentAssessment.offering.id,
+        application.currentAssessment!.offering!.id,
       );
       const parentOfferingId = numberToText(
-        application.currentAssessment.offering.parentOffering.id,
+        application.currentAssessment!.offering!.parentOffering!.id,
       );
       // Line 1 validations
       const firstDisbursementId = numberToText(firstDisbursement.id);
       expect(line1.length).toBe(IER_RECORD_EXPECTED_LENGTH);
       expect(line1).toBe(
-        `${assessmentId}${firstDisbursementId}${defaultApplicationNumber}A1B2C3D4    242963189Doe                      John           19980113B   SI  NONENAddress Line 1           Address Line 2           Victoria                 BC  Z1Z1Z1          Program name                                                               undergraduateCertificate 0001    8   0512123401234ADR1                         6${currentOfferingId}${parentOfferingId}                              2000081620001205000033330000004444000000555500000066660050100F2000060120002001COMP20000601000010000000015161000008040500NNNNN            20000801        000002100000000000000000200000000000000000000000001NNN000000000000000000000000000000000000000000000000000000000000NN0000000000000144430000000115000000000000000000000000007777000000336667000009874600000000000000017500000000000000000000000000002200000120000100001500000009656600N0000000000000000000000000000000000000000000000000000000000000000000000DISS2000081520000815Completed Sent      20000816                        CSLF0000100000BCSL0000000000CSGP0000200000CSGD0000300000CSGF0000400000CSGT0000500000BCAG0000700000SBSD0000900000BGPD0000800000    0000000000`,
+        `${assessmentId}${firstDisbursementId}${defaultApplicationNumber}A1B2C3D4    242963189Doe                      John           19980113B   SI  NONENAddress Line 1           Address Line 2           Victoria                 BC  Z1Z1Z1          Program name                                                               undergraduateCertificate 0001    8   0512123401234ADR1                         6${currentOfferingId}${parentOfferingId}                              2025081620251205000033330000004444000000555500000066660050100F${formatIER12Date(referenceSubmissionDate)}20252026COMP${formatIER12Date(referenceSubmissionDate)}000010000000015161000008040500NNNNN            ${formatIER12Date(dateOutsideDefaultIERFileGenerationRange)}        000002100000000000000000200000000000000000000000001NNN000000000000000000000000000000000000000000000000000000000000NN0000000000000144430000000115000000000000000000000000007777000000336667000009874600000000000000017500000000000000000000000000002200000120000100001500000009656600N0000000000000000000000000000000000000000000000000000000000000000000000DISS2025081520250815Completed Sent      20250816                        CSLF0000100000BCSL0000000000CSGP0000200000CSGD0000300000CSGF0000400000CSGT0000500000BCAG0000700000SBSD0000900000BGPD0000800000    0000000000`,
       );
       // Line 2 validations.
       const secondDisbursementId = numberToText(secondDisbursement.id);
       expect(line2.length).toBe(IER_RECORD_EXPECTED_LENGTH);
       expect(line2).toBe(
-        `${assessmentId}${secondDisbursementId}${defaultApplicationNumber}A1B2C3D4    242963189Doe                      John           19980113B   SI  NONENAddress Line 1           Address Line 2           Victoria                 BC  Z1Z1Z1          Program name                                                               undergraduateCertificate 0001    8   0512123401234ADR1                         6${currentOfferingId}${parentOfferingId}                              2000081620001205000033330000004444000000555500000066660050100F2000060120002001COMP20000601000010000000015161000008040500NNNNN            20000801        000002100000000000000000200000000000000000000000001NNN000000000000000000000000000000000000000000000000000000000000NN0000000000000144430000000115000000000000000000000000007777000000336667000009874600000000000000017500000000000000000000000000002200000120000100001500000009656600N0000000000000000000000000000000000000000000000000000000000000000000000COER20000801        Required  Pending   20001011                        CSLF0000000000BCSL0001516100CSGP0000123400CSGD0000597800CSGF0000910100CSGT0001213100BCAG0000181900SBSD0000002200BGPD0000202100    0000000000`,
+        `${assessmentId}${secondDisbursementId}${defaultApplicationNumber}A1B2C3D4    242963189Doe                      John           19980113B   SI  NONENAddress Line 1           Address Line 2           Victoria                 BC  Z1Z1Z1          Program name                                                               undergraduateCertificate 0001    8   0512123401234ADR1                         6${currentOfferingId}${parentOfferingId}                              2025081620251205000033330000004444000000555500000066660050100F${formatIER12Date(referenceSubmissionDate)}20252026COMP${formatIER12Date(referenceSubmissionDate)}000010000000015161000008040500NNNNN            ${formatIER12Date(dateOutsideDefaultIERFileGenerationRange)}        000002100000000000000000200000000000000000000000001NNN000000000000000000000000000000000000000000000000000000000000NN0000000000000144430000000115000000000000000000000000007777000000336667000009874600000000000000017500000000000000000000000000002200000120000100001500000009656600N0000000000000000000000000000000000000000000000000000000000000000000000COER${formatIER12Date(dateOutsideDefaultIERFileGenerationRange)}        Required  Pending   20251011                        CSLF0000000000BCSL0001516100CSGP0000123400CSGD0000597800CSGF0000910100CSGT0001213100BCAG0000181900SBSD0000002200BGPD0000202100    0000000000`,
       );
     },
   );
@@ -360,9 +358,6 @@ describe(describeProcessorRootTest(QueueNames.IER12Integration), () => {
       " when there are applications still in assessment, and one pending disbursement.",
     async () => {
       // Arrange
-      const defaultIERFileGenerationStartDate = new Date(
-        dateUtils.getISODateOnlyString(dateUtils.addDays(-1)),
-      );
       const testInputData = {
         student: {
           ...JANE_MONONYMOUS_FROM_OTHER_COUNTRY,
@@ -423,7 +418,7 @@ describe(describeProcessorRootTest(QueueNames.IER12Integration), () => {
       expect(isValidFileTimestamp(timestampResult.value)).toBe(true);
       expect(ier12Results).toStrictEqual([
         getSuccessSummaryMessages(timestampResult.value, {
-          institutionCode: locationB.institutionCode,
+          institutionCode: locationB.institutionCode!,
         }),
       ]);
       // Assert file output.
@@ -431,19 +426,19 @@ describe(describeProcessorRootTest(QueueNames.IER12Integration), () => {
       expect(uploadedFile.fileLines?.length).toBe(1);
       const [line1] = uploadedFile.fileLines;
       const [firstDisbursement] =
-        application.currentAssessment.disbursementSchedules;
-      const assessmentId = numberToText(application.currentAssessment.id);
+        application.currentAssessment!.disbursementSchedules || [];
+      const assessmentId = numberToText(application.currentAssessment!.id);
       const currentOfferingId = numberToText(
-        application.currentAssessment.offering.id,
+        application.currentAssessment!.offering!.id,
       );
       const parentOfferingId = numberToText(
-        application.currentAssessment.offering.parentOffering.id,
+        application.currentAssessment!.offering!.parentOffering!.id,
       );
       // Line 1 validations.
       const firstDisbursementId = numberToText(firstDisbursement.id);
       expect(line1.length).toBe(IER_RECORD_EXPECTED_LENGTH);
       expect(line1).toBe(
-        `${assessmentId}${firstDisbursementId}${defaultApplicationNumber}12345679    242963189Jane With Really Long Mon               19980113B   MA  NONENSome Foreign Street Addre                         New York                     SOME POSTAL CODEProgram name                                                               undergraduateCertificate 0001    8   0512123401234ADR1                         6${currentOfferingId}${parentOfferingId}                              2000081620001010000033330000004444000000555500000066660019100F2000060120002001ASMT20000601000010000000006000000004800000NNNNN            20000801        000002850000000000000000400000006002001003000003005NNY000000000000000000000000000000000000000000000000000000000000NY0000000000000144430000000000000000000000000000000000007777000000150056000000000000000000000000000000000000000000003000000000050000000065430000001700000005500000N0000000000000000000000000000000000000000000000000000000000000000000000ASMT20000801        Completed Pending   20000816                        CSLF0000100000BCSL0000600000CSGP0000200000CSGD0000300000CSGF0000400000CSGT0000500000BCAG0000700000SBSD0000900000BGPD0000800000    0000000000`,
+        `${assessmentId}${firstDisbursementId}${defaultApplicationNumber}12345679    242963189Jane With Really Long Mon               19980113B   MA  NONENSome Foreign Street Addre                         New York                     SOME POSTAL CODEProgram name                                                               undergraduateCertificate 0001    8   0512123401234ADR1                         6${currentOfferingId}${parentOfferingId}                              2025081620251010000033330000004444000000555500000066660019100F${formatIER12Date(referenceSubmissionDate)}20252026ASMT${formatIER12Date(referenceSubmissionDate)}000010000000006000000004800000NNNNN            ${formatIER12Date(dateOutsideDefaultIERFileGenerationRange)}        000002850000000000000000400000006002001003000003005NNY000000000000000000000000000000000000000000000000000000000000NY0000000000000144430000000000000000000000000000000000007777000000150056000000000000000000000000000000000000000000003000000000050000000065430000001700000005500000N0000000000000000000000000000000000000000000000000000000000000000000000ASMT${formatIER12Date(dateOutsideDefaultIERFileGenerationRange)}        Completed Pending   20250816                        CSLF0000100000BCSL0000600000CSGP0000200000CSGD0000300000CSGF0000400000CSGT0000500000BCAG0000700000SBSD0000900000BGPD0000800000    0000000000`,
       );
     },
   );
@@ -522,7 +517,7 @@ describe(describeProcessorRootTest(QueueNames.IER12Integration), () => {
       expect(isValidFileTimestamp(timestampResult.value)).toBe(true);
       expect(ier12Results).toStrictEqual([
         getSuccessSummaryMessages(timestampResult.value, {
-          institutionCode: locationB.institutionCode,
+          institutionCode: locationB.institutionCode!,
         }),
       ]);
       // Assert file output.
@@ -530,19 +525,23 @@ describe(describeProcessorRootTest(QueueNames.IER12Integration), () => {
       expect(uploadedFile.fileLines?.length).toBe(1);
       const [line1] = uploadedFile.fileLines;
       const [firstDisbursement] =
-        application.currentAssessment.disbursementSchedules;
-      const assessmentId = numberToText(application.currentAssessment.id);
+        application.currentAssessment!.disbursementSchedules || [];
+      const assessmentId = numberToText(application.currentAssessment!.id);
       const currentOfferingId = numberToText(
-        application.currentAssessment.offering.id,
+        application.currentAssessment!.offering!.id,
       );
       const parentOfferingId = numberToText(
-        application.currentAssessment.offering.parentOffering.id,
+        application.currentAssessment!.offering!.parentOffering!.id,
       );
       // Line 1 validations.
+      const expectedAssessmentDate = dateUtils.addDays(
+        1,
+        referenceSubmissionDate,
+      );
       const firstDisbursementId = numberToText(firstDisbursement.id);
       expect(line1.length).toBe(IER_RECORD_EXPECTED_LENGTH);
       expect(line1).toBe(
-        `${assessmentId}${firstDisbursementId}${defaultApplicationNumber}12345679    242963189Jane With Really Long Mon               19980113B   MA  PDAPYSome Foreign Street Addre                         New York                     SOME POSTAL CODEProgram name                                                               undergraduateCertificate 0001    8   0512123401234ADR1                         6${currentOfferingId}${parentOfferingId}                              2000081620001010000033330000004444000000555500000066660019100F2000060120002001ASMT20000601000010000000006000000004800000NNNNN            20000602        000002850000000000000000400000006002001003000003005NNY000000000000000000000000000000000000000000000000000000000000NY0000000000000144430000000000000000000000000000000000007777000000150056000000000000000000000000000000000000000000003000000000050000000065430000001700000005500000N0000000000000000000000000000000000000000000000000000000000000000000000ASMT20000601        Completed Pending   20000816                        CSLF0000100000BCSL0000600000CSGP0000200000CSGD0000300000CSGF0000400000CSGT0000500000BCAG0000700000SBSD0000900000BGPD0000800000    0000000000`,
+        `${assessmentId}${firstDisbursementId}${defaultApplicationNumber}12345679    242963189Jane With Really Long Mon               19980113B   MA  PDAPYSome Foreign Street Addre                         New York                     SOME POSTAL CODEProgram name                                                               undergraduateCertificate 0001    8   0512123401234ADR1                         6${currentOfferingId}${parentOfferingId}                              2025081620251010000033330000004444000000555500000066660019100F${formatIER12Date(referenceSubmissionDate)}20252026ASMT${formatIER12Date(referenceSubmissionDate)}000010000000006000000004800000NNNNN            ${formatIER12Date(expectedAssessmentDate)}        000002850000000000000000400000006002001003000003005NNY000000000000000000000000000000000000000000000000000000000000NY0000000000000144430000000000000000000000000000000000007777000000150056000000000000000000000000000000000000000000003000000000050000000065430000001700000005500000N0000000000000000000000000000000000000000000000000000000000000000000000ASMT${formatIER12Date(referenceSubmissionDate)}        Completed Pending   20250816                        CSLF0000100000BCSL0000600000CSGP0000200000CSGD0000300000CSGF0000400000CSGT0000500000BCAG0000700000SBSD0000900000BGPD0000800000    0000000000`,
       );
     },
   );
@@ -604,7 +603,7 @@ describe(describeProcessorRootTest(QueueNames.IER12Integration), () => {
     expect(isValidFileTimestamp(timestampResult.value)).toBe(true);
     expect(ier12Results).toStrictEqual([
       getSuccessSummaryMessages(timestampResult.value, {
-        institutionCode: locationA.institutionCode,
+        institutionCode: locationA.institutionCode!,
       }),
     ]);
     // Assert file output.
@@ -612,19 +611,23 @@ describe(describeProcessorRootTest(QueueNames.IER12Integration), () => {
     expect(uploadedFile.fileLines?.length).toBe(1);
     const [line1] = uploadedFile.fileLines;
     const [firstDisbursement] =
-      application.currentAssessment.disbursementSchedules;
-    const assessmentId = numberToText(application.currentAssessment.id);
+      application.currentAssessment!.disbursementSchedules || [];
+    const assessmentId = numberToText(application.currentAssessment!.id);
     const currentOfferingId = numberToText(
-      application.currentAssessment.offering.id,
+      application.currentAssessment!.offering!.id,
     );
     const parentOfferingId = numberToText(
-      application.currentAssessment.offering.parentOffering.id,
+      application.currentAssessment!.offering!.parentOffering!.id,
     );
     // Line 1 validations.
+    const expectedAssessmentDate = dateUtils.addDays(
+      1,
+      referenceSubmissionDate,
+    );
     const firstDisbursementId = numberToText(firstDisbursement.id);
     expect(line1.length).toBe(IER_RECORD_EXPECTED_LENGTH);
     expect(line1).toBe(
-      `${assessmentId}${firstDisbursementId}${defaultApplicationNumber}            242963189Doe                      John           19980113A   SI  NONENAddress Line 1           Address Line 2           Victoria                 BC  Z1Z1Z1          Program with long name to ensure the program name space of 75 characters isgraduateDiploma          0001    5   0512123401234ADR2XYZ                      6${currentOfferingId}${parentOfferingId}                              2000081620001010000033330000004444000000555500000066660019100F2000060120002001COMP20000601000000000000000000000001209900NNNNN            20000602        000002100000000160000000300000000000000000000000003YYN000001429700000097000000005090000000509000000145500000020015YN0000000000000144430000000000000000000000000012129800007777000000070045000000000000000000000000000000000000000000000000000000050099000065004000001600000001209900N0000000000000000000000000000000000000000000000000000000000000000000000DISS2000081520000815Completed Sent      20000816                        CSLF0000000000BCSL0000000000CSGP0000759900CSGD0000065000CSGF0000150000CSGT0000235000BCAG0000000000SBSD0000000000BGPD0000000000    0000000000`,
+      `${assessmentId}${firstDisbursementId}${defaultApplicationNumber}            242963189Doe                      John           19980113A   SI  NONENAddress Line 1           Address Line 2           Victoria                 BC  Z1Z1Z1          Program with long name to ensure the program name space of 75 characters isgraduateDiploma          0001    5   0512123401234ADR2XYZ                      6${currentOfferingId}${parentOfferingId}                              2025081620251010000033330000004444000000555500000066660019100F${formatIER12Date(referenceSubmissionDate)}20252026COMP${formatIER12Date(referenceSubmissionDate)}000000000000000000000001209900NNNNN            ${formatIER12Date(expectedAssessmentDate)}        000002100000000160000000300000000000000000000000003YYN000001429700000097000000005090000000509000000145500000020015YN0000000000000144430000000000000000000000000012129800007777000000070045000000000000000000000000000000000000000000000000000000050099000065004000001600000001209900N0000000000000000000000000000000000000000000000000000000000000000000000DISS2025081520250815Completed Sent      20250816                        CSLF0000000000BCSL0000000000CSGP0000759900CSGD0000065000CSGF0000150000CSGT0000235000BCAG0000000000SBSD0000000000BGPD0000000000    0000000000`,
     );
   });
 
@@ -680,12 +683,12 @@ describe(describeProcessorRootTest(QueueNames.IER12Integration), () => {
     await saveFakeStudentRestriction(db.dataSource, {
       student: application.student,
       application,
-      restriction: stopFullTimeDisbursementRestriction,
+      restriction: stopFullTimeDisbursementRestriction!,
     });
 
     // Queued job.
     const mockedJob = createIER12SchedulerJobMock(
-      application.currentAssessment.assessmentDate,
+      application.currentAssessment!.assessmentDate,
     );
 
     // Act
@@ -699,7 +702,7 @@ describe(describeProcessorRootTest(QueueNames.IER12Integration), () => {
     expect(isValidFileTimestamp(timestampResult.value)).toBe(true);
     expect(ier12Results).toStrictEqual([
       getSuccessSummaryMessages(timestampResult.value, {
-        institutionCode: locationB.institutionCode,
+        institutionCode: locationB.institutionCode!,
       }),
     ]);
     // Assert file output.
@@ -707,19 +710,23 @@ describe(describeProcessorRootTest(QueueNames.IER12Integration), () => {
     expect(uploadedFile.fileLines?.length).toBe(1);
     const [line1] = uploadedFile.fileLines;
     const [firstDisbursement] =
-      application.currentAssessment.disbursementSchedules;
-    const assessmentId = numberToText(application.currentAssessment.id);
+      application.currentAssessment!.disbursementSchedules || [];
+    const assessmentId = numberToText(application.currentAssessment!.id);
     const currentOfferingId = numberToText(
-      application.currentAssessment.offering.id,
+      application.currentAssessment!.offering!.id,
     );
     const parentOfferingId = numberToText(
-      application.currentAssessment.offering.parentOffering.id,
+      application.currentAssessment!.offering!.parentOffering!.id,
     );
     // Line 1 validations.
+    const expectedAssessmentDate = dateUtils.addDays(
+      1,
+      referenceSubmissionDate,
+    );
     expect(line1.length).toBe(IER_RECORD_EXPECTED_LENGTH);
     const firstDisbursementId = numberToText(firstDisbursement.id);
     expect(line1).toBe(
-      `${assessmentId}${firstDisbursementId}${defaultApplicationNumber}1           242963189Doe                      John           19980113B   SI  NONENAddress Line 1           Address Line 2           Victoria                 BC  Z1Z1Z1          Program with long name to ensure the program name space of 75 characters isgraduateDiploma          0001    5   0512123401234ADR2XYZ                      6${currentOfferingId}${parentOfferingId}                              2000081620001010000033330000004444000000555500000066660050100F2000060120002001COMP20000601000010000000006000000004800000NYNNY            20000602        000002100000000000000000200000000000000000000000001NNN000000000000000000000000000000000000000000000000000000000000NN0000000000000144430000000115000000000000000000000000007777000000336667000009874600000000000000017500000000000000000000000000002200000120000100001500000005500000N0000000000000000000000000000000000000000000000000000000000000000000000DISR20000811        Completed Pending   20000816                        CSLF0000100000BCSL0000600000CSGP0000200000CSGD0000300000CSGF0000400000CSGT0000500000BCAG0000700000SBSD0000900000BGPD0000800000    0000000000`,
+      `${assessmentId}${firstDisbursementId}${defaultApplicationNumber}1           242963189Doe                      John           19980113B   SI  NONENAddress Line 1           Address Line 2           Victoria                 BC  Z1Z1Z1          Program with long name to ensure the program name space of 75 characters isgraduateDiploma          0001    5   0512123401234ADR2XYZ                      6${currentOfferingId}${parentOfferingId}                              2025081620251010000033330000004444000000555500000066660050100F${formatIER12Date(referenceSubmissionDate)}20252026COMP${formatIER12Date(referenceSubmissionDate)}000010000000006000000004800000NYNNY            ${formatIER12Date(expectedAssessmentDate)}        000002100000000000000000200000000000000000000000001NNN000000000000000000000000000000000000000000000000000000000000NN0000000000000144430000000115000000000000000000000000007777000000336667000009874600000000000000017500000000000000000000000000002200000120000100001500000005500000N0000000000000000000000000000000000000000000000000000000000000000000000DISR20250811        Completed Pending   20250816                        CSLF0000100000BCSL0000600000CSGP0000200000CSGD0000300000CSGF0000400000CSGT0000500000BCAG0000700000SBSD0000900000BGPD0000800000    0000000000`,
     );
   });
 
@@ -772,12 +779,12 @@ describe(describeProcessorRootTest(QueueNames.IER12Integration), () => {
     await saveFakeStudentRestriction(db.dataSource, {
       student: application.student,
       application,
-      restriction: stopFullTimeDisbursementRestriction,
+      restriction: stopFullTimeDisbursementRestriction!,
     });
 
     // Queued job.
     const mockedJob = createIER12SchedulerJobMock(
-      application.currentAssessment.assessmentDate,
+      application.currentAssessment!.assessmentDate,
     );
 
     // Act
@@ -791,7 +798,7 @@ describe(describeProcessorRootTest(QueueNames.IER12Integration), () => {
     expect(isValidFileTimestamp(timestampResult.value)).toBe(true);
     expect(ier12Results).toStrictEqual([
       getSuccessSummaryMessages(timestampResult.value, {
-        institutionCode: locationB.institutionCode,
+        institutionCode: locationB.institutionCode!,
       }),
     ]);
     // Assert file output.
@@ -799,19 +806,23 @@ describe(describeProcessorRootTest(QueueNames.IER12Integration), () => {
     expect(uploadedFile.fileLines?.length).toBe(1);
     const [line1] = uploadedFile.fileLines;
     const [firstDisbursement] =
-      application.currentAssessment.disbursementSchedules;
-    const assessmentId = numberToText(application.currentAssessment.id);
+      application.currentAssessment!.disbursementSchedules || [];
+    const assessmentId = numberToText(application.currentAssessment!.id);
     const currentOfferingId = numberToText(
-      application.currentAssessment.offering.id,
+      application.currentAssessment!.offering!.id,
     );
     const parentOfferingId = numberToText(
-      application.currentAssessment.offering.parentOffering.id,
+      application.currentAssessment!.offering!.parentOffering!.id,
     );
     // Line 1 validations.
+    const expectedAssessmentDate = dateUtils.addDays(
+      1,
+      referenceSubmissionDate,
+    );
     expect(line1.length).toBe(IER_RECORD_EXPECTED_LENGTH);
     const firstDisbursementId = numberToText(firstDisbursement.id);
     expect(line1).toBe(
-      `${assessmentId}${firstDisbursementId}${defaultApplicationNumber}1           242963189Doe                      John           19980113B   SI  NONENAddress Line 1           Address Line 2           Victoria                 BC  Z1Z1Z1          Program with long name to ensure the program name space of 75 characters isgraduateDiploma          0001    5   0512123401234ADR2XYZ                      6${currentOfferingId}${parentOfferingId}                              2000081620001010000033330000004444000000555500000066660050100F2000060120002001COMP20000601000010000000006000000004800000YNNNY            20000602        000002100000000000000000200000000000000000000000001NNN000000000000000000000000000000000000000000000000000000000000NN0000000000000144430000000115000000000000000000000000007777000000336667000009874600000000000000017500000000000000000000000000002200000120000100001500000005500000N0000000000000000000000000000000000000000000000000000000000000000000000COEA20000601        Completed Pending   20000816                        CSLF0000100000BCSL0000600000CSGP0000200000CSGD0000300000CSGF0000400000CSGT0000500000BCAG0000700000SBSD0000900000BGPD0000800000    0000000000`,
+      `${assessmentId}${firstDisbursementId}${defaultApplicationNumber}1           242963189Doe                      John           19980113B   SI  NONENAddress Line 1           Address Line 2           Victoria                 BC  Z1Z1Z1          Program with long name to ensure the program name space of 75 characters isgraduateDiploma          0001    5   0512123401234ADR2XYZ                      6${currentOfferingId}${parentOfferingId}                              2025081620251010000033330000004444000000555500000066660050100F${formatIER12Date(referenceSubmissionDate)}20252026COMP${formatIER12Date(referenceSubmissionDate)}000010000000006000000004800000YNNNY            ${formatIER12Date(expectedAssessmentDate)}        000002100000000000000000200000000000000000000000001NNN000000000000000000000000000000000000000000000000000000000000NN0000000000000144430000000115000000000000000000000000007777000000336667000009874600000000000000017500000000000000000000000000002200000120000100001500000005500000N0000000000000000000000000000000000000000000000000000000000000000000000COEA${formatIER12Date(referenceSubmissionDate)}        Completed Pending   20250816                        CSLF0000100000BCSL0000600000CSGP0000200000CSGD0000300000CSGF0000400000CSGT0000500000BCAG0000700000SBSD0000900000BGPD0000800000    0000000000`,
     );
   });
 
@@ -857,12 +868,12 @@ describe(describeProcessorRootTest(QueueNames.IER12Integration), () => {
     // Create a feedback error associated with the disbursement.
     const [errorCode] = FULL_TIME_DISBURSEMENT_FEEDBACK_ERRORS;
     const [disbursementSchedule] =
-      application.currentAssessment.disbursementSchedules;
+      application.currentAssessment!.disbursementSchedules || [];
     // Assign a full-time e-Cert feedback error for the expected error code.
-    const eCertFeedbackError = await db.eCertFeedbackError.findOne({
+    const eCertFeedbackError = (await db.eCertFeedbackError.findOne({
       select: { id: true },
       where: { errorCode, offeringIntensity: OfferingIntensity.fullTime },
-    });
+    }))!;
     const feedbackError = createFakeDisbursementFeedbackError(
       { disbursementSchedule, eCertFeedbackError },
       {
@@ -888,7 +899,7 @@ describe(describeProcessorRootTest(QueueNames.IER12Integration), () => {
     expect(isValidFileTimestamp(timestampResult.value)).toBe(true);
     expect(ier12Results).toStrictEqual([
       getSuccessSummaryMessages(timestampResult.value, {
-        institutionCode: locationA.institutionCode,
+        institutionCode: locationA.institutionCode!,
       }),
     ]);
     // Assert file output.
@@ -896,26 +907,31 @@ describe(describeProcessorRootTest(QueueNames.IER12Integration), () => {
     expect(uploadedFile.fileLines?.length).toBe(1);
     const [line1] = uploadedFile.fileLines;
     const [firstDisbursement] =
-      application.currentAssessment.disbursementSchedules;
-    const assessmentId = numberToText(application.currentAssessment.id);
+      application.currentAssessment!.disbursementSchedules || [];
+    const assessmentId = numberToText(application.currentAssessment!.id);
     const currentOfferingId = numberToText(
-      application.currentAssessment.offering.id,
+      application.currentAssessment!.offering!.id,
     );
     const parentOfferingId = numberToText(
-      application.currentAssessment.offering.parentOffering.id,
+      application.currentAssessment!.offering!.parentOffering!.id,
     );
     // Line 1 validations.
+    const expectedAssessmentDate = dateUtils.addDays(
+      1,
+      referenceSubmissionDate,
+    );
     const firstDisbursementId = numberToText(firstDisbursement.id);
     const feedbackErrorUpdatedDate = dateToDateOnlyText(
       feedbackError.updatedAt,
     );
     expect(line1.length).toBe(IER_RECORD_EXPECTED_LENGTH);
     expect(line1).toBe(
-      `${assessmentId}${firstDisbursementId}${defaultApplicationNumber}            242963189Jane With Really Long Mon               19980113B   SI  NONENSome Foreign Street Addre                         New York                     SOME POSTAL CODEProgram with long name to ensure the program name space of 75 characters isgraduateDiploma          0001    5   0512123401234ADR2XYZ                      6${currentOfferingId}${parentOfferingId}                              2000081620001010000033330000004444000000555500000066660019100F2000060120002001COMP20000601000000000000000000000001209900NNNNN            20000602        000002100000000160000000300000000000000000000000001NNN000000000000000000000000000000000000000000000000000000020015NN0000000000000144430000000115000000000000000000000000007777000000070045000000000000000000000000017500000000000000000000000000002200000065004000001600000001209900N0000000000000000000000000000000000000000000000000000000000000000000000DISE${feedbackErrorUpdatedDate}20000815Completed Sent      20000816                        CSLF0000000000BCSL0000000000CSGP0000759900CSGD0000065000CSGF0000150000CSGT0000235000BCAG0000000000SBSD0000000000BGPD0000000000    0000000000`,
+      `${assessmentId}${firstDisbursementId}${defaultApplicationNumber}            242963189Jane With Really Long Mon               19980113B   SI  NONENSome Foreign Street Addre                         New York                     SOME POSTAL CODEProgram with long name to ensure the program name space of 75 characters isgraduateDiploma          0001    5   0512123401234ADR2XYZ                      6${currentOfferingId}${parentOfferingId}                              2025081620251010000033330000004444000000555500000066660019100F${formatIER12Date(referenceSubmissionDate)}20252026COMP${formatIER12Date(referenceSubmissionDate)}000000000000000000000001209900NNNNN            ${formatIER12Date(expectedAssessmentDate)}        000002100000000160000000300000000000000000000000001NNN000000000000000000000000000000000000000000000000000000020015NN0000000000000144430000000115000000000000000000000000007777000000070045000000000000000000000000017500000000000000000000000000002200000065004000001600000001209900N0000000000000000000000000000000000000000000000000000000000000000000000DISE${feedbackErrorUpdatedDate}20250815Completed Sent      20250816                        CSLF0000000000BCSL0000000000CSGP0000759900CSGD0000065000CSGF0000150000CSGT0000235000BCAG0000000000SBSD0000000000BGPD0000000000    0000000000`,
     );
   });
 
-  it("Should generate an IER12 file with one record for a student when there is one sent disbursement that had some funds withheld due to a restriction (DISW).", async () => {
+  // TODO Fix this test.
+  it.skip("Should generate an IER12 file with one record for a student when there is one sent disbursement that had some funds withheld due to a restriction (DISW).", async () => {
     // Arrange
     const testInputData = {
       student: JOHN_DOE_FROM_CANADA,
@@ -960,7 +976,7 @@ describe(describeProcessorRootTest(QueueNames.IER12Integration), () => {
 
     // Queued job.
     const mockedJob = createIER12SchedulerJobMock(
-      application.currentAssessment.assessmentDate,
+      application.currentAssessment!.assessmentDate,
     );
 
     // Act
@@ -974,7 +990,7 @@ describe(describeProcessorRootTest(QueueNames.IER12Integration), () => {
     expect(isValidFileTimestamp(timestampResult.value)).toBe(true);
     expect(ier12Results).toStrictEqual([
       getSuccessSummaryMessages(timestampResult.value, {
-        institutionCode: locationB.institutionCode,
+        institutionCode: locationB.institutionCode!,
       }),
     ]);
     // Assert file output.
@@ -982,10 +998,10 @@ describe(describeProcessorRootTest(QueueNames.IER12Integration), () => {
     expect(uploadedFile.fileLines?.length).toBe(1);
     const [line1] = uploadedFile.fileLines;
     const [firstDisbursement] =
-      application.currentAssessment.disbursementSchedules;
-    const assessmentId = numberToText(application.currentAssessment.id);
+      application.currentAssessment!.disbursementSchedules || [];
+    const assessmentId = numberToText(application.currentAssessment!.id);
     const currentOfferingId = numberToText(
-      application.currentAssessment.offering.id,
+      application.currentAssessment!.offering!.id,
     );
     const offering = await db.educationProgramOffering.findOne({
       select: {
@@ -995,14 +1011,14 @@ describe(describeProcessorRootTest(QueueNames.IER12Integration), () => {
         },
       },
       where: {
-        id: application.currentAssessment.offering.id,
+        id: application.currentAssessment!.offering!.id,
       },
       relations: {
         parentOffering: true,
       },
     });
 
-    const parentOfferingId = numberToText(offering.parentOffering.id);
+    const parentOfferingId = numberToText(offering!.parentOffering!.id);
     // Line 1 validations.
     const firstDisbursementId = numberToText(firstDisbursement.id);
     expect(line1.length).toBe(IER_RECORD_EXPECTED_LENGTH);
@@ -1053,6 +1069,8 @@ describe(describeProcessorRootTest(QueueNames.IER12Integration), () => {
       },
     );
 
+    // Add one hour to ensure the proper file upload order.
+    const assessmentDateB = dayjs(referenceSubmissionDate).add(1, "h").toDate();
     const testInputDataLocationB = {
       student: JOHN_DOE_FROM_CANADA,
       application: {
@@ -1064,8 +1082,8 @@ describe(describeProcessorRootTest(QueueNames.IER12Integration), () => {
       },
       assessment: {
         triggerType: AssessmentTriggerType.OriginalAssessment,
-        // Add one hour to ensure the proper file upload order.
-        assessmentDate: dayjs(referenceSubmissionDate).add(1, "h").toDate(),
+
+        assessmentDate: assessmentDateB,
         workflowData: WORKFLOW_DATA_MARRIED_WITH_DEPENDENTS,
         assessmentData: ASSESSMENT_DATA_MARRIED,
         disbursementSchedules: [
@@ -1110,10 +1128,10 @@ describe(describeProcessorRootTest(QueueNames.IER12Integration), () => {
     expect(isValidFileTimestamp(secondTimestampResult.value)).toBe(true);
     expect(ier12Results).toStrictEqual([
       getSuccessSummaryMessages(firstTimestampResult.value, {
-        institutionCode: locationA.institutionCode,
+        institutionCode: locationA.institutionCode!,
       }),
       getSuccessSummaryMessages(secondTimestampResult.value, {
-        institutionCode: locationB.institutionCode,
+        institutionCode: locationB.institutionCode!,
       }),
     ]);
     // Assert file output.
@@ -1123,39 +1141,39 @@ describe(describeProcessorRootTest(QueueNames.IER12Integration), () => {
     expect(fileA.fileLines?.length).toBe(1);
     const [fileALine1] = fileA.fileLines;
     const [firstDisbursementA] =
-      applicationA.currentAssessment.disbursementSchedules;
-    const assessmentAId = numberToText(applicationA.currentAssessment.id);
+      applicationA.currentAssessment!.disbursementSchedules || [];
+    const assessmentAId = numberToText(applicationA.currentAssessment!.id);
     // Line 1 validations.
     const firstDisbursementAId = numberToText(firstDisbursementA.id);
     const currentOfferingIdForApplicationA = numberToText(
-      applicationA.currentAssessment.offering.id,
+      applicationA.currentAssessment!.offering!.id,
     );
     const parentOfferingIdA = numberToText(
-      applicationA.currentAssessment.offering.parentOffering.id,
+      applicationA.currentAssessment!.offering!.parentOffering!.id,
     );
     expect(fileALine1.length).toBe(IER_RECORD_EXPECTED_LENGTH);
     expect(fileALine1).toBe(
-      `${assessmentAId}${firstDisbursementAId}${defaultApplicationNumber}            242963189Doe                      John           19980113B   MA  NONENAddress Line 1           Address Line 2           Victoria                 BC  Z1Z1Z1          Program name                                                               undergraduateCertificate 0001    8   0512123401234ADR1                         6${currentOfferingIdForApplicationA}${parentOfferingIdA}                              2000081620001010000033330000004444000000555500000066660019100F2000060120002001COMP20000601000000000000000000000000000000NNNNN            20000601        000002850000000000000000400000006002001003000003005NNY000000000000000000000000000000000000000000000000000000000000NY0000000000000144430000000000000000000000000000000000007777000000150056000000000000000000000000000000000000000000003000000000050000000065430000001700000000000000N0000000000000000000000000000000000000000000000000000000000000000000000DISS2000081520000815Completed Sent      20000816                        CSLF0000000000BCSL0000000000CSGP0000000000CSGD0000000000CSGF0000000000CSGT0000000000BCAG0000000000SBSD0000000000BGPD0000000000    0000000000`,
+      `${assessmentAId}${firstDisbursementAId}${defaultApplicationNumber}            242963189Doe                      John           19980113B   MA  NONENAddress Line 1           Address Line 2           Victoria                 BC  Z1Z1Z1          Program name                                                               undergraduateCertificate 0001    8   0512123401234ADR1                         6${currentOfferingIdForApplicationA}${parentOfferingIdA}                              2025081620251010000033330000004444000000555500000066660019100F${formatIER12Date(referenceSubmissionDate)}20252026COMP${formatIER12Date(referenceSubmissionDate)}000000000000000000000000000000NNNNN            ${formatIER12Date(referenceSubmissionDate)}        000002850000000000000000400000006002001003000003005NNY000000000000000000000000000000000000000000000000000000000000NY0000000000000144430000000000000000000000000000000000007777000000150056000000000000000000000000000000000000000000003000000000050000000065430000001700000000000000N0000000000000000000000000000000000000000000000000000000000000000000000DISS2025081520250815Completed Sent      20250816                        CSLF0000000000BCSL0000000000CSGP0000000000CSGD0000000000CSGF0000000000CSGT0000000000BCAG0000000000SBSD0000000000BGPD0000000000    0000000000`,
     );
     // Location B file validation.
     expect(fileB).toBeDefined();
     expect(fileB.fileLines?.length).toBe(1);
     const [fileBLine1] = fileB.fileLines;
     const [firstDisbursementB] =
-      applicationB.currentAssessment.disbursementSchedules;
-    const assessmentBId = numberToText(applicationB.currentAssessment.id);
+      applicationB.currentAssessment!.disbursementSchedules || [];
+    const assessmentBId = numberToText(applicationB.currentAssessment!.id);
     // Line 1 validations.
     const firstDisbursementBId = numberToText(firstDisbursementB.id);
     const currentOfferingIdForApplicationB = numberToText(
-      applicationB.currentAssessment.offering.id,
+      applicationB.currentAssessment!.offering!.id,
     );
     const parentOfferingIdB = numberToText(
-      applicationB.currentAssessment.offering.parentOffering.id,
+      applicationB.currentAssessment!.offering!.parentOffering!.id,
     );
 
     expect(fileBLine1.length).toBe(IER_RECORD_EXPECTED_LENGTH);
     expect(fileBLine1).toBe(
-      `${assessmentBId}${firstDisbursementBId}${defaultApplicationNumber}            242963189Doe                      John           19980113B   MA  NONENAddress Line 1           Address Line 2           Victoria                 BC  Z1Z1Z1          Program name                                                               undergraduateCertificate 0001    8   0512123401234ADR1                         6${currentOfferingIdForApplicationB}${parentOfferingIdB}                              2000081620001010000033330000004444000000555500000066660019100F2000060120002001COMP20000601000010000000006598000000032400NNNNN            20000601        000002850000000000000000400000006002001003000003005NNY000000000000000000000000000000000000000000000000000000000000NY0000000000000144430000000000000000000000000000000000007777000000150056000000000000000000000000000000000000000000003000000000050000000065430000001700000000792200N0000000000000000000000000000000000000000000000000000000000000000000000DISW2000081520000815Completed Sent      20000816                        CSLF0000100000BCSL0000659800CSGP0000000000CSGD0000000000CSGF0000000000CSGT0000000000BCAG0000032400SBSD0000000000BGPD0000000000    0000000000`,
+      `${assessmentBId}${firstDisbursementBId}${defaultApplicationNumber}            242963189Doe                      John           19980113B   MA  NONENAddress Line 1           Address Line 2           Victoria                 BC  Z1Z1Z1          Program name                                                               undergraduateCertificate 0001    8   0512123401234ADR1                         6${currentOfferingIdForApplicationB}${parentOfferingIdB}                              2025081620251010000033330000004444000000555500000066660019100F${formatIER12Date(referenceSubmissionDate)}20252026COMP${formatIER12Date(referenceSubmissionDate)}000010000000006598000000032400NNNNN            ${formatIER12Date(assessmentDateB)}        000002850000000000000000400000006002001003000003005NNY000000000000000000000000000000000000000000000000000000000000NY0000000000000144430000000000000000000000000000000000007777000000150056000000000000000000000000000000000000000000003000000000050000000065430000001700000000792200N0000000000000000000000000000000000000000000000000000000000000000000000DISW2025081520250815Completed Sent      20250816                        CSLF0000100000BCSL0000659800CSGP0000000000CSGD0000000000CSGF0000000000CSGT0000000000BCAG0000032400SBSD0000000000BGPD0000000000    0000000000`,
     );
   });
 
@@ -1216,7 +1234,7 @@ describe(describeProcessorRootTest(QueueNames.IER12Integration), () => {
 
     // Queued job.
     const mockedJob = createIER12SchedulerJobMock(
-      application.currentAssessment.assessmentDate,
+      application.currentAssessment!.assessmentDate,
     );
 
     // Act
@@ -1230,7 +1248,7 @@ describe(describeProcessorRootTest(QueueNames.IER12Integration), () => {
     expect(isValidFileTimestamp(timestampResult.value)).toBe(true);
     expect(ier12Results).toStrictEqual([
       getSuccessSummaryMessages(timestampResult.value, {
-        institutionCode: locationB.institutionCode,
+        institutionCode: locationB.institutionCode!,
       }),
     ]);
     // Assert file output.
@@ -1238,19 +1256,23 @@ describe(describeProcessorRootTest(QueueNames.IER12Integration), () => {
     expect(uploadedFile.fileLines?.length).toBe(1);
     const [line1] = uploadedFile.fileLines;
     const [firstDisbursement] =
-      application.currentAssessment.disbursementSchedules;
-    const assessmentId = numberToText(application.currentAssessment.id);
+      application.currentAssessment!.disbursementSchedules || [];
+    const assessmentId = numberToText(application.currentAssessment!.id);
     const currentOfferingId = numberToText(
-      application.currentAssessment.offering.id,
+      application.currentAssessment!.offering!.id,
     );
     const parentOfferingId = numberToText(
-      application.currentAssessment.offering.parentOffering.id,
+      application.currentAssessment!.offering!.parentOffering!.id,
     );
     // Line 1 validations.
+    const expectedAssessmentDate = dateUtils.addDays(
+      1,
+      referenceSubmissionDate,
+    );
     const firstDisbursementId = numberToText(firstDisbursement.id);
     expect(line1.length).toBe(IER_RECORD_EXPECTED_LENGTH);
     expect(line1).toBe(
-      `${assessmentId}${firstDisbursementId}${defaultApplicationNumber}12345679    242963189Jane With Really Long Mon               19980113B   MA  NONENSome Foreign Street Addre                         New York                     SOME POSTAL CODEProgram name                                                               undergraduateCertificate 0001    8   0512123401234ADR1                         6${currentOfferingId}${parentOfferingId}                              2000081620001010000033330000004444000000555500000066660019100F2000060120002001ASMT20000601000010000000006000000004800000NNNNN            20000602        000002850000000000000000400000006002001003000003005NNY000000000000000000000000000000000000000000000000000000000000NY0000000000000144430000000000000000000000000000000000007777000000150056000000000000000000000000000000000000000000003000000000050000000065430000001700000005500000Y0000703100000000000000001000000000541800000000000000000375000000023800ASMT20000601        Completed Pending   20000816                        CSLF0000100000BCSL0000600000CSGP0000200000CSGD0000300000CSGF0000400000CSGT0000500000BCAG0000700000SBSD0000900000BGPD0000800000    0000000000`,
+      `${assessmentId}${firstDisbursementId}${defaultApplicationNumber}12345679    242963189Jane With Really Long Mon               19980113B   MA  NONENSome Foreign Street Addre                         New York                     SOME POSTAL CODEProgram name                                                               undergraduateCertificate 0001    8   0512123401234ADR1                         6${currentOfferingId}${parentOfferingId}                              2025081620251010000033330000004444000000555500000066660019100F${formatIER12Date(referenceSubmissionDate)}20252026ASMT${formatIER12Date(referenceSubmissionDate)}000010000000006000000004800000NNNNN            ${formatIER12Date(expectedAssessmentDate)}        000002850000000000000000400000006002001003000003005NNY000000000000000000000000000000000000000000000000000000000000NY0000000000000144430000000000000000000000000000000000007777000000150056000000000000000000000000000000000000000000003000000000050000000065430000001700000005500000Y0000703100000000000000001000000000541800000000000000000375000000023800ASMT${formatIER12Date(referenceSubmissionDate)}        Completed Pending   20250816                        CSLF0000100000BCSL0000600000CSGP0000200000CSGD0000300000CSGF0000400000CSGT0000500000BCAG0000700000SBSD0000900000BGPD0000800000    0000000000`,
     );
   });
 
@@ -1305,7 +1327,7 @@ describe(describeProcessorRootTest(QueueNames.IER12Integration), () => {
 
     // Queued job.
     const mockedJob = createIER12SchedulerJobMock(
-      application.currentAssessment.assessmentDate,
+      application.currentAssessment!.assessmentDate,
     );
 
     // Act
@@ -1319,7 +1341,7 @@ describe(describeProcessorRootTest(QueueNames.IER12Integration), () => {
     expect(isValidFileTimestamp(timestampResult.value)).toBe(true);
     expect(ier12Results).toStrictEqual([
       getSuccessSummaryMessages(timestampResult.value, {
-        institutionCode: locationB.institutionCode,
+        institutionCode: locationB.institutionCode!,
       }),
     ]);
     // Assert file output.
@@ -1327,25 +1349,174 @@ describe(describeProcessorRootTest(QueueNames.IER12Integration), () => {
     expect(uploadedFile.fileLines?.length).toBe(1);
     const [line1] = uploadedFile.fileLines;
     const [firstDisbursement] =
-      application.currentAssessment.disbursementSchedules;
-    const assessmentId = numberToText(application.currentAssessment.id);
+      application.currentAssessment!.disbursementSchedules || [];
+    const assessmentId = numberToText(application.currentAssessment!.id);
     const currentOfferingId = numberToText(
-      application.currentAssessment.offering.id,
+      application.currentAssessment!.offering!.id,
     );
     const parentOfferingId = numberToText(
-      application.currentAssessment.offering.parentOffering.id,
+      application.currentAssessment!.offering!.parentOffering!.id,
     );
     // Line 1 validations.
+    const expectedAssessmentDate = dateUtils.addDays(
+      1,
+      referenceSubmissionDate,
+    );
     expect(line1.length).toBe(IER_RECORD_EXPECTED_LENGTH);
     const firstDisbursementId = numberToText(firstDisbursement.id);
     expect(line1).toBe(
-      `${assessmentId}${firstDisbursementId}${defaultApplicationNumber}1           242963189Doe                      John           19980113B   SI  NONENAddress Line 1           Address Line 2           Victoria                 BC  Z1Z1Z1          Program with long name to ensure the program name space of 75 characters isgraduateDiploma          0001    5   0512123401234ADR2XYZ                      6${currentOfferingId}${parentOfferingId}                              2000081620001010000033330000004444000000555500000066660050100F2000060120002001COMP20000601000010000000006000000004800000NNNNN            20000602        000002100000000000000000200000000000000000000000001NNN000000000000000000000000000000000000000000000000000000000000NN0000000000000144430000000115000000130000000000000000007777000000336667000009874600000000000000017500000000000000000000000000002200000120000100001500000005500000N0000000000000000000000000000000000000000000000000000000000000000000000COEA20000601        Completed Pending   20000816                        CSLF0000100000BCSL0000600000CSGP0000200000CSGD0000300000CSGF0000400000CSGT0000500000BCAG0000700000SBSD0000900000BGPD0000800000    0000000000`,
+      `${assessmentId}${firstDisbursementId}${defaultApplicationNumber}1           242963189Doe                      John           19980113B   SI  NONENAddress Line 1           Address Line 2           Victoria                 BC  Z1Z1Z1          Program with long name to ensure the program name space of 75 characters isgraduateDiploma          0001    5   0512123401234ADR2XYZ                      6${currentOfferingId}${parentOfferingId}                              2025081620251010000033330000004444000000555500000066660050100F${formatIER12Date(referenceSubmissionDate)}20252026COMP${formatIER12Date(referenceSubmissionDate)}000010000000006000000004800000NNNNN            ${formatIER12Date(expectedAssessmentDate)}        000002100000000000000000200000000000000000000000001NNN000000000000000000000000000000000000000000000000000000000000NN0000000000000144430000000115000000130000000000000000007777000000336667000009874600000000000000017500000000000000000000000000002200000120000100001500000005500000N0000000000000000000000000000000000000000000000000000000000000000000000COEA${formatIER12Date(referenceSubmissionDate)}        Completed Pending   20250816                        CSLF0000100000BCSL0000600000CSGP0000200000CSGD0000300000CSGF0000400000CSGT0000500000BCAG0000700000SBSD0000900000BGPD0000800000    0000000000`,
+    );
+  });
+
+  it("Should generate a single IER12 file for records for two students with assessments updated at different times over the past month when a one month time frame is provided.", async () => {
+    const assessmentJohnDate = dateUtils.addDays(-21);
+    const assessmentJaneDate = dateUtils.addDays(-14);
+
+    // Arrange
+    const testInputDataJohn = {
+      student: JOHN_DOE_FROM_CANADA,
+      application: {
+        applicationNumber: defaultApplicationNumber,
+        studentNumber: undefined,
+        relationshipStatus: RelationshipStatus.Married,
+        applicationStatus: ApplicationStatus.Completed,
+        applicationStatusUpdatedOn: undefined,
+      },
+      assessment: {
+        triggerType: AssessmentTriggerType.OriginalAssessment,
+        assessmentDate: assessmentJohnDate,
+        workflowData: WORKFLOW_DATA_MARRIED_WITH_DEPENDENTS,
+        assessmentData: ASSESSMENT_DATA_MARRIED,
+        disbursementSchedules: [
+          {
+            coeStatus: COEStatus.completed,
+            disbursementScheduleStatus: DisbursementScheduleStatus.Sent,
+            disbursementDate: undefined,
+            updatedAt: assessmentJohnDate,
+            dateSent: undefined,
+            disbursementValues:
+              AWARDS_SINGLE_DISBURSEMENT_RESTRICTION_WITHHELD_FUNDS,
+          },
+        ],
+      },
+      educationProgram:
+        PROGRAM_UNDERGRADUATE_CERTIFICATE_WITHOUT_INSTITUTION_PROGRAM_CODE,
+      offering: OFFERING_FULL_TIME,
+    };
+    const applicationJohn = await saveIER12TestInputData(
+      db,
+      testInputDataJohn,
+      { institutionLocation: locationA },
+      {
+        programYearPrefix: sharedProgramYearPrefix,
+        submittedDate: referenceSubmissionDate,
+      },
+    );
+
+    const testInputDataJane = {
+      student: JANE_MONONYMOUS_FROM_OTHER_COUNTRY,
+      application: {
+        applicationNumber: defaultApplicationNumber,
+        studentNumber: undefined,
+        relationshipStatus: RelationshipStatus.Married,
+        applicationStatus: ApplicationStatus.Completed,
+        applicationStatusUpdatedOn: undefined,
+      },
+      assessment: {
+        triggerType: AssessmentTriggerType.OriginalAssessment,
+
+        assessmentDate: assessmentJaneDate,
+        workflowData: WORKFLOW_DATA_MARRIED_WITH_DEPENDENTS,
+        assessmentData: ASSESSMENT_DATA_MARRIED,
+        disbursementSchedules: [
+          {
+            coeStatus: COEStatus.completed,
+            disbursementScheduleStatus: DisbursementScheduleStatus.Sent,
+            disbursementDate: undefined,
+            updatedAt: assessmentJaneDate,
+            dateSent: undefined,
+            disbursementValues:
+              AWARDS_SINGLE_DISBURSEMENT_RESTRICTION_WITHHELD_FUNDS,
+          },
+        ],
+      },
+      educationProgram:
+        PROGRAM_UNDERGRADUATE_CERTIFICATE_WITHOUT_INSTITUTION_PROGRAM_CODE,
+      offering: OFFERING_FULL_TIME,
+    };
+    const applicationJane = await saveIER12TestInputData(
+      db,
+      testInputDataJane,
+      { institutionLocation: locationA },
+      {
+        programYearPrefix: sharedProgramYearPrefix,
+        submittedDate: referenceSubmissionDate,
+      },
+    );
+    // Get one month's worth of data
+    const modifiedSince = dateUtils.addDays(-31);
+    // Queued job.
+    const mockedJob = createIER12SchedulerJobMock(modifiedSince);
+
+    // Act
+    const ier12Results = await processor.processQueue(mockedJob.job);
+
+    // Assert process result.
+    expect(ier12Results).toBeDefined();
+    // File timestamp.
+    const [timestampResult] = getFileNameAsCurrentTimestampMock.mock.results;
+    expect(isValidFileTimestamp(timestampResult.value)).toBe(true);
+    expect(ier12Results).toStrictEqual([
+      getSuccessSummaryMessages(timestampResult.value, {
+        institutionCode: locationA.institutionCode!,
+        expectedRecords: 2,
+      }),
+    ]);
+    // Assert file output.
+    const uploadedFile = getUploadedFile(sftpClientMock);
+    expect(uploadedFile.fileLines?.length).toBe(2);
+    const [line1, line2] = uploadedFile.fileLines;
+
+    const [disbursementJohn] =
+      applicationJohn.currentAssessment!.disbursementSchedules || [];
+    const assessmentJohnId = numberToText(
+      applicationJohn.currentAssessment!.id,
+    );
+    const currentOfferingJohnId = numberToText(
+      applicationJohn.currentAssessment!.offering!.id,
+    );
+    const parentOfferingJohnId = numberToText(
+      applicationJohn.currentAssessment!.offering!.parentOffering!.id,
+    );
+    // Line 1 (John) validations
+    const disbursementJohnId = numberToText(disbursementJohn.id);
+    expect(line1.length).toBe(IER_RECORD_EXPECTED_LENGTH);
+    expect(line1).toBe(
+      `${assessmentJohnId}${disbursementJohnId}${defaultApplicationNumber}            242963189Doe                      John           19980113B   MA  NONENAddress Line 1           Address Line 2           Victoria                 BC  Z1Z1Z1          Program name                                                               undergraduateCertificate 0001    8   0512123401234ADR1                         6${currentOfferingJohnId}${parentOfferingJohnId}                              2025081620251010000033330000004444000000555500000066660019100F${formatIER12Date(referenceSubmissionDate)}20252026COMP${formatIER12Date(referenceSubmissionDate)}000000000000000000000000000000NNNNN            ${formatIER12Date(assessmentJohnDate)}        000002850000000000000000400000006002001003000003005NNY000000000000000000000000000000000000000000000000000000000000NY0000000000000144430000000000000000000000000000000000007777000000150056000000000000000000000000000000000000000000003000000000050000000065430000001700000000000000N0000000000000000000000000000000000000000000000000000000000000000000000DISS2025081520250815Completed Sent      20250816                        CSLF0000000000BCSL0000000000CSGP0000000000CSGD0000000000CSGF0000000000CSGT0000000000BCAG0000000000SBSD0000000000BGPD0000000000    0000000000`,
+    );
+    const [disbursementJane] =
+      applicationJane.currentAssessment!.disbursementSchedules || [];
+    const assessmentJaneId = numberToText(
+      applicationJane.currentAssessment!.id,
+    );
+    const currentOfferingJaneId = numberToText(
+      applicationJane.currentAssessment!.offering!.id,
+    );
+    const parentOfferingJaneId = numberToText(
+      applicationJane.currentAssessment!.offering!.parentOffering!.id,
+    );
+    // Line 2 (Jane) validations.
+    const disbursementJaneId = numberToText(disbursementJane.id);
+    expect(line2.length).toBe(IER_RECORD_EXPECTED_LENGTH);
+    expect(line2).toBe(
+      `${assessmentJaneId}${disbursementJaneId}${defaultApplicationNumber}            242963189Jane With Really Long Mon               19980113B   MA  NONENSome Foreign Street Addre                         New York                     SOME POSTAL CODEProgram name                                                               undergraduateCertificate 0001    8   0512123401234ADR1                         6${currentOfferingJaneId}${parentOfferingJaneId}                              2025081620251010000033330000004444000000555500000066660019100F${formatIER12Date(referenceSubmissionDate)}20252026COMP${formatIER12Date(referenceSubmissionDate)}000010000000006598000000032400NNNNN            ${formatIER12Date(assessmentJaneDate)}        000002850000000000000000400000006002001003000003005NNY000000000000000000000000000000000000000000000000000000000000NY0000000000000144430000000000000000000000000000000000007777000000150056000000000000000000000000000000000000000000003000000000050000000065430000001700000000792200N0000000000000000000000000000000000000000000000000000000000000000000000DISW2025081520250815Completed Sent      20250816                        CSLF0000100000BCSL0000659800CSGP0000000000CSGD0000000000CSGF0000000000CSGT0000000000BCAG0000032400SBSD0000000000BGPD0000000000    0000000000`,
     );
   });
 
   it("Should generate an IER12 file for a specific location when the institution code is valid and matching applications exist.", async () => {
     // Arrange
-    const testInputDataLocationA = {
+    const testInputData = {
       student: JOHN_DOE_FROM_CANADA,
       application: {
         applicationNumber: defaultApplicationNumber,
@@ -1375,9 +1546,9 @@ describe(describeProcessorRootTest(QueueNames.IER12Integration), () => {
         PROGRAM_UNDERGRADUATE_CERTIFICATE_WITHOUT_INSTITUTION_PROGRAM_CODE,
       offering: OFFERING_FULL_TIME,
     };
-    const applicationA = await saveIER12TestInputData(
+    const application = await saveIER12TestInputData(
       db,
-      testInputDataLocationA,
+      testInputData,
       { institutionLocation: locationA },
       {
         programYearPrefix: sharedProgramYearPrefix,
@@ -1413,25 +1584,25 @@ describe(describeProcessorRootTest(QueueNames.IER12Integration), () => {
     expect(fileA.fileLines?.length).toBe(1);
     const [fileALine1] = fileA.fileLines;
     const [firstDisbursementA] =
-      applicationA.currentAssessment!.disbursementSchedules!;
-    const assessmentAId = numberToText(applicationA.currentAssessment!.id);
+      application.currentAssessment!.disbursementSchedules!;
+    const assessmentAId = numberToText(application.currentAssessment!.id);
     // Line 1 validations.
     const firstDisbursementAId = numberToText(firstDisbursementA.id);
     const currentOfferingIdForApplicationA = numberToText(
-      applicationA.currentAssessment!.offering!.id,
+      application.currentAssessment!.offering!.id,
     );
     const parentOfferingIdA = numberToText(
-      applicationA.currentAssessment!.offering!.parentOffering!.id,
+      application.currentAssessment!.offering!.parentOffering!.id,
     );
     expect(fileALine1.length).toBe(IER_RECORD_EXPECTED_LENGTH);
     expect(fileALine1).toBe(
-      `${assessmentAId}${firstDisbursementAId}${defaultApplicationNumber}            242963189Doe                      John           19980113B   MA  NONENAddress Line 1           Address Line 2           Victoria                 BC  Z1Z1Z1          Program name                                                               undergraduateCertificate 0001    8   0512123401234ADR1                         6${currentOfferingIdForApplicationA}${parentOfferingIdA}                              2000081620001010000033330000004444000000555500000066660019100F2000060120002001COMP20000601000010000000006598000000032400NNNNN            20000601        000002850000000000000000400000006002001003000003005NNY000000000000000000000000000000000000000000000000000000000000NY0000000000000144430000000000000000000000000000000000007777000000150056000000000000000000000000000000000000000000003000000000050000000065430000001700000000792200N0000000000000000000000000000000000000000000000000000000000000000000000DISW2000081520000815Completed Sent      20000816                        CSLF0000100000BCSL0000659800CSGP0000000000CSGD0000000000CSGF0000000000CSGT0000000000BCAG0000032400SBSD0000000000BGPD0000000000    0000000000`,
+      `${assessmentAId}${firstDisbursementAId}${defaultApplicationNumber}            242963189Doe                      John           19980113B   MA  NONENAddress Line 1           Address Line 2           Victoria                 BC  Z1Z1Z1          Program name                                                               undergraduateCertificate 0001    8   0512123401234ADR1                         6${currentOfferingIdForApplicationA}${parentOfferingIdA}                              2025081620251010000033330000004444000000555500000066660019100F${formatIER12Date(referenceSubmissionDate)}20252026COMP${formatIER12Date(referenceSubmissionDate)}000010000000006598000000032400NNNNN            ${formatIER12Date(referenceSubmissionDate)}        000002850000000000000000400000006002001003000003005NNY000000000000000000000000000000000000000000000000000000000000NY0000000000000144430000000000000000000000000000000000007777000000150056000000000000000000000000000000000000000000003000000000050000000065430000001700000000792200N0000000000000000000000000000000000000000000000000000000000000000000000DISW2025081520250815Completed Sent      20250816                        CSLF0000100000BCSL0000659800CSGP0000000000CSGD0000000000CSGF0000000000CSGT0000000000BCAG0000032400SBSD0000000000BGPD0000000000    0000000000`,
     );
   });
 
-  it.only("Should not generate an IER12 file for a specific location when the institution code is valid but no matching applications exist.", async () => {
+  it("Should not generate an IER12 file for a specific location when the institution code is valid but no matching applications exist.", async () => {
     // Arrange
-    const testInputDataLocationA = {
+    const testInputData = {
       student: JOHN_DOE_FROM_CANADA,
       application: {
         applicationNumber: defaultApplicationNumber,
@@ -1465,7 +1636,7 @@ describe(describeProcessorRootTest(QueueNames.IER12Integration), () => {
     // This data should not be picked up in the IER12 file.
     await saveIER12TestInputData(
       db,
-      testInputDataLocationA,
+      testInputData,
       { institutionLocation: locationA },
       {
         programYearPrefix: sharedProgramYearPrefix,
@@ -1495,7 +1666,7 @@ describe(describeProcessorRootTest(QueueNames.IER12Integration), () => {
     assertEmptyResults(ier12Results);
   });
 
-  it("Should not generate an IER12 file for a specific location when the modified since date is defaulted and the institution code is invalid.", async () => {
+  it("Should not generate an IER12 file for a specific location when the institution code is invalid.", async () => {
     // Queued job.
     const institutionCode = "ABCDE";
     const mockedJob = createIER12SchedulerJobMock(undefined, institutionCode);
@@ -1545,4 +1716,8 @@ function assertEmptyResults(ier12Results: string | string[]) {
   expect(ier12Results).toBeDefined();
   expect(ier12Results.length).toEqual(1);
   expect(ier12Results[0]).toEqual("No IER12 files were generated.");
+}
+
+function formatIER12Date(date: Date) {
+  return dayjs(date).format("YYYYMMDD");
 }

--- a/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/institution-integration/ier12-integration/_tests_/e2e/ier12-integration.scheduler.e2e-spec.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/institution-integration/ier12-integration/_tests_/e2e/ier12-integration.scheduler.e2e-spec.ts
@@ -1343,7 +1343,206 @@ describe(describeProcessorRootTest(QueueNames.IER12Integration), () => {
     );
   });
 
+  it("Should generate an IER12 file for a specific location when the institution code is valid and matching applications exist.", async () => {
+    // Arrange
+    const testInputDataLocationA = {
+      student: JOHN_DOE_FROM_CANADA,
+      application: {
+        applicationNumber: defaultApplicationNumber,
+        studentNumber: undefined,
+        relationshipStatus: RelationshipStatus.Married,
+        applicationStatus: ApplicationStatus.Completed,
+        applicationStatusUpdatedOn: undefined,
+      },
+      assessment: {
+        triggerType: AssessmentTriggerType.OriginalAssessment,
+        assessmentDate: referenceSubmissionDate,
+        workflowData: WORKFLOW_DATA_MARRIED_WITH_DEPENDENTS,
+        assessmentData: ASSESSMENT_DATA_MARRIED,
+        disbursementSchedules: [
+          {
+            coeStatus: COEStatus.completed,
+            disbursementScheduleStatus: DisbursementScheduleStatus.Sent,
+            disbursementDate: undefined,
+            updatedAt: undefined,
+            dateSent: undefined,
+            disbursementValues:
+              AWARDS_SINGLE_DISBURSEMENT_RESTRICTION_WITHHELD_FUNDS,
+          },
+        ],
+      },
+      educationProgram:
+        PROGRAM_UNDERGRADUATE_CERTIFICATE_WITHOUT_INSTITUTION_PROGRAM_CODE,
+      offering: OFFERING_FULL_TIME,
+    };
+    const applicationA = await saveIER12TestInputData(
+      db,
+      testInputDataLocationA,
+      { institutionLocation: locationA },
+      {
+        programYearPrefix: sharedProgramYearPrefix,
+        submittedDate: referenceSubmissionDate,
+      },
+    );
+
+    // Queued job.
+    const mockedJob = createIER12SchedulerJobMock(
+      referenceSubmissionDate,
+      locationA.institutionCode,
+    );
+
+    // Act
+    const ier12Results = await processor.processQueue(mockedJob.job);
+
+    // Assert
+    // Assert process result.
+    expect(ier12Results).toBeDefined();
+    // File timestamp.
+    const [firstTimestampResult] =
+      getFileNameAsCurrentTimestampMock.mock.results;
+    expect(isValidFileTimestamp(firstTimestampResult.value)).toBe(true);
+    expect(ier12Results).toStrictEqual([
+      getSuccessSummaryMessages(firstTimestampResult.value, {
+        institutionCode: locationA.institutionCode!,
+      }),
+    ]);
+    // Assert file output.
+    const [fileA] = getUploadedFiles(sftpClientMock);
+    // Location A file validation.
+    expect(fileA).toBeDefined();
+    expect(fileA.fileLines?.length).toBe(1);
+    const [fileALine1] = fileA.fileLines;
+    const [firstDisbursementA] =
+      applicationA.currentAssessment!.disbursementSchedules!;
+    const assessmentAId = numberToText(applicationA.currentAssessment!.id);
+    // Line 1 validations.
+    const firstDisbursementAId = numberToText(firstDisbursementA.id);
+    const currentOfferingIdForApplicationA = numberToText(
+      applicationA.currentAssessment!.offering!.id,
+    );
+    const parentOfferingIdA = numberToText(
+      applicationA.currentAssessment!.offering!.parentOffering!.id,
+    );
+    expect(fileALine1.length).toBe(IER_RECORD_EXPECTED_LENGTH);
+    expect(fileALine1).toBe(
+      `${assessmentAId}${firstDisbursementAId}${defaultApplicationNumber}            242963189Doe                      John           19980113B   MA  NONENAddress Line 1           Address Line 2           Victoria                 BC  Z1Z1Z1          Program name                                                               undergraduateCertificate 0001    8   0512123401234ADR1                         6${currentOfferingIdForApplicationA}${parentOfferingIdA}                              2000081620001010000033330000004444000000555500000066660019100F2000060120002001COMP20000601000010000000006598000000032400NNNNN            20000601        000002850000000000000000400000006002001003000003005NNY000000000000000000000000000000000000000000000000000000000000NY0000000000000144430000000000000000000000000000000000007777000000150056000000000000000000000000000000000000000000003000000000050000000065430000001700000000792200N0000000000000000000000000000000000000000000000000000000000000000000000DISW2000081520000815Completed Sent      20000816                        CSLF0000100000BCSL0000659800CSGP0000000000CSGD0000000000CSGF0000000000CSGT0000000000BCAG0000032400SBSD0000000000BGPD0000000000    0000000000`,
+    );
+  });
+
+  it.only("Should not generate an IER12 file for a specific location when the institution code is valid but no matching applications exist.", async () => {
+    // Arrange
+    const testInputDataLocationA = {
+      student: JOHN_DOE_FROM_CANADA,
+      application: {
+        applicationNumber: defaultApplicationNumber,
+        studentNumber: undefined,
+        relationshipStatus: RelationshipStatus.Married,
+        applicationStatus: ApplicationStatus.Completed,
+        applicationStatusUpdatedOn: undefined,
+      },
+      assessment: {
+        triggerType: AssessmentTriggerType.OriginalAssessment,
+        assessmentDate: referenceSubmissionDate,
+        workflowData: WORKFLOW_DATA_MARRIED_WITH_DEPENDENTS,
+        assessmentData: ASSESSMENT_DATA_MARRIED,
+        disbursementSchedules: [
+          {
+            coeStatus: COEStatus.completed,
+            disbursementScheduleStatus: DisbursementScheduleStatus.Sent,
+            disbursementDate: undefined,
+            updatedAt: undefined,
+            dateSent: undefined,
+            disbursementValues:
+              AWARDS_SINGLE_DISBURSEMENT_RESTRICTION_WITHHELD_FUNDS,
+          },
+        ],
+      },
+      educationProgram:
+        PROGRAM_UNDERGRADUATE_CERTIFICATE_WITHOUT_INSTITUTION_PROGRAM_CODE,
+      offering: OFFERING_FULL_TIME,
+    };
+    // Create data for a different location than the one that will be provided in the job data.
+    // This data should not be picked up in the IER12 file.
+    await saveIER12TestInputData(
+      db,
+      testInputDataLocationA,
+      { institutionLocation: locationA },
+      {
+        programYearPrefix: sharedProgramYearPrefix,
+        submittedDate: referenceSubmissionDate,
+      },
+    );
+
+    // Queued job.
+    const institutionCode = "ABCD";
+    const mockedJob = createIER12SchedulerJobMock(undefined, institutionCode);
+
+    // Act
+    const ier12Results = await processor.processQueue(mockedJob.job);
+
+    // Assert logs
+    const today = dayjs().startOf("day").toDate();
+    const modifiedSince = dateUtils.addDays(-1, today);
+    expect(
+      mockedJob.containLogMessages([
+        `Retrieving application current assessment details for IER 12 with institution code ${institutionCode}.`,
+        `Retrieving data related to IER 12 created or modified between ${modifiedSince} and ${today} with institution code ${institutionCode}.`,
+        `No assessments found for IER 12 with institution code ${institutionCode}.`,
+      ]),
+    ).toBe(true);
+
+    // Assert process result.
+    assertEmptyResults(ier12Results);
+  });
+
+  it("Should not generate an IER12 file for a specific location when the modified since date is defaulted and the institution code is invalid.", async () => {
+    // Queued job.
+    const institutionCode = "ABCDE";
+    const mockedJob = createIER12SchedulerJobMock(undefined, institutionCode);
+
+    // Act
+    const ier12Results = await processor.processQueue(mockedJob.job);
+
+    // Assert logs
+    expect(
+      mockedJob.containLogMessages([
+        "Job data institutionCode must be exactly 4 characters.",
+      ]),
+    ).toBe(true);
+
+    // Assert process result.
+    assertEmptyResults(ier12Results);
+  });
+
+  it("Should not generate an IER12 file when the modified since date is over 1 year in the past.", async () => {
+    // Queued job.
+    const modifiedSinceDate = dayjs()
+      .subtract(1, "year")
+      .subtract(1, "day")
+      .toDate();
+    const mockedJob = createIER12SchedulerJobMock(modifiedSinceDate);
+
+    // Act
+    const ier12Results = await processor.processQueue(mockedJob.job);
+
+    // Assert logs
+    expect(
+      mockedJob.containLogMessages([
+        "Modified since date cannot be more than one year in the past.",
+      ]),
+    ).toBe(true);
+
+    // Assert process result.
+    assertEmptyResults(ier12Results);
+  });
+
   afterAll(async () => {
     await app?.close();
   });
 });
+
+function assertEmptyResults(ier12Results: string | string[]) {
+  expect(ier12Results).toBeDefined();
+  expect(ier12Results.length).toEqual(1);
+  expect(ier12Results[0]).toEqual("No IER12 files were generated.");
+}

--- a/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/institution-integration/ier12-integration/_tests_/e2e/ier12-integration.scheduler.e2e-spec.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/institution-integration/ier12-integration/_tests_/e2e/ier12-integration.scheduler.e2e-spec.ts
@@ -1372,7 +1372,7 @@ describe(describeProcessorRootTest(QueueNames.IER12Integration), () => {
     );
   });
 
-  it("Should generate a single IER12 file for records for two students with assessments updated at different times over the past month when a one month time frame is provided.", async () => {
+  it("Should generate an IER12 file with two records for different students with assessments updated at different times over the past month when a one month time frame is provided.", async () => {
     const assessmentJohnDate = dateUtils.addDays(-21);
     const assessmentJaneDate = dateUtils.addDays(-14);
 
@@ -1688,6 +1688,25 @@ describe(describeProcessorRootTest(QueueNames.IER12Integration), () => {
     assertEmptyResults(ier12Results);
   });
 
+  it("Should not generate an IER12 file when the modified since date is not a valid date.", async () => {
+    // Queued job.
+    const modifiedSinceDate = "ABC-12-3456";
+    const mockedJob = createIER12SchedulerJobMock(modifiedSinceDate);
+
+    // Act
+    const ier12Results = await processor.processQueue(mockedJob.job);
+
+    // Assert logs
+    expect(
+      mockedJob.containLogMessages([
+        "Job data modifiedSince must be a valid ISO date (YYYY-MM-DD).",
+      ]),
+    ).toBe(true);
+
+    // Assert process result.
+    assertEmptyResults(ier12Results);
+  });
+
   it("Should not generate an IER12 file when the modified since date is over 1 year in the past.", async () => {
     // Queued job.
     const modifiedSinceDate = dayjs()
@@ -1702,7 +1721,7 @@ describe(describeProcessorRootTest(QueueNames.IER12Integration), () => {
     // Assert logs
     expect(
       mockedJob.containLogMessages([
-        "Modified since date cannot be more than one year in the past.",
+        "Job data modifiedSince cannot be more than one year in the past.",
       ]),
     ).toBe(true);
 
@@ -1716,9 +1735,10 @@ describe(describeProcessorRootTest(QueueNames.IER12Integration), () => {
 });
 
 function assertEmptyResults(ier12Results: string | string[]) {
-  expect(ier12Results).toBeDefined();
-  expect(ier12Results.length).toEqual(1);
-  expect(ier12Results[0]).toEqual("No IER12 files were generated.");
+  const results = Array.isArray(ier12Results) ? ier12Results : [ier12Results];
+  expect(results).toBeDefined();
+  expect(results).toHaveLength(1);
+  expect(results[0]).toBe("No IER12 files were generated.");
 }
 
 function formatIER12Date(date: Date) {

--- a/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/institution-integration/ier12-integration/_tests_/e2e/models/data-inputs/students-inputs.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/institution-integration/ier12-integration/_tests_/e2e/models/data-inputs/students-inputs.ts
@@ -14,6 +14,9 @@ export const JOHN_DOE_FROM_CANADA: IER12Student = {
     postalCode: "Z1Z1Z1",
   },
   disabilityStatus: DisabilityStatus.NotRequested,
+  // Set updatedAt and userUpdatedAt to a date outside the max range so they aren't picked up as updates by default.
+  updatedAt: new Date("2025-06-01"),
+  userUpdatedAt: new Date("2025-06-01"),
 };
 
 export const JANE_MONONYMOUS_FROM_OTHER_COUNTRY: IER12Student = {
@@ -29,4 +32,7 @@ export const JANE_MONONYMOUS_FROM_OTHER_COUNTRY: IER12Student = {
     postalCode: "SOME POSTAL CODE",
   },
   disabilityStatus: DisabilityStatus.NotRequested,
+  // Set updatedAt and userUpdatedAt to a date outside the max range so they aren't picked up as updates by default.
+  updatedAt: new Date("2025-06-01"),
+  userUpdatedAt: new Date("2025-06-01"),
 };

--- a/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/institution-integration/ier12-integration/_tests_/e2e/models/data-inputs/students-inputs.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/institution-integration/ier12-integration/_tests_/e2e/models/data-inputs/students-inputs.ts
@@ -1,5 +1,8 @@
 import { DisabilityStatus } from "@sims/sims-db";
 import { IER12Student } from "./data-inputs.models";
+import { addDays } from "@sims/utilities";
+
+const TWO_YEARS_IN_DAYS = 365 * 2;
 
 export const JOHN_DOE_FROM_CANADA: IER12Student = {
   lastName: "Doe",
@@ -15,8 +18,8 @@ export const JOHN_DOE_FROM_CANADA: IER12Student = {
   },
   disabilityStatus: DisabilityStatus.NotRequested,
   // Set updatedAt and userUpdatedAt to a date outside the max range so they aren't picked up as updates by default.
-  updatedAt: new Date("2025-06-01"),
-  userUpdatedAt: new Date("2025-06-01"),
+  updatedAt: addDays(-TWO_YEARS_IN_DAYS),
+  userUpdatedAt: addDays(-TWO_YEARS_IN_DAYS),
 };
 
 export const JANE_MONONYMOUS_FROM_OTHER_COUNTRY: IER12Student = {
@@ -33,6 +36,6 @@ export const JANE_MONONYMOUS_FROM_OTHER_COUNTRY: IER12Student = {
   },
   disabilityStatus: DisabilityStatus.NotRequested,
   // Set updatedAt and userUpdatedAt to a date outside the max range so they aren't picked up as updates by default.
-  updatedAt: new Date("2025-06-01"),
-  userUpdatedAt: new Date("2025-06-01"),
+  updatedAt: addDays(-TWO_YEARS_IN_DAYS),
+  userUpdatedAt: addDays(-TWO_YEARS_IN_DAYS),
 };

--- a/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/institution-integration/ier12-integration/_tests_/e2e/models/data-inputs/students-inputs.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/institution-integration/ier12-integration/_tests_/e2e/models/data-inputs/students-inputs.ts
@@ -1,8 +1,8 @@
 import { DisabilityStatus } from "@sims/sims-db";
 import { IER12Student } from "./data-inputs.models";
-import { addDays } from "@sims/utilities";
+import * as dayjs from "dayjs";
 
-const TWO_YEARS_IN_DAYS = 365 * 2;
+const twoYearsAgo = dayjs().subtract(2, "year").toDate();
 
 export const JOHN_DOE_FROM_CANADA: IER12Student = {
   lastName: "Doe",
@@ -18,8 +18,8 @@ export const JOHN_DOE_FROM_CANADA: IER12Student = {
   },
   disabilityStatus: DisabilityStatus.NotRequested,
   // Set updatedAt and userUpdatedAt to a date outside the max range so they aren't picked up as updates by default.
-  updatedAt: addDays(-TWO_YEARS_IN_DAYS),
-  userUpdatedAt: addDays(-TWO_YEARS_IN_DAYS),
+  updatedAt: twoYearsAgo,
+  userUpdatedAt: twoYearsAgo,
 };
 
 export const JANE_MONONYMOUS_FROM_OTHER_COUNTRY: IER12Student = {
@@ -36,6 +36,6 @@ export const JANE_MONONYMOUS_FROM_OTHER_COUNTRY: IER12Student = {
   },
   disabilityStatus: DisabilityStatus.NotRequested,
   // Set updatedAt and userUpdatedAt to a date outside the max range so they aren't picked up as updates by default.
-  updatedAt: addDays(-TWO_YEARS_IN_DAYS),
-  userUpdatedAt: addDays(-TWO_YEARS_IN_DAYS),
+  updatedAt: twoYearsAgo,
+  userUpdatedAt: twoYearsAgo,
 };

--- a/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/institution-integration/ier12-integration/_tests_/e2e/utils/mock-utils.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/institution-integration/ier12-integration/_tests_/e2e/utils/mock-utils.ts
@@ -1,5 +1,5 @@
 import { getISODateOnlyString } from "@sims/utilities";
-import { GeneratedDateQueueInDTO } from "../../../models/ier.model";
+import { IER12IntegrationQueueInDTO } from "../../../models/ier.model";
 import {
   mockBullJob,
   MockBullJobResult,
@@ -7,16 +7,19 @@ import {
 
 /**
  * Creates the mocked IER12 job payload for the scheduler.
- * @param date optional date of processing.
+ * @param modifiedSince Include modifications to IER12 related data made since this date (inclusive).
+ * @param institutionCode Institution code to limit applications to a specific institution.
  * @returns mocked IER12 payload.
  */
 export function createIER12SchedulerJobMock(
-  date?: string | Date,
-): MockBullJobResult<GeneratedDateQueueInDTO> {
+  modifiedSince?: string | Date,
+  institutionCode?: string,
+): MockBullJobResult<IER12IntegrationQueueInDTO> {
   // Queued job.
-  const data = {} as GeneratedDateQueueInDTO;
-  if (date) {
-    data.generatedDate = getISODateOnlyString(date);
+  const data = {} as IER12IntegrationQueueInDTO;
+  if (modifiedSince) {
+    data.modifiedSince = getISODateOnlyString(modifiedSince);
   }
-  return mockBullJob<GeneratedDateQueueInDTO>(data);
+  data.institutionCode = institutionCode;
+  return mockBullJob<IER12IntegrationQueueInDTO>(data);
 }

--- a/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/institution-integration/ier12-integration/_tests_/e2e/utils/mock-utils.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/institution-integration/ier12-integration/_tests_/e2e/utils/mock-utils.ts
@@ -7,7 +7,7 @@ import {
 
 /**
  * Creates the mocked IER12 job payload for the scheduler.
- * @param modifiedSince Include modifications to IER12 related data made since this date (inclusive).
+ * @param modifiedSince Inclusive date since the application or student data was modified.
  * @param institutionCode Institution code to limit applications to a specific institution.
  * @returns mocked IER12 payload.
  */

--- a/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/institution-integration/ier12-integration/_tests_/e2e/utils/mock-utils.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/institution-integration/ier12-integration/_tests_/e2e/utils/mock-utils.ts
@@ -7,19 +7,22 @@ import {
 
 /**
  * Creates the mocked IER12 job payload for the scheduler.
- * @param modifiedSince Inclusive date since the application or student data was modified.
- * @param institutionCode Institution code to limit applications to a specific institution.
+ *  @param options options.
+ * - `modifiedSince` Inclusive date since the application or student data was modified.
+ * - `institutionCode` Institution code to limit applications to a specific institution.
  * @returns mocked IER12 payload.
  */
-export function createIER12SchedulerJobMock(
-  modifiedSince?: string | Date,
-  institutionCode?: string,
-): MockBullJobResult<IER12IntegrationQueueInDTO> {
+export function createIER12SchedulerJobMock(options?: {
+  modifiedSince?: string | Date;
+  institutionCode?: string;
+}): MockBullJobResult<IER12IntegrationQueueInDTO> {
   // Queued job.
   const data = {} as IER12IntegrationQueueInDTO;
-  if (modifiedSince) {
-    data.modifiedSince = getISODateOnlyString(modifiedSince);
+  if (options?.modifiedSince) {
+    data.modifiedSince = getISODateOnlyString(options.modifiedSince);
   }
-  data.institutionCode = institutionCode;
+  if (options?.institutionCode) {
+    data.institutionCode = options.institutionCode;
+  }
   return mockBullJob<IER12IntegrationQueueInDTO>(data);
 }

--- a/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/institution-integration/ier12-integration/ier12-integration.scheduler.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/institution-integration/ier12-integration/ier12-integration.scheduler.ts
@@ -6,7 +6,7 @@ import { LoggerService, ProcessSummary } from "@sims/utilities/logger";
 import { Job, Queue } from "bull";
 import { BaseScheduler } from "../../base-scheduler";
 import { IER12IntegrationQueueInDTO } from "./models/ier.model";
-import { INSTITUTION_LOCATION_CODE_MAX_LENGTH } from "@sims/sims-db/entities/institution.model";
+import { INSTITUTION_LOCATION_CODE_MAX_LENGTH } from "@sims/sims-db";
 
 @Processor(QueueNames.IER12Integration)
 export class IER12IntegrationScheduler extends BaseScheduler<IER12IntegrationQueueInDTO> {

--- a/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/institution-integration/ier12-integration/ier12-integration.scheduler.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/institution-integration/ier12-integration/ier12-integration.scheduler.ts
@@ -5,13 +5,13 @@ import { QueueNames } from "@sims/utilities";
 import { LoggerService, ProcessSummary } from "@sims/utilities/logger";
 import { Job, Queue } from "bull";
 import { BaseScheduler } from "../../base-scheduler";
-import { GeneratedDateQueueInDTO } from "./models/ier.model";
+import { IER12IntegrationQueueInDTO } from "./models/ier.model";
 
 @Processor(QueueNames.IER12Integration)
-export class IER12IntegrationScheduler extends BaseScheduler<GeneratedDateQueueInDTO> {
+export class IER12IntegrationScheduler extends BaseScheduler<IER12IntegrationQueueInDTO> {
   constructor(
     @InjectQueue(QueueNames.IER12Integration)
-    schedulerQueue: Queue<GeneratedDateQueueInDTO>,
+    schedulerQueue: Queue<IER12IntegrationQueueInDTO>,
     private readonly ierRequest: IER12ProcessingService,
     queueService: QueueService,
     logger: LoggerService,
@@ -22,21 +22,21 @@ export class IER12IntegrationScheduler extends BaseScheduler<GeneratedDateQueueI
   /**
    * Identifies all the applications which are in assessment
    * for a particular institution and generate the request file.
-   * @param job has generatedDate Date in which the assessment for
-   * particular institution is generated.
+   * @param job The job containing the data for processing including modifiedSince and institutionCode.
    * @param processSummary process summary for logging.
    * @returns processing result log.
    */
   protected async process(
-    job: Job<GeneratedDateQueueInDTO>,
+    job: Job<IER12IntegrationQueueInDTO>,
     processSummary: ProcessSummary,
   ): Promise<string[] | string> {
     const uploadResults = await this.ierRequest.processIER12File(
       processSummary,
-      job.data.generatedDate,
+      job.data.modifiedSince,
+      job.data.institutionCode,
     );
     if (!uploadResults.length) {
-      return "No IR12 files were generated.";
+      return "No IER12 files were generated.";
     }
     return uploadResults.map(
       (uploadResult) =>

--- a/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/institution-integration/ier12-integration/ier12-integration.scheduler.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/institution-integration/ier12-integration/ier12-integration.scheduler.ts
@@ -1,11 +1,12 @@
 import { InjectQueue, Processor } from "@nestjs/bull";
 import { IER12ProcessingService } from "@sims/integrations/institution-integration/ier12-integration";
 import { QueueService } from "@sims/services/queue";
-import { QueueNames } from "@sims/utilities";
+import { addDays, getISODateOnlyString, QueueNames } from "@sims/utilities";
 import { LoggerService, ProcessSummary } from "@sims/utilities/logger";
 import { Job, Queue } from "bull";
 import { BaseScheduler } from "../../base-scheduler";
 import { IER12IntegrationQueueInDTO } from "./models/ier.model";
+import { INSTITUTION_LOCATION_CODE_MAX_LENGTH } from "@sims/sims-db/entities/institution.model";
 
 @Processor(QueueNames.IER12Integration)
 export class IER12IntegrationScheduler extends BaseScheduler<IER12IntegrationQueueInDTO> {
@@ -30,6 +31,15 @@ export class IER12IntegrationScheduler extends BaseScheduler<IER12IntegrationQue
     job: Job<IER12IntegrationQueueInDTO>,
     processSummary: ProcessSummary,
   ): Promise<string[] | string> {
+    if (
+      !this.validateJobData(
+        processSummary,
+        job.data.modifiedSince,
+        job.data.institutionCode,
+      )
+    ) {
+      return "Invalid job data.";
+    }
     const uploadResults = await this.ierRequest.processIER12File(
       processSummary,
       job.data.modifiedSince,
@@ -42,5 +52,48 @@ export class IER12IntegrationScheduler extends BaseScheduler<IER12IntegrationQue
       (uploadResult) =>
         `Uploaded file ${uploadResult.generatedFile}, with ${uploadResult.uploadedRecords} record(s).`,
     );
+  }
+
+  /**
+   * Validate the job data for IER 12 processing.
+   * @param processSummary process summary for logging.
+   * @param modifiedSince Inclusive date since the application or student data was modified.
+   * @param institutionCode Institution code to limit applications to a specific institution.
+   * @returns boolean indicating whether the job data is valid or not.
+   */
+  private validateJobData(
+    processSummary: ProcessSummary,
+    modifiedSince?: string,
+    institutionCode?: string,
+  ): boolean {
+    if (modifiedSince !== undefined) {
+      const modifiedSinceDate = new Date(modifiedSince);
+      // Date must be in ISO format (YYYY-MM-DD).
+      if (Number.isNaN(modifiedSinceDate.getTime())) {
+        processSummary.info(
+          "Job data modifiedSince must be a valid ISO date (YYYY-MM-DD).",
+        );
+        return false;
+      }
+      // Modified since cannot be more than one year in the past.
+      const oneYearAgo = addDays(-365, getISODateOnlyString(new Date()));
+      if (modifiedSinceDate < oneYearAgo) {
+        processSummary.info(
+          "Job data modifiedSince cannot be more than one year in the past.",
+        );
+        return false;
+      }
+    }
+    // Institution code, if provided, must be exactly 4 characters.
+    if (
+      institutionCode !== undefined &&
+      institutionCode.length !== INSTITUTION_LOCATION_CODE_MAX_LENGTH
+    ) {
+      processSummary.info(
+        `Job data institutionCode must be exactly ${INSTITUTION_LOCATION_CODE_MAX_LENGTH} characters.`,
+      );
+      return false;
+    }
+    return true;
   }
 }

--- a/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/institution-integration/ier12-integration/models/ier.model.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/institution-integration/ier12-integration/models/ier.model.ts
@@ -1,6 +1,6 @@
 export class IER12IntegrationQueueInDTO {
   /**
-   * Include modifications to IER12 related data made since this date (inclusive). If not provided, it will default to the previous day. The date should be in ISO format (YYYY-MM-DD).
+   * Inclusive date since the application or student data was modified. If not provided, it will default to the previous day. The date should be in ISO format (YYYY-MM-DD).
    */
   modifiedSince?: string;
   /**

--- a/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/institution-integration/ier12-integration/models/ier.model.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/institution-integration/ier12-integration/models/ier.model.ts
@@ -1,3 +1,10 @@
-export class GeneratedDateQueueInDTO {
-  generatedDate?: string;
+export class IER12IntegrationQueueInDTO {
+  /**
+   * Include modifications to IER12 related data made since this date (inclusive). If not provided, it will default to the previous day. The date should be in ISO format (YYYY-MM-DD).
+   */
+  modifiedSince?: string;
+  /**
+   * Institution code to limit applications to a specific institution.
+   */
+  institutionCode?: string;
 }

--- a/sources/packages/backend/libs/integrations/src/constants/error-code.constants.ts
+++ b/sources/packages/backend/libs/integrations/src/constants/error-code.constants.ts
@@ -10,13 +10,19 @@ export const CAS_AUTH_ERROR = "CAS_AUTH_ERROR";
 export const CAS_BAD_REQUEST = "CAS_BAD_REQUEST";
 
 /**
+ * IER12 error code used when the modified since date provided in the job data is not a valid date.
+ */
+export const IER12_MODIFIED_SINCE_DATE_INVALID =
+  "Job data modifiedSince must be a valid ISO date (YYYY-MM-DD).";
+
+/**
  * IER12 error code used when the modified since date provided in the job data is more than one year in the past.
  */
 export const IER12_MODIFIED_SINCE_DATE_OVER_ONE_YEAR =
-  "Modified since date cannot be more than one year in the past.";
+  "Job data modifiedSince cannot be more than one year in the past.";
 
 /**
  * IER12 error code used when the institution code provided in the job data is not exactly 4 characters.
  */
 export const IER12_INSTITUTION_CODE_INVALID =
-  "`Job data institutionCode must be exactly 4 characters.`,";
+  "Job data institutionCode must be exactly 4 characters.";

--- a/sources/packages/backend/libs/integrations/src/constants/error-code.constants.ts
+++ b/sources/packages/backend/libs/integrations/src/constants/error-code.constants.ts
@@ -8,3 +8,15 @@ export const CAS_AUTH_ERROR = "CAS_AUTH_ERROR";
  * CAS bad request error.
  */
 export const CAS_BAD_REQUEST = "CAS_BAD_REQUEST";
+
+/**
+ * IER12 error code used when the modified since date provided in the job data is more than one year in the past.
+ */
+export const IER12_MODIFIED_SINCE_DATE_OVER_ONE_YEAR =
+  "Modified since date cannot be more than one year in the past.";
+
+/**
+ * IER12 error code used when the institution code provided in the job data is not exactly 4 characters.
+ */
+export const IER12_INSTITUTION_CODE_INVALID =
+  "`Job data institutionCode must be exactly 4 characters.`,";

--- a/sources/packages/backend/libs/integrations/src/constants/error-code.constants.ts
+++ b/sources/packages/backend/libs/integrations/src/constants/error-code.constants.ts
@@ -8,21 +8,3 @@ export const CAS_AUTH_ERROR = "CAS_AUTH_ERROR";
  * CAS bad request error.
  */
 export const CAS_BAD_REQUEST = "CAS_BAD_REQUEST";
-
-/**
- * IER12 error code used when the modified since date provided in the job data is not a valid date.
- */
-export const IER12_MODIFIED_SINCE_DATE_INVALID =
-  "Job data modifiedSince must be a valid ISO date (YYYY-MM-DD).";
-
-/**
- * IER12 error code used when the modified since date provided in the job data is more than one year in the past.
- */
-export const IER12_MODIFIED_SINCE_DATE_OVER_ONE_YEAR =
-  "Job data modifiedSince cannot be more than one year in the past.";
-
-/**
- * IER12 error code used when the institution code provided in the job data is not exactly 4 characters.
- */
-export const IER12_INSTITUTION_CODE_INVALID =
-  "Job data institutionCode must be exactly 4 characters.";

--- a/sources/packages/backend/libs/integrations/src/institution-integration/ier12-integration/ier12.processing.service.ts
+++ b/sources/packages/backend/libs/integrations/src/institution-integration/ier12-integration/ier12.processing.service.ts
@@ -39,6 +39,10 @@ import {
   ApplicationEventCodeUtilsService,
   ApplicationEventDateUtilsService,
 } from "./utils-service";
+import {
+  IER12_INSTITUTION_CODE_INVALID,
+  IER12_MODIFIED_SINCE_DATE_OVER_ONE_YEAR,
+} from "../../constants";
 
 @Injectable()
 export class IER12ProcessingService {
@@ -63,7 +67,8 @@ export class IER12ProcessingService {
    * for the IER 12 sent File.
    * 4. Upload the content to the zoneB SFTP server.
    * @param processSummary process summary for logging.
-   * @param modifiedSince date for which the IER 12 file is generated.
+   * @param modifiedSince Inclusive date since the application or student data was modified.
+   * @param institutionCode Institution code to limit applications to a specific institution.
    * @returns processing IER 12 result.
    */
   async processIER12File(
@@ -72,18 +77,7 @@ export class IER12ProcessingService {
     institutionCode?: string,
   ): Promise<IER12UploadResult[]> {
     // Validate job data.
-    if (modifiedSince !== undefined) {
-      const oneYearAgo = addDays(-365, getISODateOnlyString(new Date()));
-      if (new Date(modifiedSince) < new Date(oneYearAgo)) {
-        processSummary.info(
-          "Modified since date cannot be more than one year in the past.",
-        );
-      }
-    }
-    if (institutionCode !== undefined && institutionCode.length !== 4) {
-      processSummary.info(
-        `Job data institutionCode must be exactly 4 characters.`,
-      );
+    if (!this.validateJobData(processSummary, modifiedSince, institutionCode)) {
       return [];
     }
 
@@ -126,17 +120,17 @@ export class IER12ProcessingService {
       );
     const fileRecords: Record<string, IER12Record[]> = {};
     for (const application of pendingApplications) {
-      const institutionCode =
+      const locationInstitutionCode =
         application.currentAssessment!.offering!.institutionLocation
           .institutionCode!;
-      if (!fileRecords[institutionCode]) {
-        fileRecords[institutionCode] = [];
+      if (!fileRecords[locationInstitutionCode]) {
+        fileRecords[locationInstitutionCode] = [];
       }
       const ier12Records = await this.createIER12Record(
         application,
         applicationAwardTotals.get(application.id) ?? [],
       );
-      fileRecords[institutionCode].push(...ier12Records);
+      fileRecords[locationInstitutionCode].push(...ier12Records);
     }
     const uploadResult: IER12UploadResult[] = [];
     try {
@@ -478,5 +472,32 @@ export class IER12ProcessingService {
    */
   private displayInstitutionCode(institutionCode?: string): string {
     return institutionCode ? ` with institution code ${institutionCode}` : "";
+  }
+
+  /**
+   * Validate the job data for IER 12 processing.
+   * @param processSummary process summary for logging.
+   * @param modifiedSince Inclusive date since the application or student data was modified.
+   * @param institutionCode Institution code to limit applications to a specific institution.
+   * @returns boolean indicating whether the job data is valid or not.
+   */
+  private validateJobData(
+    processSummary: ProcessSummary,
+    modifiedSince?: string,
+    institutionCode?: string,
+  ): boolean {
+    // Validate job data.
+    if (modifiedSince !== undefined) {
+      const oneYearAgo = addDays(-365, getISODateOnlyString(new Date()));
+      if (new Date(modifiedSince) < new Date(oneYearAgo)) {
+        processSummary.info(IER12_MODIFIED_SINCE_DATE_OVER_ONE_YEAR);
+        return false;
+      }
+    }
+    if (institutionCode !== undefined && institutionCode.length !== 4) {
+      processSummary.info(IER12_INSTITUTION_CODE_INVALID);
+      return false;
+    }
+    return true;
   }
 }

--- a/sources/packages/backend/libs/integrations/src/institution-integration/ier12-integration/ier12.processing.service.ts
+++ b/sources/packages/backend/libs/integrations/src/institution-integration/ier12-integration/ier12.processing.service.ts
@@ -41,6 +41,7 @@ import {
 } from "./utils-service";
 import {
   IER12_INSTITUTION_CODE_INVALID,
+  IER12_MODIFIED_SINCE_DATE_INVALID,
   IER12_MODIFIED_SINCE_DATE_OVER_ONE_YEAR,
 } from "../../constants";
 
@@ -488,8 +489,13 @@ export class IER12ProcessingService {
   ): boolean {
     // Validate job data.
     if (modifiedSince !== undefined) {
+      const modifiedSinceDate = new Date(modifiedSince);
+      if (Number.isNaN(modifiedSinceDate.getTime())) {
+        processSummary.info(IER12_MODIFIED_SINCE_DATE_INVALID);
+        return false;
+      }
       const oneYearAgo = addDays(-365, getISODateOnlyString(new Date()));
-      if (new Date(modifiedSince) < new Date(oneYearAgo)) {
+      if (modifiedSinceDate < oneYearAgo) {
         processSummary.info(IER12_MODIFIED_SINCE_DATE_OVER_ONE_YEAR);
         return false;
       }

--- a/sources/packages/backend/libs/integrations/src/institution-integration/ier12-integration/ier12.processing.service.ts
+++ b/sources/packages/backend/libs/integrations/src/institution-integration/ier12-integration/ier12.processing.service.ts
@@ -39,11 +39,6 @@ import {
   ApplicationEventCodeUtilsService,
   ApplicationEventDateUtilsService,
 } from "./utils-service";
-import {
-  IER12_INSTITUTION_CODE_INVALID,
-  IER12_MODIFIED_SINCE_DATE_INVALID,
-  IER12_MODIFIED_SINCE_DATE_OVER_ONE_YEAR,
-} from "../../constants";
 
 @Injectable()
 export class IER12ProcessingService {
@@ -77,13 +72,8 @@ export class IER12ProcessingService {
     modifiedSince?: string,
     institutionCode?: string,
   ): Promise<IER12UploadResult[]> {
-    // Validate job data.
-    if (!this.validateJobData(processSummary, modifiedSince, institutionCode)) {
-      return [];
-    }
-
     processSummary.info(
-      `Retrieving application current assessment details for IER 12${this.displayInstitutionCode(institutionCode)}.`,
+      "Retrieving application current assessment details for IER 12.",
     );
     // By default, the modifiedSince date is the previous day from today.
     const today = getISODateOnlyString(new Date());
@@ -94,8 +84,14 @@ export class IER12ProcessingService {
     // If not provided, the modifiedUntilDate is set to start of day today so that the default execution sends exactly one day of data.
     const modifiedUntilDate = modifiedSince ? new Date() : new Date(today);
     processSummary.info(
-      `Retrieving data related to IER 12 created or modified between ${modifiedSinceDate} and ${modifiedUntilDate}${this.displayInstitutionCode(institutionCode)}.`,
+      `Retrieving data related to IER 12 created or modified between ${modifiedSinceDate} and ${modifiedUntilDate}.`,
     );
+    if (institutionCode) {
+      processSummary.info(
+        `Filtering assessments for institution code: ${institutionCode}`,
+      );
+    }
+
     const pendingApplications =
       await this.studentAssessmentService.getPendingApplicationsCurrentAssessment(
         modifiedSinceDate,
@@ -103,14 +99,10 @@ export class IER12ProcessingService {
         institutionCode,
       );
     if (!pendingApplications.length) {
-      processSummary.info(
-        `No assessments found for IER 12${this.displayInstitutionCode(institutionCode)}.`,
-      );
+      processSummary.info("No assessments found for IER 12.");
       return [];
     }
-    processSummary.info(
-      `Found ${pendingApplications.length} assessment(s)${this.displayInstitutionCode(institutionCode)}.`,
-    );
+    processSummary.info(`Found ${pendingApplications.length} assessment(s).`);
     const pendingApplicationIds = pendingApplications.map(
       (application) => application.id,
     );
@@ -147,7 +139,7 @@ export class IER12ProcessingService {
         uploadResult.push(ierUploadResult);
       }
     } catch (error: unknown) {
-      const errorMessage = `Error while uploading content for IER 12${this.displayInstitutionCode(institutionCode)}.`;
+      const errorMessage = "Error while uploading content for IER 12.";
       this.logger.error(errorMessage, error);
       processSummary.error(errorMessage, error);
     }
@@ -464,46 +456,5 @@ export class IER12ProcessingService {
     return studentOverawardsBalance
       ? studentOverawardsBalance[awardType] > 0
       : false;
-  }
-
-  /**
-   * Helper method to display institution code in the log messages if provided.
-   * @param institutionCode institution code to be displayed in the log message.
-   * @returns formatted string with institution code if provided, otherwise an empty string.
-   */
-  private displayInstitutionCode(institutionCode?: string): string {
-    return institutionCode ? ` with institution code ${institutionCode}` : "";
-  }
-
-  /**
-   * Validate the job data for IER 12 processing.
-   * @param processSummary process summary for logging.
-   * @param modifiedSince Inclusive date since the application or student data was modified.
-   * @param institutionCode Institution code to limit applications to a specific institution.
-   * @returns boolean indicating whether the job data is valid or not.
-   */
-  private validateJobData(
-    processSummary: ProcessSummary,
-    modifiedSince?: string,
-    institutionCode?: string,
-  ): boolean {
-    // Validate job data.
-    if (modifiedSince !== undefined) {
-      const modifiedSinceDate = new Date(modifiedSince);
-      if (Number.isNaN(modifiedSinceDate.getTime())) {
-        processSummary.info(IER12_MODIFIED_SINCE_DATE_INVALID);
-        return false;
-      }
-      const oneYearAgo = addDays(-365, getISODateOnlyString(new Date()));
-      if (modifiedSinceDate < oneYearAgo) {
-        processSummary.info(IER12_MODIFIED_SINCE_DATE_OVER_ONE_YEAR);
-        return false;
-      }
-    }
-    if (institutionCode !== undefined && institutionCode.length !== 4) {
-      processSummary.info(IER12_INSTITUTION_CODE_INVALID);
-      return false;
-    }
-    return true;
   }
 }

--- a/sources/packages/backend/libs/integrations/src/institution-integration/ier12-integration/ier12.processing.service.ts
+++ b/sources/packages/backend/libs/integrations/src/institution-integration/ier12-integration/ier12.processing.service.ts
@@ -63,29 +63,59 @@ export class IER12ProcessingService {
    * for the IER 12 sent File.
    * 4. Upload the content to the zoneB SFTP server.
    * @param processSummary process summary for logging.
-   * @param generatedDate date for which the IER 12 file is generated.
+   * @param modifiedSince date for which the IER 12 file is generated.
    * @returns processing IER 12 result.
    */
   async processIER12File(
     processSummary: ProcessSummary,
-    generatedDate?: string,
+    modifiedSince?: string,
+    institutionCode?: string,
   ): Promise<IER12UploadResult[]> {
+    // Validate job data.
+    if (modifiedSince !== undefined) {
+      const oneYearAgo = addDays(-365, getISODateOnlyString(new Date()));
+      if (new Date(modifiedSince) < new Date(oneYearAgo)) {
+        processSummary.info(
+          "Modified since date cannot be more than one year in the past.",
+        );
+      }
+    }
+    if (institutionCode !== undefined && institutionCode.length !== 4) {
+      processSummary.info(
+        `Job data institutionCode must be exactly 4 characters.`,
+      );
+      return [];
+    }
+
     processSummary.info(
-      "Retrieving application current assessment details for IER 12.",
+      `Retrieving application current assessment details for IER 12${this.displayInstitutionCode(institutionCode)}.`,
     );
-    // By default, the generation start date is the previous day from today.
-    const modifiedSinceDate = generatedDate
-      ? new Date(generatedDate)
-      : addDays(-1, getISODateOnlyString(new Date()));
-    const modifiedUntilDate = addDays(1, modifiedSinceDate);
+    // By default, the modifiedSince date is the previous day from today.
+    const today = getISODateOnlyString(new Date());
+    const modifiedSinceDate = modifiedSince
+      ? new Date(modifiedSince)
+      : addDays(-1, today);
+    // If a modifiedSince date is provided, the modifiedUntilDate include all data up until the execution time to ensure that a current snapshot is sent.
+    // If not provided, the modifiedUntilDate is set to start of day today so that the default execution sends exactly one day of data.
+    const modifiedUntilDate = modifiedSince ? new Date() : new Date(today);
     processSummary.info(
-      `Retrieving data related to IER 12 created or modified between ${modifiedSinceDate} and ${modifiedUntilDate}.`,
+      `Retrieving data related to IER 12 created or modified between ${modifiedSinceDate} and ${modifiedUntilDate}${this.displayInstitutionCode(institutionCode)}.`,
     );
     const pendingApplications =
       await this.studentAssessmentService.getPendingApplicationsCurrentAssessment(
         modifiedSinceDate,
         modifiedUntilDate,
+        institutionCode,
       );
+    if (!pendingApplications.length) {
+      processSummary.info(
+        `No assessments found for IER 12${this.displayInstitutionCode(institutionCode)}.`,
+      );
+      return [];
+    }
+    processSummary.info(
+      `Found ${pendingApplications.length} assessment(s)${this.displayInstitutionCode(institutionCode)}.`,
+    );
     const pendingApplicationIds = pendingApplications.map(
       (application) => application.id,
     );
@@ -94,22 +124,17 @@ export class IER12ProcessingService {
       await this.studentAssessmentService.getDisbursementAwardTotalsForApplications(
         pendingApplicationIds,
       );
-    if (!pendingApplications.length) {
-      processSummary.info("No assessments found for IER 12.");
-      return [];
-    }
-    processSummary.info(`Found ${pendingApplications.length} assessment(s).`);
     const fileRecords: Record<string, IER12Record[]> = {};
     for (const application of pendingApplications) {
       const institutionCode =
-        application.currentAssessment.offering.institutionLocation
-          .institutionCode;
+        application.currentAssessment!.offering!.institutionLocation
+          .institutionCode!;
       if (!fileRecords[institutionCode]) {
         fileRecords[institutionCode] = [];
       }
       const ier12Records = await this.createIER12Record(
         application,
-        applicationAwardTotals.get(application.id),
+        applicationAwardTotals.get(application.id) ?? [],
       );
       fileRecords[institutionCode].push(...ier12Records);
     }
@@ -127,7 +152,7 @@ export class IER12ProcessingService {
         uploadResult.push(ierUploadResult);
       }
     } catch (error: unknown) {
-      const errorMessage = "Error while uploading content for IER 12.";
+      const errorMessage = `Error while uploading content for IER 12${this.displayInstitutionCode(institutionCode)}.`;
       this.logger.error(errorMessage, error);
       processSummary.error(errorMessage, error);
     }
@@ -444,5 +469,14 @@ export class IER12ProcessingService {
     return studentOverawardsBalance
       ? studentOverawardsBalance[awardType] > 0
       : false;
+  }
+
+  /**
+   * Helper method to display institution code in the log messages if provided.
+   * @param institutionCode institution code to be displayed in the log message.
+   * @returns formatted string with institution code if provided, otherwise an empty string.
+   */
+  private displayInstitutionCode(institutionCode?: string): string {
+    return institutionCode ? ` with institution code ${institutionCode}` : "";
   }
 }

--- a/sources/packages/backend/libs/integrations/src/services/student-assessment/student-assessment.service.ts
+++ b/sources/packages/backend/libs/integrations/src/services/student-assessment/student-assessment.service.ts
@@ -199,7 +199,7 @@ export class StudentAssessmentService {
       })
       .orderBy("currentAssessment.assessmentDate", "ASC")
       .addOrderBy("disbursementSchedule.disbursementDate", "ASC");
-    return await query.getMany();
+    return query.getMany();
   }
 
   /**

--- a/sources/packages/backend/libs/integrations/src/services/student-assessment/student-assessment.service.ts
+++ b/sources/packages/backend/libs/integrations/src/services/student-assessment/student-assessment.service.ts
@@ -27,13 +27,15 @@ export class StudentAssessmentService {
    * between the given period.
    * @param modifiedSince Inclusive date since the application or student data was modified.
    * @param modifiedUntil Exclusive date until the application or student data was modified.
+   * @param institutionCode Optional institution code to limit the applications to a specific institution.
    * @returns application details for current assessment.
    */
   async getPendingApplicationsCurrentAssessment(
     modifiedSince: Date,
     modifiedUntil: Date,
+    institutionCode?: string,
   ): Promise<Application[]> {
-    return this.applicationRepo
+    const query = this.applicationRepo
       .createQueryBuilder("application")
       .select([
         "application.id",
@@ -181,7 +183,14 @@ export class StudentAssessmentService {
               }),
             );
         }),
-      )
+      );
+    // Optionally limit applications to a specific institution.
+    if (institutionCode) {
+      query.andWhere("institutionLocation.institutionCode = :institutionCode", {
+        institutionCode,
+      });
+    }
+    query
       .setParameters({
         offeringIntensityFullTime: OfferingIntensity.fullTime,
         applicationStatusEdited: ApplicationStatus.Edited,
@@ -189,8 +198,8 @@ export class StudentAssessmentService {
         modifiedUntil,
       })
       .orderBy("currentAssessment.assessmentDate", "ASC")
-      .addOrderBy("disbursementSchedule.disbursementDate", "ASC")
-      .getMany();
+      .addOrderBy("disbursementSchedule.disbursementDate", "ASC");
+    return await query.getMany();
   }
 
   /**


### PR DESCRIPTION
## Summary
- Added institution code (institutionCode) as an option
- Added the ability to run from a point in time (modifiedSince) until the current time
- Added new tests and updated existing tests

## E2E Tests
### Notes
The existing tests relied heavily on hardcoded dates which is problematic now that we are limiting the past interval to 1 year. Dates related to application/assessment/disbursement were updated to be dynamic. However, some dates (e.g. offering related) are more static in nature as they rely on the program year (which was updated to 2025-2026). There are probably additional improvements to be made but enough time was spent updating the existing test cases. Existing assertions were only updated to incorporate new dates, as expected no changes to monetary values/status codes/etc were required.

### Queue processor for ier12-integration,
<img width="1690" height="707" alt="image" src="https://github.com/user-attachments/assets/9b1ac8e1-5abe-4aca-adae-3be4b5f7949b" />