### PR TITLE
#5921 - Fix Detail Header Wrapping

### DIFF
--- a/sources/packages/web/src/components/generic/DetailHeader.vue
+++ b/sources/packages/web/src/components/generic/DetailHeader.vue
@@ -10,7 +10,7 @@
       <span class="label-bold-normal ml-2 ml-lg-0 pr-2 text-no-wrap"
         >{{ headerKey }}:</span
       >
-      <span class="label-value-normal d-inline-block text-truncate">
+      <span class="label-value-normal d-inline-block text-truncate" :title="headerValue">
         {{ headerValue }}
       </span>
       <span

--- a/sources/packages/web/src/components/generic/DetailHeader.vue
+++ b/sources/packages/web/src/components/generic/DetailHeader.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    class="d-flex flex-column flex-lg-row flex-lg-wrap align-start align-lg-center"
+    class="d-flex flex-column flex-lg-row flex-wrap align-start align-lg-center"
   >
     <span
       v-for="([headerKey, headerValue], index) in headerEntries"

--- a/sources/packages/web/src/components/generic/DetailHeader.vue
+++ b/sources/packages/web/src/components/generic/DetailHeader.vue
@@ -1,15 +1,21 @@
 <template>
-  <div class="d-flex flex-column flex-md-row">
+  <div
+    class="d-flex flex-column flex-lg-row flex-lg-wrap align-start align-lg-center"
+  >
     <span
       v-for="([headerKey, headerValue], index) in headerEntries"
       :key="headerKey"
-      class="d-inline-flex"
+      class="d-inline-flex align-baseline"
     >
-      <span class="label-bold-normal ml-2 ml-md-0 pr-2">{{ headerKey }}:</span>
-      <span class="label-value-normal">{{ headerValue }}</span>
+      <span class="label-bold-normal ml-2 ml-lg-0 pr-2 text-no-wrap"
+        >{{ headerKey }}:</span
+      >
+      <span class="label-value-normal d-inline-block text-truncate">
+        {{ headerValue }}
+      </span>
       <span
         v-if="index < headerEntries.length - 1"
-        class="d-none d-md-inline mx-1 brand-gray-text"
+        class="d-none d-lg-inline mx-1 brand-gray-text"
         >|</span
       >
     </span>


### PR DESCRIPTION
### Summary

Updates to the layout of the header component when displaying different screen sizes.

<img width="1874" height="250" alt="image" src="https://github.com/user-attachments/assets/4fd589ca-21cf-443f-84ef-8a04827b5ae3" />

<img width="1235" height="316" alt="image" src="https://github.com/user-attachments/assets/75bb3f9a-3687-4407-bef2-25a303a5d5c2" />

<img width="482" height="454" alt="image" src="https://github.com/user-attachments/assets/b5169437-0b06-48a0-b75c-7c5f45eef396" />
