### PR TITLE
#6240 - Form submission E2E Tests for non-punitive withdrawal

### DIFF
--- a/sims.code-workspace
+++ b/sims.code-workspace
@@ -185,6 +185,7 @@
       "DBLO",
       "dependants",
       "disabilitystatusapplicationform",
+      "nonpunitivewithdrawalform",
       "ecert",
       "ENRL",
       "enrolment",

--- a/sources/packages/backend/apps/api/src/route-controllers/form-submission/_tests_/e2e/forms/non-punitive-withdrawal-form/form-constants.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/form-submission/_tests_/e2e/forms/non-punitive-withdrawal-form/form-constants.ts
@@ -1,0 +1,1 @@
+export const FORM_DEFINITION_NAME = "nonpunitivewithdrawalform";

--- a/sources/packages/backend/apps/api/src/route-controllers/form-submission/_tests_/e2e/forms/non-punitive-withdrawal-form/form-submission.students.controller.submitForm.nonPunitiveWithdrawalForm.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/form-submission/_tests_/e2e/forms/non-punitive-withdrawal-form/form-submission.students.controller.submitForm.nonPunitiveWithdrawalForm.e2e-spec.ts
@@ -1,0 +1,229 @@
+import { HttpStatus, INestApplication } from "@nestjs/common";
+import request from "supertest";
+import {
+  BEARER_AUTH_TYPE,
+  createTestingAppModule,
+  FakeStudentUsersTypes,
+  getStudentToken,
+  mockJWTUserInfo,
+  resetMockJWTUserInfo,
+} from "../../../../../../testHelpers";
+import {
+  createE2EDataSources,
+  createFakeStudentScholasticStanding,
+  createFakeUser,
+  E2EDataSources,
+  saveFakeApplication,
+  saveFakeStudent,
+} from "@sims/test-utils";
+import { TestingModule } from "@nestjs/testing";
+import {
+  Application,
+  ApplicationStatus,
+  DynamicFormConfiguration,
+  Student,
+  StudentScholasticStanding,
+  StudentScholasticStandingChangeType,
+  User,
+} from "@sims/sims-db";
+import { FORM_DEFINITION_NAME } from "./form-constants";
+import { FormSubmissionAPIInDTO } from "../../../../models/form-submission.dto";
+
+interface ApplicationWithWithdrawal {
+  application: Application;
+  scholasticStandingWithdrawal: StudentScholasticStanding;
+}
+describe(`FormSubmissionStudentsController(e2e)-submitForm-${FORM_DEFINITION_NAME}`, () => {
+  let app: INestApplication;
+  let appModule: TestingModule;
+  let db: E2EDataSources;
+  let formConfig: DynamicFormConfiguration;
+  let auditUser: User;
+
+  beforeAll(async () => {
+    const { nestApplication, dataSource, module } =
+      await createTestingAppModule();
+    app = nestApplication;
+    appModule = module;
+    db = createE2EDataSources(dataSource);
+    formConfig = await db.dynamicFormConfiguration.findOneOrFail({
+      select: { id: true },
+      where: { formDefinitionName: FORM_DEFINITION_NAME },
+    });
+    auditUser = await db.user.save(createFakeUser());
+  });
+
+  beforeEach(async () => {
+    // Clear all mocks.
+    jest.clearAllMocks();
+    await resetMockJWTUserInfo(appModule);
+  });
+
+  it(
+    `Should submit non punitive withdrawal form for an application with scholastic standing type ${StudentScholasticStandingChangeType.StudentWithdrewFromProgram}` +
+      " when the scholastic standing change is active and not already marked as non-punitive.",
+    async () => {
+      // Arrange
+      const { student, applications } = await createApplicationsWithWithdrawal(
+        db,
+        auditUser,
+      );
+      const [firstApplication] = applications;
+      // Payload to validate the submission.
+      const payload = getNonPunitiveWithdrawalFormData(
+        formConfig.id,
+        applications,
+        firstApplication.scholasticStandingWithdrawal.id,
+      );
+
+      const endpoint = "/students/form-submission";
+      const studentToken = await getStudentToken(
+        FakeStudentUsersTypes.FakeStudentUserType1,
+      );
+      // Mock the user received in the token.
+      await mockJWTUserInfo(appModule, student.user);
+
+      // Act/Assert
+      let createdSubmissionId: number;
+      await request(app.getHttpServer())
+        .post(endpoint)
+        .send(payload)
+        .auth(studentToken, BEARER_AUTH_TYPE)
+        .expect(HttpStatus.CREATED)
+        .then((response) => (createdSubmissionId = +response.body.id));
+
+      // Assert the created form submission.
+      const formSubmission = await db.formSubmission.findOneOrFail({
+        select: {
+          id: true,
+          formSubmissionItems: { id: true, submittedData: true },
+        },
+        relations: { formSubmissionItems: true },
+        where: { id: createdSubmissionId },
+      });
+      expect(formSubmission.id).toBe(createdSubmissionId);
+      const [formSubmissionItem] = formSubmission.formSubmissionItems;
+      const [expectedFormSubmissionItem] = payload.items;
+      expect(formSubmissionItem.submittedData).toEqual(
+        expectedFormSubmissionItem.formData,
+      );
+    },
+  );
+
+  it(`Should throw bad request error when requested scholastic standing withdrawal id in form data is invalid.`, async () => {
+    // Arrange
+    const { student, applications } = await createApplicationsWithWithdrawal(
+      db,
+      auditUser,
+    );
+    // Payload to validate the submission.
+    const payload = getNonPunitiveWithdrawalFormData(
+      formConfig.id,
+      applications,
+      999999, // Invalid scholastic standing withdrawal id.
+    );
+
+    const endpoint = "/students/form-submission";
+    const studentToken = await getStudentToken(
+      FakeStudentUsersTypes.FakeStudentUserType1,
+    );
+    // Mock the user received in the token.
+    await mockJWTUserInfo(appModule, student.user);
+
+    // Act/Assert
+    await request(app.getHttpServer())
+      .post(endpoint)
+      .send(payload)
+      .auth(studentToken, BEARER_AUTH_TYPE)
+      .expect(HttpStatus.BAD_REQUEST)
+      .expect({
+        message: "Failed to submit the form due to invalid dynamic data.",
+        error: "Bad Request",
+        statusCode: HttpStatus.BAD_REQUEST,
+      });
+  });
+  afterAll(async () => {
+    await app?.close();
+  });
+});
+
+/**
+ * Create applications with reported scholastic standing change type withdrawal for a student.
+ * @param db e2e data sources.
+ * @param auditUser audit user to create scholastic standing.
+ * @returns the created application and the scholastic standing withdrawal id.
+ */
+async function createApplicationsWithWithdrawal(
+  db: E2EDataSources,
+  auditUser: User,
+  applicationsCount = 1,
+): Promise<{ student: Student; applications: ApplicationWithWithdrawal[] }> {
+  const student = await saveFakeStudent(db.dataSource);
+  const applications: ApplicationWithWithdrawal[] = [];
+  for (let i = 0; i < applicationsCount; i++) {
+    const application = await saveFakeApplication(
+      db.dataSource,
+      { student },
+      {
+        applicationStatus: ApplicationStatus.Completed,
+      },
+    );
+    const scholasticStandingWithdrawal =
+      await db.studentScholasticStanding.save(
+        createFakeStudentScholasticStanding(
+          { submittedBy: auditUser, application },
+          {
+            initialValues: {
+              changeType:
+                StudentScholasticStandingChangeType.StudentWithdrewFromProgram,
+            },
+          },
+        ),
+      );
+    // Link the assessment to the scholastic standing.
+    const currentAssessment = application.currentAssessment!;
+    currentAssessment.studentScholasticStanding = scholasticStandingWithdrawal;
+    await db.studentAssessment.save(currentAssessment);
+    applications.push({
+      application,
+      scholasticStandingWithdrawal,
+    });
+  }
+  return { student, applications };
+}
+/**
+ * Gets the form submission data for non-punitive withdrawal form.
+ * @param dynamicFormConfigId The ID of the dynamic form configuration.
+ * @param eligibleApplications The list of eligible applications with withdrawal information.
+ * @param scholasticStandingWithdrawalId The ID of the scholastic standing withdrawal.
+ * @param options options to generate the form data.
+ * - `eligibleCircumstances` eligible circumstances for the non-punitive withdrawal.
+ * @returns The form submission data.
+ */
+function getNonPunitiveWithdrawalFormData(
+  dynamicFormConfigId: number,
+  eligibleApplications: ApplicationWithWithdrawal[],
+  scholasticStandingWithdrawalId: number,
+  options?: { eligibleCircumstances?: string },
+): FormSubmissionAPIInDTO {
+  return {
+    items: [
+      {
+        dynamicConfigurationId: dynamicFormConfigId,
+        formData: {
+          actions: ["UpdateNonPunitiveScholasticStandingWithdrawal"],
+          eligibleCircumstances:
+            options?.eligibleCircumstances ?? "withdrawnFromStudies",
+          nonPunitiveWithdrawalId: scholasticStandingWithdrawalId,
+          scholasticStandingWithdrawals: eligibleApplications.map(
+            (application) => ({
+              applicationNumber: application.application.applicationNumber,
+              scholasticStandingId: application.scholasticStandingWithdrawal.id,
+            }),
+          ),
+        },
+        files: [],
+      },
+    ],
+  };
+}

--- a/sources/packages/backend/apps/api/src/route-controllers/form-submission/_tests_/e2e/forms/non-punitive-withdrawal-form/form-submission.students.controller.submitForm.nonPunitiveWithdrawalForm.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/form-submission/_tests_/e2e/forms/non-punitive-withdrawal-form/form-submission.students.controller.submitForm.nonPunitiveWithdrawalForm.e2e-spec.ts
@@ -149,9 +149,10 @@ describe(`FormSubmissionStudentsController(e2e)-submitForm-${FORM_DEFINITION_NAM
 
 /**
  * Create applications with reported scholastic standing change type withdrawal for a student.
- * @param db e2e data sources.
- * @param auditUser audit user to create scholastic standing.
- * @returns the created application and the scholastic standing withdrawal id.
+ * @param db E2E data sources.
+ * @param auditUser Audit user to create scholastic standing.
+ * @param applicationsCount Number of applications to be created with withdrawal for a student.
+ * @returns Student and applications with withdrawal.
  */
 async function createApplicationsWithWithdrawal(
   db: E2EDataSources,
@@ -180,10 +181,10 @@ async function createApplicationsWithWithdrawal(
           },
         ),
       );
-    // Link the assessment to the scholastic standing.
-    const currentAssessment = application.currentAssessment!;
-    currentAssessment.studentScholasticStanding = scholasticStandingWithdrawal;
-    await db.studentAssessment.save(currentAssessment);
+    // Link the current assessment to the scholastic standing.
+    application.currentAssessment!.studentScholasticStanding =
+      scholasticStandingWithdrawal;
+    await db.application.save(application);
     applications.push({
       application,
       scholasticStandingWithdrawal,
@@ -196,8 +197,8 @@ async function createApplicationsWithWithdrawal(
  * @param dynamicFormConfigId The ID of the dynamic form configuration.
  * @param eligibleApplications The list of eligible applications with withdrawal information.
  * @param scholasticStandingWithdrawalId The ID of the scholastic standing withdrawal.
- * @param options options to generate the form data.
- * - `eligibleCircumstances` eligible circumstances for the non-punitive withdrawal.
+ * @param options Options to generate the form data.
+ * - `eligibleCircumstances` Eligible circumstances for the non-punitive withdrawal.
  * @returns The form submission data.
  */
 function getNonPunitiveWithdrawalFormData(

--- a/sources/packages/backend/apps/api/src/route-controllers/form-submission/_tests_/e2e/forms/non-punitive-withdrawal-form/form-submission.students.controller.submitForm.nonPunitiveWithdrawalForm.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/form-submission/_tests_/e2e/forms/non-punitive-withdrawal-form/form-submission.students.controller.submitForm.nonPunitiveWithdrawalForm.e2e-spec.ts
@@ -60,7 +60,7 @@ describe(`FormSubmissionStudentsController(e2e)-submitForm-${FORM_DEFINITION_NAM
   });
 
   it(
-    `Should submit non punitive withdrawal form for an application with scholastic standing type ${StudentScholasticStandingChangeType.StudentWithdrewFromProgram}` +
+    `Should submit non-punitive withdrawal form for an application with scholastic standing type ${StudentScholasticStandingChangeType.StudentWithdrewFromProgram}` +
       " when the scholastic standing change is active and not already marked as non-punitive.",
     async () => {
       // Arrange
@@ -142,6 +142,7 @@ describe(`FormSubmissionStudentsController(e2e)-submitForm-${FORM_DEFINITION_NAM
         statusCode: HttpStatus.BAD_REQUEST,
       });
   });
+
   afterAll(async () => {
     await app?.close();
   });
@@ -192,6 +193,7 @@ async function createApplicationsWithWithdrawal(
   }
   return { student, applications };
 }
+
 /**
  * Gets the form submission data for non-punitive withdrawal form.
  * @param dynamicFormConfigId The ID of the dynamic form configuration.

--- a/sources/packages/backend/apps/test-db-seeding/src/clean-db/clean-db.ts
+++ b/sources/packages/backend/apps/test-db-seeding/src/clean-db/clean-db.ts
@@ -17,10 +17,15 @@ export class CleanDatabase {
     const dropIsValidSystemLookupKeyFunctionPromise = this.dataSource.query(
       "DROP FUNCTION IF EXISTS sims.is_valid_system_lookup_key(TEXT,TEXT)",
     );
+    const dropIsValidSystemLookupKeyArrayFunctionPromise =
+      this.dataSource.query(
+        "DROP FUNCTION IF EXISTS sims.is_valid_system_lookup_key_array(input_keys TEXT[], input_category TEXT)",
+      );
     await Promise.all([
       dropExtensionPGTRGMPromise,
       dropCreateHistoryEntryFunctionPromise,
       dropIsValidSystemLookupKeyFunctionPromise,
+      dropIsValidSystemLookupKeyArrayFunctionPromise,
     ]);
   }
 }


### PR DESCRIPTION
## E2E Tests

```spec
FormSubmissionStudentsController(e2e)-submitForm-nonpunitivewithdrawalform
    √ Should submit non punitive withdrawal form for an application with scholastic standing type Student withdrew from program when the scholastic standing change is active and not already marked as non-punitive. (866 ms)
    √ Should throw bad request error when requested scholastic standing withdrawal id in form data is invalid. (249 ms)
```

- Added drop function `sims.is_valid_system_lookup_key_array` to data seed cleanup as the reset e2e data was failing.