### PR TITLE
#6228 - Scholastic Standing History navigation fix

### DIFF
--- a/sources/packages/web/src/views/aest/student/applicationDetails/ViewScholasticStanding.vue
+++ b/sources/packages/web/src/views/aest/student/applicationDetails/ViewScholasticStanding.vue
@@ -146,7 +146,8 @@ export default {
           payload,
         );
         snackBar.success("Scholastic standing reversed successfully.");
-        await router.push(goToAssessmentSummary.value);
+        const location = props.backTarget?.to ?? goToAssessmentSummary.value;
+        await router.push(location);
         return true;
       } catch {
         snackBar.error(


### PR DESCRIPTION
## Summary
- Added navigation to backTarget (as used by Scholastic Standing History) from Reverse scholastic standing modal. Fallback is still assessments to support existing usage.

## Screenshots
### Reversal from Scholastic Standing History
<img width="1475" height="432" alt="image" src="https://github.com/user-attachments/assets/dce43d30-4dbf-4c99-a435-e9ff0a3f188e" />

<img width="1065" height="712" alt="image" src="https://github.com/user-attachments/assets/2704f267-8170-407d-b8bf-13cc4c6af476" />

<img width="1597" height="373" alt="image" src="https://github.com/user-attachments/assets/0ecba451-72ea-447c-aea8-92eb942ca0fe" />

### Reversal from Assessements
<img width="1422" height="521" alt="image" src="https://github.com/user-attachments/assets/30270671-8a56-4a97-8492-acd4a0eb1045" />

<img width="1055" height="724" alt="image" src="https://github.com/user-attachments/assets/e98074a1-91f3-4f68-9ca5-99328cd91a6d" />

<img width="1503" height="558" alt="image" src="https://github.com/user-attachments/assets/72b981e8-d5cf-416c-be7e-a18acf4325a9" />
