### PR TITLE
#393 - Cherry pick #6277 fix into main

### DIFF
--- a/sources/packages/backend/apps/api/src/route-controllers/institution/_tests_/e2e/institution.aest.controller.createInstitution.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/institution/_tests_/e2e/institution.aest.controller.createInstitution.e2e-spec.ts
@@ -16,6 +16,10 @@ import {
   BC_PROVINCE_CODE,
   INSTITUTION_TYPE_BC_PUBLIC,
 } from "@sims/sims-db/constant";
+import {
+  getInstitutionProfilePayload,
+  INTERNATIONAL_COUNTRY_CODE,
+} from "./institution.utils";
 
 describe("InstitutionAESTController(e2e)-createInstitution", () => {
   let app: INestApplication;
@@ -149,6 +153,34 @@ describe("InstitutionAESTController(e2e)-createInstitution", () => {
       organizationStatus: payload.organizationStatus,
       medicalSchoolStatus: null,
     });
+  });
+
+  it("Should create international institution when province is provided as empty string.", async () => {
+    // Arrange
+    const payload = {
+      ...getInstitutionProfilePayload(),
+      legalOperatingName: "Create Institution legal operating name",
+    };
+    payload.country = INTERNATIONAL_COUNTRY_CODE;
+    payload.province = "";
+    const endpoint = "/aest/institution";
+    const token = await getAESTToken(AESTGroups.BusinessAdministrators);
+
+    // Act/Assert
+    let institutionId: number;
+    await request(app.getHttpServer())
+      .post(endpoint)
+      .send(payload)
+      .auth(token, BEARER_AUTH_TYPE)
+      .expect(HttpStatus.CREATED)
+      .then((response) => {
+        expect(response.body.id).toBeGreaterThan(0);
+        institutionId = response.body.id;
+      });
+    const isInstitutionSaved = await db.institution.exists({
+      where: { id: institutionId },
+    });
+    expect(isInstitutionSaved).toBe(true);
   });
 
   it("Should throw bad request error when country is not Canada and medical status is not provided.", async () => {

--- a/sources/packages/backend/apps/api/src/route-controllers/institution/_tests_/e2e/institution.utils.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/institution/_tests_/e2e/institution.utils.ts
@@ -7,6 +7,11 @@ import { CANADA_COUNTRY_CODE, BC_PROVINCE_CODE } from "@sims/sims-db/constant";
 import { InstitutionProfileAPIInDTO } from "../../models/institution.dto";
 
 /**
+ * International country code to test the international institutions.
+ */
+export const INTERNATIONAL_COUNTRY_CODE = "AF";
+
+/**
  * Get the institution profile payload.
  * @returns institution profile payload.
  */

--- a/sources/packages/backend/apps/api/src/route-controllers/institution/models/institution.dto.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/institution/models/institution.dto.ts
@@ -9,7 +9,7 @@ import {
   ValidateNested,
 } from "class-validator";
 import { OmitType } from "@nestjs/mapped-types";
-import { Type } from "class-transformer";
+import { Transform, Type } from "class-transformer";
 import { DesignationStatus } from "../../../route-controllers/institution-locations/models/institution-location.dto";
 import {
   AddressDetailsAPIInDTO,
@@ -64,6 +64,7 @@ export class InstitutionProfileAPIInDTO extends InstitutionContactAPIInDTO {
   @IsNotEmpty()
   @Length(2, 2)
   country: string;
+  @Transform(({ value }) => value || null)
   @ValidateIf(
     (input: InstitutionProfileAPIInDTO) =>
       input.country === CANADA_COUNTRY_CODE || !!input.province,


### PR DESCRIPTION
## Cherry picked the following commit from `V3.5.1`
https://github.com/bcgov/SIMS/commit/4224aed44958dd40d7b393384878b0e0f69e1694

## Added E2E Test
```spec
InstitutionAESTController(e2e)-createInstitution
    √ Should create international institution when province is provided as empty string. (68 ms)
```