### PR TITLE
#6167 - Update CSG-FT Program Year Limit

### DIFF
--- a/sources/packages/backend/workflow/src/workflow-definitions/fulltime-assessment-decisions.dmn
+++ b/sources/packages/backend/workflow/src/workflow-definitions/fulltime-assessment-decisions.dmn
@@ -2835,10 +2835,10 @@
           <text>100</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_1rq1wim">
-          <text>4200</text>
+          <text>6300</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_069pmc5">
-          <text>round half up(4200 * (1/8) * 12 * (1/52),2)</text>
+          <text>round half up(6300 * (1/52),2)</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_1ktze4j">
           <text>0</text>
@@ -2894,10 +2894,10 @@
           <text>100</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_11xiwxw">
-          <text>4200</text>
+          <text>6300</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_1i0ci8q">
-          <text>round half up(4200 * (1/8) * 12 * (1/52),2)</text>
+          <text>round half up(6300 * (1/52),2)</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_00kdff9">
           <text>0</text>

--- a/sources/packages/backend/workflow/test/2025-2026/fulltime-assessment/awards-amount/fulltime-assessment-awards-amount-CSGF.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2025-2026/fulltime-assessment/awards-amount/fulltime-assessment-awards-amount-CSGF.e2e-spec.ts
@@ -1,0 +1,36 @@
+import { CredentialType, ProgramLengthOptions } from "../../../models";
+import {
+  ZeebeMockedClient,
+  createFakeConsolidatedFulltimeData,
+  executeFullTimeAssessmentForProgramYear,
+} from "../../../test-utils";
+import { PROGRAM_YEAR } from "../../constants/program-year.constants";
+
+describe(`E2E Test Workflow fulltime-assessment-${PROGRAM_YEAR}-awards-amount-CSGF.`, () => {
+  it("Should cap CSGF at 6300 when offering weeks exceed the annual cap threshold.", async () => {
+    // Arrange
+    const assessmentConsolidatedData =
+      createFakeConsolidatedFulltimeData(PROGRAM_YEAR);
+    assessmentConsolidatedData.programCredentialType =
+      CredentialType.UnderGraduateCertificate;
+    assessmentConsolidatedData.programLength =
+      ProgramLengthOptions.TwoToThreeYears;
+    assessmentConsolidatedData.offeringWeeks = 60;
+    assessmentConsolidatedData.studentDataTaxReturnIncome = 0;
+
+    // Act
+    const calculatedAssessment = await executeFullTimeAssessmentForProgramYear(
+      PROGRAM_YEAR,
+      assessmentConsolidatedData,
+    );
+
+    // Assert
+    expect(calculatedAssessment.variables.awardEligibilityCSGF).toBe(true);
+    expect(calculatedAssessment.variables.federalAwardNetCSGFAmount).toBe(6300);
+  });
+
+  afterAll(async () => {
+    // Closes the singleton instance created during test executions.
+    await ZeebeMockedClient.getMockedZeebeInstance().close();
+  });
+});

--- a/sources/packages/backend/workflow/test/2025-2026/fulltime-assessment/eligibility/fulltime-assessment-eligibility-CSGF.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2025-2026/fulltime-assessment/eligibility/fulltime-assessment-eligibility-CSGF.e2e-spec.ts
@@ -154,6 +154,40 @@ describe(`E2E Test Workflow fulltime-assessment-${PROGRAM_YEAR}-eligibility-CSGF
     expect(calculatedAssessment.variables.awardEligibilityCSGF).toBe(false);
   });
 
+  it("Should cap CSGF at the 6300 annual maximum when offering weeks exceed the limit in 2025-2026.", async () => {
+    // Arrange
+    const assessmentConsolidatedData =
+      createFakeConsolidatedFulltimeData(PROGRAM_YEAR);
+    assessmentConsolidatedData.programCredentialType =
+      CredentialType.UnderGraduateCertificate;
+    assessmentConsolidatedData.programLength =
+      ProgramLengthOptions.TwoToThreeYears;
+    assessmentConsolidatedData.offeringWeeks = 60;
+    assessmentConsolidatedData.studentDataTaxReturnIncome = 0;
+
+    // Act
+    const calculatedAssessment = await executeFullTimeAssessmentForProgramYear(
+      PROGRAM_YEAR,
+      assessmentConsolidatedData,
+    );
+
+    // Assert
+    const expectedWeeklyAmount = 121.15;
+    const annualCap = 6300;
+    const uncappedAmount =
+      expectedWeeklyAmount * assessmentConsolidatedData.offeringWeeks;
+
+    expect(calculatedAssessment.variables.awardEligibilityCSGF).toBe(true);
+    // 121.15 * 60 weeks = 7269, which is above the annual cap and should be capped to 6300.
+    expect(uncappedAmount).toBeGreaterThan(annualCap);
+    expect(
+      calculatedAssessment.variables.federalAwardNetCSGFAmount,
+    ).toBeCloseTo(annualCap, 2);
+    expect(
+      calculatedAssessment.variables.federalAwardNetCSGFAmount,
+    ).toBeLessThan(uncappedAmount);
+  });
+
   afterAll(async () => {
     // Closes the singleton instance created during test executions.
     await ZeebeMockedClient.getMockedZeebeInstance().close();

--- a/sources/packages/backend/workflow/test/2025-2026/fulltime-assessment/eligibility/fulltime-assessment-eligibility-CSGF.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2025-2026/fulltime-assessment/eligibility/fulltime-assessment-eligibility-CSGF.e2e-spec.ts
@@ -154,40 +154,6 @@ describe(`E2E Test Workflow fulltime-assessment-${PROGRAM_YEAR}-eligibility-CSGF
     expect(calculatedAssessment.variables.awardEligibilityCSGF).toBe(false);
   });
 
-  it("Should cap CSGF at the 6300 annual maximum when offering weeks exceed the limit in 2025-2026.", async () => {
-    // Arrange
-    const assessmentConsolidatedData =
-      createFakeConsolidatedFulltimeData(PROGRAM_YEAR);
-    assessmentConsolidatedData.programCredentialType =
-      CredentialType.UnderGraduateCertificate;
-    assessmentConsolidatedData.programLength =
-      ProgramLengthOptions.TwoToThreeYears;
-    assessmentConsolidatedData.offeringWeeks = 60;
-    assessmentConsolidatedData.studentDataTaxReturnIncome = 0;
-
-    // Act
-    const calculatedAssessment = await executeFullTimeAssessmentForProgramYear(
-      PROGRAM_YEAR,
-      assessmentConsolidatedData,
-    );
-
-    // Assert
-    const expectedWeeklyAmount = 121.15;
-    const annualCap = 6300;
-    const uncappedAmount =
-      expectedWeeklyAmount * assessmentConsolidatedData.offeringWeeks;
-
-    expect(calculatedAssessment.variables.awardEligibilityCSGF).toBe(true);
-    // 121.15 * 60 weeks = 7269, which is above the annual cap and should be capped to 6300.
-    expect(uncappedAmount).toBeGreaterThan(annualCap);
-    expect(
-      calculatedAssessment.variables.federalAwardNetCSGFAmount,
-    ).toBeCloseTo(annualCap, 2);
-    expect(
-      calculatedAssessment.variables.federalAwardNetCSGFAmount,
-    ).toBeLessThan(uncappedAmount);
-  });
-
   afterAll(async () => {
     // Closes the singleton instance created during test executions.
     await ZeebeMockedClient.getMockedZeebeInstance().close();

--- a/sources/packages/backend/workflow/test/2026-2027/fulltime-assessment/awards-amount/fulltime-assessment-awards-amount-CSGF.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2026-2027/fulltime-assessment/awards-amount/fulltime-assessment-awards-amount-CSGF.e2e-spec.ts
@@ -1,0 +1,36 @@
+import { CredentialType, ProgramLengthOptions } from "../../../models";
+import {
+  ZeebeMockedClient,
+  createFakeConsolidatedFulltimeData,
+  executeFullTimeAssessmentForProgramYear,
+} from "../../../test-utils";
+import { PROGRAM_YEAR } from "../../constants/program-year.constants";
+
+describe(`E2E Test Workflow fulltime-assessment-${PROGRAM_YEAR}-awards-amount-CSGF.`, () => {
+  it("Should cap CSGF at 6300 when offering weeks exceed the annual cap threshold.", async () => {
+    // Arrange
+    const assessmentConsolidatedData =
+      createFakeConsolidatedFulltimeData(PROGRAM_YEAR);
+    assessmentConsolidatedData.programCredentialType =
+      CredentialType.UnderGraduateCertificate;
+    assessmentConsolidatedData.programLength =
+      ProgramLengthOptions.TwoToThreeYears;
+    assessmentConsolidatedData.offeringWeeks = 60;
+    assessmentConsolidatedData.studentDataTaxReturnIncome = 0;
+
+    // Act
+    const calculatedAssessment = await executeFullTimeAssessmentForProgramYear(
+      PROGRAM_YEAR,
+      assessmentConsolidatedData,
+    );
+
+    // Assert
+    expect(calculatedAssessment.variables.awardEligibilityCSGF).toBe(true);
+    expect(calculatedAssessment.variables.federalAwardNetCSGFAmount).toBe(6300);
+  });
+
+  afterAll(async () => {
+    // Closes the singleton instance created during test executions.
+    await ZeebeMockedClient.getMockedZeebeInstance().close();
+  });
+});


### PR DESCRIPTION
### Summary

Updated workflow logic to account for new limit.
New e2e test to validate new CSG-FT logic.

### Identify Existing Data Query

```sql

WITH applications_csgf_awards AS (
  SELECT
    app.id AS application_id,
    app.application_number,
    app.student_id,
    py.program_year,
    sa.id AS assessment_id,
    sa.assessment_date,
    COALESCE((sa.assessment_data ->> 'finalFederalAwardNetCSGFAmount')::numeric, 0) AS csgf_award
  FROM sims.applications app
  INNER JOIN sims.program_years py
    ON py.id = app.program_year_id
  INNER JOIN sims.student_assessments sa
    ON sa.id = app.current_assessment_id
  INNER JOIN sims.education_programs_offerings epo
    ON epo.id = sa.offering_id
  WHERE py.program_year = '2025-2026'
    AND app.is_archived = FALSE
    AND app.application_status IN ('Assessment', 'Enrolment', 'Completed')
    AND sa.student_assessment_status = 'Completed'
    AND epo.offering_intensity = 'Full Time'
),
impacted_students AS (
  SELECT
    student_id,
    program_year,
    SUM(csgf_award) AS total_csgf_award
  FROM applications_csgf_awards
  GROUP BY student_id, program_year
  HAVING SUM(csgf_award) >= 4200
)
SELECT
  u.id AS user_id,
  u.first_name,
  u.last_name,
  u.email,
  s.id AS student_id,
  i.program_year,
  i.total_csgf_award
FROM impacted_students i
INNER JOIN sims.students s
  ON s.id = i.student_id
INNER JOIN sims.users u
  ON u.id = s.user_id
ORDER BY i.total_csgf_award DESC, u.last_name, u.first_name;
```