### PR TITLE
#5837 - Upgrade Vuetify - Part 2

### DIFF
--- a/sources/packages/web/package-lock.json
+++ b/sources/packages/web/package-lock.json
@@ -26,7 +26,7 @@
         "uuid": "^14.0.0",
         "vue": "^3.5.34",
         "vue-router": "^5.0.7",
-        "vuetify": "^4.1.0",
+        "vuetify": "^4.1.1",
         "vuex": "^4.1.0"
       },
       "devDependencies": {
@@ -4543,9 +4543,9 @@
       }
     },
     "node_modules/vuetify": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-4.1.0.tgz",
-      "integrity": "sha512-Pq05N76NMM1TVM6z2wWlV0XhQcwuNSjevlr8xhnNYpBkLZC3yjTGzHYbE1rXE4ircf1SImRcJ8khwKE3Xb2Glg==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-4.1.1.tgz",
+      "integrity": "sha512-m75ZkDIBwstDhID/zPtQmh9m601G/C4wnvCmlA6hgvhD7EOwR9I4DClpxPQiNTd1toKWHCr3kD2XJqU1fh0tYA==",
       "license": "MIT",
       "funding": {
         "type": "github",

--- a/sources/packages/web/package.json
+++ b/sources/packages/web/package.json
@@ -30,7 +30,7 @@
     "uuid": "^14.0.0",
     "vue": "^3.5.34",
     "vue-router": "^5.0.7",
-    "vuetify": "^4.1.0",
+    "vuetify": "^4.1.1",
     "vuex": "^4.1.0"
   },
   "devDependencies": {

--- a/sources/packages/web/src/assets/css/base.scss
+++ b/sources/packages/web/src/assets/css/base.scss
@@ -132,10 +132,6 @@ strong {
   font-size: $font-header-xlarge;
 }
 
-.header-button {
-  bottom: 12px;
-}
-
 .label-bold {
   font-size: $font-size-content !important;
   line-height: $line-height-header-sm !important;

--- a/sources/packages/web/src/assets/css/formio-shared.scss
+++ b/sources/packages/web/src/assets/css/formio-shared.scss
@@ -802,6 +802,7 @@ td .formio-custom-tooltip:hover .tooltip-text {
   border-radius: 5px;
   border: 1px solid $application-changed-value-color;
   padding: 4px;
+  margin-top: 10px;
 }
 
 .changed-value-content-base {
@@ -877,8 +878,6 @@ td .formio-custom-tooltip:hover .tooltip-text {
 
 // Global override to thin Bootstrap's table-bordered borders within form.io forms.
 .ff-form-container .formio-component-datagrid .datagrid-table {
-  width: 100%;
-  max-width: 100%;
   border-spacing: 0;
   border: 0px !important;
   padding: 0 !important;

--- a/sources/packages/web/src/assets/css/formio-shared.scss
+++ b/sources/packages/web/src/assets/css/formio-shared.scss
@@ -215,6 +215,7 @@
 }
 
 .formio-component .col-form-label {
+  display: block;
   font-weight: $font-weight-bold;
 }
 
@@ -876,12 +877,24 @@ td .formio-custom-tooltip:hover .tooltip-text {
 
 // Global override to thin Bootstrap's table-bordered borders within form.io forms.
 .ff-form-container .formio-component-datagrid .datagrid-table {
+  width: 100%;
+  max-width: 100%;
   border-spacing: 0;
   border: 0px !important;
   padding: 0 !important;
+
+  // Datagrid rows can include Bootstrap .row with negative side margins.
+  // Resetting margins here prevents horizontal overflow inside table cells.
+  .row {
+    margin-left: 0;
+    margin-right: 0;
+  }
+
   td,
   th {
     border: 1px solid #ddd !important;
+    overflow-wrap: anywhere;
+    word-break: break-word;
   }
 }
 
@@ -923,4 +936,19 @@ td .formio-custom-tooltip:hover .tooltip-text {
   margin: 0;
   padding: 0;
   min-width: 0;
+}
+
+.formio-component h1,
+.formio-component h2,
+.formio-component h3,
+.formio-component h4,
+.formio-component h5,
+.formio-component h6 {
+  margin-top: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.formio-component p {
+  margin-top: 0.25rem;
+  margin-bottom: 0.25rem;
 }

--- a/sources/packages/web/src/components/aest/CASManualIntervention.vue
+++ b/sources/packages/web/src/components/aest/CASManualIntervention.vue
@@ -1,12 +1,10 @@
 <template>
-  <body-header-container :enable-card-view="true">
-    <template #header>
-      <body-header
-        title="Manual Intervention Invoices"
-        sub-title="Please see below the list of manual intervention invoices."
-        :records-count="paginatedInvoices.count"
-      />
-    </template>
+  <body-header-container
+    :enable-card-view="true"
+    title="Manual Intervention Invoices"
+    sub-title="Please see below the list of manual intervention invoices."
+    :records-count="paginatedInvoices.count"
+  >
     <content-group>
       <toggle-content :toggled="!paginatedInvoices.count && !invoiceLoading">
         <v-data-table-server

--- a/sources/packages/web/src/components/aest/institution/modals/ApproveDenyDesignationModal.vue
+++ b/sources/packages/web/src/components/aest/institution/modals/ApproveDenyDesignationModal.vue
@@ -73,6 +73,7 @@
           v-model="formModel.note"
           variant="outlined"
           :rules="[checkNotesLengthRule]"
+          hide-details="auto"
         />
       </template>
       <template #footer>

--- a/sources/packages/web/src/components/aest/institution/modals/ApproveProgramModal.vue
+++ b/sources/packages/web/src/components/aest/institution/modals/ApproveProgramModal.vue
@@ -1,6 +1,6 @@
 <template>
   <v-form ref="approveProgramForm">
-    <modal-dialog-base title="Approve program" :showDialog="showDialog">
+    <modal-dialog-base title="Approve program" :show-dialog="showDialog">
       <template #content>
         <error-summary :errors="approveProgramForm.errors" />
         <div class="pb-2">
@@ -24,6 +24,7 @@
           v-model="formModel.approvedNote"
           variant="outlined"
           :rules="[checkNotesLengthRule]"
+          hide-details="auto"
         />
       </template>
       <template #footer>
@@ -31,10 +32,10 @@
           <template #="{ notAllowed }">
             <footer-buttons
               :processing="processing"
-              primaryLabel="Approve now"
-              @primaryClick="submit"
-              @secondaryClick="cancel"
-              :disablePrimaryButton="notAllowed"
+              primary-label="Approve now"
+              @primary-click="submit"
+              @secondary-click="cancel"
+              :disable-primary-button="notAllowed"
             />
           </template>
         </check-permission-role>

--- a/sources/packages/web/src/components/aest/institution/modals/AssessOfferingModal.vue
+++ b/sources/packages/web/src/components/aest/institution/modals/AssessOfferingModal.vue
@@ -1,6 +1,6 @@
 <template>
   <v-form ref="assessOfferingForm">
-    <modal-dialog-base :showDialog="showDialog" :title="title">
+    <modal-dialog-base :show-dialog="showDialog" :title="title">
       <template #content>
         <error-summary :errors="assessOfferingForm.errors" />
         <div class="pb-2">
@@ -12,6 +12,7 @@
           v-model="formModel.assessmentNotes"
           variant="outlined"
           :rules="[checkNotesLengthRule]"
+          hide-details="auto"
         />
       </template>
       <template #footer>
@@ -19,10 +20,10 @@
           <template #="{ notAllowed }">
             <footer-buttons
               :processing="processing"
-              :primaryLabel="primaryLabel"
-              @primaryClick="submit"
-              @secondaryClick="cancel"
-              :disablePrimaryButton="notAllowed"
+              :primary-label="primaryLabel"
+              @primary-click="submit"
+              @secondary-click="cancel"
+              :disable-primary-button="notAllowed"
           /></template>
         </check-permission-role>
       </template>

--- a/sources/packages/web/src/components/aest/institution/modals/DeclineProgramModal.vue
+++ b/sources/packages/web/src/components/aest/institution/modals/DeclineProgramModal.vue
@@ -1,6 +1,6 @@
 <template>
   <v-form ref="declineProgramForm">
-    <modal-dialog-base title="Decline program" :showDialog="showDialog">
+    <modal-dialog-base title="Decline program" :show-dialog="showDialog">
       <template #content>
         <error-summary :errors="declineProgramForm.errors" />
         <div class="pb-2">
@@ -15,16 +15,17 @@
           v-model="formModel.declinedNote"
           variant="outlined"
           :rules="[checkNotesLengthRule]"
+          hide-details="auto"
       /></template>
       <template #footer>
         <check-permission-role :role="Role.InstitutionApproveDeclineProgram">
           <template #="{ notAllowed }">
             <footer-buttons
               :processing="processing"
-              primaryLabel="Decline now"
-              @primaryClick="submit"
-              @secondaryClick="cancel"
-              :disablePrimaryButton="notAllowed"
+              primary-label="Decline now"
+              @primary-click="submit"
+              @secondary-click="cancel"
+              :disable-primary-button="notAllowed"
             />
           </template>
         </check-permission-role>

--- a/sources/packages/web/src/components/aest/students/FormSubmissionPendingAppealsTable.vue
+++ b/sources/packages/web/src/components/aest/students/FormSubmissionPendingAppealsTable.vue
@@ -1,63 +1,68 @@
 <template>
-  <body-header
+  <body-header-container
     title="Pending appeals"
     :records-count="applicationAppeals.count"
     sub-title="Appeals that require ministry review."
-  />
-  <search-table
-    v-model="searchCriteria"
-    search-label="Search name or application number"
-    :loading="isLoading"
-    @search="searchAppeals"
   >
-    <template #append-search>
-      <v-btn-toggle
-        v-model="selectedFilter"
-        color="primary"
-        density="compact"
-        class="btn-toggle"
-        selected-class="selected-btn-toggle"
-        @update:model-value="onFilterChange"
-      >
-        <v-btn value="all" rounded="xl" color="primary" class="mr-2">All</v-btn>
-        <v-btn :value="true" rounded="xl" color="primary" class="mr-2"
-          >Application</v-btn
+    <search-table
+      v-model="searchCriteria"
+      search-label="Search name or application number"
+      :loading="isLoading"
+      @search="searchAppeals"
+    >
+      <template #append-search>
+        <v-btn-toggle
+          v-model="selectedFilter"
+          color="primary"
+          density="compact"
+          class="btn-toggle"
+          selected-class="selected-btn-toggle"
+          @update:model-value="onFilterChange"
         >
-        <v-btn :value="false" rounded="xl" color="primary">Other</v-btn>
-      </v-btn-toggle>
-    </template>
-    <toggle-content :toggled="!applicationAppeals.count && !isLoading">
-      <v-data-table-server
-        :headers="PendingAppealsTableHeaders"
-        :items="applicationAppeals.results"
-        :items-length="applicationAppeals.count"
-        :loading="isLoading"
-        :items-per-page="DEFAULT_PAGE_LIMIT"
-        :items-per-page-options="ITEMS_PER_PAGE"
-        @update:options="pageSortEvent"
-        :mobile="isMobile"
-      >
-        <template #loading>
-          <v-skeleton-loader type="table-row@5"></v-skeleton-loader>
-        </template>
-        <template #[`item.submittedDate`]="{ item }">
-          {{ dateOnlyLongString(item.submittedDate) }}
-        </template>
-        <template #[`item.firstName`]="{ item }">
-          {{ emptyStringFiller(item.firstName) }}
-        </template>
-        <template #[`item.applicationNumber`]="{ item }">
-          {{ emptyStringFiller(item.applicationNumber) }}
-        </template>
-        <template #[`item.appealType`]="{ item }">
-          {{ item.applicationId ? "Application" : "Other" }}
-        </template>
-        <template #[`item.action`]="{ item }">
-          <v-btn color="primary" @click="goToAppealsApproval(item)">View</v-btn>
-        </template>
-      </v-data-table-server>
-    </toggle-content>
-  </search-table>
+          <v-btn value="all" rounded="xl" color="primary" class="mr-2"
+            >All</v-btn
+          >
+          <v-btn :value="true" rounded="xl" color="primary" class="mr-2"
+            >Application</v-btn
+          >
+          <v-btn :value="false" rounded="xl" color="primary">Other</v-btn>
+        </v-btn-toggle>
+      </template>
+      <toggle-content :toggled="!applicationAppeals.count && !isLoading">
+        <v-data-table-server
+          :headers="PendingAppealsTableHeaders"
+          :items="applicationAppeals.results"
+          :items-length="applicationAppeals.count"
+          :loading="isLoading"
+          :items-per-page="DEFAULT_PAGE_LIMIT"
+          :items-per-page-options="ITEMS_PER_PAGE"
+          @update:options="pageSortEvent"
+          :mobile="isMobile"
+        >
+          <template #loading>
+            <v-skeleton-loader type="table-row@5"></v-skeleton-loader>
+          </template>
+          <template #[`item.submittedDate`]="{ item }">
+            {{ dateOnlyLongString(item.submittedDate) }}
+          </template>
+          <template #[`item.firstName`]="{ item }">
+            {{ emptyStringFiller(item.firstName) }}
+          </template>
+          <template #[`item.applicationNumber`]="{ item }">
+            {{ emptyStringFiller(item.applicationNumber) }}
+          </template>
+          <template #[`item.appealType`]="{ item }">
+            {{ item.applicationId ? "Application" : "Other" }}
+          </template>
+          <template #[`item.action`]="{ item }">
+            <v-btn color="primary" @click="goToAppealsApproval(item)"
+              >View</v-btn
+            >
+          </template>
+        </v-data-table-server>
+      </toggle-content>
+    </search-table>
+  </body-header-container>
 </template>
 
 <script setup lang="ts">

--- a/sources/packages/web/src/components/aest/students/FormSubmissionPendingFormsTable.vue
+++ b/sources/packages/web/src/components/aest/students/FormSubmissionPendingFormsTable.vue
@@ -1,46 +1,49 @@
 <template>
-  <body-header
+  <body-header-container
     title="Pending forms"
     :records-count="pendingForms.count"
     sub-title="Forms that require ministry review."
-  />
-  <search-table
-    v-model="searchCriteria"
-    search-label="Search name"
-    :loading="isLoading"
-    @search="searchForms"
   >
-    <toggle-content :toggled="!pendingForms.count && !isLoading">
-      <v-data-table-server
-        :headers="PendingFormsTableHeaders"
-        :items="pendingForms.results"
-        :items-length="pendingForms.count"
-        :loading="isLoading"
-        :items-per-page="DEFAULT_PAGE_LIMIT"
-        :items-per-page-options="ITEMS_PER_PAGE"
-        @update:options="pageSortEvent"
-        :mobile="isMobile"
-      >
-        <template #loading>
-          <v-skeleton-loader type="table-row@5"></v-skeleton-loader>
-        </template>
-        <template #[`item.submittedDate`]="{ item }">
-          {{ dateOnlyLongString(item.submittedDate) }}
-        </template>
-        <template #[`item.firstName`]="{ item }">
-          {{ emptyStringFiller(item.firstName) }}
-        </template>
-        <template #[`item.formNames`]="{ item }">
-          <div v-for="formName in item.formNames" :key="formName">
-            {{ formName }}
-          </div>
-        </template>
-        <template #[`item.action`]="{ item }">
-          <v-btn color="primary" @click="goToFormSubmission(item)">View</v-btn>
-        </template>
-      </v-data-table-server>
-    </toggle-content>
-  </search-table>
+    <search-table
+      v-model="searchCriteria"
+      search-label="Search name"
+      :loading="isLoading"
+      @search="searchForms"
+    >
+      <toggle-content :toggled="!pendingForms.count && !isLoading">
+        <v-data-table-server
+          :headers="PendingFormsTableHeaders"
+          :items="pendingForms.results"
+          :items-length="pendingForms.count"
+          :loading="isLoading"
+          :items-per-page="DEFAULT_PAGE_LIMIT"
+          :items-per-page-options="ITEMS_PER_PAGE"
+          @update:options="pageSortEvent"
+          :mobile="isMobile"
+        >
+          <template #loading>
+            <v-skeleton-loader type="table-row@5"></v-skeleton-loader>
+          </template>
+          <template #[`item.submittedDate`]="{ item }">
+            {{ dateOnlyLongString(item.submittedDate) }}
+          </template>
+          <template #[`item.firstName`]="{ item }">
+            {{ emptyStringFiller(item.firstName) }}
+          </template>
+          <template #[`item.formNames`]="{ item }">
+            <div v-for="formName in item.formNames" :key="formName">
+              {{ formName }}
+            </div>
+          </template>
+          <template #[`item.action`]="{ item }">
+            <v-btn color="primary" @click="goToFormSubmission(item)"
+              >View</v-btn
+            >
+          </template>
+        </v-data-table-server>
+      </toggle-content>
+    </search-table>
+  </body-header-container>
 </template>
 
 <script setup lang="ts">
@@ -64,6 +67,7 @@ import {
 } from "@/services/http/dto";
 import { FormSubmissionService } from "@/services/FormSubmissionService";
 import { useDisplay } from "vuetify";
+import BodyHeaderContainer from "@/components/layouts/BodyHeaderContainer.vue";
 
 const { mobile: isMobile } = useDisplay();
 

--- a/sources/packages/web/src/components/aest/students/LegacyPendingAppealsTable.vue
+++ b/sources/packages/web/src/components/aest/students/LegacyPendingAppealsTable.vue
@@ -1,51 +1,57 @@
 <template>
-  <body-header
-    :title="pageTitle"
-    :records-count="applicationAppeals.count"
-    :sub-title="pageDescription"
-  >
-    <template #actions>
-      <v-text-field
-        density="compact"
-        label="Search name or application number"
-        variant="outlined"
-        v-model="searchCriteria"
-        @keyup.enter="searchAppeals"
-        prepend-inner-icon="mdi-magnify"
-        hide-details="auto"
+  <body-header-container>
+    <template #header>
+      <body-header
+        :title="pageTitle"
+        :records-count="applicationAppeals.count"
+        :sub-title="pageDescription"
       >
-      </v-text-field>
+        <template #actions>
+          <v-text-field
+            density="compact"
+            label="Search name or application number"
+            variant="outlined"
+            v-model="searchCriteria"
+            @keyup.enter="searchAppeals"
+            prepend-inner-icon="mdi-magnify"
+            hide-details="auto"
+          >
+          </v-text-field>
+        </template>
+      </body-header>
     </template>
-  </body-header>
-  <content-group>
-    <toggle-content :toggled="!applicationAppeals.count && !isLoading">
-      <v-data-table-server
-        :headers="PendingChangeRequestsTableHeaders"
-        :items="applicationAppeals.results"
-        :items-length="applicationAppeals.count"
-        :loading="isLoading"
-        :items-per-page="DEFAULT_PAGE_LIMIT"
-        :items-per-page-options="ITEMS_PER_PAGE"
-        @update:options="pageSortEvent"
-      >
-        <template #loading>
-          <v-skeleton-loader type="table-row@5"></v-skeleton-loader>
-        </template>
-        <template #[`item.submittedDate`]="{ item }">
-          {{ dateOnlyLongString(item.submittedDate) }}
-        </template>
-        <template #[`item.firstName`]="{ item }">
-          {{ emptyStringFiller(item.firstName) }}
-        </template>
-        <template #[`item.applicationNumber`]="{ item }">
-          {{ emptyStringFiller(item.applicationNumber) }}
-        </template>
-        <template #[`item.action`]="{ item }">
-          <v-btn color="primary" @click="goToAppealsApproval(item)">View</v-btn>
-        </template>
-      </v-data-table-server>
-    </toggle-content>
-  </content-group>
+    <content-group>
+      <toggle-content :toggled="!applicationAppeals.count && !isLoading">
+        <v-data-table-server
+          :headers="PendingChangeRequestsTableHeaders"
+          :items="applicationAppeals.results"
+          :items-length="applicationAppeals.count"
+          :loading="isLoading"
+          :items-per-page="DEFAULT_PAGE_LIMIT"
+          :items-per-page-options="ITEMS_PER_PAGE"
+          @update:options="pageSortEvent"
+        >
+          <template #loading>
+            <v-skeleton-loader type="table-row@5"></v-skeleton-loader>
+          </template>
+          <template #[`item.submittedDate`]="{ item }">
+            {{ dateOnlyLongString(item.submittedDate) }}
+          </template>
+          <template #[`item.firstName`]="{ item }">
+            {{ emptyStringFiller(item.firstName) }}
+          </template>
+          <template #[`item.applicationNumber`]="{ item }">
+            {{ emptyStringFiller(item.applicationNumber) }}
+          </template>
+          <template #[`item.action`]="{ item }">
+            <v-btn color="primary" @click="goToAppealsApproval(item)"
+              >View</v-btn
+            >
+          </template>
+        </v-data-table-server>
+      </toggle-content>
+    </content-group>
+  </body-header-container>
 </template>
 
 <script setup lang="ts">

--- a/sources/packages/web/src/components/aest/students/StudentLoanBalancePartTime.vue
+++ b/sources/packages/web/src/components/aest/students/StudentLoanBalancePartTime.vue
@@ -1,13 +1,11 @@
 <template>
-  <body-header-container :enable-card-view="true">
-    <template #header>
-      <body-header
-        title="Part-Time monthly loan balance"
-        sub-title="Balance of part-time Canada Student Loan outstanding between the student and NSLSC at any given time.
+  <body-header-container
+    :enable-card-view="true"
+    title="Part-Time monthly loan balance"
+    sub-title="Balance of part-time Canada Student Loan outstanding between the student and NSLSC at any given time.
         This amount is updated once per month, and affects a student's eligibility for future funding, as a student 
         cannot exceed the maximum limit in total outstanding balance."
-      />
-    </template>
+  >
     <content-group>
       <toggle-content
         :toggled="!studentLoanBalanceDetails.length"

--- a/sources/packages/web/src/components/aest/students/assessment/ManualReassessment.vue
+++ b/sources/packages/web/src/components/aest/students/assessment/ManualReassessment.vue
@@ -1,11 +1,9 @@
 <template>
-  <body-header-container :enable-card-view="true">
-    <template #header>
-      <body-header
-        title="Trigger Reassessment Manually"
-        sub-title="Manual system trigger to re-perform assessment using existing application inputs. This should be used as a means of triggering the assessment or other downstream actions (COE requests, eCert requests) without requiring the student to edit and resubmit their application."
-      />
-    </template>
+  <body-header-container
+    :enable-card-view="true"
+    title="Trigger Reassessment Manually"
+    sub-title="Manual system trigger to re-perform assessment using existing application inputs. This should be used as a means of triggering the assessment or other downstream actions (COE requests, eCert requests) without requiring the student to edit and resubmit their application."
+  >
     <content-group>
       <check-permission-role :role="Role.AESTManualTriggerReassessment">
         <template #="{ notAllowed }">

--- a/sources/packages/web/src/components/aest/students/modals/TriggerReassessmentModal.vue
+++ b/sources/packages/web/src/components/aest/students/modals/TriggerReassessmentModal.vue
@@ -1,8 +1,8 @@
 <template>
   <v-form ref="reassessmentForm">
-    <modal-dialog-base :showDialog="showDialog" title="Trigger Reassessment">
+    <modal-dialog-base :show-dialog="showDialog" title="Trigger Reassessment">
       <template #content>
-        <p class="pt-1 brand-gray-text">
+        <p class="brand-gray-text mt-0">
           Triggering reassessment will not change student's application inputs
           currently on file. This will rerun the student's assessment,
           potentially requiring a school to reconfirm enrolment, and potentially
@@ -21,9 +21,9 @@
       <template #footer>
         <footer-buttons
           :processing="loading"
-          primaryLabel="Trigger reassessment"
-          @secondaryClick="cancel"
-          @primaryClick="triggerReassessment"
+          primary-label="Trigger reassessment"
+          @secondary-click="cancel"
+          @primary-click="triggerReassessment"
         />
       </template>
     </modal-dialog-base>

--- a/sources/packages/web/src/components/common/InstitutionUserSummary.vue
+++ b/sources/packages/web/src/components/common/InstitutionUserSummary.vue
@@ -36,9 +36,8 @@
             </li>
           </ul>
         </template>
-
         <template #actions>
-          <v-row class="m-0 p-0">
+          <v-row density="compact">
             <v-text-field
               density="compact"
               label="Search name"

--- a/sources/packages/web/src/components/common/ManageProgramAndOfferingSummary.vue
+++ b/sources/packages/web/src/components/common/ManageProgramAndOfferingSummary.vue
@@ -1,24 +1,19 @@
 <template>
-  <v-card>
-    <v-container :fluid="true">
-      <program-details
-        :program-id="programId"
-        :location-id="locationId"
-        :education-program="educationProgram"
-        :allow-edit="allowEdit && isProgramEditable"
-        :allow-deactivate="allowDeactivate && isProgramEditable"
-        :can-create-offering="canCreateOffering"
-        @program-data-updated="$emit('programDataUpdated')"
-      />
-      <hr class="horizontal-divider" />
-      <offering-summary
-        :program-id="programId"
-        :location-id="locationId"
-        :allow-edit="allowEdit && isProgramEditable"
-        :institution-id="institutionId"
-      />
-    </v-container>
-  </v-card>
+  <program-details
+    :program-id="programId"
+    :location-id="locationId"
+    :education-program="educationProgram"
+    :allow-edit="allowEdit && isProgramEditable"
+    :allow-deactivate="allowDeactivate && isProgramEditable"
+    :can-create-offering="canCreateOffering"
+    @program-data-updated="$emit('programDataUpdated')"
+  />
+  <offering-summary
+    :program-id="programId"
+    :location-id="locationId"
+    :allow-edit="allowEdit && isProgramEditable"
+    :institution-id="institutionId"
+  />
 </template>
 
 <script lang="ts">

--- a/sources/packages/web/src/components/common/ProgramDetails.vue
+++ b/sources/packages/web/src/components/common/ProgramDetails.vue
@@ -2,7 +2,6 @@
   <body-header :title="educationProgram.name" data-cy="programName">
     <template #status-chip>
       <status-chip-program
-        class="ml-2 mb-2"
         :status="educationProgram.programStatus"
         :is-active="educationProgram.isActive && !educationProgram.isExpired"
         data-cy="programStatus"

--- a/sources/packages/web/src/components/common/ProgramDetails.vue
+++ b/sources/packages/web/src/components/common/ProgramDetails.vue
@@ -1,121 +1,130 @@
 <template>
-  <body-header :title="educationProgram.name" data-cy="programName">
-    <template #status-chip>
-      <status-chip-program
-        :status="educationProgram.programStatus"
-        :is-active="educationProgram.isActive && !educationProgram.isExpired"
-        data-cy="programStatus"
-      ></status-chip-program>
-    </template>
-    <template #actions>
-      <v-menu class="label-bold-menu">
-        <template #activator="{ props }">
+  <body-header-container>
+    <template #header>
+      <body-header :title="educationProgram.name" data-cy="programName">
+        <template #status-chip>
+          <status-chip-program
+            :status="educationProgram.programStatus"
+            :is-active="
+              educationProgram.isActive && !educationProgram.isExpired
+            "
+            data-cy="programStatus"
+          ></status-chip-program>
+        </template>
+        <template #actions>
+          <v-menu class="label-bold-menu">
+            <template #activator="{ props }">
+              <v-btn
+                color="primary"
+                v-bind="props"
+                prepend-icon="fa:fa fa-chevron-circle-down"
+                class="float-right"
+              >
+                Program actions
+              </v-btn>
+            </template>
+            <v-list
+              active-class="active-list-item"
+              density="compact"
+              bg-color="default"
+              color="primary"
+            >
+              <v-list-item @click="goToProgram" :title="programActionLabel" />
+              <v-divider-inset-opaque />
+              <check-permission-role
+                :role="Role.InstitutionDeactivateEducationProgram"
+              >
+                <template #="{ notAllowed }">
+                  <v-list-item
+                    :disabled="!allowDeactivate || notAllowed"
+                    base-color="danger"
+                    @click="deactivate"
+                    title="Deactivate"
+                  />
+                </template>
+              </check-permission-role>
+            </v-list>
+          </v-menu>
           <v-btn
+            v-if="allowEdit"
+            class="mr-4 float-right"
+            @click="goToAddNewOffering()"
             color="primary"
-            v-bind="props"
-            prepend-icon="fa:fa fa-chevron-circle-down"
-            class="float-right"
+            prepend-icon="fa:fa fa-plus-circle"
+            data-cy="addNewOfferingButton"
+            :disabled="!canCreateOffering"
           >
-            Program actions
+            Add offering
           </v-btn>
         </template>
-        <v-list
-          active-class="active-list-item"
-          density="compact"
-          bg-color="default"
-          color="primary"
-        >
-          <v-list-item @click="goToProgram" :title="programActionLabel" />
-          <v-divider-inset-opaque />
-          <check-permission-role
-            :role="Role.InstitutionDeactivateEducationProgram"
-          >
-            <template #="{ notAllowed }">
-              <v-list-item
-                :disabled="!allowDeactivate || notAllowed"
-                base-color="danger"
-                @click="deactivate"
-                title="Deactivate"
-              />
-            </template>
-          </check-permission-role>
-        </v-list>
-      </v-menu>
-      <v-btn
-        v-if="allowEdit"
-        class="mr-4 float-right"
-        @click="goToAddNewOffering()"
-        color="primary"
-        prepend-icon="fa:fa fa-plus-circle"
-        data-cy="addNewOfferingButton"
-        :disabled="!canCreateOffering"
-      >
-        Add offering
-      </v-btn>
+      </body-header>
     </template>
-  </body-header>
-  <v-row>
-    <v-col md="5">
-      <title-value
-        property-title="Description"
-        :property-value="educationProgram.description"
-        data-cy="programDescription"
-      />
-    </v-col>
-    <v-col md="4">
-      <title-value property-title="Offering" data-cy="programOffering" />
-      <p class="label-value muted-content clearfix">
-        <span
-          v-if="
-            educationProgram.programIntensity ===
-              ProgramIntensity.fullTimePartTime ||
-            educationProgram.programIntensity === ProgramIntensity.fullTime
-          "
-        >
-          {{ mapOfferingIntensity(OfferingIntensity.fullTime) }}
-        </span>
-        <br />
-        <span
-          v-if="
-            educationProgram.programIntensity ===
-            ProgramIntensity.fullTimePartTime
-          "
-        >
-          {{ mapOfferingIntensity(OfferingIntensity.partTime) }}
-        </span>
-      </p>
-    </v-col>
-    <v-col>
-      <title-value
-        property-title="Credential Type"
-        :property-value="educationProgram.credentialTypeToDisplay"
-        data-cy="programCredential"
-      />
-    </v-col>
-  </v-row>
-  <v-row>
-    <v-col md="5">
-      <title-value
-        property-title="Classification of Instructional Programs (CIP)"
-        :property-value="educationProgram.cipCode"
-        data-cy="programCIP"
-      />
-    </v-col>
-    <v-col md="4"
-      ><title-value
-        property-title="National Occupational Classification (NOC)"
-        :property-value="educationProgram.nocCode"
-        data-cy="programNOCCode"
-      />
-    </v-col>
-    <v-col
-      ><title-value
-        property-title="Institution Program Code"
-        :property-value="educationProgram.institutionProgramCode"
-        data-cy="programCode"
-      />
-    </v-col>
-  </v-row>
+    <content-group>
+      <v-row>
+        <v-col md="5">
+          <title-value
+            property-title="Description"
+            :property-value="educationProgram.description"
+            data-cy="programDescription"
+          />
+        </v-col>
+        <v-col md="4">
+          <title-value property-title="Offering" data-cy="programOffering" />
+          <p class="label-value muted-content clearfix">
+            <span
+              v-if="
+                educationProgram.programIntensity ===
+                  ProgramIntensity.fullTimePartTime ||
+                educationProgram.programIntensity === ProgramIntensity.fullTime
+              "
+            >
+              {{ mapOfferingIntensity(OfferingIntensity.fullTime) }}
+            </span>
+            <br />
+            <span
+              v-if="
+                educationProgram.programIntensity ===
+                ProgramIntensity.fullTimePartTime
+              "
+            >
+              {{ mapOfferingIntensity(OfferingIntensity.partTime) }}
+            </span>
+          </p>
+        </v-col>
+        <v-col>
+          <title-value
+            property-title="Credential Type"
+            :property-value="educationProgram.credentialTypeToDisplay"
+            data-cy="programCredential"
+          />
+        </v-col>
+      </v-row>
+      <v-row>
+        <v-col md="5">
+          <title-value
+            property-title="Classification of Instructional Programs (CIP)"
+            :property-value="educationProgram.cipCode"
+            data-cy="programCIP"
+          />
+        </v-col>
+        <v-col md="4"
+          ><title-value
+            property-title="National Occupational Classification (NOC)"
+            :property-value="educationProgram.nocCode"
+            data-cy="programNOCCode"
+          />
+        </v-col>
+        <v-col
+          ><title-value
+            property-title="Institution Program Code"
+            :property-value="educationProgram.institutionProgramCode"
+            data-cy="programCode"
+          />
+        </v-col>
+      </v-row>
+    </content-group>
+  </body-header-container>
+
   <education-program-deactivation-modal
     ref="deactivateEducationProgramModal"
     :notes-required="notesRequired"

--- a/sources/packages/web/src/components/common/ProgramOfferingDetailHeader.vue
+++ b/sources/packages/web/src/components/common/ProgramOfferingDetailHeader.vue
@@ -3,7 +3,7 @@
     <!-- Basic details -->
     <div class="row">
       <header-title-value title="Submitted" :value="submitted" />
-      <v-divider-vertical-opaque class="mx-2 my-0" />
+      <v-divider-vertical-opaque />
       <header-title-value title="Institution name"
         ><template #value
           ><span class="link-primary" @click="goToInstitutionProfile()">

--- a/sources/packages/web/src/components/common/ProgramOfferingDetailHeader.vue
+++ b/sources/packages/web/src/components/common/ProgramOfferingDetailHeader.vue
@@ -1,59 +1,51 @@
 <template>
-  <div>
-    <!-- Basic details -->
-    <div class="row">
-      <header-title-value title="Submitted" :value="submitted" />
-      <v-divider-vertical-opaque />
-      <header-title-value title="Institution name"
-        ><template #value
-          ><span class="link-primary" @click="goToInstitutionProfile()">
-            {{ headerDetails.institutionName }}
-          </span>
-        </template></header-title-value
-      >
-      <v-divider-vertical-opaque
-        v-if="headerDetails.locationName"
-        class="mx-2 my-0"
-      />
-      <header-title-value
-        v-if="headerDetails.locationName"
-        title="Location"
-        :value="headerDetails.locationName"
-      /><v-divider-vertical-opaque
-        v-if="headerDetails.parentOfferingId"
-        class="mx-2 my-0"
-      />
-      <header-title-value
-        v-if="headerDetails.parentOfferingId"
-        title="Parent offering ID"
-        :value="headerDetails.parentOfferingId"
-      />
-    </div>
-    <!-- Assessment details if assessed by ministry -->
-    <div class="row mt-1" v-if="showApprovalDetails">
-      <header-title-value
-        :title="approvalLabel.assessedByLabel"
-        :value="headerDetails.assessedBy"
-      />
-      <v-divider-vertical-opaque
-        v-if="headerDetails.assessedDate"
-        class="mx-2 my-0"
-      />
-      <header-title-value
-        :title="approvalLabel.assessedDateLabel"
-        v-if="headerDetails.assessedDate"
-        :value="dateOnlyLongString(headerDetails.assessedDate)"
-      />
-      <v-divider-vertical-opaque
-        v-if="headerDetails.effectiveEndDate"
-        class="mx-2 my-0"
-      />
-      <header-title-value
-        v-if="headerDetails.effectiveEndDate"
-        title="Effective end date"
-        :value="dateOnlyLongString(headerDetails.effectiveEndDate)"
-      />
-    </div>
+  <!-- Basic details -->
+  <div class="row">
+    <header-title-value title="Submitted" :value="submitted" />
+    <v-divider-vertical-opaque />
+    <header-title-value title="Institution name"
+      ><template #value
+        ><span class="link-primary" @click="goToInstitutionProfile()">
+          {{ headerDetails.institutionName }}
+        </span>
+      </template></header-title-value
+    >
+    <v-divider-vertical-opaque v-if="headerDetails.locationName" />
+    <header-title-value
+      v-if="headerDetails.locationName"
+      title="Location"
+      :value="headerDetails.locationName"
+    /><v-divider-vertical-opaque v-if="headerDetails.parentOfferingId" />
+    <header-title-value
+      v-if="headerDetails.parentOfferingId"
+      title="Parent offering ID"
+      :value="headerDetails.parentOfferingId"
+    />
+  </div>
+  <!-- Assessment details if assessed by ministry -->
+  <div class="row mt-1" v-if="showApprovalDetails">
+    <header-title-value
+      :title="approvalLabel.assessedByLabel"
+      :value="headerDetails.assessedBy"
+    />
+    <v-divider-vertical-opaque
+      v-if="headerDetails.assessedDate"
+      class="mx-2 my-0"
+    />
+    <header-title-value
+      :title="approvalLabel.assessedDateLabel"
+      v-if="headerDetails.assessedDate"
+      :value="dateOnlyLongString(headerDetails.assessedDate)"
+    />
+    <v-divider-vertical-opaque
+      v-if="headerDetails.effectiveEndDate"
+      class="mx-2 my-0"
+    />
+    <header-title-value
+      v-if="headerDetails.effectiveEndDate"
+      title="Effective end date"
+      :value="dateOnlyLongString(headerDetails.effectiveEndDate)"
+    />
   </div>
 </template>
 

--- a/sources/packages/web/src/components/common/Reports.vue
+++ b/sources/packages/web/src/components/common/Reports.vue
@@ -1,24 +1,27 @@
 <template>
-  <body-header title="Export reports" />
-  <formio
-    formName="exportfinancialreports"
-    @loaded="formLoaded"
-    @changed="formChanged"
-    @submitted="exportReport"
-  ></formio>
-  <v-row class="justify-center m-4">
-    <check-permission-role :role="Role.AESTReports">
-      <template #="{ notAllowed }">
-        <v-btn
-          color="primary"
-          @click="submitForm"
-          :disabled="notAllowed"
-          :loading="loading"
-          >Export CSV file</v-btn
-        >
+  <body-header-container title="Export reports">
+    <formio
+      form-name="exportfinancialreports"
+      @loaded="formLoaded"
+      @changed="formChanged"
+      @submitted="exportReport"
+    ></formio>
+    <footer-buttons :show-secondary-button="false">
+      <template #primary-buttons>
+        <check-permission-role :role="Role.AESTReports">
+          <template #="{ notAllowed }">
+            <v-btn
+              color="primary"
+              @click="submitForm"
+              :disabled="notAllowed"
+              :loading="loading"
+              >Export CSV file</v-btn
+            >
+          </template>
+        </check-permission-role>
       </template>
-    </check-permission-role>
-  </v-row>
+    </footer-buttons>
+  </body-header-container>
 </template>
 
 <script lang="ts">

--- a/sources/packages/web/src/components/common/SearchStudents.vue
+++ b/sources/packages/web/src/components/common/SearchStudents.vue
@@ -55,7 +55,7 @@
             hide-details
           />
         </v-col>
-        <v-col cols="12" lg="2">
+        <v-col cols="auto">
           <v-btn color="primary" @click="searchStudents()"> Search </v-btn>
         </v-col>
       </v-row>

--- a/sources/packages/web/src/components/common/SearchStudents.vue
+++ b/sources/packages/web/src/components/common/SearchStudents.vue
@@ -1,6 +1,6 @@
 <template>
   <v-form ref="searchStudentsForm">
-    <content-group class="mb-8">
+    <content-group class="mb-2">
       <v-row density="compact">
         <v-col cols="12" lg="2">
           <v-text-field

--- a/sources/packages/web/src/components/common/SharedLogin.vue
+++ b/sources/packages/web/src/components/common/SharedLogin.vue
@@ -7,7 +7,7 @@
             <h1 class="category-header-large primary-color">
               {{ props.title }}
             </h1>
-            <p class="my-2">
+            <p>
               <slot name="subtitle">{{ props.subtitle }}</slot>
             </p>
           </v-col>
@@ -21,7 +21,6 @@
               </h2>
               <p>{{ props.loginAreaText }}</p>
               <v-btn
-                class="mt-4"
                 color="primary"
                 @click="login"
                 prepend-icon="fa:fa fa-user"
@@ -33,21 +32,20 @@
         </v-row>
       </template>
       <template v-else>
-        <v-row no-gutters>
+        <v-row no-gutters density="compact">
           <v-col md="9">
-            <h1 class="category-header-large primary-color">
+            <h1 class="category-header-large primary-color mb-0">
               {{ props.title }}
             </h1>
             <p class="my-2">
               <slot name="subtitle">{{ props.subtitle }}</slot>
             </p>
             <content-group>
-              <h2 class="category-header-medium primary-color mb-2">
+              <h2 class="category-header-medium primary-color m-0 p-0">
                 {{ props.loginAreaTitle }}
               </h2>
               <p>{{ props.loginAreaText }}</p>
               <v-btn
-                class="mt-4"
                 color="primary"
                 @click="login"
                 prepend-icon="fa:fa fa-user"

--- a/sources/packages/web/src/components/common/StudentOverawardDetails.vue
+++ b/sources/packages/web/src/components/common/StudentOverawardDetails.vue
@@ -1,41 +1,41 @@
 <template>
-  <body-header-container :enable-card-view="true">
-    <template #header>
-      <body-header
-        title="Overaward balances"
-        sub-title="A balance of overawards broken down by award type"
-      />
-    </template>
-    <v-row>
-      <v-col>
-        <title-value
-          :property-value="
-            formatCurrency(overawardBalance.overawardBalanceValues?.CSLF)
-          "
-        >
-          <template #title>
-            {{ FullTimeAwardTypes.CSLF }}
-            <tooltip-icon>{{
-              getAwardDescription(FullTimeAwardTypes.CSLF)
-            }}</tooltip-icon></template
-          ></title-value
-        >
-      </v-col>
-      <v-col>
-        <title-value
-          :property-value="
-            formatCurrency(overawardBalance.overawardBalanceValues?.BCSL)
-          "
-        >
-          <template #title>
-            {{ FullTimeAwardTypes.BCSL }}
-            <tooltip-icon>{{
-              getAwardDescription(FullTimeAwardTypes.BCSL)
-            }}</tooltip-icon></template
+  <body-header-container
+    :enable-card-view="true"
+    title="Overaward balances"
+    sub-title="A balance of overawards broken down by award type"
+  >
+    <content-group>
+      <v-row>
+        <v-col>
+          <title-value
+            :property-value="
+              formatCurrency(overawardBalance.overawardBalanceValues?.CSLF)
+            "
           >
-        </title-value>
-      </v-col>
-    </v-row>
+            <template #title>
+              {{ FullTimeAwardTypes.CSLF }}
+              <tooltip-icon>{{
+                getAwardDescription(FullTimeAwardTypes.CSLF)
+              }}</tooltip-icon></template
+            ></title-value
+          >
+        </v-col>
+        <v-col>
+          <title-value
+            :property-value="
+              formatCurrency(overawardBalance.overawardBalanceValues?.BCSL)
+            "
+          >
+            <template #title>
+              {{ FullTimeAwardTypes.BCSL }}
+              <tooltip-icon>{{
+                getAwardDescription(FullTimeAwardTypes.BCSL)
+              }}</tooltip-icon></template
+            >
+          </title-value>
+        </v-col>
+      </v-row>
+    </content-group>
   </body-header-container>
 
   <overaward-details

--- a/sources/packages/web/src/components/common/notes/CreateNoteModal.vue
+++ b/sources/packages/web/src/components/common/notes/CreateNoteModal.vue
@@ -3,13 +3,9 @@
     <modal-dialog-base title="Create new note" :show-dialog="showDialog">
       <template #content>
         <error-summary :errors="addNewNoteForm.errors" />
-        <div class="pb-2">
-          <span class="label-value"
-            >Add a note with relevant decisions or actions taken on this
-            account.</span
-          >
-        </div>
-        <!-- TODO add placeholder for v-select when we have stable vuetify 3.-->
+        <p class="mt-0">
+          Add a note with relevant decisions or actions taken on this account.
+        </p>
         <v-select
           label="Note type"
           density="compact"
@@ -23,6 +19,7 @@
           v-model="formModel.description"
           variant="outlined"
           :rules="[checkNotesLengthRule]"
+          hide-details="auto"
       /></template>
       <template #footer>
         <check-permission-role :role="allowedRole">

--- a/sources/packages/web/src/components/common/restriction/AddRestriction.vue
+++ b/sources/packages/web/src/components/common/restriction/AddRestriction.vue
@@ -16,20 +16,23 @@
           v-model="selectedCategory"
           variant="outlined"
           @update:model-value="categoryReasonItems()"
-          :rules="[(v) => !!v || 'Category is required.']" />
+          :rules="[(v) => !!v || 'Category is required.']"
+          hide-details="auto" />
         <v-select
           label="Reason"
           density="compact"
           :items="restrictionReasons"
           v-model="formModel.restrictionId"
           variant="outlined"
-          :rules="[(v) => !!v || 'Reason is required.']" />
+          :rules="[(v) => !!v || 'Reason is required.']"
+          hide-details="auto" />
         <v-textarea
           label="Notes"
           placeholder="Long text..."
           v-model="formModel.noteDescription"
           variant="outlined"
           :rules="[checkNotesLengthRule]"
+          hide-details="auto"
       /></template>
       <template #footer>
         <check-permission-role :role="allowedRole">

--- a/sources/packages/web/src/components/common/sin/AddExpiryDate.vue
+++ b/sources/packages/web/src/components/common/sin/AddExpiryDate.vue
@@ -29,10 +29,10 @@
         <check-permission-role :role="Role.StudentAddSINExpiry">
           <template #="{ notAllowed }">
             <footer-buttons
-              primaryLabel="Add expiry date now"
-              @secondaryClick="cancel"
-              @primaryClick="submit"
-              :disablePrimaryButton="notAllowed"
+              primary-label="Add expiry date now"
+              @secondary-click="cancel"
+              @primary-click="submit"
+              :disable-primary-button="notAllowed"
             />
           </template>
         </check-permission-role>

--- a/sources/packages/web/src/components/common/students/StudentApplicationsSimplifiedSummary.vue
+++ b/sources/packages/web/src/components/common/students/StudentApplicationsSimplifiedSummary.vue
@@ -1,12 +1,9 @@
 <!-- This component is shared between ministry and institution users. -->
 <template>
-  <body-header-container>
-    <template #header>
-      <body-header
-        title="Applications"
-        :records-count="applicationsAndCount.count"
-      ></body-header>
-    </template>
+  <body-header-container
+    title="Applications"
+    :records-count="applicationsAndCount.count"
+  >
     <content-group>
       <toggle-content
         :toggled="!applicationsAndCount.count"

--- a/sources/packages/web/src/components/common/students/StudentProfile.vue
+++ b/sources/packages/web/src/components/common/students/StudentProfile.vue
@@ -18,108 +18,122 @@
         </template>
       </body-header>
     </template>
-    <h3 class="category-header-medium">Student profile</h3>
-    <content-group>
-      <v-row>
-        <v-col
-          ><title-value
-            property-title="Given names"
-            :property-value="emptyStringFiller(studentDetail.firstName)"
-          />
-        </v-col>
-        <v-col
-          ><title-value
-            property-title="Last name"
-            :property-value="studentDetail.lastName"
-          />
-        </v-col>
-        <v-col>
-          <title-value
-            property-title="Date of birth"
-            :property-value="studentDetail.birthDateFormatted"
-        /></v-col>
-      </v-row>
-      <v-row>
-        <v-col
-          ><title-value
-            property-title="Gender"
-            :property-value="genderDisplayFormat(studentDetail.gender)"
-          />
-        </v-col>
-        <v-col
-          ><title-value
-            property-title="Email"
-            :property-value="studentDetail.email"
-          />
-        </v-col>
-        <v-col>
-          <disability-status-update-tile-value
-            :student-id="studentId"
-            :allow-disability-status-update="allowUpdateActions"
-            :disability-status="studentDetail.disabilityStatus"
-            @disability-status-updated="loadStudentProfile"
-          />
-        </v-col>
-      </v-row>
-      <v-row>
-        <v-col>
-          <modified-independent-status-title-value
-            :student-id="studentId"
-            :modified-independent-status="
-              studentDetail.modifiedIndependentStatus
-            "
-            :allow-update-actions="allowUpdateActions"
-            @modified-independent-status-updated="loadStudentProfile"
-          />
-        </v-col>
-        <v-col cols="8"
-          ><title-value
-            property-title="SIN"
-            :property-value="sinDisplayFormat(studentDetail.sin)"
-        /></v-col>
-      </v-row>
-    </content-group>
-    <h3 class="category-header-medium mt-4">Contact information</h3>
-    <content-group
-      ><v-row>
-        <v-col
-          ><title-value
-            property-title="Address line 1"
-            :property-value="address.addressLine1"
-          />
-        </v-col>
-        <v-col
-          ><title-value
-            property-title="Address line 2"
-            :property-value="emptyStringFiller(address.addressLine2)"
-          />
-        </v-col>
-        <v-col>
-          <title-value property-title="City" :property-value="address.city"
-        /></v-col>
-      </v-row>
-      <v-row>
-        <v-col
-          ><title-value
-            property-title="Province"
-            :property-value="address.provinceState"
-          />
-        </v-col>
-        <v-col
-          ><title-value
-            property-title="Postal/Zip Code"
-            :property-value="address.postalCode"
-          />
-        </v-col>
-        <v-col>
-          <title-value
-            property-title="Phone number"
-            :property-value="studentDetail.contact?.phone"
-        /></v-col>
-      </v-row>
-    </content-group>
-    <template v-if="showLegacyMatch">
-      <h3 class="category-header-medium mt-4">Legacy match</h3>
+    <body-header-container
+      title="Student profile"
+      header-size="medium"
+      header-color="secondary"
+    >
+      <content-group>
+        <v-row>
+          <v-col
+            ><title-value
+              property-title="Given names"
+              :property-value="emptyStringFiller(studentDetail.firstName)"
+            />
+          </v-col>
+          <v-col
+            ><title-value
+              property-title="Last name"
+              :property-value="studentDetail.lastName"
+            />
+          </v-col>
+          <v-col>
+            <title-value
+              property-title="Date of birth"
+              :property-value="studentDetail.birthDateFormatted"
+          /></v-col>
+        </v-row>
+        <v-row>
+          <v-col
+            ><title-value
+              property-title="Gender"
+              :property-value="genderDisplayFormat(studentDetail.gender)"
+            />
+          </v-col>
+          <v-col
+            ><title-value
+              property-title="Email"
+              :property-value="studentDetail.email"
+            />
+          </v-col>
+          <v-col>
+            <disability-status-update-tile-value
+              :student-id="studentId"
+              :allow-disability-status-update="allowUpdateActions"
+              :disability-status="studentDetail.disabilityStatus"
+              @disability-status-updated="loadStudentProfile"
+            />
+          </v-col>
+        </v-row>
+        <v-row>
+          <v-col>
+            <modified-independent-status-title-value
+              :student-id="studentId"
+              :modified-independent-status="
+                studentDetail.modifiedIndependentStatus
+              "
+              :allow-update-actions="allowUpdateActions"
+              @modified-independent-status-updated="loadStudentProfile"
+            />
+          </v-col>
+          <v-col cols="8"
+            ><title-value
+              property-title="SIN"
+              :property-value="sinDisplayFormat(studentDetail.sin)"
+          /></v-col>
+        </v-row>
+      </content-group>
+    </body-header-container>
+    <body-header-container
+      title="Contact information"
+      header-size="medium"
+      header-color="secondary"
+    >
+      <content-group
+        ><v-row>
+          <v-col
+            ><title-value
+              property-title="Address line 1"
+              :property-value="address.addressLine1"
+            />
+          </v-col>
+          <v-col
+            ><title-value
+              property-title="Address line 2"
+              :property-value="emptyStringFiller(address.addressLine2)"
+            />
+          </v-col>
+          <v-col>
+            <title-value property-title="City" :property-value="address.city"
+          /></v-col>
+        </v-row>
+        <v-row>
+          <v-col
+            ><title-value
+              property-title="Province"
+              :property-value="address.provinceState"
+            />
+          </v-col>
+          <v-col
+            ><title-value
+              property-title="Postal/Zip Code"
+              :property-value="address.postalCode"
+            />
+          </v-col>
+          <v-col>
+            <title-value
+              property-title="Phone number"
+              :property-value="studentDetail.contact?.phone"
+          /></v-col>
+        </v-row>
+      </content-group>
+    </body-header-container>
+    <body-header-container
+      v-if="showLegacyMatch"
+      title="Legacy match"
+      header-size="medium"
+      header-color="secondary"
+    >
       <content-group>
         <student-profile-legacy-matches
           :student-id="studentId"
@@ -127,7 +141,7 @@
           @legacy-profile-linked="loadStudentProfile"
         />
       </content-group>
-    </template>
+    </body-header-container>
     <edit-student-profile-modal
       ref="studentEditProfile"
     ></edit-student-profile-modal>

--- a/sources/packages/web/src/components/common/students/assessment/History.vue
+++ b/sources/packages/web/src/components/common/students/assessment/History.vue
@@ -1,72 +1,66 @@
 <template>
-  <v-card>
-    <v-container>
-      <body-header
-        title="Completed changes"
-        class="m-1"
-        sub-title="Any events that resulted in a change to the students assessment."
-        :records-count="assessmentHistory.length"
+  <body-header-container
+    enable-card-view="true"
+    title="Completed changes"
+    sub-title="Any events that resulted in a change to the students assessment."
+    :records-count="assessmentHistory.length"
+  >
+    <content-group>
+      <toggle-content
+        :toggled="!assessmentHistory.length"
+        message="No assessments found."
       >
-      </body-header>
-      <content-group class="mt-4">
-        <toggle-content
-          :toggled="!assessmentHistory.length"
-          message="No assessments found."
+        <v-data-table
+          :headers="CompletedChangesHeaders"
+          :items="assessmentHistory"
+          :items-per-page="DEFAULT_PAGE_LIMIT"
+          :items-per-page-options="ITEMS_PER_PAGE"
+          :mobile="isMobile"
         >
-          <v-data-table
-            :headers="CompletedChangesHeaders"
-            :items="assessmentHistory"
-            :items-per-page="DEFAULT_PAGE_LIMIT"
-            :items-per-page-options="ITEMS_PER_PAGE"
-            :mobile="isMobile"
-          >
-            <template #[`item.submittedDate`]="{ item }">
-              {{ dateOnlyLongString(item.submittedDate) }}
-            </template>
-            <template #[`item.triggerType`]="{ item }">
-              {{ item.triggerType }}
-            </template>
-            <template #[`item.tags`]="{ item }">
-              <assessment-tags :assessment="item" />
-            </template>
-            <template #[`item.requestForm`]="{ item }">
-              <template v-if="canShowViewRequest(item)">
-                <v-btn
-                  @click="viewRequest(item)"
-                  color="primary"
-                  variant="text"
-                  class="text-decoration-underline"
-                  prepend-icon="fa:far fa-file-alt"
-                >
-                  {{ getViewRequestLabel(item) }}</v-btn
-                >
-              </template>
-            </template>
-            <template #[`item.status`]="{ item }">
-              <status-chip-assessment-history :status="item.status" />
-            </template>
-            <template #[`item.assessmentDate`]="{ item }">
-              {{
-                emptyStringFiller(
-                  getISODateHourMinuteString(item.assessmentDate),
-                )
-              }}
-            </template>
-            <template #[`item.assessment`]="{ item }">
+          <template #[`item.submittedDate`]="{ item }">
+            {{ dateOnlyLongString(item.submittedDate) }}
+          </template>
+          <template #[`item.triggerType`]="{ item }">
+            {{ item.triggerType }}
+          </template>
+          <template #[`item.tags`]="{ item }">
+            <assessment-tags :assessment="item" />
+          </template>
+          <template #[`item.requestForm`]="{ item }">
+            <template v-if="canShowViewRequest(item)">
               <v-btn
-                v-if="!item.hasUnsuccessfulWeeks"
-                :disabled="!item.assessmentDate"
-                @click="$emit('viewAssessment', item.assessmentId)"
+                @click="viewRequest(item)"
                 color="primary"
+                variant="text"
+                class="text-decoration-underline"
+                prepend-icon="fa:far fa-file-alt"
               >
-                View</v-btn
+                {{ getViewRequestLabel(item) }}</v-btn
               >
             </template>
-          </v-data-table>
-        </toggle-content>
-      </content-group>
-    </v-container>
-  </v-card>
+          </template>
+          <template #[`item.status`]="{ item }">
+            <status-chip-assessment-history :status="item.status" />
+          </template>
+          <template #[`item.assessmentDate`]="{ item }">
+            {{
+              emptyStringFiller(getISODateHourMinuteString(item.assessmentDate))
+            }}
+          </template>
+          <template #[`item.assessment`]="{ item }">
+            <v-btn
+              v-if="!item.hasUnsuccessfulWeeks"
+              :disabled="!item.assessmentDate"
+              @click="$emit('viewAssessment', item.assessmentId)"
+              color="primary"
+            >
+              View</v-btn
+            >
+          </template>
+        </v-data-table>
+      </toggle-content>
+    </content-group>
+  </body-header-container>
 </template>
 <script lang="ts">
 import {

--- a/sources/packages/web/src/components/common/students/assessment/Request.vue
+++ b/sources/packages/web/src/components/common/students/assessment/Request.vue
@@ -1,50 +1,48 @@
 <template>
-  <v-card v-if="requestedAssessments.length || showWhenEmpty">
-    <v-container>
-      <body-header
-        title="Unapproved changes"
-        sub-title="Pending or declined requests submitted by the student or institution."
-        :records-count="requestedAssessments.length"
+  <body-header-container
+    enable-card-view="true"
+    v-if="requestedAssessments.length || showWhenEmpty"
+    title="Unapproved changes"
+    sub-title="Pending or declined requests submitted by the student or institution."
+    :records-count="requestedAssessments.length"
+  >
+    <content-group>
+      <toggle-content
+        :toggled="!requestedAssessments.length"
+        message="No requests found."
       >
-      </body-header>
-      <content-group>
-        <toggle-content
-          :toggled="!requestedAssessments.length"
-          message="No requests found."
+        <v-data-table
+          :headers="UnapprovedChangesHeaders"
+          :items="requestedAssessments"
+          :items-per-page="DEFAULT_PAGE_LIMIT"
+          :items-per-page-options="ITEMS_PER_PAGE"
+          :mobile="isMobile"
         >
-          <v-data-table
-            :headers="UnapprovedChangesHeaders"
-            :items="requestedAssessments"
-            :items-per-page="DEFAULT_PAGE_LIMIT"
-            :items-per-page-options="ITEMS_PER_PAGE"
-            :mobile="isMobile"
-          >
-            <template #[`item.submittedDate`]="{ item }">
-              {{ dateOnlyLongString(item.submittedDate) }}
-            </template>
-            <template #[`item.requestType`]="{ item }">
-              {{ getRequestTypeToDisplay(item.requestType) }}
-            </template>
-            <template #[`item.requestForm`]="{ item }">
-              <v-btn
-                v-if="canShowViewRequest(item)"
-                @click="viewRequestForm(item)"
-                color="primary"
-                variant="text"
-                class="text-decoration-underline"
-                prepend-icon="fa:far fa-file-alt"
-              >
-                View request</v-btn
-              >
-            </template>
-            <template #[`item.status`]="{ item }">
-              <status-chip-requested-assessment :status="item.status" />
-            </template>
-          </v-data-table>
-        </toggle-content>
-      </content-group>
-    </v-container>
-  </v-card>
+          <template #[`item.submittedDate`]="{ item }">
+            {{ dateOnlyLongString(item.submittedDate) }}
+          </template>
+          <template #[`item.requestType`]="{ item }">
+            {{ getRequestTypeToDisplay(item.requestType) }}
+          </template>
+          <template #[`item.requestForm`]="{ item }">
+            <v-btn
+              v-if="canShowViewRequest(item)"
+              @click="viewRequestForm(item)"
+              color="primary"
+              variant="text"
+              class="text-decoration-underline"
+              prepend-icon="fa:far fa-file-alt"
+            >
+              View request</v-btn
+            >
+          </template>
+          <template #[`item.status`]="{ item }">
+            <status-chip-requested-assessment :status="item.status" />
+          </template>
+        </v-data-table>
+      </toggle-content>
+    </content-group>
+  </body-header-container>
 </template>
 <script lang="ts">
 import {

--- a/sources/packages/web/src/components/generic/BodyHeader.vue
+++ b/sources/packages/web/src/components/generic/BodyHeader.vue
@@ -8,10 +8,10 @@
           :class="headerClass"
         />
       </v-col>
-      <v-col cols="auto">
+      <v-col cols="auto" v-if="$slots['status-chip']" class="ml-2">
         <slot name="status-chip"></slot>
       </v-col>
-      <v-col>
+      <v-col v-if="$slots['actions']" class="ml-2">
         <slot name="actions"></slot>
       </v-col>
     </v-row>

--- a/sources/packages/web/src/components/generic/HeaderNavigator.vue
+++ b/sources/packages/web/src/components/generic/HeaderNavigator.vue
@@ -23,10 +23,8 @@
         <slot name="sub-title-details"></slot>
       </span>
     </v-col>
-    <v-col>
-      <div class="float-right header-button">
-        <slot name="buttons"> </slot>
-      </div>
+    <v-col class="d-flex justify-end">
+      <slot name="buttons"></slot>
     </v-col>
   </v-row>
 </template>

--- a/sources/packages/web/src/components/generic/ModalDialogBase.vue
+++ b/sources/packages/web/src/components/generic/ModalDialogBase.vue
@@ -25,7 +25,7 @@
         </slot>
       </v-card-title>
       <v-divider-inset-opaque />
-      <v-card-text class="p-4">
+      <v-card-text class="px-4">
         <div class="pb-2" v-if="subTitle">{{ subTitle }}</div>
         <slot name="content">Please add the modal content here!</slot>
       </v-card-text>

--- a/sources/packages/web/src/components/generic/ModalDialogBase.vue
+++ b/sources/packages/web/src/components/generic/ModalDialogBase.vue
@@ -16,12 +16,15 @@
     >
       <v-card-title>
         <slot name="header">
-          <h2 v-if="title" class="category-header-large primary-color mt-3">
+          <h2
+            v-if="title"
+            class="category-header-large primary-color mt-2 mb-0"
+          >
             {{ title }}
           </h2>
         </slot>
       </v-card-title>
-      <v-divider-inset-opaque class="my-1" />
+      <v-divider-inset-opaque />
       <v-card-text class="p-4">
         <div class="pb-2" v-if="subTitle">{{ subTitle }}</div>
         <slot name="content">Please add the modal content here!</slot>

--- a/sources/packages/web/src/components/generic/SearchTable.vue
+++ b/sources/packages/web/src/components/generic/SearchTable.vue
@@ -1,6 +1,6 @@
 <template>
   <content-group>
-    <v-row class="m-0 p-0 mb-2" align="center">
+    <v-row density="compact">
       <v-col md="auto" class="flex-grow-1 pa-0 pr-2 mb-1">
         <!--
           Custom search input slot. When provided, it replaces the default
@@ -18,12 +18,12 @@
           />
         </slot>
       </v-col>
-      <v-col cols="auto" class="pa-0 pr-2 mb-1">
+      <v-col cols="auto">
         <v-btn color="primary" :loading="loading" @click="$emit('search')"
           >Search</v-btn
         >
       </v-col>
-      <v-col cols="auto" class="pa-0 mb-1">
+      <v-col cols="auto">
         <!--
           On medium and larger screens the append-search slot content is shown
           inline. On smaller screens it collapses into a dropdown menu to avoid

--- a/sources/packages/web/src/components/institutions/modals/AddInstitutionUserModal.vue
+++ b/sources/packages/web/src/components/institutions/modals/AddInstitutionUserModal.vue
@@ -1,7 +1,7 @@
 <template>
   <v-form ref="addUserForm">
     <modal-dialog-base
-      :showDialog="showDialog"
+      :show-dialog="showDialog"
       data-cy="addNewUserModal"
       title="Add new user"
     >
@@ -9,7 +9,7 @@
         <institution-user-management
           ref="institutionUserManagement"
           :errors="addUserForm.errors"
-          :initialData="initialData"
+          :initial-data="initialData"
         >
           <template #user-name="{ formModel }">
             <!-- Business BCeID  -->
@@ -18,7 +18,6 @@
               v-if="hasBusinessGuid && canSearchBCeIDUsers"
               v-model="formModel.selectedBCeIDUser"
               :items="bceidUsers"
-              class="mr-3 bceid-input"
               density="compact"
               variant="outlined"
               label="Business BCeID user Id"
@@ -30,7 +29,6 @@
               hide-details="auto"
               v-else
               v-model.trim="formModel.selectedBCeIDUser"
-              class="mr-3 bceid-input"
               density="compact"
               variant="outlined"
               :label="userNameLabel"
@@ -44,11 +42,11 @@
           <template #="{ notAllowed }">
             <footer-buttons
               :processing="processing"
-              primaryLabel="Add user now"
+              primary-label="Add user now"
               data-cy="addNewUserModal"
-              @primaryClick="submit"
-              @secondaryClick="cancel"
-              :disablePrimaryButton="notAllowed"
+              @primary-click="submit"
+              @secondary-click="cancel"
+              :disable-primary-button="notAllowed"
             />
           </template>
         </check-permission-role>
@@ -216,9 +214,3 @@ export default defineComponent({
   },
 });
 </script>
-<style scoped>
-.bceid-input {
-  /* Temporary fix for v-text-field/v-autocomplete. To be review in upcoming vuetify versions. */
-  width: 300px;
-}
-</style>

--- a/sources/packages/web/src/components/institutions/modals/InstitutionUserManagement.vue
+++ b/sources/packages/web/src/components/institutions/modals/InstitutionUserManagement.vue
@@ -1,33 +1,33 @@
 <!-- Shared modal content for modals AddInstitutionUserModal and EditInstitutionUserModal -->
 <template>
   <error-summary :errors="errors" />
-  <content-group>
+  <content-group class="mb-3">
     <v-row no-gutters>
       <v-row align="center" no-gutters>
-        <v-col cols="auto">
+        <v-col cols="12">
           <!-- This slot holds the BCeID basic(plain text)/business(dropdown) and readonly views(plain readonly text input). -->
-          <slot name="user-name" :formModel="formModel" />
+          <slot name="user-name" :form-model="formModel" />
         </v-col>
-        <v-col cols="auto">
+        <v-col cols="6">
           <v-switch
+            size="small"
             hide-details
             label="Admin"
             color="primary"
             inset
             class="mr-3"
             v-model="formModel.isAdmin"
-            data-cy="isAdmin"
           ></v-switch>
         </v-col>
-        <v-col cols="auto">
+        <v-col cols="6">
           <v-switch
+            size="small"
             hide-details
             :disabled="!formModel.isAdmin"
             label="Legal Signing Authority"
             inset
             color="primary"
             v-model="formModel.isLegalSigningAuthority"
-            data-cy="isLegalSigningAuthority"
           ></v-switch>
         </v-col>
       </v-row>
@@ -38,57 +38,56 @@
     >
     </v-input>
   </content-group>
-  <h3
-    class="category-header-medium primary-color mt-4 mb-2"
+  <body-header-container
+    title="Assign user to locations"
+    header-size="medium"
     v-if="!formModel.isAdmin"
-    data-cy="assignLocationToUser"
   >
-    Assign user to locations
-  </h3>
-  <content-group v-if="!formModel.isAdmin">
-    <toggle-content :toggled="!formModel.locationAuthorizations.length">
-      <v-row class="mb-1"
-        ><v-col><strong>Locations</strong> </v-col
-        ><v-col>
-          <strong>Roles</strong>
-        </v-col>
-      </v-row>
-      <v-row
-        no-gutters
-        v-for="location in formModel.locationAuthorizations"
-        :key="location.id"
-        class="mb-2"
-        data-cy="location"
-        ><v-col>
-          <div>{{ location.name }}</div>
-          {{ location.address }}
-        </v-col>
-        <v-col>
-          <v-radio-group
-            hide-details
-            inline
-            v-model="location.userAccess"
-            color="primary"
-            class="mt-2"
-            data-cy="userAccess"
-          >
-            <v-radio label="User" value="user" color="primary"></v-radio>
-            <v-radio
-              label="Read-only"
-              value="read-only-user"
+    <content-group>
+      <toggle-content :toggled="!formModel.locationAuthorizations.length">
+        <v-row class="mb-1"
+          ><v-col><strong>Locations</strong> </v-col
+          ><v-col>
+            <strong>Roles</strong>
+          </v-col>
+        </v-row>
+        <v-row
+          no-gutters
+          v-for="location in formModel.locationAuthorizations"
+          :key="location.id"
+          class="mb-2"
+          data-cy="location"
+          ><v-col>
+            <div>{{ location.name }}</div>
+            {{ location.address }}
+          </v-col>
+          <v-col>
+            <v-radio-group
+              hide-details
+              inline
+              v-model="location.userAccess"
               color="primary"
-            ></v-radio>
-            <v-radio label="No access" value="none" color="primary"></v-radio>
-          </v-radio-group>
-        </v-col>
-      </v-row>
-      <v-input
-        :rules="[hasLocationAuthorizationValidationRule()]"
-        hide-details="auto"
-      >
-      </v-input>
-    </toggle-content>
-  </content-group>
+              class="mt-2"
+              data-cy="userAccess"
+            >
+              <v-radio label="User" value="user" color="primary"></v-radio>
+              <v-radio
+                label="Read-only"
+                value="read-only-user"
+                color="primary"
+              ></v-radio>
+              <v-radio label="No access" value="none" color="primary"></v-radio>
+            </v-radio-group>
+          </v-col>
+        </v-row>
+        <v-input
+          :rules="[hasLocationAuthorizationValidationRule()]"
+          hide-details="auto"
+        >
+        </v-input>
+      </toggle-content>
+    </content-group>
+  </body-header-container>
 </template>
 
 <script lang="ts">

--- a/sources/packages/web/src/components/layouts/BodyHeaderContainer.vue
+++ b/sources/packages/web/src/components/layouts/BodyHeaderContainer.vue
@@ -2,7 +2,7 @@
   <div class="mb-3">
     <v-card v-if="props.enableCardView">
       <v-container :fluid="true">
-        <slot name="header"></slot>
+        <slot name="header"><body-header v-bind="headerProps" /></slot>
         <div class="mt-2">
           <slot></slot>
         </div>
@@ -28,6 +28,7 @@ interface Props {
   hideSubTitle?: boolean;
   headerSize?: "large" | "medium" | "small" | "x-small";
   headerColor?: "primary" | "secondary" | "secondary-light";
+  recordsCount?: number;
 }
 
 const props = withDefaults(defineProps<Props>(), {
@@ -38,6 +39,7 @@ const props = withDefaults(defineProps<Props>(), {
   hideSubTitle: false,
   headerSize: "large",
   headerColor: "primary",
+  recordsCount: undefined,
 });
 
 const headerProps = computed(() => {
@@ -47,6 +49,7 @@ const headerProps = computed(() => {
     titleHeaderLevel: props.titleHeaderLevel,
     headerSize: props.headerSize,
     headerColor: props.headerColor,
+    recordsCount: props.recordsCount,
   };
 });
 </script>

--- a/sources/packages/web/src/components/layouts/FullPageContainer.vue
+++ b/sources/packages/web/src/components/layouts/FullPageContainer.vue
@@ -4,7 +4,7 @@
       <slot name="header"></slot>
       <slot name="sub-header"></slot>
     </header>
-    <div class="ml-5 mb-2">
+    <div class="mb-2">
       <slot name="details-header"></slot>
     </div>
     <slot name="alerts"></slot>

--- a/sources/packages/web/src/components/students/StudentApplicationsExtendedSummary.vue
+++ b/sources/packages/web/src/components/students/StudentApplicationsExtendedSummary.vue
@@ -1,12 +1,9 @@
 <!-- This component is student specific. -->
 <template>
-  <body-header-container>
-    <template #header>
-      <body-header
-        title="Applications"
-        :records-count="applicationsAndCount.count"
-      ></body-header>
-    </template>
+  <body-header-container
+    title="Applications"
+    :records-count="applicationsAndCount.count"
+  >
     <content-group>
       <toggle-content
         :toggled="!applicationsAndCount.count"
@@ -232,7 +229,8 @@ export default defineComponent({
           StudentAppealService.shared.getEligibleApplicationsForAppeal(),
         ]);
         applicationsAndCount.value = applicationsResult;
-        eligibleApplicationsForAppeal.value = eligibleAppealsResult.applications;
+        eligibleApplicationsForAppeal.value =
+          eligibleAppealsResult.applications;
       } finally {
         loading.value = false;
       }

--- a/sources/packages/web/src/views/aest/SearchInstitutions.vue
+++ b/sources/packages/web/src/views/aest/SearchInstitutions.vue
@@ -1,98 +1,97 @@
 <template>
   <full-page-container>
-    <body-header
+    <body-header-container
       title="Search Institution"
       sub-title="Look up an institution by entering their information below."
-    >
-    </body-header>
-    <v-form ref="searchInstitutionsForm">
-      <content-group class="mb-8">
-        <v-row>
-          <v-col cols="12" md>
-            <v-text-field
-              density="compact"
-              label="Legal name"
-              variant="outlined"
-              v-model="legalName"
-              data-cy="legalName"
-              @keyup.enter="searchInstitutions"
-              hide-details
-            />
-          </v-col>
-          <v-col cols="12" md>
-            <v-text-field
-              density="compact"
-              label="Operating name"
-              variant="outlined"
-              v-model="operatingName"
-              data-cy="operatingName"
-              @keyup.enter="searchInstitutions"
-              hide-details
-            />
-          </v-col>
-          <v-col cols="12" md>
-            <v-text-field
-              density="compact"
-              label="Institution location code"
-              variant="outlined"
-              :maxlength="4"
-              :model-value="locationCode"
-              @update:model-value="locationCode = $event?.toUpperCase() ?? ''"
-              @keyup.enter="searchInstitutions"
-              hide-details
-            />
-          </v-col>
-          <v-col cols="12" md="auto" class="d-flex justify-end">
-            <v-btn
-              color="primary"
-              data-cy="searchInstitutions"
-              @click="searchInstitutions"
-            >
-              Search
-            </v-btn>
-          </v-col>
-        </v-row>
-        <v-input :rules="[isValidSearch()]" hide-details="auto" error />
+      ><content-group>
+        <v-form ref="searchInstitutionsForm">
+          <v-row>
+            <v-col cols="12" md>
+              <v-text-field
+                density="compact"
+                label="Legal name"
+                variant="outlined"
+                v-model="legalName"
+                data-cy="legalName"
+                @keyup.enter="searchInstitutions"
+                hide-details
+              />
+            </v-col>
+            <v-col cols="12" md>
+              <v-text-field
+                density="compact"
+                label="Operating name"
+                variant="outlined"
+                v-model="operatingName"
+                data-cy="operatingName"
+                @keyup.enter="searchInstitutions"
+                hide-details
+              />
+            </v-col>
+            <v-col cols="12" md>
+              <v-text-field
+                density="compact"
+                label="Institution location code"
+                variant="outlined"
+                :maxlength="4"
+                :model-value="locationCode"
+                @update:model-value="locationCode = $event?.toUpperCase() ?? ''"
+                @keyup.enter="searchInstitutions"
+                hide-details
+              />
+            </v-col>
+            <v-col cols="12" md="auto" class="d-flex justify-end">
+              <v-btn
+                color="primary"
+                data-cy="searchInstitutions"
+                @click="searchInstitutions"
+              >
+                Search
+              </v-btn>
+            </v-col>
+          </v-row>
+          <v-input :rules="[isValidSearch()]" hide-details="auto" error />
+        </v-form>
       </content-group>
-    </v-form>
-    <template v-if="institutionsFound">
-      <body-header title="Results" />
-      <content-group>
-        <v-data-table
-          v-if="institutionsFound"
-          :headers="SearchInstitutionsHeaders"
-          :items="institutions"
-          :items-per-page="DEFAULT_PAGE_LIMIT"
-          :items-per-page-options="ITEMS_PER_PAGE"
-          :mobile="isMobile"
-        >
-          <template #[`item.operatingName`]="{ item }">
-            <div class="p-text-capitalize">
-              {{ item.operatingName }}
-            </div>
-          </template>
-          <template #[`item.legalName`]="{ item }">
-            <div class="p-text-capitalize">
-              {{ item.legalName }}
-            </div>
-          </template>
-          <template #[`item.country`]="{ item }">
-            {{ emptyStringFiller(item.country) }}
-          </template>
-          <template #[`item.classification`]="{ item }">
-            {{ getClassificationToDisplay(item.classification) }}
-          </template>
-          <template #[`item.action`]="{ item }">
-            <v-btn
-              color="primary"
-              data-cy="viewInstitution"
-              @click="goToViewInstitution(item.id)"
-              >View</v-btn
-            >
-          </template>
-        </v-data-table>
-      </content-group>
-    </template>
+      <template v-if="institutionsFound">
+        <body-header title="Results" class="mt-2" />
+        <content-group>
+          <v-data-table
+            v-if="institutionsFound"
+            :headers="SearchInstitutionsHeaders"
+            :items="institutions"
+            :items-per-page="DEFAULT_PAGE_LIMIT"
+            :items-per-page-options="ITEMS_PER_PAGE"
+            :mobile="isMobile"
+          >
+            <template #[`item.operatingName`]="{ item }">
+              <div class="p-text-capitalize">
+                {{ item.operatingName }}
+              </div>
+            </template>
+            <template #[`item.legalName`]="{ item }">
+              <div class="p-text-capitalize">
+                {{ item.legalName }}
+              </div>
+            </template>
+            <template #[`item.country`]="{ item }">
+              {{ emptyStringFiller(item.country) }}
+            </template>
+            <template #[`item.classification`]="{ item }">
+              {{ getClassificationToDisplay(item.classification) }}
+            </template>
+            <template #[`item.action`]="{ item }">
+              <v-btn
+                color="primary"
+                data-cy="viewInstitution"
+                @click="goToViewInstitution(item.id)"
+                >View</v-btn
+              >
+            </template>
+          </v-data-table>
+        </content-group>
+      </template>
+    </body-header-container>
   </full-page-container>
 </template>
 <script setup lang="ts">

--- a/sources/packages/web/src/views/aest/SearchInstitutions.vue
+++ b/sources/packages/web/src/views/aest/SearchInstitutions.vue
@@ -1,11 +1,11 @@
 <template>
-  <full-page-container full-width="true">
+  <full-page-container :full-width="true">
     <body-header-container
       title="Search Institution"
       sub-title="Look up an institution by entering their information below."
       ><content-group>
         <v-form ref="searchInstitutionsForm">
-          <v-row>
+          <v-row density="compact">
             <v-col cols="12" md>
               <v-text-field
                 density="compact"

--- a/sources/packages/web/src/views/aest/SearchInstitutions.vue
+++ b/sources/packages/web/src/views/aest/SearchInstitutions.vue
@@ -1,5 +1,5 @@
 <template>
-  <full-page-container>
+  <full-page-container full-width="true">
     <body-header-container
       title="Search Institution"
       sub-title="Look up an institution by entering their information below."

--- a/sources/packages/web/src/views/aest/SearchStudents.vue
+++ b/sources/packages/web/src/views/aest/SearchStudents.vue
@@ -1,15 +1,11 @@
 <template>
   <full-page-container :full-width="true">
-    <body-header-container>
-      <template #header>
-        <body-header title="Search Students">
-          <template #subtitle
-            >Lookup students by entering their information below.</template
-          >
-        </body-header>
-      </template>
+    <body-header-container
+      title="Search Students"
+      sub-title="Lookup students by entering their information below."
+    >
+      <search-students @go-to-student-view="goToStudentView" />
     </body-header-container>
-    <search-students @go-to-student-view="goToStudentView" />
   </full-page-container>
 </template>
 <script lang="ts">

--- a/sources/packages/web/src/views/aest/institution/Designation.vue
+++ b/sources/packages/web/src/views/aest/institution/Designation.vue
@@ -1,17 +1,13 @@
 <template>
   <tab-container>
-    <body-header-container>
-      <template #header>
-        <body-header
-          title="Designation agreements"
-          :recordsCount="designations?.length"
-        >
-        </body-header>
-      </template>
+    <body-header-container
+      title="Designation agreements"
+      :records-count="designations?.length"
+    >
       <designation-agreement-summary
         :designations="designations"
-        toggleMessage="No designation agreements found"
-        @viewDesignation="goToViewDesignation"
+        toggle-message="No designation agreements found"
+        @view-designation="goToViewDesignation"
       />
     </body-header-container>
   </tab-container>

--- a/sources/packages/web/src/views/aest/institution/OfferingChangeRequests.vue
+++ b/sources/packages/web/src/views/aest/institution/OfferingChangeRequests.vue
@@ -3,46 +3,47 @@
     <template #header>
       <header-navigator
         title="Institution requests"
-        subTitle="Offering Change Requests"
+        sub-title="Offering Change Requests"
       />
     </template>
-    <body-header
+    <body-header-container
       title="Pending offering change requests"
-      :recordsCount="offeringChangeRequests.length"
-      subTitle="Offering change requests that require ministry review."
-    />
-    <content-group>
-      <toggle-content
-        :toggled="
-          !offeringChangeRequests.length && !offeringChangeRequestsLoading
-        "
-        message="No offering change requests found."
-      >
-        <v-data-table
-          :headers="PendingOfferingChangeRequestsHeaders"
-          :items="offeringChangeRequests"
-          :items-per-page="DEFAULT_PAGE_LIMIT"
-          :items-per-page-options="ITEMS_PER_PAGE"
-          :loading="offeringChangeRequestsLoading"
+      :records-count="offeringChangeRequests.length"
+      sub-title="Offering change requests that require ministry review."
+    >
+      <content-group>
+        <toggle-content
+          :toggled="
+            !offeringChangeRequests.length && !offeringChangeRequestsLoading
+          "
+          message="No offering change requests found."
         >
-          <template #[`item.submittedDate`]="{ item }">
-            <span>
-              {{ dateOnlyLongString(item.submittedDate) }}
-            </span>
-          </template>
-          <template #[`item.actions`]="{ item }">
-            <v-btn
-              color="primary"
-              @click="
-                viewOfferingChangeRequest(item.offeringId, item.programId)
-              "
-            >
-              View request
-            </v-btn>
-          </template>
-        </v-data-table>
-      </toggle-content>
-    </content-group>
+          <v-data-table
+            :headers="PendingOfferingChangeRequestsHeaders"
+            :items="offeringChangeRequests"
+            :items-per-page="DEFAULT_PAGE_LIMIT"
+            :items-per-page-options="ITEMS_PER_PAGE"
+            :loading="offeringChangeRequestsLoading"
+          >
+            <template #[`item.submittedDate`]="{ item }">
+              <span>
+                {{ dateOnlyLongString(item.submittedDate) }}
+              </span>
+            </template>
+            <template #[`item.actions`]="{ item }">
+              <v-btn
+                color="primary"
+                @click="
+                  viewOfferingChangeRequest(item.offeringId, item.programId)
+                "
+              >
+                View request
+              </v-btn>
+            </template>
+          </v-data-table>
+        </toggle-content>
+      </content-group>
+    </body-header-container>
   </full-page-container>
 </template>
 <script lang="ts">

--- a/sources/packages/web/src/views/aest/institution/PendingDesignation.vue
+++ b/sources/packages/web/src/views/aest/institution/PendingDesignation.vue
@@ -3,56 +3,60 @@
     <template #header>
       <header-navigator title="Institution requests" sub-title="Designations" />
     </template>
-    <body-header
-      title="Pending designation requests"
-      sub-title="Pending designation requests that require ministry review."
-      :records-count="designations?.length"
-    >
-      <template #actions>
-        <v-text-field
-          label="Search Designations"
-          density="compact"
-          v-model="searchCriteria"
-          variant="outlined"
-          @keyup.enter="searchDesignations"
-          prepend-inner-icon="mdi-magnify"
-          hide-details="auto"
-        />
-      </template>
-    </body-header>
-    <content-group>
-      <toggle-content
-        :toggled="!designations.length"
-        message="No pending designation requests found."
-      >
-        <v-data-table
-          :headers="PendingDesignationsHeaders"
-          :items="designations"
-          :items-per-page="DEFAULT_PAGE_LIMIT"
-          :items-per-page-options="ITEMS_PER_PAGE"
-          :mobile="isMobile"
+    <body-header-container>
+      <template #header>
+        <body-header
+          title="Pending designation requests"
+          sub-title="Pending designation requests that require ministry review."
+          :records-count="designations?.length"
         >
-          <template #[`item.legalOperatingName`]="{ item }">
-            {{ item.legalOperatingName }}
-          </template>
-          <template #[`item.submittedDate`]="{ item }">
-            {{ dateOnlyLongString(item.submittedDate) }}
-          </template>
-          <template #[`item.designationStatus`]="{ item }">
-            <status-chip-designation :status="item.designationStatus" />
-          </template>
-          <template #[`item.designationId`]="{ item }">
-            <v-btn
+          <template #actions>
+            <v-text-field
+              label="Search Designations"
+              density="compact"
+              v-model="searchCriteria"
               variant="outlined"
-              color="primary"
-              @click="goToViewDesignation(item.designationId)"
-            >
-              View
-            </v-btn>
+              @keyup.enter="searchDesignations"
+              prepend-inner-icon="mdi-magnify"
+              hide-details="auto"
+            />
           </template>
-        </v-data-table>
-      </toggle-content>
-    </content-group>
+        </body-header>
+      </template>
+      <content-group>
+        <toggle-content
+          :toggled="!designations.length"
+          message="No pending designation requests found."
+        >
+          <v-data-table
+            :headers="PendingDesignationsHeaders"
+            :items="designations"
+            :items-per-page="DEFAULT_PAGE_LIMIT"
+            :items-per-page-options="ITEMS_PER_PAGE"
+            :mobile="isMobile"
+          >
+            <template #[`item.legalOperatingName`]="{ item }">
+              {{ item.legalOperatingName }}
+            </template>
+            <template #[`item.submittedDate`]="{ item }">
+              {{ dateOnlyLongString(item.submittedDate) }}
+            </template>
+            <template #[`item.designationStatus`]="{ item }">
+              <status-chip-designation :status="item.designationStatus" />
+            </template>
+            <template #[`item.designationId`]="{ item }">
+              <v-btn
+                variant="outlined"
+                color="primary"
+                @click="goToViewDesignation(item.designationId)"
+              >
+                View
+              </v-btn>
+            </template>
+          </v-data-table>
+        </toggle-content>
+      </content-group>
+    </body-header-container>
   </full-page-container>
 </template>
 

--- a/sources/packages/web/src/views/aest/institution/Profile.vue
+++ b/sources/packages/web/src/views/aest/institution/Profile.vue
@@ -20,142 +20,155 @@
           </template>
         </body-header>
       </template>
-      <p class="category-header-medium">Institution profile</p>
-      <content-group>
-        <v-row>
-          <v-col>
-            <title-value
-              property-title="Legal operating name"
-              :property-value="institutionProfileDetail.legalOperatingName"
-            />
-            <title-value
-              property-title="Institution name"
-              :property-value="institutionProfileDetail.operatingName"
-            />
-            <title-value
-              property-title="Primary phone number"
-              :property-value="institutionProfileDetail.primaryPhone"
-            />
-            <title-value
-              property-title="Primary email"
-              :property-value="institutionProfileDetail.primaryEmail"
-            />
-            <title-value
-              property-title="Website"
-              :property-value="institutionProfileDetail.website"
-            />
-            <title-value
-              property-title="Established date"
-              :property-value="institutionProfileDetail.establishedDate"
-            />
-          </v-col>
-          <v-divider :thickness="2" vertical />
-          <v-col>
-            <title-value
-              property-title="Regulatory body"
-              :property-value="
-                getRegulatoryBodyToDisplay(
-                  institutionProfileDetail.regulatingBody,
-                )
-              "
-            />
-            <title-value
-              v-if="institutionProfileDetail.regulatingBody === 'other'"
-              property-title="Other regulatory body"
-              :property-value="institutionProfileDetail.otherRegulatingBody"
-            />
-            <title-value
-              property-title="Country"
-              :property-value="
-                emptyStringFiller(institutionProfileDetail.countryName)
-              "
-            />
-            <title-value
-              property-title="Province"
-              :property-value="
-                emptyStringFiller(institutionProfileDetail.provinceName)
-              "
-            />
-            <title-value
-              property-title="Classification"
-              :property-value="
-                getClassificationToDisplay(
-                  institutionProfileDetail.classification,
-                )
-              "
-            />
-            <title-value
-              property-title="Organization status"
-              :property-value="
-                getOrganizationStatusToDisplay(
-                  institutionProfileDetail.organizationStatus,
-                )
-              "
-            />
-            <title-value
-              property-title="Medical"
-              :property-value="
-                getMedicalSchoolStatusToDisplay(
-                  institutionProfileDetail.medicalSchoolStatus,
-                )
-              "
-            />
-          </v-col>
-        </v-row>
-      </content-group>
-      <p class="category-header-medium mt-5">Contact information</p>
-      <v-row>
-        <v-col
-          ><content-group
-            ><span class="label-bold">Institution primary contact</span>
-            <v-row class="mt-1 mb-2 ml-0 text-muted">
-              {{ institutionProfileDetail.primaryContactFirstName }}
-              {{ institutionProfileDetail.primaryContactLastName }}
-            </v-row>
-            <v-row class="mt-1 mb-2 ml-0 text-muted">
-              {{ institutionProfileDetail.primaryContactEmail }}
-            </v-row>
-            <v-row class="mt-1 mb-2 ml-0 text-muted">
-              {{ institutionProfileDetail.primaryContactPhone }}
-            </v-row>
-          </content-group></v-col
-        >
-      </v-row>
-      <p class="category-header-medium mt-5">Mailing address</p>
-      <content-group>
-        <title-value
-          property-title="Address line 1"
-          :property-value="
-            institutionProfileDetail.mailingAddress?.addressLine1
-          "
-        />
-        <title-value
-          property-title="Address line 2"
-          :property-value="
-            emptyStringFiller(
-              institutionProfileDetail.mailingAddress?.addressLine2,
-            )
-          "
-        />
-        <title-value
-          property-title="City"
-          :property-value="institutionProfileDetail.mailingAddress?.city"
-        />
-        <title-value
-          property-title="Postal Code"
-          :property-value="institutionProfileDetail.mailingAddress?.postalCode"
-        />
-        <title-value
-          property-title="Province"
-          :property-value="
-            institutionProfileDetail.mailingAddress?.provinceState
-          "
-        />
-        <title-value
-          property-title="Country"
-          :property-value="institutionProfileDetail.mailingAddress?.country"
-        />
-      </content-group>
+      <body-header-container
+        title="Institution profile"
+        header-size="medium"
+        header-color="secondary"
+      >
+        <content-group>
+          <v-row>
+            <v-col>
+              <title-value
+                property-title="Legal operating name"
+                :property-value="institutionProfileDetail.legalOperatingName"
+              />
+              <title-value
+                property-title="Institution name"
+                :property-value="institutionProfileDetail.operatingName"
+              />
+              <title-value
+                property-title="Primary phone number"
+                :property-value="institutionProfileDetail.primaryPhone"
+              />
+              <title-value
+                property-title="Primary email"
+                :property-value="institutionProfileDetail.primaryEmail"
+              />
+              <title-value
+                property-title="Website"
+                :property-value="institutionProfileDetail.website"
+              />
+              <title-value
+                property-title="Established date"
+                :property-value="institutionProfileDetail.establishedDate"
+              />
+            </v-col>
+            <v-divider :thickness="2" vertical />
+            <v-col>
+              <title-value
+                property-title="Regulatory body"
+                :property-value="
+                  getRegulatoryBodyToDisplay(
+                    institutionProfileDetail.regulatingBody,
+                  )
+                "
+              />
+              <title-value
+                v-if="institutionProfileDetail.regulatingBody === 'other'"
+                property-title="Other regulatory body"
+                :property-value="institutionProfileDetail.otherRegulatingBody"
+              />
+              <title-value
+                property-title="Country"
+                :property-value="
+                  emptyStringFiller(institutionProfileDetail.countryName)
+                "
+              />
+              <title-value
+                property-title="Province"
+                :property-value="
+                  emptyStringFiller(institutionProfileDetail.provinceName)
+                "
+              />
+              <title-value
+                property-title="Classification"
+                :property-value="
+                  getClassificationToDisplay(
+                    institutionProfileDetail.classification,
+                  )
+                "
+              />
+              <title-value
+                property-title="Organization status"
+                :property-value="
+                  getOrganizationStatusToDisplay(
+                    institutionProfileDetail.organizationStatus,
+                  )
+                "
+              />
+              <title-value
+                property-title="Medical"
+                :property-value="
+                  getMedicalSchoolStatusToDisplay(
+                    institutionProfileDetail.medicalSchoolStatus,
+                  )
+                "
+              />
+            </v-col>
+          </v-row>
+        </content-group>
+      </body-header-container>
+      <body-header-container
+        title="Contact information"
+        header-size="medium"
+        header-color="secondary"
+      >
+        <content-group
+          ><span class="label-bold">Institution primary contact</span>
+          <v-row class="mt-1 mb-2 ml-0 text-muted">
+            {{ institutionProfileDetail.primaryContactFirstName }}
+            {{ institutionProfileDetail.primaryContactLastName }}
+          </v-row>
+          <v-row class="mt-1 mb-2 ml-0 text-muted">
+            {{ institutionProfileDetail.primaryContactEmail }}
+          </v-row>
+          <v-row class="mt-1 mb-2 ml-0 text-muted">
+            {{ institutionProfileDetail.primaryContactPhone }}
+          </v-row>
+        </content-group>
+      </body-header-container>
+      <body-header-container
+        title="Mailing address"
+        header-size="medium"
+        header-color="secondary"
+      >
+        <content-group>
+          <title-value
+            property-title="Address line 1"
+            :property-value="
+              institutionProfileDetail.mailingAddress?.addressLine1
+            "
+          />
+          <title-value
+            property-title="Address line 2"
+            :property-value="
+              emptyStringFiller(
+                institutionProfileDetail.mailingAddress?.addressLine2,
+              )
+            "
+          />
+          <title-value
+            property-title="City"
+            :property-value="institutionProfileDetail.mailingAddress?.city"
+          />
+          <title-value
+            property-title="Postal Code"
+            :property-value="
+              institutionProfileDetail.mailingAddress?.postalCode
+            "
+          />
+          <title-value
+            property-title="Province"
+            :property-value="
+              institutionProfileDetail.mailingAddress?.provinceState
+            "
+          />
+          <title-value
+            property-title="Country"
+            :property-value="institutionProfileDetail.mailingAddress?.country"
+          />
+        </content-group>
+      </body-header-container>
     </body-header-container>
   </tab-container>
 </template>

--- a/sources/packages/web/src/views/aest/institution/ProfileEdit.vue
+++ b/sources/packages/web/src/views/aest/institution/ProfileEdit.vue
@@ -1,18 +1,18 @@
 <template>
-  <v-container>
-    <header-navigator
-      title="Profile"
-      sub-title="Edit Profile"
-      :route-location="institutionProfileRoute"
-    />
-    <full-page-container>
-      <institution-profile-form
-        :profile-data="institutionProfileModel"
-        @submit-institution-profile="updateInstitution"
-        :allowed-role="Role.InstitutionEditProfile"
-      ></institution-profile-form>
-    </full-page-container>
-  </v-container>
+  <full-page-container>
+    <template #header>
+      <header-navigator
+        title="Profile"
+        sub-title="Edit Profile"
+        :route-location="institutionProfileRoute"
+      />
+    </template>
+    <institution-profile-form
+      :profile-data="institutionProfileModel"
+      @submit-institution-profile="updateInstitution"
+      :allowed-role="Role.InstitutionEditProfile"
+    ></institution-profile-form>
+  </full-page-container>
 </template>
 
 <script lang="ts">

--- a/sources/packages/web/src/views/aest/institution/ProgramDetails.vue
+++ b/sources/packages/web/src/views/aest/institution/ProgramDetails.vue
@@ -1,21 +1,24 @@
 <template>
-  <v-container>
-    <header-navigator
-      title="Back all programs"
-      :route-location="{
-        name: AESTRoutesConst.INSTITUTION_PROGRAMS,
-        params: { institutionId: institutionId },
-      }"
-      sub-title="View program"
-    >
-      <template #buttons>
-        <v-row class="p-0 m-0" v-if="isPendingProgram">
-          <check-permission-role :role="Role.InstitutionApproveDeclineProgram">
+  <full-page-container full-width="true">
+    <template #header>
+      <header-navigator
+        title="Back all programs"
+        :route-location="{
+          name: AESTRoutesConst.INSTITUTION_PROGRAMS,
+          params: { institutionId: institutionId },
+        }"
+        sub-title="View program"
+      >
+        <template #buttons>
+          <check-permission-role
+            v-if="isPendingProgram"
+            :role="Role.InstitutionApproveDeclineProgram"
+          >
             <template #="{ notAllowed }">
               <v-btn
+                class="mr-2"
                 variant="outlined"
                 color="primary"
-                class="mr-2"
                 @click="declineProgram"
                 :disabled="notAllowed"
                 >Decline</v-btn
@@ -28,21 +31,24 @@
               >
             </template>
           </check-permission-role>
-        </v-row>
-      </template>
-    </header-navigator>
-    <program-offering-detail-header
-      class="m-4"
-      :header-details="{
-        ...educationProgram,
-        status: educationProgram.programStatus,
-      }"
-    />
-    <institution-restriction-banner
-      :location-id="locationId"
-      :program-id="programId"
-      :institution-id="institutionId"
-    />
+        </template>
+      </header-navigator>
+    </template>
+    <template #details-header>
+      <program-offering-detail-header
+        :header-details="{
+          ...educationProgram,
+          status: educationProgram.programStatus,
+        }"
+      />
+    </template>
+    <template #alerts>
+      <institution-restriction-banner
+        :location-id="locationId"
+        :program-id="programId"
+        :institution-id="institutionId"
+      />
+    </template>
     <manage-program-and-offering-summary
       :program-id="programId"
       :location-id="locationId"
@@ -53,10 +59,10 @@
       @program-data-updated="programDataUpdated"
     />
     <!-- approve program modal -->
-    <ApproveProgramModal ref="approveProgramModal" />
+    <approve-program-modal ref="approveProgramModal" />
     <!-- decline program modal -->
-    <DeclineProgramModal ref="declineProgramModal" />
-  </v-container>
+    <decline-program-modal ref="declineProgramModal" />
+  </full-page-container>
 </template>
 
 <script lang="ts">

--- a/sources/packages/web/src/views/aest/institution/Programs.vue
+++ b/sources/packages/web/src/views/aest/institution/Programs.vue
@@ -7,7 +7,7 @@
           :records-count="institutionProgramsSummary.count"
         >
           <template #actions>
-            <v-row>
+            <v-row density="compact">
               <v-col>
                 <v-text-field
                   density="compact"

--- a/sources/packages/web/src/views/aest/institution/ViewOffering.vue
+++ b/sources/packages/web/src/views/aest/institution/ViewOffering.vue
@@ -3,37 +3,35 @@
     <template #header>
       <header-navigator
         title="Study period offerings"
-        :routeLocation="programRoute"
-        subTitle="View Request"
+        :route-location="programRoute"
+        sub-title="View Request"
       >
         <template #buttons v-if="showActionButtons">
-          <v-row class="m-0 p-0">
-            <check-permission-role
-              :role="Role.InstitutionApproveDeclineOffering"
-            >
-              <template #="{ notAllowed }">
-                <v-btn
-                  variant="outlined"
-                  :disabled="notAllowed"
-                  color="primary"
-                  @click="assessOffering(OfferingStatus.CreationDeclined)"
-                  >Decline</v-btn
-                >
-                <v-btn
-                  class="ml-2"
-                  color="primary"
-                  :disabled="notAllowed"
-                  @click="assessOffering(OfferingStatus.Approved)"
-                  >Approve offering</v-btn
-                >
-              </template>
-            </check-permission-role>
-          </v-row>
+          <check-permission-role :role="Role.InstitutionApproveDeclineOffering">
+            <template #="{ notAllowed }">
+              <v-btn
+                variant="outlined"
+                :disabled="notAllowed"
+                color="primary"
+                @click="assessOffering(OfferingStatus.CreationDeclined)"
+                >Decline</v-btn
+              >
+              <v-btn
+                class="ml-2"
+                color="primary"
+                :disabled="notAllowed"
+                @click="assessOffering(OfferingStatus.Approved)"
+                >Approve offering</v-btn
+              >
+            </template>
+          </check-permission-role>
         </template>
       </header-navigator>
+    </template>
+    <template #details-header>
       <program-offering-detail-header
         class="m-4"
-        :headerDetails="{
+        :header-details="{
           ...initialData,
           status: initialData.offeringStatus,
         }"
@@ -42,7 +40,7 @@
     <offering-form :data="initialData"></offering-form>
     <assess-offering-modal
       ref="assessOfferingModalRef"
-      :offeringStatus="offeringApprovalStatus"
+      :offering-status="offeringApprovalStatus"
     />
   </full-page-container>
 </template>

--- a/sources/packages/web/src/views/aest/institution/ViewPendingOfferingChangeRequests.vue
+++ b/sources/packages/web/src/views/aest/institution/ViewPendingOfferingChangeRequests.vue
@@ -24,8 +24,9 @@
               hide-details="auto"
             >
             </v-text-field>
-          </template> </body-header
-      ></template>
+          </template>
+        </body-header>
+      </template>
       <content-group>
         <toggle-content :toggled="!applications?.count">
           <v-data-table-server

--- a/sources/packages/web/src/views/aest/institution/ViewPendingOfferingChangeRequests.vue
+++ b/sources/packages/web/src/views/aest/institution/ViewPendingOfferingChangeRequests.vue
@@ -1,59 +1,63 @@
 <template>
   <full-page-container :full-width="true">
     <template #header>
-      <header-navigator title="Institution requests" subTitle="Change Requests" />
+      <header-navigator
+        title="Institution requests"
+        sub-title="Change Requests"
+      />
     </template>
-    <body-header
-      title="Pending change requests"
-      :recordsCount="applications?.count"
-    >
-      <template #subtitle>
-        Change requests that require ministry review.
-      </template>
-      <template #actions>
-        <v-text-field
-          density="compact"
-          label="Search name or application #"
-          variant="outlined"
-          v-model="searchCriteria"
-          @keyup.enter="searchApplicationOfferingChangeRecords"
-          prepend-inner-icon="mdi-magnify"
-          hide-details="auto"
+    <body-header-container>
+      <template #header>
+        <body-header
+          title="Pending change requests"
+          sub-title="Change requests that require ministry review."
+          :records-count="applications?.count"
         >
-        </v-text-field>
-      </template>
-    </body-header>
-    <content-group>
-      <toggle-content :toggled="!applications?.count">
-        <v-data-table-server
-          v-if="applications?.count"
-          :headers="AllInProgressOfferingChangeSummaryHeaders"
-          :items="applications?.results"
-          :items-length="applications.count"
-          :loading="loading"
-          item-value="applicationId"
-          v-model:items-per-page="DEFAULT_PAGE_LIMIT"
-          :items-per-page-options="ITEMS_PER_PAGE"
-          @update:options="paginationAndSortEvent"
-        >
-          <template #[`item.dateSubmitted`]="{ item }">
-            {{ dateOnlyLongString(item.createdAt) }}
-          </template>
-          <template #[`item.fullName`]="{ item }">
-            {{ item.fullName }}
-          </template>
-          <template #[`item.applicationNumber`]="{ item }">
-            {{ item.applicationNumber }}
-          </template>
-          <template #[`item.status`]="{ item }">
-            <status-chip-application-offering-change :status="item.status" />
-          </template>
-          <template #[`item.id`]="{ item }">
-            <v-btn color="primary" @click="viewAssessment(item)">View</v-btn>
-          </template>
-        </v-data-table-server>
-      </toggle-content>
-    </content-group>
+          <template #actions>
+            <v-text-field
+              density="compact"
+              label="Search name or application #"
+              variant="outlined"
+              v-model="searchCriteria"
+              @keyup.enter="searchApplicationOfferingChangeRecords"
+              prepend-inner-icon="mdi-magnify"
+              hide-details="auto"
+            >
+            </v-text-field>
+          </template> </body-header
+      ></template>
+      <content-group>
+        <toggle-content :toggled="!applications?.count">
+          <v-data-table-server
+            v-if="applications?.count"
+            :headers="AllInProgressOfferingChangeSummaryHeaders"
+            :items="applications?.results"
+            :items-length="applications.count"
+            :loading="loading"
+            item-value="applicationId"
+            v-model:items-per-page="DEFAULT_PAGE_LIMIT"
+            :items-per-page-options="ITEMS_PER_PAGE"
+            @update:options="paginationAndSortEvent"
+          >
+            <template #[`item.dateSubmitted`]="{ item }">
+              {{ dateOnlyLongString(item.createdAt) }}
+            </template>
+            <template #[`item.fullName`]="{ item }">
+              {{ item.fullName }}
+            </template>
+            <template #[`item.applicationNumber`]="{ item }">
+              {{ item.applicationNumber }}
+            </template>
+            <template #[`item.status`]="{ item }">
+              <status-chip-application-offering-change :status="item.status" />
+            </template>
+            <template #[`item.id`]="{ item }">
+              <v-btn color="primary" @click="viewAssessment(item)">View</v-btn>
+            </template>
+          </v-data-table-server>
+        </toggle-content>
+      </content-group>
+    </body-header-container>
   </full-page-container>
 </template>
 <script lang="ts">

--- a/sources/packages/web/src/views/aest/institution/ViewPendingOfferings.vue
+++ b/sources/packages/web/src/views/aest/institution/ViewPendingOfferings.vue
@@ -3,7 +3,7 @@
     <template #header>
       <header-navigator title="Institution requests" sub-title="Offerings" />
     </template>
-    <body-header-container :enable-card-view="true">
+    <body-header-container>
       <template #header>
         <body-header
           title="Pending offerings"

--- a/sources/packages/web/src/views/aest/institution/ViewPendingOfferings.vue
+++ b/sources/packages/web/src/views/aest/institution/ViewPendingOfferings.vue
@@ -3,76 +3,80 @@
     <template #header>
       <header-navigator title="Institution requests" sub-title="Offerings" />
     </template>
-    <body-header
-      title="Pending offerings"
-      :records-count="offeringsAndCount?.count"
-    >
-      <template #subtitle>
-        Offering requests that require Ministry review.
-      </template>
-      <template #actions>
-        <v-text-field
-          density="compact"
-          label="Search offering name"
-          variant="outlined"
-          v-model="searchCriteria"
-          @keyup.enter="searchOfferings"
-          prepend-inner-icon="mdi-magnify"
-          hide-details="auto"
+    <body-header-container :enable-card-view="true">
+      <template #header>
+        <body-header
+          title="Pending offerings"
+          :records-count="offeringsAndCount?.count"
         >
-        </v-text-field>
+          <template #subtitle>
+            Offering requests that require Ministry review.
+          </template>
+          <template #actions>
+            <v-text-field
+              density="compact"
+              label="Search offering name"
+              variant="outlined"
+              v-model="searchCriteria"
+              @keyup.enter="searchOfferings"
+              prepend-inner-icon="mdi-magnify"
+              hide-details="auto"
+            >
+            </v-text-field>
+          </template>
+        </body-header>
       </template>
-    </body-header>
-    <content-group>
-      <toggle-content :toggled="!offeringsAndCount?.count && !loading">
-        <v-data-table-server
-          :headers="PendingOfferingsHeaders"
-          :items="offeringsAndCount?.results"
-          :items-length="offeringsAndCount?.count"
-          :loading="loading"
-          item-value="id"
-          :items-per-page="DEFAULT_PAGE_LIMIT"
-          :items-per-page-options="ITEMS_PER_PAGE"
-          :mobile="isMobile"
-          @update:options="pageSortEvent"
-        >
-          <template #loading>
-            <v-skeleton-loader type="table-row@5"></v-skeleton-loader>
-          </template>
-          <template #[`item.submittedDate`]="{ item }">
-            {{ dateOnlyLongString(item.submittedDate) }}
-          </template>
-          <template #[`item.locationName`]="{ item }">
-            {{ item.locationName }}
-          </template>
-          <template #[`item.programName`]="{ item }">
-            {{ item.programName }}
-          </template>
-          <template #[`item.name`]="{ item }">
-            {{ item.name }}
-          </template>
-          <template #[`item.studyDates`]="{ item }">
-            {{
-              dateOnlyLongPeriodString(item.studyStartDate, item.studyEndDate)
-            }}
-          </template>
-          <template #[`item.offeringIntensity`]="{ item }">
-            {{ mapOfferingIntensity(item.offeringIntensity) }}
-          </template>
-          <template #[`item.offeringType`]="{ item }">
-            {{ item.offeringType }}
-          </template>
-          <template #[`item.offeringDelivered`]="{ item }">
-            <div class="p-text-capitalize">
-              {{ item.offeringDelivered }}
-            </div>
-          </template>
-          <template #[`item.actions`]="{ item }">
-            <v-btn color="primary" @click="viewOffering(item)">View</v-btn>
-          </template>
-        </v-data-table-server>
-      </toggle-content>
-    </content-group>
+      <content-group>
+        <toggle-content :toggled="!offeringsAndCount?.count && !loading">
+          <v-data-table-server
+            :headers="PendingOfferingsHeaders"
+            :items="offeringsAndCount?.results"
+            :items-length="offeringsAndCount?.count"
+            :loading="loading"
+            item-value="id"
+            :items-per-page="DEFAULT_PAGE_LIMIT"
+            :items-per-page-options="ITEMS_PER_PAGE"
+            :mobile="isMobile"
+            @update:options="pageSortEvent"
+          >
+            <template #loading>
+              <v-skeleton-loader type="table-row@5"></v-skeleton-loader>
+            </template>
+            <template #[`item.submittedDate`]="{ item }">
+              {{ dateOnlyLongString(item.submittedDate) }}
+            </template>
+            <template #[`item.locationName`]="{ item }">
+              {{ item.locationName }}
+            </template>
+            <template #[`item.programName`]="{ item }">
+              {{ item.programName }}
+            </template>
+            <template #[`item.name`]="{ item }">
+              {{ item.name }}
+            </template>
+            <template #[`item.studyDates`]="{ item }">
+              {{
+                dateOnlyLongPeriodString(item.studyStartDate, item.studyEndDate)
+              }}
+            </template>
+            <template #[`item.offeringIntensity`]="{ item }">
+              {{ mapOfferingIntensity(item.offeringIntensity) }}
+            </template>
+            <template #[`item.offeringType`]="{ item }">
+              {{ item.offeringType }}
+            </template>
+            <template #[`item.offeringDelivered`]="{ item }">
+              <div class="p-text-capitalize">
+                {{ item.offeringDelivered }}
+              </div>
+            </template>
+            <template #[`item.actions`]="{ item }">
+              <v-btn color="primary" @click="viewOffering(item)">View</v-btn>
+            </template>
+          </v-data-table-server>
+        </toggle-content>
+      </content-group>
+    </body-header-container>
   </full-page-container>
 </template>
 

--- a/sources/packages/web/src/views/aest/institution/ViewPendingPrograms.vue
+++ b/sources/packages/web/src/views/aest/institution/ViewPendingPrograms.vue
@@ -3,57 +3,61 @@
     <template #header>
       <header-navigator title="Institution requests" sub-title="Programs" />
     </template>
-    <body-header
-      title="Pending programs"
-      :records-count="programsAndCount?.count"
-    >
-      <template #subtitle>
-        Program requests that require Ministry review.
-      </template>
-      <template #actions>
-        <v-text-field
-          density="compact"
-          label="Search program or institution name"
-          variant="outlined"
-          v-model="searchCriteria"
-          @keyup.enter="searchPrograms"
-          prepend-inner-icon="mdi-magnify"
-          hide-details="auto"
+    <body-header-container>
+      <template #header>
+        <body-header
+          title="Pending programs"
+          :records-count="programsAndCount?.count"
         >
-        </v-text-field>
+          <template #subtitle>
+            Program requests that require Ministry review.
+          </template>
+          <template #actions>
+            <v-text-field
+              density="compact"
+              label="Search program or institution name"
+              variant="outlined"
+              v-model="searchCriteria"
+              @keyup.enter="searchPrograms"
+              prepend-inner-icon="mdi-magnify"
+              hide-details="auto"
+            >
+            </v-text-field>
+          </template>
+        </body-header>
       </template>
-    </body-header>
-    <content-group>
-      <toggle-content :toggled="!programsAndCount?.count && !loading">
-        <v-data-table-server
-          :headers="PendingProgramsHeaders"
-          :items="programsAndCount?.results"
-          :items-length="programsAndCount?.count"
-          :loading="loading"
-          item-value="id"
-          :items-per-page="DEFAULT_PAGE_LIMIT"
-          :items-per-page-options="ITEMS_PER_PAGE"
-          :mobile="isMobile"
-          @update:options="pageSortEvent"
-        >
-          <template #loading>
-            <v-skeleton-loader type="table-row@5"></v-skeleton-loader>
-          </template>
-          <template #[`item.institutionOperatingName`]="{ item }">
-            {{ item.institutionOperatingName }}
-          </template>
-          <template #[`item.programName`]="{ item }">
-            {{ item.programName }}
-          </template>
-          <template #[`item.submittedDate`]="{ item }">
-            {{ dateOnlyLongString(item.submittedDate) }}
-          </template>
-          <template #[`item.actions`]="{ item }">
-            <v-btn color="primary" @click="viewProgram(item)">View</v-btn>
-          </template>
-        </v-data-table-server>
-      </toggle-content>
-    </content-group>
+      <content-group>
+        <toggle-content :toggled="!programsAndCount?.count && !loading">
+          <v-data-table-server
+            :headers="PendingProgramsHeaders"
+            :items="programsAndCount?.results"
+            :items-length="programsAndCount?.count"
+            :loading="loading"
+            item-value="id"
+            :items-per-page="DEFAULT_PAGE_LIMIT"
+            :items-per-page-options="ITEMS_PER_PAGE"
+            :mobile="isMobile"
+            @update:options="pageSortEvent"
+          >
+            <template #loading>
+              <v-skeleton-loader type="table-row@5"></v-skeleton-loader>
+            </template>
+            <template #[`item.institutionOperatingName`]="{ item }">
+              {{ item.institutionOperatingName }}
+            </template>
+            <template #[`item.programName`]="{ item }">
+              {{ item.programName }}
+            </template>
+            <template #[`item.submittedDate`]="{ item }">
+              {{ dateOnlyLongString(item.submittedDate) }}
+            </template>
+            <template #[`item.actions`]="{ item }">
+              <v-btn color="primary" @click="viewProgram(item)">View</v-btn>
+            </template>
+          </v-data-table-server>
+        </toggle-content>
+      </content-group>
+    </body-header-container>
   </full-page-container>
 </template>
 

--- a/sources/packages/web/src/views/aest/student/ApplicationChangeRequests.vue
+++ b/sources/packages/web/src/views/aest/student/ApplicationChangeRequests.vue
@@ -6,60 +6,64 @@
         sub-title="Change Requests (2025-2026 and later)"
       />
     </template>
-    <body-header
-      title="Pending change requests"
-      :records-count="changeRequests.count"
-      sub-title="Change requests that require ministry review."
-    >
-      <template #actions>
-        <v-text-field
-          density="compact"
-          label="Search name or application #"
-          variant="outlined"
-          v-model="searchCriteria"
-          @keyup.enter="resetPageAndLoadApplications"
-          prepend-inner-icon="mdi-magnify"
-          hide-details="auto"
-        />
-      </template>
-    </body-header>
-    <content-group>
-      <toggle-content :toggled="!changeRequests.count && !isLoading">
-        <v-data-table-server
-          :headers="PendingChangeRequestsTableHeaders"
-          :items="changeRequests.results"
-          :items-length="changeRequests.count"
-          :loading="isLoading"
-          :items-per-page="DEFAULT_PAGE_LIMIT"
-          :items-per-page-options="ITEMS_PER_PAGE"
-          @update:options="paginationAndSortEvent"
+    <body-header-container>
+      <template #header>
+        <body-header
+          title="Pending change requests"
+          :records-count="changeRequests.count"
+          sub-title="Change requests that require ministry review."
         >
-          <template #loading>
-            <v-skeleton-loader type="table-row@5"></v-skeleton-loader>
+          <template #actions>
+            <v-text-field
+              density="compact"
+              label="Search name or application #"
+              variant="outlined"
+              v-model="searchCriteria"
+              @keyup.enter="resetPageAndLoadApplications"
+              prepend-inner-icon="mdi-magnify"
+              hide-details="auto"
+            />
           </template>
-          <template #[`item.submittedDate`]="{ item }">
-            {{ dateOnlyLongString(item.submittedDate) }}
-          </template>
-          <template #[`item.firstName`]="{ item }">
-            {{ emptyStringFiller(item.firstName) }}
-          </template>
-          <template #[`item.action`]="{ item }">
-            <v-btn
-              color="primary"
-              @click="
-                navigateToApplicationVersion(
-                  item.applicationId,
-                  item.studentId,
-                  item.precedingApplicationId,
-                )
-              "
-            >
-              View
-            </v-btn>
-          </template>
-        </v-data-table-server>
-      </toggle-content>
-    </content-group>
+        </body-header>
+      </template>
+      <content-group>
+        <toggle-content :toggled="!changeRequests.count && !isLoading">
+          <v-data-table-server
+            :headers="PendingChangeRequestsTableHeaders"
+            :items="changeRequests.results"
+            :items-length="changeRequests.count"
+            :loading="isLoading"
+            :items-per-page="DEFAULT_PAGE_LIMIT"
+            :items-per-page-options="ITEMS_PER_PAGE"
+            @update:options="paginationAndSortEvent"
+          >
+            <template #loading>
+              <v-skeleton-loader type="table-row@5"></v-skeleton-loader>
+            </template>
+            <template #[`item.submittedDate`]="{ item }">
+              {{ dateOnlyLongString(item.submittedDate) }}
+            </template>
+            <template #[`item.firstName`]="{ item }">
+              {{ emptyStringFiller(item.firstName) }}
+            </template>
+            <template #[`item.action`]="{ item }">
+              <v-btn
+                color="primary"
+                @click="
+                  navigateToApplicationVersion(
+                    item.applicationId,
+                    item.studentId,
+                    item.precedingApplicationId,
+                  )
+                "
+              >
+                View
+              </v-btn>
+            </template>
+          </v-data-table-server>
+        </toggle-content>
+      </content-group>
+    </body-header-container>
   </full-page-container>
 </template>
 

--- a/sources/packages/web/src/views/aest/student/DisabilityProfile.vue
+++ b/sources/packages/web/src/views/aest/student/DisabilityProfile.vue
@@ -72,12 +72,11 @@
       text="Are you sure you want to delete the draft disability profile?"
     />
     <body-header-container
-      :enable-card-view="true"
       v-if="archivedProfiles.length"
+      :enable-card-view="true"
+      title="History"
+      sub-title="Disability profile history."
     >
-      <template #header>
-        <body-header title="History" sub-title="Disability profile history." />
-      </template>
       <content-group>
         <v-data-table
           :headers="DisabilityProfileArchivedHeaders"

--- a/sources/packages/web/src/views/aest/student/StudentAccountApplications.vue
+++ b/sources/packages/web/src/views/aest/student/StudentAccountApplications.vue
@@ -3,48 +3,48 @@
     <template #header>
       <header-navigator title="Student requests" sub-title="Accounts" />
     </template>
-    <body-header
+    <body-header-container
       title="Pending account requests"
       sub-title="Basic BCeID account requests that require ministry review."
       :records-count="accountApplications?.length"
     >
-    </body-header>
-    <content-group>
-      <toggle-content
-        :toggled="!accountApplications.length"
-        message="No pending account requests found."
-      >
-        <v-data-table
-          :headers="StudentAccountRequestsHeaders"
-          :items="accountApplications"
-          :items-per-page="DEFAULT_PAGE_LIMIT"
-          :items-per-page-options="ITEMS_PER_PAGE"
-          :mobile="isMobile"
+      <content-group>
+        <toggle-content
+          :toggled="!accountApplications.length"
+          message="No pending account requests found."
         >
-          <template #[`item.submittedDate`]="{ item }">
-            {{ dateOnlyLongString(item.submittedDate) }}
-          </template>
-          <template #[`item.givenNames`]="{ item }">
-            {{ item.givenNames }}
-          </template>
-          <template #[`item.lastName`]="{ item }">
-            {{ item.lastName }}
-          </template>
-          <template #[`item.dateOfBirth`]="{ item }">
-            {{ dateOnlyLongString(item.dateOfBirth) }}
-          </template>
-          <template #[`item.action`]="{ item }">
-            <v-btn
-              color="primary"
-              @click="goToStudentAccountApplication(item.id)"
-              data-cy="viewStudentAccountApplicationMobile"
-            >
-              View
-            </v-btn>
-          </template>
-        </v-data-table>
-      </toggle-content>
-    </content-group>
+          <v-data-table
+            :headers="StudentAccountRequestsHeaders"
+            :items="accountApplications"
+            :items-per-page="DEFAULT_PAGE_LIMIT"
+            :items-per-page-options="ITEMS_PER_PAGE"
+            :mobile="isMobile"
+          >
+            <template #[`item.submittedDate`]="{ item }">
+              {{ dateOnlyLongString(item.submittedDate) }}
+            </template>
+            <template #[`item.givenNames`]="{ item }">
+              {{ item.givenNames }}
+            </template>
+            <template #[`item.lastName`]="{ item }">
+              {{ item.lastName }}
+            </template>
+            <template #[`item.dateOfBirth`]="{ item }">
+              {{ dateOnlyLongString(item.dateOfBirth) }}
+            </template>
+            <template #[`item.action`]="{ item }">
+              <v-btn
+                color="primary"
+                @click="goToStudentAccountApplication(item.id)"
+                data-cy="viewStudentAccountApplicationMobile"
+              >
+                View
+              </v-btn>
+            </template>
+          </v-data-table>
+        </toggle-content>
+      </content-group>
+    </body-header-container>
   </full-page-container>
 </template>
 

--- a/sources/packages/web/src/views/aest/student/StudentApplicationExceptions.vue
+++ b/sources/packages/web/src/views/aest/student/StudentApplicationExceptions.vue
@@ -3,64 +3,68 @@
     <template #header>
       <header-navigator title="Student requests" sub-title="Exceptions" />
     </template>
-    <body-header
-      title="Pending exception requests"
-      :records-count="applicationExceptions.count"
-      sub-title="Exception requests that require ministry review."
-    >
-      <template #actions>
-        <v-text-field
-          density="compact"
-          label="Search name or application #"
-          variant="outlined"
-          v-model="searchCriteria"
-          data-cy="searchExceptions"
-          @keyup.enter="searchExceptions"
-          prepend-inner-icon="mdi-magnify"
-          hide-details="auto"
+    <body-header-container>
+      <template #header>
+        <body-header
+          title="Pending exception requests"
+          :records-count="applicationExceptions.count"
+          sub-title="Exception requests that require ministry review."
         >
-        </v-text-field>
-      </template>
-    </body-header>
-    <content-group>
-      <toggle-content
-        :toggled="!applicationExceptions.results?.length && !loading"
-        message="No pending exception requests."
-      >
-        <v-data-table-server
-          v-if="applicationExceptions?.count"
-          :headers="ExceptionRequestsHeaders"
-          :items="applicationExceptions?.results"
-          :items-length="applicationExceptions?.count"
-          :loading="loading"
-          :items-per-page="DEFAULT_PAGE_LIMIT"
-          :items-per-page-options="ITEMS_PER_PAGE"
-          @update:options="pageSortEvent"
-        >
-          <template #loading>
-            <v-skeleton-loader type="table-row@5"></v-skeleton-loader>
-          </template>
-          <template #[`item.submittedDate`]="{ item }">
-            {{ dateOnlyLongString(item.submittedDate) }}
-          </template>
-          <template #[`item.givenNames`]="{ item }">
-            {{ item.givenNames }}
-          </template>
-          <template #[`item.lastName`]="{ item }">
-            {{ item.lastName }}
-          </template>
-          <template #[`item.action`]="{ item }">
-            <v-btn
-              color="primary"
-              @click="
-                goToAssessmentsSummary(item.applicationId, item.studentId)
-              "
-              >View</v-btn
+          <template #actions>
+            <v-text-field
+              density="compact"
+              label="Search name or application #"
+              variant="outlined"
+              v-model="searchCriteria"
+              data-cy="searchExceptions"
+              @keyup.enter="searchExceptions"
+              prepend-inner-icon="mdi-magnify"
+              hide-details="auto"
             >
+            </v-text-field>
           </template>
-        </v-data-table-server>
-      </toggle-content>
-    </content-group>
+        </body-header>
+      </template>
+      <content-group>
+        <toggle-content
+          :toggled="!applicationExceptions.results?.length && !loading"
+          message="No pending exception requests."
+        >
+          <v-data-table-server
+            v-if="applicationExceptions?.count"
+            :headers="ExceptionRequestsHeaders"
+            :items="applicationExceptions?.results"
+            :items-length="applicationExceptions?.count"
+            :loading="loading"
+            :items-per-page="DEFAULT_PAGE_LIMIT"
+            :items-per-page-options="ITEMS_PER_PAGE"
+            @update:options="pageSortEvent"
+          >
+            <template #loading>
+              <v-skeleton-loader type="table-row@5"></v-skeleton-loader>
+            </template>
+            <template #[`item.submittedDate`]="{ item }">
+              {{ dateOnlyLongString(item.submittedDate) }}
+            </template>
+            <template #[`item.givenNames`]="{ item }">
+              {{ item.givenNames }}
+            </template>
+            <template #[`item.lastName`]="{ item }">
+              {{ item.lastName }}
+            </template>
+            <template #[`item.action`]="{ item }">
+              <v-btn
+                color="primary"
+                @click="
+                  goToAssessmentsSummary(item.applicationId, item.studentId)
+                "
+                >View</v-btn
+              >
+            </template>
+          </v-data-table-server>
+        </toggle-content>
+      </content-group>
+    </body-header-container>
   </full-page-container>
 </template>
 

--- a/sources/packages/web/src/views/aest/student/StudentMSFAAActivity.vue
+++ b/sources/packages/web/src/views/aest/student/StudentMSFAAActivity.vue
@@ -1,9 +1,9 @@
 <template>
   <tab-container>
-    <body-header-container>
-      <template #header>
-        <body-header title="Activity" :records-count="msfaaActivity?.length" />
-      </template>
+    <body-header-container
+      title="Activity"
+      :records-count="msfaaActivity?.length"
+    >
       <content-group>
         <toggle-content
           :toggled="!msfaaActivity?.length && !isLoading"

--- a/sources/packages/web/src/views/aest/student/applicationDetails/StudentApplicationView.vue
+++ b/sources/packages/web/src/views/aest/student/applicationDetails/StudentApplicationView.vue
@@ -46,20 +46,20 @@
       </header-navigator>
       <application-header-title :application-id="applicationId" />
     </template>
-    <h2 class="color-blue">Student Application Details</h2>
-    <StudentApplication
-      @render="formRender"
-      :selected-form="selectedForm"
-      :initial-data="initialData"
-      :program-year-id="applicationDetail.applicationProgramYearID"
-      :is-read-only="true"
-      :is-data-ready="isDataReady"
-    />
+    <body-header-container title="Application details">
+      <StudentApplication
+        @render="formRender"
+        :selected-form="selectedForm"
+        :initial-data="initialData"
+        :program-year-id="applicationDetail.applicationProgramYearID"
+        :is-read-only="true"
+        :is-data-ready="isDataReady"
+      />
+    </body-header-container>
     <assess-application-change-request-modal
       ref="assessApplicationChangeRequestModal"
     />
   </full-page-container>
-  <router-view />
 </template>
 <script lang="ts">
 import { onMounted, ref, defineComponent } from "vue";

--- a/sources/packages/web/src/views/aest/student/applicationDetails/StudentApplicationView.vue
+++ b/sources/packages/web/src/views/aest/student/applicationDetails/StudentApplicationView.vue
@@ -46,7 +46,7 @@
       </header-navigator>
       <application-header-title :application-id="applicationId" />
     </template>
-    <body-header-container title="Application details">
+    <body-header-container title="Student Application Details">
       <StudentApplication
         @render="formRender"
         :selected-form="selectedForm"

--- a/sources/packages/web/src/views/institution/student/InstitutionSearchStudents.vue
+++ b/sources/packages/web/src/views/institution/student/InstitutionSearchStudents.vue
@@ -1,13 +1,6 @@
 <template>
   <full-page-container :full-width="true">
-    <body-header-container>
-      <template #header>
-        <body-header title="Search Students">
-          <template #subtitle
-            >Lookup students by entering their information below.</template
-          >
-        </body-header>
-      </template>
+    <body-header-container title="Search Students" subtitle="">
     </body-header-container>
     <search-students @go-to-student-view="goToStudentView" />
   </full-page-container>

--- a/sources/packages/web/src/views/institution/student/InstitutionSearchStudents.vue
+++ b/sources/packages/web/src/views/institution/student/InstitutionSearchStudents.vue
@@ -1,6 +1,9 @@
 <template>
   <full-page-container :full-width="true">
-    <body-header-container title="Search Students" subtitle="">
+    <body-header-container
+      title="Search Students"
+      sub-title="Lookup students by entering their information below."
+    >
     </body-header-container>
     <search-students @go-to-student-view="goToStudentView" />
   </full-page-container>

--- a/sources/packages/web/src/views/student/Login.vue
+++ b/sources/packages/web/src/views/student/Login.vue
@@ -3,7 +3,7 @@
     title="Welcome to StudentAid BC"
     subtitle="Access your student account to apply for student financial assistance."
     login-area-title="Log in or Register"
-    login-area-text="Whether you are a new or returning user-log in or register using the BC Services Card account."
+    login-area-text="Whether you are a new or returning user—log in or register using the BC Services Card account."
     login-area-button="Log in/Register"
     @login="login(IdentityProviders.BCSC)"
   >

--- a/sources/packages/web/src/views/student/Login.vue
+++ b/sources/packages/web/src/views/student/Login.vue
@@ -3,7 +3,7 @@
     title="Welcome to StudentAid BC"
     subtitle="Access your student account to apply for student financial assistance."
     login-area-title="Log in or Register"
-    login-area-text="Whether you are a new or returning user—log in or register using the BC Services Card account."
+    login-area-text="Whether you are a new or returning user-log in or register using the BC Services Card account."
     login-area-button="Log in/Register"
     @login="login(IdentityProviders.BCSC)"
   >

--- a/sources/packages/web/src/views/student/form-submissions/StudentFormsSelectorAppealsSection.vue
+++ b/sources/packages/web/src/views/student/form-submissions/StudentFormsSelectorAppealsSection.vue
@@ -1,12 +1,10 @@
 <template>
-  <body-header-container :enable-card-view="true">
-    <template #header>
-      <body-header
-        title="Appeal forms"
-        sub-title="There are two appeal paths available. Please review the options below and select the appropriate path."
-      />
-    </template>
-    <v-expansion-panels class="mt-5" v-model="selectedAppealType">
+  <body-header-container
+    :enable-card-view="true"
+    title="Appeal forms"
+    sub-title="There are two appeal paths available. Please review the options below and select the appropriate path."
+  >
+    <v-expansion-panels v-model="selectedAppealType">
       <v-expansion-panel
         :value="AppealTypes.Application"
         collapse-icon="$expanderCollapseIcon"
@@ -79,7 +77,6 @@
             </template>
           </v-form>
           <footer-buttons
-            class="mt-4"
             primary-label="Request appeal(s)"
             justify="end"
             @primary-click="fillApplicationAppeals"
@@ -140,7 +137,6 @@
             </v-input>
           </v-form>
           <footer-buttons
-            class="mt-4"
             primary-label="Request appeal"
             justify="end"
             @primary-click="fillStudentAppeals"

--- a/sources/packages/web/src/views/student/form-submissions/StudentFormsSelectorFormsSection.vue
+++ b/sources/packages/web/src/views/student/form-submissions/StudentFormsSelectorFormsSection.vue
@@ -1,12 +1,10 @@
 <template>
-  <body-header-container :enable-card-view="true">
-    <template #header>
-      <body-header
-        title="Student forms"
-        sub-title="Standard forms to be submitted for StudentAid BC review."
-      />
-    </template>
-    <v-expansion-panels class="mt-5">
+  <body-header-container
+    :enable-card-view="true"
+    title="Student forms"
+    sub-title="Standard forms to be submitted for StudentAid BC review."
+  >
+    <v-expansion-panels>
       <v-expansion-panel
         collapse-icon="$expanderCollapseIcon"
         expand-icon="$expanderExpandIcon"
@@ -60,7 +58,6 @@
             </v-input>
           </v-form>
           <footer-buttons
-            class="mt-4"
             primary-label="Fill form"
             justify="end"
             @primary-click="fillStudentForm"

--- a/sources/packages/web/src/views/supporting-user/Login.vue
+++ b/sources/packages/web/src/views/supporting-user/Login.vue
@@ -3,7 +3,7 @@
     title="Welcome to StudentAid BC"
     subtitle="We help with the cost of post-secondary education through student loans, grants, and other financial assistance programs."
     login-area-title="Log in or Register"
-    login-area-text="Whether you are a new or returning user—log in or register using the BC Services Card account."
+    login-area-text="Whether you are a new or returning user-log in or register using the BC Services Card account."
     login-area-button="Log in/Register"
     @login="login"
   >

--- a/sources/packages/web/src/views/supporting-user/Login.vue
+++ b/sources/packages/web/src/views/supporting-user/Login.vue
@@ -3,7 +3,7 @@
     title="Welcome to StudentAid BC"
     subtitle="We help with the cost of post-secondary education through student loans, grants, and other financial assistance programs."
     login-area-title="Log in or Register"
-    login-area-text="Whether you are a new or returning user-log in or register using the BC Services Card account."
+    login-area-text="Whether you are a new or returning user—log in or register using the BC Services Card account."
     login-area-button="Log in/Register"
     @login="login"
   >


### PR DESCRIPTION
# PR Goal

- One more round of fixes, targeting improving spacing issues introduced in the prior PR.
- Focus on the Ministry and some students' pages.
_Plase note:_ one more effort will be executed on institution-related and student-related (e.g., NOA) components, and final overall review.

## Overall Changes

- `content-group` and/or page body container were mostly moved inside components' specific slots, causing some additional diffs in the files.
- Adjusted `formio-component` styles to `h1-h6` and `p` trying to keep a similar look and feel prior to the upgrade.
- Added `hide-details` to prevent extra spacing at the end of modals.
- Combined `body-header` into `body-header-container` when the `body-header` was only set with string properties (not using slots).
- Applied the combination of `body-header-container` + `body-header` when missing.
- Used `footer-buttons` when possible to align buttons.
- Replaced `h3`, `h2`, etc. by the `body-header-container`.
- Removed unnecessary `v-card` and `v-container`.
- Adjusted `body-header` spacing between its slots, also hiding the slots when no content was provided.

## Minor refactor in the institution management user modal

<img width="931" height="653" alt="image" src="https://github.com/user-attachments/assets/92b9f663-44e3-4950-b4ea-0ab02d15e1e3" />

## Student Application with improved spacing

<img width="1063" height="1329" alt="image" src="https://github.com/user-attachments/assets/ec9e7b33-7bf5-4114-b40e-22f5e92d807b" />

