### PR TITLE
#5451 - Step-parent/Legal guardian label updates

### DIFF
--- a/sources/packages/forms/src/form-definitions/supportingusersparent2022-2023.json
+++ b/sources/packages/forms/src/form-definitions/supportingusersparent2022-2023.json
@@ -467,12 +467,12 @@
                       "shortcut": ""
                     },
                     {
-                      "label": "Legal Guardian",
+                      "label": "Legal guardian",
                       "value": "legalGuardian",
                       "shortcut": ""
                     },
                     {
-                      "label": "Step Parent",
+                      "label": "Step-parent",
                       "value": "stepParent",
                       "shortcut": ""
                     }

--- a/sources/packages/forms/src/form-definitions/supportingusersparent2024-2025.json
+++ b/sources/packages/forms/src/form-definitions/supportingusersparent2024-2025.json
@@ -467,12 +467,12 @@
                       "shortcut": ""
                     },
                     {
-                      "label": "Legal Guardian",
+                      "label": "Legal guardian",
                       "value": "legalGuardian",
                       "shortcut": ""
                     },
                     {
-                      "label": "Step Parent",
+                      "label": "Step-parent",
                       "value": "stepParent",
                       "shortcut": ""
                     }

--- a/sources/packages/forms/src/form-definitions/supportingusersparent2025-2026.json
+++ b/sources/packages/forms/src/form-definitions/supportingusersparent2025-2026.json
@@ -592,12 +592,12 @@
                       "shortcut": ""
                     },
                     {
-                      "label": "Legal Guardian",
+                      "label": "Legal guardian",
                       "value": "legalGuardian",
                       "shortcut": ""
                     },
                     {
-                      "label": "Step Parent",
+                      "label": "Step-parent",
                       "value": "stepParent",
                       "shortcut": ""
                     }

--- a/sources/packages/forms/src/form-definitions/supportingusersparent2026-2027.json
+++ b/sources/packages/forms/src/form-definitions/supportingusersparent2026-2027.json
@@ -592,12 +592,12 @@
                       "shortcut": ""
                     },
                     {
-                      "label": "Legal Guardian",
+                      "label": "Legal guardian",
                       "value": "legalGuardian",
                       "shortcut": ""
                     },
                     {
-                      "label": "Step Parent",
+                      "label": "Step-parent",
                       "value": "stepParent",
                       "shortcut": ""
                     }


### PR DESCRIPTION
## Summary
- Change "Step Parent" to "Step-parent".
- Change "Legal Guardian" to "Legal guardian".
- A full search was done and only the Supporting Users Parent form was impacted (all program years).

## Screenshots
### Supporting Users -> Parent Form
<img width="1020" height="778" alt="image" src="https://github.com/user-attachments/assets/a7b0b3d4-d782-4d52-bec0-8cac7d778f82" />
