### PR TITLE
#5837 - Upgrade Vuetify - Part 4

### DIFF
--- a/sources/packages/forms/src/form-definitions/programinformationrequest.json
+++ b/sources/packages/forms/src/form-definitions/programinformationrequest.json
@@ -19,7 +19,6 @@
       ],
       "content": "<span class=\"category-header-large primary-color mr-2\">{{ data.studentFullName }}</span> <span class=\"fa fa-circle formio-status-chip {{ data.programInfoRequestStatus }} mt-1\">{{ data.pirStatus }}</span>",
       "refreshOnChange": true,
-      "customClass": "mt-5",
       "key": "html16",
       "type": "htmlelement",
       "input": false,

--- a/sources/packages/web/package-lock.json
+++ b/sources/packages/web/package-lock.json
@@ -26,7 +26,7 @@
         "uuid": "^14.0.0",
         "vue": "^3.5.38",
         "vue-router": "^5.1.0",
-        "vuetify": "^4.1.1",
+        "vuetify": "^4.1.2",
         "vuex": "^4.1.0"
       },
       "devDependencies": {
@@ -4514,9 +4514,9 @@
       }
     },
     "node_modules/vuetify": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-4.1.1.tgz",
-      "integrity": "sha512-m75ZkDIBwstDhID/zPtQmh9m601G/C4wnvCmlA6hgvhD7EOwR9I4DClpxPQiNTd1toKWHCr3kD2XJqU1fh0tYA==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-4.1.2.tgz",
+      "integrity": "sha512-2SUzXt2Q71/cVmSZhU6kOmAo1ev3NZaI/ynj55TTcu6jXAc9kezoqZKY+Xm+0STnAOcCoTseF0qPSs01LjUaaA==",
       "license": "MIT",
       "funding": {
         "type": "github",

--- a/sources/packages/web/package.json
+++ b/sources/packages/web/package.json
@@ -30,7 +30,7 @@
     "uuid": "^14.0.0",
     "vue": "^3.5.38",
     "vue-router": "^5.1.0",
-    "vuetify": "^4.1.1",
+    "vuetify": "^4.1.2",
     "vuex": "^4.1.0"
   },
   "devDependencies": {

--- a/sources/packages/web/src/assets/css/base.scss
+++ b/sources/packages/web/src/assets/css/base.scss
@@ -204,12 +204,6 @@ strong {
   background-color: $banner-background-warning !important;
 }
 
-// Active class for nav bar.
-.navigation-btn .active-btn {
-  color: $brand-blue !important;
-  background-color: $color-white !important;
-}
-
 // Btn toggle groups for nav bar adjustment.
 .navigation-btn.v-btn-group {
   min-width: fit-content;

--- a/sources/packages/web/src/components/aest/students/bypassedRestrictions/BypassRestrictionModal.vue
+++ b/sources/packages/web/src/components/aest/students/bypassedRestrictions/BypassRestrictionModal.vue
@@ -25,20 +25,23 @@
             :disabled="readOnly"
             hide-details="auto"
           >
-            <template #item="{ props, item }">
+            <template #item="{ props, internalItem }">
               <v-list-item v-bind="props" title="" class="my-2">
-                {{ item.title }}
+                {{ internalItem.title }}
                 <chip-tag
                   color="black"
                   class="float-right"
-                  :label="item.raw.restrictedParty"
+                  :label="internalItem.raw.restrictedParty"
                 />
               </v-list-item>
             </template>
-            <template #selection="{ item }">
+            <template #selection="{ internalItem }">
               <v-list-item title="">
-                {{ item.title }}
-                <chip-tag color="black" :label="item.raw.restrictedParty" />
+                {{ internalItem.title }}
+                <chip-tag
+                  color="black"
+                  :label="internalItem.raw.restrictedParty"
+                />
               </v-list-item>
             </template>
           </v-select>

--- a/sources/packages/web/src/components/common/OfferingSummary.vue
+++ b/sources/packages/web/src/components/common/OfferingSummary.vue
@@ -1,157 +1,161 @@
 <template>
-  <body-header
-    title="Study period offerings"
-    :records-count="offeringsAndCount.count"
-  >
-    <template #actions>
-      <v-form ref="searchOfferingsForm">
-        <div class="d-flex flex-wrap align-center ga-3">
-          <!-- Search Field -->
-          <v-text-field
-            density="compact"
-            label="Search Offering Name"
-            variant="outlined"
-            v-model="searchBox"
-            data-cy="searchBox"
-            @keyup.enter="searchOfferingTable"
-            prepend-inner-icon="mdi-magnify"
-            hide-details="auto"
-            class="flex-grow-1"
-          />
-
-          <!-- Date Range Group - stays together -->
-          <div class="d-flex align-center ga-2 flex-grow-1">
-            <v-date-input
-              density="compact"
-              variant="outlined"
-              label="From (Study Start Date)"
-              :input-format="DATE_ONLY_ISO_FORMAT"
-              hide-details="auto"
-              prepend-icon=""
-              append-inner-icon="mdi-calendar"
-              v-model="startDate"
-            />
-            <v-date-input
-              density="compact"
-              variant="outlined"
-              label="To (Study Start Date)"
-              :input-format="DATE_ONLY_ISO_FORMAT"
-              hide-details="auto"
-              prepend-icon=""
-              append-inner-icon="mdi-calendar"
-              v-model="endDate"
-            />
-            <tooltip-icon>
-              This date range allows you to filter by the study start date.
-              <br />
-              To show offerings for a specific program year enter
-              <br />
-              August 1st 20XX in the first entry field and then enter <br />
-              July 31st 20YY where program year is 20XX - 20YY.
-            </tooltip-icon>
-          </div>
-
-          <!-- Search Button -->
-          <v-btn
-            color="primary"
-            data-cy="searchOfferings"
-            @click="searchOfferingTable()"
-          >
-            Search
-          </v-btn>
-
-          <!-- Intensity Filter Group -->
-          <v-btn-toggle
-            v-model="intensityFilter"
-            density="compact"
-            class="btn-toggle"
-            selected-class="selected-btn-toggle"
-            mandatory
-            @click="searchOfferingTable()"
-          >
-            <v-btn
-              rounded="xl"
-              color="primary"
-              value="All"
-              size="small"
-              class="mr-1"
-              >All</v-btn
-            >
-            <v-btn
-              rounded="xl"
-              color="primary"
-              value="Full Time"
-              size="small"
-              class="mr-1"
-              >Full-time</v-btn
-            >
-            <v-btn
-              rounded="xl"
-              color="primary"
-              value="Part Time"
-              size="small"
-              class="mr-1"
-              >Part-time</v-btn
-            >
-          </v-btn-toggle>
-        </div>
-        <!-- Error display at bottom -->
-        <v-input :rules="[isValidSearch()]" hide-details="auto" error />
-      </v-form>
-    </template>
-  </body-header>
-  <content-group>
-    <toggle-content
-      :toggled="!offeringsAndCount.count && !loading"
-      message="No study period offerings found."
-    >
-      <v-data-table-server
-        :headers="OfferingSummaryHeaders"
-        :items="offeringsAndCount?.results"
-        :items-length="offeringsAndCount?.count"
-        :loading="loading"
-        item-value="id"
-        :items-per-page="DEFAULT_PAGE_LIMIT"
-        :items-per-page-options="ITEMS_PER_PAGE"
-        :mobile="isMobile"
-        @update:options="pageSortEvent"
+  <body-header-container>
+    <template #header>
+      <body-header
+        title="Study period offerings"
+        :records-count="offeringsAndCount.count"
       >
-        <template #[`item.name`]="{ item }">
-          {{ item.name }}
+        <template #actions>
+          <v-form ref="searchOfferingsForm">
+            <div class="d-flex flex-wrap align-center ga-3">
+              <!-- Search Field -->
+              <v-text-field
+                density="compact"
+                label="Search Offering Name"
+                variant="outlined"
+                v-model="searchBox"
+                data-cy="searchBox"
+                @keyup.enter="searchOfferingTable"
+                prepend-inner-icon="mdi-magnify"
+                hide-details="auto"
+                class="flex-grow-1"
+              />
+
+              <!-- Date Range Group - stays together -->
+              <div class="d-flex align-center ga-2 flex-grow-1">
+                <v-date-input
+                  density="compact"
+                  variant="outlined"
+                  label="From (Study Start Date)"
+                  :input-format="DATE_ONLY_ISO_FORMAT"
+                  hide-details="auto"
+                  prepend-icon=""
+                  append-inner-icon="mdi-calendar"
+                  v-model="startDate"
+                />
+                <v-date-input
+                  density="compact"
+                  variant="outlined"
+                  label="To (Study Start Date)"
+                  :input-format="DATE_ONLY_ISO_FORMAT"
+                  hide-details="auto"
+                  prepend-icon=""
+                  append-inner-icon="mdi-calendar"
+                  v-model="endDate"
+                />
+                <tooltip-icon>
+                  This date range allows you to filter by the study start date.
+                  <br />
+                  To show offerings for a specific program year enter
+                  <br />
+                  August 1st 20XX in the first entry field and then enter <br />
+                  July 31st 20YY where program year is 20XX - 20YY.
+                </tooltip-icon>
+              </div>
+
+              <!-- Search Button -->
+              <v-btn
+                color="primary"
+                data-cy="searchOfferings"
+                @click="searchOfferingTable()"
+              >
+                Search
+              </v-btn>
+
+              <!-- Intensity Filter Group -->
+              <v-btn-toggle
+                v-model="intensityFilter"
+                density="compact"
+                class="btn-toggle"
+                selected-class="selected-btn-toggle"
+                mandatory
+                @click="searchOfferingTable()"
+              >
+                <v-btn
+                  rounded="xl"
+                  color="primary"
+                  value="All"
+                  size="small"
+                  class="mr-1"
+                  >All</v-btn
+                >
+                <v-btn
+                  rounded="xl"
+                  color="primary"
+                  value="Full Time"
+                  size="small"
+                  class="mr-1"
+                  >Full-time</v-btn
+                >
+                <v-btn
+                  rounded="xl"
+                  color="primary"
+                  value="Part Time"
+                  size="small"
+                  class="mr-1"
+                  >Part-time</v-btn
+                >
+              </v-btn-toggle>
+            </div>
+            <!-- Error display at bottom -->
+            <v-input :rules="[isValidSearch()]" hide-details="auto" error />
+          </v-form>
         </template>
-        <template #[`item.yearOfStudy`]="{ item }">
-          {{ item.yearOfStudy }}
-        </template>
-        <template #[`item.studyStartDate`]="{ item }">
-          {{ item.studyStartDate }}
-        </template>
-        <template #[`item.studyEndDate`]="{ item }">
-          {{ item.studyEndDate }}
-        </template>
-        <template #[`item.offeringIntensity`]="{ item }">
-          {{ mapOfferingIntensity(item.offeringIntensity) }}
-        </template>
-        <template #[`item.offeringDelivered`]="{ item }">
-          <div class="p-text-capitalize">
-            {{ item.offeringDelivered }}
-          </div>
-        </template>
-        <template #[`item.offeringStatus`]="{ item }">
-          <status-chip-offering :status="item.offeringStatus" />
-        </template>
-        <template #[`item.action`]="{ item }">
-          <v-btn
-            color="primary"
-            variant="text"
-            @click="offeringButtonAction(item.id)"
-            append-icon="mdi-pencil-outline"
-          >
-            {{ offeringActionLabel }}
-          </v-btn>
-        </template>
-      </v-data-table-server>
-    </toggle-content>
-  </content-group>
+      </body-header>
+    </template>
+    <content-group>
+      <toggle-content
+        :toggled="!offeringsAndCount.count && !loading"
+        message="No study period offerings found."
+      >
+        <v-data-table-server
+          :headers="OfferingSummaryHeaders"
+          :items="offeringsAndCount?.results"
+          :items-length="offeringsAndCount?.count"
+          :loading="loading"
+          item-value="id"
+          :items-per-page="DEFAULT_PAGE_LIMIT"
+          :items-per-page-options="ITEMS_PER_PAGE"
+          :mobile="isMobile"
+          @update:options="pageSortEvent"
+        >
+          <template #[`item.name`]="{ item }">
+            {{ item.name }}
+          </template>
+          <template #[`item.yearOfStudy`]="{ item }">
+            {{ item.yearOfStudy }}
+          </template>
+          <template #[`item.studyStartDate`]="{ item }">
+            {{ item.studyStartDate }}
+          </template>
+          <template #[`item.studyEndDate`]="{ item }">
+            {{ item.studyEndDate }}
+          </template>
+          <template #[`item.offeringIntensity`]="{ item }">
+            {{ mapOfferingIntensity(item.offeringIntensity) }}
+          </template>
+          <template #[`item.offeringDelivered`]="{ item }">
+            <div class="p-text-capitalize">
+              {{ item.offeringDelivered }}
+            </div>
+          </template>
+          <template #[`item.offeringStatus`]="{ item }">
+            <status-chip-offering :status="item.offeringStatus" />
+          </template>
+          <template #[`item.action`]="{ item }">
+            <v-btn
+              color="primary"
+              variant="text"
+              @click="offeringButtonAction(item.id)"
+              append-icon="mdi-pencil-outline"
+            >
+              {{ offeringActionLabel }}
+            </v-btn>
+          </template>
+        </v-data-table-server>
+      </toggle-content>
+    </content-group>
+  </body-header-container>
 </template>
 
 <script lang="ts">

--- a/sources/packages/web/src/components/common/ProgramDetails.vue
+++ b/sources/packages/web/src/components/common/ProgramDetails.vue
@@ -8,6 +8,7 @@
             :is-active="
               educationProgram.isActive && !educationProgram.isExpired
             "
+            data-cy="programStatus"
           ></status-chip-program>
         </template>
         <template #actions>

--- a/sources/packages/web/src/components/common/ProgramDetails.vue
+++ b/sources/packages/web/src/components/common/ProgramDetails.vue
@@ -8,7 +8,6 @@
             :is-active="
               educationProgram.isActive && !educationProgram.isExpired
             "
-            data-cy="programStatus"
           ></status-chip-program>
         </template>
         <template #actions>

--- a/sources/packages/web/src/components/common/SharedLogin.vue
+++ b/sources/packages/web/src/components/common/SharedLogin.vue
@@ -29,7 +29,9 @@
             </content-group>
           </body-header-container>
         </v-col>
-        <v-col cols="12" md="3" align-self="end"><slot name="image" /></v-col>
+        <v-col cols="12" md="3" class="align-self-end"
+          ><slot name="image"
+        /></v-col>
       </v-row>
       <v-row v-if="$slots['banner-message']">
         <v-col cols="12">

--- a/sources/packages/web/src/components/common/students/StudentDisabilityDisabilities.vue
+++ b/sources/packages/web/src/components/common/students/StudentDisabilityDisabilities.vue
@@ -16,7 +16,7 @@
         @delete-disability="deleteDisability(index)"
       />
     </v-expansion-panels>
-    <v-row class="mt-2" v-if="!readOnly" justify="end">
+    <v-row class="mt-2 justify-end" v-if="!readOnly">
       <v-col cols="auto">
         <v-btn
           prepend-icon="fas fa-plus"

--- a/sources/packages/web/src/components/common/students/applicationDetails/StudentAppealRequestsApproval.vue
+++ b/sources/packages/web/src/components/common/students/applicationDetails/StudentAppealRequestsApproval.vue
@@ -38,7 +38,7 @@
     @submitted="$emit('submitted', $event)"
   >
     <template #approval-actions="{ submit }" v-if="!readOnly">
-      <v-row justify="center" class="m-2">
+      <v-row class="m-2 justify-center">
         <v-btn
           color="primary"
           variant="outlined"

--- a/sources/packages/web/src/components/form-submissions/FormSubmissionApproval.vue
+++ b/sources/packages/web/src/components/form-submissions/FormSubmissionApproval.vue
@@ -46,7 +46,10 @@
               />
               <!-- Users without approval authorization do not need to see any information other than the note above. -->
               <template v-if="decision.canAssessItemDecision">
-                <v-row justify="space-between" class="mt-2 mb-1 mx-0">
+                <v-row
+                  class="mt-2 mb-1 mx-0 justify-space-between"
+                  density="compact"
+                >
                   <v-input
                     v-model="decision.decisionStatus"
                     :rules="[
@@ -99,7 +102,6 @@
                     >
                     <template v-else>
                       <v-btn
-                        class="float-right mr-2"
                         color="primary"
                         variant="outlined"
                         :loading="decision.saveDecisionInProgress"
@@ -107,7 +109,6 @@
                         >Cancel
                       </v-btn>
                       <v-btn
-                        class="float-right"
                         color="primary"
                         :loading="decision.saveDecisionInProgress"
                         @click="saveDecision(decision)"

--- a/sources/packages/web/src/components/form-submissions/FormSubmissionDecisionHistory.vue
+++ b/sources/packages/web/src/components/form-submissions/FormSubmissionDecisionHistory.vue
@@ -7,8 +7,8 @@
       :dot-color="history.statusColor"
       size="x-small"
     >
-      <v-sheet color="grey-lighten-4 p-3" rounded class="content-footer">
-        <h4 class="text-body-2">
+      <v-sheet color="grey-lighten-4 p-2" rounded class="content-footer">
+        <h4 class="text-body-medium my-0">
           <strong class="secondary-color-light">
             Saved as {{ history.decisionStatus }} on
             {{ getISODateHourMinuteString(history.decisionDate) }}

--- a/sources/packages/web/src/components/form-submissions/FormSubmissionHistory.vue
+++ b/sources/packages/web/src/components/form-submissions/FormSubmissionHistory.vue
@@ -50,7 +50,6 @@
             v-for="submission in filteredSubmissions"
             :key="submission.id"
             variant="elevated"
-            :ripple="false"
             @click="
               canViewFormSubmittedData &&
               submission.canViewFormSubmittedData !== false

--- a/sources/packages/web/src/components/generic/FooterButtons.vue
+++ b/sources/packages/web/src/components/generic/FooterButtons.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-row :justify="justify" class="mt-2 mb-1" density="compact">
+  <v-row :class="['mt-2 mb-1', justifyClass]" density="compact">
     <v-btn
       :disabled="processing"
       :color="secondaryButtonColor"
@@ -24,7 +24,7 @@
   </v-row>
 </template>
 <script lang="ts">
-import { defineComponent, PropType } from "vue";
+import { computed, defineComponent, PropType } from "vue";
 export default defineComponent({
   emits: ["primaryClick", "secondaryClick"],
   props: {
@@ -99,6 +99,12 @@ export default defineComponent({
       required: false,
       default: false,
     },
+  },
+  setup(props) {
+    const justifyClass = computed(() => `justify-${props.justify}`);
+    return {
+      justifyClass,
+    };
   },
 });
 </script>

--- a/sources/packages/web/src/components/generic/FormioContainer.vue
+++ b/sources/packages/web/src/components/generic/FormioContainer.vue
@@ -1,11 +1,11 @@
 <template>
   <formio
-    :formName="formName"
+    :form-name="formName"
     :data="formData"
-    :readOnly="readOnly"
+    :read-only="readOnly"
     :is-data-ready="isDataReady"
     @loaded="formLoaded"
-    @customEvent="formCustomEvent"
+    @custom-event="formCustomEvent"
     @render="formRender"
     @changed="formChanged"
   ></formio>

--- a/sources/packages/web/src/components/generic/FormioContainer.vue
+++ b/sources/packages/web/src/components/generic/FormioContainer.vue
@@ -1,11 +1,11 @@
 <template>
   <formio
-    :form-name="formName"
+    :formName="formName"
     :data="formData"
-    :read-only="readOnly"
+    :readOnly="readOnly"
     :is-data-ready="isDataReady"
     @loaded="formLoaded"
-    @custom-event="formCustomEvent"
+    @customEvent="formCustomEvent"
     @render="formRender"
     @changed="formChanged"
   ></formio>

--- a/sources/packages/web/src/components/generic/HeaderNavigator.vue
+++ b/sources/packages/web/src/components/generic/HeaderNavigator.vue
@@ -23,7 +23,7 @@
         <slot name="sub-title-details"></slot>
       </span>
     </v-col>
-    <v-col class="d-flex justify-end">
+    <v-col class="d-flex justify-end" v-if="$slots.buttons">
       <div>
         <slot name="buttons"></slot>
       </div>

--- a/sources/packages/web/src/components/generic/HeaderNavigator.vue
+++ b/sources/packages/web/src/components/generic/HeaderNavigator.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-row align="end" class="mb-1 user-select-none">
+  <v-row class="mb-1 user-select-none align-end">
     <v-col>
       <slot name="title">
         <div v-if="routeLocation || backTarget" class="header-title">

--- a/sources/packages/web/src/components/generic/ModalDialogBase.vue
+++ b/sources/packages/web/src/components/generic/ModalDialogBase.vue
@@ -9,7 +9,7 @@
     :content-class="showFullScreen ? 'modal-dialog-fullscreen' : undefined"
   >
     <v-card
-      elevation="10"
+      elevation="4"
       :max-width="showFullScreen ? undefined : maxWidth"
       :min-width="showFullScreen ? undefined : minWidth"
       class="modal-height"

--- a/sources/packages/web/src/components/generic/ToggleContent.vue
+++ b/sources/packages/web/src/components/generic/ToggleContent.vue
@@ -1,6 +1,6 @@
 <template>
   <div v-if="toggled">
-    <v-row justify="center" class="mt-1">
+    <v-row class="mt-1 justify-center">
       <slot name="image">
         <v-img
           height="150"
@@ -9,7 +9,7 @@
         />
       </slot>
     </v-row>
-    <v-row justify="center" class="mt-2">
+    <v-row class="mt-2 justify-center">
       <slot name="message">
         <h3 class="muted-content-strong">{{ message }}</h3>
       </slot>

--- a/sources/packages/web/src/components/institutions/active-application/ActiveApplicationSummaryData.vue
+++ b/sources/packages/web/src/components/institutions/active-application/ActiveApplicationSummaryData.vue
@@ -1,24 +1,26 @@
 <template>
-  <v-card class="mt-5">
-    <v-container :fluid="true">
-      <body-header
-        title="Applications"
-        :records-count="applicationsListAndCount.count"
-      >
-        <template #actions>
-          <v-text-field
-            density="compact"
-            label="Search name or application #"
-            variant="outlined"
-            v-model="searchCriteria"
-            data-cy="searchCriteria"
-            @keyup.enter="searchActiveApplications"
-            prepend-inner-icon="mdi-magnify"
-            hide-details="auto"
-          >
-          </v-text-field>
-        </template>
-      </body-header>
+  <tab-container>
+    <body-header-container>
+      <template #header>
+        <body-header
+          title="Applications"
+          :records-count="applicationsListAndCount.count"
+        >
+          <template #actions>
+            <v-text-field
+              density="compact"
+              label="Search name or application #"
+              variant="outlined"
+              v-model="searchCriteria"
+              data-cy="searchCriteria"
+              @keyup.enter="searchActiveApplications"
+              prepend-inner-icon="mdi-magnify"
+              hide-details="auto"
+            >
+            </v-text-field>
+          </template>
+        </body-header>
+      </template>
       <content-group>
         <toggle-content
           :toggled="!applicationsListAndCount.count && !loading"
@@ -76,8 +78,8 @@
           </v-data-table-server>
         </toggle-content>
       </content-group>
-    </v-container>
-  </v-card>
+    </body-header-container>
+  </tab-container>
 </template>
 
 <script lang="ts">

--- a/sources/packages/web/src/components/institutions/modals/InstitutionUserManagement.vue
+++ b/sources/packages/web/src/components/institutions/modals/InstitutionUserManagement.vue
@@ -3,7 +3,7 @@
   <error-summary :errors="errors" />
   <content-group class="mb-3">
     <v-row no-gutters>
-      <v-row align="center" no-gutters>
+      <v-row class="align-center" no-gutters>
         <v-col cols="12">
           <!-- This slot holds the BCeID basic(plain text)/business(dropdown) and readonly views(plain readonly text input). -->
           <slot name="user-name" :form-model="formModel" />

--- a/sources/packages/web/src/components/layouts/FullPageContainer.vue
+++ b/sources/packages/web/src/components/layouts/FullPageContainer.vue
@@ -10,27 +10,27 @@
     <slot name="alerts"></slot>
     <v-container fluid>
       <template v-if="layoutTemplate === LayoutTemplates.CenteredCard">
-        <v-row justify="center">
+        <v-row class="justify-center">
           <v-card class="mt-4 p-4 w-100" :class="widthClass">
             <slot></slot>
           </v-card>
         </v-row>
       </template>
       <template v-else-if="layoutTemplate === LayoutTemplates.Centered">
-        <v-row justify="center">
+        <v-row class="justify-center">
           <div class="mt-4 w-100" :class="widthClass">
             <slot></slot>
           </div>
         </v-row>
       </template>
       <template v-else-if="layoutTemplate === LayoutTemplates.CenteredTab">
-        <v-row justify="center">
+        <v-row class="justify-center">
           <div class="w-100" :class="widthClass">
             <slot name="tab-header"></slot><slot></slot>
           </div> </v-row
       ></template>
       <template v-else-if="layoutTemplate === LayoutTemplates.CenteredCardTab">
-        <v-row justify="center">
+        <v-row class="justify-center">
           <div class="mt-4 p-4 w-100" :class="widthClass">
             <slot name="tab-header"></slot>
             <v-card class="mt-4 p-4"><slot></slot></v-card>

--- a/sources/packages/web/src/components/layouts/TabContainer.vue
+++ b/sources/packages/web/src/components/layouts/TabContainer.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="mt-8">
+  <div class="mt-4">
     <!-- Default slot (with and without v-card) -->
     <v-card v-if="enableCardView">
       <v-container :fluid="true">

--- a/sources/packages/web/src/plugins/vuetify.ts
+++ b/sources/packages/web/src/plugins/vuetify.ts
@@ -52,7 +52,6 @@ export default createVuetify({
       icon: "fa:fa fa-user",
       variant: "outlined",
       elevation: 1,
-      color: "secondary",
       "aria-label": "Account",
       class: "mr-5 nav-item-label ml-2",
     },

--- a/sources/packages/web/src/plugins/vuetify.ts
+++ b/sources/packages/web/src/plugins/vuetify.ts
@@ -54,7 +54,7 @@ export default createVuetify({
       elevation: 1,
       color: "secondary",
       "aria-label": "Account",
-      class: "mr-5 nav-item-label",
+      class: "mr-5 nav-item-label ml-2",
     },
   },
   theme: {

--- a/sources/packages/web/src/views/LandingPage.vue
+++ b/sources/packages/web/src/views/LandingPage.vue
@@ -43,7 +43,7 @@
             rel="noopener noreferrer"
           >
             <v-card-text>
-              <v-row align="center">
+              <v-row class="align-center">
                 <v-col cols="12" sm="3" class="d-flex justify-center">
                   <v-img
                     min-height="150"
@@ -94,7 +94,7 @@
         >
           <v-card border="1" flat href="/institution/login">
             <v-card-text>
-              <v-row align="center">
+              <v-row class="align-center">
                 <v-col cols="12" sm="3" class="d-flex justify-center">
                   <v-img
                     min-height="150"

--- a/sources/packages/web/src/views/aest/AppAEST.vue
+++ b/sources/packages/web/src/views/aest/AppAEST.vue
@@ -2,10 +2,11 @@
   <idle-time-checker :client-id-type="ClientIdType.AEST">
     <v-app-bar color="white">
       <b-c-logo :subtitle="MINISTRY_NAME"></b-c-logo>
-      <v-btn-toggle
+      <v-btn-group
         selected-class="active-btn label-bold"
-        v-model="toggleNav"
         class="navigation-btn float-left"
+        variant="plain"
+        :rounded="false"
       >
         <check-permission-role :role="Role.AESTCreateInstitution">
           <template #="{ notAllowed }">
@@ -23,11 +24,9 @@
               variant="text"
               prepend-icon="fa:far fa-edit"
               :disabled="notAllowed"
-              @click="
-                $router.push({
-                  name: AESTRoutesConst.INSTITUTION_PROFILE_CREATE,
-                })
-              "
+              :to="{
+                name: AESTRoutesConst.INSTITUTION_PROFILE_CREATE,
+              }"
               >Create institution</v-btn
             >
           </template>
@@ -48,7 +47,7 @@
             </v-list-item>
           </v-list>
         </v-menu>
-      </v-btn-toggle>
+      </v-btn-group>
     </v-app-bar>
     <router-view name="sidebar"></router-view>
     <v-main class="body-background">
@@ -66,7 +65,7 @@ import BCLogo from "@/components/generic/BCLogo.vue";
 import IdleTimeChecker from "@/components/common/IdleTimeChecker.vue";
 import { AESTRoutesConst } from "@/constants/routes/RouteConstants";
 import CheckPermissionRole from "@/components/generic/CheckPermissionRole.vue";
-import { ref, defineComponent } from "vue";
+import { defineComponent } from "vue";
 import { MINISTRY_NAME } from "@/constants/message-constants";
 
 export default defineComponent({
@@ -74,7 +73,6 @@ export default defineComponent({
   setup() {
     const { executeLogout } = useAuth();
     const { isAuthenticated } = useAuth();
-    const toggleNav = ref();
     const logoff = async () => {
       await executeLogout(ClientIdType.AEST);
     };
@@ -90,7 +88,6 @@ export default defineComponent({
       ClientIdType,
       AESTRoutesConst,
       Role,
-      toggleNav,
       MINISTRY_NAME,
     };
   },

--- a/sources/packages/web/src/views/aest/AppAEST.vue
+++ b/sources/packages/web/src/views/aest/AppAEST.vue
@@ -2,12 +2,7 @@
   <idle-time-checker :client-id-type="ClientIdType.AEST">
     <v-app-bar color="white">
       <b-c-logo :subtitle="MINISTRY_NAME"></b-c-logo>
-      <v-btn-group
-        selected-class="active-btn label-bold"
-        class="navigation-btn float-left"
-        variant="plain"
-        :rounded="false"
-      >
+      <v-btn-group class="navigation-btn" :rounded="false">
         <check-permission-role :role="Role.AESTCreateInstitution">
           <template #="{ notAllowed }">
             <v-btn

--- a/sources/packages/web/src/views/aest/institution/InstitutionDetails.vue
+++ b/sources/packages/web/src/views/aest/institution/InstitutionDetails.vue
@@ -19,7 +19,7 @@
       </header-navigator>
     </template>
     <template #tab-header>
-      <v-tabs :model="tab" stacked color="primary" grow show-arrows="always">
+      <v-tabs v-model="tab" stacked color="primary" grow show-arrows="always">
         <v-tab
           v-for="item in items"
           :key="item.label"

--- a/sources/packages/web/src/views/aest/institution/InstitutionDetails.vue
+++ b/sources/packages/web/src/views/aest/institution/InstitutionDetails.vue
@@ -22,15 +22,12 @@
       <v-tabs :model="tab" stacked color="primary"
         ><v-tab
           v-for="item in items"
-          :key="item"
+          :key="item.label"
           :value="item.value"
           :to="item.command()"
-          :ripple="false"
-          ><div>
-            <v-icon start :icon="item.icon" class="px-1"></v-icon>
-            <span class="mx-2 label-bold"> {{ item.label }} </span>
-          </div>
-        </v-tab>
+          :text="item.label"
+          :prepend-icon="item.icon"
+        />
       </v-tabs>
     </template>
     <router-view />

--- a/sources/packages/web/src/views/aest/institution/InstitutionDetails.vue
+++ b/sources/packages/web/src/views/aest/institution/InstitutionDetails.vue
@@ -19,8 +19,8 @@
       </header-navigator>
     </template>
     <template #tab-header>
-      <v-tabs :model="tab" stacked color="primary"
-        ><v-tab
+      <v-tabs :model="tab" stacked color="primary" grow show-arrows="always">
+        <v-tab
           v-for="item in items"
           :key="item.label"
           :value="item.value"

--- a/sources/packages/web/src/views/aest/institution/InstitutionDetails.vue
+++ b/sources/packages/web/src/views/aest/institution/InstitutionDetails.vue
@@ -57,7 +57,7 @@ export default defineComponent({
       {
         label: "Profile",
         value: "profile-tab",
-        icon: "fa:far fa-address-book",
+        icon: "fa:fas fa-address-book",
         command: () => ({
           name: AESTRoutesConst.INSTITUTION_PROFILE,
           params: { institutionId: props.institutionId },
@@ -66,7 +66,7 @@ export default defineComponent({
       {
         label: "Programs",
         value: "programs",
-        icon: "fa:far fa-folder-open",
+        icon: "fa:fas fa-folder-open",
         command: () => ({
           name: AESTRoutesConst.INSTITUTION_PROGRAMS,
           params: { institutionId: props.institutionId },
@@ -75,7 +75,7 @@ export default defineComponent({
       {
         label: "Locations",
         value: "locations-tab",
-        icon: "mdi-map-marker-outline",
+        icon: "fa:fas fa-location-pin",
         command: () => ({
           name: AESTRoutesConst.INSTITUTION_LOCATIONS,
           params: { institutionId: props.institutionId },
@@ -84,7 +84,7 @@ export default defineComponent({
       {
         label: "Users",
         value: "users-tab",
-        icon: "fa:far fa-user",
+        icon: "fa:fas fa-user",
         command: () => ({
           name: AESTRoutesConst.INSTITUTION_USERS,
           params: { institutionId: props.institutionId },
@@ -93,7 +93,7 @@ export default defineComponent({
       {
         label: "Designations",
         value: "designation-tab",
-        icon: "fa:far fa-bookmark",
+        icon: "fa:fas fa-bookmark",
         command: () => ({
           name: AESTRoutesConst.INSTITUTION_DESIGNATION,
           params: { institutionId: props.institutionId },
@@ -102,7 +102,7 @@ export default defineComponent({
       {
         label: "Restrictions",
         value: "restrictions-tab",
-        icon: "fa:far fa-times-circle",
+        icon: "fa:fas fa-times-circle",
         command: () => ({
           name: AESTRoutesConst.INSTITUTION_RESTRICTIONS,
           params: { institutionId: props.institutionId },

--- a/sources/packages/web/src/views/aest/institution/ViewOfferingChangeRequest.vue
+++ b/sources/packages/web/src/views/aest/institution/ViewOfferingChangeRequest.vue
@@ -40,9 +40,9 @@
       ></offering-application-banner>
     </template>
     <template #tab-header>
-      <v-tabs stacked v-model="tab" color="primary">
-        <v-tab value="requested-change" :ripple="false">Requested Change</v-tab>
-        <v-tab value="active-offering" :ripple="false">Active Offering</v-tab>
+      <v-tabs v-model="tab" color="primary">
+        <v-tab value="requested-change" text="Requested Change" />
+        <v-tab value="active-offering" text="Active Offering" />
       </v-tabs>
     </template>
     <v-window v-model="tab">

--- a/sources/packages/web/src/views/aest/student/StudentDetails.vue
+++ b/sources/packages/web/src/views/aest/student/StudentDetails.vue
@@ -61,7 +61,7 @@ export default defineComponent({
     const items = computed(() => [
       {
         label: "Profile",
-        icon: "fa:far fa-address-book",
+        icon: "fa:fas fa-address-book",
         command: () => ({
           name: AESTRoutesConst.STUDENT_PROFILE,
           params: { studentId: props.studentId },
@@ -72,7 +72,7 @@ export default defineComponent({
         ? [
             {
               label: "Disability",
-              icon: "fa:fa fa-universal-access",
+              icon: "fa:fas fa-universal-access",
               command: () => ({
                 name: AESTRoutesConst.STUDENT_DISABILITY_PROFILE,
                 params: { studentId: props.studentId },
@@ -82,7 +82,7 @@ export default defineComponent({
         : []),
       {
         label: "Applications",
-        icon: "fa:far fa-folder-open",
+        icon: "fa:fas fa-folder-open",
         command: () => ({
           name: AESTRoutesConst.STUDENT_APPLICATIONS,
           params: { studentId: props.studentId },
@@ -98,7 +98,7 @@ export default defineComponent({
       },
       {
         label: "Restrictions",
-        icon: "fa:far fa-times-circle",
+        icon: "fa:fas fa-times-circle",
         command: () => ({
           name: AESTRoutesConst.STUDENT_RESTRICTION,
           params: { studentId: props.studentId },
@@ -106,7 +106,7 @@ export default defineComponent({
       },
       {
         label: "File Uploads",
-        icon: "fa:far fa-file-alt",
+        icon: "fa:fas fa-file-alt",
         command: () => ({
           name: AESTRoutesConst.STUDENT_FILE_UPLOADS,
           params: { studentId: props.studentId },
@@ -114,7 +114,7 @@ export default defineComponent({
       },
       {
         label: "Social insurance number",
-        icon: "fa:far fa-check-square",
+        icon: "fa:fas fa-check-square",
         command: () => ({
           name: AESTRoutesConst.SIN_MANAGEMENT,
           params: { studentId: props.studentId },
@@ -122,7 +122,7 @@ export default defineComponent({
       },
       {
         label: "CAS Supplier Information",
-        icon: "fa:fa fa-calculator",
+        icon: "fa:fas fa-calculator",
         command: () => ({
           name: AESTRoutesConst.CAS_SUPPLIER_MANAGEMENT,
           params: { studentId: props.studentId },
@@ -130,7 +130,7 @@ export default defineComponent({
       },
       {
         label: "Balances",
-        icon: "fa:fa fa-circle-dollar-to-slot",
+        icon: "fa:fas fa-circle-dollar-to-slot",
         command: () => ({
           name: AESTRoutesConst.STUDENT_BALANCES,
           params: { studentId: props.studentId },
@@ -138,7 +138,7 @@ export default defineComponent({
       },
       {
         label: "MSFAA",
-        icon: "fa:fa fa-file-signature",
+        icon: "fa:fas fa-file-signature",
         command: () => ({
           name: AESTRoutesConst.STUDENT_MSFAA,
           params: { studentId: props.studentId },
@@ -146,7 +146,7 @@ export default defineComponent({
       },
       {
         label: "Notes",
-        icon: "fa:fa fa-sticky-note",
+        icon: "fa:fas fa-sticky-note",
         command: () => ({
           name: AESTRoutesConst.STUDENT_NOTES,
           params: { studentId: props.studentId },

--- a/sources/packages/web/src/views/aest/student/StudentDetails.vue
+++ b/sources/packages/web/src/views/aest/student/StudentDetails.vue
@@ -21,8 +21,6 @@
           :key="item.label"
           :to="item.command()"
           :prepend-icon="item.icon"
-          :ripple="false"
-          class="font-weight-bold"
         />
       </v-tabs>
     </template>

--- a/sources/packages/web/src/views/aest/student/applicationDetails/ApplicationOfferingChangeRequestForm.vue
+++ b/sources/packages/web/src/views/aest/student/applicationDetails/ApplicationOfferingChangeRequestForm.vue
@@ -68,9 +68,9 @@
         class="mb-6"
         :application-offering-change-details="studentApplicationOfferingDetails"
       />
-      <v-tabs stacked v-model="tab" color="primary">
-        <v-tab value="requested-change" :ripple="false">Requested Change</v-tab>
-        <v-tab value="active-offering" :ripple="false">Active Offering</v-tab>
+      <v-tabs v-model="tab" color="primary">
+        <v-tab value="requested-change" text="Requested Change" />
+        <v-tab value="active-offering" text="Active Offering" />
       </v-tabs>
     </template>
     <v-window v-model="tab">

--- a/sources/packages/web/src/views/institution/AppInstitution.vue
+++ b/sources/packages/web/src/views/institution/AppInstitution.vue
@@ -2,11 +2,7 @@
   <IdleTimeChecker :client-id-type="ClientIdType.Institution">
     <v-app-bar color="white">
       <b-c-logo subtitle="Institutions" />
-      <v-btn-group
-        selected-class="active-btn label-bold"
-        class="navigation-btn float-left"
-        :rounded="false"
-      >
+      <v-btn-group class="navigation-btn" :rounded="false">
         <v-btn
           v-if="isAuthenticatedInstitutionUser"
           class="nav-item-label"

--- a/sources/packages/web/src/views/institution/AppInstitution.vue
+++ b/sources/packages/web/src/views/institution/AppInstitution.vue
@@ -2,10 +2,10 @@
   <IdleTimeChecker :client-id-type="ClientIdType.Institution">
     <v-app-bar color="white">
       <b-c-logo subtitle="Institutions" />
-      <v-btn-toggle
+      <v-btn-group
         selected-class="active-btn label-bold"
-        v-model="toggleNav"
         class="navigation-btn float-left"
+        :rounded="false"
       >
         <v-btn
           v-if="isAuthenticatedInstitutionUser"
@@ -59,7 +59,7 @@
             </template>
           </v-list>
         </v-menu>
-      </v-btn-toggle>
+      </v-btn-group>
     </v-app-bar>
     <router-view name="sidebar"></router-view>
     <v-main class="body-background">
@@ -78,12 +78,11 @@ import { useAuth } from "@/composables";
 import BCLogo from "@/components/generic/BCLogo.vue";
 import "@/assets/css/institution.scss";
 import IdleTimeChecker from "@/components/common/IdleTimeChecker.vue";
-import { ref, defineComponent } from "vue";
+import { defineComponent } from "vue";
 
 export default defineComponent({
   components: { BCLogo, IdleTimeChecker },
   setup() {
-    const toggleNav = ref();
     const { executeLogout } = useAuth();
     const { isAdmin, isAuthenticated, isAuthenticatedInstitutionUser } =
       useInstitutionAuth();
@@ -105,7 +104,6 @@ export default defineComponent({
       logoff,
       InstitutionRoutesConst,
       ClientIdType,
-      toggleNav,
     };
   },
 });

--- a/sources/packages/web/src/views/institution/locations/active-applications/ActiveApplicationReportAChange.vue
+++ b/sources/packages/web/src/views/institution/locations/active-applications/ActiveApplicationReportAChange.vue
@@ -3,16 +3,16 @@
     <template #header>
       <header-navigator
         title="Report a change"
-        :routeLocation="goBackRouteParams"
-        subTitle="View Application"
+        :route-location="goBackRouteParams"
+        sub-title="View Application"
       />
     </template>
     <scholastic-standing-form
-      :initialData="initialData"
-      :showFooter="true"
-      :showCompleteInfo="true"
+      :initial-data="initialData"
+      :show-footer="true"
+      :show-complete-info="true"
       :processing="processing"
-      :readOnly="isReadOnlyUser(locationId)"
+      :read-only="isReadOnlyUser(locationId)"
       :is-parent-data-ready="isDataReady"
       @submit="submit"
       @cancel="goBack"
@@ -99,7 +99,7 @@ export default defineComponent({
           params: {
             locationId: props.locationId,
           },
-        } as RouteLocationRaw),
+        }) as RouteLocationRaw,
     );
 
     const goBack = () => {

--- a/sources/packages/web/src/views/institution/locations/active-applications/LocationActiveApplicationSummary.vue
+++ b/sources/packages/web/src/views/institution/locations/active-applications/LocationActiveApplicationSummary.vue
@@ -4,27 +4,21 @@
       <header-navigator
         :title="locationName"
         data-cy="reportAChangeHeader"
-        subTitle="Report a Change"
+        sub-title="Report a Change"
       />
     </template>
     <template #tab-header>
       <v-tabs v-model="tab" stacked color="primary">
         <v-tab
           :value="ActiveApplicationTab.AvailableToReportTab"
-          :ripple="false"
-        >
-          <span class="label-bold" data-cy="availableToReportTab">
-            Available to report
-          </span>
-        </v-tab>
+          text="Available to report"
+          class="label-bold"
+        />
         <v-tab
           :value="ActiveApplicationTab.UnavailableToReportTab"
-          :ripple="false"
-        >
-          <span class="label-bold" data-cy="unavailableToReportTab">
-            Unavailable to report
-          </span>
-        </v-tab>
+          text="Unavailable to report"
+          class="label-bold"
+        />
       </v-tabs>
     </template>
     <v-window v-model="tab">
@@ -33,7 +27,7 @@
         :eager="false"
       >
         <active-application-summary-data
-          :locationId="locationId"
+          :location-id="locationId"
           :archived="false"
         />
       </v-window-item>
@@ -42,7 +36,7 @@
         :eager="false"
       >
         <active-application-summary-data
-          :locationId="locationId"
+          :location-id="locationId"
           :archived="true"
         />
       </v-window-item>
@@ -71,7 +65,7 @@ export default defineComponent({
 
   setup(props) {
     const { getLocationName } = useInstitutionState();
-    const tab = ref("active-application-tab");
+    const tab = ref(ActiveApplicationTab.AvailableToReportTab);
 
     const locationName = computed(() => {
       return getLocationName(props.locationId);

--- a/sources/packages/web/src/views/institution/locations/active-applications/LocationActiveApplicationSummary.vue
+++ b/sources/packages/web/src/views/institution/locations/active-applications/LocationActiveApplicationSummary.vue
@@ -8,16 +8,14 @@
       />
     </template>
     <template #tab-header>
-      <v-tabs v-model="tab" stacked color="primary">
+      <v-tabs v-model="tab" color="primary">
         <v-tab
           :value="ActiveApplicationTab.AvailableToReportTab"
           text="Available to report"
-          class="label-bold"
         />
         <v-tab
           :value="ActiveApplicationTab.UnavailableToReportTab"
           text="Unavailable to report"
-          class="label-bold"
         />
       </v-tabs>
     </template>

--- a/sources/packages/web/src/views/institution/locations/confirmation-of-enrollment/COESummaryData.vue
+++ b/sources/packages/web/src/views/institution/locations/confirmation-of-enrollment/COESummaryData.vue
@@ -1,52 +1,54 @@
 <template>
-  <v-card class="mt-5">
-    <v-container :fluid="true">
-      <body-header :title="header" :records-count="disbursements.count">
-        <template #subtitle>
-          <slot name="coeSummarySubtitle">{{ coeSummarySubtitle }}</slot>
-        </template>
-        <template #actions>
-          <v-row class="justify-end" density="compact">
-            <v-col cols="auto">
-              <v-btn-toggle
-                v-model="intensityFilter"
-                density="compact"
-                class="btn-toggle"
-                selected-class="selected-btn-toggle"
-                @update:model-value="resetPageAndLoadEnrollments"
-              >
-                <v-btn
-                  rounded="xl"
-                  color="primary"
-                  :value="IntensityFilter.All"
-                  class="mr-2"
-                  >All</v-btn
+  <tab-container>
+    <body-header-container>
+      <template #header>
+        <body-header :title="header" :records-count="disbursements.count">
+          <template #subtitle>
+            <slot name="coeSummarySubtitle">{{ coeSummarySubtitle }}</slot>
+          </template>
+          <template #actions>
+            <v-row class="justify-end" density="compact">
+              <v-col cols="auto">
+                <v-btn-toggle
+                  v-model="intensityFilter"
+                  density="compact"
+                  class="btn-toggle"
+                  selected-class="selected-btn-toggle"
+                  @update:model-value="resetPageAndLoadEnrollments"
                 >
-                <v-btn
-                  v-for="intensity in Object.values(OfferingIntensity)"
-                  :key="intensity"
-                  rounded="xl"
-                  color="primary"
-                  :value="intensity"
-                  class="mr-2"
-                  >{{ mapOfferingIntensity(intensity) }}</v-btn
-                >
-              </v-btn-toggle>
-            </v-col>
-            <v-col>
-              <v-text-field
-                density="compact"
-                label="Search by name or application number"
-                variant="outlined"
-                v-model="searchQuery"
-                @keyup.enter="resetPageAndLoadEnrollments"
-                prepend-inner-icon="mdi-magnify"
-                hide-details="auto"
-              />
-            </v-col>
-          </v-row>
-        </template>
-      </body-header>
+                  <v-btn
+                    rounded="xl"
+                    color="primary"
+                    :value="IntensityFilter.All"
+                    class="mr-2"
+                    >All</v-btn
+                  >
+                  <v-btn
+                    v-for="intensity in Object.values(OfferingIntensity)"
+                    :key="intensity"
+                    rounded="xl"
+                    color="primary"
+                    :value="intensity"
+                    class="mr-2"
+                    >{{ mapOfferingIntensity(intensity) }}</v-btn
+                  >
+                </v-btn-toggle>
+              </v-col>
+              <v-col>
+                <v-text-field
+                  density="compact"
+                  label="Search by name or application number"
+                  variant="outlined"
+                  v-model="searchQuery"
+                  @keyup.enter="resetPageAndLoadEnrollments"
+                  prepend-inner-icon="mdi-magnify"
+                  hide-details="auto"
+                />
+              </v-col>
+            </v-row>
+          </template>
+        </body-header>
+      </template>
       <content-group>
         <toggle-content
           :toggled="!enrollmentsLoading && !disbursements.count"
@@ -101,8 +103,8 @@
           </v-data-table-server>
         </toggle-content>
       </content-group>
-    </v-container>
-  </v-card>
+    </body-header-container>
+  </tab-container>
 </template>
 
 <script lang="ts">

--- a/sources/packages/web/src/views/institution/locations/confirmation-of-enrollment/LocationCOESummary.vue
+++ b/sources/packages/web/src/views/institution/locations/confirmation-of-enrollment/LocationCOESummary.vue
@@ -3,44 +3,36 @@
     <template #header>
       <header-navigator
         :title="locationName"
-        subTitle="Confirmation Of Enrolment"
+        sub-title="Confirmation Of Enrolment"
         data-cy="confirmationOfEnrolmentHeader"
       />
     </template>
     <template #tab-header>
       <v-tabs v-model="tab" stacked color="primary">
-        <v-tab :value="COETab.ConfirmEnrollmentTab" :ripple="false">
-          <div>
-            <v-icon start icon="fa:far fa-check-square"></v-icon>
-            <span class="label-bold" data-cy="confirmEnrolmentTab">
-              Confirm enrolment
-            </span>
-          </div>
-        </v-tab>
-
-        <v-tab :value="COETab.UpcomingEnrollmentTab" :ripple="false">
-          <div>
-            <v-icon start icon="fa:far fa-folder-open" class="px-1"></v-icon>
-            <span class="label-bold" data-cy="upcomingEnrolmentTab">
-              Upcoming and Previous Enrolments
-            </span>
-          </div>
-        </v-tab>
-      </v-tabs></template
-    >
+        <v-tab
+          text="Confirm enrolment"
+          :value="COETab.ConfirmEnrollmentTab"
+          class="label-bold"
+        />
+        <v-tab
+          text="Upcoming and Previous Enrolments"
+          :value="COETab.UpcomingEnrollmentTab"
+          class="label-bold"
+        /> </v-tabs
+    ></template>
     <v-window v-model="tab">
       <v-window-item :value="COETab.ConfirmEnrollmentTab" :eager="false">
         <c-o-e-summary-data
-          :locationId="locationId"
-          :enrollmentPeriod="EnrollmentPeriod.Current"
+          :location-id="locationId"
+          :enrollment-period="EnrollmentPeriod.Current"
           header="Available to confirm enrolment"
-          subTitle="Confirm enrolment so that funding can be dispersed."
+          sub-title="Confirm enrolment so that funding can be dispersed."
         />
       </v-window-item>
       <v-window-item :value="COETab.UpcomingEnrollmentTab" :eager="false">
         <c-o-e-summary-data
-          :locationId="locationId"
-          :enrollmentPeriod="EnrollmentPeriod.Upcoming"
+          :location-id="locationId"
+          :enrollment-period="EnrollmentPeriod.Upcoming"
           header="Upcoming and Previous Enrolments"
         >
           <template #coeSummarySubtitle>

--- a/sources/packages/web/src/views/institution/locations/confirmation-of-enrollment/LocationCOESummary.vue
+++ b/sources/packages/web/src/views/institution/locations/confirmation-of-enrollment/LocationCOESummary.vue
@@ -72,7 +72,7 @@ export default defineComponent({
   },
   setup(props) {
     const { getLocationName } = useInstitutionState();
-    const tab = ref("coe-tab");
+    const tab = ref(COETab.ConfirmEnrollmentTab);
 
     const locationName = computed(() => {
       return getLocationName(props.locationId);

--- a/sources/packages/web/src/views/institution/locations/confirmation-of-enrollment/LocationCOESummary.vue
+++ b/sources/packages/web/src/views/institution/locations/confirmation-of-enrollment/LocationCOESummary.vue
@@ -8,16 +8,11 @@
       />
     </template>
     <template #tab-header>
-      <v-tabs v-model="tab" stacked color="primary">
-        <v-tab
-          text="Confirm enrolment"
-          :value="COETab.ConfirmEnrollmentTab"
-          class="label-bold"
-        />
+      <v-tabs v-model="tab" color="primary">
+        <v-tab text="Confirm enrolment" :value="COETab.ConfirmEnrollmentTab" />
         <v-tab
           text="Upcoming and Previous Enrolments"
           :value="COETab.UpcomingEnrollmentTab"
-          class="label-bold"
         /> </v-tabs
     ></template>
     <v-window v-model="tab">

--- a/sources/packages/web/src/views/institution/locations/program-info-request/LocationProgramInfoRequestSummary.vue
+++ b/sources/packages/web/src/views/institution/locations/program-info-request/LocationProgramInfoRequestSummary.vue
@@ -7,101 +7,105 @@
         data-cy="programInformationRequestsHeader"
       />
     </template>
-    <body-header
-      title="Active applications"
-      data-cy="activeApplicationsTab"
-      :records-count="applications.count"
-    >
-      <template #actions>
-        <v-row class="justify-end" density="compact">
-          <v-col cols="auto">
-            <v-btn-toggle
-              v-model="intensityFilter"
-              density="compact"
-              class="btn-toggle"
-              selected-class="selected-btn-toggle"
-              @update:model-value="resetPageAndLoadApplications"
-            >
-              <v-btn
-                rounded="xl"
-                color="primary"
-                :value="IntensityFilter.All"
-                class="mr-2"
-                >All</v-btn
-              >
-              <v-btn
-                v-for="intensity in Object.values(OfferingIntensity)"
-                :key="intensity"
-                rounded="xl"
-                color="primary"
-                :value="intensity"
-                class="mr-2"
-                >{{ mapOfferingIntensity(intensity) }}</v-btn
-              >
-            </v-btn-toggle>
-          </v-col>
-          <v-col>
-            <v-text-field
-              density="compact"
-              label="Search by name or application"
-              variant="outlined"
-              v-model="searchQuery"
-              @keyup.enter="resetPageAndLoadApplications"
-              prepend-inner-icon="mdi-magnify"
-              hide-details="auto"
-              placeholder="Enter name or application"
-            ></v-text-field>
-          </v-col>
-        </v-row>
-      </template>
-    </body-header>
-    <content-group>
-      <toggle-content
-        :toggled="!applications.count"
-        message="No program information requests found"
-      >
-        <v-data-table-server
-          v-if="applications?.count"
-          :headers="PIRSummaryHeaders"
-          :items="applications.results"
-          :items-length="applications.count"
-          :loading="applicationsLoading"
-          :items-per-page="DEFAULT_PAGE_LIMIT"
-          :items-per-page-options="ITEMS_PER_PAGE"
-          @update:options="paginationAndSortEvent"
+    <body-header-container>
+      <template #header>
+        <body-header
+          title="Active applications"
+          data-cy="activeApplicationsTab"
+          :records-count="applications.count"
         >
-          <template #[`item.submittedDate`]="{ item }">
-            {{ dateOnlyLongString(item.submittedDate) }}
+          <template #actions>
+            <v-row class="justify-end" density="compact">
+              <v-col cols="auto">
+                <v-btn-toggle
+                  v-model="intensityFilter"
+                  density="compact"
+                  class="btn-toggle"
+                  selected-class="selected-btn-toggle"
+                  @update:model-value="resetPageAndLoadApplications"
+                >
+                  <v-btn
+                    rounded="xl"
+                    color="primary"
+                    :value="IntensityFilter.All"
+                    class="mr-2"
+                    >All</v-btn
+                  >
+                  <v-btn
+                    v-for="intensity in Object.values(OfferingIntensity)"
+                    :key="intensity"
+                    rounded="xl"
+                    color="primary"
+                    :value="intensity"
+                    class="mr-2"
+                    >{{ mapOfferingIntensity(intensity) }}</v-btn
+                  >
+                </v-btn-toggle>
+              </v-col>
+              <v-col>
+                <v-text-field
+                  density="compact"
+                  label="Search by name or application"
+                  variant="outlined"
+                  v-model="searchQuery"
+                  @keyup.enter="resetPageAndLoadApplications"
+                  prepend-inner-icon="mdi-magnify"
+                  hide-details="auto"
+                  placeholder="Enter name or application"
+                ></v-text-field>
+              </v-col>
+            </v-row>
           </template>
-          <template #[`item.program`]="{ item }">
-            {{ item.program }}
-          </template>
-          <template #[`item.studyStartPeriod`]="{ item }">
-            {{ dateOnlyLongString(item.studyStartPeriod) }}
-          </template>
-          <template #[`item.studyEndPeriod`]="{ item }">
-            {{ dateOnlyLongString(item.studyEndPeriod) }}
-          </template>
-          <template #[`item.studentNumber`]="{ item }">
-            {{ emptyStringFiller(item.studentNumber) }}
-          </template>
-          <template #[`item.studyIntensity`]="{ item }">
-            {{ mapOfferingIntensity(item.studyIntensity) }}
-          </template>
-          <template #[`item.pirStatus`]="{ item }">
-            <status-chip-program-info-request :status="item.pirStatus" />
-          </template>
-          <template #[`item.actions`]="{ item }">
-            <v-btn
-              color="primary"
-              @click="goToViewApplication(item.applicationId)"
-            >
-              View
-            </v-btn>
-          </template>
-        </v-data-table-server>
-      </toggle-content>
-    </content-group>
+        </body-header>
+      </template>
+      <content-group>
+        <toggle-content
+          :toggled="!applications.count"
+          message="No program information requests found"
+        >
+          <v-data-table-server
+            v-if="applications?.count"
+            :headers="PIRSummaryHeaders"
+            :items="applications.results"
+            :items-length="applications.count"
+            :loading="applicationsLoading"
+            :items-per-page="DEFAULT_PAGE_LIMIT"
+            :items-per-page-options="ITEMS_PER_PAGE"
+            @update:options="paginationAndSortEvent"
+          >
+            <template #[`item.submittedDate`]="{ item }">
+              {{ dateOnlyLongString(item.submittedDate) }}
+            </template>
+            <template #[`item.program`]="{ item }">
+              {{ item.program }}
+            </template>
+            <template #[`item.studyStartPeriod`]="{ item }">
+              {{ dateOnlyLongString(item.studyStartPeriod) }}
+            </template>
+            <template #[`item.studyEndPeriod`]="{ item }">
+              {{ dateOnlyLongString(item.studyEndPeriod) }}
+            </template>
+            <template #[`item.studentNumber`]="{ item }">
+              {{ emptyStringFiller(item.studentNumber) }}
+            </template>
+            <template #[`item.studyIntensity`]="{ item }">
+              {{ mapOfferingIntensity(item.studyIntensity) }}
+            </template>
+            <template #[`item.pirStatus`]="{ item }">
+              <status-chip-program-info-request :status="item.pirStatus" />
+            </template>
+            <template #[`item.actions`]="{ item }">
+              <v-btn
+                color="primary"
+                @click="goToViewApplication(item.applicationId)"
+              >
+                View
+              </v-btn>
+            </template>
+          </v-data-table-server>
+        </toggle-content>
+      </content-group>
+    </body-header-container>
   </full-page-container>
 </template>
 

--- a/sources/packages/web/src/views/institution/locations/programs/LocationProgramView.vue
+++ b/sources/packages/web/src/views/institution/locations/programs/LocationProgramView.vue
@@ -1,5 +1,5 @@
 <template>
-  <full-page-container :full-width="true" layout-template="centered">
+  <full-page-container :full-width="true" layout-template="centered-card">
     <template #header>
       <header-navigator
         title="Programs"

--- a/sources/packages/web/src/views/institution/locations/programs/LocationPrograms.vue
+++ b/sources/packages/web/src/views/institution/locations/programs/LocationPrograms.vue
@@ -7,111 +7,118 @@
         sub-title="Programs"
       />
     </template>
-    <body-header title="All programs" :records-count="programAndCount?.count">
-      <template #actions>
-        <div class="d-flex justify-end">
-          <v-btn
-            v-if="!isReadOnlyUser(locationId)"
-            color="primary"
-            @click="goToAddNewProgram()"
-            data-cy="createProgram"
-            prepend-icon="fa:fa fa-plus-circle"
-          >
-            Create program
-          </v-btn>
-        </div>
-      </template>
-    </body-header>
-    <search-table
-      v-model="searchBox"
-      search-label="Search Program name or SABC program code or CIP"
-      :loading="loading"
-      @search="searchProgramTable"
-    >
-      <template #append-search>
-        <v-btn-toggle
-          :model-value="selectedStatuses"
-          @update:model-value="handleStatusChange"
-          multiple
-          density="compact"
-          class="flex-wrap btn-toggle"
-          selected-class="selected-btn-toggle"
+    <body-header-container>
+      <template #header>
+        <body-header
+          title="All programs"
+          :records-count="programAndCount?.count"
         >
-          <v-btn rounded="xl" :value="ALL_STATUS" color="primary" class="mx-2"
-            >All</v-btn
-          >
-          <v-btn
-            rounded="xl"
-            :value="ProgramStatus.Approved"
-            color="primary"
-            class="mr-2"
-            >Approved</v-btn
-          >
-          <v-btn
-            rounded="xl"
-            :value="ProgramStatus.Pending"
-            color="primary"
-            class="mr-2"
-            >Pending</v-btn
-          >
-          <v-btn
-            rounded="xl"
-            :value="ProgramStatus.Declined"
-            color="primary"
-            class="mr-2"
-            >Declined</v-btn
-          >
-          <v-btn rounded="xl" :value="INACTIVE_PROGRAM" color="primary"
-            >Inactive</v-btn
-          >
-        </v-btn-toggle>
-      </template>
-      <toggle-content
-        :toggled="!programAndCount?.count"
-        message="You don't have programs yet"
-      >
-        <v-data-table-server
-          v-if="programAndCount?.count"
-          :headers="ProgramSummaryHeaders"
-          :items="programAndCount?.results"
-          :items-length="programAndCount?.count"
-          :loading="loading"
-          :items-per-page="DEFAULT_PAGE_LIMIT"
-          :items-per-page-options="ITEMS_PER_PAGE"
-          v-model:sort-by="sortBy"
-          :mobile="isMobile"
-          @update:options="paginationAndSortEvent"
-        >
-          <template #item="{ item }">
-            <tr>
-              <td>{{ item.programName }}</td>
-              <td>
-                {{ item.credentialTypeToDisplay }}
-              </td>
-              <td>{{ item.cipCode }}</td>
-              <td>{{ emptyStringFiller(item.sabcCode) }}</td>
-              <td data-cy="programStudyPeriods">
-                {{ item.totalOfferings }}
-              </td>
-              <td data-cy="programStatus">
-                <status-chip-program
-                  :status="item.programStatus"
-                  :is-active="item.isActive && !item.isExpired"
-                ></status-chip-program>
-              </td>
-              <td>
-                <v-btn
-                  color="primary"
-                  @click="goToViewProgram(item.programId)"
-                  data-cy="viewProgram"
-                  >View</v-btn
-                >
-              </td>
-            </tr>
+          <template #actions>
+            <div class="d-flex justify-end">
+              <v-btn
+                v-if="!isReadOnlyUser(locationId)"
+                color="primary"
+                @click="goToAddNewProgram()"
+                data-cy="createProgram"
+                prepend-icon="fa:fa fa-plus-circle"
+              >
+                Create program
+              </v-btn>
+            </div>
           </template>
-        </v-data-table-server>
-      </toggle-content>
-    </search-table>
+        </body-header>
+      </template>
+      <search-table
+        v-model="searchBox"
+        search-label="Search Program name or SABC program code or CIP"
+        :loading="loading"
+        @search="searchProgramTable"
+      >
+        <template #append-search>
+          <v-btn-toggle
+            :model-value="selectedStatuses"
+            @update:model-value="handleStatusChange"
+            multiple
+            density="compact"
+            class="flex-wrap btn-toggle"
+            selected-class="selected-btn-toggle"
+          >
+            <v-btn rounded="xl" :value="ALL_STATUS" color="primary" class="mx-2"
+              >All</v-btn
+            >
+            <v-btn
+              rounded="xl"
+              :value="ProgramStatus.Approved"
+              color="primary"
+              class="mr-2"
+              >Approved</v-btn
+            >
+            <v-btn
+              rounded="xl"
+              :value="ProgramStatus.Pending"
+              color="primary"
+              class="mr-2"
+              >Pending</v-btn
+            >
+            <v-btn
+              rounded="xl"
+              :value="ProgramStatus.Declined"
+              color="primary"
+              class="mr-2"
+              >Declined</v-btn
+            >
+            <v-btn rounded="xl" :value="INACTIVE_PROGRAM" color="primary"
+              >Inactive</v-btn
+            >
+          </v-btn-toggle>
+        </template>
+        <toggle-content
+          :toggled="!programAndCount?.count"
+          message="You don't have programs yet"
+        >
+          <v-data-table-server
+            v-if="programAndCount?.count"
+            :headers="ProgramSummaryHeaders"
+            :items="programAndCount?.results"
+            :items-length="programAndCount?.count"
+            :loading="loading"
+            :items-per-page="DEFAULT_PAGE_LIMIT"
+            :items-per-page-options="ITEMS_PER_PAGE"
+            v-model:sort-by="sortBy"
+            :mobile="isMobile"
+            @update:options="paginationAndSortEvent"
+          >
+            <template #item="{ item }">
+              <tr>
+                <td>{{ item.programName }}</td>
+                <td>
+                  {{ item.credentialTypeToDisplay }}
+                </td>
+                <td>{{ item.cipCode }}</td>
+                <td>{{ emptyStringFiller(item.sabcCode) }}</td>
+                <td data-cy="programStudyPeriods">
+                  {{ item.totalOfferings }}
+                </td>
+                <td data-cy="programStatus">
+                  <status-chip-program
+                    :status="item.programStatus"
+                    :is-active="item.isActive && !item.isExpired"
+                  ></status-chip-program>
+                </td>
+                <td>
+                  <v-btn
+                    color="primary"
+                    @click="goToViewProgram(item.programId)"
+                    data-cy="viewProgram"
+                    >View</v-btn
+                  >
+                </td>
+              </tr>
+            </template>
+          </v-data-table-server>
+        </toggle-content>
+      </search-table>
+    </body-header-container>
   </full-page-container>
 </template>
 

--- a/sources/packages/web/src/views/institution/locations/request-a-change/RequestAChange.vue
+++ b/sources/packages/web/src/views/institution/locations/request-a-change/RequestAChange.vue
@@ -7,13 +7,12 @@
       />
     </template>
     <template #tab-header>
-      <v-tabs stacked color="primary"
+      <v-tabs color="primary"
         ><v-tab
           v-for="item in tabItems"
           :key="item.label"
           :to="item.command()"
           :text="item.label"
-          class="label-bold"
         />
       </v-tabs>
     </template>

--- a/sources/packages/web/src/views/institution/locations/request-a-change/RequestAChange.vue
+++ b/sources/packages/web/src/views/institution/locations/request-a-change/RequestAChange.vue
@@ -12,11 +12,9 @@
           v-for="item in tabItems"
           :key="item.label"
           :to="item.command()"
-          :ripple="false"
-          ><div>
-            <span class="label-bold"> {{ item.label }} </span>
-          </div>
-        </v-tab>
+          :text="item.label"
+          class="label-bold"
+        />
       </v-tabs>
     </template>
     <router-view />

--- a/sources/packages/web/src/views/institution/student/InstitutionStudentDetails.vue
+++ b/sources/packages/web/src/views/institution/student/InstitutionStudentDetails.vue
@@ -14,8 +14,6 @@
           :key="item.label"
           :to="item.command()"
           :prepend-icon="item.icon"
-          :ripple="false"
-          class="font-weight-bold"
         />
       </v-tabs>
     </template>

--- a/sources/packages/web/src/views/student/AppStudent.vue
+++ b/sources/packages/web/src/views/student/AppStudent.vue
@@ -3,11 +3,11 @@
     <v-app-bar color="white">
       <b-c-logo subtitle="Student Application" @click="logoClick" />
       <v-spacer />
-      <v-btn-toggle
+      <v-btn-group
         selected-class="active-btn label-bold"
-        v-model="toggleNav"
         v-if="!smallScreen"
         class="navigation-btn float-left"
+        :rounded="false"
       >
         <v-btn
           v-if="hasAuthenticatedStudentAccount"
@@ -92,7 +92,7 @@
             </template>
           </v-list>
         </v-menu>
-      </v-btn-toggle>
+      </v-btn-group>
       <v-app-bar-nav-icon
         variant="text"
         @click.stop="drawer = !drawer"
@@ -148,7 +148,6 @@ export default defineComponent({
   components: { BCLogo, IdleTimeChecker },
   setup() {
     const { isFormSubmissionEnabled } = useFeatureToggles();
-    const toggleNav = ref();
     const { executeLogout } = useAuth();
     const router = useRouter();
     const { isAuthenticated } = useAuth();
@@ -284,7 +283,6 @@ export default defineComponent({
       StudentRoutesConst,
       ClientIdType,
       hasAuthenticatedStudentAccount,
-      toggleNav,
       smallScreen,
       drawer,
       showNavigationDrawer,

--- a/sources/packages/web/src/views/student/AppStudent.vue
+++ b/sources/packages/web/src/views/student/AppStudent.vue
@@ -3,12 +3,7 @@
     <v-app-bar color="white">
       <b-c-logo subtitle="Student Application" @click="logoClick" />
       <v-spacer />
-      <v-btn-group
-        selected-class="active-btn label-bold"
-        v-if="!smallScreen"
-        class="navigation-btn float-left"
-        :rounded="false"
-      >
+      <v-btn-group v-if="!smallScreen" class="navigation-btn" :rounded="false">
         <v-btn
           v-if="hasAuthenticatedStudentAccount"
           class="nav-item-label"

--- a/sources/packages/web/src/views/student/StudentApplicationSummary.vue
+++ b/sources/packages/web/src/views/student/StudentApplicationSummary.vue
@@ -3,14 +3,13 @@
     <template #header>
       <header-navigator title="Applications" sub-title="My Applications">
         <template #buttons>
-          <start-application :class="{ 'mb-2': isMobile }" />
+          <start-application />
         </template>
       </header-navigator>
     </template>
     <v-row>
       <v-col cols="12" :class="{ 'pa-0': isMobile }">
         <student-applications-extended-summary
-          :dense="isMobile"
           @edit-application-action="editApplicationAction"
           @change-application-action="changeApplicationAction"
           @open-confirm-cancel="confirmCancelApplication"

--- a/sources/packages/web/src/views/student/application-offering-change-request/ApplicationOfferingChangeFormView.vue
+++ b/sources/packages/web/src/views/student/application-offering-change-request/ApplicationOfferingChangeFormView.vue
@@ -4,7 +4,7 @@
       <header-navigator
         title="Financial Aid Application"
         sub-title="View Request"
-        :routeLocation="goBackRouteParams"
+        :route-location="goBackRouteParams"
       >
         <template
           #buttons
@@ -34,10 +34,8 @@
           v-for="item in items"
           :key="item.label"
           :to="item.command()"
-          :ripple="false"
-        >
-          <span class="label-bold"> {{ item.label }} </span>
-        </v-tab>
+          :text="item.label"
+        />
       </v-tabs>
     </template>
     <router-view />
@@ -101,7 +99,7 @@ export default defineComponent({
         ({
           name: StudentRoutesConst.STUDENT_APPLICATION_DETAILS,
           params: { id: props.applicationId },
-        } as RouteLocationRaw),
+        }) as RouteLocationRaw,
     );
     const items = ref([
       {

--- a/sources/packages/web/src/views/student/financial-aid-application/Applications.vue
+++ b/sources/packages/web/src/views/student/financial-aid-application/Applications.vue
@@ -1,15 +1,12 @@
 <template>
-  <v-container>
-    <v-btn
-      color="primary"
-      class="float-right"
-      :disabled="!hasValidSIN"
-      @click="goToStudentApplication()"
-      prepend-icon="fa:fa fa-edit"
-    >
-      Start New Application
-    </v-btn>
-  </v-container>
+  <v-btn
+    color="primary"
+    :disabled="!hasValidSIN"
+    @click="goToStudentApplication()"
+    prepend-icon="fa:fa fa-edit"
+  >
+    Start New Application
+  </v-btn>
 </template>
 <script lang="ts">
 import { StudentRoutesConst } from "@/constants/routes/RouteConstants";

--- a/sources/packages/web/src/views/student/form-submissions/StudentForms.vue
+++ b/sources/packages/web/src/views/student/form-submissions/StudentForms.vue
@@ -6,7 +6,6 @@
     <template #tab-header>
       <v-tabs color="primary" grow>
         <v-tab
-          class="label-bold"
           prepend-icon="fa:fas fa-inbox"
           text="Submissions"
           :to="{
@@ -16,7 +15,6 @@
           value="form-selector"
         />
         <v-tab
-          class="label-bold"
           prepend-icon="fa:fas fa-clock-rotate-left"
           text="History"
           :to="{


### PR DESCRIPTION
- Upgraded minor Vuetify version.
- Search and adapt Vuetify migration leftovers to comply with the migration guide (e.g., `dense`, `align`, `justify`).
- Added `body-header-container` and `tab-container` to pages that were missing (e.g., `OfferingSummary.vue`, `ActiveApplicationSummaryData.vue`).
- `v-tab` component styles had their styles adjusted to look closer.

<img width="1634" height="479" alt="image" src="https://github.com/user-attachments/assets/a243bf54-505c-4127-91ad-c03f7dde5ca2" />

<img width="1559" height="529" alt="image" src="https://github.com/user-attachments/assets/e5e7b879-0278-4d6e-8157-6f47a916ebc7" />

<img width="1627" height="346" alt="image" src="https://github.com/user-attachments/assets/54a2fccc-9eb0-4850-8502-c0d57ef402e6" />

<img width="1611" height="375" alt="image" src="https://github.com/user-attachments/assets/53c31c7a-bf86-48dd-9222-4aa38274b24f" />

<img width="1620" height="361" alt="image" src="https://github.com/user-attachments/assets/c11bac36-2b63-402c-b33b-21c5e15ad48b" />

- Top bar `v-btn-toggle` replaced by `v-btn-group`. `v-btn-toggle` was maybe the only option in the past, but they do not seem a right fit for the top menu, the route keeps the selected state.

<img width="1148" height="256" alt="image" src="https://github.com/user-attachments/assets/be1f60cf-1118-4073-919a-496f0a124518" />


## Improved header slots

### Before

<img width="1497" height="545" alt="image" src="https://github.com/user-attachments/assets/3aa1aefc-43ed-46ec-9058-21e350aeda93" />

### Adjusted

<img width="1498" height="504" alt="image" src="https://github.com/user-attachments/assets/15a9d10d-eb54-4ba9-8e33-78abe84c4831" />

