### PR TITLE
#6171 - Full-time withdrawal count

### DIFF
--- a/sources/packages/backend/apps/api/src/route-controllers/student-scholastic-standings/_tests_/e2e/student-scholastic-standings.aest.controller.getScholasticStandingSummary.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/student-scholastic-standings/_tests_/e2e/student-scholastic-standings.aest.controller.getScholasticStandingSummary.e2e-spec.ts
@@ -6,6 +6,8 @@ import {
   saveFakeApplication,
   saveFakeStudent,
   saveFakeSFASIndividual,
+  RestrictionCode,
+  saveFakeStudentRestriction,
 } from "@sims/test-utils";
 import {
   AESTGroups,
@@ -68,6 +70,24 @@ describe("StudentScholasticStandingsAESTController(e2e)-getScholasticStandingSum
         unsuccessfulCompletion: 12,
       },
     });
+    const restriction = await db.restriction.findOne({
+      where: {
+        restrictionCode: RestrictionCode.WTHD,
+      },
+    });
+    // Add an active WTHD restriction for the student.
+    await saveFakeStudentRestriction(
+      db.dataSource,
+      {
+        student,
+        application: fullTimeApplication,
+        restriction,
+      },
+      {
+        isActive: true,
+      },
+    );
+
     const endpoint = `/aest/scholastic-standing/summary/student/${student.id}`;
     const token = await getAESTToken(AESTGroups.BusinessAdministrators);
     // Act/Assert
@@ -78,7 +98,7 @@ describe("StudentScholasticStandingsAESTController(e2e)-getScholasticStandingSum
       .expect({
         fullTimeLifetimeUnsuccessfulCompletionWeeks: 18,
         partTimeLifetimeUnsuccessfulCompletionWeeks: 15,
-        fullTimeWithdrawalsCount: 0,
+        fullTimeWithdrawalsCount: 1,
       });
   });
 

--- a/sources/packages/backend/apps/api/src/route-controllers/student-scholastic-standings/_tests_/e2e/student-scholastic-standings.aest.controller.getScholasticStandingSummary.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/student-scholastic-standings/_tests_/e2e/student-scholastic-standings.aest.controller.getScholasticStandingSummary.e2e-spec.ts
@@ -78,6 +78,7 @@ describe("StudentScholasticStandingsAESTController(e2e)-getScholasticStandingSum
       .expect({
         fullTimeLifetimeUnsuccessfulCompletionWeeks: 18,
         partTimeLifetimeUnsuccessfulCompletionWeeks: 15,
+        fullTimeWithdrawalsCount: 0,
       });
   });
 
@@ -120,6 +121,7 @@ describe("StudentScholasticStandingsAESTController(e2e)-getScholasticStandingSum
       .expect({
         fullTimeLifetimeUnsuccessfulCompletionWeeks: 15,
         partTimeLifetimeUnsuccessfulCompletionWeeks: 0,
+        fullTimeWithdrawalsCount: 0,
       });
   });
 });

--- a/sources/packages/backend/apps/api/src/route-controllers/student-scholastic-standings/_tests_/e2e/student-scholastic-standings.aest.controller.getScholasticStandingSummary.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/student-scholastic-standings/_tests_/e2e/student-scholastic-standings.aest.controller.getScholasticStandingSummary.e2e-spec.ts
@@ -71,6 +71,7 @@ describe("StudentScholasticStandingsAESTController(e2e)-getScholasticStandingSum
       },
     });
     const restriction = await db.restriction.findOne({
+      select: { id: true },
       where: {
         restrictionCode: RestrictionCode.WTHD,
       },

--- a/sources/packages/backend/apps/api/src/route-controllers/student-scholastic-standings/_tests_/e2e/student-scholastic-standings.institutions.controller.getScholasticStandingSummary.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/student-scholastic-standings/_tests_/e2e/student-scholastic-standings.institutions.controller.getScholasticStandingSummary.e2e-spec.ts
@@ -1,11 +1,13 @@
 import { HttpStatus, INestApplication } from "@nestjs/common";
 import {
   E2EDataSources,
+  RestrictionCode,
   createE2EDataSources,
   createFakeInstitutionLocation,
   createFakeStudentScholasticStanding,
   saveFakeApplication,
   saveFakeStudent,
+  saveFakeStudentRestriction,
 } from "@sims/test-utils";
 import {
   BEARER_AUTH_TYPE,
@@ -146,6 +148,7 @@ describe("StudentScholasticStandingsInstitutionsController(e2e)-getScholasticSta
       .expect({
         fullTimeLifetimeUnsuccessfulCompletionWeeks: 30,
         partTimeLifetimeUnsuccessfulCompletionWeeks: 0,
+        fullTimeWithdrawalsCount: 0,
       });
   });
 
@@ -168,6 +171,58 @@ describe("StudentScholasticStandingsInstitutionsController(e2e)-getScholasticSta
       .expect({
         fullTimeLifetimeUnsuccessfulCompletionWeeks: 0,
         partTimeLifetimeUnsuccessfulCompletionWeeks: 0,
+        fullTimeWithdrawalsCount: 0,
+      });
+  });
+
+  it("Should return full time withdrawals count for the provided student as a part of the student scholastic summary when the student has one active and one inactive WTHD restrictions.", async () => {
+    // Arrange
+    const student = await saveFakeStudent(db.dataSource);
+    const application = await saveFakeApplication(db.dataSource, {
+      institutionLocation: collegeFLocation,
+      student,
+    });
+    const restriction = await db.restriction.findOne({
+      where: {
+        restrictionCode: RestrictionCode.WTHD,
+      },
+    });
+    // Create one active and one inactive WTHD restriction for the student.
+    await saveFakeStudentRestriction(
+      db.dataSource,
+      {
+        student,
+        application,
+        restriction,
+      },
+      {
+        isActive: true,
+      },
+    );
+    await saveFakeStudentRestriction(
+      db.dataSource,
+      {
+        student,
+        application,
+        restriction,
+      },
+      {
+        isActive: false,
+      },
+    );
+    const institutionUserToken = await getInstitutionToken(
+      InstitutionTokenTypes.CollegeFUser,
+    );
+    const endpoint = `/institutions/scholastic-standing/summary/student/${student.id}`;
+    // Act/Assert
+    await request(app.getHttpServer())
+      .get(endpoint)
+      .auth(institutionUserToken, BEARER_AUTH_TYPE)
+      .expect(HttpStatus.OK)
+      .expect({
+        fullTimeLifetimeUnsuccessfulCompletionWeeks: 0,
+        partTimeLifetimeUnsuccessfulCompletionWeeks: 0,
+        fullTimeWithdrawalsCount: 1,
       });
   });
 });

--- a/sources/packages/backend/apps/api/src/route-controllers/student-scholastic-standings/_tests_/e2e/student-scholastic-standings.institutions.controller.getScholasticStandingSummary.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/student-scholastic-standings/_tests_/e2e/student-scholastic-standings.institutions.controller.getScholasticStandingSummary.e2e-spec.ts
@@ -175,7 +175,7 @@ describe("StudentScholasticStandingsInstitutionsController(e2e)-getScholasticSta
       });
   });
 
-  it("Should return full time withdrawals count for the provided student as a part of the student scholastic summary when the student has two active and one inactive WTHD restrictions.", async () => {
+  it("Should return full time withdrawals count for the provided student as a part of the student scholastic summary when the student has one active, one inactive and one deleted WTHD restrictions.", async () => {
     // Arrange
     const student = await saveFakeStudent(db.dataSource);
     const application = await saveFakeApplication(db.dataSource, {
@@ -187,7 +187,6 @@ describe("StudentScholasticStandingsInstitutionsController(e2e)-getScholasticSta
         restrictionCode: RestrictionCode.WTHD,
       },
     });
-    // Create two active and one inactive WTHD restriction for the student.
     await Promise.all([
       saveFakeStudentRestriction(
         db.dataSource,
@@ -208,7 +207,7 @@ describe("StudentScholasticStandingsInstitutionsController(e2e)-getScholasticSta
           restriction,
         },
         {
-          isActive: true,
+          isActive: false,
         },
       ),
       saveFakeStudentRestriction(
@@ -220,6 +219,7 @@ describe("StudentScholasticStandingsInstitutionsController(e2e)-getScholasticSta
         },
         {
           isActive: false,
+          deletedAt: new Date(),
         },
       ),
     ]);

--- a/sources/packages/backend/apps/api/src/route-controllers/student-scholastic-standings/_tests_/e2e/student-scholastic-standings.institutions.controller.getScholasticStandingSummary.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/student-scholastic-standings/_tests_/e2e/student-scholastic-standings.institutions.controller.getScholasticStandingSummary.e2e-spec.ts
@@ -175,7 +175,7 @@ describe("StudentScholasticStandingsInstitutionsController(e2e)-getScholasticSta
       });
   });
 
-  it("Should return full time withdrawals count for the provided student as a part of the student scholastic summary when the student has one active and one inactive WTHD restrictions.", async () => {
+  it("Should return full time withdrawals count for the provided student as a part of the student scholastic summary when the student has two active and one inactive WTHD restrictions.", async () => {
     // Arrange
     const student = await saveFakeStudent(db.dataSource);
     const application = await saveFakeApplication(db.dataSource, {
@@ -187,29 +187,42 @@ describe("StudentScholasticStandingsInstitutionsController(e2e)-getScholasticSta
         restrictionCode: RestrictionCode.WTHD,
       },
     });
-    // Create one active and one inactive WTHD restriction for the student.
-    await saveFakeStudentRestriction(
-      db.dataSource,
-      {
-        student,
-        application,
-        restriction,
-      },
-      {
-        isActive: true,
-      },
-    );
-    await saveFakeStudentRestriction(
-      db.dataSource,
-      {
-        student,
-        application,
-        restriction,
-      },
-      {
-        isActive: false,
-      },
-    );
+    // Create two active and one inactive WTHD restriction for the student.
+    await Promise.all([
+      saveFakeStudentRestriction(
+        db.dataSource,
+        {
+          student,
+          application,
+          restriction,
+        },
+        {
+          isActive: true,
+        },
+      ),
+      saveFakeStudentRestriction(
+        db.dataSource,
+        {
+          student,
+          application,
+          restriction,
+        },
+        {
+          isActive: true,
+        },
+      ),
+      saveFakeStudentRestriction(
+        db.dataSource,
+        {
+          student,
+          application,
+          restriction,
+        },
+        {
+          isActive: false,
+        },
+      ),
+    ]);
     const institutionUserToken = await getInstitutionToken(
       InstitutionTokenTypes.CollegeFUser,
     );
@@ -222,7 +235,7 @@ describe("StudentScholasticStandingsInstitutionsController(e2e)-getScholasticSta
       .expect({
         fullTimeLifetimeUnsuccessfulCompletionWeeks: 0,
         partTimeLifetimeUnsuccessfulCompletionWeeks: 0,
-        fullTimeWithdrawalsCount: 1,
+        fullTimeWithdrawalsCount: 2,
       });
   });
 });

--- a/sources/packages/backend/apps/api/src/route-controllers/student-scholastic-standings/_tests_/e2e/student-scholastic-standings.institutions.controller.getScholasticStandingSummary.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/student-scholastic-standings/_tests_/e2e/student-scholastic-standings.institutions.controller.getScholasticStandingSummary.e2e-spec.ts
@@ -175,7 +175,7 @@ describe("StudentScholasticStandingsInstitutionsController(e2e)-getScholasticSta
       });
   });
 
-  it("Should return full time withdrawals count for the provided student as a part of the student scholastic summary when the student has one active, one inactive and one deleted WTHD restrictions.", async () => {
+  it("Should return full-time withdrawals count for the provided student as a part of the student scholastic summary when the student has one active, one inactive and one deleted WTHD restrictions.", async () => {
     // Arrange
     const student = await saveFakeStudent(db.dataSource);
     const application = await saveFakeApplication(db.dataSource, {
@@ -183,6 +183,7 @@ describe("StudentScholasticStandingsInstitutionsController(e2e)-getScholasticSta
       student,
     });
     const restriction = await db.restriction.findOne({
+      select: { id: true },
       where: {
         restrictionCode: RestrictionCode.WTHD,
       },

--- a/sources/packages/backend/apps/api/src/route-controllers/student-scholastic-standings/_tests_/e2e/student-scholastic-standings.institutions.controller.saveScholasticStanding.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/student-scholastic-standings/_tests_/e2e/student-scholastic-standings.institutions.controller.saveScholasticStanding.e2e-spec.ts
@@ -1446,7 +1446,7 @@ describe("StudentScholasticStandingsInstitutionsController(e2e)-saveScholasticSt
       ]);
     });
 
-    it(`Should create an ${RestrictionCode.SSR} restriction when the student withdrew and there is an active ${RestrictionCode.WTHD} restriction.`, async () => {
+    it(`Should create a ${RestrictionCode.WTHD} and an ${RestrictionCode.SSR} restriction when the student withdrew and there is an active ${RestrictionCode.WTHD} restriction.`, async () => {
       // Arrange
       const withdrawalDate = addToDateOnlyString(new Date(), -5, "day");
       const payload = {
@@ -1508,10 +1508,17 @@ describe("StudentScholasticStandingsInstitutionsController(e2e)-saveScholasticSt
             restrictionCode: RestrictionCode.WTHD,
           },
         },
+        {
+          id: expect.any(Number),
+          restriction: {
+            id: wthdRestriction.id,
+            restrictionCode: RestrictionCode.WTHD,
+          },
+        },
       ]);
     });
 
-    it(`Should create a ${RestrictionCode.WTHD} and an ${RestrictionCode.SSRN} restriction when the student withdraws and there is an inactive ${RestrictionCode.SSR} restriction.`, async () => {
+    it(`Should create a ${RestrictionCode.WTHD} and an ${RestrictionCode.SSRN} restriction when the student withdrew and there is an inactive ${RestrictionCode.SSR} restriction.`, async () => {
       // Arrange
       const withdrawalDate = addToDateOnlyString(new Date(), -5, "day");
       const payload = {
@@ -1598,7 +1605,7 @@ describe("StudentScholasticStandingsInstitutionsController(e2e)-saveScholasticSt
         restriction: true,
       },
       where: { isActive: true, student: { id: studentId } },
-      order: { restriction: { restrictionCode: "ASC" } },
+      order: { restriction: { restrictionCode: "ASC" }, id: "ASC" },
     });
   }
 });

--- a/sources/packages/backend/apps/api/src/route-controllers/student-scholastic-standings/_tests_/e2e/student-scholastic-standings.students.controller.getScholasticStandingSummary.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/student-scholastic-standings/_tests_/e2e/student-scholastic-standings.students.controller.getScholasticStandingSummary.e2e-spec.ts
@@ -133,8 +133,7 @@ describe("StudentScholasticStandingsStudentsController(e2e)-getScholasticStandin
           restriction,
         },
         {
-          isActive: true,
-          resolvedAt: new Date(),
+          isActive: false,
         },
       );
       // Mock the user received in the token.

--- a/sources/packages/backend/apps/api/src/route-controllers/student-scholastic-standings/_tests_/e2e/student-scholastic-standings.students.controller.getScholasticStandingSummary.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/student-scholastic-standings/_tests_/e2e/student-scholastic-standings.students.controller.getScholasticStandingSummary.e2e-spec.ts
@@ -80,6 +80,7 @@ describe("StudentScholasticStandingsStudentsController(e2e)-getScholasticStandin
       .expect({
         fullTimeLifetimeUnsuccessfulCompletionWeeks: 17,
         partTimeLifetimeUnsuccessfulCompletionWeeks: 0,
+        fullTimeWithdrawalsCount: 0,
       });
   });
 
@@ -130,6 +131,7 @@ describe("StudentScholasticStandingsStudentsController(e2e)-getScholasticStandin
         .expect({
           fullTimeLifetimeUnsuccessfulCompletionWeeks: 5,
           partTimeLifetimeUnsuccessfulCompletionWeeks: 0,
+          fullTimeWithdrawalsCount: 0,
         });
     },
   );

--- a/sources/packages/backend/apps/api/src/route-controllers/student-scholastic-standings/_tests_/e2e/student-scholastic-standings.students.controller.getScholasticStandingSummary.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/student-scholastic-standings/_tests_/e2e/student-scholastic-standings.students.controller.getScholasticStandingSummary.e2e-spec.ts
@@ -1,10 +1,12 @@
 import { HttpStatus, INestApplication } from "@nestjs/common";
 import {
   E2EDataSources,
+  RestrictionCode,
   createE2EDataSources,
   createFakeStudentScholasticStanding,
   saveFakeApplication,
   saveFakeStudent,
+  saveFakeStudentRestriction,
 } from "@sims/test-utils";
 import {
   BEARER_AUTH_TYPE,
@@ -117,6 +119,24 @@ describe("StudentScholasticStandingsStudentsController(e2e)-getScholasticStandin
         scholasticStanding,
         reversedScholasticStanding,
       ]);
+      const restriction = await db.restriction.findOne({
+        where: {
+          restrictionCode: RestrictionCode.WTHD,
+        },
+      });
+      // Add a resolved WTHD restriction for the student that should still be counted.
+      await saveFakeStudentRestriction(
+        db.dataSource,
+        {
+          student,
+          application,
+          restriction,
+        },
+        {
+          isActive: true,
+          resolvedAt: new Date(),
+        },
+      );
       // Mock the user received in the token.
       await mockJWTUserInfo(appModule, student.user);
       const endpoint = "/students/scholastic-standing/summary";
@@ -131,7 +151,7 @@ describe("StudentScholasticStandingsStudentsController(e2e)-getScholasticStandin
         .expect({
           fullTimeLifetimeUnsuccessfulCompletionWeeks: 5,
           partTimeLifetimeUnsuccessfulCompletionWeeks: 0,
-          fullTimeWithdrawalsCount: 0,
+          fullTimeWithdrawalsCount: 1,
         });
     },
   );

--- a/sources/packages/backend/apps/api/src/route-controllers/student-scholastic-standings/_tests_/e2e/student-scholastic-standings.students.controller.getScholasticStandingSummary.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/student-scholastic-standings/_tests_/e2e/student-scholastic-standings.students.controller.getScholasticStandingSummary.e2e-spec.ts
@@ -120,6 +120,7 @@ describe("StudentScholasticStandingsStudentsController(e2e)-getScholasticStandin
         reversedScholasticStanding,
       ]);
       const restriction = await db.restriction.findOne({
+        select: { id: true },
         where: {
           restrictionCode: RestrictionCode.WTHD,
         },

--- a/sources/packages/backend/apps/api/src/route-controllers/student-scholastic-standings/models/student-scholastic-standings.dto.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/student-scholastic-standings/models/student-scholastic-standings.dto.ts
@@ -50,11 +50,12 @@ export class ScholasticStandingSubmittedDetailsAPIOutDTO extends IntersectionTyp
 }
 
 /**
- * Represents the scholastic standing unsuccessful completion weeks.
+ * Represents the scholastic standing summary details.
  */
 export class ScholasticStandingSummaryDetailsAPIOutDTO {
   fullTimeLifetimeUnsuccessfulCompletionWeeks: number;
   partTimeLifetimeUnsuccessfulCompletionWeeks: number;
+  fullTimeWithdrawalsCount: number;
 }
 
 /**

--- a/sources/packages/backend/apps/api/src/route-controllers/student-scholastic-standings/student-scholastic-standings.aest.controller.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/student-scholastic-standings/student-scholastic-standings.aest.controller.ts
@@ -77,7 +77,7 @@ export class ScholasticStandingAESTController extends BaseController {
    * @returns Scholastic Standing Summary details.
    */
   @Get("summary/student/:studentId")
-  @ApiNotFoundResponse({ description: "Student does not exists." })
+  @ApiNotFoundResponse({ description: "Student does not exist." })
   async getScholasticStandingSummary(
     @Param("studentId", ParseIntPipe) studentId: number,
   ): Promise<ScholasticStandingSummaryDetailsAPIOutDTO> {

--- a/sources/packages/backend/apps/api/src/route-controllers/student-scholastic-standings/student-scholastic-standings.controller.service.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/student-scholastic-standings/student-scholastic-standings.controller.service.ts
@@ -22,7 +22,7 @@ import {
   APPLICATION_WITHDRAWAL_TEXT_CONTENT_FORMAT_ERROR,
   APPLICATION_WITHDRAWAL_VALIDATION_ERROR,
 } from "../../constants";
-import { RestrictionCode } from "@sims/services/restriction/model/restriction.model";
+import { RestrictionCode } from "@sims/services";
 
 /**
  * Scholastic standing controller service.
@@ -84,7 +84,7 @@ export class ScholasticStandingControllerService {
   ): Promise<ScholasticStandingSummaryDetailsAPIOutDTO> {
     const studentExists = await this.studentService.studentExists(studentId);
     if (!studentExists) {
-      throw new NotFoundException("Student does not exists.");
+      throw new NotFoundException("Student does not exist.");
     }
     const [
       {
@@ -96,9 +96,10 @@ export class ScholasticStandingControllerService {
       this.studentScholasticStandingsService.getScholasticStandingSummary(
         studentId,
       ),
-      this.studentRestrictionService.countRestrictionByCodes(studentId, [
+      this.studentRestrictionService.countRestrictionByCode(
+        studentId,
         RestrictionCode.WTHD,
-      ]),
+      ),
     ]);
 
     return {

--- a/sources/packages/backend/apps/api/src/route-controllers/student-scholastic-standings/student-scholastic-standings.controller.service.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/student-scholastic-standings/student-scholastic-standings.controller.service.ts
@@ -96,7 +96,7 @@ export class ScholasticStandingControllerService {
       this.studentScholasticStandingsService.getScholasticStandingSummary(
         studentId,
       ),
-      this.studentRestrictionService.countActiveRestrictionByCodes(studentId, [
+      this.studentRestrictionService.countRestrictionByCodes(studentId, [
         RestrictionCode.WTHD,
       ]),
     ]);

--- a/sources/packages/backend/apps/api/src/route-controllers/student-scholastic-standings/student-scholastic-standings.controller.service.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/student-scholastic-standings/student-scholastic-standings.controller.service.ts
@@ -5,6 +5,7 @@ import {
 } from "@nestjs/common";
 import {
   ApplicationWithdrawalTextValidationResult,
+  StudentRestrictionService,
   StudentScholasticStandingsService,
   StudentService,
 } from "../../services";
@@ -21,6 +22,7 @@ import {
   APPLICATION_WITHDRAWAL_TEXT_CONTENT_FORMAT_ERROR,
   APPLICATION_WITHDRAWAL_VALIDATION_ERROR,
 } from "../../constants";
+import { RestrictionCode } from "@sims/services/restriction/model/restriction.model";
 
 /**
  * Scholastic standing controller service.
@@ -29,6 +31,7 @@ import {
 export class ScholasticStandingControllerService {
   constructor(
     private readonly studentService: StudentService,
+    private readonly studentRestrictionService: StudentRestrictionService,
     private readonly studentScholasticStandingsService: StudentScholasticStandingsService,
   ) {}
 
@@ -83,17 +86,27 @@ export class ScholasticStandingControllerService {
     if (!studentExists) {
       throw new NotFoundException("Student does not exists.");
     }
-    const scholasticStandingSummary =
-      await this.studentScholasticStandingsService.getScholasticStandingSummary(
+    const [
+      {
+        fullTimeUnsuccessfulCompletionWeeks,
+        partTimeUnsuccessfulCompletionWeeks,
+      },
+      fullTimeWithdrawalsCount,
+    ] = await Promise.all([
+      this.studentScholasticStandingsService.getScholasticStandingSummary(
         studentId,
-      );
-    const partTimeLifetimeUnsuccessfulCompletionWeeks =
-      scholasticStandingSummary.partTimeUnsuccessfulCompletionWeeks;
-    const fullTimeLifetimeUnsuccessfulCompletionWeeks =
-      scholasticStandingSummary.fullTimeUnsuccessfulCompletionWeeks;
+      ),
+      this.studentRestrictionService.countActiveRestrictionByCodes(studentId, [
+        RestrictionCode.WTHD,
+      ]),
+    ]);
+
     return {
-      fullTimeLifetimeUnsuccessfulCompletionWeeks,
-      partTimeLifetimeUnsuccessfulCompletionWeeks,
+      fullTimeLifetimeUnsuccessfulCompletionWeeks:
+        fullTimeUnsuccessfulCompletionWeeks,
+      partTimeLifetimeUnsuccessfulCompletionWeeks:
+        partTimeUnsuccessfulCompletionWeeks,
+      fullTimeWithdrawalsCount,
     };
   }
 
@@ -104,7 +117,7 @@ export class ScholasticStandingControllerService {
    */
   assertTextValidationsAreValid(
     textValidations: ApplicationWithdrawalTextValidationResult[],
-  ) {
+  ): void {
     const textValidationsErrors = textValidations.filter(
       (textValidation) => textValidation.errors.length,
     );
@@ -136,7 +149,7 @@ export class ScholasticStandingControllerService {
    */
   assertValidationsAreValid(
     validationsResult: ApplicationWithdrawalValidationResult[],
-  ) {
+  ): void {
     const validations = validationsResult.filter(
       (validationResult) =>
         validationResult.errors.length || validationResult.warnings.length,

--- a/sources/packages/backend/apps/api/src/route-controllers/student-scholastic-standings/student-scholastic-standings.institutions.controller.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/student-scholastic-standings/student-scholastic-standings.institutions.controller.ts
@@ -198,7 +198,7 @@ export class ScholasticStandingInstitutionsController extends BaseController {
   @IsBCPublicInstitution()
   @HasStudentDataAccess("studentId")
   @Get("summary/student/:studentId")
-  @ApiNotFoundResponse({ description: "Student does not exists." })
+  @ApiNotFoundResponse({ description: "Student does not exist." })
   async getScholasticStandingSummary(
     @Param("studentId", ParseIntPipe) studentId: number,
   ): Promise<ScholasticStandingSummaryDetailsAPIOutDTO> {

--- a/sources/packages/backend/apps/api/src/services/restriction/student-restriction.service.ts
+++ b/sources/packages/backend/apps/api/src/services/restriction/student-restriction.service.ts
@@ -439,6 +439,25 @@ export class StudentRestrictionService extends RecordDataModelService<StudentRes
   }
 
   /**
+   * Get a count of active student restrictions by their codes.
+   * @param studentId student ID.
+   * @param restrictionCodes restriction codes.
+   * @returns count of student restrictions.
+   */
+  async countActiveRestrictionByCodes(
+    studentId: number,
+    restrictionCodes: string[],
+  ): Promise<number> {
+    return this.repo.count({
+      where: {
+        isActive: true,
+        student: { id: studentId },
+        restriction: { restrictionCode: In(restrictionCodes) },
+      },
+    });
+  }
+
+  /**
    * Verify if the student has a valid SIN to apply to the particular offering.
    * The SIN number must be a permanent one or a temporary with expiry date later
    * then the end date of the offering.

--- a/sources/packages/backend/apps/api/src/services/restriction/student-restriction.service.ts
+++ b/sources/packages/backend/apps/api/src/services/restriction/student-restriction.service.ts
@@ -394,7 +394,7 @@ export class StudentRestrictionService extends RecordDataModelService<StudentRes
    */
   async hasAnyActiveRestriction(
     studentId: number,
-    restrictionCodes: string[],
+    restrictionCodes: RestrictionCode[],
     entityManager?: EntityManager,
   ): Promise<boolean> {
     const repo = entityManager?.getRepository(StudentRestriction) ?? this.repo;
@@ -420,7 +420,7 @@ export class StudentRestrictionService extends RecordDataModelService<StudentRes
    */
   async getRestrictionByCodes(
     studentId: number,
-    restrictionCodes: string[],
+    restrictionCodes: RestrictionCode[],
   ): Promise<StudentRestriction[]> {
     return this.repo.find({
       select: {
@@ -439,19 +439,19 @@ export class StudentRestrictionService extends RecordDataModelService<StudentRes
   }
 
   /**
-   * Get a count of student restrictions by their codes.
+   * Get a count of student restrictions by code.
    * @param studentId student ID.
-   * @param restrictionCodes restriction codes.
-   * @returns count of student restrictions.
+   * @param restrictionCode restriction code.
+   * @returns count of student restrictions for the specified code.
    */
-  async countRestrictionByCodes(
+  async countRestrictionByCode(
     studentId: number,
-    restrictionCodes: string[],
+    restrictionCode: RestrictionCode,
   ): Promise<number> {
     return this.repo.count({
       where: {
         student: { id: studentId },
-        restriction: { restrictionCode: In(restrictionCodes) },
+        restriction: { restrictionCode },
       },
     });
   }

--- a/sources/packages/backend/apps/api/src/services/restriction/student-restriction.service.ts
+++ b/sources/packages/backend/apps/api/src/services/restriction/student-restriction.service.ts
@@ -439,18 +439,17 @@ export class StudentRestrictionService extends RecordDataModelService<StudentRes
   }
 
   /**
-   * Get a count of active student restrictions by their codes.
+   * Get a count of student restrictions by their codes.
    * @param studentId student ID.
    * @param restrictionCodes restriction codes.
    * @returns count of student restrictions.
    */
-  async countActiveRestrictionByCodes(
+  async countRestrictionByCodes(
     studentId: number,
     restrictionCodes: string[],
   ): Promise<number> {
     return this.repo.count({
       where: {
-        isActive: true,
         student: { id: studentId },
         restriction: { restrictionCode: In(restrictionCodes) },
       },

--- a/sources/packages/backend/apps/api/src/services/student-scholastic-standings/student-scholastic-standings.service.ts
+++ b/sources/packages/backend/apps/api/src/services/student-scholastic-standings/student-scholastic-standings.service.ts
@@ -315,8 +315,7 @@ export class StudentScholasticStandingsService extends RecordDataModelService<St
    * Once SSR or SSRN are present in the student account, any of the
    * above mentioned restrictions will create a new SSRN restriction
    * (if one is not present or active yet).
-   * 'Student withdrew from program' will always create a new WTHD restriction
-   * if one is not present or active yet.
+   * 'Student withdrew from program' will always create a new WTHD restriction.
    * @param scholasticStandingData scholastic standing data.
    * @param studentId student id.
    * @param auditUserId user that should be considered the one that is
@@ -404,24 +403,12 @@ export class StudentScholasticStandingsService extends RecordDataModelService<St
       scholasticStandingData.scholasticStandingChangeType ===
       StudentScholasticStandingChangeType.StudentWithdrewFromProgram
     ) {
-      // Check for "WTHD" restriction since it should always be created if one is not present and active.
+      // Check for "WTHD" restriction since it affects SSR/SSRN creation.
       const hasActiveWTHD = existingRestrictions.some(
         (studentRestriction) =>
           studentRestriction.restriction.restrictionCode ===
             RestrictionCode.WTHD && studentRestriction.isActive,
       );
-      // Check if "WTHD" restriction is already present for the student,
-      // if not, then create a new one.
-      if (!hasActiveWTHD) {
-        const wthdRestriction =
-          await this.studentRestrictionSharedService.createRestrictionToSave(
-            studentId,
-            RestrictionCode.WTHD,
-            auditUserId,
-            applicationId,
-          );
-        restrictions.push(wthdRestriction);
-      }
       // Check if an SSR or SSRN was created for the student.
       const createdSSROrSSRN = restrictions.some((studentRestriction) =>
         SCHOLASTIC_ESCALATION_RESTRICTIONS.includes(
@@ -440,6 +427,15 @@ export class StudentScholasticStandingsService extends RecordDataModelService<St
           );
         restrictions.push(ssrRestriction);
       }
+      // Always create a new "WTHD" restriction.
+      const wthdRestriction =
+        await this.studentRestrictionSharedService.createRestrictionToSave(
+          studentId,
+          RestrictionCode.WTHD,
+          auditUserId,
+          applicationId,
+        );
+      restrictions.push(wthdRestriction);
     }
     return restrictions;
   }

--- a/sources/packages/backend/apps/api/src/services/student-scholastic-standings/student-scholastic-standings.service.ts
+++ b/sources/packages/backend/apps/api/src/services/student-scholastic-standings/student-scholastic-standings.service.ts
@@ -279,7 +279,7 @@ export class StudentScholasticStandingsService extends RecordDataModelService<St
    * @param auditUserId user that should be considered the one that is
    * causing the changes.
    * @param applicationId application id.
-   * @returns a new student restriction object(s), that need to be saved.
+   * @returns new student restriction(s), that need to be saved.
    */
   async getScholasticStandingRestrictions(
     scholasticStandingData: ScholasticStanding,
@@ -329,7 +329,7 @@ export class StudentScholasticStandingsService extends RecordDataModelService<St
     auditUserId: number,
     applicationId: number,
   ): Promise<StudentRestriction[]> {
-    const restrictions: StudentRestriction[] = [];
+    const newRestrictions: StudentRestriction[] = [];
     if (
       !SCHOLASTIC_RESTRICTION_TYPES_FULL_TIME.includes(
         scholasticStandingData.scholasticStandingChangeType,
@@ -337,7 +337,7 @@ export class StudentScholasticStandingsService extends RecordDataModelService<St
     ) {
       // If the scholastic standing change type is not related to withdrawal
       // or unsuccessful completion then no restrictions are required.
-      return restrictions;
+      return newRestrictions;
     }
     // Get all existing restrictions for the student that potentially will be required
     // to determine the new restriction(s) to be created.
@@ -369,7 +369,7 @@ export class StudentScholasticStandingsService extends RecordDataModelService<St
             auditUserId,
             applicationId,
           );
-        restrictions.push(ssrnRestriction);
+        newRestrictions.push(ssrnRestriction);
       }
     } else if (
       scholasticStandingData.scholasticStandingChangeType ===
@@ -395,8 +395,8 @@ export class StudentScholasticStandingsService extends RecordDataModelService<St
             auditUserId,
             applicationId,
           );
-        restrictions.push(ssrRestriction);
-        return restrictions;
+        newRestrictions.push(ssrRestriction);
+        return newRestrictions;
       }
     }
     if (
@@ -410,7 +410,7 @@ export class StudentScholasticStandingsService extends RecordDataModelService<St
             RestrictionCode.WTHD && studentRestriction.isActive,
       );
       // Check if an SSR or SSRN was created for the student.
-      const createdSSROrSSRN = restrictions.some((studentRestriction) =>
+      const createdSSROrSSRN = newRestrictions.some((studentRestriction) =>
         SCHOLASTIC_ESCALATION_RESTRICTIONS.includes(
           studentRestriction.restriction.restrictionCode as RestrictionCode,
         ),
@@ -425,7 +425,7 @@ export class StudentScholasticStandingsService extends RecordDataModelService<St
             auditUserId,
             applicationId,
           );
-        restrictions.push(ssrRestriction);
+        newRestrictions.push(ssrRestriction);
       }
       // Always create a new "WTHD" restriction.
       const wthdRestriction =
@@ -435,9 +435,9 @@ export class StudentScholasticStandingsService extends RecordDataModelService<St
           auditUserId,
           applicationId,
         );
-      restrictions.push(wthdRestriction);
+      newRestrictions.push(wthdRestriction);
     }
-    return restrictions;
+    return newRestrictions;
   }
 
   /**
@@ -453,7 +453,7 @@ export class StudentScholasticStandingsService extends RecordDataModelService<St
    * @param auditUserId user that should be considered the one that is
    * causing the changes.
    * @param applicationId application id.
-   * @returns a new student restriction objects, that need to be saved.
+   * @returns new student restriction(s), that need to be saved.
    */
   private async getPartTimeStudentRestrictions(
     scholasticStandingData: ScholasticStanding,

--- a/sources/packages/backend/libs/test-utils/src/factories/student-restriction.ts
+++ b/sources/packages/backend/libs/test-utils/src/factories/student-restriction.ts
@@ -26,6 +26,7 @@ import { E2EDataSources, RestrictionCode } from "@sims/test-utils";
  * - `isActive` option for specifying if the student restriction is active.
  * - `updatedAt` option for specifying the updated date of the student restriction.
  * - `deletedAt` option for specifying if the student restriction is deleted.
+ * - `resolvedAt` option for specifying the resolved date of the student restriction.
  * @returns persisted student restriction.
  */
 export function createFakeStudentRestriction(
@@ -37,7 +38,12 @@ export function createFakeStudentRestriction(
     resolutionNote?: Note;
     creator?: User;
   },
-  options?: { isActive?: boolean; updatedAt?: Date; deletedAt?: Date },
+  options?: {
+    isActive?: boolean;
+    updatedAt?: Date;
+    deletedAt?: Date;
+    resolvedAt?: Date;
+  },
 ): StudentRestriction {
   const studentRestriction = new StudentRestriction();
   studentRestriction.student = relations.student;
@@ -49,6 +55,7 @@ export function createFakeStudentRestriction(
   studentRestriction.creator = relations?.creator;
   studentRestriction.updatedAt = options?.updatedAt;
   studentRestriction.deletedAt = options?.deletedAt;
+  studentRestriction.resolvedAt = options?.resolvedAt;
   return studentRestriction;
 }
 
@@ -66,6 +73,7 @@ export function createFakeStudentRestriction(
  * - `isActive` option for specifying if the student restriction is active.
  * - `updatedAt` option for specifying the updated date of the student restriction.
  * - `deletedAt` option for specifying if the student restriction is deleted.
+ * - `resolvedAt` option for specifying the resolved date of the student restriction.
  * @returns a persisted fake student restriction.
  */
 export async function saveFakeStudentRestriction(
@@ -78,7 +86,12 @@ export async function saveFakeStudentRestriction(
     resolutionNote?: Note;
     creator?: User;
   },
-  options?: { isActive?: boolean; updatedAt?: Date; deletedAt?: Date },
+  options?: {
+    isActive?: boolean;
+    updatedAt?: Date;
+    deletedAt?: Date;
+    resolvedAt?: Date;
+  },
 ): Promise<StudentRestriction> {
   const [restrictionNote, resolutionNote] = await saveFakeStudentNotes(
     dataSource,

--- a/sources/packages/backend/libs/test-utils/src/factories/student-restriction.ts
+++ b/sources/packages/backend/libs/test-utils/src/factories/student-restriction.ts
@@ -26,7 +26,6 @@ import { E2EDataSources, RestrictionCode } from "@sims/test-utils";
  * - `isActive` option for specifying if the student restriction is active.
  * - `updatedAt` option for specifying the updated date of the student restriction.
  * - `deletedAt` option for specifying if the student restriction is deleted.
- * - `resolvedAt` option for specifying the resolved date of the student restriction.
  * @returns persisted student restriction.
  */
 export function createFakeStudentRestriction(
@@ -38,12 +37,7 @@ export function createFakeStudentRestriction(
     resolutionNote?: Note;
     creator?: User;
   },
-  options?: {
-    isActive?: boolean;
-    updatedAt?: Date;
-    deletedAt?: Date;
-    resolvedAt?: Date;
-  },
+  options?: { isActive?: boolean; updatedAt?: Date; deletedAt?: Date },
 ): StudentRestriction {
   const studentRestriction = new StudentRestriction();
   studentRestriction.student = relations.student;
@@ -55,7 +49,6 @@ export function createFakeStudentRestriction(
   studentRestriction.creator = relations?.creator;
   studentRestriction.updatedAt = options?.updatedAt;
   studentRestriction.deletedAt = options?.deletedAt;
-  studentRestriction.resolvedAt = options?.resolvedAt;
   return studentRestriction;
 }
 
@@ -73,7 +66,6 @@ export function createFakeStudentRestriction(
  * - `isActive` option for specifying if the student restriction is active.
  * - `updatedAt` option for specifying the updated date of the student restriction.
  * - `deletedAt` option for specifying if the student restriction is deleted.
- * - `resolvedAt` option for specifying the resolved date of the student restriction.
  * @returns a persisted fake student restriction.
  */
 export async function saveFakeStudentRestriction(
@@ -86,12 +78,7 @@ export async function saveFakeStudentRestriction(
     resolutionNote?: Note;
     creator?: User;
   },
-  options?: {
-    isActive?: boolean;
-    updatedAt?: Date;
-    deletedAt?: Date;
-    resolvedAt?: Date;
-  },
+  options?: { isActive?: boolean; updatedAt?: Date; deletedAt?: Date },
 ): Promise<StudentRestriction> {
   const [restrictionNote, resolutionNote] = await saveFakeStudentNotes(
     dataSource,

--- a/sources/packages/web/src/components/common/students/StudentRestrictions.vue
+++ b/sources/packages/web/src/components/common/students/StudentRestrictions.vue
@@ -178,7 +178,7 @@ export default defineComponent({
       default: false,
     },
   },
-  emits: ["restrictions-updated"],
+  emits: ["restriction-created", "restriction-deleted"],
   setup(props, { emit }) {
     const studentRestrictions = ref<RestrictionSummaryAPIOutDTO[]>([]);
     const { dateOnlyLongString } = useFormatters();
@@ -260,7 +260,7 @@ export default defineComponent({
         );
         await loadStudentRestrictions();
         snackBar.success("The restriction has been added to student.");
-        emit("restrictions-updated");
+        emit("restriction-created");
         return true;
       } catch {
         snackBar.error("Unexpected error while adding the restriction.");
@@ -286,7 +286,7 @@ export default defineComponent({
         );
         snackBar.success("Restriction deleted.");
         await loadStudentRestrictions();
-        emit("restrictions-updated");
+        emit("restriction-deleted");
         return true;
       } catch (error: unknown) {
         if (error instanceof ApiProcessError) {

--- a/sources/packages/web/src/components/common/students/StudentRestrictions.vue
+++ b/sources/packages/web/src/components/common/students/StudentRestrictions.vue
@@ -178,7 +178,8 @@ export default defineComponent({
       default: false,
     },
   },
-  setup(props) {
+  emits: ["restrictions-updated"],
+  setup(props, { emit }) {
     const studentRestrictions = ref<RestrictionSummaryAPIOutDTO[]>([]);
     const { dateOnlyLongString } = useFormatters();
     const showModal = ref(false);
@@ -259,6 +260,7 @@ export default defineComponent({
         );
         await loadStudentRestrictions();
         snackBar.success("The restriction has been added to student.");
+        emit("restrictions-updated");
         return true;
       } catch {
         snackBar.error("Unexpected error while adding the restriction.");
@@ -284,6 +286,7 @@ export default defineComponent({
         );
         snackBar.success("Restriction deleted.");
         await loadStudentRestrictions();
+        emit("restrictions-updated");
         return true;
       } catch (error: unknown) {
         if (error instanceof ApiProcessError) {

--- a/sources/packages/web/src/components/common/students/StudentScholasticStandingLimitedHistory.vue
+++ b/sources/packages/web/src/components/common/students/StudentScholasticStandingLimitedHistory.vue
@@ -1,5 +1,5 @@
 <template>
-  <body-header-container :enableCardView="true">
+  <body-header-container :enable-card-view="true">
     <template #header>
       <body-header title="Scholastic Standing Limited History" />
     </template>
@@ -17,38 +17,37 @@
         {{
           scholasticStandingSummary.fullTimeLifetimeUnsuccessfulCompletionWeeks
         }}
+      </p>
+      <p class="label-bold-normal">
+        Number of full-time withdrawals from study:
+        {{ scholasticStandingSummary.fullTimeWithdrawalsCount }}
       </p></content-group
     >
   </body-header-container>
 </template>
-<script lang="ts">
+<script setup lang="ts">
 import { ScholasticStandingSummaryDetailsAPIOutDTO } from "@/services/http/dto";
 import { ScholasticStandingService } from "@/services/ScholasticStandingService";
-import { defineComponent, onMounted, ref } from "vue";
+import { onMounted, ref } from "vue";
 
-export default defineComponent({
-  props: {
-    studentId: {
-      type: Number,
-      required: false,
-    },
-    showPartTimeSummary: {
-      type: Boolean,
-      required: false,
-      default: true,
-    },
-  },
-  setup(props) {
-    const scholasticStandingSummary = ref(
-      {} as ScholasticStandingSummaryDetailsAPIOutDTO,
-    );
-    onMounted(async () => {
-      scholasticStandingSummary.value =
-        await ScholasticStandingService.shared.getScholasticStandingSummary({
-          studentId: props.studentId,
-        });
+interface Props {
+  studentId?: number;
+  showPartTimeSummary?: boolean;
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  studentId: undefined,
+  showPartTimeSummary: true,
+});
+
+const scholasticStandingSummary = ref(
+  {} as ScholasticStandingSummaryDetailsAPIOutDTO,
+);
+
+onMounted(async () => {
+  scholasticStandingSummary.value =
+    await ScholasticStandingService.shared.getScholasticStandingSummary({
+      studentId: props.studentId,
     });
-    return { scholasticStandingSummary };
-  },
 });
 </script>

--- a/sources/packages/web/src/components/common/students/StudentScholasticStandingLimitedHistory.vue
+++ b/sources/packages/web/src/components/common/students/StudentScholasticStandingLimitedHistory.vue
@@ -19,7 +19,7 @@
         }}
       </p>
       <p class="label-bold-normal">
-        Number of full-time withdrawals from study:
+        Number of Full-time withdrawals from study:
         {{ scholasticStandingSummary.fullTimeWithdrawalsCount }}
       </p></content-group
     >

--- a/sources/packages/web/src/components/common/students/StudentScholasticStandingLimitedHistory.vue
+++ b/sources/packages/web/src/components/common/students/StudentScholasticStandingLimitedHistory.vue
@@ -45,9 +45,17 @@ const scholasticStandingSummary = ref(
 );
 
 onMounted(async () => {
+  await loadSummary();
+});
+
+const loadSummary = async () => {
   scholasticStandingSummary.value =
     await ScholasticStandingService.shared.getScholasticStandingSummary({
       studentId: props.studentId,
     });
+};
+
+defineExpose({
+  loadSummary,
 });
 </script>

--- a/sources/packages/web/src/services/http/dto/ScholasticStanding.dto.ts
+++ b/sources/packages/web/src/services/http/dto/ScholasticStanding.dto.ts
@@ -43,6 +43,7 @@ export interface ScholasticStandingSubmittedDetailsAPIOutDTO
 export interface ScholasticStandingSummaryDetailsAPIOutDTO {
   fullTimeLifetimeUnsuccessfulCompletionWeeks: number;
   partTimeLifetimeUnsuccessfulCompletionWeeks: number;
+  fullTimeWithdrawalsCount: number;
 }
 
 /**

--- a/sources/packages/web/src/views/aest/student/StudentRestrictions.vue
+++ b/sources/packages/web/src/views/aest/student/StudentRestrictions.vue
@@ -5,7 +5,8 @@
       :can-add-restrictions="true"
       :can-resolve-restriction="true"
       :can-delete-restriction="true"
-      @restrictions-updated="onRestrictionsUpdated"
+      @restriction-created="restrictionsChanged"
+      @restriction-deleted="restrictionsChanged"
     ></student-restrictions>
     <student-scholastic-standing-limited-history
       ref="scholasticStandingLimitedHistoryComponent"
@@ -28,8 +29,8 @@ defineProps<Props>();
 const scholasticStandingLimitedHistoryComponent =
   ref<InstanceType<typeof StudentScholasticStandingLimitedHistory>>();
 
-const onRestrictionsUpdated = () => {
-  // Reload the scholastic standing limited history when restrictions are updated
+const restrictionsChanged = () => {
+  // Reload the scholastic standing limited history when restrictions are created or deleted.
   scholasticStandingLimitedHistoryComponent.value?.loadSummary();
 };
 </script>

--- a/sources/packages/web/src/views/aest/student/StudentRestrictions.vue
+++ b/sources/packages/web/src/views/aest/student/StudentRestrictions.vue
@@ -1,27 +1,35 @@
 <template>
-  <tab-container :enableCardView="false"
+  <tab-container :enable-card-view="false"
     ><student-restrictions
-      :studentId="studentId"
+      :student-id="studentId"
       :can-add-restrictions="true"
       :can-resolve-restriction="true"
       :can-delete-restriction="true"
+      @restrictions-updated="onRestrictionsUpdated"
     ></student-restrictions>
-    <student-scholastic-standing-limited-history :studentId="studentId"
-  /></tab-container>
+    <student-scholastic-standing-limited-history
+      ref="scholasticStandingLimitedHistoryComponent"
+      :student-id="studentId"
+    />
+  </tab-container>
 </template>
 
-<script lang="ts">
-import { defineComponent } from "vue";
+<script setup lang="ts">
 import StudentRestrictions from "@/components/common/students/StudentRestrictions.vue";
 import StudentScholasticStandingLimitedHistory from "@/components/common/students/StudentScholasticStandingLimitedHistory.vue";
+import { ref } from "vue";
 
-export default defineComponent({
-  components: { StudentRestrictions, StudentScholasticStandingLimitedHistory },
-  props: {
-    studentId: {
-      type: Number,
-      required: true,
-    },
-  },
-});
+interface Props {
+  studentId: number;
+}
+
+defineProps<Props>();
+
+const scholasticStandingLimitedHistoryComponent =
+  ref<InstanceType<typeof StudentScholasticStandingLimitedHistory>>();
+
+const onRestrictionsUpdated = () => {
+  // Reload the scholastic standing limited history when restrictions are updated
+  scholasticStandingLimitedHistoryComponent.value?.loadSummary();
+};
 </script>


### PR DESCRIPTION
## Summary
- Add Full Time Withdrawals count to Student Scholastic Standing.
- Update logic to create a WTHD restriction even if one is already present.
- Added UI logic for Ministry to update the counts when a restriction is added/deleted.
- Minor refactoring.
- Added/update E2E tests.

## Screenshots
### Institution -> Student Restrictions
<img width="1848" height="846" alt="image" src="https://github.com/user-attachments/assets/9b1efe3d-2e78-4334-9cbf-20db8bfcfd20" />

### Ministry -> Student Restrictions
<img width="1361" height="1002" alt="image" src="https://github.com/user-attachments/assets/c03026e9-fc42-418f-845a-32f199cb0306" />

### Student -> Account Activity
<img width="1528" height="646" alt="image" src="https://github.com/user-attachments/assets/781cc9ac-cf50-4e57-9404-f02310a0bacb" />

## E2E Tests
### StudentScholasticStandingsAESTController(e2e)-getScholasticStandingSummary
<img width="1325" height="310" alt="image" src="https://github.com/user-attachments/assets/a38269c7-0287-46c9-8091-445d77186a0d" />

### StudentScholasticStandingsInstitutionsController(e2e)-getScholasticStandingSummary
<img width="1315" height="336" alt="image" src="https://github.com/user-attachments/assets/8f023502-eb6b-42b0-9de3-57334f8d6390" />

### StudentScholasticStandingsStudentsController(e2e)-getScholasticStandingSummary
<img width="1320" height="312" alt="image" src="https://github.com/user-attachments/assets/59882d04-843c-4296-8f7d-83ba21a4adfc" />

### StudentScholasticStandingsInstitutionsController(e2e)-saveScholasticStanding
<img width="1971" height="838" alt="image" src="https://github.com/user-attachments/assets/c252c925-cb1f-4792-ad4d-63e57dff7eef" />
