### PR TITLE
#5969 - Update PIR outcome Styling

### DIFF
--- a/sources/packages/forms/src/form-definitions/sfaa2022-23.json
+++ b/sources/packages/forms/src/form-definitions/sfaa2022-23.json
@@ -897,9 +897,14 @@
                   "components": [
                     {
                       "label": "HTML",
-                      "tag": "h4",
-                      "className": "category-header-medium-small",
-                      "attrs": [{ "attr": "", "value": "" }],
+                      "tag": "h3",
+                      "className": "category-header-medium primary-color",
+                      "attrs": [
+                        {
+                          "attr": "",
+                          "value": ""
+                        }
+                      ],
                       "content": "Program information request summary",
                       "refreshOnChange": false,
                       "key": "pirSummaryHeader",

--- a/sources/packages/forms/src/form-definitions/sfaa2023-24.json
+++ b/sources/packages/forms/src/form-definitions/sfaa2023-24.json
@@ -897,8 +897,8 @@
                   "components": [
                     {
                       "label": "HTML",
-                      "tag": "h4",
-                      "className": "category-header-medium-small",
+                      "tag": "h3",
+                      "className": "category-header-medium primary-color",
                       "attrs": [
                         {
                           "attr": "",

--- a/sources/packages/forms/src/form-definitions/sfaa2024-25.json
+++ b/sources/packages/forms/src/form-definitions/sfaa2024-25.json
@@ -903,8 +903,8 @@
                   "components": [
                     {
                       "label": "HTML",
-                      "tag": "h4",
-                      "className": "category-header-medium-small",
+                      "tag": "h3",
+                      "className": "category-header-medium primary-color",
                       "attrs": [
                         {
                           "attr": "",

--- a/sources/packages/forms/src/form-definitions/sfaa2025-26-ft.json
+++ b/sources/packages/forms/src/form-definitions/sfaa2025-26-ft.json
@@ -1216,8 +1216,8 @@
                   "components": [
                     {
                       "label": "HTML",
-                      "tag": "h4",
-                      "className": "category-header-medium-small",
+                      "tag": "h3",
+                      "className": "category-header-medium primary-color",
                       "attrs": [
                         {
                           "attr": "",

--- a/sources/packages/forms/src/form-definitions/sfaa2025-26-pt.json
+++ b/sources/packages/forms/src/form-definitions/sfaa2025-26-pt.json
@@ -1173,8 +1173,8 @@
                   "components": [
                     {
                       "label": "HTML",
-                      "tag": "h4",
-                      "className": "category-header-medium-small",
+                      "tag": "h3",
+                      "className": "category-header-medium primary-color",
                       "attrs": [
                         {
                           "attr": "",

--- a/sources/packages/forms/src/form-definitions/sfaa2026-27-ft.json
+++ b/sources/packages/forms/src/form-definitions/sfaa2026-27-ft.json
@@ -1216,8 +1216,8 @@
                   "components": [
                     {
                       "label": "HTML",
-                      "tag": "h4",
-                      "className": "category-header-medium-small",
+                      "tag": "h3",
+                      "className": "category-header-medium primary-color",
                       "attrs": [
                         {
                           "attr": "",

--- a/sources/packages/forms/src/form-definitions/sfaa2026-27-pt.json
+++ b/sources/packages/forms/src/form-definitions/sfaa2026-27-pt.json
@@ -1194,6 +1194,7 @@
                       "input": true,
                       "tableView": false,
                       "label": "PIR Summary",
+                      "hideLabel": true,
                       "persistent": false,
                       "components": [
                         {

--- a/sources/packages/forms/src/form-definitions/sfaa2026-27-pt.json
+++ b/sources/packages/forms/src/form-definitions/sfaa2026-27-pt.json
@@ -1173,8 +1173,8 @@
                   "components": [
                     {
                       "label": "HTML",
-                      "tag": "h4",
-                      "className": "category-header-medium-small",
+                      "tag": "h3",
+                      "className": "category-header-medium primary-color",
                       "attrs": [
                         {
                           "attr": "",
@@ -1194,7 +1194,6 @@
                       "input": true,
                       "tableView": false,
                       "label": "PIR Summary",
-                      "hideLabel": true,
                       "persistent": false,
                       "components": [
                         {


### PR DESCRIPTION
### Summary

Update form definitions to use a header styling for the PIR outcome panel.

<img width="1151" height="301" alt="image" src="https://github.com/user-attachments/assets/af5958a4-02f7-463a-9983-852f4974c33d" />
