### PR TITLE
#4593 - Associate legacy msfaa: check null pt msfaa

### DIFF
--- a/sources/packages/backend/apps/workers/src/controllers/disbursement/_tests_/e2e/disbursement.controller.associateMSFAA.e2e-spec.ts
+++ b/sources/packages/backend/apps/workers/src/controllers/disbursement/_tests_/e2e/disbursement.controller.associateMSFAA.e2e-spec.ts
@@ -263,7 +263,7 @@ describe("DisbursementController(e2e)-associateMSFAA", () => {
     expect(cancelledMSFAANumber.cancelledDate).not.toBe(null);
   });
 
-  it("Should create a new MSFAA number for part-time applications when the valid SFAS part-time application does not have a part-time MSFAA number.", async () => {
+  it("Should import the MSFAA number for part-time application when the valid SFAS part-time application has a part-time MSFAA number.", async () => {
     // Arrange
     const legacyApplicationStartDate = addDays(-100);
     const legacyApplicationEndDate = addDays(-10);
@@ -281,14 +281,8 @@ describe("DisbursementController(e2e)-associateMSFAA", () => {
     const savedSFASIndividual = await saveFakeSFASIndividual(db.dataSource, {
       initialValues: { student },
     });
-    await db.sfasIndividual
-      .createQueryBuilder()
-      .update()
-      .set({ partTimeMSFAANumber: () => "NULL" })
-      .where("id = :id", { id: savedSFASIndividual.id })
-      .execute();
 
-    await db.sfasPartTimeApplications.save(
+    const savedSFASPartTimeApplication = await db.sfasPartTimeApplications.save(
       createFakeSFASPartTimeApplication(
         { individual: savedSFASIndividual },
         {
@@ -313,7 +307,7 @@ describe("DisbursementController(e2e)-associateMSFAA", () => {
       MockedZeebeJobResult.Complete,
     );
 
-    const createdMSFAANumber = await db.msfaaNumber.findOne({
+    const importedMSFAANumber = await db.msfaaNumber.findOne({
       select: {
         id: true,
         msfaaNumber: true,
@@ -346,12 +340,12 @@ describe("DisbursementController(e2e)-associateMSFAA", () => {
       },
     });
 
-    expect(disbursementSchedule.msfaaNumber.id).toBe(createdMSFAANumber.id);
-    expect(createdMSFAANumber).toEqual({
+    expect(disbursementSchedule.msfaaNumber.id).toBe(importedMSFAANumber.id);
+    expect(importedMSFAANumber).toEqual({
       id: expect.any(Number),
-      msfaaNumber: disbursementSchedule.msfaaNumber.msfaaNumber,
+      msfaaNumber: savedSFASIndividual.partTimeMSFAANumber,
       referenceApplication: { id: application.id },
-      dateSigned: null,
+      dateSigned: savedSFASPartTimeApplication.endDate,
       serviceProviderReceivedDate: null,
       dateRequested: null,
     });

--- a/sources/packages/backend/apps/workers/src/controllers/disbursement/_tests_/e2e/disbursement.controller.associateMSFAA.e2e-spec.ts
+++ b/sources/packages/backend/apps/workers/src/controllers/disbursement/_tests_/e2e/disbursement.controller.associateMSFAA.e2e-spec.ts
@@ -340,7 +340,9 @@ describe("DisbursementController(e2e)-associateMSFAA", () => {
       },
     });
 
-    expect(disbursementSchedule.msfaaNumber.id).toBe(importedMSFAANumber.id);
+    expect(disbursementSchedule.msfaaNumber.msfaaNumber).toBe(
+      importedMSFAANumber.msfaaNumber,
+    );
     expect(importedMSFAANumber).toEqual({
       id: disbursementSchedule.msfaaNumber.id,
       msfaaNumber: savedSFASIndividual.partTimeMSFAANumber,

--- a/sources/packages/backend/apps/workers/src/controllers/disbursement/_tests_/e2e/disbursement.controller.associateMSFAA.e2e-spec.ts
+++ b/sources/packages/backend/apps/workers/src/controllers/disbursement/_tests_/e2e/disbursement.controller.associateMSFAA.e2e-spec.ts
@@ -263,6 +263,100 @@ describe("DisbursementController(e2e)-associateMSFAA", () => {
     expect(cancelledMSFAANumber.cancelledDate).not.toBe(null);
   });
 
+  it("Should create a new MSFAA number for part-time applications when the valid SFAS part-time application does not have a part-time MSFAA number.", async () => {
+    // Arrange
+    const legacyApplicationStartDate = addDays(-100);
+    const legacyApplicationEndDate = addDays(-10);
+
+    const student = await saveFakeStudent(db.dataSource);
+    const application = await saveFakeApplicationDisbursements(
+      db.dataSource,
+      { student },
+      {
+        offeringIntensity: OfferingIntensity.partTime,
+        applicationStatus: ApplicationStatus.Completed,
+      },
+    );
+
+    const savedSFASIndividual = await saveFakeSFASIndividual(db.dataSource, {
+      initialValues: { student },
+    });
+    await db.sfasIndividual
+      .createQueryBuilder()
+      .update()
+      .set({ partTimeMSFAANumber: () => "NULL" })
+      .where("id = :id", { id: savedSFASIndividual.id })
+      .execute();
+
+    await db.sfasPartTimeApplications.save(
+      createFakeSFASPartTimeApplication(
+        { individual: savedSFASIndividual },
+        {
+          initialValues: {
+            startDate: getISODateOnlyString(legacyApplicationStartDate),
+            endDate: getISODateOnlyString(legacyApplicationEndDate),
+          },
+        },
+      ),
+    );
+
+    // Act
+    const associateMSFAAPayload = createFakeAssociateMSFAAPayload({
+      assessmentId: application.currentAssessment.id,
+    });
+    const saveResult = await disbursementController.associateMSFAA(
+      associateMSFAAPayload,
+    );
+
+    // Asserts
+    expect(FakeWorkerJobResult.getResultType(saveResult)).toBe(
+      MockedZeebeJobResult.Complete,
+    );
+
+    const createdMSFAANumber = await db.msfaaNumber.findOne({
+      select: {
+        id: true,
+        msfaaNumber: true,
+        dateSigned: true,
+        dateRequested: true,
+        serviceProviderReceivedDate: true,
+        referenceApplication: { id: true },
+      },
+      relations: {
+        referenceApplication: true,
+      },
+      where: {
+        student: { id: student.id },
+      },
+      order: {
+        id: "DESC",
+      },
+    });
+    const disbursementSchedule = await db.disbursementSchedule.findOne({
+      select: {
+        id: true,
+        msfaaNumber: { id: true, msfaaNumber: true },
+      },
+      relations: {
+        msfaaNumber: true,
+        studentAssessment: true,
+      },
+      where: {
+        studentAssessment: { id: application.currentAssessment.id },
+      },
+    });
+
+    expect(disbursementSchedule.msfaaNumber.id).toBe(createdMSFAANumber.id);
+    expect(createdMSFAANumber).toEqual({
+      id: expect.any(Number),
+      msfaaNumber: disbursementSchedule.msfaaNumber.msfaaNumber,
+      referenceApplication: { id: application.id },
+      dateSigned: null,
+      serviceProviderReceivedDate: null,
+      dateRequested: null,
+    });
+  });
+
   it("Should create a new MSFAA number for part-time applications by creating and activating in SIMS when MSFAA is not found or invalid SFAS application offering end date.", async () => {
     // Arrange
     const firstLegacyApplicationStartDate = addDays(-MAX_MSFAA_VALID_DAYS + 10);

--- a/sources/packages/backend/apps/workers/src/controllers/disbursement/_tests_/e2e/disbursement.controller.associateMSFAA.e2e-spec.ts
+++ b/sources/packages/backend/apps/workers/src/controllers/disbursement/_tests_/e2e/disbursement.controller.associateMSFAA.e2e-spec.ts
@@ -342,7 +342,7 @@ describe("DisbursementController(e2e)-associateMSFAA", () => {
 
     expect(disbursementSchedule.msfaaNumber.id).toBe(importedMSFAANumber.id);
     expect(importedMSFAANumber).toEqual({
-      id: expect.any(Number),
+      id: disbursementSchedule.msfaaNumber.id,
       msfaaNumber: savedSFASIndividual.partTimeMSFAANumber,
       referenceApplication: { id: application.id },
       dateSigned: savedSFASPartTimeApplication.endDate,

--- a/sources/packages/backend/libs/services/src/sfas/sfas-part-time-application.service.ts
+++ b/sources/packages/backend/libs/services/src/sfas/sfas-part-time-application.service.ts
@@ -84,7 +84,10 @@ export class SFASPartTimeApplicationsService extends DataModelService<SFASPartTi
       },
       where: {
         applicationCancelDate: IsNull(),
-        individual: { student: { id: studentId }, msfaaNumber: Not(IsNull()) },
+        individual: {
+          student: { id: studentId },
+          partTimeMSFAANumber: Not(IsNull()),
+        },
         endDate: MoreThanOrEqual(getISODateOnlyString(minMSFAAValidDate)),
       },
       order: {


### PR DESCRIPTION
### As a part of this PR, the following was completed:

- Updated the SFAS part-time application lookup to require a non-null part-time MSFAA number on the associated SFAS individual, aligning the query filter with the method’s purpose (fetching a valid MSFAA from a part-time application).
- Added an e2e test for the above logic:

  DisbursementController(e2e)-associateMSFAA
    √ Should import the MSFAA number for part-time application when the valid SFAS part-time application has a part-time MSFAA number.
    
    
<img width="1371" height="327" alt="image" src="https://github.com/user-attachments/assets/bdff6e10-303a-4aa6-a1c0-6ec324ffe76c" />
