### PR TITLE
#6100 - Change partner current year income appeal name

### DIFF
--- a/sources/packages/backend/apps/api/src/route-controllers/form-submission/_tests_/e2e/form-submission.students.controller.getSubmissionForms.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/form-submission/_tests_/e2e/form-submission.students.controller.getSubmissionForms.e2e-spec.ts
@@ -64,7 +64,7 @@ describe("FormSubmissionStudentsController(e2e)-getSubmissionForms", () => {
             {
               id: expect.any(Number),
               formDefinitionName: "partnercurrentyearincomeappeal",
-              formType: "Partner current year income",
+              formType: "Spouse/common-law partner current year income",
               formCategory: "Student appeal",
               formDescription:
                 "If your spouse/common-law partner has had, or is anticipated to have, a significant decrease in gross income, you may submit this appeal to request assessment using their current year estimated gross income.",

--- a/sources/packages/backend/apps/db-migrations/src/migrations/1781046516078-UpdatePartnerCurrentYearIncomeAppealForm.ts
+++ b/sources/packages/backend/apps/db-migrations/src/migrations/1781046516078-UpdatePartnerCurrentYearIncomeAppealForm.ts
@@ -1,0 +1,22 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+import { getSQLFileData } from "../utilities/sqlLoader";
+
+export class UpdatePartnerCurrentYearIncomeAppealForm1781046516078 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      getSQLFileData(
+        "Update-partner-current-year-income-appeal-form.sql",
+        "DynamicFormConfigurations",
+      ),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      getSQLFileData(
+        "Rollback-update-partner-current-year-income-appeal-form.sql",
+        "DynamicFormConfigurations",
+      ),
+    );
+  }
+}

--- a/sources/packages/backend/apps/db-migrations/src/sql/DynamicFormConfigurations/Rollback-update-partner-current-year-income-appeal-form.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/DynamicFormConfigurations/Rollback-update-partner-current-year-income-appeal-form.sql
@@ -1,0 +1,7 @@
+-- Roll back partner current year income appeal display name in dynamic form configurations.
+UPDATE
+  sims.dynamic_form_configurations
+SET
+  form_type = 'Partner current year income'
+WHERE
+  form_definition_name = 'partnercurrentyearincomeappeal';

--- a/sources/packages/backend/apps/db-migrations/src/sql/DynamicFormConfigurations/Update-partner-current-year-income-appeal-form.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/DynamicFormConfigurations/Update-partner-current-year-income-appeal-form.sql
@@ -1,0 +1,7 @@
+-- Update partner current year income appeal display name in dynamic form configurations.
+UPDATE
+  sims.dynamic_form_configurations
+SET
+  form_type = 'Spouse/common-law partner current year income'
+WHERE
+  form_definition_name = 'partnercurrentyearincomeappeal';

--- a/sources/packages/forms/src/form-definitions/partnercurrentyearincomeappeal.json
+++ b/sources/packages/forms/src/form-definitions/partnercurrentyearincomeappeal.json
@@ -69,7 +69,7 @@
           "value": ""
         }
       ],
-      "content": "If your partner or common-law partner has had, or is anticipated to have, a significant decrease in gross income for {{data.currentTaxYear}}, you may submit this appeal to request assessment using their current year estimated gross income.",
+      "content": "If your spouse/common-law partner has had, or is anticipated to have, a significant decrease in gross income for {{data.currentTaxYear}}, you may submit this appeal to request assessment using their current year estimated gross income.",
       "refreshOnChange": true,
       "key": "partnerCurrentYearIncomeTest1",
       "type": "htmlelement",


### PR DESCRIPTION
### **As a part of this PR, the following were updated:**

- Updated the appeal name from "Partner current year income" to "Spouse/common-law partner current year income"
<img width="1920" height="1016" alt="image" src="https://github.com/user-attachments/assets/70d5b157-b5e1-41e4-b791-b1c93956a01f" />

---------------------------------------------------------------------------------------------------------------------------------------

- Updated the form description to "Spouse/common-law partner current year income"
- Updated line under form description from "If your partner or common-law partner"... to "If your spouse/common-law partner"
<img width="1921" height="1017" alt="image" src="https://github.com/user-attachments/assets/e6938f35-b898-47c6-bbcf-dfa79b9988f9" />

---------------------------------------------------------------------------------------------------------------------------------------

- Adjusted the existing e2e test `form-submission.students.controller.getSubmissionForms.e2e-spec.ts` to update the updated form type for this appeal form.
