### PR TITLE
#6187 - Fix Additional Transportation Question not Updating Mandatory Questions

### DIFF
--- a/sources/packages/forms/src/form-definitions/sfaa2025-26-ft.json
+++ b/sources/packages/forms/src/form-definitions/sfaa2025-26-ft.json
@@ -8503,6 +8503,8 @@
                   "label": "I confirm I am eligible for this exception category and understand that this process requires ministry review and will lead to delays in my funding.",
                   "customClass": "formio-component-weight-bold",
                   "tableView": true,
+                  "defaultValue": false,
+                  "redrawOn": "additionalTransportRequested",
                   "validate": {
                     "required": true,
                     "customMessage": "You must confirm you understand the exception eligibility criteria."
@@ -8510,11 +8512,9 @@
                   "validateWhenHidden": false,
                   "key": "additionalTransportConfirmation",
                   "type": "checkbox",
-                  "dataGridLabel": false,
                   "input": true,
                   "lockKey": true,
-                  "hideOnChildrenHidden": false,
-                  "defaultValue": false
+                  "hideOnChildrenHidden": false
                 }
               ],
               "lockKey": true

--- a/sources/packages/forms/src/form-definitions/sfaa2025-26-pt.json
+++ b/sources/packages/forms/src/form-definitions/sfaa2025-26-pt.json
@@ -6000,6 +6000,8 @@
                   "label": "I confirm I am eligible for this exception category and understand that this process requires ministry review and will lead to delays in my funding.",
                   "customClass": "formio-component-weight-bold",
                   "tableView": true,
+                  "defaultValue": false,
+                  "redrawOn": "additionalTransportRequested",
                   "validate": {
                     "required": true,
                     "customMessage": "You must confirm you understand the exception eligibility criteria."
@@ -6007,11 +6009,9 @@
                   "validateWhenHidden": false,
                   "key": "additionalTransportationConfirmation",
                   "type": "checkbox",
-                  "dataGridLabel": false,
                   "input": true,
                   "lockKey": true,
-                  "hideOnChildrenHidden": false,
-                  "defaultValue": false
+                  "hideOnChildrenHidden": false
                 }
               ],
               "lockKey": true

--- a/sources/packages/forms/src/form-definitions/sfaa2026-27-ft.json
+++ b/sources/packages/forms/src/form-definitions/sfaa2026-27-ft.json
@@ -6457,6 +6457,8 @@
                   "label": "I confirm I am eligible for this exception category and understand that this process requires ministry review and will lead to delays in my funding.",
                   "customClass": "formio-component-weight-bold",
                   "tableView": true,
+                  "defaultValue": false,
+                  "redrawOn": "additionalTransportRequested",
                   "validate": {
                     "required": true,
                     "customMessage": "You must confirm you understand the exception eligibility criteria."
@@ -6464,11 +6466,9 @@
                   "validateWhenHidden": false,
                   "key": "additionalTransportConfirmation",
                   "type": "checkbox",
-                  "dataGridLabel": false,
                   "input": true,
                   "lockKey": true,
-                  "hideOnChildrenHidden": false,
-                  "defaultValue": false
+                  "hideOnChildrenHidden": false
                 }
               ],
               "lockKey": true

--- a/sources/packages/forms/src/form-definitions/sfaa2026-27-pt.json
+++ b/sources/packages/forms/src/form-definitions/sfaa2026-27-pt.json
@@ -5078,6 +5078,8 @@
                   "label": "I confirm I am eligible for this exception category and understand that this process requires ministry review and will lead to delays in my funding.",
                   "customClass": "formio-component-weight-bold",
                   "tableView": true,
+                  "defaultValue": false,
+                  "redrawOn": "additionalTransportRequested",
                   "validate": {
                     "required": true,
                     "customMessage": "You must confirm you understand the exception eligibility criteria."
@@ -5085,11 +5087,9 @@
                   "validateWhenHidden": false,
                   "key": "additionalTransportationConfirmation",
                   "type": "checkbox",
-                  "dataGridLabel": false,
                   "input": true,
                   "lockKey": true,
-                  "hideOnChildrenHidden": false,
-                  "defaultValue": false
+                  "hideOnChildrenHidden": false
                 }
               ],
               "lockKey": true


### PR DESCRIPTION
### Summary

Update form definitions to force redrawing the transportation confirmation checkbox which was causing the form to be in a invalid state.