### PR TITLE
#6240 - Non punitive withdrawal formio fix

### DIFF
--- a/sources/packages/forms/src/form-definitions/nonpunitivewithdrawalform.json
+++ b/sources/packages/forms/src/form-definitions/nonpunitivewithdrawalform.json
@@ -58,7 +58,7 @@
       "customOptions": "",
       "validate": {
         "required": true,
-        "custom": "// Ensure the selected value is one of the available ones to be selected.\r\nconst isAvailableItem = data.scholasticStandingWithdrawals.filter(item => item.scholasticStandingId === value).length === 1;\r\nvalid = isAvailableItem || \"The selected item is not present in the list of available items.\""
+        "custom": "// Ensure the selected value is one of the available ones to be selected.\r\nconst isAvailableItem =\r\n  Array.isArray(data.scholasticStandingWithdrawals) &&\r\n  data.scholasticStandingWithdrawals.filter(\r\n    (item) => item.scholasticStandingId === input\r\n  ).length === 1;\r\nvalid =\r\n  isAvailableItem ||\r\n  \"The selected item is not present in the list of available items.\";"
       },
       "validateWhenHidden": false,
       "key": "nonPunitiveWithdrawalId",


### PR DESCRIPTION
## Root cause

The custom validation executed for the select component `nonPunitiveWithdrawalId` was always evaluating to false as the script variable `value` is being returned as undefined. 

```ts
// Ensure the selected value is one of the available ones to be selected.
const isAvailableItem = data.scholasticStandingWithdrawals.filter(item => item.scholasticStandingId === value).length === 1;
valid = isAvailableItem || "The selected item is not present in the list of available items."
```


## Solution

Using script variable `input` instead of `value` returns the correct user input. 

<img width="804" height="605" alt="image" src="https://github.com/user-attachments/assets/c38fdae6-8ed1-415f-8e87-3b35d6b193a0" />

The script was also formatted and array safe check added. 

```ts
// Ensure the selected value is one of the available ones to be selected.
const isAvailableItem =
  Array.isArray(data.scholasticStandingWithdrawals) &&
  data.scholasticStandingWithdrawals.filter(
    (item) => item.scholasticStandingId === input
  ).length === 1;
valid =
  isAvailableItem ||
  "The selected item is not present in the list of available items.";
```

## Manual testing

### Submission
<img width="1195" height="526" alt="image" src="https://github.com/user-attachments/assets/b6160a4e-68b8-4874-b97c-24d6cc48c5d0" />

### Read only
<img width="1296" height="748" alt="image" src="https://github.com/user-attachments/assets/819c4577-0ba5-4e81-b8aa-f721a56c727f" />

<img width="1223" height="236" alt="image" src="https://github.com/user-attachments/assets/a48a04eb-7505-4b25-bbab-b10419a7dca3" />
