### PR TITLE
#6282 - Institution under review restriction - Institution UI

### DIFF
--- a/sources/packages/backend/apps/api/src/route-controllers/application/_tests_/e2e/application.students.controller.getApplicationWarnings.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/application/_tests_/e2e/application.students.controller.getApplicationWarnings.e2e-spec.ts
@@ -350,7 +350,7 @@ describe("ApplicationStudentsController(e2e)-getApplicationWarnings", () => {
     },
   );
 
-  it("Should return an institution restriction and prevent the assessment acceptance when there is an effective restriction on institution with an action to 'Stop accept assessment'.", async () => {
+  it("Should return an institution restriction and prevent the assessment acceptance when there is an effective restriction on institution with an action to Stop accept assessment.", async () => {
     // Arrange
     const student = await saveFakeStudent(db.dataSource);
     const msfaaNumber = createFakeMSFAANumber(
@@ -411,7 +411,13 @@ describe("ApplicationStudentsController(e2e)-getApplicationWarnings", () => {
       .expect({
         canAcceptAssessment: false,
         eCertFailedValidations: [],
-        acceptAssessmentRestrictions: [restriction.restrictionCode],
+        acceptAssessmentRestrictions: [
+          {
+            code: restriction.restrictionCode,
+            message:
+              "Your assessment cannot be accepted at this time because the institution associated with your application is currently under review.",
+          },
+        ],
       });
   });
 

--- a/sources/packages/backend/apps/api/src/route-controllers/application/models/application.dto.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/application/models/application.dto.ts
@@ -294,11 +294,16 @@ export class ApplicationAssessmentStatusDetailsAPIOutDTO {
   assessmentDate: Date;
 }
 
+export class AcceptAssessmentRestrictionAPIOutDTO {
+  code: string;
+  message?: string;
+}
+
 export class ApplicationWarningsAPIOutDTO {
   eCertFailedValidations: ECertFailedValidation[];
   canAcceptAssessment: boolean;
   eCertFailedValidationsInfo?: ECertFailedValidationsInfoAPIOutDTO;
-  acceptAssessmentRestrictions: string[];
+  acceptAssessmentRestrictions: AcceptAssessmentRestrictionAPIOutDTO[];
 }
 
 export class ApplicationSupportingUsersAPIOutDTO {

--- a/sources/packages/backend/apps/api/src/route-controllers/application/models/application.dto.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/application/models/application.dto.ts
@@ -294,8 +294,17 @@ export class ApplicationAssessmentStatusDetailsAPIOutDTO {
   assessmentDate: Date;
 }
 
+/**
+ * Restriction information for accepting an assessment.
+ */
 export class AcceptAssessmentRestrictionAPIOutDTO {
+  /**
+   * Restriction code.
+   */
   code: string;
+  /**
+   * Optional message that could be set for the restriction.
+   */
   message?: string;
 }
 

--- a/sources/packages/backend/apps/api/src/route-controllers/restriction/_tests_/e2e/restriction.aest.controller.getActiveInstitutionRestrictions.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/restriction/_tests_/e2e/restriction.aest.controller.getActiveInstitutionRestrictions.e2e-spec.ts
@@ -80,6 +80,7 @@ describe("RestrictionAESTController(e2e)-getActiveInstitutionRestrictions.", () 
               RestrictionActionType.StopFullTimeDisbursement,
               RestrictionActionType.StopOfferingCreate,
             ],
+            restrictionNotificationType: RestrictionNotificationType.Error,
           },
         ],
       });

--- a/sources/packages/backend/apps/api/src/route-controllers/restriction/_tests_/e2e/restriction.institutions.controller.getActiveInstitutionRestrictions.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/restriction/_tests_/e2e/restriction.institutions.controller.getActiveInstitutionRestrictions.e2e-spec.ts
@@ -119,6 +119,7 @@ describe("RestrictionInstitutionsController(e2e)-getActiveInstitutionRestriction
                 RestrictionActionType.StopFullTimeDisbursement,
                 RestrictionActionType.StopOfferingCreate,
               ],
+              restrictionNotificationType: RestrictionNotificationType.Error,
             },
           ],
         });
@@ -176,6 +177,7 @@ describe("RestrictionInstitutionsController(e2e)-getActiveInstitutionRestriction
                 RestrictionActionType.StopFullTimeDisbursement,
                 RestrictionActionType.StopOfferingCreate,
               ],
+              restrictionNotificationType: RestrictionNotificationType.Error,
             },
           ],
         });

--- a/sources/packages/backend/apps/api/src/route-controllers/restriction/models/restriction.dto.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/restriction/models/restriction.dto.ts
@@ -14,6 +14,7 @@ import {
   RESTRICTION_CATEGORY_MAX_LENGTH,
   RestrictionActionType,
   FieldRequirementType,
+  InstitutionRestrictionDisplayScope,
 } from "@sims/sims-db";
 
 /**
@@ -177,6 +178,8 @@ export class InstitutionActiveRestrictionAPIOutDTO {
   restrictionCode: string;
   restrictionActions: RestrictionActionType[];
   restrictionNotificationType: RestrictionNotificationType;
+  displayScope?: InstitutionRestrictionDisplayScope;
+  bannerMessage?: string;
 }
 
 /**

--- a/sources/packages/backend/apps/api/src/route-controllers/restriction/models/restriction.dto.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/restriction/models/restriction.dto.ts
@@ -176,6 +176,7 @@ export class InstitutionActiveRestrictionAPIOutDTO {
   locationId?: number;
   restrictionCode: string;
   restrictionActions: RestrictionActionType[];
+  restrictionNotificationType: RestrictionNotificationType;
 }
 
 /**

--- a/sources/packages/backend/apps/api/src/route-controllers/restriction/restriction.aest.controller.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/restriction/restriction.aest.controller.ts
@@ -326,6 +326,7 @@ export class RestrictionAESTController extends BaseController {
     }
     return this.restrictionControllerService.getActiveInstitutionRestrictions(
       institutionId,
+      "ministryBanner",
     );
   }
 

--- a/sources/packages/backend/apps/api/src/route-controllers/restriction/restriction.controller.service.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/restriction/restriction.controller.service.ts
@@ -196,6 +196,7 @@ export class RestrictionControllerService {
           locationIds: options?.authorizedLocationIds,
           isActive: true,
           excludeNoEffectRestrictions: options?.excludeNoEffectRestrictions,
+          includeRestrictionsMetadata: true,
         },
       );
     return {
@@ -206,6 +207,12 @@ export class RestrictionControllerService {
         restrictionCode: institutionRestriction.restriction.restrictionCode,
         restrictionNotificationType:
           institutionRestriction.restriction.notificationType,
+        displayScope:
+          institutionRestriction.restriction.metadata?.institution
+            ?.displayScope,
+        bannerMessage:
+          institutionRestriction.restriction.metadata?.institution?.messages
+            ?.banner,
       })),
     };
   }

--- a/sources/packages/backend/apps/api/src/route-controllers/restriction/restriction.controller.service.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/restriction/restriction.controller.service.ts
@@ -177,6 +177,9 @@ export class RestrictionControllerService {
   /**
    * Get active institution restrictions.
    * @param institutionId institution id.
+   * @param bannerMessage type of banner message to be returned for the restriction.
+   * - `institutionBanner` for institution banner message.
+   * - `ministryBanner` for ministry banner message.
    * @param options options for filtering restrictions.
    * - `authorizedLocationIds` authorized locations for the user.
    * - `excludeNoEffectRestrictions` indicates whether to exclude no effect restrictions.
@@ -184,6 +187,7 @@ export class RestrictionControllerService {
    */
   async getActiveInstitutionRestrictions(
     institutionId: number,
+    bannerMessage: "institutionBanner" | "ministryBanner",
     options?: {
       authorizedLocationIds?: number[];
       excludeNoEffectRestrictions?: boolean;
@@ -208,11 +212,12 @@ export class RestrictionControllerService {
         restrictionNotificationType:
           institutionRestriction.restriction.notificationType,
         displayScope:
-          institutionRestriction.restriction.metadata?.institution
-            ?.displayScope,
+          institutionRestriction.restriction.metadata
+            ?.institutionRestrictionScope,
         bannerMessage:
-          institutionRestriction.restriction.metadata?.institution?.messages
-            ?.banner,
+          institutionRestriction.restriction.metadata?.messages?.[
+            bannerMessage
+          ],
       })),
     };
   }

--- a/sources/packages/backend/apps/api/src/route-controllers/restriction/restriction.controller.service.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/restriction/restriction.controller.service.ts
@@ -204,6 +204,8 @@ export class RestrictionControllerService {
         locationId: institutionRestriction.location?.id,
         restrictionActions: institutionRestriction.restriction.actionType,
         restrictionCode: institutionRestriction.restriction.restrictionCode,
+        restrictionNotificationType:
+          institutionRestriction.restriction.notificationType,
       })),
     };
   }

--- a/sources/packages/backend/apps/api/src/route-controllers/restriction/restriction.institutions.controller.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/restriction/restriction.institutions.controller.ts
@@ -84,10 +84,7 @@ export class RestrictionInstitutionsController extends BaseController {
     const authorizedLocationIds = userToken.authorizations.getLocationsIds();
     return this.restrictionControllerService.getActiveInstitutionRestrictions(
       institutionId,
-      {
-        authorizedLocationIds,
-        excludeNoEffectRestrictions: true,
-      },
+      { authorizedLocationIds, excludeNoEffectRestrictions: true },
     );
   }
 }

--- a/sources/packages/backend/apps/api/src/route-controllers/restriction/restriction.institutions.controller.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/restriction/restriction.institutions.controller.ts
@@ -84,7 +84,10 @@ export class RestrictionInstitutionsController extends BaseController {
     const authorizedLocationIds = userToken.authorizations.getLocationsIds();
     return this.restrictionControllerService.getActiveInstitutionRestrictions(
       institutionId,
-      { authorizedLocationIds, excludeNoEffectRestrictions: true },
+      {
+        authorizedLocationIds,
+        excludeNoEffectRestrictions: true,
+      },
     );
   }
 }

--- a/sources/packages/backend/apps/api/src/route-controllers/restriction/restriction.institutions.controller.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/restriction/restriction.institutions.controller.ts
@@ -84,6 +84,7 @@ export class RestrictionInstitutionsController extends BaseController {
     const authorizedLocationIds = userToken.authorizations.getLocationsIds();
     return this.restrictionControllerService.getActiveInstitutionRestrictions(
       institutionId,
+      "institutionBanner",
       { authorizedLocationIds, excludeNoEffectRestrictions: true },
     );
   }

--- a/sources/packages/backend/apps/api/src/services/restriction/institution-restriction.service.ts
+++ b/sources/packages/backend/apps/api/src/services/restriction/institution-restriction.service.ts
@@ -55,6 +55,7 @@ export class InstitutionRestrictionService extends RecordDataModelService<Instit
    * - `isActive` indicates whether to select only active restrictions.
    * - `locationIds` location ids.
    * - `excludeNoEffectRestrictions` indicates whether to exclude restrictions with no effect.
+   * - `includeRestrictionsMetadata` indicates whether to include the restriction metadata in the result.
    * @returns Institution restrictions.
    */
   async getInstitutionRestrictions(
@@ -63,6 +64,7 @@ export class InstitutionRestrictionService extends RecordDataModelService<Instit
       isActive?: boolean;
       locationIds?: number[];
       excludeNoEffectRestrictions?: boolean;
+      includeRestrictionsMetadata?: boolean;
     },
   ): Promise<InstitutionRestriction[]> {
     const restrictionsQuery = this.repo
@@ -78,6 +80,7 @@ export class InstitutionRestrictionService extends RecordDataModelService<Instit
         "restriction.description",
         "restriction.actionType",
         "restriction.notificationType",
+
         "location.id",
         "location.name",
         "program.id",
@@ -88,6 +91,9 @@ export class InstitutionRestrictionService extends RecordDataModelService<Instit
       .leftJoin("institutionRestrictions.location", "location")
       .leftJoin("institutionRestrictions.program", "program")
       .where("institution.id = :institutionId", { institutionId });
+    if (options?.includeRestrictionsMetadata) {
+      restrictionsQuery.addSelect("restriction.metadata");
+    }
     if (options?.isActive !== undefined && options.isActive !== null) {
       restrictionsQuery.andWhere(
         "institutionRestrictions.isActive = :isActive",

--- a/sources/packages/backend/apps/api/src/services/restriction/institution-restriction.service.ts
+++ b/sources/packages/backend/apps/api/src/services/restriction/institution-restriction.service.ts
@@ -1,5 +1,12 @@
 import { Injectable } from "@nestjs/common";
-import { DataSource, EntityManager, Equal, Not, Repository } from "typeorm";
+import {
+  Brackets,
+  DataSource,
+  EntityManager,
+  Equal,
+  Not,
+  Repository,
+} from "typeorm";
 import {
   RecordDataModelService,
   InstitutionRestriction,
@@ -70,6 +77,7 @@ export class InstitutionRestrictionService extends RecordDataModelService<Instit
         "restriction.restrictionCode",
         "restriction.description",
         "restriction.actionType",
+        "restriction.notificationType",
         "location.id",
         "location.name",
         "program.id",
@@ -87,9 +95,15 @@ export class InstitutionRestrictionService extends RecordDataModelService<Instit
       );
     }
     if (options?.locationIds?.length) {
-      restrictionsQuery.andWhere("location.id IN (:...locationIds)", {
-        locationIds: options.locationIds,
-      });
+      restrictionsQuery.andWhere(
+        new Brackets((qb) => {
+          // Ensure the user will have access to its specific locations restrictions
+          // or institution scoped restrictions.
+          qb.where("location.id IN (:...locationIds)", {
+            locationIds: options.locationIds,
+          }).orWhere("location.id IS NULL");
+        }),
+      );
     }
     if (options?.excludeNoEffectRestrictions) {
       restrictionsQuery.andWhere(

--- a/sources/packages/backend/apps/api/src/services/student-assessment/student-assessment.models.ts
+++ b/sources/packages/backend/apps/api/src/services/student-assessment/student-assessment.models.ts
@@ -1,6 +1,9 @@
 import { ECertFailedValidationResult } from "@sims/integrations/services";
 import { ECertPreValidatorResult } from "@sims/integrations/services/disbursement-schedule/e-cert-calculation";
-import { AcceptAssessmentRestrictionsEvaluationResult } from "@sims/services";
+import {
+  AcceptAssessmentRestriction,
+  AcceptAssessmentRestrictionsEvaluationResult,
+} from "@sims/services";
 
 /**
  * Consolidate different evaluation results to determine if a
@@ -16,7 +19,7 @@ export class AcceptAssessmentEvaluationResult {
       acceptAssessmentRestrictionsEvaluationResult.canAcceptAssessment;
     this.eCertFailedValidations = eCertPreValidatorResult.failedValidations;
     this.acceptAssessmentRestrictions =
-      acceptAssessmentRestrictionsEvaluationResult.restrictionCodes;
+      acceptAssessmentRestrictionsEvaluationResult.restrictions;
     this.hasFailedECertValidations =
       !eCertPreValidatorResult.canAcceptAssessment;
     this.hasAcceptAssessmentRestrictions =
@@ -46,7 +49,7 @@ export class AcceptAssessmentEvaluationResult {
    * Additional information about institution restrictions that would prevent the
    * Student Assessment from being accepted by the Student.
    */
-  readonly acceptAssessmentRestrictions: string[];
+  readonly acceptAssessmentRestrictions: AcceptAssessmentRestriction[];
   /**
    * Additional information about the failed e-Cert validations that would prevent
    * the Student Assessment from being accepted by the Student.

--- a/sources/packages/backend/apps/db-migrations/src/migrations/1783566892238-UpdateInstitutionRestrictionsMetadata.ts
+++ b/sources/packages/backend/apps/db-migrations/src/migrations/1783566892238-UpdateInstitutionRestrictionsMetadata.ts
@@ -1,0 +1,22 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+import { getSQLFileData } from "../utilities/sqlLoader";
+
+export class UpdateInstitutionRestrictionsMetadata1783566892238 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      getSQLFileData(
+        "Update-institution-restrictions-metadata.sql",
+        "Restrictions",
+      ),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      getSQLFileData(
+        "Rollback-update-institution-restrictions-metadata.sql",
+        "Restrictions",
+      ),
+    );
+  }
+}

--- a/sources/packages/backend/apps/db-migrations/src/sql/Restrictions/Insert-iur-restriction.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/Restrictions/Insert-iur-restriction.sql
@@ -21,21 +21,5 @@ VALUES
             'Stop part-time accept assessment'
         ] :: sims.restriction_action_types [],
         'Error' :: sims.restriction_notification_types,
-        '{
-            "student": {
-                "messages": {
-                    "acceptAssessment": "Your assessment cannot be accepted at this time because the institution associated with your application is currently under review."
-                }
-            },
-            "institution": {
-                "messages": {
-                    "banner": "Your institution is currently under review."
-                },
-                "displayScope": "institution"
-            },
-            "fieldRequirements": {
-                "program": "not allowed",
-                "location": "not allowed"
-            }
-        }' :: JSONB
+        '{"fieldRequirements":{ "location": "not allowed", "program": "not allowed" }}' :: JSONB
     );

--- a/sources/packages/backend/apps/db-migrations/src/sql/Restrictions/Insert-iur-restriction.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/Restrictions/Insert-iur-restriction.sql
@@ -21,5 +21,21 @@ VALUES
             'Stop part-time accept assessment'
         ] :: sims.restriction_action_types [],
         'Error' :: sims.restriction_notification_types,
-        '{"fieldRequirements":{ "location": "not allowed", "program": "not allowed" }}' :: JSONB
+        '{
+            "student": {
+                "messages": {
+                    "acceptAssessment": "Your assessment cannot be accepted at this time because the institution associated with your application is currently under review."
+                }
+            },
+            "institution": {
+                "messages": {
+                    "banner": "Your institution is currently under review."
+                },
+                "displayScope": "institution"
+            },
+            "fieldRequirements": {
+                "program": "not allowed",
+                "location": "not allowed"
+            }
+        }' :: JSONB
     );

--- a/sources/packages/backend/apps/db-migrations/src/sql/Restrictions/Rollback-update-institution-restrictions-metadata.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/Restrictions/Rollback-update-institution-restrictions-metadata.sql
@@ -1,0 +1,13 @@
+UPDATE
+    sims.restrictions
+SET
+    metadata = '{"fieldRequirements":{ "location": "not allowed", "program": "not allowed" }}' :: JSONB
+WHERE
+    restriction_code = 'IUR';
+
+UPDATE
+    sims.restrictions
+SET
+    metadata = '{"fieldRequirements":{ "program": "required", "location": "required" }}' :: JSONB
+WHERE
+    restriction_code = 'SUS';

--- a/sources/packages/backend/apps/db-migrations/src/sql/Restrictions/Update-institution-restrictions-metadata.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/Restrictions/Update-institution-restrictions-metadata.sql
@@ -1,0 +1,32 @@
+UPDATE
+    sims.restrictions
+SET
+    metadata = '{
+        "messages": {
+            "institutionBanner": "Your institution is currently under review.",
+            "studentAcceptAssessment": "Your assessment cannot be accepted at this time because the institution associated with your application is currently under review."
+        },
+        "institutionRestrictionScope": "institution",
+        "fieldRequirements": {
+            "program": "not allowed",
+            "location": "not allowed"
+        }
+    }' :: JSONB
+WHERE
+    restriction_code = 'IUR';
+
+UPDATE
+    sims.restrictions
+SET
+    metadata = '{
+        "messages": {
+            "ministryBanner": "This program is currently restricted."
+        },
+        "institutionRestrictionScope": "program",
+        "fieldRequirements": {
+            "program": "required",
+            "location": "required"
+        }
+    }' :: JSONB
+WHERE
+    restriction_code = 'SUS';

--- a/sources/packages/backend/libs/services/src/restriction/model/restriction.model.ts
+++ b/sources/packages/backend/libs/services/src/restriction/model/restriction.model.ts
@@ -93,6 +93,9 @@ export enum RestrictedParty {
   Institution = "Institution",
 }
 
+/**
+ * Restriction information preventing a student from accepting an assessment.
+ */
 export interface AcceptAssessmentRestriction {
   code: string;
   message?: string;

--- a/sources/packages/backend/libs/services/src/restriction/model/restriction.model.ts
+++ b/sources/packages/backend/libs/services/src/restriction/model/restriction.model.ts
@@ -93,6 +93,11 @@ export enum RestrictedParty {
   Institution = "Institution",
 }
 
+export interface AcceptAssessmentRestriction {
+  code: string;
+  message?: string;
+}
+
 /**
  * Evaluate if a student assessment can be accepted by the student based on institution restrictions.
  * Institutions may have restrictions that can prevent students from accepting assessments.
@@ -103,7 +108,7 @@ export interface AcceptAssessmentRestrictionsEvaluationResult {
    */
   canAcceptAssessment: boolean;
   /**
-   * List of restriction codes that prevent the student from accepting the assessment.
+   * List of restrictions that prevent the student from accepting the assessment.
    */
-  restrictionCodes: string[];
+  restrictions: AcceptAssessmentRestriction[];
 }

--- a/sources/packages/backend/libs/services/src/restriction/restriction-shared.service.ts
+++ b/sources/packages/backend/libs/services/src/restriction/restriction-shared.service.ts
@@ -86,6 +86,7 @@ export class RestrictionSharedService extends RecordDataModelService<Restriction
         "institutionRestriction.id",
         "restriction.id",
         "restriction.restrictionCode",
+        "restriction.metadata",
       ])
       .innerJoin("institutionRestriction.restriction", "restriction")
       .where("institutionRestriction.isActive = TRUE")

--- a/sources/packages/backend/libs/services/src/restriction/restriction-shared.service.ts
+++ b/sources/packages/backend/libs/services/src/restriction/restriction-shared.service.ts
@@ -212,8 +212,7 @@ export class RestrictionSharedService extends RecordDataModelService<Restriction
         restrictions: effectiveInstitutionRestrictions.map((restriction) => ({
           code: restriction.restriction.restrictionCode,
           message:
-            restriction.restriction.metadata?.student?.messages
-              ?.acceptAssessment,
+            restriction.restriction.metadata?.messages?.studentAcceptAssessment,
         })),
       };
     }

--- a/sources/packages/backend/libs/services/src/restriction/restriction-shared.service.ts
+++ b/sources/packages/backend/libs/services/src/restriction/restriction-shared.service.ts
@@ -208,14 +208,17 @@ export class RestrictionSharedService extends RecordDataModelService<Restriction
     if (effectiveInstitutionRestrictions.length) {
       return {
         canAcceptAssessment: false,
-        restrictionCodes: effectiveInstitutionRestrictions.map(
-          (restriction) => restriction.restriction.restrictionCode,
-        ),
+        restrictions: effectiveInstitutionRestrictions.map((restriction) => ({
+          code: restriction.restriction.restrictionCode,
+          message:
+            restriction.restriction.metadata?.student?.messages
+              ?.acceptAssessment,
+        })),
       };
     }
     return {
       canAcceptAssessment: true,
-      restrictionCodes: [],
+      restrictions: [],
     };
   }
 }

--- a/sources/packages/backend/libs/sims-db/src/entities/restriction.model.ts
+++ b/sources/packages/backend/libs/sims-db/src/entities/restriction.model.ts
@@ -127,7 +127,7 @@ export enum ActionEffectiveConditionNames {
  * Possible visualization scopes for institution restrictions.
  * This is used to determine where the restriction should be displayed.
  * For example, if a restriction is only applicable to a specific program,
- * then it should only be displayed on the program page.
+ * then it should only be displayed on a program page.
  */
 export enum InstitutionRestrictionDisplayScope {
   Institution = "institution",

--- a/sources/packages/backend/libs/sims-db/src/entities/restriction.model.ts
+++ b/sources/packages/backend/libs/sims-db/src/entities/restriction.model.ts
@@ -136,30 +136,13 @@ export enum InstitutionRestrictionDisplayScope {
 }
 
 /**
- * Metadata for further information on how this restriction should be affecting institutions.
- * Note: a single restriction can have effects on both institutions and students.
- */
-export interface InstitutionRestrictionMetadata {
-  /**
-   * The display scope of the restriction, which determines where the restriction should be
-   * displayed in the institution's context.
-   * This is applicable for restrictions defined as Error or Warning, since No Effect
-   * restrictions are not displayed to the institution.
-   */
-  displayScope?: InstitutionRestrictionDisplayScope;
-  messages?: {
-    banner?: string;
-  };
-}
-
-/**
  * Metadata for further information on how this restriction should be affecting students.
  * Note: a single restriction can have effects on both institutions and students.
  */
-export interface StudentRestrictionMetadata {
-  messages?: {
-    acceptAssessment?: string;
-  };
+export interface RestrictionMessages {
+  institutionBanner?: string;
+  ministryBanner?: string;
+  studentAcceptAssessment?: string;
 }
 
 /**
@@ -171,11 +154,11 @@ export interface RestrictionMetadata {
    */
   fieldRequirements: Record<string, FieldRequirementType>;
   /**
-   * Institution related information about how this restriction.
+   * Possible scopes for a institution-related restriction.
    */
-  institution?: InstitutionRestrictionMetadata;
+  institutionRestrictionScope?: InstitutionRestrictionDisplayScope;
   /**
    * Student related information about how this restriction.
    */
-  student?: StudentRestrictionMetadata;
+  messages?: RestrictionMessages;
 }

--- a/sources/packages/backend/libs/sims-db/src/entities/restriction.model.ts
+++ b/sources/packages/backend/libs/sims-db/src/entities/restriction.model.ts
@@ -124,6 +124,45 @@ export enum ActionEffectiveConditionNames {
 }
 
 /**
+ * Possible visualization scopes for institution restrictions.
+ * This is used to determine where the restriction should be displayed.
+ * For example, if a restriction is only applicable to a specific program,
+ * then it should only be displayed on the program page.
+ */
+export enum InstitutionRestrictionDisplayScope {
+  Institution = "institution",
+  Location = "location",
+  Program = "program",
+}
+
+/**
+ * Metadata for further information on how this restriction should be affecting institutions.
+ * Note: a single restriction can have effects on both institutions and students.
+ */
+export interface InstitutionRestrictionMetadata {
+  /**
+   * The display scope of the restriction, which determines where the restriction should be
+   * displayed in the institution's context.
+   * This is applicable for restrictions defined as Error or Warning, since No Effect
+   * restrictions are not displayed to the institution.
+   */
+  displayScope?: InstitutionRestrictionDisplayScope;
+  messages?: {
+    banner?: string;
+  };
+}
+
+/**
+ * Metadata for further information on how this restriction should be affecting students.
+ * Note: a single restriction can have effects on both institutions and students.
+ */
+export interface StudentRestrictionMetadata {
+  messages?: {
+    acceptAssessment?: string;
+  };
+}
+
+/**
  * Restriction metadata.
  */
 export interface RestrictionMetadata {
@@ -131,4 +170,12 @@ export interface RestrictionMetadata {
    * The restricted party(student or institution) field requirements for the restriction.
    */
   fieldRequirements: Record<string, FieldRequirementType>;
+  /**
+   * Institution related information about how this restriction.
+   */
+  institution?: InstitutionRestrictionMetadata;
+  /**
+   * Student related information about how this restriction.
+   */
+  student?: StudentRestrictionMetadata;
 }

--- a/sources/packages/web/src/assets/css/base.scss
+++ b/sources/packages/web/src/assets/css/base.scss
@@ -183,6 +183,12 @@ strong {
   border: 1px solid #e8e8e8;
 }
 
+// Reduces the default left indent of a bullet list.
+.list-indent-compact {
+  margin-top: 4px;
+  padding-left: 0px;
+}
+
 .muted-content-strong {
   color: $color-muted;
   font-weight: $font-weight-bold;

--- a/sources/packages/web/src/assets/css/base.scss
+++ b/sources/packages/web/src/assets/css/base.scss
@@ -184,6 +184,7 @@ strong {
 }
 
 // Reduces the default left indent of a bullet list.
+// and its top margin making it more compact.
 .list-indent-compact {
   margin-top: 4px;
   padding-left: 0px;

--- a/sources/packages/web/src/assets/css/base.scss
+++ b/sources/packages/web/src/assets/css/base.scss
@@ -183,7 +183,7 @@ strong {
   border: 1px solid #e8e8e8;
 }
 
-// Reduces the default left indent of a bullet list.
+// Reduces the default left indent of a bullet list
 // and its top margin making it more compact.
 .list-indent-compact {
   margin-top: 4px;

--- a/sources/packages/web/src/components/generic/Banner.vue
+++ b/sources/packages/web/src/components/generic/Banner.vue
@@ -1,20 +1,20 @@
 <template>
   <v-alert
-    :type="type"
+    :type="props.type"
     variant="outlined"
     :icon="bannerIcon"
     class="sims-banner"
   >
     <template #title>
-      <div class="label-bold-normal">{{ header }}</div>
+      <div class="label-bold-normal">{{ props.header }}</div>
     </template>
     <v-row>
       <v-col>
         <div class="label-value-normal">
-          <slot name="content">{{ summary }}</slot>
-          <slot name="content-list" v-if="summaryList">
+          <slot name="content">{{ props.summary }}</slot>
+          <slot name="content-list" v-if="props.summaryList">
             <ul class="list-indent-compact">
-              <li v-for="(item, index) in summaryList" :key="index">
+              <li v-for="(item, index) in props.summaryList" :key="index">
                 {{ item }}
               </li>
             </ul>
@@ -25,42 +25,36 @@
     </v-row>
   </v-alert>
 </template>
-<script lang="ts">
+<script setup lang="ts">
 import { BannerTypes } from "@/types/contracts/Banner";
-import { PropType, computed, defineComponent } from "vue";
+import { computed } from "vue";
 
-export default defineComponent({
-  props: {
-    type: {
-      type: String as PropType<BannerTypes>,
-      required: true,
-    },
-    header: {
-      type: String,
-    },
-    summary: {
-      type: String,
-    },
-    summaryList: {
-      type: Array<string>,
-    },
+const props = withDefaults(
+  defineProps<{
+    type: BannerTypes;
+    header?: string;
+    summary?: string;
+    summaryList?: string[];
+  }>(),
+  {
+    header: undefined,
+    summary: undefined,
+    summaryList: undefined,
   },
-  setup(props) {
-    const bannerIcon = computed(() => {
-      switch (props.type) {
-        case BannerTypes.Success:
-          return "fa:fa fa-circle-check";
-        case BannerTypes.Warning:
-          return "fa:fa fa-triangle-exclamation";
-        case BannerTypes.Error:
-          return "fa:fa fa-circle-exclamation";
-        case BannerTypes.Info:
-          return "fa:fa fa-circle-info";
-        default:
-          return "";
-      }
-    });
-    return { bannerIcon };
-  },
+);
+
+const bannerIcon = computed(() => {
+  switch (props.type) {
+    case BannerTypes.Success:
+      return "fa:fa fa-circle-check";
+    case BannerTypes.Warning:
+      return "fa:fa fa-triangle-exclamation";
+    case BannerTypes.Error:
+      return "fa:fa fa-circle-exclamation";
+    case BannerTypes.Info:
+      return "fa:fa fa-circle-info";
+    default:
+      return "";
+  }
 });
 </script>

--- a/sources/packages/web/src/components/generic/Banner.vue
+++ b/sources/packages/web/src/components/generic/Banner.vue
@@ -8,12 +8,12 @@
     <template #title>
       <div class="label-bold-normal">{{ header }}</div>
     </template>
-    <v-row>
+    <v-row density="compact" no-gutters>
       <v-col>
         <div class="label-value-normal">
           <slot name="content">{{ summary }}</slot>
           <slot name="content-list" v-if="summaryList">
-            <ul>
+            <ul class="list-indent-compact">
               <li v-for="(item, index) in summaryList" :key="index">
                 {{ item }}
               </li>

--- a/sources/packages/web/src/components/generic/Banner.vue
+++ b/sources/packages/web/src/components/generic/Banner.vue
@@ -8,7 +8,7 @@
     <template #title>
       <div class="label-bold-normal">{{ header }}</div>
     </template>
-    <v-row density="compact" no-gutters>
+    <v-row>
       <v-col>
         <div class="label-value-normal">
           <slot name="content">{{ summary }}</slot>

--- a/sources/packages/web/src/components/institutions/banners/InstitutionRestrictionBanner.vue
+++ b/sources/packages/web/src/components/institutions/banners/InstitutionRestrictionBanner.vue
@@ -1,26 +1,33 @@
 <template>
   <banner
     v-if="restrictionErrorMessages.length"
-    class="my-2"
+    class="mt-2"
     :type="BannerTypes.Error"
-    header="Institution Restricted"
+    :header="bannerTitle"
     :summary-list="restrictionErrorMessages"
   />
   <banner
     v-if="restrictionWarningMessages.length"
-    class="my-2"
+    class="mt-2"
     :type="BannerTypes.Warning"
-    header="Institution Restricted"
+    :header="bannerTitle"
     :summary-list="restrictionWarningMessages"
   />
 </template>
 <script lang="ts">
-import { computed, defineComponent, onMounted } from "vue";
+import { computed, defineComponent, onMounted, PropType } from "vue";
 import { BannerTypes } from "@/types/contracts/Banner";
-import { useInstitutionRestrictionState } from "@/composables";
-import { RestrictionCode } from "@/types";
+import {
+  InstitutionRestriction,
+  useInstitutionRestrictionState,
+} from "@/composables";
+import { InstitutionRestrictionDisplayScope } from "@/types";
 export default defineComponent({
   props: {
+    scope: {
+      type: String as PropType<InstitutionRestrictionDisplayScope>,
+      required: true,
+    },
     locationId: {
       type: Number,
       required: false,
@@ -41,35 +48,55 @@ export default defineComponent({
     const { getEffectiveRestrictionState, updateInstitutionRestrictionState } =
       useInstitutionRestrictionState();
     const effectiveRestrictionState = getEffectiveRestrictionState(() => ({
+      scope: props.scope,
       locationId: props.locationId,
       programId: props.programId,
       institutionId: props.institutionId,
     }));
 
-    const getRestrictionMessages = (restrictionsCodes: string[]) => {
-      const messages = restrictionsCodes.map((code) => {
-        if (code === RestrictionCode.InstitutionUnderReview) {
-          return "Your institution is currently under review.";
-        }
-        return "Your institution has active restrictions.";
-      });
+    const getDefaultBannerMessage = () => {
+      switch (props.scope) {
+        case InstitutionRestrictionDisplayScope.Institution:
+          return "Your institution has active restrictions.";
+        case InstitutionRestrictionDisplayScope.Location:
+          return "Your location has active restrictions.";
+        case InstitutionRestrictionDisplayScope.Program:
+          return "The program has active restrictions.";
+        default:
+          throw new Error(`Unknown scope: ${props.scope}.`);
+      }
+    };
+
+    const getRestrictionMessages = (restrictions: InstitutionRestriction[]) => {
+      const messages = restrictions.map(
+        (restriction) => restriction.bannerMessage || getDefaultBannerMessage(),
+      );
       return [...new Set(messages)];
     };
 
     const restrictionWarningMessages = computed(() => {
       return getRestrictionMessages(
-        effectiveRestrictionState.value.warningRestrictions.map(
-          (restriction) => restriction.restrictionCode,
-        ),
+        effectiveRestrictionState.value.warningRestrictions,
       );
     });
 
     const restrictionErrorMessages = computed(() => {
       return getRestrictionMessages(
-        effectiveRestrictionState.value.errorRestrictions.map(
-          (restriction) => restriction.restrictionCode,
-        ),
+        effectiveRestrictionState.value.errorRestrictions,
       );
+    });
+
+    const bannerTitle = computed(() => {
+      switch (props.scope) {
+        case InstitutionRestrictionDisplayScope.Institution:
+          return "Institution Restricted";
+        case InstitutionRestrictionDisplayScope.Program:
+          return "Program Restricted";
+        case InstitutionRestrictionDisplayScope.Location:
+          return "Location Restricted";
+        default:
+          throw new Error(`Unknown scope: ${props.scope}.`);
+      }
     });
 
     onMounted(
@@ -81,6 +108,7 @@ export default defineComponent({
       effectiveRestrictionState,
       restrictionWarningMessages,
       restrictionErrorMessages,
+      bannerTitle,
     };
   },
 });

--- a/sources/packages/web/src/components/institutions/banners/InstitutionRestrictionBanner.vue
+++ b/sources/packages/web/src/components/institutions/banners/InstitutionRestrictionBanner.vue
@@ -1,7 +1,7 @@
 <template>
   <banner
     v-for="banner in banners"
-    :key="banner.type"
+    :key="banner.key"
     class="mt-2"
     :type="banner.type"
     :header="bannerTitle"
@@ -101,21 +101,25 @@ export default defineComponent({
      * @returns a list of banners to be displayed for the given scope, if some restrictions exist.
      */
     const banners = computed(() => {
+      let key = 1;
       return [
         {
+          key: key++,
           type: BannerTypes.Error,
           summaryList: getRestrictionMessages(
             effectiveRestrictionState.value.errorRestrictions,
           ),
         },
         {
+          key: key++,
           type: BannerTypes.Warning,
           summaryList: getRestrictionMessages(
             effectiveRestrictionState.value.warningRestrictions,
           ),
         },
         {
-          type: BannerTypes.Info,
+          key: key++,
+          type: BannerTypes.Error,
           summaryList: getRestrictionMessages(
             effectiveRestrictionState.value.noEffectRestrictions,
           ),

--- a/sources/packages/web/src/components/institutions/banners/InstitutionRestrictionBanner.vue
+++ b/sources/packages/web/src/components/institutions/banners/InstitutionRestrictionBanner.vue
@@ -1,24 +1,35 @@
 <template>
   <banner
-    v-if="effectiveRestrictionStatus.hasEffectiveRestriction"
+    v-if="restrictionErrorMessages.length"
     class="my-2"
     :type="BannerTypes.Error"
-    header="This program is currently restricted"
+    header="Institution Restricted"
+    :summary-list="restrictionErrorMessages"
+  />
+  <banner
+    v-if="restrictionWarningMessages.length"
+    class="my-2"
+    :type="BannerTypes.Warning"
+    header="Institution Restricted"
+    :summary-list="restrictionWarningMessages"
   />
 </template>
 <script lang="ts">
-import { defineComponent, onMounted } from "vue";
+import { computed, defineComponent, onMounted } from "vue";
 import { BannerTypes } from "@/types/contracts/Banner";
 import { useInstitutionRestrictionState } from "@/composables";
+import { RestrictionCode } from "@/types";
 export default defineComponent({
   props: {
     locationId: {
       type: Number,
-      required: true,
+      required: false,
+      default: undefined,
     },
     programId: {
       type: Number,
-      required: true,
+      required: false,
+      default: undefined,
     },
     institutionId: {
       type: Number,
@@ -27,19 +38,49 @@ export default defineComponent({
     },
   },
   setup(props) {
-    const { getEffectiveRestrictionStatus, updateInstitutionRestrictionState } =
+    const { getEffectiveRestrictionState, updateInstitutionRestrictionState } =
       useInstitutionRestrictionState();
-    const effectiveRestrictionStatus = getEffectiveRestrictionStatus(() => ({
+    const effectiveRestrictionState = getEffectiveRestrictionState(() => ({
       locationId: props.locationId,
       programId: props.programId,
       institutionId: props.institutionId,
     }));
+
+    const getRestrictionMessages = (restrictionsCodes: string[]) => {
+      const messages = restrictionsCodes.map((code) => {
+        if (code === RestrictionCode.InstitutionUnderReview) {
+          return "Your institution is currently under review.";
+        }
+        return "Your institution has active restrictions.";
+      });
+      return [...new Set(messages)];
+    };
+
+    const restrictionWarningMessages = computed(() => {
+      return getRestrictionMessages(
+        effectiveRestrictionState.value.warningRestrictions.map(
+          (restriction) => restriction.restrictionCode,
+        ),
+      );
+    });
+
+    const restrictionErrorMessages = computed(() => {
+      return getRestrictionMessages(
+        effectiveRestrictionState.value.errorRestrictions.map(
+          (restriction) => restriction.restrictionCode,
+        ),
+      );
+    });
+
     onMounted(
       async () => await updateInstitutionRestrictionState(props.institutionId),
     );
+
     return {
       BannerTypes,
-      effectiveRestrictionStatus,
+      effectiveRestrictionState,
+      restrictionWarningMessages,
+      restrictionErrorMessages,
     };
   },
 });

--- a/sources/packages/web/src/components/institutions/banners/InstitutionRestrictionBanner.vue
+++ b/sources/packages/web/src/components/institutions/banners/InstitutionRestrictionBanner.vue
@@ -1,17 +1,11 @@
 <template>
   <banner
-    v-if="restrictionErrorMessages.length"
+    v-for="banner in banners"
+    :key="banner.type"
     class="mt-2"
-    :type="BannerTypes.Error"
+    :type="banner.type"
     :header="bannerTitle"
-    :summary-list="restrictionErrorMessages"
-  />
-  <banner
-    v-if="restrictionWarningMessages.length"
-    class="mt-2"
-    :type="BannerTypes.Warning"
-    :header="bannerTitle"
-    :summary-list="restrictionWarningMessages"
+    :summary-list="banner.summaryList"
   />
 </template>
 <script lang="ts">
@@ -101,16 +95,31 @@ export default defineComponent({
       return [...new Set(messages)];
     };
 
-    const restrictionWarningMessages = computed(() => {
-      return getRestrictionMessages(
-        effectiveRestrictionState.value.warningRestrictions,
-      );
-    });
-
-    const restrictionErrorMessages = computed(() => {
-      return getRestrictionMessages(
-        effectiveRestrictionState.value.errorRestrictions,
-      );
+    /**
+     * Create each banner based on the restriction type and the messages for the given scope.
+     * @returns a list of banners to be displayed for the given scope, if some restrictions exist.
+     */
+    const banners = computed(() => {
+      return [
+        {
+          type: BannerTypes.Error,
+          summaryList: getRestrictionMessages(
+            effectiveRestrictionState.value.errorRestrictions,
+          ),
+        },
+        {
+          type: BannerTypes.Warning,
+          summaryList: getRestrictionMessages(
+            effectiveRestrictionState.value.warningRestrictions,
+          ),
+        },
+        {
+          type: BannerTypes.Info,
+          summaryList: getRestrictionMessages(
+            effectiveRestrictionState.value.noEffectRestrictions,
+          ),
+        },
+      ].filter((banner) => banner.summaryList.length > 0);
     });
 
     onMounted(
@@ -120,8 +129,7 @@ export default defineComponent({
     return {
       BannerTypes,
       effectiveRestrictionState,
-      restrictionWarningMessages,
-      restrictionErrorMessages,
+      banners,
       bannerTitle,
     };
   },

--- a/sources/packages/web/src/components/institutions/banners/InstitutionRestrictionBanner.vue
+++ b/sources/packages/web/src/components/institutions/banners/InstitutionRestrictionBanner.vue
@@ -54,6 +54,27 @@ export default defineComponent({
       institutionId: props.institutionId,
     }));
 
+    /**
+     * Banner title based on the scope of the restriction.
+     * @returns The banner title for the given scope.
+     */
+    const bannerTitle = computed(() => {
+      switch (props.scope) {
+        case InstitutionRestrictionDisplayScope.Institution:
+          return "Institution Restricted";
+        case InstitutionRestrictionDisplayScope.Program:
+          return "Program Restricted";
+        case InstitutionRestrictionDisplayScope.Location:
+          return "Location Restricted";
+        default:
+          throw new Error(`Unknown scope: ${props.scope}.`);
+      }
+    });
+
+    /**
+     * Default message for a specific scope when no banner message is provided by the restriction.
+     * @returns The default message for the given scope.
+     */
     const getDefaultBannerMessage = () => {
       switch (props.scope) {
         case InstitutionRestrictionDisplayScope.Institution:
@@ -67,6 +88,12 @@ export default defineComponent({
       }
     };
 
+    /**
+     * Get the default banner message for a specific restriction if no banner message
+     * is provided, ensuring they will not be duplicated.
+     * @param restrictions the list of restrictions to get the banner messages from.
+     * @returns a list of unique banner messages for the given restrictions.
+     */
     const getRestrictionMessages = (restrictions: InstitutionRestriction[]) => {
       const messages = restrictions.map(
         (restriction) => restriction.bannerMessage || getDefaultBannerMessage(),
@@ -84,19 +111,6 @@ export default defineComponent({
       return getRestrictionMessages(
         effectiveRestrictionState.value.errorRestrictions,
       );
-    });
-
-    const bannerTitle = computed(() => {
-      switch (props.scope) {
-        case InstitutionRestrictionDisplayScope.Institution:
-          return "Institution Restricted";
-        case InstitutionRestrictionDisplayScope.Program:
-          return "Program Restricted";
-        case InstitutionRestrictionDisplayScope.Location:
-          return "Location Restricted";
-        default:
-          throw new Error(`Unknown scope: ${props.scope}.`);
-      }
     });
 
     onMounted(

--- a/sources/packages/web/src/components/institutions/banners/InstitutionRestrictionBanner.vue
+++ b/sources/packages/web/src/components/institutions/banners/InstitutionRestrictionBanner.vue
@@ -69,7 +69,7 @@ export default defineComponent({
      * Default message for a specific scope when no banner message is provided by the restriction.
      * @returns The default message for the given scope.
      */
-    const getDefaultBannerMessage = () => {
+    const getDefaultBannerMessage = computed(() => {
       switch (props.scope) {
         case InstitutionRestrictionDisplayScope.Institution:
           return "Your institution has active restrictions.";
@@ -80,7 +80,7 @@ export default defineComponent({
         default:
           throw new Error(`Unknown scope: ${props.scope}.`);
       }
-    };
+    });
 
     /**
      * Get the default banner message for a specific restriction if no banner message
@@ -90,7 +90,8 @@ export default defineComponent({
      */
     const getRestrictionMessages = (restrictions: InstitutionRestriction[]) => {
       const messages = restrictions.map(
-        (restriction) => restriction.bannerMessage || getDefaultBannerMessage(),
+        (restriction) =>
+          restriction.bannerMessage || getDefaultBannerMessage.value,
       );
       return [...new Set(messages)];
     };

--- a/sources/packages/web/src/components/layouts/FullPageContainer.vue
+++ b/sources/packages/web/src/components/layouts/FullPageContainer.vue
@@ -8,7 +8,7 @@
       <slot name="details-header"></slot>
     </div>
     <slot name="alerts"></slot>
-    <v-container fluid>
+    <v-container fluid :class="{ 'pt-0': !!$slots.alerts }">
       <template v-if="layoutTemplate === LayoutTemplates.CenteredCard">
         <v-row class="justify-center">
           <v-card class="mt-4 p-4 w-100" :class="widthClass">

--- a/sources/packages/web/src/composables/useInstitutionRestrictionState.ts
+++ b/sources/packages/web/src/composables/useInstitutionRestrictionState.ts
@@ -48,21 +48,6 @@ const institutionRestrictionMap = ref(
   new Map<number | undefined, InstitutionRestriction[]>(),
 );
 export function useInstitutionRestrictionState() {
-  /**
-   * Determine if a scoped identifier matches a restriction identifier.
-   * Restrictions without a specific scope (undefined/null) apply to all scopes.
-   * @param selectedScopeId the identifier of the selected scope (location or program).
-   * @param restrictionScopeId the identifier of the restriction's scope (location or program).
-   * @returns true if the selected scope matches the restriction's scope, or if either is undefined/null.
-   */
-  const matchesRestrictionScope = (
-    selectedScopeId: number | undefined,
-    restrictionScopeId: number | null | undefined,
-  ): boolean =>
-    restrictionScopeId == null ||
-    selectedScopeId == null ||
-    selectedScopeId === restrictionScopeId;
-
   const updateInstitutionRestrictionState = async (institutionId?: number) => {
     const institutionRestrictions =
       await RestrictionService.shared.getActiveInstitutionRestrictions({
@@ -111,14 +96,10 @@ export function useInstitutionRestrictionState() {
         .get(institutionId)
         ?.filter(
           (institutionRestriction) =>
-            matchesRestrictionScope(
-              locationId,
-              institutionRestriction.locationId,
-            ) ||
-            matchesRestrictionScope(
-              programId,
-              institutionRestriction.programId,
-            ),
+            (locationId === institutionRestriction.locationId ||
+              !institutionRestriction.locationId) &&
+            (programId === institutionRestriction.programId ||
+              !institutionRestriction.programId),
         );
       const scopedRestrictions = effectiveRestrictions?.filter(
         (restriction) => !scope || restriction.displayScope === scope,

--- a/sources/packages/web/src/composables/useInstitutionRestrictionState.ts
+++ b/sources/packages/web/src/composables/useInstitutionRestrictionState.ts
@@ -24,10 +24,18 @@ export interface InstitutionRestriction {
 }
 
 export interface EffectiveRestrictionState {
-  hasEffectiveRestriction: boolean;
-  errorRestrictions: InstitutionRestriction[];
-  warningRestrictions: InstitutionRestriction[];
+  /**
+   * Indicates whether the institution can create an offering.
+   */
   canCreateOffering: boolean;
+  /**
+   * Error restrictions for a given scope (location, program, or institution).
+   */
+  errorRestrictions: InstitutionRestriction[];
+  /**
+   * Warning restrictions for a given scope (location, program, or institution).
+   */
+  warningRestrictions: InstitutionRestriction[];
 }
 
 interface Params {
@@ -40,6 +48,21 @@ const institutionRestrictionMap = ref(
   new Map<number | undefined, InstitutionRestriction[]>(),
 );
 export function useInstitutionRestrictionState() {
+  /**
+   * Determine if a scoped identifier matches a restriction identifier.
+   * Restrictions without a specific scope (undefined/null) apply to all scopes.
+   * @param selectedScopeId the identifier of the selected scope (location or program).
+   * @param restrictionScopeId the identifier of the restriction's scope (location or program).
+   * @returns true if the selected scope matches the restriction's scope, or if either is undefined/null.
+   */
+  const matchesRestrictionScope = (
+    selectedScopeId: number | undefined,
+    restrictionScopeId: number | null | undefined,
+  ): boolean =>
+    restrictionScopeId == null ||
+    selectedScopeId == null ||
+    selectedScopeId === restrictionScopeId;
+
   const updateInstitutionRestrictionState = async (institutionId?: number) => {
     const institutionRestrictions =
       await RestrictionService.shared.getActiveInstitutionRestrictions({
@@ -88,11 +111,19 @@ export function useInstitutionRestrictionState() {
         .get(institutionId)
         ?.filter(
           (institutionRestriction) =>
-            (!locationId || institutionRestriction.locationId === locationId) &&
-            (!programId || institutionRestriction.programId === programId),
+            matchesRestrictionScope(
+              locationId,
+              institutionRestriction.locationId,
+            ) ||
+            matchesRestrictionScope(
+              programId,
+              institutionRestriction.programId,
+            ),
         );
+      const scopedRestrictions = effectiveRestrictions?.filter(
+        (restriction) => restriction.displayScope === scope,
+      );
       return {
-        hasEffectiveRestriction: !!effectiveRestrictions?.length,
         canCreateOffering: !effectiveRestrictions?.some(
           (effectiveRestriction) =>
             effectiveRestriction.restrictionActions.includes(
@@ -100,18 +131,16 @@ export function useInstitutionRestrictionState() {
             ),
         ),
         errorRestrictions:
-          effectiveRestrictions?.filter(
+          scopedRestrictions?.filter(
             (restriction) =>
-              restriction.displayScope === scope &&
               restriction.restrictionNotificationType ===
-                RestrictionNotificationType.Error,
+              RestrictionNotificationType.Error,
           ) ?? [],
         warningRestrictions:
-          effectiveRestrictions?.filter(
+          scopedRestrictions?.filter(
             (restriction) =>
-              restriction.displayScope === scope &&
               restriction.restrictionNotificationType ===
-                RestrictionNotificationType.Warning,
+              RestrictionNotificationType.Warning,
           ) ?? [],
       };
     });

--- a/sources/packages/web/src/composables/useInstitutionRestrictionState.ts
+++ b/sources/packages/web/src/composables/useInstitutionRestrictionState.ts
@@ -1,13 +1,29 @@
 import { RestrictionService } from "@/services/RestrictionService";
-import { EffectiveRestrictionStatus, RestrictionActionType } from "@/types";
+import { RestrictionActionType, RestrictionNotificationType } from "@/types";
 import { computed, ComputedRef, MaybeRefOrGetter, ref, toValue } from "vue";
+
+/**
+ * Subset of notification types that will be considered for institutions.
+ */
+export type InstitutionRestrictionNotificationType =
+  | RestrictionNotificationType.Warning
+  | RestrictionNotificationType.Error;
 
 interface InstitutionRestriction {
   programId?: number;
   locationId?: number;
   restrictionCode: string;
   restrictionActions: RestrictionActionType[];
+  restrictionNotificationType: InstitutionRestrictionNotificationType;
 }
+
+export interface EffectiveRestrictionState {
+  hasEffectiveRestriction: boolean;
+  errorRestrictions: InstitutionRestriction[];
+  warningRestrictions: InstitutionRestriction[];
+  canCreateOffering: boolean;
+}
+
 interface Params {
   locationId?: number;
   institutionId?: number;
@@ -29,6 +45,8 @@ export function useInstitutionRestrictionState() {
         programId: item.programId,
         restrictionCode: item.restrictionCode,
         restrictionActions: item.restrictionActions,
+        restrictionNotificationType:
+          item.restrictionNotificationType as InstitutionRestrictionNotificationType,
       })),
     );
   };
@@ -52,17 +70,17 @@ export function useInstitutionRestrictionState() {
    * @param params getter parameters.
    * @returns effective restriction status.
    */
-  const getEffectiveRestrictionStatus = (
+  const getEffectiveRestrictionState = (
     params: MaybeRefOrGetter<Params>,
-  ): ComputedRef<EffectiveRestrictionStatus> =>
+  ): ComputedRef<EffectiveRestrictionState> =>
     computed(() => {
       const { locationId, institutionId, programId } = toValue(params);
       const effectiveRestrictions = institutionRestrictionMap.value
         .get(institutionId)
         ?.filter(
           (institutionRestriction) =>
-            institutionRestriction.locationId === locationId &&
-            institutionRestriction.programId === programId,
+            (!locationId || institutionRestriction.locationId === locationId) &&
+            (!programId || institutionRestriction.programId === programId),
         );
       return {
         hasEffectiveRestriction: !!effectiveRestrictions?.length,
@@ -72,12 +90,24 @@ export function useInstitutionRestrictionState() {
               RestrictionActionType.StopOfferingCreate,
             ),
         ),
+        errorRestrictions:
+          effectiveRestrictions?.filter(
+            (effectiveRestriction) =>
+              effectiveRestriction.restrictionNotificationType ===
+              RestrictionNotificationType.Error,
+          ) ?? [],
+        warningRestrictions:
+          effectiveRestrictions?.filter(
+            (effectiveRestriction) =>
+              effectiveRestriction.restrictionNotificationType ===
+              RestrictionNotificationType.Warning,
+          ) ?? [],
       };
     });
 
   return {
     updateInstitutionRestrictionState,
     hasActiveRestriction,
-    getEffectiveRestrictionStatus,
+    getEffectiveRestrictionState,
   };
 }

--- a/sources/packages/web/src/composables/useInstitutionRestrictionState.ts
+++ b/sources/packages/web/src/composables/useInstitutionRestrictionState.ts
@@ -1,5 +1,9 @@
 import { RestrictionService } from "@/services/RestrictionService";
-import { RestrictionActionType, RestrictionNotificationType } from "@/types";
+import {
+  InstitutionRestrictionDisplayScope,
+  RestrictionActionType,
+  RestrictionNotificationType,
+} from "@/types";
 import { computed, ComputedRef, MaybeRefOrGetter, ref, toValue } from "vue";
 
 /**
@@ -9,12 +13,14 @@ export type InstitutionRestrictionNotificationType =
   | RestrictionNotificationType.Warning
   | RestrictionNotificationType.Error;
 
-interface InstitutionRestriction {
+export interface InstitutionRestriction {
   programId?: number;
   locationId?: number;
   restrictionCode: string;
   restrictionActions: RestrictionActionType[];
   restrictionNotificationType: InstitutionRestrictionNotificationType;
+  displayScope?: InstitutionRestrictionDisplayScope;
+  bannerMessage?: string;
 }
 
 export interface EffectiveRestrictionState {
@@ -25,6 +31,7 @@ export interface EffectiveRestrictionState {
 }
 
 interface Params {
+  scope: InstitutionRestrictionDisplayScope;
   locationId?: number;
   institutionId?: number;
   programId?: number;
@@ -47,6 +54,8 @@ export function useInstitutionRestrictionState() {
         restrictionActions: item.restrictionActions,
         restrictionNotificationType:
           item.restrictionNotificationType as InstitutionRestrictionNotificationType,
+        displayScope: item.displayScope,
+        bannerMessage: item.bannerMessage,
       })),
     );
   };
@@ -74,7 +83,7 @@ export function useInstitutionRestrictionState() {
     params: MaybeRefOrGetter<Params>,
   ): ComputedRef<EffectiveRestrictionState> =>
     computed(() => {
-      const { locationId, institutionId, programId } = toValue(params);
+      const { scope, locationId, institutionId, programId } = toValue(params);
       const effectiveRestrictions = institutionRestrictionMap.value
         .get(institutionId)
         ?.filter(
@@ -92,15 +101,17 @@ export function useInstitutionRestrictionState() {
         ),
         errorRestrictions:
           effectiveRestrictions?.filter(
-            (effectiveRestriction) =>
-              effectiveRestriction.restrictionNotificationType ===
-              RestrictionNotificationType.Error,
+            (restriction) =>
+              restriction.displayScope === scope &&
+              restriction.restrictionNotificationType ===
+                RestrictionNotificationType.Error,
           ) ?? [],
         warningRestrictions:
           effectiveRestrictions?.filter(
-            (effectiveRestriction) =>
-              effectiveRestriction.restrictionNotificationType ===
-              RestrictionNotificationType.Warning,
+            (restriction) =>
+              restriction.displayScope === scope &&
+              restriction.restrictionNotificationType ===
+                RestrictionNotificationType.Warning,
           ) ?? [],
       };
     });

--- a/sources/packages/web/src/composables/useInstitutionRestrictionState.ts
+++ b/sources/packages/web/src/composables/useInstitutionRestrictionState.ts
@@ -42,9 +42,11 @@ interface Params {
   programId?: number;
   scope?: InstitutionRestrictionDisplayScope;
 }
+
 const institutionRestrictionMap = ref(
   new Map<number | undefined, InstitutionRestriction[]>(),
 );
+
 export function useInstitutionRestrictionState() {
   const updateInstitutionRestrictionState = async (institutionId?: number) => {
     const institutionRestrictions =
@@ -82,7 +84,7 @@ export function useInstitutionRestrictionState() {
   /**
    * Get the effective institution restriction state for a location and program.
    * @param params getter parameters.
-   * @returns effective restriction status.
+   * @returns effective restriction state.
    */
   const getEffectiveRestrictionState = (
     params: MaybeRefOrGetter<Params>,

--- a/sources/packages/web/src/composables/useInstitutionRestrictionState.ts
+++ b/sources/packages/web/src/composables/useInstitutionRestrictionState.ts
@@ -6,19 +6,12 @@ import {
 } from "@/types";
 import { computed, ComputedRef, MaybeRefOrGetter, ref, toValue } from "vue";
 
-/**
- * Subset of notification types that will be considered for institutions.
- */
-export type InstitutionRestrictionNotificationType =
-  | RestrictionNotificationType.Warning
-  | RestrictionNotificationType.Error;
-
 export interface InstitutionRestriction {
   programId?: number;
   locationId?: number;
   restrictionCode: string;
   restrictionActions: RestrictionActionType[];
-  restrictionNotificationType: InstitutionRestrictionNotificationType;
+  restrictionNotificationType: RestrictionNotificationType;
   displayScope?: InstitutionRestrictionDisplayScope;
   bannerMessage?: string;
 }
@@ -36,6 +29,11 @@ export interface EffectiveRestrictionState {
    * Warning restrictions for a given scope (location, program, or institution).
    */
   warningRestrictions: InstitutionRestriction[];
+  /**
+   * No effect restrictions for a given scope (location, program, or institution).
+   * Not available for all clients, but can be used to display a banner message for informational purposes.
+   */
+  noEffectRestrictions: InstitutionRestriction[];
 }
 
 interface Params {
@@ -60,8 +58,7 @@ export function useInstitutionRestrictionState() {
         programId: item.programId,
         restrictionCode: item.restrictionCode,
         restrictionActions: item.restrictionActions,
-        restrictionNotificationType:
-          item.restrictionNotificationType as InstitutionRestrictionNotificationType,
+        restrictionNotificationType: item.restrictionNotificationType,
         displayScope: item.displayScope,
         bannerMessage: item.bannerMessage,
       })),
@@ -96,9 +93,9 @@ export function useInstitutionRestrictionState() {
         .get(institutionId)
         ?.filter(
           (institutionRestriction) =>
-            (locationId === institutionRestriction.locationId ||
+            (institutionRestriction.locationId === locationId ||
               !institutionRestriction.locationId) &&
-            (programId === institutionRestriction.programId ||
+            (institutionRestriction.programId === programId ||
               !institutionRestriction.programId),
         );
       const scopedRestrictions = effectiveRestrictions?.filter(
@@ -122,6 +119,12 @@ export function useInstitutionRestrictionState() {
             (restriction) =>
               restriction.restrictionNotificationType ===
               RestrictionNotificationType.Warning,
+          ) ?? [],
+        noEffectRestrictions:
+          scopedRestrictions?.filter(
+            (restriction) =>
+              restriction.restrictionNotificationType ===
+              RestrictionNotificationType.NoEffect,
           ) ?? [],
       };
     });

--- a/sources/packages/web/src/composables/useInstitutionRestrictionState.ts
+++ b/sources/packages/web/src/composables/useInstitutionRestrictionState.ts
@@ -39,10 +39,10 @@ export interface EffectiveRestrictionState {
 }
 
 interface Params {
-  scope: InstitutionRestrictionDisplayScope;
   locationId?: number;
   institutionId?: number;
   programId?: number;
+  scope?: InstitutionRestrictionDisplayScope;
 }
 const institutionRestrictionMap = ref(
   new Map<number | undefined, InstitutionRestriction[]>(),
@@ -98,7 +98,7 @@ export function useInstitutionRestrictionState() {
     );
 
   /**
-   * Get the effective institution restriction status for a location and program.
+   * Get the effective institution restriction state for a location and program.
    * @param params getter parameters.
    * @returns effective restriction status.
    */
@@ -106,7 +106,7 @@ export function useInstitutionRestrictionState() {
     params: MaybeRefOrGetter<Params>,
   ): ComputedRef<EffectiveRestrictionState> =>
     computed(() => {
-      const { scope, locationId, institutionId, programId } = toValue(params);
+      const { locationId, institutionId, programId, scope } = toValue(params);
       const effectiveRestrictions = institutionRestrictionMap.value
         .get(institutionId)
         ?.filter(
@@ -121,7 +121,7 @@ export function useInstitutionRestrictionState() {
             ),
         );
       const scopedRestrictions = effectiveRestrictions?.filter(
-        (restriction) => restriction.displayScope === scope,
+        (restriction) => !scope || restriction.displayScope === scope,
       );
       return {
         canCreateOffering: !effectiveRestrictions?.some(

--- a/sources/packages/web/src/services/http/dto/Application.dto.ts
+++ b/sources/packages/web/src/services/http/dto/Application.dto.ts
@@ -229,8 +229,17 @@ export interface ApplicationAssessmentStatusDetailsAPIOutDTO {
   assessmentDate: Date;
 }
 
+/**
+ * Restriction information for accepting an assessment.
+ */
 export interface AcceptAssessmentRestrictionAPIOutDTO {
+  /**
+   * Restriction code.
+   */
   code: string;
+  /**
+   * Optional message that could be set for the restriction.
+   */
   message?: string;
 }
 

--- a/sources/packages/web/src/services/http/dto/Application.dto.ts
+++ b/sources/packages/web/src/services/http/dto/Application.dto.ts
@@ -229,11 +229,16 @@ export interface ApplicationAssessmentStatusDetailsAPIOutDTO {
   assessmentDate: Date;
 }
 
+export interface AcceptAssessmentRestrictionAPIOutDTO {
+  code: string;
+  message?: string;
+}
+
 export interface ApplicationWarningsAPIOutDTO {
   eCertFailedValidations: ECertFailedValidation[];
   canAcceptAssessment: boolean;
   eCertFailedValidationsInfo?: ECertFailedValidationsInfoAPIOutDTO;
-  acceptAssessmentRestrictions: string[];
+  acceptAssessmentRestrictions: AcceptAssessmentRestrictionAPIOutDTO[];
 }
 
 export interface ApplicationSupportingUsersAPIOutDTO {

--- a/sources/packages/web/src/services/http/dto/Restriction.dto.ts
+++ b/sources/packages/web/src/services/http/dto/Restriction.dto.ts
@@ -1,5 +1,6 @@
 import {
   FieldRequirementType,
+  InstitutionDisplayScope,
   RestrictionActionType,
   RestrictionNotificationType,
   RestrictionType,
@@ -117,6 +118,8 @@ export interface InstitutionActiveRestrictionAPIOutDTO {
   restrictionCode: string;
   restrictionActions: RestrictionActionType[];
   restrictionNotificationType: RestrictionNotificationType;
+  displayScope?: InstitutionDisplayScope;
+  bannerMessage?: string;
 }
 
 /**

--- a/sources/packages/web/src/services/http/dto/Restriction.dto.ts
+++ b/sources/packages/web/src/services/http/dto/Restriction.dto.ts
@@ -116,6 +116,7 @@ export interface InstitutionActiveRestrictionAPIOutDTO {
   locationId?: number;
   restrictionCode: string;
   restrictionActions: RestrictionActionType[];
+  restrictionNotificationType: RestrictionNotificationType;
 }
 
 /**

--- a/sources/packages/web/src/types/contracts/RestrictionContract.ts
+++ b/sources/packages/web/src/types/contracts/RestrictionContract.ts
@@ -158,17 +158,6 @@ export enum FieldRequirementType {
 }
 
 /**
- * Restriction codes that are used for specific UI scenarios,
- * for instance, to display a specific content based on a restriction code.
- */
-export enum RestrictionCode {
-  /**
-   * Institution under review.
-   */
-  InstitutionUnderReview = "IUR",
-}
-
-/**
  * Possible visualization scopes for institution restrictions.
  * This is used to determine where the restriction should be displayed.
  * For example, if a restriction is only applicable to a specific program,

--- a/sources/packages/web/src/types/contracts/RestrictionContract.ts
+++ b/sources/packages/web/src/types/contracts/RestrictionContract.ts
@@ -167,3 +167,15 @@ export enum RestrictionCode {
    */
   InstitutionUnderReview = "IUR",
 }
+
+/**
+ * Possible visualization scopes for institution restrictions.
+ * This is used to determine where the restriction should be displayed.
+ * For example, if a restriction is only applicable to a specific program,
+ * then it should only be displayed on the program page.
+ */
+export enum InstitutionRestrictionDisplayScope {
+  Institution = "institution",
+  Location = "location",
+  Program = "program",
+}

--- a/sources/packages/web/src/types/contracts/RestrictionContract.ts
+++ b/sources/packages/web/src/types/contracts/RestrictionContract.ts
@@ -161,7 +161,7 @@ export enum FieldRequirementType {
  * Possible visualization scopes for institution restrictions.
  * This is used to determine where the restriction should be displayed.
  * For example, if a restriction is only applicable to a specific program,
- * then it should only be displayed on the program page.
+ * then it should only be displayed on a program page.
  */
 export enum InstitutionRestrictionDisplayScope {
   Institution = "institution",

--- a/sources/packages/web/src/types/contracts/RestrictionContract.ts
+++ b/sources/packages/web/src/types/contracts/RestrictionContract.ts
@@ -124,11 +124,6 @@ export enum RestrictionActionType {
   StopOfferingCreate = "Stop offering create",
 }
 
-export interface EffectiveRestrictionStatus {
-  hasEffectiveRestriction: boolean;
-  canCreateOffering: boolean;
-}
-
 export interface RestrictionDetail {
   restrictionId: number;
   restrictionType: RestrictionType;

--- a/sources/packages/web/src/views/aest/institution/ProgramDetails.vue
+++ b/sources/packages/web/src/views/aest/institution/ProgramDetails.vue
@@ -44,6 +44,7 @@
     </template>
     <template #alerts>
       <institution-restriction-banner
+        :scope="InstitutionRestrictionDisplayScope.Program"
         :location-id="locationId"
         :program-id="programId"
         :institution-id="institutionId"
@@ -69,7 +70,11 @@
 import { AESTRoutesConst } from "@/constants/routes/RouteConstants";
 import ManageProgramAndOfferingSummary from "@/components/common/ManageProgramAndOfferingSummary.vue";
 import { ref, onMounted, computed, defineComponent } from "vue";
-import { ProgramStatus, Role } from "@/types";
+import {
+  InstitutionRestrictionDisplayScope,
+  ProgramStatus,
+  Role,
+} from "@/types";
 import { EducationProgramService } from "@/services/EducationProgramService";
 import ApproveProgramModal from "@/components/aest/institution/modals/ApproveProgramModal.vue";
 import { ModalDialog, useSnackBar } from "@/composables";
@@ -183,6 +188,7 @@ export default defineComponent({
       declineProgram,
       Role,
       programDataUpdated,
+      InstitutionRestrictionDisplayScope,
     };
   },
 });

--- a/sources/packages/web/src/views/institution/InstitutionDashboard.vue
+++ b/sources/packages/web/src/views/institution/InstitutionDashboard.vue
@@ -4,6 +4,8 @@
       <institution-restriction-banner
         :scope="InstitutionRestrictionDisplayScope.Institution"
       />
+      <!-- Users will be able to retrieve only restrictions for the locations they have access to, 
+       so, not providing a location will ensure all accessible locations are considered. -->
       <institution-restriction-banner
         :scope="InstitutionRestrictionDisplayScope.Location"
       />

--- a/sources/packages/web/src/views/institution/InstitutionDashboard.vue
+++ b/sources/packages/web/src/views/institution/InstitutionDashboard.vue
@@ -1,21 +1,19 @@
 <template>
-  <full-page-container
-    :full-width="true"
-    layout-template="centered"
-    data-cy="institutionWelcomePage"
-  >
+  <full-page-container :full-width="true" layout-template="centered">
     <template #alerts>
+      <institution-restriction-banner />
       <announcement-banner dashboard="institution-dashboard" />
     </template>
-    <formio-container formName="institutionWelcomePage" />
+    <formio-container form-name="institutionWelcomePage" />
   </full-page-container>
 </template>
 
 <script lang="ts">
 import { defineComponent } from "vue";
 import AnnouncementBanner from "@/components/common/AnnouncementBanner.vue";
+import InstitutionRestrictionBanner from "@/components/institutions/banners/InstitutionRestrictionBanner.vue";
 
 export default defineComponent({
-  components: { AnnouncementBanner },
+  components: { AnnouncementBanner, InstitutionRestrictionBanner },
 });
 </script>

--- a/sources/packages/web/src/views/institution/InstitutionDashboard.vue
+++ b/sources/packages/web/src/views/institution/InstitutionDashboard.vue
@@ -1,19 +1,20 @@
 <template>
   <full-page-container :full-width="true" layout-template="centered">
     <template #alerts>
-      <institution-restriction-banner />
+      <institution-restriction-banner
+        :scope="InstitutionRestrictionDisplayScope.Institution"
+      />
+      <institution-restriction-banner
+        :scope="InstitutionRestrictionDisplayScope.Location"
+      />
       <announcement-banner dashboard="institution-dashboard" />
     </template>
     <formio-container form-name="institutionWelcomePage" />
   </full-page-container>
 </template>
 
-<script lang="ts">
-import { defineComponent } from "vue";
+<script setup lang="ts">
 import AnnouncementBanner from "@/components/common/AnnouncementBanner.vue";
+import { InstitutionRestrictionDisplayScope } from "@/types";
 import InstitutionRestrictionBanner from "@/components/institutions/banners/InstitutionRestrictionBanner.vue";
-
-export default defineComponent({
-  components: { AnnouncementBanner, InstitutionRestrictionBanner },
-});
 </script>

--- a/sources/packages/web/src/views/institution/locations/programs/LocationProgramAddEdit.vue
+++ b/sources/packages/web/src/views/institution/locations/programs/LocationProgramAddEdit.vue
@@ -26,6 +26,7 @@
         </template>
       </banner>
       <institution-restriction-banner
+        :scope="InstitutionRestrictionDisplayScope.Program"
         :location-id="locationId"
         :program-id="programId"
         :institution-id="institutionId"
@@ -54,7 +55,12 @@ import {
   AESTRoutesConst,
 } from "@/constants/routes/RouteConstants";
 import { ref, computed, defineComponent, isReadonly, watchEffect } from "vue";
-import { ApiProcessError, ClientIdType, FormIOForm } from "@/types";
+import {
+  ApiProcessError,
+  ClientIdType,
+  FormIOForm,
+  InstitutionRestrictionDisplayScope,
+} from "@/types";
 import { useFormioUtils, useInstitutionAuth, useSnackBar } from "@/composables";
 import { AuthService } from "@/services/AuthService";
 import { BannerTypes } from "@/types/contracts/Banner";
@@ -259,6 +265,7 @@ export default defineComponent({
       subTitle,
       BannerTypes,
       processing,
+      InstitutionRestrictionDisplayScope,
     };
   },
 });

--- a/sources/packages/web/src/views/institution/locations/programs/LocationProgramView.vue
+++ b/sources/packages/web/src/views/institution/locations/programs/LocationProgramView.vue
@@ -19,10 +19,13 @@
         }"
       />
     </template>
-    <institution-restriction-banner
-      :location-id="locationId"
-      :program-id="programId"
-    />
+    <template #alerts>
+      <institution-restriction-banner
+        :scope="InstitutionRestrictionDisplayScope.Program"
+        :location-id="locationId"
+        :program-id="programId"
+      />
+    </template>
     <manage-program-and-offering-summary
       :program-id="programId"
       :location-id="locationId"
@@ -47,6 +50,7 @@ import {
   useInstitutionAuth,
   useInstitutionRestrictionState,
 } from "@/composables";
+import { InstitutionRestrictionDisplayScope } from "@/types";
 
 export default defineComponent({
   components: {
@@ -66,9 +70,10 @@ export default defineComponent({
   },
   setup(props) {
     const { isReadOnlyUser } = useInstitutionAuth();
-    const { getEffectiveRestrictionStatus } = useInstitutionRestrictionState();
+    const { getEffectiveRestrictionState } = useInstitutionRestrictionState();
     const educationProgram = ref({} as EducationProgramAPIOutDTO);
-    const effectiveRestrictionStatus = getEffectiveRestrictionStatus(() => ({
+    const effectiveRestrictionStatus = getEffectiveRestrictionState(() => ({
+      scope: InstitutionRestrictionDisplayScope.Program,
       locationId: props.locationId,
       programId: props.programId,
     }));
@@ -97,6 +102,7 @@ export default defineComponent({
       programDataUpdated,
       isReadOnly,
       effectiveRestrictionStatus,
+      InstitutionRestrictionDisplayScope,
     };
   },
 });

--- a/sources/packages/web/src/views/institution/locations/programs/LocationProgramView.vue
+++ b/sources/packages/web/src/views/institution/locations/programs/LocationProgramView.vue
@@ -32,7 +32,7 @@
       :education-program="educationProgram"
       :allow-edit="!isReadOnly"
       :allow-deactivate="!isReadOnly"
-      :can-create-offering="effectiveRestrictionStatus.canCreateOffering"
+      :can-create-offering="effectiveRestrictionState.canCreateOffering"
       @program-data-updated="programDataUpdated"
     />
   </full-page-container>
@@ -72,7 +72,7 @@ export default defineComponent({
     const { isReadOnlyUser } = useInstitutionAuth();
     const { getEffectiveRestrictionState } = useInstitutionRestrictionState();
     const educationProgram = ref({} as EducationProgramAPIOutDTO);
-    const effectiveRestrictionStatus = getEffectiveRestrictionState(() => ({
+    const effectiveRestrictionState = getEffectiveRestrictionState(() => ({
       scope: InstitutionRestrictionDisplayScope.Program,
       locationId: props.locationId,
       programId: props.programId,
@@ -101,7 +101,7 @@ export default defineComponent({
       InstitutionRoutesConst,
       programDataUpdated,
       isReadOnly,
-      effectiveRestrictionStatus,
+      effectiveRestrictionState,
       InstitutionRestrictionDisplayScope,
     };
   },

--- a/sources/packages/web/src/views/student/NoticeOfAssessment.vue
+++ b/sources/packages/web/src/views/student/NoticeOfAssessment.vue
@@ -240,7 +240,7 @@ export default defineComponent({
     /**
      * Get unique institution restriction messages to be displayed to the student.
      * If a restriction does not have a message, a default message will be used instead.
-     * @param restrictions List of institution restrictions to be evaluated.
+     * @param restrictions list of institution restrictions to be evaluated.
      * @returns list of unique messages to be displayed to the student.
      */
     const getInstitutionRestrictionMessages = (

--- a/sources/packages/web/src/views/student/NoticeOfAssessment.vue
+++ b/sources/packages/web/src/views/student/NoticeOfAssessment.vue
@@ -87,15 +87,12 @@
                 >StudentAid BC</a
               >.
             </li>
-            <!-- Institution 'Stop accept assessment' restriction messages. -->
-            <li v-if="acceptValidation.hasInstitutionUnderReview">
-              Your assessment cannot be accepted at this time because the
-              institution associated with your application is currently under
-              review.
-            </li>
-            <!-- Generic institution restriction message. -->
-            <li v-else-if="acceptValidation.hasInstitutionRestriction">
-              {{ INSTITUTION_RESTRICTED_DEFAULT_MESSAGE }}
+            <!-- Institution restrictions. -->
+            <li
+              v-for="restriction in acceptValidation.institutionRestrictionMessages"
+              :key="restriction"
+            >
+              {{ restriction }}
             </li>
           </ul>
         </template>
@@ -128,7 +125,10 @@ import NoticeOfAssessmentFormView from "@/components/common/NoticeOfAssessmentFo
 import { ModalDialog, useSnackBar } from "@/composables";
 import { StudentAssessmentsService } from "@/services/StudentAssessmentsService";
 import { StudentRoutesConst } from "@/constants/routes/RouteConstants";
-import { AssessmentNOAAPIOutDTO } from "@/services/http/dto";
+import {
+  AcceptAssessmentRestrictionAPIOutDTO,
+  AssessmentNOAAPIOutDTO,
+} from "@/services/http/dto";
 import { computed, defineComponent, onMounted, ref } from "vue";
 import {
   ApplicationStatus,
@@ -136,7 +136,6 @@ import {
   ClientIdType,
   BannerTypes,
   ECertFailedValidation,
-  RestrictionCode,
   ApiProcessError,
 } from "@/types";
 import CancelApplication from "@/components/students/modals/CancelApplication.vue";
@@ -177,8 +176,7 @@ export default defineComponent({
       hasStopDisbursementInstitutionRestriction: false,
       noEstimatedAwardAmounts: false,
       hasEffectiveAviationRestriction: false,
-      hasInstitutionUnderReview: false,
-      hasInstitutionRestriction: false,
+      institutionRestrictionMessages: [] as string[],
     });
 
     /**
@@ -238,6 +236,23 @@ export default defineComponent({
         });
       }
     };
+
+    /**
+     * Get unique institution restriction messages to be displayed to the student.
+     * If a restriction does not have a message, a default message will be used instead.
+     * @param restrictions List of institution restrictions to be evaluated.
+     * @returns list of unique messages to be displayed to the student.
+     */
+    const getInstitutionRestrictionMessages = (
+      restrictions: AcceptAssessmentRestrictionAPIOutDTO[],
+    ) => {
+      const messages = restrictions.map(
+        (restriction) =>
+          restriction.message || INSTITUTION_RESTRICTED_DEFAULT_MESSAGE,
+      );
+      return [...new Set(messages)];
+    };
+
     onMounted(async () => {
       const warnings =
         await StudentAssessmentsService.shared.getApplicationWarnings(
@@ -273,16 +288,9 @@ export default defineComponent({
         hasEffectiveAviationRestriction:
           warnings.eCertFailedValidationsInfo
             ?.hasEffectiveAviationRestriction ?? false,
-        hasInstitutionUnderReview:
-          warnings.acceptAssessmentRestrictions.includes(
-            RestrictionCode.InstitutionUnderReview,
-          ),
-        /**
-         * Generic institution restriction message to be displayed when some restriction is
-         * present but there is no specific message to be displayed for the restriction.
-         */
-        hasInstitutionRestriction:
-          !!warnings.acceptAssessmentRestrictions.length,
+        institutionRestrictionMessages: getInstitutionRestrictionMessages(
+          warnings.acceptAssessmentRestrictions,
+        ),
       };
     });
 


### PR DESCRIPTION
# PR Goal

Enable the institution to see restriction notifications in the dashboard.

## Sample metadata

- Extended the restrictions metadata to allow defining the `scope` that a restriction should be displayed for institutions.
- Created configurations to allow messages to be set at the DB level for different places. For now, institutions banners and accepting assessment restrictions.

### IUR Restriction

```json
{
    "messages": {
        "institutionBanner": "Your institution is currently under review.",
        "studentAcceptAssessment": "Your assessment cannot be accepted at this time because the institution associated with your application is currently under review."
    },
    "institutionRestrictionScope": "institution",
    "fieldRequirements": {
        "program": "not allowed",
        "location": "not allowed"
    }
}
```

### SUS Restriction

- SUS is currently defined as "No effect," and it is not accessible by institutions, only by the Ministry.
- A specific property, `ministryBanner`, was implemented to prevent metadata from sharing the same message and to reduce the risk of future maintenance inadvertently configuring a ministry-specific message to display for an institution.

```json
{
    "messages": {
        "ministryBanner": "This program is currently restricted."
    },
    "institutionRestrictionScope": "program",
    "fieldRequirements": {
        "program": "required",
        "location": "required"
    }
}
```

## Student Message

- Student acceptance is blocked due to IUR being customized from the DB.

<img width="1535" height="599" alt="image" src="https://github.com/user-attachments/assets/4b0575c1-e01f-4ae3-8598-d3990797e49b" />

## Institution Dashboard 

- As required in the ticket, display a banner in the dashboard when an IUR is added to the institution.

<img width="1227" height="519" alt="image" src="https://github.com/user-attachments/assets/8f0b3183-f605-49f1-97ae-29e2a88adb8f" />

- Not directly related to the ACs, but as an agreed-upon restrictions framework extension, prepared the dashboard to display warning and location-level restrictions.

<img width="1529" height="502" alt="image" src="https://github.com/user-attachments/assets/b3e6f2cd-58cf-4de7-934f-9d01b5f4a11b" />

- Not directly related to the ACs, but as an agreed-upon restrictions framework extension, prepared program-scoped restrictions.

<img width="1534" height="621" alt="image" src="https://github.com/user-attachments/assets/86adc7c7-5e9c-49f6-8055-59fd0760f56f" />

## Ministry No Effect Restricion

- For Ministry users with access to the "No Effect" restriction, the idea is to show the banner as "info" only.

<img width="1882" height="619" alt="image" src="https://github.com/user-attachments/assets/d044ed94-f871-41e2-9c70-b51d523d45a5" />

## DB Migration Rollback

<img width="804" height="161" alt="image" src="https://github.com/user-attachments/assets/0f216ad3-32f9-46b8-b443-6556e726b363" />




