### PR TITLE
#6187 - Formio selected location program and the CSP fix

### DIFF
--- a/sources/packages/backend/package-lock.json
+++ b/sources/packages/backend/package-lock.json
@@ -5547,9 +5547,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5564,9 +5561,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5581,9 +5575,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5598,9 +5589,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5615,9 +5603,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5632,9 +5617,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5649,9 +5631,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5666,9 +5645,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/sources/packages/backend/package-lock.json
+++ b/sources/packages/backend/package-lock.json
@@ -5547,6 +5547,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5561,6 +5564,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5575,6 +5581,9 @@
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5589,6 +5598,9 @@
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5603,6 +5615,9 @@
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5617,6 +5632,9 @@
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5631,6 +5649,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5645,6 +5666,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/sources/packages/forms/src/form-definitions/sfaa2025-26-ft.json
+++ b/sources/packages/forms/src/form-definitions/sfaa2025-26-ft.json
@@ -8590,7 +8590,7 @@
                       "attr": ""
                     }
                   ],
-                  "content": "<strong> Please confirm that you match the criteria below and are eligible for this exception category.</strong>\n<br />\nYou require additional financial support for transportation due to one of the following criteria:\n<li>Public transit takes more than two hours from your neighborhood to your school and back by the quickest/most direct route.</li>\n<li>I am in a clinical or practicum placement that requires additional travel.</li>\n<li>I have special circumstances that require additional travel (work, family responsibilities, living distance from school).</li>",
+                  "content": "<strong> Please confirm that you match the criteria below and are eligible for this exception category.</strong>\n<br />\nYou require additional financial support for transportation due to one of the following criteria:\n<ul>\n<li>Public transit takes more than two hours from your neighborhood to your school and back by the quickest/most direct route.</li>\n<li>I am in a clinical or practicum placement that requires additional travel.</li>\n<li>I have special circumstances that require additional travel (work, family responsibilities, living distance from school).</li>\n</ul>",
                   "refreshOnChange": false,
                   "key": "additionalTransportExceptionPanelContent",
                   "type": "htmlelement",

--- a/sources/packages/forms/src/form-definitions/sfaa2025-26-ft.json
+++ b/sources/packages/forms/src/form-definitions/sfaa2025-26-ft.json
@@ -968,7 +968,7 @@
                   "collapsible": false,
                   "hideLabel": true,
                   "key": "programDesc",
-                  "customConditional": "show =\r\n  ((!!data.selectedProgram &&\r\n  data.hasSelectedLocation &&\r\n  !!!data.mySchoolIsNotListed &&\r\n  !(data.myProgramNotListed ? data.myProgramNotListed.programnotListed : false)\r\n  ) || (data.isReadOnly && data.selectedProgramDesc?.id));\r\n",
+                  "customConditional": "show =\r\n  ((data.hasSelectedProgram &&\r\n  data.hasSelectedLocation &&\r\n  !!!data.mySchoolIsNotListed &&\r\n  !(data.myProgramNotListed ? data.myProgramNotListed.programnotListed : false)\r\n  ) || (data.isReadOnly && data.selectedProgramDesc?.id));\r\n",
                   "type": "panel",
                   "clearOnHide": true,
                   "label": "programDesc",
@@ -1164,7 +1164,7 @@
                   },
                   "validateWhenHidden": false,
                   "key": "selectedOffering",
-                  "customConditional": "show =\n  (data.hasSelectedLocation &&\n  !!data.selectedProgram &&\n  !!!data.mySchoolIsNotListed &&\n  !(data.myProgramNotListed ? data.myProgramNotListed.programnotListed : false) &&\n  !(data.myStudyPeriodIsntListed ? data.myStudyPeriodIsntListed.offeringnotListed : false) &&\n  !data.isProgramSectionReadOnly\n  );",
+                  "customConditional": "show =\n  (data.hasSelectedLocation &&\n  data.hasSelectedProgram &&\n  !!!data.mySchoolIsNotListed &&\n  !(data.myProgramNotListed ? data.myProgramNotListed.programnotListed : false) &&\n  !(data.myStudyPeriodIsntListed ? data.myStudyPeriodIsntListed.offeringnotListed : false) &&\n  !data.isProgramSectionReadOnly\n  );",
                   "type": "select",
                   "input": true,
                   "searchThreshold": 0.3
@@ -1195,7 +1195,7 @@
                     }
                   ],
                   "key": "myStudyPeriodIsntListed",
-                  "customConditional": "show =\n  (data.hasSelectedLocation &&\n  !!data.selectedProgram &&\n  !!!data.mySchoolIsNotListed &&\n  !(data.myProgramNotListed ? data.myProgramNotListed.programnotListed : false)\n  );\n\n",
+                  "customConditional": "show =\n  (data.hasSelectedLocation &&\n  data.hasSelectedProgram &&\n  !!!data.mySchoolIsNotListed &&\n  !(data.myProgramNotListed ? data.myProgramNotListed.programnotListed : false)\n  );\n\n",
                   "type": "selectboxes",
                   "input": true,
                   "inputType": "checkbox",

--- a/sources/packages/forms/src/form-definitions/sfaa2025-26-ft.json
+++ b/sources/packages/forms/src/form-definitions/sfaa2025-26-ft.json
@@ -406,6 +406,24 @@
       "scrollToTop": true,
       "components": [
         {
+          "label": "Has selected location",
+          "calculateValue": "value = !!data.selectedLocation || !!(data.selectedLocationName?.trim());",
+          "calculateServer": true,
+          "key": "hasSelectedLocation",
+          "type": "hidden",
+          "input": true,
+          "tableView": false
+        },
+        {
+          "label": "Has selected program",
+          "calculateValue": "value = !!data.selectedProgram || !!(data.selectedProgramName?.trim());",
+          "calculateServer": true,
+          "key": "hasSelectedProgram",
+          "type": "hidden",
+          "input": true,
+          "tableView": false
+        },
+        {
           "label": "HTML",
           "className": "alert alert-warning fa fa-exclamation-triangle w-100",
           "attrs": [
@@ -571,7 +589,7 @@
           "collapsible": false,
           "hideLabel": true,
           "key": "panel2",
-          "customConditional": "show =\n  (!!data.selectedLocation &&\n  !!!data.mySchoolIsNotListed) ||\n  !!data.isReadOnly;",
+          "customConditional": "show =\n  (data.hasSelectedLocation &&\n  !!!data.mySchoolIsNotListed) ||\n  !!data.isReadOnly;",
           "type": "panel",
           "clearOnHide": true,
           "label": "Panel",
@@ -591,7 +609,7 @@
               "content": "Program selection",
               "refreshOnChange": false,
               "key": "html40",
-              "customConditional": "show =\r\n  (!!data.selectedLocation &&\r\n  !!!data.mySchoolIsNotListed) ||\r\n  !!data.isReadOnly;\r\n\r\n",
+              "customConditional": "show =\r\n  (data.hasSelectedLocation &&\r\n  !!!data.mySchoolIsNotListed) ||\r\n  !!data.isReadOnly;\r\n\r\n",
               "type": "htmlelement",
               "input": false,
               "tableView": false
@@ -619,7 +637,7 @@
                   },
                   "validateWhenHidden": false,
                   "key": "selectedProgram",
-                  "customConditional": "show =\r\n  !!data.selectedLocation &&\r\n  !!!data.mySchoolIsNotListed &&\r\n  !(data.myProgramNotListed ? data.myProgramNotListed.programnotListed : false) &&\r\n  !data.isProgramSectionReadOnly;\r\n  \r\n\r\n",
+                  "customConditional": "show =\r\n  data.hasSelectedLocation &&\r\n  !!!data.mySchoolIsNotListed &&\r\n  !(data.myProgramNotListed ? data.myProgramNotListed.programnotListed : false) &&\r\n  !data.isProgramSectionReadOnly;\r\n  \r\n\r\n",
                   "type": "select",
                   "input": true,
                   "lockKey": true,
@@ -676,7 +694,7 @@
                     }
                   ],
                   "key": "myProgramNotListed",
-                  "customConditional": "show = (!!data.selectedLocation && !!!data.mySchoolIsNotListed);",
+                  "customConditional": "show = (data.hasSelectedLocation && !!!data.mySchoolIsNotListed);",
                   "type": "selectboxes",
                   "input": true,
                   "inputType": "checkbox",
@@ -950,7 +968,7 @@
                   "collapsible": false,
                   "hideLabel": true,
                   "key": "programDesc",
-                  "customConditional": "show =\r\n  ((!!data.selectedProgram &&\r\n  !!data.selectedLocation &&\r\n  !!!data.mySchoolIsNotListed &&\r\n  !(data.myProgramNotListed ? data.myProgramNotListed.programnotListed : false)\r\n  ) || (data.isReadOnly && data.selectedProgramDesc?.id));\r\n",
+                  "customConditional": "show =\r\n  ((!!data.selectedProgram &&\r\n  data.hasSelectedLocation &&\r\n  !!!data.mySchoolIsNotListed &&\r\n  !(data.myProgramNotListed ? data.myProgramNotListed.programnotListed : false)\r\n  ) || (data.isReadOnly && data.selectedProgramDesc?.id));\r\n",
                   "type": "panel",
                   "clearOnHide": true,
                   "label": "programDesc",
@@ -1146,7 +1164,7 @@
                   },
                   "validateWhenHidden": false,
                   "key": "selectedOffering",
-                  "customConditional": "show =\n  (!!data.selectedLocation &&\n  !!data.selectedProgram &&\n  !!!data.mySchoolIsNotListed &&\n  !(data.myProgramNotListed ? data.myProgramNotListed.programnotListed : false) &&\n  !(data.myStudyPeriodIsntListed ? data.myStudyPeriodIsntListed.offeringnotListed : false) &&\n  !data.isProgramSectionReadOnly\n  );",
+                  "customConditional": "show =\n  (data.hasSelectedLocation &&\n  !!data.selectedProgram &&\n  !!!data.mySchoolIsNotListed &&\n  !(data.myProgramNotListed ? data.myProgramNotListed.programnotListed : false) &&\n  !(data.myStudyPeriodIsntListed ? data.myStudyPeriodIsntListed.offeringnotListed : false) &&\n  !data.isProgramSectionReadOnly\n  );",
                   "type": "select",
                   "input": true,
                   "searchThreshold": 0.3
@@ -1177,7 +1195,7 @@
                     }
                   ],
                   "key": "myStudyPeriodIsntListed",
-                  "customConditional": "show =\n  (!!data.selectedLocation &&\n  !!data.selectedProgram &&\n  !!!data.mySchoolIsNotListed &&\n  !(data.myProgramNotListed ? data.myProgramNotListed.programnotListed : false)\n  );\n\n",
+                  "customConditional": "show =\n  (data.hasSelectedLocation &&\n  !!data.selectedProgram &&\n  !!!data.mySchoolIsNotListed &&\n  !(data.myProgramNotListed ? data.myProgramNotListed.programnotListed : false)\n  );\n\n",
                   "type": "selectboxes",
                   "input": true,
                   "inputType": "checkbox",

--- a/sources/packages/forms/src/form-definitions/sfaa2025-26-pt.json
+++ b/sources/packages/forms/src/form-definitions/sfaa2025-26-pt.json
@@ -399,6 +399,24 @@
       "scrollToTop": true,
       "components": [
         {
+          "label": "Has selected location",
+          "calculateValue": "value = !!data.selectedLocation || !!(data.selectedLocationName?.trim());",
+          "calculateServer": true,
+          "key": "hasSelectedLocation",
+          "type": "hidden",
+          "input": true,
+          "tableView": false
+        },
+        {
+          "label": "Has selected program",
+          "calculateValue": "value = !!data.selectedProgram || !!(data.selectedProgramName?.trim());",
+          "calculateServer": true,
+          "key": "hasSelectedProgram",
+          "type": "hidden",
+          "input": true,
+          "tableView": false
+        },
+        {
           "label": "HTML",
           "className": "alert alert-warning fa fa-exclamation-triangle w-100",
           "attrs": [
@@ -550,7 +568,7 @@
           "collapsible": false,
           "hideLabel": true,
           "key": "panel2",
-          "customConditional": "show =\n  (!!data.selectedLocation &&\n  !!!data.mySchoolIsNotListed) ||\n  !!data.isReadOnly;",
+          "customConditional": "show =\n  (data.hasSelectedLocation &&\n  !!!data.mySchoolIsNotListed) ||\n  !!data.isReadOnly;",
           "type": "panel",
           "clearOnHide": true,
           "label": "Panel",
@@ -570,7 +588,7 @@
               "content": "Program selection",
               "refreshOnChange": false,
               "key": "html40",
-              "customConditional": "show =\r\n  (!!data.selectedLocation &&\r\n  !!!data.mySchoolIsNotListed) ||\r\n  !!data.isReadOnly;\r\n\r\n",
+              "customConditional": "show =\r\n  (data.hasSelectedLocation &&\r\n  !!!data.mySchoolIsNotListed) ||\r\n  !!data.isReadOnly;\r\n\r\n",
               "type": "htmlelement",
               "input": false,
               "tableView": false
@@ -598,7 +616,7 @@
                   },
                   "validateWhenHidden": false,
                   "key": "selectedProgram",
-                  "customConditional": "show =\r\n  !!data.selectedLocation &&\r\n  !!!data.mySchoolIsNotListed &&\r\n  !(data.myProgramNotListed ? data.myProgramNotListed.programnotListed : false) &&\r\n  !data.isProgramSectionReadOnly;\r\n  \r\n\r\n",
+                  "customConditional": "show =\r\n  data.hasSelectedLocation &&\r\n  !!!data.mySchoolIsNotListed &&\r\n  !(data.myProgramNotListed ? data.myProgramNotListed.programnotListed : false) &&\r\n  !data.isProgramSectionReadOnly;\r\n  \r\n\r\n",
                   "type": "select",
                   "input": true,
                   "lockKey": true,
@@ -655,7 +673,7 @@
                     }
                   ],
                   "key": "myProgramNotListed",
-                  "customConditional": "show = (!!data.selectedLocation && !!!data.mySchoolIsNotListed);",
+                  "customConditional": "show = (data.hasSelectedLocation && !!!data.mySchoolIsNotListed);",
                   "type": "selectboxes",
                   "input": true,
                   "inputType": "checkbox",
@@ -907,7 +925,7 @@
                   "collapsible": false,
                   "hideLabel": true,
                   "key": "programDesc",
-                  "customConditional": "show =\r\n  ((!!data.selectedProgram &&\r\n  !!data.selectedLocation &&\r\n  !!!data.mySchoolIsNotListed &&\r\n  !(data.myProgramNotListed ? data.myProgramNotListed.programnotListed : false)\r\n  ) || (data.isReadOnly && data.selectedProgramDesc?.id));\r\n",
+                  "customConditional": "show =\r\n  ((!!data.selectedProgram &&\r\n  data.hasSelectedLocation &&\r\n  !!!data.mySchoolIsNotListed &&\r\n  !(data.myProgramNotListed ? data.myProgramNotListed.programnotListed : false)\r\n  ) || (data.isReadOnly && data.selectedProgramDesc?.id));\r\n",
                   "type": "panel",
                   "clearOnHide": true,
                   "label": "programDesc",
@@ -1103,7 +1121,7 @@
                   },
                   "validateWhenHidden": false,
                   "key": "selectedOffering",
-                  "customConditional": "show =\n  (!!data.selectedLocation &&\n  !!data.selectedProgram &&\n  !!!data.mySchoolIsNotListed &&\n  !(data.myProgramNotListed ? data.myProgramNotListed.programnotListed : false) &&\n  !(data.myStudyPeriodIsntListed ? data.myStudyPeriodIsntListed.offeringnotListed : false) &&\n  !data.isProgramSectionReadOnly\n  );",
+                  "customConditional": "show =\n  (data.hasSelectedLocation &&\n  !!data.selectedProgram &&\n  !!!data.mySchoolIsNotListed &&\n  !(data.myProgramNotListed ? data.myProgramNotListed.programnotListed : false) &&\n  !(data.myStudyPeriodIsntListed ? data.myStudyPeriodIsntListed.offeringnotListed : false) &&\n  !data.isProgramSectionReadOnly\n  );",
                   "type": "select",
                   "input": true,
                   "searchThreshold": 0.3
@@ -1134,7 +1152,7 @@
                     }
                   ],
                   "key": "myStudyPeriodIsntListed",
-                  "customConditional": "show =\n  (!!data.selectedLocation &&\n  !!data.selectedProgram &&\n  !!!data.mySchoolIsNotListed &&\n  !(data.myProgramNotListed ? data.myProgramNotListed.programnotListed : false)\n  );\n\n",
+                  "customConditional": "show =\n  (data.hasSelectedLocation &&\n  !!data.selectedProgram &&\n  !!!data.mySchoolIsNotListed &&\n  !(data.myProgramNotListed ? data.myProgramNotListed.programnotListed : false)\n  );\n\n",
                   "type": "selectboxes",
                   "input": true,
                   "inputType": "checkbox",

--- a/sources/packages/forms/src/form-definitions/sfaa2025-26-pt.json
+++ b/sources/packages/forms/src/form-definitions/sfaa2025-26-pt.json
@@ -925,7 +925,7 @@
                   "collapsible": false,
                   "hideLabel": true,
                   "key": "programDesc",
-                  "customConditional": "show =\r\n  ((!!data.selectedProgram &&\r\n  data.hasSelectedLocation &&\r\n  !!!data.mySchoolIsNotListed &&\r\n  !(data.myProgramNotListed ? data.myProgramNotListed.programnotListed : false)\r\n  ) || (data.isReadOnly && data.selectedProgramDesc?.id));\r\n",
+                  "customConditional": "show =\r\n  ((data.hasSelectedProgram &&\r\n  data.hasSelectedLocation &&\r\n  !!!data.mySchoolIsNotListed &&\r\n  !(data.myProgramNotListed ? data.myProgramNotListed.programnotListed : false)\r\n  ) || (data.isReadOnly && data.selectedProgramDesc?.id));\r\n",
                   "type": "panel",
                   "clearOnHide": true,
                   "label": "programDesc",
@@ -1121,7 +1121,7 @@
                   },
                   "validateWhenHidden": false,
                   "key": "selectedOffering",
-                  "customConditional": "show =\n  (data.hasSelectedLocation &&\n  !!data.selectedProgram &&\n  !!!data.mySchoolIsNotListed &&\n  !(data.myProgramNotListed ? data.myProgramNotListed.programnotListed : false) &&\n  !(data.myStudyPeriodIsntListed ? data.myStudyPeriodIsntListed.offeringnotListed : false) &&\n  !data.isProgramSectionReadOnly\n  );",
+                  "customConditional": "show =\n  (data.hasSelectedLocation &&\n  data.hasSelectedProgram &&\n  !!!data.mySchoolIsNotListed &&\n  !(data.myProgramNotListed ? data.myProgramNotListed.programnotListed : false) &&\n  !(data.myStudyPeriodIsntListed ? data.myStudyPeriodIsntListed.offeringnotListed : false) &&\n  !data.isProgramSectionReadOnly\n  );",
                   "type": "select",
                   "input": true,
                   "searchThreshold": 0.3
@@ -1152,7 +1152,7 @@
                     }
                   ],
                   "key": "myStudyPeriodIsntListed",
-                  "customConditional": "show =\n  (data.hasSelectedLocation &&\n  !!data.selectedProgram &&\n  !!!data.mySchoolIsNotListed &&\n  !(data.myProgramNotListed ? data.myProgramNotListed.programnotListed : false)\n  );\n\n",
+                  "customConditional": "show =\n  (data.hasSelectedLocation &&\n  data.hasSelectedProgram &&\n  !!!data.mySchoolIsNotListed &&\n  !(data.myProgramNotListed ? data.myProgramNotListed.programnotListed : false)\n  );\n\n",
                   "type": "selectboxes",
                   "input": true,
                   "inputType": "checkbox",

--- a/sources/packages/forms/src/form-definitions/sfaa2026-27-ft.json
+++ b/sources/packages/forms/src/form-definitions/sfaa2026-27-ft.json
@@ -968,7 +968,7 @@
                   "collapsible": false,
                   "hideLabel": true,
                   "key": "programDesc",
-                  "customConditional": "show =\r\n  ((!!data.selectedProgram &&\r\n  data.hasSelectedLocation &&\r\n  !!!data.mySchoolIsNotListed &&\r\n  !(data.myProgramNotListed ? data.myProgramNotListed.programnotListed : false)\r\n  ) || (data.isReadOnly && data.selectedProgramDesc?.id));\r\n",
+                  "customConditional": "show =\r\n  ((data.hasSelectedProgram &&\r\n  data.hasSelectedLocation &&\r\n  !!!data.mySchoolIsNotListed &&\r\n  !(data.myProgramNotListed ? data.myProgramNotListed.programnotListed : false)\r\n  ) || (data.isReadOnly && data.selectedProgramDesc?.id));\r\n",
                   "type": "panel",
                   "clearOnHide": true,
                   "label": "programDesc",
@@ -1164,7 +1164,7 @@
                   },
                   "validateWhenHidden": false,
                   "key": "selectedOffering",
-                  "customConditional": "show =\n  (data.hasSelectedLocation &&\n  !!data.selectedProgram &&\n  !!!data.mySchoolIsNotListed &&\n  !(data.myProgramNotListed ? data.myProgramNotListed.programnotListed : false) &&\n  !(data.myStudyPeriodIsntListed ? data.myStudyPeriodIsntListed.offeringnotListed : false) &&\n  !data.isProgramSectionReadOnly\n  );",
+                  "customConditional": "show =\n  (data.hasSelectedLocation &&\n  data.hasSelectedProgram &&\n  !!!data.mySchoolIsNotListed &&\n  !(data.myProgramNotListed ? data.myProgramNotListed.programnotListed : false) &&\n  !(data.myStudyPeriodIsntListed ? data.myStudyPeriodIsntListed.offeringnotListed : false) &&\n  !data.isProgramSectionReadOnly\n  );",
                   "type": "select",
                   "input": true,
                   "searchThreshold": 0.3
@@ -1195,7 +1195,7 @@
                     }
                   ],
                   "key": "myStudyPeriodIsntListed",
-                  "customConditional": "show =\n  (data.hasSelectedLocation &&\n  !!data.selectedProgram &&\n  !!!data.mySchoolIsNotListed &&\n  !(data.myProgramNotListed ? data.myProgramNotListed.programnotListed : false)\n  );\n\n",
+                  "customConditional": "show =\n  (data.hasSelectedLocation &&\n  data.hasSelectedProgram &&\n  !!!data.mySchoolIsNotListed &&\n  !(data.myProgramNotListed ? data.myProgramNotListed.programnotListed : false)\n  );\n\n",
                   "type": "selectboxes",
                   "input": true,
                   "inputType": "checkbox",

--- a/sources/packages/forms/src/form-definitions/sfaa2026-27-ft.json
+++ b/sources/packages/forms/src/form-definitions/sfaa2026-27-ft.json
@@ -406,6 +406,24 @@
       "scrollToTop": true,
       "components": [
         {
+          "label": "Has selected location",
+          "calculateValue": "value = !!data.selectedLocation || !!(data.selectedLocationName?.trim());",
+          "calculateServer": true,
+          "key": "hasSelectedLocation",
+          "type": "hidden",
+          "input": true,
+          "tableView": false
+        },
+        {
+          "label": "Has selected program",
+          "calculateValue": "value = !!data.selectedProgram || !!(data.selectedProgramName?.trim());",
+          "calculateServer": true,
+          "key": "hasSelectedProgram",
+          "type": "hidden",
+          "input": true,
+          "tableView": false
+        },
+        {
           "label": "HTML",
           "className": "alert alert-warning fa fa-exclamation-triangle w-100",
           "attrs": [
@@ -571,7 +589,7 @@
           "collapsible": false,
           "hideLabel": true,
           "key": "panel2",
-          "customConditional": "show =\n  (!!data.selectedLocation &&\n  !!!data.mySchoolIsNotListed) ||\n  !!data.isReadOnly;",
+          "customConditional": "show =\n  (data.hasSelectedLocation &&\n  !!!data.mySchoolIsNotListed) ||\n  !!data.isReadOnly;",
           "type": "panel",
           "clearOnHide": true,
           "label": "Panel",
@@ -591,7 +609,7 @@
               "content": "Program selection",
               "refreshOnChange": false,
               "key": "html40",
-              "customConditional": "show =\r\n  (!!data.selectedLocation &&\r\n  !!!data.mySchoolIsNotListed) ||\r\n  !!data.isReadOnly;\r\n\r\n",
+              "customConditional": "show =\r\n  (data.hasSelectedLocation &&\r\n  !!!data.mySchoolIsNotListed) ||\r\n  !!data.isReadOnly;\r\n\r\n",
               "type": "htmlelement",
               "input": false,
               "tableView": false
@@ -619,7 +637,7 @@
                   },
                   "validateWhenHidden": false,
                   "key": "selectedProgram",
-                  "customConditional": "show =\r\n  !!data.selectedLocation &&\r\n  !!!data.mySchoolIsNotListed &&\r\n  !(data.myProgramNotListed ? data.myProgramNotListed.programnotListed : false) &&\r\n  !data.isProgramSectionReadOnly;\r\n  \r\n\r\n",
+                  "customConditional": "show =\r\n  data.hasSelectedLocation &&\r\n  !!!data.mySchoolIsNotListed &&\r\n  !(data.myProgramNotListed ? data.myProgramNotListed.programnotListed : false) &&\r\n  !data.isProgramSectionReadOnly;\r\n  \r\n\r\n",
                   "type": "select",
                   "input": true,
                   "lockKey": true,
@@ -676,7 +694,7 @@
                     }
                   ],
                   "key": "myProgramNotListed",
-                  "customConditional": "show = (!!data.selectedLocation && !!!data.mySchoolIsNotListed);",
+                  "customConditional": "show = (data.hasSelectedLocation && !!!data.mySchoolIsNotListed);",
                   "type": "selectboxes",
                   "input": true,
                   "inputType": "checkbox",
@@ -950,7 +968,7 @@
                   "collapsible": false,
                   "hideLabel": true,
                   "key": "programDesc",
-                  "customConditional": "show =\r\n  ((!!data.selectedProgram &&\r\n  !!data.selectedLocation &&\r\n  !!!data.mySchoolIsNotListed &&\r\n  !(data.myProgramNotListed ? data.myProgramNotListed.programnotListed : false)\r\n  ) || (data.isReadOnly && data.selectedProgramDesc?.id));\r\n",
+                  "customConditional": "show =\r\n  ((!!data.selectedProgram &&\r\n  data.hasSelectedLocation &&\r\n  !!!data.mySchoolIsNotListed &&\r\n  !(data.myProgramNotListed ? data.myProgramNotListed.programnotListed : false)\r\n  ) || (data.isReadOnly && data.selectedProgramDesc?.id));\r\n",
                   "type": "panel",
                   "clearOnHide": true,
                   "label": "programDesc",
@@ -1146,7 +1164,7 @@
                   },
                   "validateWhenHidden": false,
                   "key": "selectedOffering",
-                  "customConditional": "show =\n  (!!data.selectedLocation &&\n  !!data.selectedProgram &&\n  !!!data.mySchoolIsNotListed &&\n  !(data.myProgramNotListed ? data.myProgramNotListed.programnotListed : false) &&\n  !(data.myStudyPeriodIsntListed ? data.myStudyPeriodIsntListed.offeringnotListed : false) &&\n  !data.isProgramSectionReadOnly\n  );",
+                  "customConditional": "show =\n  (data.hasSelectedLocation &&\n  !!data.selectedProgram &&\n  !!!data.mySchoolIsNotListed &&\n  !(data.myProgramNotListed ? data.myProgramNotListed.programnotListed : false) &&\n  !(data.myStudyPeriodIsntListed ? data.myStudyPeriodIsntListed.offeringnotListed : false) &&\n  !data.isProgramSectionReadOnly\n  );",
                   "type": "select",
                   "input": true,
                   "searchThreshold": 0.3
@@ -1177,7 +1195,7 @@
                     }
                   ],
                   "key": "myStudyPeriodIsntListed",
-                  "customConditional": "show =\n  (!!data.selectedLocation &&\n  !!data.selectedProgram &&\n  !!!data.mySchoolIsNotListed &&\n  !(data.myProgramNotListed ? data.myProgramNotListed.programnotListed : false)\n  );\n\n",
+                  "customConditional": "show =\n  (data.hasSelectedLocation &&\n  !!data.selectedProgram &&\n  !!!data.mySchoolIsNotListed &&\n  !(data.myProgramNotListed ? data.myProgramNotListed.programnotListed : false)\n  );\n\n",
                   "type": "selectboxes",
                   "input": true,
                   "inputType": "checkbox",

--- a/sources/packages/forms/src/form-definitions/sfaa2026-27-pt.json
+++ b/sources/packages/forms/src/form-definitions/sfaa2026-27-pt.json
@@ -399,6 +399,24 @@
       "scrollToTop": true,
       "components": [
         {
+          "label": "Has selected location",
+          "calculateValue": "value = !!data.selectedLocation || !!(data.selectedLocationName?.trim());",
+          "calculateServer": true,
+          "key": "hasSelectedLocation",
+          "type": "hidden",
+          "input": true,
+          "tableView": false
+        },
+        {
+          "label": "Has selected program",
+          "calculateValue": "value = !!data.selectedProgram || !!(data.selectedProgramName?.trim());",
+          "calculateServer": true,
+          "key": "hasSelectedProgram",
+          "type": "hidden",
+          "input": true,
+          "tableView": false
+        },
+        {
           "label": "HTML",
           "className": "alert alert-warning fa fa-exclamation-triangle w-100",
           "attrs": [
@@ -550,7 +568,7 @@
           "collapsible": false,
           "hideLabel": true,
           "key": "panel2",
-          "customConditional": "show =\n  (!!data.selectedLocation &&\n  !!!data.mySchoolIsNotListed) ||\n  !!data.isReadOnly;",
+          "customConditional": "show =\n  (data.hasSelectedLocation &&\n  !!!data.mySchoolIsNotListed) ||\n  !!data.isReadOnly;",
           "type": "panel",
           "clearOnHide": true,
           "label": "Panel",
@@ -570,7 +588,7 @@
               "content": "Program selection",
               "refreshOnChange": false,
               "key": "html40",
-              "customConditional": "show =\r\n  (!!data.selectedLocation &&\r\n  !!!data.mySchoolIsNotListed) ||\r\n  !!data.isReadOnly;\r\n\r\n",
+              "customConditional": "show =\r\n  (data.hasSelectedLocation &&\r\n  !!!data.mySchoolIsNotListed) ||\r\n  !!data.isReadOnly;\r\n\r\n",
               "type": "htmlelement",
               "input": false,
               "tableView": false
@@ -598,7 +616,7 @@
                   },
                   "validateWhenHidden": false,
                   "key": "selectedProgram",
-                  "customConditional": "show =\r\n  !!data.selectedLocation &&\r\n  !!!data.mySchoolIsNotListed &&\r\n  !(data.myProgramNotListed ? data.myProgramNotListed.programnotListed : false) &&\r\n  !data.isProgramSectionReadOnly;\r\n  \r\n\r\n",
+                  "customConditional": "show =\r\n  data.hasSelectedLocation &&\r\n  !!!data.mySchoolIsNotListed &&\r\n  !(data.myProgramNotListed ? data.myProgramNotListed.programnotListed : false) &&\r\n  !data.isProgramSectionReadOnly;\r\n  \r\n\r\n",
                   "type": "select",
                   "input": true,
                   "lockKey": true,
@@ -655,7 +673,7 @@
                     }
                   ],
                   "key": "myProgramNotListed",
-                  "customConditional": "show = (!!data.selectedLocation && !!!data.mySchoolIsNotListed);",
+                  "customConditional": "show = (data.hasSelectedLocation && !!!data.mySchoolIsNotListed);",
                   "type": "selectboxes",
                   "input": true,
                   "inputType": "checkbox",
@@ -907,7 +925,7 @@
                   "collapsible": false,
                   "hideLabel": true,
                   "key": "programDesc",
-                  "customConditional": "show =\r\n  ((!!data.selectedProgram &&\r\n  !!data.selectedLocation &&\r\n  !!!data.mySchoolIsNotListed &&\r\n  !(data.myProgramNotListed ? data.myProgramNotListed.programnotListed : false)\r\n  ) || (data.isReadOnly && data.selectedProgramDesc?.id));\r\n",
+                  "customConditional": "show =\r\n  ((!!data.selectedProgram &&\r\n  data.hasSelectedLocation &&\r\n  !!!data.mySchoolIsNotListed &&\r\n  !(data.myProgramNotListed ? data.myProgramNotListed.programnotListed : false)\r\n  ) || (data.isReadOnly && data.selectedProgramDesc?.id));\r\n",
                   "type": "panel",
                   "clearOnHide": true,
                   "label": "programDesc",
@@ -1103,7 +1121,7 @@
                   },
                   "validateWhenHidden": false,
                   "key": "selectedOffering",
-                  "customConditional": "show =\n  (!!data.selectedLocation &&\n  !!data.selectedProgram &&\n  !!!data.mySchoolIsNotListed &&\n  !(data.myProgramNotListed ? data.myProgramNotListed.programnotListed : false) &&\n  !(data.myStudyPeriodIsntListed ? data.myStudyPeriodIsntListed.offeringnotListed : false) &&\n  !data.isProgramSectionReadOnly\n  );",
+                  "customConditional": "show =\n  (data.hasSelectedLocation &&\n  !!data.selectedProgram &&\n  !!!data.mySchoolIsNotListed &&\n  !(data.myProgramNotListed ? data.myProgramNotListed.programnotListed : false) &&\n  !(data.myStudyPeriodIsntListed ? data.myStudyPeriodIsntListed.offeringnotListed : false) &&\n  !data.isProgramSectionReadOnly\n  );",
                   "type": "select",
                   "input": true,
                   "searchThreshold": 0.3
@@ -1134,7 +1152,7 @@
                     }
                   ],
                   "key": "myStudyPeriodIsntListed",
-                  "customConditional": "show =\n  (!!data.selectedLocation &&\n  !!data.selectedProgram &&\n  !!!data.mySchoolIsNotListed &&\n  !(data.myProgramNotListed ? data.myProgramNotListed.programnotListed : false)\n  );\n\n",
+                  "customConditional": "show =\n  (data.hasSelectedLocation &&\n  !!data.selectedProgram &&\n  !!!data.mySchoolIsNotListed &&\n  !(data.myProgramNotListed ? data.myProgramNotListed.programnotListed : false)\n  );\n\n",
                   "type": "selectboxes",
                   "input": true,
                   "inputType": "checkbox",

--- a/sources/packages/forms/src/form-definitions/sfaa2026-27-pt.json
+++ b/sources/packages/forms/src/form-definitions/sfaa2026-27-pt.json
@@ -925,7 +925,7 @@
                   "collapsible": false,
                   "hideLabel": true,
                   "key": "programDesc",
-                  "customConditional": "show =\r\n  ((!!data.selectedProgram &&\r\n  data.hasSelectedLocation &&\r\n  !!!data.mySchoolIsNotListed &&\r\n  !(data.myProgramNotListed ? data.myProgramNotListed.programnotListed : false)\r\n  ) || (data.isReadOnly && data.selectedProgramDesc?.id));\r\n",
+                  "customConditional": "show =\r\n  ((data.hasSelectedProgram &&\r\n  data.hasSelectedLocation &&\r\n  !!!data.mySchoolIsNotListed &&\r\n  !(data.myProgramNotListed ? data.myProgramNotListed.programnotListed : false)\r\n  ) || (data.isReadOnly && data.selectedProgramDesc?.id));\r\n",
                   "type": "panel",
                   "clearOnHide": true,
                   "label": "programDesc",
@@ -1121,7 +1121,7 @@
                   },
                   "validateWhenHidden": false,
                   "key": "selectedOffering",
-                  "customConditional": "show =\n  (data.hasSelectedLocation &&\n  !!data.selectedProgram &&\n  !!!data.mySchoolIsNotListed &&\n  !(data.myProgramNotListed ? data.myProgramNotListed.programnotListed : false) &&\n  !(data.myStudyPeriodIsntListed ? data.myStudyPeriodIsntListed.offeringnotListed : false) &&\n  !data.isProgramSectionReadOnly\n  );",
+                  "customConditional": "show =\n  (data.hasSelectedLocation &&\n  data.hasSelectedProgram &&\n  !!!data.mySchoolIsNotListed &&\n  !(data.myProgramNotListed ? data.myProgramNotListed.programnotListed : false) &&\n  !(data.myStudyPeriodIsntListed ? data.myStudyPeriodIsntListed.offeringnotListed : false) &&\n  !data.isProgramSectionReadOnly\n  );",
                   "type": "select",
                   "input": true,
                   "searchThreshold": 0.3
@@ -1152,7 +1152,7 @@
                     }
                   ],
                   "key": "myStudyPeriodIsntListed",
-                  "customConditional": "show =\n  (data.hasSelectedLocation &&\n  !!data.selectedProgram &&\n  !!!data.mySchoolIsNotListed &&\n  !(data.myProgramNotListed ? data.myProgramNotListed.programnotListed : false)\n  );\n\n",
+                  "customConditional": "show =\n  (data.hasSelectedLocation &&\n  data.hasSelectedProgram &&\n  !!!data.mySchoolIsNotListed &&\n  !(data.myProgramNotListed ? data.myProgramNotListed.programnotListed : false)\n  );\n\n",
                   "type": "selectboxes",
                   "input": true,
                   "inputType": "checkbox",

--- a/sources/packages/web/nginx/default.conf.dev.template
+++ b/sources/packages/web/nginx/default.conf.dev.template
@@ -19,7 +19,7 @@ server {
     try_files $uri $uri/ /index.html;
   }
   add_header 'X-Content-Type-Options' "nosniff";
-  add_header 'Content-Security-Policy' "default-src 'self'; connect-src 'self' *.gov.bc.ca http://localhost:*; script-src 'self' 'unsafe-eval' https://cdn.form.io/flatpickr-formio/ https://cdn.form.io/ace/ https://cdn.form.io/ckeditor/; style-src 'self' 'unsafe-inline' https://cdn.form.io/flatpickr-formio/; font-src 'self' data:; img-src 'self' data:; worker-src 'self' blob:;";
+  add_header 'Content-Security-Policy' "default-src 'self'; connect-src 'self' *.gov.bc.ca http://localhost:* https://cdn.form.io/moment-timezone/; script-src 'self' 'unsafe-eval' https://cdn.form.io/flatpickr-formio/ https://cdn.form.io/ace/ https://cdn.form.io/ckeditor/; style-src 'self' 'unsafe-inline' https://cdn.form.io/flatpickr-formio/; font-src 'self' data:; img-src 'self' data:; worker-src 'self' blob:;";
   add_header 'Strict-Transport-Security' "max-age=31536000; includeSubDomains; preload";
   add_header 'Referrer-Policy' "same-origin";
   add_header 'X-Frame-Options' "sameorigin";

--- a/sources/packages/web/nginx/default.conf.template
+++ b/sources/packages/web/nginx/default.conf.template
@@ -19,7 +19,7 @@ server {
     try_files $uri $uri/ /index.html;
   }
   add_header 'X-Content-Type-Options' "nosniff";
-  add_header 'Content-Security-Policy' "default-src 'self'; connect-src 'self' *.gov.bc.ca; script-src 'self' 'unsafe-eval' https://cdn.form.io/flatpickr-formio/ https://cdn.form.io/ace/ https://cdn.form.io/ckeditor/; style-src 'self' 'unsafe-inline' https://cdn.form.io/flatpickr-formio/; font-src 'self' data:; img-src 'self' data:; worker-src 'self' blob:;";
+  add_header 'Content-Security-Policy' "default-src 'self'; connect-src 'self' *.gov.bc.ca https://cdn.form.io/moment-timezone/; script-src 'self' 'unsafe-eval' https://cdn.form.io/flatpickr-formio/ https://cdn.form.io/ace/ https://cdn.form.io/ckeditor/; style-src 'self' 'unsafe-inline' https://cdn.form.io/flatpickr-formio/; font-src 'self' data:; img-src 'self' data:; worker-src 'self' blob:;";
   add_header 'Strict-Transport-Security' "max-age=31536000; includeSubDomains; preload";
   add_header 'Referrer-Policy' "same-origin";
   add_header 'X-Frame-Options' "sameorigin";


### PR DESCRIPTION
## Selected location and program not appearing in change request
### Root cause
With the recent version(s) of form.io, if a input component is hidden, then the component value is being reset to `undefined` even if the component value is supplied in the form-data(initial data). 

For e.g. In student application,  `selectedLocation` is the key for the component that is used to choose the institution location. 
<img width="1136" height="105" alt="image" src="https://github.com/user-attachments/assets/d045813e-c270-4c8b-b692-52f8f42e5409" />

And during the read-only view, we display a read-only input text component(No 2 in screenshot) having the location name value and hide the select component(No 1 in screenshot).
<img width="1197" height="228" alt="image" src="https://github.com/user-attachments/assets/f11e6c62-1ebb-434c-bc6e-34ae20f018c3" />


During such a situation where the read-only view is displayed, `data.selectedLocation` is reset to `undefined` even if the intital data has a value to it, say `{selectedLocation: 1}`. 

### Solution
Added a calculated variable which also considers the read-only variables supplied to identify if the functional value of the component was set or not. 
e.g. hidden variable name `hasSelectedLocation` with value as `!!data.selectedLocation || !!(data.selectedLocationName?.trim());` 

## CSP issue

Updated CSP to allow the content from the blocked url. 

<img width="1761" height="211" alt="image" src="https://github.com/user-attachments/assets/7b3a2043-f9fa-452b-ab63-cbc845d52fec" />

### After fix
<img width="1624" height="480" alt="image" src="https://github.com/user-attachments/assets/51fa4955-f1cc-4a43-97ef-08ee906751b5" />

## Change request testing

### Program page with selected program and offering
<img width="1078" height="949" alt="image" src="https://github.com/user-attachments/assets/419db021-1dcc-43ac-902f-c03f27571090" />

### Program page with PIR(Program present offering not present)
<img width="1090" height="983" alt="image" src="https://github.com/user-attachments/assets/adedf99b-0913-4542-a695-da87b4ecdd68" />


### Program page with PIR(Program and offering not present)
<img width="1072" height="902" alt="image" src="https://github.com/user-attachments/assets/3bafd70d-47ad-49d1-b5df-93e5b001c785" />

## Additional transport banner fix for PY2025-26 FT
Fix related to the ticket #6163 
<img width="1288" height="885" alt="image" src="https://github.com/user-attachments/assets/e2dc76f4-cc21-4b1e-ab64-ffdc845667ae" />
