### PR TITLE
#6230 - Program suspension restriction amendments - 2

### DIFF
--- a/sources/packages/backend/apps/api/src/route-controllers/assessment/assessment.controller.service.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/assessment/assessment.controller.service.ts
@@ -291,7 +291,7 @@ export class AssessmentControllerService {
     ) {
       const eligibleDisbursements =
         await this.eCertGenerationService.getEligibleDisbursements({
-          applicationId: assessment.application.id,
+          applicationIds: [assessment.application.id],
           allowNonCompleted: true,
         });
       firstEligibleDisbursement = eligibleDisbursements.find(

--- a/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/esdc-integration/ecert-integration/_tests_/e-cert-utils.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/esdc-integration/ecert-integration/_tests_/e-cert-utils.ts
@@ -1,5 +1,7 @@
 import {
+  Application,
   ApplicationStatus,
+  Assessment,
   COEStatus,
   DisbursementSchedule,
   DisbursementValue,
@@ -16,6 +18,7 @@ import {
   saveFakeApplicationDisbursements,
   saveFakeStudent,
 } from "@sims/test-utils";
+import { getISODateOnlyString, addDays } from "@sims/utilities";
 import { In } from "typeorm";
 
 export const AVIATION_CREDENTIAL_TEST_INPUTS = [
@@ -264,4 +267,53 @@ export async function loadDisbursementAndStudentRestrictions(
     },
     loadEagerRelations: false,
   });
+}
+
+/**
+ * Create application with a disbursement schedule eligible for e-Cert.
+ * @param db e2e data sources.
+ * @param offeringIntensity offering intensity.
+ * @returns application with a disbursement schedule eligible for e-Cert.
+ */
+export async function createEligibleECertApplication(
+  db: E2EDataSources,
+  offeringIntensity: OfferingIntensity,
+): Promise<Application> {
+  const eligibleDisbursement: Partial<DisbursementSchedule> = {
+    coeStatus: COEStatus.completed,
+    coeUpdatedAt: new Date(),
+  };
+  // Student with valid SIN.
+  const student = await saveFakeStudent(db.dataSource);
+  // Valid MSFAA Number.
+  const msfaaNumber = await db.msfaaNumber.save(
+    createFakeMSFAANumber(
+      { student },
+      {
+        msfaaState: MSFAAStates.Signed,
+        msfaaInitialValues: {
+          offeringIntensity,
+        },
+      },
+    ),
+  );
+  return saveFakeApplicationDisbursements(
+    db.dataSource,
+    {
+      student,
+      msfaaNumber,
+    },
+    {
+      offeringIntensity,
+      applicationStatus: ApplicationStatus.Completed,
+      currentAssessmentInitialValues: {
+        assessmentData: { weeks: 5 } as Assessment,
+        assessmentDate: new Date(),
+      },
+      firstDisbursementInitialValues: {
+        ...eligibleDisbursement,
+        disbursementDate: getISODateOnlyString(addDays(1)),
+      },
+    },
+  );
 }

--- a/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/esdc-integration/ecert-integration/_tests_/ecert-full-time-process-integration.scheduler.e2e-spec.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/esdc-integration/ecert-integration/_tests_/ecert-full-time-process-integration.scheduler.e2e-spec.ts
@@ -101,6 +101,7 @@ describe(
         {
           id: In([
             NotificationMessageType.MinistryNotificationDisbursementBlocked,
+            NotificationMessageType.ProgramSuspensionBlockingApplication,
           ]),
         },
         { emailContacts: ["dummy@some.domain"] },

--- a/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/esdc-integration/ecert-integration/_tests_/ecert-full-time-process-integration.scheduler.e2e-spec.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/esdc-integration/ecert-integration/_tests_/ecert-full-time-process-integration.scheduler.e2e-spec.ts
@@ -44,6 +44,7 @@ import {
 } from "@sims/test-utils";
 import { getUploadedFile } from "@sims/test-utils/mocks";
 import { ArrayContains, In, IsNull, Like, Not } from "typeorm";
+import MockDate from "mockdate";
 import {
   createTestingAppModule,
   describeQueueProcessorRootTest,
@@ -54,7 +55,9 @@ import {
   QueueNames,
   addDays,
   formatDate,
+  getDateOnlyFormat,
   getISODateOnlyString,
+  getPSTPDTDateTime,
 } from "@sims/utilities";
 import { FullTimeECertProcessIntegrationScheduler } from "../ecert-full-time-process-integration.scheduler";
 import { DeepMocked } from "@golevelup/ts-jest";
@@ -65,6 +68,7 @@ import {
   AVIATION_CREDENTIAL_TEST_INPUTS,
   awardAssert,
   createBlockedDisbursementTestData,
+  createEligibleECertApplication,
   loadAwardValues,
   loadDisbursementAndStudentRestrictions,
 } from "./e-cert-utils";
@@ -83,7 +87,12 @@ describe(
     let sharedMinistryUser: User;
     let stopFullTimeBCLoanRestriction: Restriction;
     let stopFullTimeBCGrantRestriction: Restriction;
+    let susRestriction: Restriction;
     const MAX_LIFE_TIME_BC_LOAN_AMOUNT = 50000;
+    const OFFERING_INTENSITY = OfferingIntensity.fullTime;
+    const BLOCK_DISBURSEMENT_ACTION_TYPE =
+      RestrictionActionType.StopFullTimeDisbursement;
+    const MINISTRY_NOTIFICATION_EMAIL = "dummy@some.domain";
 
     beforeAll(async () => {
       // Env variable required for querying the eligible e-Cert records.
@@ -106,7 +115,7 @@ describe(
             NotificationMessageType.ProgramSuspensionBlockingApplication,
           ]),
         },
-        { emailContacts: ["dummy@some.domain"] },
+        { emailContacts: [MINISTRY_NOTIFICATION_EMAIL] },
       );
       // Create common restrictions used on tests having distinct action types
       // to ensure the proper restrictions are applied during e-Cert generation.
@@ -125,10 +134,17 @@ describe(
             },
           }),
         ]);
+      susRestriction = await db.restriction.findOne({
+        select: { id: true },
+        where: {
+          restrictionCode: RestrictionCode.SUS,
+        },
+      });
     });
 
     beforeEach(async () => {
       jest.clearAllMocks();
+      MockDate.reset();
       // Ensures that every disbursement on database is cancelled allowing the e-Certs to
       // be generated with the data created for every specific scenario.
       await db.disbursementSchedule.update(
@@ -180,7 +196,7 @@ describe(
             applicationStatus: ApplicationStatus.Completed,
             relationshipStatus: RelationshipStatus.MarriedUnable,
           },
-          offeringIntensity: OfferingIntensity.fullTime,
+          offeringIntensity: OFFERING_INTENSITY,
           currentAssessmentInitialValues: {
             assessmentData: { weeks: 5 } as Assessment,
             assessmentDate: new Date(),
@@ -308,7 +324,7 @@ describe(
         db.dataSource,
         { student, disbursementValues: firstDisbursementValues, msfaaNumber },
         {
-          offeringIntensity: OfferingIntensity.fullTime,
+          offeringIntensity: OFFERING_INTENSITY,
           applicationStatus: ApplicationStatus.Completed,
           currentAssessmentInitialValues: {
             assessmentData: { weeks: 5 } as Assessment,
@@ -503,7 +519,7 @@ describe(
             disbursementValues: reassessmentDisbursementValues,
           },
           {
-            offeringIntensity: OfferingIntensity.fullTime,
+            offeringIntensity: OFFERING_INTENSITY,
             applicationStatus: ApplicationStatus.Completed,
             currentAssessmentInitialValues: {
               assessmentData: { weeks: 5 } as Assessment,
@@ -671,7 +687,7 @@ describe(
             disbursementValues: reassessmentDisbursementValues,
           },
           {
-            offeringIntensity: OfferingIntensity.fullTime,
+            offeringIntensity: OFFERING_INTENSITY,
             applicationStatus: ApplicationStatus.Completed,
             currentAssessmentInitialValues: {
               assessmentData: { weeks: 5 } as Assessment,
@@ -808,7 +824,7 @@ describe(
           ],
         },
         {
-          offeringIntensity: OfferingIntensity.fullTime,
+          offeringIntensity: OFFERING_INTENSITY,
           applicationStatus: ApplicationStatus.Completed,
           currentAssessmentInitialValues: {
             assessmentData: { weeks: 5 } as Assessment,
@@ -859,7 +875,7 @@ describe(
           ],
         },
         {
-          offeringIntensity: OfferingIntensity.fullTime,
+          offeringIntensity: OFFERING_INTENSITY,
           applicationStatus: ApplicationStatus.Completed,
           currentAssessmentInitialValues: {
             assessmentData: { weeks: 5 } as Assessment,
@@ -1049,7 +1065,7 @@ describe(
             ],
           },
           {
-            offeringIntensity: OfferingIntensity.fullTime,
+            offeringIntensity: OFFERING_INTENSITY,
             applicationStatus: ApplicationStatus.Completed,
             currentAssessmentInitialValues: {
               assessmentData: { weeks: 5 } as Assessment,
@@ -1164,7 +1180,7 @@ describe(
           ],
         },
         {
-          offeringIntensity: OfferingIntensity.fullTime,
+          offeringIntensity: OFFERING_INTENSITY,
           applicationStatus: ApplicationStatus.Completed,
           currentAssessmentInitialValues: {
             assessmentData: { weeks: 5 } as Assessment,
@@ -1287,7 +1303,7 @@ describe(
             ],
           },
           {
-            offeringIntensity: OfferingIntensity.fullTime,
+            offeringIntensity: OFFERING_INTENSITY,
             applicationStatus: ApplicationStatus.Completed,
             currentAssessmentInitialValues: {
               assessmentData: { weeks: 5 } as Assessment,
@@ -1373,7 +1389,7 @@ describe(
         db.dataSource,
         { student, msfaaNumber },
         {
-          offeringIntensity: OfferingIntensity.fullTime,
+          offeringIntensity: OFFERING_INTENSITY,
           applicationStatus: ApplicationStatus.Completed,
           currentAssessmentInitialValues: {
             assessmentData: { weeks: 5 } as Assessment,
@@ -1554,7 +1570,7 @@ describe(
         db.dataSource,
         { student, msfaaNumber },
         {
-          offeringIntensity: OfferingIntensity.fullTime,
+          offeringIntensity: OFFERING_INTENSITY,
           applicationStatus: ApplicationStatus.Completed,
           currentAssessmentInitialValues: {
             assessmentData: { weeks: 5 } as Assessment,
@@ -1624,7 +1640,7 @@ describe(
         db.dataSource,
         { student, msfaaNumber },
         {
-          offeringIntensity: OfferingIntensity.fullTime,
+          offeringIntensity: OFFERING_INTENSITY,
           applicationStatus: ApplicationStatus.Completed,
           currentAssessmentInitialValues: {
             assessmentData: { weeks: 5 } as Assessment,
@@ -1693,7 +1709,7 @@ describe(
             {
               msfaaState: MSFAAStates.Signed,
               msfaaInitialValues: {
-                offeringIntensity: OfferingIntensity.fullTime,
+                offeringIntensity: OFFERING_INTENSITY,
               },
             },
           ),
@@ -1725,7 +1741,7 @@ describe(
             ],
           },
           {
-            offeringIntensity: OfferingIntensity.fullTime,
+            offeringIntensity: OFFERING_INTENSITY,
             applicationStatus: ApplicationStatus.Completed,
             currentAssessmentInitialValues: {
               assessmentData: { weeks: 5 } as Assessment,
@@ -1844,7 +1860,7 @@ describe(
 
     it(
       "Should have the e-Cert generated for a full-time application and the bypass active when " +
-        `a student has an active '${RestrictionActionType.StopFullTimeDisbursement}' restriction and it is bypassed with behavior '${RestrictionBypassBehaviors.AllDisbursements}'.`,
+        `a student has an active '${BLOCK_DISBURSEMENT_ACTION_TYPE}' restriction and it is bypassed with behavior '${RestrictionBypassBehaviors.AllDisbursements}'.`,
       async () => {
         // Arrange
         // Student with valid SIN.
@@ -1856,7 +1872,7 @@ describe(
             {
               msfaaState: MSFAAStates.Signed,
               msfaaInitialValues: {
-                offeringIntensity: OfferingIntensity.fullTime,
+                offeringIntensity: OFFERING_INTENSITY,
               },
             },
           ),
@@ -1876,7 +1892,7 @@ describe(
             ],
           },
           {
-            offeringIntensity: OfferingIntensity.fullTime,
+            offeringIntensity: OFFERING_INTENSITY,
             applicationStatus: ApplicationStatus.Completed,
             currentAssessmentInitialValues: {
               assessmentData: { weeks: 5 } as Assessment,
@@ -1896,8 +1912,7 @@ describe(
             creator: sharedMinistryUser,
           },
           {
-            restrictionActionType:
-              RestrictionActionType.StopFullTimeDisbursement,
+            restrictionActionType: BLOCK_DISBURSEMENT_ACTION_TYPE,
             initialValues: {
               bypassBehavior: RestrictionBypassBehaviors.AllDisbursements,
             },
@@ -1950,7 +1965,7 @@ describe(
             {
               msfaaState: MSFAAStates.Signed,
               msfaaInitialValues: {
-                offeringIntensity: OfferingIntensity.fullTime,
+                offeringIntensity: OFFERING_INTENSITY,
               },
             },
           ),
@@ -1970,7 +1985,7 @@ describe(
             ],
           },
           {
-            offeringIntensity: OfferingIntensity.fullTime,
+            offeringIntensity: OFFERING_INTENSITY,
             applicationStatus: ApplicationStatus.Completed,
             currentAssessmentInitialValues: {
               assessmentData: { weeks: 5 } as Assessment,
@@ -2009,8 +2024,7 @@ describe(
             creator: sharedMinistryUser,
           },
           {
-            restrictionActionType:
-              RestrictionActionType.StopFullTimeDisbursement,
+            restrictionActionType: BLOCK_DISBURSEMENT_ACTION_TYPE,
             initialValues: {
               bypassBehavior: RestrictionBypassBehaviors.AllDisbursements,
             },
@@ -2051,7 +2065,7 @@ describe(
 
     it(
       "Should prevent an e-Cert generation and keep the bypass active when " +
-        `multiple '${RestrictionActionType.StopFullTimeDisbursement}' restrictions exist and only one is bypassed and it is bypassed with behavior '${RestrictionBypassBehaviors.NextDisbursementOnly}'.`,
+        `multiple '${BLOCK_DISBURSEMENT_ACTION_TYPE}' restrictions exist and only one is bypassed and it is bypassed with behavior '${RestrictionBypassBehaviors.NextDisbursementOnly}'.`,
       async () => {
         // Arrange
         // Student with valid SIN.
@@ -2063,7 +2077,7 @@ describe(
             {
               msfaaState: MSFAAStates.Signed,
               msfaaInitialValues: {
-                offeringIntensity: OfferingIntensity.fullTime,
+                offeringIntensity: OFFERING_INTENSITY,
               },
             },
           ),
@@ -2083,7 +2097,7 @@ describe(
             ],
           },
           {
-            offeringIntensity: OfferingIntensity.fullTime,
+            offeringIntensity: OFFERING_INTENSITY,
             applicationStatus: ApplicationStatus.Completed,
             currentAssessmentInitialValues: {
               assessmentData: { weeks: 5 } as Assessment,
@@ -2103,8 +2117,7 @@ describe(
             creator: sharedMinistryUser,
           },
           {
-            restrictionActionType:
-              RestrictionActionType.StopFullTimeDisbursement,
+            restrictionActionType: BLOCK_DISBURSEMENT_ACTION_TYPE,
             initialValues: {
               bypassBehavior: RestrictionBypassBehaviors.NextDisbursementOnly,
             },
@@ -2118,9 +2131,7 @@ describe(
           where: {
             restrictionType: RestrictionType.Provincial,
             actionEffectiveConditions: IsNull(),
-            actionType: ArrayContains([
-              RestrictionActionType.StopFullTimeDisbursement,
-            ]),
+            actionType: ArrayContains([BLOCK_DISBURSEMENT_ACTION_TYPE]),
           },
         });
         // Create a non-bypassed student restriction to stop disbursement.
@@ -2139,7 +2150,7 @@ describe(
         expect(
           mockedJob.containLogMessages([
             `Current active restriction bypasses [Restriction Code(Restriction ID)]: ${restrictionBypass.studentRestriction.restriction.restrictionCode}(${restrictionBypass.studentRestriction.id}).`,
-            `Student has an active '${RestrictionActionType.StopFullTimeDisbursement}' restriction and the disbursement calculation will not proceed.`,
+            `Student has an active '${BLOCK_DISBURSEMENT_ACTION_TYPE}' restriction and the disbursement calculation will not proceed.`,
           ]),
         ).toBe(true);
 
@@ -2169,7 +2180,7 @@ describe(
         // Arrange
         const { student, disbursement } =
           await createBlockedDisbursementTestData(db, {
-            offeringIntensity: OfferingIntensity.fullTime,
+            offeringIntensity: OFFERING_INTENSITY,
             isValidSIN: true,
             disbursementValues: [],
           });
@@ -2234,7 +2245,7 @@ describe(
       const { student, disbursement } = await createBlockedDisbursementTestData(
         db,
         {
-          offeringIntensity: OfferingIntensity.fullTime,
+          offeringIntensity: OFFERING_INTENSITY,
           isValidSIN: true,
           disbursementValues: [],
         },
@@ -2303,7 +2314,7 @@ describe(
     it(
       "Should block the disbursement and log the information when the institution" +
         " has an effective institution restriction for the application location and program" +
-        ` with action type ${RestrictionActionType.StopFullTimeDisbursement}.`,
+        ` with action type ${BLOCK_DISBURSEMENT_ACTION_TYPE}.`,
       async () => {
         // Arrange
         // Eligible COE basic properties.
@@ -2320,7 +2331,7 @@ describe(
             {
               msfaaState: MSFAAStates.Signed,
               msfaaInitialValues: {
-                offeringIntensity: OfferingIntensity.fullTime,
+                offeringIntensity: OFFERING_INTENSITY,
               },
             },
           ),
@@ -2332,7 +2343,7 @@ describe(
             msfaaNumber,
           },
           {
-            offeringIntensity: OfferingIntensity.fullTime,
+            offeringIntensity: OFFERING_INTENSITY,
             applicationStatus: ApplicationStatus.Completed,
             currentAssessmentInitialValues: {
               assessmentData: { weeks: 5 } as Assessment,
@@ -2349,9 +2360,7 @@ describe(
           select: { id: true },
           where: {
             restrictionType: RestrictionType.Institution,
-            actionType: ArrayContains([
-              RestrictionActionType.StopFullTimeDisbursement,
-            ]),
+            actionType: ArrayContains([BLOCK_DISBURSEMENT_ACTION_TYPE]),
           },
         });
         const offering = application.currentAssessment.offering;
@@ -2384,7 +2393,7 @@ describe(
         // Assert log messages for the blocked disbursement.
         expect(
           mockedJob.containLogMessages([
-            `Institution has an effective '${RestrictionActionType.StopFullTimeDisbursement}' restriction` +
+            `Institution has an effective '${BLOCK_DISBURSEMENT_ACTION_TYPE}' restriction` +
               ` for program ${program.id} and location ${location.id} and the disbursement calculation will not proceed.`,
             "The step determined that the calculation should be interrupted. This disbursement will not be part of the next e-Cert generation.",
           ]),
@@ -2400,6 +2409,170 @@ describe(
           },
         });
         expect(scheduleIsPending).toBe(true);
+      },
+    );
+
+    it(
+      "Should block the disbursement and create program suspension blocking application notification" +
+        ` when the application location and program has effective institution restriction ${RestrictionCode.SUS}.`,
+      async () => {
+        // Arrange
+        const application = await createEligibleECertApplication(
+          db,
+          OFFERING_INTENSITY,
+        );
+        const offering = application.currentAssessment.offering;
+        const location = offering.institutionLocation;
+        const program = offering.educationProgram;
+        const institution = location.institution;
+        // Add institution restriction for the application location and program.
+        await saveFakeInstitutionRestriction(db, {
+          restriction: susRestriction,
+          institution,
+          program,
+          location,
+        });
+        // Queued job.
+        const mockedJob = mockBullJob<void>();
+        const now = new Date();
+        MockDate.set(now);
+
+        // Act
+        await processor.processQueue(mockedJob.job);
+
+        // Assert
+        // Assert log messages.
+        const [disbursement] =
+          application.currentAssessment.disbursementSchedules;
+        // Assert log messages for the blocked disbursement.
+        expect(
+          mockedJob.containLogMessages([
+            `Institution has an effective '${BLOCK_DISBURSEMENT_ACTION_TYPE}' restriction` +
+              ` for program ${program.id} and location ${location.id} and the disbursement calculation will not proceed.`,
+            "The step determined that the calculation should be interrupted. This disbursement will not be part of the next e-Cert generation.",
+            `Program suspension blocking application notification created for disbursement ID ${disbursement.id}.`,
+          ]),
+        ).toBe(true);
+        // Assert that the disbursement is still in status 'Pending' with date sent null.
+        const scheduleIsPending = await db.disbursementSchedule.exists({
+          where: {
+            id: disbursement.id,
+            dateSent: IsNull(),
+            disbursementScheduleStatus: DisbursementScheduleStatus.Pending,
+          },
+        });
+        expect(scheduleIsPending).toBe(true);
+        // Assert that the notification was created for the disbursement.
+        const notification = await db.notification.findOne({
+          select: {
+            id: true,
+            messagePayload: true,
+          },
+          where: {
+            dateSent: IsNull(),
+            notificationMessage: {
+              id: NotificationMessageType.ProgramSuspensionBlockingApplication,
+            },
+            metadata: { disbursementId: disbursement.id },
+          },
+          loadEagerRelations: false,
+        });
+        const student = application.student;
+        expect(notification).toEqual({
+          id: expect.any(Number),
+          messagePayload: {
+            email_address: MINISTRY_NOTIFICATION_EMAIL,
+            template_id: expect.any(String),
+            personalisation: {
+              dateTime: `${getPSTPDTDateTime(now)} PST/PDT`,
+              lastName: student.user.lastName,
+              givenNames: student.user.firstName,
+              birthDate: getDateOnlyFormat(student.birthDate),
+              studentEmail: student.user.email,
+              applicationNumber: application.applicationNumber,
+              programName: program.name,
+              institutionOperatingName: institution.operatingName,
+            },
+          },
+        });
+      },
+    );
+
+    it(
+      "Should block the disbursement but not create a program suspension blocking application notification" +
+        ` when the application location and program has effective institution restriction ${RestrictionCode.SUS}` +
+        " and the notification already exists for the disbursement.",
+      async () => {
+        // Arrange
+        const application = await createEligibleECertApplication(
+          db,
+          OFFERING_INTENSITY,
+        );
+        const offering = application.currentAssessment.offering;
+        const location = offering.institutionLocation;
+        const program = offering.educationProgram;
+        const institution = location.institution;
+        // Add institution restriction for the application location and program.
+        await saveFakeInstitutionRestriction(db, {
+          restriction: susRestriction,
+          institution,
+          program,
+          location,
+        });
+        const [disbursement] =
+          application.currentAssessment.disbursementSchedules;
+        // Create a sent notification.
+        const existingNotification = createFakeNotification(
+          {
+            user: systemUsersService.systemUser,
+            auditUser: systemUsersService.systemUser,
+            notificationMessage: {
+              id: NotificationMessageType.ProgramSuspensionBlockingApplication,
+            } as NotificationMessage,
+          },
+          {
+            initialValue: {
+              metadata: {
+                disbursementId: disbursement.id,
+              },
+              dateSent: new Date(),
+            },
+          },
+        );
+        await db.notification.save(existingNotification);
+        // Queued job.
+        const mockedJob = mockBullJob<void>();
+
+        // Act
+        await processor.processQueue(mockedJob.job);
+
+        // Assert
+        // Assert log messages for the blocked disbursement.
+        expect(
+          mockedJob.containLogMessages([
+            `Program suspension blocking application notification should not be created at this moment for disbursement ID ${disbursement.id}.`,
+          ]),
+        ).toBe(true);
+        // Assert that the disbursement is still in status 'Pending' with date sent null.
+        const scheduleIsPending = await db.disbursementSchedule.exists({
+          where: {
+            id: disbursement.id,
+            dateSent: IsNull(),
+            disbursementScheduleStatus: DisbursementScheduleStatus.Pending,
+          },
+        });
+        expect(scheduleIsPending).toBe(true);
+        // Assert that new notification was not created for the disbursement.
+        const isNewNotificationCreated = await db.notification.exists({
+          where: {
+            dateSent: IsNull(),
+            notificationMessage: {
+              id: NotificationMessageType.ProgramSuspensionBlockingApplication,
+            },
+            metadata: { disbursementId: disbursement.id },
+          },
+        });
+        expect(isNewNotificationCreated).toBe(false);
       },
     );
 
@@ -2424,7 +2597,7 @@ describe(
               {
                 msfaaState: MSFAAStates.Signed,
                 msfaaInitialValues: {
-                  offeringIntensity: OfferingIntensity.fullTime,
+                  offeringIntensity: OFFERING_INTENSITY,
                 },
               },
             ),
@@ -2436,7 +2609,7 @@ describe(
               msfaaNumber,
             },
             {
-              offeringIntensity: OfferingIntensity.fullTime,
+              offeringIntensity: OFFERING_INTENSITY,
               applicationStatus: ApplicationStatus.Completed,
               currentAssessmentInitialValues: {
                 assessmentData: { weeks: 5 } as Assessment,
@@ -2519,7 +2692,7 @@ describe(
               {
                 msfaaState: MSFAAStates.Signed,
                 msfaaInitialValues: {
-                  offeringIntensity: OfferingIntensity.fullTime,
+                  offeringIntensity: OFFERING_INTENSITY,
                 },
               },
             ),
@@ -2531,7 +2704,7 @@ describe(
               msfaaNumber,
             },
             {
-              offeringIntensity: OfferingIntensity.fullTime,
+              offeringIntensity: OFFERING_INTENSITY,
               applicationStatus: ApplicationStatus.Completed,
               currentAssessmentInitialValues: {
                 assessmentData: { weeks: 5 } as Assessment,
@@ -2608,7 +2781,7 @@ describe(
             {
               msfaaState: MSFAAStates.Signed,
               msfaaInitialValues: {
-                offeringIntensity: OfferingIntensity.fullTime,
+                offeringIntensity: OFFERING_INTENSITY,
               },
             },
           ),
@@ -2620,7 +2793,7 @@ describe(
             msfaaNumber,
           },
           {
-            offeringIntensity: OfferingIntensity.fullTime,
+            offeringIntensity: OFFERING_INTENSITY,
             applicationStatus: ApplicationStatus.Completed,
             currentAssessmentInitialValues: {
               assessmentData: { weeks: 5 } as Assessment,
@@ -2707,7 +2880,7 @@ describe(
                 {
                   msfaaState: MSFAAStates.Signed,
                   msfaaInitialValues: {
-                    offeringIntensity: OfferingIntensity.fullTime,
+                    offeringIntensity: OFFERING_INTENSITY,
                   },
                 },
               ),
@@ -2727,7 +2900,7 @@ describe(
                   ],
                 },
                 {
-                  offeringIntensity: OfferingIntensity.fullTime,
+                  offeringIntensity: OFFERING_INTENSITY,
                   applicationStatus: ApplicationStatus.Completed,
                   currentAssessmentInitialValues: {
                     assessmentData: { weeks: 5 } as Assessment,
@@ -2833,7 +3006,7 @@ describe(
                   ],
                 },
                 {
-                  offeringIntensity: OfferingIntensity.fullTime,
+                  offeringIntensity: OFFERING_INTENSITY,
                   applicationStatus: ApplicationStatus.Completed,
                   currentAssessmentInitialValues: {
                     assessmentData: { weeks: 5 } as Assessment,
@@ -2880,7 +3053,7 @@ describe(
             // Assert log messages for the blocked disbursement.
             expect(
               mockedJob.containLogMessages([
-                `Student has an active '${RestrictionActionType.StopFullTimeDisbursement}' restriction and the disbursement calculation will not proceed.`,
+                `Student has an active '${BLOCK_DISBURSEMENT_ACTION_TYPE}' restriction and the disbursement calculation will not proceed.`,
                 "The step determined that the calculation should be interrupted. This disbursement will not be part of the next e-Cert generation.",
               ]),
             ).toBe(true);
@@ -2957,7 +3130,7 @@ describe(
                 ],
               },
               {
-                offeringIntensity: OfferingIntensity.fullTime,
+                offeringIntensity: OFFERING_INTENSITY,
                 applicationStatus: ApplicationStatus.Completed,
                 currentAssessmentInitialValues: {
                   assessmentData: { weeks: 5 } as Assessment,
@@ -3087,7 +3260,7 @@ describe(
                 ],
               },
               {
-                offeringIntensity: OfferingIntensity.fullTime,
+                offeringIntensity: OFFERING_INTENSITY,
                 applicationStatus: ApplicationStatus.Completed,
                 currentAssessmentInitialValues: {
                   assessmentData: { weeks: 5 } as Assessment,
@@ -3202,7 +3375,7 @@ describe(
         db.dataSource,
         { student, msfaaNumber },
         {
-          offeringIntensity: OfferingIntensity.fullTime,
+          offeringIntensity: OFFERING_INTENSITY,
           applicationStatus: ApplicationStatus.Completed,
           currentAssessmentInitialValues: {
             assessmentData: { weeks: 5 } as Assessment,

--- a/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/esdc-integration/ecert-integration/_tests_/ecert-full-time-process-integration.scheduler.e2e-spec.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/esdc-integration/ecert-integration/_tests_/ecert-full-time-process-integration.scheduler.e2e-spec.ts
@@ -99,7 +99,9 @@ describe(
       // Insert fake email contact to send ministry email.
       await db.notificationMessage.update(
         {
-          id: NotificationMessageType.MinistryNotificationDisbursementBlocked,
+          id: In([
+            NotificationMessageType.MinistryNotificationDisbursementBlocked,
+          ]),
         },
         { emailContacts: ["dummy@some.domain"] },
       );

--- a/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/esdc-integration/ecert-integration/_tests_/ecert-part-time-process-integration.scheduler.e2e-spec.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/esdc-integration/ecert-integration/_tests_/ecert-part-time-process-integration.scheduler.e2e-spec.ts
@@ -34,7 +34,7 @@ import {
   saveFakeInstitutionRestriction,
 } from "@sims/test-utils";
 import { getUploadedFile } from "@sims/test-utils/mocks";
-import { ArrayContains, IsNull, Like, Not } from "typeorm";
+import { ArrayContains, In, IsNull, Like, Not } from "typeorm";
 import {
   createTestingAppModule,
   describeQueueProcessorRootTest,
@@ -85,7 +85,10 @@ describe(
       // Insert fake email contact to send ministry email.
       await db.notificationMessage.update(
         {
-          id: NotificationMessageType.MinistryNotificationDisbursementBlocked,
+          id: In([
+            NotificationMessageType.MinistryNotificationDisbursementBlocked,
+            NotificationMessageType.ProgramSuspensionBlockingApplication,
+          ]),
         },
         { emailContacts: ["dummy@some.domain"] },
       );

--- a/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/esdc-integration/ecert-integration/_tests_/ecert-part-time-process-integration.scheduler.e2e-spec.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/esdc-integration/ecert-integration/_tests_/ecert-part-time-process-integration.scheduler.e2e-spec.ts
@@ -10,6 +10,7 @@ import {
   NotificationMessageType,
   OfferingIntensity,
   RelationshipStatus,
+  Restriction,
   RestrictionActionType,
   RestrictionBypassBehaviors,
   RestrictionType,
@@ -37,13 +38,20 @@ import {
 } from "@sims/test-utils";
 import { getUploadedFile } from "@sims/test-utils/mocks";
 import { ArrayContains, In, IsNull, Like, Not } from "typeorm";
+import MockDate from "mockdate";
 import {
   createTestingAppModule,
   describeQueueProcessorRootTest,
   mockBullJob,
 } from "../../../../../../test/helpers";
 import { INestApplication } from "@nestjs/common";
-import { QueueNames, addDays, getISODateOnlyString } from "@sims/utilities";
+import {
+  QueueNames,
+  addDays,
+  getDateOnlyFormat,
+  getISODateOnlyString,
+  getPSTPDTDateTime,
+} from "@sims/utilities";
 import { DeepMocked } from "@golevelup/ts-jest";
 import { PartTimeECertProcessIntegrationScheduler } from "../ecert-part-time-process-integration.scheduler";
 import Client from "ssh2-sftp-client";
@@ -54,6 +62,7 @@ import {
   AVIATION_CREDENTIAL_TEST_INPUTS,
   awardAssert,
   createBlockedDisbursementTestData,
+  createEligibleECertApplication,
   loadAwardValues,
   loadDisbursementAndStudentRestrictions,
   loadDisbursementSchedules,
@@ -72,6 +81,11 @@ describe(
     let sftpClientMock: DeepMocked<Client>;
     let systemUsersService: SystemUsersService;
     let sharedMinistryUser: User;
+    let susRestriction: Restriction;
+    const OFFERING_INTENSITY = OfferingIntensity.partTime;
+    const BLOCK_DISBURSEMENT_ACTION_TYPE =
+      RestrictionActionType.StopPartTimeDisbursement;
+    const MINISTRY_NOTIFICATION_EMAIL = "dummy@some.domain";
 
     beforeAll(async () => {
       // Env variable required for querying the eligible e-Cert records.
@@ -92,14 +106,21 @@ describe(
             NotificationMessageType.ProgramSuspensionBlockingApplication,
           ]),
         },
-        { emailContacts: ["dummy@some.domain"] },
+        { emailContacts: [MINISTRY_NOTIFICATION_EMAIL] },
       );
       // Create a Ministry user to b used, for instance, for audit.
       sharedMinistryUser = await db.user.save(createFakeUser());
+      susRestriction = await db.restriction.findOne({
+        select: { id: true },
+        where: {
+          restrictionCode: RestrictionCode.SUS,
+        },
+      });
     });
 
     beforeEach(async () => {
       jest.clearAllMocks();
+      MockDate.reset();
       // Ensures that every disbursement on database is cancelled allowing the e-Certs to
       // be generated with the data created for every specific scenario.
       await db.disbursementSchedule.update(
@@ -369,7 +390,7 @@ describe(
           {
             msfaaState: MSFAAStates.Signed,
             msfaaInitialValues: {
-              offeringIntensity: OfferingIntensity.partTime,
+              offeringIntensity: OFFERING_INTENSITY,
             },
           },
         ),
@@ -393,7 +414,7 @@ describe(
             applicationStatus: ApplicationStatus.Completed,
             relationshipStatus: RelationshipStatus.MarriedUnable,
           },
-          offeringIntensity: OfferingIntensity.partTime,
+          offeringIntensity: OFFERING_INTENSITY,
           currentAssessmentInitialValues: {
             assessmentData: { weeks: 5 } as Assessment,
             assessmentDate: new Date(),
@@ -499,7 +520,7 @@ describe(
           {
             msfaaState: MSFAAStates.Signed,
             msfaaInitialValues: {
-              offeringIntensity: OfferingIntensity.partTime,
+              offeringIntensity: OFFERING_INTENSITY,
             },
           },
         ),
@@ -519,7 +540,7 @@ describe(
           ],
         },
         {
-          offeringIntensity: OfferingIntensity.partTime,
+          offeringIntensity: OFFERING_INTENSITY,
           applicationStatus: ApplicationStatus.Completed,
           currentAssessmentInitialValues: {
             assessmentData: { weeks: 5 } as Assessment,
@@ -560,7 +581,7 @@ describe(
           {
             msfaaState: MSFAAStates.Signed,
             msfaaInitialValues: {
-              offeringIntensity: OfferingIntensity.partTime,
+              offeringIntensity: OFFERING_INTENSITY,
             },
           },
         ),
@@ -587,7 +608,7 @@ describe(
           ],
         },
         {
-          offeringIntensity: OfferingIntensity.partTime,
+          offeringIntensity: OFFERING_INTENSITY,
           applicationStatus: ApplicationStatus.Completed,
           createSecondDisbursement: true,
           currentAssessmentInitialValues: {
@@ -675,7 +696,7 @@ describe(
           {
             msfaaState: MSFAAStates.Signed,
             msfaaInitialValues: {
-              offeringIntensity: OfferingIntensity.partTime,
+              offeringIntensity: OFFERING_INTENSITY,
             },
           },
         ),
@@ -690,7 +711,7 @@ describe(
           {
             msfaaState: MSFAAStates.Signed,
             msfaaInitialValues: {
-              offeringIntensity: OfferingIntensity.partTime,
+              offeringIntensity: OFFERING_INTENSITY,
             },
           },
         ),
@@ -701,7 +722,7 @@ describe(
         db.dataSource,
         { student: studentA, msfaaNumber: msfaaNumberA },
         {
-          offeringIntensity: OfferingIntensity.partTime,
+          offeringIntensity: OFFERING_INTENSITY,
           applicationStatus: ApplicationStatus.Completed,
           currentAssessmentInitialValues: {
             assessmentData: { weeks: 5 } as Assessment,
@@ -726,7 +747,7 @@ describe(
         db.dataSource,
         { student: studentB, msfaaNumber: msfaaNumberB },
         {
-          offeringIntensity: OfferingIntensity.partTime,
+          offeringIntensity: OFFERING_INTENSITY,
           applicationStatus: ApplicationStatus.Completed,
           currentAssessmentInitialValues: {
             assessmentData: { weeks: 5 } as Assessment,
@@ -822,7 +843,7 @@ describe(
           {
             msfaaState: MSFAAStates.Signed,
             msfaaInitialValues: {
-              offeringIntensity: OfferingIntensity.partTime,
+              offeringIntensity: OFFERING_INTENSITY,
             },
           },
         ),
@@ -848,7 +869,7 @@ describe(
         db.dataSource,
         { student, msfaaNumber },
         {
-          offeringIntensity: OfferingIntensity.partTime,
+          offeringIntensity: OFFERING_INTENSITY,
           applicationStatus: ApplicationStatus.Completed,
           currentAssessmentInitialValues: {
             assessmentDate: new Date(),
@@ -930,7 +951,7 @@ describe(
           {
             msfaaState: MSFAAStates.Signed,
             msfaaInitialValues: {
-              offeringIntensity: OfferingIntensity.partTime,
+              offeringIntensity: OFFERING_INTENSITY,
             },
           },
         ),
@@ -963,7 +984,7 @@ describe(
           ],
         },
         {
-          offeringIntensity: OfferingIntensity.partTime,
+          offeringIntensity: OFFERING_INTENSITY,
           applicationStatus: ApplicationStatus.Completed,
           currentAssessmentInitialValues: {
             assessmentData: { weeks: 5 } as Assessment,
@@ -1017,7 +1038,7 @@ describe(
             {
               msfaaState: MSFAAStates.Signed,
               msfaaInitialValues: {
-                offeringIntensity: OfferingIntensity.partTime,
+                offeringIntensity: OFFERING_INTENSITY,
               },
             },
           ),
@@ -1037,7 +1058,7 @@ describe(
             ],
           },
           {
-            offeringIntensity: OfferingIntensity.partTime,
+            offeringIntensity: OFFERING_INTENSITY,
             applicationStatus: ApplicationStatus.Completed,
             currentAssessmentInitialValues: {
               assessmentData: { weeks: 5 } as Assessment,
@@ -1057,8 +1078,7 @@ describe(
             creator: sharedMinistryUser,
           },
           {
-            restrictionActionType:
-              RestrictionActionType.StopPartTimeDisbursement,
+            restrictionActionType: BLOCK_DISBURSEMENT_ACTION_TYPE,
             initialValues: {
               bypassBehavior: RestrictionBypassBehaviors.NextDisbursementOnly,
             },
@@ -1137,7 +1157,7 @@ describe(
             {
               msfaaState: MSFAAStates.Signed,
               msfaaInitialValues: {
-                offeringIntensity: OfferingIntensity.partTime,
+                offeringIntensity: OFFERING_INTENSITY,
               },
             },
           ),
@@ -1157,7 +1177,7 @@ describe(
             ],
           },
           {
-            offeringIntensity: OfferingIntensity.partTime,
+            offeringIntensity: OFFERING_INTENSITY,
             applicationStatus: ApplicationStatus.Completed,
             currentAssessmentInitialValues: {
               assessmentData: { weeks: 5 } as Assessment,
@@ -1236,7 +1256,7 @@ describe(
 
     it(
       "Should prevent an e-Cert generation and keep the bypass active when " +
-        `multiple '${RestrictionActionType.StopPartTimeDisbursement}' restrictions exist and only one is bypassed and it is bypassed with behavior '${RestrictionBypassBehaviors.NextDisbursementOnly}'.`,
+        `multiple '${BLOCK_DISBURSEMENT_ACTION_TYPE}' restrictions exist and only one is bypassed and it is bypassed with behavior '${RestrictionBypassBehaviors.NextDisbursementOnly}'.`,
       async () => {
         // Arrange
         // Student with valid SIN.
@@ -1248,7 +1268,7 @@ describe(
             {
               msfaaState: MSFAAStates.Signed,
               msfaaInitialValues: {
-                offeringIntensity: OfferingIntensity.partTime,
+                offeringIntensity: OFFERING_INTENSITY,
               },
             },
           ),
@@ -1268,7 +1288,7 @@ describe(
             ],
           },
           {
-            offeringIntensity: OfferingIntensity.partTime,
+            offeringIntensity: OFFERING_INTENSITY,
             applicationStatus: ApplicationStatus.Completed,
             currentAssessmentInitialValues: {
               assessmentData: { weeks: 5 } as Assessment,
@@ -1288,8 +1308,7 @@ describe(
             creator: sharedMinistryUser,
           },
           {
-            restrictionActionType:
-              RestrictionActionType.StopPartTimeDisbursement,
+            restrictionActionType: BLOCK_DISBURSEMENT_ACTION_TYPE,
             initialValues: {
               bypassBehavior: RestrictionBypassBehaviors.NextDisbursementOnly,
             },
@@ -1302,9 +1321,7 @@ describe(
           select: { id: true },
           where: {
             restrictionType: RestrictionType.Provincial,
-            actionType: ArrayContains([
-              RestrictionActionType.StopPartTimeDisbursement,
-            ]),
+            actionType: ArrayContains([BLOCK_DISBURSEMENT_ACTION_TYPE]),
             actionEffectiveConditions: IsNull(),
           },
         });
@@ -1324,7 +1341,7 @@ describe(
         expect(
           mockedJob.containLogMessages([
             `Current active restriction bypasses [Restriction Code(Restriction ID)]: ${restrictionBypass.studentRestriction.restriction.restrictionCode}(${restrictionBypass.studentRestriction.id}).`,
-            `Student has an active '${RestrictionActionType.StopPartTimeDisbursement}' restriction and the disbursement calculation will not proceed.`,
+            `Student has an active '${BLOCK_DISBURSEMENT_ACTION_TYPE}' restriction and the disbursement calculation will not proceed.`,
           ]),
         ).toBe(true);
 
@@ -1437,7 +1454,7 @@ describe(
           {
             msfaaState: MSFAAStates.Signed,
             msfaaInitialValues: {
-              offeringIntensity: OfferingIntensity.partTime,
+              offeringIntensity: OFFERING_INTENSITY,
             },
           },
         ),
@@ -1457,7 +1474,7 @@ describe(
           ],
         },
         {
-          offeringIntensity: OfferingIntensity.partTime,
+          offeringIntensity: OFFERING_INTENSITY,
           applicationStatus: ApplicationStatus.Completed,
           currentAssessmentInitialValues: {
             assessmentData: { weeks: 5 } as Assessment,
@@ -1579,7 +1596,7 @@ describe(
           ],
         },
         {
-          offeringIntensity: OfferingIntensity.partTime,
+          offeringIntensity: OFFERING_INTENSITY,
           applicationStatus: ApplicationStatus.Completed,
           currentAssessmentInitialValues: {
             assessmentData: { weeks: 5 } as Assessment,
@@ -1649,7 +1666,7 @@ describe(
     it(
       "Should block the disbursement and log the information when the institution" +
         " has an effective institution restriction for the application location and program" +
-        ` with action type ${RestrictionActionType.StopPartTimeDisbursement}.`,
+        ` with action type ${BLOCK_DISBURSEMENT_ACTION_TYPE}.`,
       async () => {
         // Arrange
         // Eligible COE basic properties.
@@ -1666,7 +1683,7 @@ describe(
             {
               msfaaState: MSFAAStates.Signed,
               msfaaInitialValues: {
-                offeringIntensity: OfferingIntensity.partTime,
+                offeringIntensity: OFFERING_INTENSITY,
               },
             },
           ),
@@ -1678,7 +1695,7 @@ describe(
             msfaaNumber,
           },
           {
-            offeringIntensity: OfferingIntensity.partTime,
+            offeringIntensity: OFFERING_INTENSITY,
             applicationStatus: ApplicationStatus.Completed,
             currentAssessmentInitialValues: {
               assessmentData: { weeks: 5 } as Assessment,
@@ -1695,9 +1712,7 @@ describe(
           select: { id: true },
           where: {
             restrictionType: RestrictionType.Institution,
-            actionType: ArrayContains([
-              RestrictionActionType.StopPartTimeDisbursement,
-            ]),
+            actionType: ArrayContains([BLOCK_DISBURSEMENT_ACTION_TYPE]),
           },
         });
         const offering = application.currentAssessment.offering;
@@ -1730,7 +1745,7 @@ describe(
         // Assert log messages for the blocked disbursement.
         expect(
           mockedJob.containLogMessages([
-            `Institution has an effective '${RestrictionActionType.StopPartTimeDisbursement}' restriction` +
+            `Institution has an effective '${BLOCK_DISBURSEMENT_ACTION_TYPE}' restriction` +
               ` for program ${program.id} and location ${location.id} and the disbursement calculation will not proceed.`,
             "The step determined that the calculation should be interrupted. This disbursement will not be part of the next e-Cert generation.",
           ]),
@@ -1752,7 +1767,7 @@ describe(
     it(
       "Should create the e-Cert and log the information when the institution" +
         " does not have an effective institution restriction for the application location and program" +
-        ` with action type ${RestrictionActionType.StopPartTimeDisbursement}.`,
+        ` with action type ${BLOCK_DISBURSEMENT_ACTION_TYPE}.`,
       async () => {
         // Arrange
         // Eligible COE basic properties.
@@ -1769,7 +1784,7 @@ describe(
             {
               msfaaState: MSFAAStates.Signed,
               msfaaInitialValues: {
-                offeringIntensity: OfferingIntensity.partTime,
+                offeringIntensity: OFFERING_INTENSITY,
               },
             },
           ),
@@ -1781,7 +1796,7 @@ describe(
             msfaaNumber,
           },
           {
-            offeringIntensity: OfferingIntensity.partTime,
+            offeringIntensity: OFFERING_INTENSITY,
             applicationStatus: ApplicationStatus.Completed,
             currentAssessmentInitialValues: {
               assessmentData: { weeks: 5 } as Assessment,
@@ -1798,9 +1813,7 @@ describe(
           select: { id: true },
           where: {
             restrictionType: RestrictionType.Institution,
-            actionType: ArrayContains([
-              RestrictionActionType.StopPartTimeDisbursement,
-            ]),
+            actionType: ArrayContains([BLOCK_DISBURSEMENT_ACTION_TYPE]),
           },
         });
         const location =
@@ -1852,6 +1865,170 @@ describe(
       },
     );
 
+    it(
+      "Should block the disbursement and create program suspension blocking application notification" +
+        ` when the application location and program has effective institution restriction ${RestrictionCode.SUS}.`,
+      async () => {
+        // Arrange
+        const application = await createEligibleECertApplication(
+          db,
+          OFFERING_INTENSITY,
+        );
+        const offering = application.currentAssessment.offering;
+        const location = offering.institutionLocation;
+        const program = offering.educationProgram;
+        const institution = location.institution;
+        // Add institution restriction for the application location and program.
+        await saveFakeInstitutionRestriction(db, {
+          restriction: susRestriction,
+          institution,
+          program,
+          location,
+        });
+        // Queued job.
+        const mockedJob = mockBullJob<void>();
+        const now = new Date();
+        MockDate.set(now);
+
+        // Act
+        await processor.processQueue(mockedJob.job);
+
+        // Assert
+        // Assert log messages.
+        const [disbursement] =
+          application.currentAssessment.disbursementSchedules;
+        // Assert log messages for the blocked disbursement.
+        expect(
+          mockedJob.containLogMessages([
+            `Institution has an effective '${BLOCK_DISBURSEMENT_ACTION_TYPE}' restriction` +
+              ` for program ${program.id} and location ${location.id} and the disbursement calculation will not proceed.`,
+            "The step determined that the calculation should be interrupted. This disbursement will not be part of the next e-Cert generation.",
+            `Program suspension blocking application notification created for disbursement ID ${disbursement.id}.`,
+          ]),
+        ).toBe(true);
+        // Assert that the disbursement is still in status 'Pending' with date sent null.
+        const scheduleIsPending = await db.disbursementSchedule.exists({
+          where: {
+            id: disbursement.id,
+            dateSent: IsNull(),
+            disbursementScheduleStatus: DisbursementScheduleStatus.Pending,
+          },
+        });
+        expect(scheduleIsPending).toBe(true);
+        // Assert that the notification was created for the disbursement.
+        const notification = await db.notification.findOne({
+          select: {
+            id: true,
+            messagePayload: true,
+          },
+          where: {
+            dateSent: IsNull(),
+            notificationMessage: {
+              id: NotificationMessageType.ProgramSuspensionBlockingApplication,
+            },
+            metadata: { disbursementId: disbursement.id },
+          },
+          loadEagerRelations: false,
+        });
+        const student = application.student;
+        expect(notification).toEqual({
+          id: expect.any(Number),
+          messagePayload: {
+            email_address: MINISTRY_NOTIFICATION_EMAIL,
+            template_id: expect.any(String),
+            personalisation: {
+              dateTime: `${getPSTPDTDateTime(now)} PST/PDT`,
+              lastName: student.user.lastName,
+              givenNames: student.user.firstName,
+              birthDate: getDateOnlyFormat(student.birthDate),
+              studentEmail: student.user.email,
+              applicationNumber: application.applicationNumber,
+              programName: program.name,
+              institutionOperatingName: institution.operatingName,
+            },
+          },
+        });
+      },
+    );
+
+    it(
+      "Should block the disbursement but not create a program suspension blocking application notification" +
+        ` when the application location and program has effective institution restriction ${RestrictionCode.SUS}` +
+        " and the notification already exists for the disbursement.",
+      async () => {
+        // Arrange
+        const application = await createEligibleECertApplication(
+          db,
+          OFFERING_INTENSITY,
+        );
+        const offering = application.currentAssessment.offering;
+        const location = offering.institutionLocation;
+        const program = offering.educationProgram;
+        const institution = location.institution;
+        // Add institution restriction for the application location and program.
+        await saveFakeInstitutionRestriction(db, {
+          restriction: susRestriction,
+          institution,
+          program,
+          location,
+        });
+        const [disbursement] =
+          application.currentAssessment.disbursementSchedules;
+        // Create a sent notification.
+        const existingNotification = createFakeNotification(
+          {
+            user: systemUsersService.systemUser,
+            auditUser: systemUsersService.systemUser,
+            notificationMessage: {
+              id: NotificationMessageType.ProgramSuspensionBlockingApplication,
+            } as NotificationMessage,
+          },
+          {
+            initialValue: {
+              metadata: {
+                disbursementId: disbursement.id,
+              },
+              dateSent: new Date(),
+            },
+          },
+        );
+        await db.notification.save(existingNotification);
+        // Queued job.
+        const mockedJob = mockBullJob<void>();
+
+        // Act
+        await processor.processQueue(mockedJob.job);
+
+        // Assert
+        // Assert log messages for the blocked disbursement.
+        expect(
+          mockedJob.containLogMessages([
+            `Program suspension blocking application notification should not be created at this moment for disbursement ID ${disbursement.id}.`,
+          ]),
+        ).toBe(true);
+        // Assert that the disbursement is still in status 'Pending' with date sent null.
+        const scheduleIsPending = await db.disbursementSchedule.exists({
+          where: {
+            id: disbursement.id,
+            dateSent: IsNull(),
+            disbursementScheduleStatus: DisbursementScheduleStatus.Pending,
+          },
+        });
+        expect(scheduleIsPending).toBe(true);
+        // Assert that new notification was not created for the disbursement.
+        const isNewNotificationCreated = await db.notification.exists({
+          where: {
+            dateSent: IsNull(),
+            notificationMessage: {
+              id: NotificationMessageType.ProgramSuspensionBlockingApplication,
+            },
+            metadata: { disbursementId: disbursement.id },
+          },
+        });
+        expect(isNewNotificationCreated).toBe(false);
+      },
+    );
+
     describe("Scholastic standing impact on part-time applications e-Cert generation", () => {
       [
         StudentScholasticStandingChangeType.SchoolTransfer,
@@ -1873,7 +2050,7 @@ describe(
               {
                 msfaaState: MSFAAStates.Signed,
                 msfaaInitialValues: {
-                  offeringIntensity: OfferingIntensity.partTime,
+                  offeringIntensity: OFFERING_INTENSITY,
                 },
               },
             ),
@@ -1885,7 +2062,7 @@ describe(
               msfaaNumber,
             },
             {
-              offeringIntensity: OfferingIntensity.partTime,
+              offeringIntensity: OFFERING_INTENSITY,
               applicationStatus: ApplicationStatus.Completed,
               currentAssessmentInitialValues: {
                 assessmentData: { weeks: 5 } as Assessment,
@@ -1968,7 +2145,7 @@ describe(
               {
                 msfaaState: MSFAAStates.Signed,
                 msfaaInitialValues: {
-                  offeringIntensity: OfferingIntensity.partTime,
+                  offeringIntensity: OFFERING_INTENSITY,
                 },
               },
             ),
@@ -1980,7 +2157,7 @@ describe(
               msfaaNumber,
             },
             {
-              offeringIntensity: OfferingIntensity.partTime,
+              offeringIntensity: OFFERING_INTENSITY,
               applicationStatus: ApplicationStatus.Completed,
               currentAssessmentInitialValues: {
                 assessmentData: { weeks: 5 } as Assessment,
@@ -2060,7 +2237,7 @@ describe(
             {
               msfaaState: MSFAAStates.Signed,
               msfaaInitialValues: {
-                offeringIntensity: OfferingIntensity.partTime,
+                offeringIntensity: OFFERING_INTENSITY,
               },
             },
           ),
@@ -2072,7 +2249,7 @@ describe(
             msfaaNumber,
           },
           {
-            offeringIntensity: OfferingIntensity.partTime,
+            offeringIntensity: OFFERING_INTENSITY,
             applicationStatus: ApplicationStatus.Completed,
             currentAssessmentInitialValues: {
               assessmentData: { weeks: 5 } as Assessment,
@@ -2160,7 +2337,7 @@ describe(
                 {
                   msfaaState: MSFAAStates.Signed,
                   msfaaInitialValues: {
-                    offeringIntensity: OfferingIntensity.partTime,
+                    offeringIntensity: OFFERING_INTENSITY,
                   },
                 },
               ),
@@ -2185,7 +2362,7 @@ describe(
                   ],
                 },
                 {
-                  offeringIntensity: OfferingIntensity.partTime,
+                  offeringIntensity: OFFERING_INTENSITY,
                   applicationStatus: ApplicationStatus.Completed,
                   currentAssessmentInitialValues: {
                     assessmentData: { weeks: 5 } as Assessment,
@@ -2277,7 +2454,7 @@ describe(
                 {
                   msfaaState: MSFAAStates.Signed,
                   msfaaInitialValues: {
-                    offeringIntensity: OfferingIntensity.partTime,
+                    offeringIntensity: OFFERING_INTENSITY,
                   },
                 },
               ),
@@ -2302,7 +2479,7 @@ describe(
                   ],
                 },
                 {
-                  offeringIntensity: OfferingIntensity.partTime,
+                  offeringIntensity: OFFERING_INTENSITY,
                   applicationStatus: ApplicationStatus.Completed,
                   currentAssessmentInitialValues: {
                     assessmentData: { weeks: 5 } as Assessment,
@@ -2349,7 +2526,7 @@ describe(
             // Assert log messages for the blocked disbursement.
             expect(
               mockedJob.containLogMessages([
-                `Student has an active '${RestrictionActionType.StopPartTimeDisbursement}' restriction and the disbursement calculation will not proceed.`,
+                `Student has an active '${BLOCK_DISBURSEMENT_ACTION_TYPE}' restriction and the disbursement calculation will not proceed.`,
                 "The step determined that the calculation should be interrupted. This disbursement will not be part of the next e-Cert generation.",
               ]),
             ).toBe(true);
@@ -2411,7 +2588,7 @@ describe(
               {
                 msfaaState: MSFAAStates.Signed,
                 msfaaInitialValues: {
-                  offeringIntensity: OfferingIntensity.partTime,
+                  offeringIntensity: OFFERING_INTENSITY,
                 },
               },
             ),
@@ -2436,7 +2613,7 @@ describe(
                 ],
               },
               {
-                offeringIntensity: OfferingIntensity.partTime,
+                offeringIntensity: OFFERING_INTENSITY,
                 applicationStatus: ApplicationStatus.Completed,
                 currentAssessmentInitialValues: {
                   assessmentData: { weeks: 5 } as Assessment,
@@ -2552,7 +2729,7 @@ describe(
               {
                 msfaaState: MSFAAStates.Signed,
                 msfaaInitialValues: {
-                  offeringIntensity: OfferingIntensity.partTime,
+                  offeringIntensity: OFFERING_INTENSITY,
                 },
               },
             ),
@@ -2577,7 +2754,7 @@ describe(
                 ],
               },
               {
-                offeringIntensity: OfferingIntensity.partTime,
+                offeringIntensity: OFFERING_INTENSITY,
                 applicationStatus: ApplicationStatus.Completed,
                 currentAssessmentInitialValues: {
                   assessmentData: { weeks: 5 } as Assessment,

--- a/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/student-application-notifications/_tests_/student-application-notifications.scheduler.e2e-spec.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/student-application-notifications/_tests_/student-application-notifications.scheduler.e2e-spec.ts
@@ -1,6 +1,7 @@
 import { INestApplication } from "@nestjs/common";
 import {
   addDays,
+  getDateOnlyFormat,
   getISODateOnlyString,
   getPSTPDTDateTime,
   QueueNames,
@@ -12,18 +13,23 @@ import {
 } from "../../../../../test/helpers";
 import {
   E2EDataSources,
+  MSFAAStates,
   createE2EDataSources,
   createFakeCRAIncomeVerification,
   createFakeDisbursementSchedule,
   createFakeEducationProgramOffering,
+  createFakeMSFAANumber,
   createFakeNotification,
   createFakeSINValidation,
   createFakeStudentAssessment,
   saveFakeApplication,
   saveFakeApplicationDisbursements,
+  saveFakeApplicationRestrictionBypass,
+  saveFakeInstitutionRestriction,
   saveFakeStudent,
 } from "@sims/test-utils";
 import {
+  Application,
   ApplicationStatus,
   Assessment,
   AssessmentStatus,
@@ -37,11 +43,17 @@ import {
   NotificationMessage,
   NotificationMessageType,
   OfferingIntensity,
+  Restriction,
   WorkflowData,
 } from "@sims/sims-db";
 import { IsNull, Not } from "typeorm";
+import MockDate from "mockdate";
 import { StudentApplicationNotificationsScheduler } from "../../student-application-notifications/student-application-notifications.scheduler";
-import { FileProcessingIssueType, SystemUsersService } from "@sims/services";
+import {
+  FileProcessingIssueType,
+  RestrictionCode,
+  SystemUsersService,
+} from "@sims/services";
 import { GC_NOTIFY_TEMPLATE_IDS } from "@sims/test-utils/constants";
 
 describe(
@@ -51,6 +63,7 @@ describe(
     let processor: StudentApplicationNotificationsScheduler;
     let db: E2EDataSources;
     let systemUsersService: SystemUsersService;
+    let susRestriction: Restriction;
     const MINISTRY_EMAIL_ADDRESS = "dummy@some.domain";
 
     beforeAll(async () => {
@@ -68,22 +81,31 @@ describe(
         },
         { emailContacts: [MINISTRY_EMAIL_ADDRESS] },
       );
+      susRestriction = await db.restriction.findOne({
+        select: { id: true },
+        where: {
+          restrictionCode: RestrictionCode.SUS,
+        },
+      });
     });
 
     beforeEach(async () => {
+      MockDate.reset();
       // Cancel all applications to ensure that existing data will not affect these tests.
       await db.application.update(
         { applicationStatus: Not(ApplicationStatus.Cancelled) },
         { applicationStatus: ApplicationStatus.Cancelled },
       );
+      // Mark all notifications as sent to ensure that existing data will not affect these tests.
+      await db.notification.update(
+        {
+          dateSent: IsNull(),
+        },
+        { dateSent: new Date() },
+      );
     });
 
     describe("StudentPDPPDReminderNotification", () => {
-      beforeEach(async () => {
-        await markNotificationsSent(
-          NotificationMessageType.StudentPDPPDApplicationNotification,
-        );
-      });
       it(
         "Should generate a notification for PD/PPD student mismatch close to the offering end date " +
           "when the application is Assessment/Completed and at least one disbursement is pending and there is a PD/PPD mismatch.",
@@ -316,11 +338,6 @@ describe(
     });
 
     describe("StudentSecondDisbursementReminderNotification", () => {
-      beforeEach(async () => {
-        await markNotificationsSent(
-          NotificationMessageType.StudentSecondDisbursementNotification,
-        );
-      });
       it(
         "Should generate a second disbursement reminder notification for a student when the " +
           "application is Completed and the second disbursement with Required COE status " +
@@ -486,11 +503,6 @@ describe(
     });
 
     describe("StudentCOERequiredNearEndDateReminderNotification", () => {
-      beforeEach(async () => {
-        await markNotificationsSent(
-          NotificationMessageType.StudentCOERequiredNearEndDateNotification,
-        );
-      });
       it(
         "Should generate a notification for a student when the study end date is within 10 days " +
           "and at least one COE is required on the most recent assessment.",
@@ -711,9 +723,6 @@ describe(
             },
             { dateReceived: new Date() },
           );
-          await markNotificationsSent(
-            NotificationMessageType.MinistryFileProcessingIssue,
-          );
         });
         it(`Should generate a notification for CRA file processing issues when the file was sent ${daysPastSent} days ago with no response file received.`, async () => {
           // Arrange
@@ -845,9 +854,6 @@ describe(
           },
           { dateReceived: new Date() },
         );
-        await markNotificationsSent(
-          NotificationMessageType.MinistryFileProcessingIssue,
-        );
       });
       positiveCRASINNotificationData.forEach(({ daysPastSent }) => {
         it(`Should generate a notification for SIN file processing issues when the file was sent ${daysPastSent} days ago with no response file received.`, async () => {
@@ -963,11 +969,6 @@ describe(
     });
 
     describe("StudentAssessmentReminderNotification", () => {
-      beforeEach(async () => {
-        markNotificationsSent(
-          NotificationMessageType.StudentAssessmentReminder,
-        );
-      });
       // The following scenarios should generate notifications.
       const positiveAssessmentNotificationData = [
         {
@@ -1249,6 +1250,161 @@ describe(
       });
     });
 
+    describe("ProgramSuspensionBlockingAssessmentNotification", () => {
+      it(`Should generate program suspension blocking application notification when an application is blocked from confirming assessment due to effective ${RestrictionCode.SUS} restriction.`, async () => {
+        // Arrange
+        // Create an application pending assessment confirmation.
+        const application = await createApplicationPendingAcceptAssessment();
+        const offering = application.currentAssessment.offering;
+        const location = offering.institutionLocation;
+        const program = offering.educationProgram;
+        const institution = location.institution;
+        // Add institution restriction for the application location and program.
+        await saveFakeInstitutionRestriction(db, {
+          restriction: susRestriction,
+          institution,
+          program,
+          location,
+        });
+
+        // Queued job.
+        const mockedJob = mockBullJob<void>();
+        const now = new Date();
+        MockDate.set(now);
+
+        // Act
+        await processor.processQueue(mockedJob.job);
+
+        // Assert
+        expect(
+          mockedJob.containLogMessages([
+            `Program suspension blocking application notifications created for the assessments: ${application.currentAssessment.id}`,
+          ]),
+        ).toBe(true);
+        const notification = await findNotification(
+          NotificationMessageType.ProgramSuspensionBlockingApplication,
+        );
+        expect(notification).toBeDefined();
+        const student = application.student;
+        expect(notification!.messagePayload).toStrictEqual({
+          email_address: MINISTRY_EMAIL_ADDRESS,
+          template_id: expect.any(String),
+          personalisation: {
+            dateTime: `${getPSTPDTDateTime(now)} PST/PDT`,
+            lastName: student.user.lastName,
+            birthDate: getDateOnlyFormat(student.birthDate),
+            givenNames: student.user.firstName,
+            programName: program.name,
+            studentEmail: student.user.email,
+            applicationNumber: application.applicationNumber,
+            institutionOperatingName: institution.operatingName,
+          },
+        });
+        expect(notification!.metadata).toStrictEqual({
+          assessmentId: application.currentAssessment!.id,
+        });
+      });
+      it(
+        `Should not generate program suspension blocking application notification when an application is blocked from confirming assessment due to effective ${RestrictionCode.SUS} restriction` +
+          " and a notification has already been sent for the assessment.",
+        async () => {
+          // Arrange
+          // Create an application pending assessment confirmation.
+          const application = await createApplicationPendingAcceptAssessment();
+          const offering = application.currentAssessment.offering;
+          const location = offering.institutionLocation;
+          const program = offering.educationProgram;
+          const institution = location.institution;
+          // Add institution restriction for the application location and program.
+          await saveFakeInstitutionRestriction(db, {
+            restriction: susRestriction,
+            institution,
+            program,
+            location,
+          });
+          // Create an existing notification for the assessment.
+          const existingNotification = createFakeNotification(
+            {
+              user: systemUsersService.systemUser,
+              auditUser: systemUsersService.systemUser,
+              notificationMessage: {
+                id: NotificationMessageType.ProgramSuspensionBlockingApplication,
+              } as NotificationMessage,
+            },
+            {
+              initialValue: {
+                metadata: {
+                  assessmentId: application.currentAssessment!.id,
+                },
+                dateSent: new Date(),
+              },
+            },
+          );
+          await db.notification.save(existingNotification);
+          // Queued job.
+          const mockedJob = mockBullJob<void>();
+
+          // Act
+          await processor.processQueue(mockedJob.job);
+
+          // Assert
+          expect(
+            mockedJob.containLogMessages([
+              "No applications blocked by program suspension restriction without an existing notification are found.",
+            ]),
+          ).toBe(true);
+          const isNewNotificationCreated = await notificationExists(
+            NotificationMessageType.ProgramSuspensionBlockingApplication,
+          );
+          expect(isNewNotificationCreated).toBe(false);
+        },
+      );
+      it(
+        `Should not generate program suspension blocking application notification when an application is blocked from confirming assessment due to ${RestrictionCode.SUS} restriction` +
+          " and the restriction is bypassed.",
+        async () => {
+          // Arrange
+          // Create an application pending assessment confirmation.
+          const application = await createApplicationPendingAcceptAssessment();
+          const offering = application.currentAssessment.offering;
+          const location = offering.institutionLocation;
+          const program = offering.educationProgram;
+          const institution = location.institution;
+          // Add institution restriction for the application location and program.
+          const institutionRestriction = await saveFakeInstitutionRestriction(
+            db,
+            {
+              restriction: susRestriction,
+              institution,
+              program,
+              location,
+            },
+          );
+          // Create an application restriction bypass.
+          await saveFakeApplicationRestrictionBypass(db, {
+            application,
+            institutionRestriction,
+          });
+          // Queued job.
+          const mockedJob = mockBullJob<void>();
+
+          // Act
+          await processor.processQueue(mockedJob.job);
+
+          // Assert
+          expect(
+            mockedJob.containLogMessages([
+              "No applications blocked by program suspension restriction without an existing notification are found.",
+            ]),
+          ).toBe(true);
+          const isNewNotificationCreated = await notificationExists(
+            NotificationMessageType.ProgramSuspensionBlockingApplication,
+          );
+          expect(isNewNotificationCreated).toBe(false);
+        },
+      );
+    });
+
     /**
      * Helper function to find a notification for assertions.
      * @param messageType The type of notification message to find.
@@ -1285,11 +1441,6 @@ describe(
       userId: number = systemUsersService.systemUser.id,
     ): Promise<boolean> {
       return await db.notification.exists({
-        select: {
-          id: true,
-          messagePayload: true,
-        },
-        relations: { notificationMessage: true },
         where: {
           notificationMessage: {
             id: messageType,
@@ -1301,17 +1452,37 @@ describe(
     }
 
     /**
-     * Marks the notifications of the specified message type as sent by updating the dateSent to the current date.
-     * @param messageType The type of notification message to update.
+     * Creates an application pending accept assessment with the specified offering intensity.
+     * @param offeringIntensity application offering intensity.
+     * @returns application.
      */
-    async function markNotificationsSent(messageType: NotificationMessageType) {
-      await db.notification.update(
+    async function createApplicationPendingAcceptAssessment(
+      offeringIntensity = OfferingIntensity.fullTime,
+    ): Promise<Application> {
+      // Student with valid SIN.
+      const student = await saveFakeStudent(db.dataSource);
+      // Valid MSFAA Number.
+      const msfaaNumber = await db.msfaaNumber.save(
+        createFakeMSFAANumber(
+          { student },
+          {
+            msfaaState: MSFAAStates.Signed,
+            msfaaInitialValues: {
+              offeringIntensity,
+            },
+          },
+        ),
+      );
+      return saveFakeApplicationDisbursements(
+        db.dataSource,
+        { student, msfaaNumber },
         {
-          notificationMessage: {
-            id: messageType,
+          offeringIntensity,
+          applicationStatus: ApplicationStatus.Assessment,
+          currentAssessmentInitialValues: {
+            noaApprovalStatus: AssessmentStatus.required,
           },
         },
-        { dateSent: new Date() },
       );
     }
   },

--- a/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/student-application-notifications/_tests_/student-application-notifications.scheduler.e2e-spec.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/student-application-notifications/_tests_/student-application-notifications.scheduler.e2e-spec.ts
@@ -1350,7 +1350,7 @@ describe(
           // Assert
           expect(
             mockedJob.containLogMessages([
-              "No applications blocked by program suspension restriction without an existing notification are found.",
+              "No applications blocked by the program suspension restriction without an existing notification were found.",
             ]),
           ).toBe(true);
           const isNewNotificationCreated = await notificationExists(
@@ -1394,7 +1394,7 @@ describe(
           // Assert
           expect(
             mockedJob.containLogMessages([
-              "No applications blocked by program suspension restriction without an existing notification are found.",
+              "No applications blocked by the program suspension restriction without an existing notification were found.",
             ]),
           ).toBe(true);
           const isNewNotificationCreated = await notificationExists(

--- a/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/student-application-notifications/_tests_/student-application-notifications.scheduler.e2e-spec.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/processors/schedulers/student-application-notifications/_tests_/student-application-notifications.scheduler.e2e-spec.ts
@@ -1304,6 +1304,7 @@ describe(
           assessmentId: application.currentAssessment!.id,
         });
       });
+
       it(
         `Should not generate program suspension blocking application notification when an application is blocked from confirming assessment due to effective ${RestrictionCode.SUS} restriction` +
           " and a notification has already been sent for the assessment.",
@@ -1359,6 +1360,7 @@ describe(
           expect(isNewNotificationCreated).toBe(false);
         },
       );
+
       it(
         `Should not generate program suspension blocking application notification when an application is blocked from confirming assessment due to ${RestrictionCode.SUS} restriction` +
           " and the restriction is bypassed.",

--- a/sources/packages/backend/apps/queue-consumers/src/queue-consumers.module.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/queue-consumers.module.ts
@@ -86,6 +86,7 @@ import {
   StudentAssessmentReminderNotification,
   CASInvoiceBatchService,
   CASInvoiceService,
+  ProgramSuspensionBlockingAssessmentNotification,
 } from "./services";
 import { SFASIntegrationModule } from "@sims/integrations/sfas-integration";
 import { ATBCIntegrationModule } from "@sims/integrations/atbc-integration";
@@ -190,6 +191,7 @@ import { LoggerModule } from "@sims/utilities/logger";
     StudentSecondDisbursementReminderNotification,
     StudentCOERequiredNearEndDateReminderNotification,
     StudentAssessmentReminderNotification,
+    ProgramSuspensionBlockingAssessmentNotification,
     MinistryCRAFileProcessingIssueNotification,
     MinistrySINFileProcessingIssueNotification,
     CASInvoiceBatchService,

--- a/sources/packages/backend/apps/queue-consumers/src/services/application/application.service.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/services/application/application.service.ts
@@ -26,6 +26,8 @@ import {
 } from "@sims/utilities";
 import { STUDENT_ASSESSMENT_NOTIFICATION_OVERDUE_DAYS } from "@sims/services/constants";
 import { ECertPreValidationService } from "@sims/integrations/services/disbursement-schedule/e-cert-calculation";
+import { ECertFailedValidation } from "@sims/integrations/services";
+import { RestrictionCode } from "@sims/services";
 
 interface SecondDisbursementStillPending {
   assessmentId: number;
@@ -458,6 +460,65 @@ export class ApplicationService {
   }
 
   /**
+   * Get application that are blocked at accept assessment due to program suspension restriction.
+   * @returns applications with assessments blocked by program suspension restriction.
+   */
+  async getApplicationsBlockedByProgramSuspension(): Promise<Application[]> {
+    // Sub query to defined if a notification was already sent to the current assessment.
+    const {
+      query: notificationExistsQuery,
+      parameters: notificationExistsParameters,
+    } = this.getNotificationExistsSubQuery(
+      NotificationMessageType.ProgramSuspensionBlockingApplication,
+      {
+        assessmentMetadata: { parentQueryAssessmentAlias: "currentAssessment" },
+      },
+    );
+    // Get all applications pending for accept assessment and that have not been notified yet
+    // about the program suspension restriction blocking the assessment acceptance.
+    const applicationsPendingAcceptAssessment =
+      await this.getPendingAcceptAssessmentBaseQuery()
+        .andWhere("application.isArchived = false")
+        .andWhere(
+          `NOT EXISTS (${notificationExistsQuery})`,
+          notificationExistsParameters,
+        )
+        .getMany();
+    if (!applicationsPendingAcceptAssessment.length) {
+      return [];
+    }
+    // Get the accept assessment validation results for the applications pending accept assessment.
+    const applicationIds = applicationsPendingAcceptAssessment.map(
+      (application) => application.id,
+    );
+    const acceptAssessmentValidationResults =
+      await this.eCertPreValidationService.executeAcceptAssessmentValidations(
+        applicationIds,
+      );
+    const applicationIdsBlockedByProgramSuspension =
+      acceptAssessmentValidationResults
+        .filter(
+          (validation) =>
+            !validation.validationResult.canAcceptAssessment &&
+            validation.validationResult.failedValidations.some(
+              (failedValidation) =>
+                failedValidation.resultType ===
+                  ECertFailedValidation.HasStopDisbursementInstitutionRestriction &&
+                failedValidation.additionalInfo.restrictionCodes.includes(
+                  RestrictionCode.SUS,
+                ),
+            ),
+        )
+        .map((validationResult) => validationResult.applicationId);
+    if (!applicationIdsBlockedByProgramSuspension.length) {
+      return [];
+    }
+    return applicationsPendingAcceptAssessment.filter((application) =>
+      applicationIdsBlockedByProgramSuspension.includes(application.id),
+    );
+  }
+
+  /**
    * Get existing notification sub query for a specific notification message type and options if provided.
    * @param notificationMessageId notification message type id to check for existing notifications.
    * @param options optional parameters to customize the sub query, such as assessment parent alias.
@@ -499,10 +560,12 @@ export class ApplicationService {
         "application.applicationNumber",
         "currentAssessment.id",
         "student.id",
+        "student.birthDate",
         "user.id",
         "user.firstName",
         "user.lastName",
         "user.email",
+        "offering.id",
         "program.id",
         "program.name",
         "location.id",

--- a/sources/packages/backend/apps/queue-consumers/src/services/application/application.service.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/services/application/application.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from "@nestjs/common";
-import { Brackets, Repository } from "typeorm";
+import { Brackets, Repository, SelectQueryBuilder } from "typeorm";
 import {
   Application,
   ApplicationStatus,
@@ -14,6 +14,7 @@ import {
   COEStatus,
   ApplicationEditStatus,
   AssessmentStatus,
+  QueryAndParamsForExecution,
 } from "@sims/sims-db";
 import { ConfigService } from "@sims/utilities/config";
 import { InjectRepository } from "@nestjs/typeorm";
@@ -418,35 +419,17 @@ export class ApplicationService {
    */
   async getApplicationsWithOverdueAssessments(): Promise<Application[]> {
     // Sub query to defined if a notification was already sent to the current assessment.
-    const notificationExistsQuery = this.notificationRepo
-      .createQueryBuilder("notification")
-      .select("1")
-      .innerJoin("notification.notificationMessage", "notificationMessage")
-      .where("notificationMessage.id = :notificationMessageId")
-      .andWhere(
-        "notification.metadata->>'assessmentId' = currentAssessment.id :: text",
-      )
-      .getQuery();
+    const {
+      query: notificationExistsQuery,
+      parameters: notificationExistsParameters,
+    } = this.getNotificationExistsSubQuery(
+      NotificationMessageType.StudentAssessmentReminder,
+      {
+        assessmentMetadata: { parentQueryAssessmentAlias: "currentAssessment" },
+      },
+    );
 
-    const applications = await this.applicationRepo
-      .createQueryBuilder("application")
-      .select([
-        "application.id",
-        "application.applicationNumber",
-        "currentAssessment.id",
-        "student.id",
-        "user.id",
-        "user.firstName",
-        "user.lastName",
-        "user.email",
-      ])
-      .innerJoin("application.currentAssessment", "currentAssessment")
-      .innerJoin("application.student", "student")
-      .innerJoin("student.user", "user")
-      .innerJoin("currentAssessment.offering", "offering")
-      .where("currentAssessment.noaApprovalStatus = :noaApprovalStatus", {
-        noaApprovalStatus: AssessmentStatus.required,
-      })
+    const applications = await this.getPendingAcceptAssessmentBaseQuery()
       .andWhere(
         "currentAssessment.noaApprovalStatusUpdatedOn < NOW() - (:overdueDays * INTERVAL '1 day')",
         {
@@ -454,13 +437,10 @@ export class ApplicationService {
         },
       )
       .andWhere("offering.studyEndDate >= CURRENT_DATE")
-      .andWhere("application.applicationStatus = :applicationStatus", {
-        applicationStatus: ApplicationStatus.Assessment,
-      })
-      .andWhere(`NOT EXISTS (${notificationExistsQuery})`, {
-        notificationMessageId:
-          NotificationMessageType.StudentAssessmentReminder,
-      })
+      .andWhere(
+        `NOT EXISTS (${notificationExistsQuery})`,
+        notificationExistsParameters,
+      )
       .getMany();
 
     const eligibleApplications: Application[] = [];
@@ -475,5 +455,72 @@ export class ApplicationService {
       }
     }, applications);
     return eligibleApplications;
+  }
+
+  /**
+   * Get existing notification sub query for a specific notification message type and options if provided.
+   * @param notificationMessageId notification message type id to check for existing notifications.
+   * @param options optional parameters to customize the sub query, such as assessment parent alias.
+   * - `parentQueryAssessmentAlias` student id for the student.
+   * @returns query and parameters to be used in the parent query builder.
+   */
+  private getNotificationExistsSubQuery(
+    notificationMessageId: NotificationMessageType,
+    options?: {
+      assessmentMetadata?: {
+        parentQueryAssessmentAlias: string;
+      };
+    },
+  ): QueryAndParamsForExecution {
+    const notificationExistsQuery = this.notificationRepo
+      .createQueryBuilder("notification")
+      .select("1")
+      .where("notification.notificationMessage.id = :notificationMessageId");
+    if (options?.assessmentMetadata?.parentQueryAssessmentAlias) {
+      notificationExistsQuery.andWhere(
+        `notification.metadata->>'assessmentId' = ${options.assessmentMetadata.parentQueryAssessmentAlias}.id :: text`,
+      );
+    }
+    return {
+      query: notificationExistsQuery.getQuery(),
+      parameters: { notificationMessageId },
+    };
+  }
+
+  /**
+   * Get pending accept assessment base query to retrieve applications with pending assessment.
+   * @returns base query builder for pending accept assessments.
+   */
+  private getPendingAcceptAssessmentBaseQuery(): SelectQueryBuilder<Application> {
+    return this.applicationRepo
+      .createQueryBuilder("application")
+      .select([
+        "application.id",
+        "application.applicationNumber",
+        "currentAssessment.id",
+        "student.id",
+        "user.id",
+        "user.firstName",
+        "user.lastName",
+        "user.email",
+        "program.id",
+        "program.name",
+        "location.id",
+        "institution.id",
+        "institution.operatingName",
+      ])
+      .innerJoin("application.currentAssessment", "currentAssessment")
+      .innerJoin("application.student", "student")
+      .innerJoin("student.user", "user")
+      .innerJoin("currentAssessment.offering", "offering")
+      .innerJoin("offering.educationProgram", "program")
+      .innerJoin("offering.institutionLocation", "location")
+      .innerJoin("location.institution", "institution")
+      .where("currentAssessment.noaApprovalStatus = :noaApprovalStatus", {
+        noaApprovalStatus: AssessmentStatus.required,
+      })
+      .andWhere("application.applicationStatus = :applicationStatus", {
+        applicationStatus: ApplicationStatus.Assessment,
+      });
   }
 }

--- a/sources/packages/backend/apps/queue-consumers/src/services/application/application.service.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/services/application/application.service.ts
@@ -446,6 +446,7 @@ export class ApplicationService {
       .getMany();
 
     const eligibleApplications: Application[] = [];
+    //TODO: This execution can be improved by using the newly created executeAcceptAssessmentValidations.
     await processInParallel(async (application) => {
       const validationResult =
         await this.eCertPreValidationService.executePreValidations(

--- a/sources/packages/backend/apps/queue-consumers/src/services/student-application-notification/student-application-notification-processor/index.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/services/student-application-notification/student-application-notification-processor/index.ts
@@ -4,3 +4,4 @@ export * from "./student-coe-required-near-end-date-notification";
 export * from "./ministry-cra-file-processing-issue-notification";
 export * from "./ministry-sin-file-processing-issue-notification";
 export * from "./student-assessment-reminder-notification";
+export * from "./program-suspension-blocking-assessment-notification";

--- a/sources/packages/backend/apps/queue-consumers/src/services/student-application-notification/student-application-notification-processor/program-suspension-blocking-assessment-notification.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/services/student-application-notification/student-application-notification-processor/program-suspension-blocking-assessment-notification.ts
@@ -1,0 +1,60 @@
+import { Injectable } from "@nestjs/common";
+import { ApplicationService } from "../../";
+import { ProcessSummary } from "@sims/utilities/logger";
+import {
+  NotificationActionsService,
+  StudentAcceptAssessmentReminderNotification,
+} from "@sims/services";
+import { STUDENT_ASSESSMENT_NOTIFICATION_OVERDUE_DAYS } from "@sims/services/constants/system-configurations-constants";
+
+/**
+ * Creates a notification for a blocked assessment acceptance due to a program suspension restriction for the ministry.
+ */
+@Injectable()
+export class ProgramSuspensionBlockingAssessmentNotification {
+  constructor(
+    private readonly applicationService: ApplicationService,
+    private readonly notificationActionsService: NotificationActionsService,
+  ) {}
+
+  /**
+   * Creates an assessment reminder notification.
+   * @param processSummary process summary for logging.
+   */
+  async createNotification(processSummary: ProcessSummary): Promise<void> {
+    const notificationLog = new ProcessSummary();
+    processSummary.children(notificationLog);
+
+    const applications =
+      await this.applicationService.getApplicationsWithOverdueAssessments();
+
+    if (!applications.length) {
+      notificationLog.info(
+        `No assessments awaiting acceptance ${STUDENT_ASSESSMENT_NOTIFICATION_OVERDUE_DAYS} days past due found to generate reminder notifications.`,
+      );
+      return;
+    }
+
+    const notifications =
+      applications.map<StudentAcceptAssessmentReminderNotification>(
+        (application) => ({
+          userId: application.student.user.id,
+          givenNames: application.student.user.firstName,
+          lastName: application.student.user.lastName,
+          toAddress: application.student.user.email,
+          applicationNumber: application.applicationNumber,
+          assessmentId: application.currentAssessment!.id,
+        }),
+      );
+
+    await this.notificationActionsService.saveStudentAssessmentReminderNotification(
+      notifications,
+    );
+
+    notificationLog.info(
+      `Overdue assessments awaiting acceptance that generated reminder notifications: ${applications
+        .map((application) => application.applicationNumber)
+        .join(", ")}`,
+    );
+  }
+}

--- a/sources/packages/backend/apps/queue-consumers/src/services/student-application-notification/student-application-notification-processor/program-suspension-blocking-assessment-notification.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/services/student-application-notification/student-application-notification-processor/program-suspension-blocking-assessment-notification.ts
@@ -29,7 +29,7 @@ export class ProgramSuspensionBlockingAssessmentNotification {
       await this.applicationService.getApplicationsBlockedByProgramSuspension();
     if (!applications.length) {
       notificationLog.info(
-        "No applications blocked by program suspension restriction are found to generate notifications.",
+        "No applications blocked by program suspension restriction without an existing notification are found.",
       );
       return;
     }

--- a/sources/packages/backend/apps/queue-consumers/src/services/student-application-notification/student-application-notification-processor/program-suspension-blocking-assessment-notification.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/services/student-application-notification/student-application-notification-processor/program-suspension-blocking-assessment-notification.ts
@@ -3,9 +3,10 @@ import { ApplicationService } from "../../";
 import { ProcessSummary } from "@sims/utilities/logger";
 import {
   NotificationActionsService,
-  StudentAcceptAssessmentReminderNotification,
+  ProgramSuspensionBlockingApplicationNotification,
 } from "@sims/services";
-import { STUDENT_ASSESSMENT_NOTIFICATION_OVERDUE_DAYS } from "@sims/services/constants/system-configurations-constants";
+import { NOTIFICATION_MISSING_EMAIL_CONTACTS } from "@sims/services/constants";
+import { CustomNamedError } from "@sims/utilities";
 
 /**
  * Creates a notification for a blocked assessment acceptance due to a program suspension restriction for the ministry.
@@ -24,36 +25,52 @@ export class ProgramSuspensionBlockingAssessmentNotification {
   async createNotification(processSummary: ProcessSummary): Promise<void> {
     const notificationLog = new ProcessSummary();
     processSummary.children(notificationLog);
-
     const applications =
-      await this.applicationService.getApplicationsWithOverdueAssessments();
-
+      await this.applicationService.getApplicationsBlockedByProgramSuspension();
     if (!applications.length) {
       notificationLog.info(
-        `No assessments awaiting acceptance ${STUDENT_ASSESSMENT_NOTIFICATION_OVERDUE_DAYS} days past due found to generate reminder notifications.`,
+        "No applications blocked by program suspension restriction are found to generate notifications.",
       );
       return;
     }
-
     const notifications =
-      applications.map<StudentAcceptAssessmentReminderNotification>(
+      applications.map<ProgramSuspensionBlockingApplicationNotification>(
         (application) => ({
-          userId: application.student.user.id,
           givenNames: application.student.user.firstName,
           lastName: application.student.user.lastName,
-          toAddress: application.student.user.email,
+          studentEmail: application.student.user.email,
+          birthDate: application.student.birthDate,
           applicationNumber: application.applicationNumber,
-          assessmentId: application.currentAssessment!.id,
+          institutionOperatingName:
+            application.currentAssessment.offering.institutionLocation
+              .institution.operatingName,
+          programName:
+            application.currentAssessment.offering.educationProgram.name,
+          metadata: { assessmentId: application.currentAssessment.id },
         }),
       );
-
-    await this.notificationActionsService.saveStudentAssessmentReminderNotification(
-      notifications,
-    );
+    try {
+      await this.notificationActionsService.saveProgramSuspensionBlockingApplicationNotification(
+        notifications,
+      );
+    } catch (error: unknown) {
+      // Log process summary warning to create alerts when email contacts are missing for the notification
+      // without failing the entire process.
+      if (
+        error instanceof CustomNamedError &&
+        error.name === NOTIFICATION_MISSING_EMAIL_CONTACTS
+      ) {
+        notificationLog.warn(
+          `Program suspension blocking application notification cannot be created: ${error.message}`,
+        );
+        return;
+      }
+      throw error;
+    }
 
     notificationLog.info(
-      `Overdue assessments awaiting acceptance that generated reminder notifications: ${applications
-        .map((application) => application.applicationNumber)
+      `Program suspension blocking application notifications created for the assessments: ${applications
+        .map((application) => application.currentAssessment.id)
         .join(", ")}`,
     );
   }

--- a/sources/packages/backend/apps/queue-consumers/src/services/student-application-notification/student-application-notification-processor/program-suspension-blocking-assessment-notification.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/services/student-application-notification/student-application-notification-processor/program-suspension-blocking-assessment-notification.ts
@@ -19,7 +19,7 @@ export class ProgramSuspensionBlockingAssessmentNotification {
   ) {}
 
   /**
-   * Creates an assessment reminder notification.
+   * Creates a program suspension blocking assessment notification for the ministry.
    * @param processSummary process summary for logging.
    */
   async createNotification(processSummary: ProcessSummary): Promise<void> {
@@ -29,7 +29,7 @@ export class ProgramSuspensionBlockingAssessmentNotification {
       await this.applicationService.getApplicationsBlockedByProgramSuspension();
     if (!applications.length) {
       notificationLog.info(
-        "No applications blocked by program suspension restriction without an existing notification are found.",
+        "No applications blocked by the program suspension restriction without an existing notification were found.",
       );
       return;
     }

--- a/sources/packages/backend/apps/queue-consumers/src/services/student-application-notification/student-application-notification.service.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/services/student-application-notification/student-application-notification.service.ts
@@ -7,6 +7,7 @@ import {
   MinistryCRAFileProcessingIssueNotification,
   MinistrySINFileProcessingIssueNotification,
   StudentAssessmentReminderNotification,
+  ProgramSuspensionBlockingAssessmentNotification,
 } from "./student-application-notification-processor";
 
 @Injectable()
@@ -18,6 +19,7 @@ export class StudentApplicationNotificationService {
     private readonly ministryCRAFileProcessingIssueNotification: MinistryCRAFileProcessingIssueNotification,
     private readonly ministrySINFileProcessingIssueNotification: MinistrySINFileProcessingIssueNotification,
     private readonly studentAssessmentReminderNotification: StudentAssessmentReminderNotification,
+    private readonly programSuspensionBlockingAssessmentNotification: ProgramSuspensionBlockingAssessmentNotification,
   ) {}
 
   /**
@@ -34,6 +36,7 @@ export class StudentApplicationNotificationService {
       this.ministryCRAFileProcessingIssueNotification,
       this.ministrySINFileProcessingIssueNotification,
       this.studentAssessmentReminderNotification,
+      this.programSuspensionBlockingAssessmentNotification,
     ].map((notification) => notification.createNotification(processSummary));
     await Promise.allSettled(notifications);
   }

--- a/sources/packages/backend/libs/integrations/src/esdc-integration/e-cert-integration/e-cert-integration.module.ts
+++ b/sources/packages/backend/libs/integrations/src/esdc-integration/e-cert-integration/e-cert-integration.module.ts
@@ -52,6 +52,7 @@ import { FullTimeECertFileHandler } from "./full-time-e-cert-file-handler";
 import { PartTimeECertFileHandler } from "./part-time-e-cert-file-handler";
 import {
   MinistryBlockedDisbursementNotification,
+  ProgramSuspensionBlockingDisbursementNotification,
   StudentBlockedDisbursementNotification,
 } from "@sims/integrations/services/disbursement-schedule/e-cert-notification";
 
@@ -102,6 +103,7 @@ import {
     ECertPreValidationService,
     MinistryBlockedDisbursementNotification,
     StudentBlockedDisbursementNotification,
+    ProgramSuspensionBlockingDisbursementNotification,
   ],
   exports: [
     FullTimeECertFileHandler,

--- a/sources/packages/backend/libs/integrations/src/services/disbursement-schedule/disbursement-schedule.models.ts
+++ b/sources/packages/backend/libs/integrations/src/services/disbursement-schedule/disbursement-schedule.models.ts
@@ -313,6 +313,10 @@ export class EligibleECertDisbursement {
    * @param disabilityDetails students Disability status both from application submitted
    * and the student profile disability status verification.
    * @param modifiedIndependentDetails student's "estranged from parents" information.
+   * @param applicationEligibleDisbursementIndex The index is used to identify if the disbursement is either first or second eligible disbursement
+   * for the application.
+   ** Note: An eligible disbursement means a disbursement that is pending and satisfies all the preliminary conditions
+   ** for e-Cert generation.
    * @param restrictions all active student restrictions actions. These actions can
    * impact the e-Cert calculations.
    * This is a shared array reference between all the disbursements of a single student.
@@ -336,6 +340,7 @@ export class EligibleECertDisbursement {
     readonly maxLifetimeBCLoanAmount: number,
     readonly disabilityDetails: DisabilityDetails,
     readonly modifiedIndependentDetails: ModifiedIndependentDetails,
+    readonly applicationEligibleDisbursementIndex: 1 | 2,
     private readonly restrictions: StudentActiveRestriction[],
     private readonly restrictionBypass: ApplicationActiveRestrictionBypass[],
     private readonly institutionRestrictions: InstitutionActiveRestriction[],

--- a/sources/packages/backend/libs/integrations/src/services/disbursement-schedule/disbursement-schedule.models.ts
+++ b/sources/packages/backend/libs/integrations/src/services/disbursement-schedule/disbursement-schedule.models.ts
@@ -294,6 +294,7 @@ export type EligibleECertOffering = Pick<
 export class EligibleECertDisbursement {
   private readonly studentRestrictionsBypassedIds: number[];
   private readonly institutionRestrictionsBypassedIds: number[];
+  private failedValidationsInternal: ECertFailedValidationResult[];
   /**
    * Creates a new instance of a eligible e-Cert to be calculated.
    * @param studentId student id.
@@ -397,6 +398,20 @@ export class EligibleECertDisbursement {
    */
   get activeRestrictionBypasses(): ReadonlyArray<ApplicationActiveRestrictionBypass> {
     return this.restrictionBypass;
+  }
+
+  /**
+   * Failed validation results from e-Cert pre-validation.
+   */
+  set failedValidations(failedValidations: ECertFailedValidationResult[]) {
+    this.failedValidationsInternal = failedValidations;
+  }
+
+  /**
+   * Failed validation results from e-Cert pre-validation.
+   */
+  get failedValidations(): ReadonlyArray<ECertFailedValidationResult> {
+    return this.failedValidationsInternal ?? [];
   }
 
   /**

--- a/sources/packages/backend/libs/integrations/src/services/disbursement-schedule/e-cert-calculation/e-cert-pre-validation-service-models.ts
+++ b/sources/packages/backend/libs/integrations/src/services/disbursement-schedule/e-cert-calculation/e-cert-pre-validation-service-models.ts
@@ -6,7 +6,7 @@ import {
 import { ProcessSummary } from "@sims/utilities/logger";
 import { EntityManager } from "typeorm";
 
-const ACCEPT_ASSESSMENT_BLOCKING_VALIDATIONS = [
+export const ACCEPT_ASSESSMENT_BLOCKING_VALIDATIONS = [
   ECertFailedValidation.DisabilityStatusNotConfirmed,
   ECertFailedValidation.MSFAACanceled,
   ECertFailedValidation.MSFAANotSigned,
@@ -53,6 +53,10 @@ export class ECertPreValidatorResult {
   }
 }
 
+export interface ApplicationECertPreValidatorResult {
+  applicationId: number;
+  validationResult: ECertPreValidatorResult;
+}
 /**
  * Allow validations to be executed before the e-Cert disbursement time.
  */
@@ -68,6 +72,7 @@ export interface ECertPreValidator {
    * used by {@link ECertProcessStep}.
    * @param log keep it compliant with the required parameters
    * used by {@link ECertProcessStep}.
+   * @param targetValidations list of validations that should only be executed. If not provided, all validations must be executed.
    * @returns list of failed validations, otherwise an empty array if
    * no blocking conditions were found.
    */
@@ -75,5 +80,6 @@ export interface ECertPreValidator {
     eCertDisbursement: EligibleECertDisbursement,
     entityManager: EntityManager,
     log: ProcessSummary,
+    targetValidations?: ECertFailedValidation[],
   ): Promise<ECertPreValidatorResult>;
 }

--- a/sources/packages/backend/libs/integrations/src/services/disbursement-schedule/e-cert-calculation/e-cert-pre-validation-service-models.ts
+++ b/sources/packages/backend/libs/integrations/src/services/disbursement-schedule/e-cert-calculation/e-cert-pre-validation-service-models.ts
@@ -67,6 +67,8 @@ export interface ECertPreValidator {
    * The intention is to know ahead of time of the existence
    * of such conditions in a way that an action can be taken
    * to allow the money to be disbursed.
+   * TODO: The method signature is asynchronous only due to CSLP validation in part-time that calls database to get student loan balance.
+   * Once the student loan balance is loaded to eligible disbursement, this method can be synchronous.
    * @param eCertDisbursement eligible disbursement to be validated.
    * @param entityManager keep it compliant with the required parameters
    * used by {@link ECertProcessStep}.

--- a/sources/packages/backend/libs/integrations/src/services/disbursement-schedule/e-cert-calculation/e-cert-pre-validation-service.ts
+++ b/sources/packages/backend/libs/integrations/src/services/disbursement-schedule/e-cert-calculation/e-cert-pre-validation-service.ts
@@ -2,6 +2,8 @@ import { Injectable } from "@nestjs/common";
 import { ECertGenerationService } from "@sims/integrations/services";
 import { EligibleECertDisbursement } from "@sims/integrations/services/disbursement-schedule/disbursement-schedule.models";
 import {
+  ACCEPT_ASSESSMENT_BLOCKING_VALIDATIONS,
+  ApplicationECertPreValidatorResult,
   ECertPreValidator,
   ECertPreValidatorResult,
 } from "@sims/integrations/services/disbursement-schedule/e-cert-calculation";
@@ -60,6 +62,48 @@ export class ECertPreValidationService {
     );
     this.logger.logProcessSummary(log);
     return validations;
+  }
+
+  /**
+   * Execute the validations that would block a student from accepting an assessment.
+   * @param applicationIds applications to have its first eligible disbursements validated.
+   * @returns accept assessment validation result.
+   */
+  async executeAcceptAssessmentValidations(
+    applicationIds: number[],
+  ): Promise<ApplicationECertPreValidatorResult[]> {
+    const eligibleDisbursements =
+      await this.eCertGenerationService.getEligibleDisbursements({
+        applicationIds,
+        allowNonCompleted: true,
+      });
+
+    if (!eligibleDisbursements.length) {
+      return [];
+    }
+    // Get only the first eligible disbursement for each application to validate the assessment acceptance.
+    const applicationFirstEligibleDisbursements = eligibleDisbursements.filter(
+      (disbursement) => disbursement.applicationEligibleDisbursementIndex === 1,
+    );
+    const log = new ProcessSummary();
+    const applicationECertPreValidatorResults: ApplicationECertPreValidatorResult[] =
+      [];
+    for (const firstEligibleDisbursement of applicationFirstEligibleDisbursements) {
+      const eCertPreValidator = this.getECertPreValidator(
+        firstEligibleDisbursement,
+      );
+      const validationResult = await eCertPreValidator.executePreValidations(
+        firstEligibleDisbursement,
+        this.dataSource.manager,
+        log,
+        ACCEPT_ASSESSMENT_BLOCKING_VALIDATIONS,
+      );
+      applicationECertPreValidatorResults.push({
+        applicationId: firstEligibleDisbursement.applicationId,
+        validationResult,
+      });
+    }
+    return applicationECertPreValidatorResults;
   }
 
   /**

--- a/sources/packages/backend/libs/integrations/src/services/disbursement-schedule/e-cert-calculation/e-cert-pre-validation-service.ts
+++ b/sources/packages/backend/libs/integrations/src/services/disbursement-schedule/e-cert-calculation/e-cert-pre-validation-service.ts
@@ -43,7 +43,7 @@ export class ECertPreValidationService {
   ): Promise<ECertPreValidatorResult> {
     const [firstEligibleDisbursement] =
       await this.eCertGenerationService.getEligibleDisbursements({
-        applicationId,
+        applicationIds: [applicationId],
         allowNonCompleted: allowNonCompleted ?? false,
       });
     if (!firstEligibleDisbursement) {

--- a/sources/packages/backend/libs/integrations/src/services/disbursement-schedule/e-cert-calculation/e-cert-pre-validation-service.ts
+++ b/sources/packages/backend/libs/integrations/src/services/disbursement-schedule/e-cert-calculation/e-cert-pre-validation-service.ts
@@ -55,7 +55,7 @@ export class ECertPreValidationService {
       firstEligibleDisbursement,
     );
     const log = new ProcessSummary();
-    const validations = eCertPreValidator.executePreValidations(
+    const validations = await eCertPreValidator.executePreValidations(
       firstEligibleDisbursement,
       this.dataSource.manager,
       log,

--- a/sources/packages/backend/libs/integrations/src/services/disbursement-schedule/e-cert-generation.service.ts
+++ b/sources/packages/backend/libs/integrations/src/services/disbursement-schedule/e-cert-generation.service.ts
@@ -255,19 +255,11 @@ export class ECertGenerationService {
     > = {};
     // Convert the application records to be returned as disbursements to allow
     // easier processing along the calculation steps.
-    const eligibleDisbursements =
-      eligibleApplications.flatMap<EligibleECertDisbursement>((application) => {
-        return application.currentAssessment.disbursementSchedules.map(
-          (disbursement) =>
-            this.buildEligibleECertDisbursement(
-              application,
-              disbursement,
-              groupedStudentRestrictions,
-              groupedInstitutionRestrictions,
-            ),
-        );
-      });
-    return eligibleDisbursements;
+    return this.buildEligibleECertDisbursements(
+      eligibleApplications,
+      groupedStudentRestrictions,
+      groupedInstitutionRestrictions,
+    );
   }
 
   /**
@@ -448,61 +440,71 @@ export class ECertGenerationService {
   }
 
   /**
-   * Builds the eligible disbursement to be used in the e-Cert generation/validation.
-   * @param application application to which the disbursement belongs.
-   * @param eligibleDisbursement disbursement that is eligible to be part of the e-Cert.
+   * Builds eligible disbursements from applications to be used in the e-Cert generation/validation.
+   * @param eligibleApplications eligible applications to be considered for e-Cert generation.
    * @param groupedStudentRestrictions grouped student restrictions to be used in the e-Cert calculations.
    * @param groupedInstitutionRestrictions grouped institution restrictions to be used in the e-Cert calculations.
    * @returns eligible disbursement to be used in the e-Cert generation/validation.
    */
-  private buildEligibleECertDisbursement(
-    application: Application,
-    eligibleDisbursement: DisbursementSchedule,
+  private buildEligibleECertDisbursements(
+    eligibleApplications: Application[],
     groupedStudentRestrictions: GroupedStudentActiveRestrictions,
     groupedInstitutionRestrictions: Record<
       number,
       InstitutionActiveRestriction[]
     >,
-  ): EligibleECertDisbursement {
-    const workflowData = application.currentAssessment.workflowData;
-    const student = application.student;
-    const institutionId =
-      application.currentAssessment.offering.institutionLocation.institution.id;
-    if (!groupedInstitutionRestrictions[institutionId]) {
-      const institutionRestrictions =
-        application.currentAssessment.offering.institutionLocation.institution
-          .restrictions;
-      groupedInstitutionRestrictions[institutionId] =
-        mapInstitutionActiveRestrictions(institutionRestrictions);
-    }
-    const disabilityDetails: DisabilityDetails = {
-      calculatedPDPPDStatus: workflowData.calculatedData.pdppdStatus,
-      studentProfileDisabilityStatus: student.disabilityStatus,
-    };
-    const modifiedIndependentDetails: ModifiedIndependentDetails = {
-      estrangedFromParents: workflowData.studentData.estrangedFromParents,
-      studentProfileModifiedIndependent: student.modifiedIndependentStatus,
-    };
-    const restrictionBypasses =
-      application.restrictionBypasses.map<ApplicationActiveRestrictionBypass>(
-        (bypass) => new ApplicationActiveRestrictionBypass(bypass),
-      );
-    return new EligibleECertDisbursement(
-      student.id,
-      !!student.sinValidation.isValidSIN,
-      institutionId,
-      application.currentAssessment.id,
-      application.id,
-      application.applicationNumber,
-      eligibleDisbursement,
-      application.currentAssessment.offering,
-      application.programYear.maxLifetimeBCLoanAmount,
-      disabilityDetails,
-      modifiedIndependentDetails,
-      groupedStudentRestrictions[student.id],
-      restrictionBypasses,
-      groupedInstitutionRestrictions[institutionId],
-      application.studentScholasticStandings,
+  ): EligibleECertDisbursement[] {
+    return eligibleApplications.flatMap<EligibleECertDisbursement>(
+      (application) => {
+        const workflowData = application.currentAssessment.workflowData;
+        return application.currentAssessment.disbursementSchedules.map(
+          (disbursement, index) => {
+            const student = application.student;
+            const institutionId =
+              application.currentAssessment.offering.institutionLocation
+                .institution.id;
+            if (!groupedInstitutionRestrictions[institutionId]) {
+              const institutionRestrictions =
+                application.currentAssessment.offering.institutionLocation
+                  .institution.restrictions;
+              groupedInstitutionRestrictions[institutionId] =
+                mapInstitutionActiveRestrictions(institutionRestrictions);
+            }
+            const disabilityDetails: DisabilityDetails = {
+              calculatedPDPPDStatus: workflowData.calculatedData.pdppdStatus,
+              studentProfileDisabilityStatus: student.disabilityStatus,
+            };
+            const modifiedIndependentDetails: ModifiedIndependentDetails = {
+              estrangedFromParents:
+                workflowData.studentData.estrangedFromParents,
+              studentProfileModifiedIndependent:
+                student.modifiedIndependentStatus,
+            };
+            const restrictionBypasses =
+              application.restrictionBypasses.map<ApplicationActiveRestrictionBypass>(
+                (bypass) => new ApplicationActiveRestrictionBypass(bypass),
+              );
+            return new EligibleECertDisbursement(
+              student.id,
+              !!student.sinValidation.isValidSIN,
+              institutionId,
+              application.currentAssessment.id,
+              application.id,
+              application.applicationNumber,
+              disbursement,
+              application.currentAssessment.offering,
+              application.programYear.maxLifetimeBCLoanAmount,
+              disabilityDetails,
+              modifiedIndependentDetails,
+              (index + 1) as 1 | 2,
+              groupedStudentRestrictions[student.id],
+              restrictionBypasses,
+              groupedInstitutionRestrictions[institutionId],
+              application.studentScholasticStandings,
+            );
+          },
+        );
+      },
     );
   }
 }

--- a/sources/packages/backend/libs/integrations/src/services/disbursement-schedule/e-cert-generation.service.ts
+++ b/sources/packages/backend/libs/integrations/src/services/disbursement-schedule/e-cert-generation.service.ts
@@ -50,7 +50,7 @@ export class ECertGenerationService {
    * execute all calculations steps.
    * @param options query options.
    * - `offeringIntensity`: offering intensity to retrieve the disbursements.
-   * - `applicationId`: restricts the query to a specific application.
+   * - `applicationIds`: restricts the query to specific applications.
    * - `checkDisbursementMinDate`: check only for disbursements that are close
    * to the date to be disbursed and can already be part of an e-Cert.
    * - `allowNonCompleted`: only select completed applications or allow any status.
@@ -58,7 +58,7 @@ export class ECertGenerationService {
    */
   async getEligibleDisbursements(options: {
     offeringIntensity?: OfferingIntensity;
-    applicationId?: number;
+    applicationIds?: number[];
     checkDisbursementMinDate?: boolean;
     allowNonCompleted?: boolean;
   }): Promise<EligibleECertDisbursement[]> {
@@ -213,10 +213,13 @@ export class ECertGenerationService {
         },
       );
     }
-    if (options.applicationId) {
-      eligibleApplicationsQuery.andWhere("application.id = :applicationId", {
-        applicationId: options.applicationId,
-      });
+    if (options.applicationIds?.length) {
+      eligibleApplicationsQuery.andWhere(
+        "application.id IN (:...applicationIds)",
+        {
+          applicationIds: options.applicationIds,
+        },
+      );
     }
     if (options.offeringIntensity) {
       eligibleApplicationsQuery.andWhere(
@@ -254,52 +257,14 @@ export class ECertGenerationService {
     // easier processing along the calculation steps.
     const eligibleDisbursements =
       eligibleApplications.flatMap<EligibleECertDisbursement>((application) => {
-        const workflowData = application.currentAssessment.workflowData;
         return application.currentAssessment.disbursementSchedules.map(
-          (disbursement) => {
-            const student = application.student;
-            const institutionId =
-              application.currentAssessment.offering.institutionLocation
-                .institution.id;
-            if (!groupedInstitutionRestrictions[institutionId]) {
-              const institutionRestrictions =
-                application.currentAssessment.offering.institutionLocation
-                  .institution.restrictions;
-              groupedInstitutionRestrictions[institutionId] =
-                mapInstitutionActiveRestrictions(institutionRestrictions);
-            }
-            const disabilityDetails: DisabilityDetails = {
-              calculatedPDPPDStatus: workflowData.calculatedData.pdppdStatus,
-              studentProfileDisabilityStatus: student.disabilityStatus,
-            };
-            const modifiedIndependentDetails: ModifiedIndependentDetails = {
-              estrangedFromParents:
-                workflowData.studentData.estrangedFromParents,
-              studentProfileModifiedIndependent:
-                student.modifiedIndependentStatus,
-            };
-            const restrictionBypasses =
-              application.restrictionBypasses.map<ApplicationActiveRestrictionBypass>(
-                (bypass) => new ApplicationActiveRestrictionBypass(bypass),
-              );
-            return new EligibleECertDisbursement(
-              student.id,
-              !!student.sinValidation.isValidSIN,
-              institutionId,
-              application.currentAssessment.id,
-              application.id,
-              application.applicationNumber,
+          (disbursement) =>
+            this.buildEligibleECertDisbursement(
+              application,
               disbursement,
-              application.currentAssessment.offering,
-              application.programYear.maxLifetimeBCLoanAmount,
-              disabilityDetails,
-              modifiedIndependentDetails,
-              groupedStudentRestrictions[student.id],
-              restrictionBypasses,
-              groupedInstitutionRestrictions[institutionId],
-              application.studentScholasticStandings,
-            );
-          },
+              groupedStudentRestrictions,
+              groupedInstitutionRestrictions,
+            ),
         );
       });
     return eligibleDisbursements;
@@ -480,5 +445,64 @@ export class ECertGenerationService {
       .where("studentAssessment.id = :assessmentId", { assessmentId })
       .getRawOne();
     return queryResult?.lifetimeMaximumCSLP ?? 0;
+  }
+
+  /**
+   * Builds the eligible disbursement to be used in the e-Cert generation/validation.
+   * @param application application to which the disbursement belongs.
+   * @param eligibleDisbursement disbursement that is eligible to be part of the e-Cert.
+   * @param groupedStudentRestrictions grouped student restrictions to be used in the e-Cert calculations.
+   * @param groupedInstitutionRestrictions grouped institution restrictions to be used in the e-Cert calculations.
+   * @returns eligible disbursement to be used in the e-Cert generation/validation.
+   */
+  private buildEligibleECertDisbursement(
+    application: Application,
+    eligibleDisbursement: DisbursementSchedule,
+    groupedStudentRestrictions: GroupedStudentActiveRestrictions,
+    groupedInstitutionRestrictions: Record<
+      number,
+      InstitutionActiveRestriction[]
+    >,
+  ): EligibleECertDisbursement {
+    const workflowData = application.currentAssessment.workflowData;
+    const student = application.student;
+    const institutionId =
+      application.currentAssessment.offering.institutionLocation.institution.id;
+    if (!groupedInstitutionRestrictions[institutionId]) {
+      const institutionRestrictions =
+        application.currentAssessment.offering.institutionLocation.institution
+          .restrictions;
+      groupedInstitutionRestrictions[institutionId] =
+        mapInstitutionActiveRestrictions(institutionRestrictions);
+    }
+    const disabilityDetails: DisabilityDetails = {
+      calculatedPDPPDStatus: workflowData.calculatedData.pdppdStatus,
+      studentProfileDisabilityStatus: student.disabilityStatus,
+    };
+    const modifiedIndependentDetails: ModifiedIndependentDetails = {
+      estrangedFromParents: workflowData.studentData.estrangedFromParents,
+      studentProfileModifiedIndependent: student.modifiedIndependentStatus,
+    };
+    const restrictionBypasses =
+      application.restrictionBypasses.map<ApplicationActiveRestrictionBypass>(
+        (bypass) => new ApplicationActiveRestrictionBypass(bypass),
+      );
+    return new EligibleECertDisbursement(
+      student.id,
+      !!student.sinValidation.isValidSIN,
+      institutionId,
+      application.currentAssessment.id,
+      application.id,
+      application.applicationNumber,
+      eligibleDisbursement,
+      application.currentAssessment.offering,
+      application.programYear.maxLifetimeBCLoanAmount,
+      disabilityDetails,
+      modifiedIndependentDetails,
+      groupedStudentRestrictions[student.id],
+      restrictionBypasses,
+      groupedInstitutionRestrictions[institutionId],
+      application.studentScholasticStandings,
+    );
   }
 }

--- a/sources/packages/backend/libs/integrations/src/services/disbursement-schedule/e-cert-notification/blocked-disbursement/ministry-blocked-disbursement-notification.ts
+++ b/sources/packages/backend/libs/integrations/src/services/disbursement-schedule/e-cert-notification/blocked-disbursement/ministry-blocked-disbursement-notification.ts
@@ -3,7 +3,7 @@ import {
   DisbursementBlockedNotification,
   NotificationActionsService,
 } from "@sims/services";
-import { Notification, NotificationMessageType, Student } from "@sims/sims-db";
+import { NotificationMessageType, Student } from "@sims/sims-db";
 import { EntityManager } from "typeorm";
 import { ECertNotification } from "../e-cert-notification";
 import { EligibleECertDisbursement } from "../../disbursement-schedule.models";
@@ -29,18 +29,11 @@ export class MinistryBlockedDisbursementNotification extends ECertNotification {
     eCertDisbursement: EligibleECertDisbursement,
     entityManager: EntityManager,
   ): Promise<boolean> {
-    const hasNotification = await entityManager
-      .getRepository(Notification)
-      .exists({
-        where: {
-          notificationMessage: {
-            id: NotificationMessageType.MinistryNotificationDisbursementBlocked,
-          },
-          metadata: {
-            disbursementId: eCertDisbursement.disbursement.id,
-          },
-        },
-      });
+    const hasNotification = await this.getExistingDisbursementNotification(
+      NotificationMessageType.MinistryNotificationDisbursementBlocked,
+      eCertDisbursement,
+      entityManager,
+    );
     return !hasNotification;
   }
 

--- a/sources/packages/backend/libs/integrations/src/services/disbursement-schedule/e-cert-notification/blocked-disbursement/ministry-blocked-disbursement-notification.ts
+++ b/sources/packages/backend/libs/integrations/src/services/disbursement-schedule/e-cert-notification/blocked-disbursement/ministry-blocked-disbursement-notification.ts
@@ -16,7 +16,10 @@ export class MinistryBlockedDisbursementNotification extends ECertNotification {
   constructor(
     private readonly notificationActionsService: NotificationActionsService,
   ) {
-    super("Ministry Blocked Disbursement");
+    super(
+      "Ministry Blocked Disbursement",
+      NotificationMessageType.MinistryNotificationDisbursementBlocked,
+    );
   }
 
   /**
@@ -30,7 +33,6 @@ export class MinistryBlockedDisbursementNotification extends ECertNotification {
     entityManager: EntityManager,
   ): Promise<boolean> {
     const hasNotification = await this.getExistingDisbursementNotification(
-      NotificationMessageType.MinistryNotificationDisbursementBlocked,
       eCertDisbursement,
       entityManager,
     );

--- a/sources/packages/backend/libs/integrations/src/services/disbursement-schedule/e-cert-notification/blocked-disbursement/program-suspension-blocking-disbursement-notification.ts
+++ b/sources/packages/backend/libs/integrations/src/services/disbursement-schedule/e-cert-notification/blocked-disbursement/program-suspension-blocking-disbursement-notification.ts
@@ -7,7 +7,10 @@ import {
 import { Application, NotificationMessageType } from "@sims/sims-db";
 import { EntityManager } from "typeorm";
 import { ECertNotification } from "../e-cert-notification";
-import { EligibleECertDisbursement } from "../../disbursement-schedule.models";
+import {
+  ECertFailedValidation,
+  EligibleECertDisbursement,
+} from "../../disbursement-schedule.models";
 
 /**
  * Creates a notification for a blocked disbursement due to a program suspension restriction for the ministry.
@@ -33,10 +36,16 @@ export class ProgramSuspensionBlockingDisbursementNotification extends ECertNoti
     eCertDisbursement: EligibleECertDisbursement,
     entityManager: EntityManager,
   ): Promise<boolean> {
-    const hasEffectiveSuspensionRestriction = eCertDisbursement
-      .getEffectiveRestrictions()
-      .some((restriction) => restriction.code === RestrictionCode.SUS);
-    if (!hasEffectiveSuspensionRestriction) {
+    const hasBlockingSuspensionRestriction =
+      eCertDisbursement.failedValidations.some(
+        (failedValidation) =>
+          failedValidation.resultType ===
+            ECertFailedValidation.HasStopDisbursementInstitutionRestriction &&
+          failedValidation.additionalInfo.restrictionCodes.includes(
+            RestrictionCode.SUS,
+          ),
+      );
+    if (!hasBlockingSuspensionRestriction) {
       return false;
     }
     // Check if the notification already exists for the given disbursement
@@ -57,43 +66,45 @@ export class ProgramSuspensionBlockingDisbursementNotification extends ECertNoti
     eCertDisbursement: EligibleECertDisbursement,
     entityManager: EntityManager,
   ): Promise<void> {
-    const application = await entityManager.getRepository(Application).findOne({
-      select: {
-        id: true,
-        applicationNumber: true,
-        student: {
+    const application = await entityManager
+      .getRepository(Application)
+      .findOneOrFail({
+        select: {
           id: true,
-          birthDate: true,
-          user: {
+          applicationNumber: true,
+          student: {
             id: true,
-            firstName: true,
-            lastName: true,
-            email: true,
-          },
-        },
-        currentAssessment: {
-          id: true,
-          offering: {
-            id: true,
-            educationProgram: { id: true, name: true },
-            institutionLocation: {
+            birthDate: true,
+            user: {
               id: true,
-              institution: { id: true, operatingName: true },
+              firstName: true,
+              lastName: true,
+              email: true,
+            },
+          },
+          currentAssessment: {
+            id: true,
+            offering: {
+              id: true,
+              educationProgram: { id: true, name: true },
+              institutionLocation: {
+                id: true,
+                institution: { id: true, operatingName: true },
+              },
             },
           },
         },
-      },
-      relations: {
-        currentAssessment: {
-          offering: {
-            educationProgram: true,
-            institutionLocation: { institution: true },
+        relations: {
+          currentAssessment: {
+            offering: {
+              educationProgram: true,
+              institutionLocation: { institution: true },
+            },
           },
+          student: { user: true },
         },
-        student: { user: true },
-      },
-      where: { id: eCertDisbursement.applicationId },
-    });
+        where: { id: eCertDisbursement.applicationId },
+      });
     const notification: ProgramSuspensionBlockingApplicationNotification = {
       givenNames: application.student.user.firstName,
       lastName: application.student.user.lastName,

--- a/sources/packages/backend/libs/integrations/src/services/disbursement-schedule/e-cert-notification/blocked-disbursement/program-suspension-blocking-disbursement-notification.ts
+++ b/sources/packages/backend/libs/integrations/src/services/disbursement-schedule/e-cert-notification/blocked-disbursement/program-suspension-blocking-disbursement-notification.ts
@@ -107,7 +107,7 @@ export class ProgramSuspensionBlockingDisbursementNotification extends ECertNoti
       metadata: { disbursementId: eCertDisbursement.disbursement.id },
     };
     await this.notificationActionsService.saveProgramSuspensionBlockingApplicationNotification(
-      notification,
+      [notification],
       entityManager,
     );
   }

--- a/sources/packages/backend/libs/integrations/src/services/disbursement-schedule/e-cert-notification/blocked-disbursement/program-suspension-blocking-disbursement-notification.ts
+++ b/sources/packages/backend/libs/integrations/src/services/disbursement-schedule/e-cert-notification/blocked-disbursement/program-suspension-blocking-disbursement-notification.ts
@@ -1,0 +1,112 @@
+import { Injectable } from "@nestjs/common";
+import {
+  NotificationActionsService,
+  ProgramSuspensionBlockingApplicationNotification,
+  RestrictionCode,
+} from "@sims/services";
+import { Application, NotificationMessageType } from "@sims/sims-db";
+import { EntityManager } from "typeorm";
+import { ECertNotification } from "../e-cert-notification";
+import { EligibleECertDisbursement } from "../../disbursement-schedule.models";
+
+/**
+ * Creates a notification for a blocked disbursement due to a program suspension restriction for the ministry.
+ */
+@Injectable()
+export class ProgramSuspensionBlockingDisbursementNotification extends ECertNotification {
+  constructor(
+    private readonly notificationActionsService: NotificationActionsService,
+  ) {
+    super("Program suspension blocking application");
+  }
+
+  /**
+   * Determines whether a notification should be created or not.
+   * @param eCertDisbursement eligible disbursement to be potentially added to an e-Cert.
+   * @param entityManager entity manager to execute in transaction.
+   * @returns true if a notification should be created, false otherwise.
+   */
+  protected async shouldCreateNotification(
+    eCertDisbursement: EligibleECertDisbursement,
+    entityManager: EntityManager,
+  ): Promise<boolean> {
+    const hasEffectiveSuspensionRestriction = eCertDisbursement
+      .getEffectiveRestrictions()
+      .some((restriction) => restriction.code === RestrictionCode.SUS);
+    if (!hasEffectiveSuspensionRestriction) {
+      return false;
+    }
+    // Check if the notification already exists for the given disbursement
+    // when there is an effective program suspension restriction.
+    const hasNotification = await this.getExistingDisbursementNotification(
+      NotificationMessageType.MinistryNotificationDisbursementBlocked,
+      eCertDisbursement,
+      entityManager,
+    );
+    return !hasNotification;
+  }
+
+  /**
+   * Creates a notification for the given e-Cert disbursement.
+   * @param eCertDisbursement eligible disbursement to be potentially added to an e-Cert.
+   * @param entityManager entity manager to execute in transaction.
+   */
+  protected async createNotification(
+    eCertDisbursement: EligibleECertDisbursement,
+    entityManager: EntityManager,
+  ): Promise<void> {
+    const application = await entityManager.getRepository(Application).findOne({
+      select: {
+        id: true,
+        applicationNumber: true,
+        student: {
+          id: true,
+          birthDate: true,
+          user: {
+            id: true,
+            firstName: true,
+            lastName: true,
+            email: true,
+          },
+        },
+        currentAssessment: {
+          id: true,
+          offering: {
+            id: true,
+            educationProgram: { id: true, name: true },
+            institutionLocation: {
+              id: true,
+              institution: { id: true, operatingName: true },
+            },
+          },
+        },
+      },
+      relations: {
+        currentAssessment: {
+          offering: {
+            educationProgram: true,
+            institutionLocation: { institution: true },
+          },
+        },
+        student: { user: true },
+      },
+      where: { id: eCertDisbursement.applicationId },
+    });
+    const notification: ProgramSuspensionBlockingApplicationNotification = {
+      givenNames: application.student.user.firstName,
+      lastName: application.student.user.lastName,
+      studentEmail: application.student.user.email,
+      birthDate: application.student.birthDate,
+      applicationNumber: application.applicationNumber,
+      institutionOperatingName:
+        application.currentAssessment.offering.institutionLocation.institution
+          .operatingName,
+      programName: application.currentAssessment.offering.educationProgram.name,
+      metadata: { disbursementId: eCertDisbursement.disbursement.id },
+    };
+    await this.notificationActionsService.saveProgramSuspensionBlockingApplicationNotification(
+      notification,
+      entityManager,
+    );
+  }
+}

--- a/sources/packages/backend/libs/integrations/src/services/disbursement-schedule/e-cert-notification/blocked-disbursement/program-suspension-blocking-disbursement-notification.ts
+++ b/sources/packages/backend/libs/integrations/src/services/disbursement-schedule/e-cert-notification/blocked-disbursement/program-suspension-blocking-disbursement-notification.ts
@@ -17,7 +17,10 @@ export class ProgramSuspensionBlockingDisbursementNotification extends ECertNoti
   constructor(
     private readonly notificationActionsService: NotificationActionsService,
   ) {
-    super("Program suspension blocking application");
+    super(
+      "Program suspension blocking application",
+      NotificationMessageType.ProgramSuspensionBlockingApplication,
+    );
   }
 
   /**
@@ -39,7 +42,6 @@ export class ProgramSuspensionBlockingDisbursementNotification extends ECertNoti
     // Check if the notification already exists for the given disbursement
     // when there is an effective program suspension restriction.
     const hasNotification = await this.getExistingDisbursementNotification(
-      NotificationMessageType.MinistryNotificationDisbursementBlocked,
       eCertDisbursement,
       entityManager,
     );

--- a/sources/packages/backend/libs/integrations/src/services/disbursement-schedule/e-cert-notification/blocked-disbursement/student-blocked-disbursement-notification.ts
+++ b/sources/packages/backend/libs/integrations/src/services/disbursement-schedule/e-cert-notification/blocked-disbursement/student-blocked-disbursement-notification.ts
@@ -26,7 +26,10 @@ export class StudentBlockedDisbursementNotification extends ECertNotification {
   constructor(
     private readonly notificationActionsService: NotificationActionsService,
   ) {
-    super("Student Blocked Disbursement");
+    super(
+      "Student Blocked Disbursement",
+      NotificationMessageType.StudentNotificationDisbursementBlocked,
+    );
   }
 
   /**
@@ -46,8 +49,7 @@ export class StudentBlockedDisbursementNotification extends ECertNotification {
       .addSelect("max(notification.createdAt)", "maxCreatedAt")
       .innerJoin("notification.notificationMessage", "notificationMessage")
       .where("notificationMessage.id = :notificationMessageId", {
-        notificationMessageId:
-          NotificationMessageType.StudentNotificationDisbursementBlocked,
+        notificationMessageId: this.notificationMessageType,
       })
       .andWhere("notification.metadata->>'disbursementId' = :disbursementId", {
         disbursementId: eCertDisbursement.disbursement.id,

--- a/sources/packages/backend/libs/integrations/src/services/disbursement-schedule/e-cert-notification/e-cert-notification.service.ts
+++ b/sources/packages/backend/libs/integrations/src/services/disbursement-schedule/e-cert-notification/e-cert-notification.service.ts
@@ -4,6 +4,7 @@ import { EntityManager } from "typeorm";
 import { EligibleECertDisbursement } from "../disbursement-schedule.models";
 import {
   MinistryBlockedDisbursementNotification,
+  ProgramSuspensionBlockingDisbursementNotification,
   StudentBlockedDisbursementNotification,
 } from ".";
 
@@ -12,6 +13,7 @@ export class ECertNotificationService {
   constructor(
     private readonly ministryBlockedDisbursementNotification: MinistryBlockedDisbursementNotification,
     private readonly studentBlockedDisbursementNotification: StudentBlockedDisbursementNotification,
+    private readonly programSuspensionBlockingDisbursementNotification: ProgramSuspensionBlockingDisbursementNotification,
   ) {}
 
   /**
@@ -28,6 +30,7 @@ export class ECertNotificationService {
     const notifications = [
       this.ministryBlockedDisbursementNotification,
       this.studentBlockedDisbursementNotification,
+      this.programSuspensionBlockingDisbursementNotification,
     ].map((notification) =>
       notification.notify(eCertDisbursement, entityManager, log),
     );

--- a/sources/packages/backend/libs/integrations/src/services/disbursement-schedule/e-cert-notification/e-cert-notification.ts
+++ b/sources/packages/backend/libs/integrations/src/services/disbursement-schedule/e-cert-notification/e-cert-notification.ts
@@ -2,6 +2,8 @@ import { EntityManager } from "typeorm";
 import { EligibleECertDisbursement } from "../disbursement-schedule.models";
 import { ProcessSummary } from "@sims/utilities/logger";
 import { Notification, NotificationMessageType } from "@sims/sims-db";
+import { CustomNamedError } from "@sims/utilities";
+import { NOTIFICATION_MISSING_EMAIL_CONTACTS } from "@sims/services/constants";
 
 /**
  * Provides a basic structure for creating and
@@ -86,7 +88,20 @@ export abstract class ECertNotification {
       );
       return false;
     }
-    await this.createNotification(eCertDisbursement, entityManager);
+    try {
+      await this.createNotification(eCertDisbursement, entityManager);
+    } catch (error: unknown) {
+      // Log process summary warning to create alerts when email contacts are missing for the notification
+      // without failing the entire process.
+      if (
+        error instanceof CustomNamedError &&
+        error.name === NOTIFICATION_MISSING_EMAIL_CONTACTS
+      ) {
+        notificationLog.warn(error.message);
+        return false;
+      }
+      throw error;
+    }
     notificationLog.info(
       `${this.notificationName} notification created for disbursement ID ${eCertDisbursement.disbursement.id}.`,
     );

--- a/sources/packages/backend/libs/integrations/src/services/disbursement-schedule/e-cert-notification/e-cert-notification.ts
+++ b/sources/packages/backend/libs/integrations/src/services/disbursement-schedule/e-cert-notification/e-cert-notification.ts
@@ -13,8 +13,12 @@ export abstract class ECertNotification {
   /**
    * Initializes a new instance of {@link ECertNotification}.
    * @param notificationName friendly name of the notification for logging
+   * @param notificationMessageType type of the notification message.
    */
-  protected constructor(private readonly notificationName: string) {}
+  protected constructor(
+    private readonly notificationName: string,
+    protected readonly notificationMessageType: NotificationMessageType,
+  ) {}
 
   /**
    * Determines whether a notification should be created or not.
@@ -41,20 +45,18 @@ export abstract class ECertNotification {
 
   /**
    * Get existing notification of the specified type for the given e-Cert disbursement.
-   * @param notificationMessageType type of the notification message.
    * @param eCertDisbursement eligible disbursement to be potentially added to an e-Cert.
    * @param entityManager entity manager to execute in transaction.
    * @returns true if the notification exists, false otherwise.
    */
   protected async getExistingDisbursementNotification(
-    notificationMessageType: NotificationMessageType,
     eCertDisbursement: EligibleECertDisbursement,
     entityManager: EntityManager,
   ): Promise<boolean> {
     return entityManager.getRepository(Notification).exists({
       where: {
         notificationMessage: {
-          id: notificationMessageType,
+          id: this.notificationMessageType,
         },
         metadata: {
           disbursementId: eCertDisbursement.disbursement.id,
@@ -97,7 +99,9 @@ export abstract class ECertNotification {
         error instanceof CustomNamedError &&
         error.name === NOTIFICATION_MISSING_EMAIL_CONTACTS
       ) {
-        notificationLog.warn(error.message);
+        notificationLog.warn(
+          `${this.notificationName} notification cannot be created: ${error.message}`,
+        );
         return false;
       }
       throw error;

--- a/sources/packages/backend/libs/integrations/src/services/disbursement-schedule/e-cert-notification/e-cert-notification.ts
+++ b/sources/packages/backend/libs/integrations/src/services/disbursement-schedule/e-cert-notification/e-cert-notification.ts
@@ -1,6 +1,7 @@
 import { EntityManager } from "typeorm";
 import { EligibleECertDisbursement } from "../disbursement-schedule.models";
 import { ProcessSummary } from "@sims/utilities/logger";
+import { Notification, NotificationMessageType } from "@sims/sims-db";
 
 /**
  * Provides a basic structure for creating and
@@ -35,6 +36,30 @@ export abstract class ECertNotification {
     eCertDisbursement: EligibleECertDisbursement,
     entityManager: EntityManager,
   ): Promise<void>;
+
+  /**
+   * Get existing notification of the specified type for the given e-Cert disbursement.
+   * @param notificationMessageType type of the notification message.
+   * @param eCertDisbursement eligible disbursement to be potentially added to an e-Cert.
+   * @param entityManager entity manager to execute in transaction.
+   * @returns true if the notification exists, false otherwise.
+   */
+  protected async getExistingDisbursementNotification(
+    notificationMessageType: NotificationMessageType,
+    eCertDisbursement: EligibleECertDisbursement,
+    entityManager: EntityManager,
+  ): Promise<boolean> {
+    return entityManager.getRepository(Notification).exists({
+      where: {
+        notificationMessage: {
+          id: notificationMessageType,
+        },
+        metadata: {
+          disbursementId: eCertDisbursement.disbursement.id,
+        },
+      },
+    });
+  }
 
   /**
    * Creates a notification defined by {@link createNotification} if the requirements

--- a/sources/packages/backend/libs/integrations/src/services/disbursement-schedule/e-cert-notification/index.ts
+++ b/sources/packages/backend/libs/integrations/src/services/disbursement-schedule/e-cert-notification/index.ts
@@ -1,4 +1,5 @@
 export * from "./blocked-disbursement/ministry-blocked-disbursement-notification";
 export * from "./blocked-disbursement/student-blocked-disbursement-notification";
+export * from "./blocked-disbursement/program-suspension-blocking-disbursement-notification";
 export * from "./e-cert-notification";
 export * from "./e-cert-notification.service";

--- a/sources/packages/backend/libs/integrations/src/services/disbursement-schedule/e-cert-processing-steps/validate-disbursement-base.ts
+++ b/sources/packages/backend/libs/integrations/src/services/disbursement-schedule/e-cert-processing-steps/validate-disbursement-base.ts
@@ -74,22 +74,13 @@ export abstract class ValidateDisbursementBase {
       validationResults,
       targetValidations,
     );
-    // When a student has an active 'SchoolTransfer' or 'StudentWithdrewFromProgram' scholastic standing event on their application,
-    // create an additional eCert blocker to prevent further funds from being disbursed.
-    if (
-      eCertDisbursement.hasActiveStudentScholasticStanding([
-        StudentScholasticStandingChangeType.SchoolTransfer,
-        StudentScholasticStandingChangeType.StudentWithdrewFromProgram,
-      ])
-    ) {
-      log.info(
-        `Student application has an active scholastic standing change with change type '${StudentScholasticStandingChangeType.SchoolTransfer}' or '${StudentScholasticStandingChangeType.StudentWithdrewFromProgram}'.`,
-      );
-      validationResults.push({
-        resultType: ECertFailedValidation.ActiveTransferOrWithdraw,
-      });
-    }
-
+    // Active School Transfer or Withdraw.
+    this.validateActiveSchoolTransferOrWithdraw(
+      eCertDisbursement,
+      log,
+      validationResults,
+      targetValidations,
+    );
     return validationResults;
   }
 
@@ -354,6 +345,42 @@ export abstract class ValidateDisbursementBase {
       );
       validationResults.push({
         resultType: ECertFailedValidation.NoEstimatedAwardAmounts,
+      });
+    }
+  }
+
+  /**
+   * When a student has an active 'SchoolTransfer' or 'StudentWithdrewFromProgram' scholastic standing event on their application,
+   * create an additional eCert blocker to prevent further funds from being disbursed.
+   * @param eCertDisbursement eligible disbursement to be potentially added to an e-Cert.
+   * @param log cumulative log summary.
+   * @param targetValidations list of validations that should only be executed. If not provided, all validations must be executed.
+   */
+  private validateActiveSchoolTransferOrWithdraw(
+    eCertDisbursement: EligibleECertDisbursement,
+    log: ProcessSummary,
+    validationResults: ECertFailedValidationResult[],
+    targetValidations?: ECertFailedValidation[],
+  ): void {
+    if (
+      !this.canExecuteValidation(
+        ECertFailedValidation.ActiveTransferOrWithdraw,
+        targetValidations,
+      )
+    ) {
+      return;
+    }
+    if (
+      eCertDisbursement.hasActiveStudentScholasticStanding([
+        StudentScholasticStandingChangeType.SchoolTransfer,
+        StudentScholasticStandingChangeType.StudentWithdrewFromProgram,
+      ])
+    ) {
+      log.info(
+        `Student application has an active scholastic standing change with change type '${StudentScholasticStandingChangeType.SchoolTransfer}' or '${StudentScholasticStandingChangeType.StudentWithdrewFromProgram}'.`,
+      );
+      validationResults.push({
+        resultType: ECertFailedValidation.ActiveTransferOrWithdraw,
       });
     }
   }

--- a/sources/packages/backend/libs/integrations/src/services/disbursement-schedule/e-cert-processing-steps/validate-disbursement-base.ts
+++ b/sources/packages/backend/libs/integrations/src/services/disbursement-schedule/e-cert-processing-steps/validate-disbursement-base.ts
@@ -24,64 +24,56 @@ export abstract class ValidateDisbursementBase {
    * Validate common requirements independently of the offering intensity.
    * @param eCertDisbursement eligible disbursement to be potentially added to an e-Cert.
    * @param log cumulative log summary.
+   * @param targetValidations list of validations that should only be executed. If not provided, all validations must be executed.
    */
   protected validate(
     eCertDisbursement: EligibleECertDisbursement,
     log: ProcessSummary,
+    targetValidations?: ECertFailedValidation[],
   ): ECertFailedValidationResult[] {
     const validationResults: ECertFailedValidationResult[] = [];
     // COE
-    if (eCertDisbursement.disbursement.coeStatus !== COEStatus.completed) {
-      log.info("Waiting for confirmation of enrolment to be completed.");
-      validationResults.push({
-        resultType: ECertFailedValidation.NonCompletedCOE,
-      });
-    }
+    this.validateCOEStatus(
+      eCertDisbursement,
+      log,
+      validationResults,
+      targetValidations,
+    );
     // SIN
-    if (!eCertDisbursement.hasValidSIN) {
-      log.info("Student SIN is invalid or the validation is pending.");
-      validationResults.push({ resultType: ECertFailedValidation.InvalidSIN });
-    }
+    this.validateSINStatus(
+      eCertDisbursement,
+      log,
+      validationResults,
+      targetValidations,
+    );
     // MSFAA cancelation.
-    if (eCertDisbursement.disbursement.msfaaNumber?.cancelledDate) {
-      log.info("Student MSFAA associated with the disbursement is cancelled.");
-      validationResults.push({
-        resultType: ECertFailedValidation.MSFAACanceled,
-      });
-    }
+    this.validateCancelledMSFAA(
+      eCertDisbursement,
+      log,
+      validationResults,
+      targetValidations,
+    );
     // MSFAA signed.
-    if (!eCertDisbursement.disbursement.msfaaNumber?.dateSigned) {
-      log.info(
-        "Student MSFAA associated with the disbursement is not signed or there is no MSFAA associated with the application.",
-      );
-      validationResults.push({
-        resultType: ECertFailedValidation.MSFAANotSigned,
-      });
-    }
+    this.validateSignedMSFAA(
+      eCertDisbursement,
+      log,
+      validationResults,
+      targetValidations,
+    );
     // Disability Status PD/PPD Verified.
-    const disabilityStatusValidation = eCertDisbursement.disabilityDetails
-      .calculatedPDPPDStatus
-      ? [DisabilityStatus.PD, DisabilityStatus.PPD].includes(
-          eCertDisbursement.disabilityDetails.studentProfileDisabilityStatus,
-        )
-      : true;
-    if (!disabilityStatusValidation) {
-      log.info(`Student disability Status PD/PPD is not verified.`);
-      validationResults.push({
-        resultType: ECertFailedValidation.DisabilityStatusNotConfirmed,
-      });
-    }
+    this.validateDisabilityStatus(
+      eCertDisbursement,
+      log,
+      validationResults,
+      targetValidations,
+    );
     // No estimated awards amounts to be disbursed.
-    const hasEstimatedAwards =
-      eCertDisbursement.disbursement.hasEstimatedAwards;
-    if (!hasEstimatedAwards) {
-      log.info(
-        "Disbursement estimated awards do not contain any amount to be disbursed.",
-      );
-      validationResults.push({
-        resultType: ECertFailedValidation.NoEstimatedAwardAmounts,
-      });
-    }
+    this.validateEstimatedAwards(
+      eCertDisbursement,
+      log,
+      validationResults,
+      targetValidations,
+    );
     // When a student has an active 'SchoolTransfer' or 'StudentWithdrewFromProgram' scholastic standing event on their application,
     // create an additional eCert blocker to prevent further funds from being disbursed.
     if (
@@ -107,6 +99,7 @@ export abstract class ValidateDisbursementBase {
    * @param restrictionActionType restriction action type to be validated.
    * @param validationResults list of failed validations to be updated.
    * @param log cumulative log summary.
+   * @param targetValidations list of validations that should only be executed. If not provided, all validations must be executed.
    */
   protected validateStopDisbursementRestriction(
     eCertDisbursement: EligibleECertDisbursement,
@@ -115,7 +108,20 @@ export abstract class ValidateDisbursementBase {
       | RestrictionActionType.StopPartTimeDisbursement,
     validationResults: ECertFailedValidationResult[],
     log: ProcessSummary,
+    targetValidations?: ECertFailedValidation[],
   ): void {
+    const canExecuteValidation =
+      this.canExecuteValidation(
+        ECertFailedValidation.HasStopDisbursementRestriction,
+        targetValidations,
+      ) ||
+      this.canExecuteValidation(
+        ECertFailedValidation.HasStopDisbursementInstitutionRestriction,
+        targetValidations,
+      );
+    if (!canExecuteValidation) {
+      return;
+    }
     // Validate stop disbursement restrictions.
     const stopDisbursementRestrictions = getRestrictionsByActionType(
       eCertDisbursement,
@@ -172,5 +178,195 @@ export abstract class ValidateDisbursementBase {
       eCertDisbursement.activeRestrictionBypasses,
       log,
     );
+  }
+
+  /**
+   * Validate COE status for the given disbursement.
+   * @param eCertDisbursement eligible disbursement to be potentially added to an e-Cert.
+   * @param log cumulative log summary.
+   * @param targetValidations list of validations that should only be executed. If not provided, all validations must be executed.
+   */
+  private validateCOEStatus(
+    eCertDisbursement: EligibleECertDisbursement,
+    log: ProcessSummary,
+    validationResults: ECertFailedValidationResult[],
+    targetValidations?: ECertFailedValidation[],
+  ): void {
+    if (
+      !this.canExecuteValidation(
+        ECertFailedValidation.NonCompletedCOE,
+        targetValidations,
+      )
+    ) {
+      return;
+    }
+    if (eCertDisbursement.disbursement.coeStatus !== COEStatus.completed) {
+      log.info("Waiting for confirmation of enrolment to be completed.");
+      validationResults.push({
+        resultType: ECertFailedValidation.NonCompletedCOE,
+      });
+    }
+  }
+
+  /**
+   * Validate SIN status of the application student.
+   * @param eCertDisbursement eligible disbursement to be potentially added to an e-Cert.
+   * @param log cumulative log summary.
+   * @param targetValidations list of validations that should only be executed. If not provided, all validations must be executed.
+   */
+  private validateSINStatus(
+    eCertDisbursement: EligibleECertDisbursement,
+    log: ProcessSummary,
+    validationResults: ECertFailedValidationResult[],
+    targetValidations?: ECertFailedValidation[],
+  ): void {
+    if (
+      !this.canExecuteValidation(
+        ECertFailedValidation.InvalidSIN,
+        targetValidations,
+      )
+    ) {
+      return;
+    }
+    if (!eCertDisbursement.hasValidSIN) {
+      log.info("Student SIN is invalid or the validation is pending.");
+      validationResults.push({ resultType: ECertFailedValidation.InvalidSIN });
+    }
+  }
+
+  /**
+   * Validate cancelled MSFAA for the given disbursement.
+   * @param eCertDisbursement eligible disbursement to be potentially added to an e-Cert.
+   * @param log cumulative log summary.
+   * @param targetValidations list of validations that should only be executed. If not provided, all validations must be executed.
+   */
+  private validateCancelledMSFAA(
+    eCertDisbursement: EligibleECertDisbursement,
+    log: ProcessSummary,
+    validationResults: ECertFailedValidationResult[],
+    targetValidations?: ECertFailedValidation[],
+  ): void {
+    if (
+      !this.canExecuteValidation(
+        ECertFailedValidation.MSFAACanceled,
+        targetValidations,
+      )
+    ) {
+      return;
+    }
+    if (eCertDisbursement.disbursement.msfaaNumber?.cancelledDate) {
+      log.info("Student MSFAA associated with the disbursement is cancelled.");
+      validationResults.push({
+        resultType: ECertFailedValidation.MSFAACanceled,
+      });
+    }
+  }
+
+  /**
+   * Validate signed MSFAA for the given disbursement.
+   * @param eCertDisbursement eligible disbursement to be potentially added to an e-Cert.
+   * @param log cumulative log summary.
+   * @param targetValidations list of validations that should only be executed. If not provided, all validations must be executed.
+   */
+  private validateSignedMSFAA(
+    eCertDisbursement: EligibleECertDisbursement,
+    log: ProcessSummary,
+    validationResults: ECertFailedValidationResult[],
+    targetValidations?: ECertFailedValidation[],
+  ): void {
+    if (
+      !this.canExecuteValidation(
+        ECertFailedValidation.MSFAANotSigned,
+        targetValidations,
+      )
+    ) {
+      return;
+    }
+    if (!eCertDisbursement.disbursement.msfaaNumber?.dateSigned) {
+      log.info(
+        "Student MSFAA associated with the disbursement is not signed or there is no MSFAA associated with the application.",
+      );
+      validationResults.push({
+        resultType: ECertFailedValidation.MSFAANotSigned,
+      });
+    }
+  }
+
+  /**
+   * Validate if the application disability status match with student disability status.
+   * @param eCertDisbursement eligible disbursement to be potentially added to an e-Cert.
+   * @param log cumulative log summary.
+   * @param targetValidations list of validations that should only be executed. If not provided, all validations must be executed.
+   */
+  private validateDisabilityStatus(
+    eCertDisbursement: EligibleECertDisbursement,
+    log: ProcessSummary,
+    validationResults: ECertFailedValidationResult[],
+    targetValidations?: ECertFailedValidation[],
+  ): void {
+    if (
+      !this.canExecuteValidation(
+        ECertFailedValidation.DisabilityStatusNotConfirmed,
+        targetValidations,
+      )
+    ) {
+      return;
+    }
+    const disabilityStatusValidation = eCertDisbursement.disabilityDetails
+      .calculatedPDPPDStatus
+      ? [DisabilityStatus.PD, DisabilityStatus.PPD].includes(
+          eCertDisbursement.disabilityDetails.studentProfileDisabilityStatus,
+        )
+      : true;
+    if (!disabilityStatusValidation) {
+      log.info(`Student disability Status PD/PPD is not verified.`);
+      validationResults.push({
+        resultType: ECertFailedValidation.DisabilityStatusNotConfirmed,
+      });
+    }
+  }
+
+  /**
+   * Validate if the disbursement has estimated awards to be disbursed.
+   * @param eCertDisbursement eligible disbursement to be potentially added to an e-Cert.
+   * @param log cumulative log summary.
+   * @param targetValidations list of validations that should only be executed. If not provided, all validations must be executed.
+   */
+  private validateEstimatedAwards(
+    eCertDisbursement: EligibleECertDisbursement,
+    log: ProcessSummary,
+    validationResults: ECertFailedValidationResult[],
+    targetValidations?: ECertFailedValidation[],
+  ): void {
+    if (
+      !this.canExecuteValidation(
+        ECertFailedValidation.NoEstimatedAwardAmounts,
+        targetValidations,
+      )
+    ) {
+      return;
+    }
+    const hasEstimatedAwards =
+      eCertDisbursement.disbursement.hasEstimatedAwards;
+    if (!hasEstimatedAwards) {
+      log.info(
+        "Disbursement estimated awards do not contain any amount to be disbursed.",
+      );
+      validationResults.push({
+        resultType: ECertFailedValidation.NoEstimatedAwardAmounts,
+      });
+    }
+  }
+
+  /**
+   * Check if a specific validation can be executed based on the list of validations to execute.
+   * @param validation validation to check.
+   * @param targetValidations list of validations that should only be executed. If not provided, all validations must be executed.
+   */
+  protected canExecuteValidation(
+    validation: ECertFailedValidation,
+    targetValidations?: ECertFailedValidation[],
+  ): boolean {
+    return !targetValidations?.length || targetValidations.includes(validation);
   }
 }

--- a/sources/packages/backend/libs/integrations/src/services/disbursement-schedule/e-cert-processing-steps/validate-disbursement-full-time-step.ts
+++ b/sources/packages/backend/libs/integrations/src/services/disbursement-schedule/e-cert-processing-steps/validate-disbursement-full-time-step.ts
@@ -65,7 +65,11 @@ export class ValidateDisbursementFullTimeStep
     targetValidations?: ECertFailedValidation[],
   ): Promise<ECertPreValidatorResult> {
     log.info("Executing full-time disbursement validations.");
-    const validationResults = super.validate(eCertDisbursement, log);
+    const validationResults = super.validate(
+      eCertDisbursement,
+      log,
+      targetValidations,
+    );
     // Validate stop full-time disbursement restrictions.
     super.validateStopDisbursementRestriction(
       eCertDisbursement,
@@ -81,6 +85,7 @@ export class ValidateDisbursementFullTimeStep
       validationResults,
       targetValidations,
     );
+    eCertDisbursement.failedValidations = validationResults;
     return new ECertPreValidatorResult(validationResults);
   }
 

--- a/sources/packages/backend/libs/integrations/src/services/disbursement-schedule/e-cert-processing-steps/validate-disbursement-full-time-step.ts
+++ b/sources/packages/backend/libs/integrations/src/services/disbursement-schedule/e-cert-processing-steps/validate-disbursement-full-time-step.ts
@@ -9,6 +9,7 @@ import { ECertProcessStep, ValidateDisbursementBase } from ".";
 import { Injectable } from "@nestjs/common";
 import {
   ECertFailedValidation,
+  ECertFailedValidationResult,
   EligibleECertDisbursement,
 } from "../disbursement-schedule.models";
 import {
@@ -53,6 +54,7 @@ export class ValidateDisbursementFullTimeStep
    * @param _entityManager not used for full-time.
    * @param log keep it compliant with the required parameters
    * used by {@link ECertProcessStep}.
+   * @param targetValidations list of validations that should only be executed. If not provided, all validations must be executed.
    * @returns list of failed validations, otherwise an empty array if
    * no blocking conditions were found.
    */
@@ -60,6 +62,7 @@ export class ValidateDisbursementFullTimeStep
     eCertDisbursement: EligibleECertDisbursement,
     _entityManager: EntityManager,
     log: ProcessSummary,
+    targetValidations?: ECertFailedValidation[],
   ): Promise<ECertPreValidatorResult> {
     log.info("Executing full-time disbursement validations.");
     const validationResults = super.validate(eCertDisbursement, log);
@@ -69,8 +72,38 @@ export class ValidateDisbursementFullTimeStep
       RestrictionActionType.StopFullTimeDisbursement,
       validationResults,
       log,
+      targetValidations,
     );
     // Validate modified independent status when estranged from parents.
+    this.validateModifiedIndependentStatus(
+      eCertDisbursement,
+      log,
+      validationResults,
+      targetValidations,
+    );
+    return new ECertPreValidatorResult(validationResults);
+  }
+
+  /**
+   * Validate if application modified independent status match with student modified independent status.
+   * @param eCertDisbursement eligible disbursement to be potentially added to an e-Cert.
+   * @param log cumulative log summary.
+   * @param targetValidations list of validations that should only be executed. If not provided, all validations must be executed.
+   */
+  private validateModifiedIndependentStatus(
+    eCertDisbursement: EligibleECertDisbursement,
+    log: ProcessSummary,
+    validationResults: ECertFailedValidationResult[],
+    targetValidations?: ECertFailedValidation[],
+  ): void {
+    if (
+      !this.canExecuteValidation(
+        ECertFailedValidation.ModifiedIndependentStatusNotApproved,
+        targetValidations,
+      )
+    ) {
+      return;
+    }
     if (
       eCertDisbursement.modifiedIndependentDetails.estrangedFromParents ===
         FormYesNoOptions.Yes &&
@@ -85,6 +118,5 @@ export class ValidateDisbursementFullTimeStep
         resultType: ECertFailedValidation.ModifiedIndependentStatusNotApproved,
       });
     }
-    return new ECertPreValidatorResult(validationResults);
   }
 }

--- a/sources/packages/backend/libs/integrations/src/services/disbursement-schedule/e-cert-processing-steps/validate-disbursement-part-time-step.ts
+++ b/sources/packages/backend/libs/integrations/src/services/disbursement-schedule/e-cert-processing-steps/validate-disbursement-part-time-step.ts
@@ -59,6 +59,7 @@ export class ValidateDisbursementPartTimeStep
    * used by {@link ECertProcessStep}.
    * @param log keep it compliant with the required parameters
    * used by {@link ECertProcessStep}.
+   * @param targetValidations list of validations that should only be executed. If not provided, all validations must be executed.
    * @returns list of failed validations, otherwise an empty array if
    * no blocking conditions were found.
    */
@@ -66,27 +67,43 @@ export class ValidateDisbursementPartTimeStep
     eCertDisbursement: EligibleECertDisbursement,
     entityManager: EntityManager,
     log: ProcessSummary,
+    targetValidations?: ECertFailedValidation[],
   ): Promise<ECertPreValidatorResult> {
     log.info("Executing part-time disbursement validations.");
-    const validationResults = super.validate(eCertDisbursement, log);
+    const validationResults = super.validate(
+      eCertDisbursement,
+      log,
+      targetValidations,
+    );
     // Validate stop part-time disbursement restrictions.
     super.validateStopDisbursementRestriction(
       eCertDisbursement,
       RestrictionActionType.StopPartTimeDisbursement,
       validationResults,
       log,
+      targetValidations,
     );
 
     // Validate CSLP.
-    const validateLifetimeMaximumCSLP = await this.validateCSLPLifetimeMaximum(
-      eCertDisbursement,
-      entityManager,
-      log,
-    );
-    if (!validateLifetimeMaximumCSLP) {
-      validationResults.push({
-        resultType: ECertFailedValidation.LifetimeMaximumCSLP,
-      });
+    // TODO: This validation is not moved to individual method considering the time taken to extend the pre validations.
+    // This can be done in future efforts.
+    if (
+      this.canExecuteValidation(
+        ECertFailedValidation.LifetimeMaximumCSLP,
+        targetValidations,
+      )
+    ) {
+      const validateLifetimeMaximumCSLP =
+        await this.validateCSLPLifetimeMaximum(
+          eCertDisbursement,
+          entityManager,
+          log,
+        );
+      if (!validateLifetimeMaximumCSLP) {
+        validationResults.push({
+          resultType: ECertFailedValidation.LifetimeMaximumCSLP,
+        });
+      }
     }
     return new ECertPreValidatorResult(validationResults);
   }

--- a/sources/packages/backend/libs/integrations/src/services/disbursement-schedule/e-cert-processing-steps/validate-disbursement-part-time-step.ts
+++ b/sources/packages/backend/libs/integrations/src/services/disbursement-schedule/e-cert-processing-steps/validate-disbursement-part-time-step.ts
@@ -105,6 +105,7 @@ export class ValidateDisbursementPartTimeStep
         });
       }
     }
+    eCertDisbursement.failedValidations = validationResults;
     return new ECertPreValidatorResult(validationResults);
   }
 

--- a/sources/packages/backend/libs/services/src/constants/error-code.constants.ts
+++ b/sources/packages/backend/libs/services/src/constants/error-code.constants.ts
@@ -78,3 +78,9 @@ export const FILE_SAVE_ERROR = "FILE_SAVE_ERROR";
  * for instance, T4A files.
  */
 export const FILE_HASH_DUPLICATION_ERROR = "FILE_HASH_DUPLICATION_ERROR";
+/**
+ * Notification message is missing email contacts, which are required to send the email.
+ ** Email contacts are currently in use for only ministry notifications.
+ */
+export const NOTIFICATION_MISSING_EMAIL_CONTACTS =
+  "NOTIFICATION_MISSING_EMAIL_CONTACTS";

--- a/sources/packages/backend/libs/services/src/notifications/notification/notification-actions.service.ts
+++ b/sources/packages/backend/libs/services/src/notifications/notification/notification-actions.service.ts
@@ -1639,24 +1639,27 @@ export class NotificationActionsService {
     if (!emailContacts?.length) {
       return;
     }
-    const ministryNotificationsToSend = emailContacts.map((emailContact) => ({
-      userId: auditUser.id,
-      messageType: NotificationMessageType.ProgramSuspensionBlockingApplication,
-      messagePayload: {
-        email_address: emailContact,
-        template_id: templateId,
-        personalisation: {
-          givenNames: notification.givenNames ?? "",
-          lastName: notification.lastName,
-          birthDate: getDateOnlyFormat(notification.birthDate),
-          studentEmail: notification.studentEmail,
-          applicationNumber: notification.applicationNumber,
-          dateTime: this.getDateTimeOnPSTTimeZone(),
-          institutionOperatingName: notification.institutionOperatingName,
-          programName: notification.programName,
+    const ministryNotificationsToSend =
+      emailContacts.map<SaveNotificationModel>((emailContact) => ({
+        userId: auditUser.id,
+        messageType:
+          NotificationMessageType.ProgramSuspensionBlockingApplication,
+        messagePayload: {
+          email_address: emailContact,
+          template_id: templateId,
+          personalisation: {
+            givenNames: notification.givenNames ?? "",
+            lastName: notification.lastName,
+            birthDate: getDateOnlyFormat(notification.birthDate),
+            studentEmail: notification.studentEmail,
+            applicationNumber: notification.applicationNumber,
+            dateTime: this.getDateTimeOnPSTTimeZone(),
+            institutionOperatingName: notification.institutionOperatingName,
+            programName: notification.programName,
+          },
+          metadata: notification.metadata,
         },
-      },
-    }));
+      }));
     // Save notifications to be sent to the ministry into the notification table.
     await this.notificationService.saveNotifications(
       ministryNotificationsToSend,

--- a/sources/packages/backend/libs/services/src/notifications/notification/notification-actions.service.ts
+++ b/sources/packages/backend/libs/services/src/notifications/notification/notification-actions.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from "@nestjs/common";
 import { NotificationMessage, NotificationMessageType } from "@sims/sims-db";
 import {
   base64Encode,
+  CustomNamedError,
   getDateOnlyFormat,
   getPSTPDTDateTime,
 } from "@sims/utilities";
@@ -42,12 +43,14 @@ import {
   MinistryFileProcessingIssueNotification,
   SaveNotificationModel,
   StudentAcceptAssessmentReminderNotification,
+  ProgramSuspensionBlockingApplicationNotification,
 } from "..";
 import { NotificationService } from "./notification.service";
 import { LoggerService } from "@sims/utilities/logger";
 import { ECE_RESPONSE_ATTACHMENT_FILE_NAME } from "@sims/integrations/constants";
 import { SystemUsersService } from "@sims/services/system-users";
 import { NotificationMetadata } from "@sims/sims-db/entities/notification-metadata.type";
+import { NOTIFICATION_MISSING_EMAIL_CONTACTS } from "@sims/services/constants";
 
 @Injectable()
 export class NotificationActionsService {
@@ -1283,23 +1286,71 @@ export class NotificationActionsService {
     );
   }
 
+  async saveMinistryFormSubmittedNotification(
+    notification: MinistryFormSubmittedNotification,
+    entityManager: EntityManager,
+  ): Promise<void> {
+    const auditUser = this.systemUsersService.systemUser;
+    const { templateId, emailContacts } =
+      await this.assertNotificationMessageDetails(
+        NotificationMessageType.MinistryFormSubmitted,
+      );
+    if (!emailContacts?.length) {
+      return;
+    }
+
+    const ministryNotificationsToSend = emailContacts.map((emailContact) => ({
+      userId: auditUser.id,
+      messageType: NotificationMessageType.MinistryFormSubmitted,
+      messagePayload: {
+        email_address: emailContact,
+        template_id: templateId,
+        personalisation: {
+          givenNames: notification.givenNames ?? "",
+          lastName: notification.lastName,
+          birthDate: getDateOnlyFormat(notification.birthDate),
+          studentEmail: notification.email,
+          formCategory: notification.formCategory,
+          formNames: notification.formNames,
+          applicationNumber: notification.applicationNumber ?? "N/A",
+          dateTime: this.getDateTimeOnPSTTimeZone(),
+        },
+      },
+    }));
+    // Save notifications to be sent to the ministry into the notification table.
+    await this.notificationService.saveNotifications(
+      ministryNotificationsToSend,
+      auditUser.id,
+      { entityManager },
+    );
+  }
+
   /**
    * Asserts the notification message details of a notification message.
    * @param notificationMessageTypeId id of the notification message.
+   * @param options assert notification message options.
+   * - `throwOnMissingEmailContacts` when set to true, throw an error if email contacts are missing. Default value is false.
    * @returns notification details of the notification message.
    */
   private async assertNotificationMessageDetails(
     notificationMessageTypeId: NotificationMessageType,
+    options?: { throwOnMissingEmailContacts?: boolean },
   ): Promise<Pick<NotificationMessage, "templateId" | "emailContacts">> {
     const { templateId, emailContacts } =
       await this.notificationMessageService.getNotificationMessageDetails(
         notificationMessageTypeId,
       );
     if (!emailContacts?.length) {
-      this.logger.error(
-        `Email template id ${notificationMessageTypeId} requires a configured email to be sent.`,
-      );
-      return { templateId, emailContacts };
+      const throwOnMissingEmailContacts =
+        options?.throwOnMissingEmailContacts ?? false;
+      const errorMessage = `Notification message ${notificationMessageTypeId} is missing email contacts.`;
+      this.logger.error(errorMessage);
+      if (throwOnMissingEmailContacts) {
+        throw new CustomNamedError(
+          errorMessage,
+          NOTIFICATION_MISSING_EMAIL_CONTACTS,
+        );
+      }
     }
     return { templateId, emailContacts };
   }
@@ -1571,27 +1622,26 @@ export class NotificationActionsService {
   }
 
   /**
-   * Creates a ministry notification when a student submits a form submission,
-   * using the form category directly from the dynamic form configuration.
+   * Creates a ministry notification when a when a program suspension restriction is blocking an application
+   * at accept assessment or at e-Cert.
    * @param notification notification details.
    * @param entityManager entity manager to execute in transaction.
    */
-  async saveMinistryFormSubmittedNotification(
-    notification: MinistryFormSubmittedNotification,
+  async saveProgramSuspensionBlockingApplicationNotification(
+    notification: ProgramSuspensionBlockingApplicationNotification,
     entityManager: EntityManager,
   ): Promise<void> {
     const auditUser = this.systemUsersService.systemUser;
     const { templateId, emailContacts } =
       await this.assertNotificationMessageDetails(
-        NotificationMessageType.MinistryFormSubmitted,
+        NotificationMessageType.ProgramSuspensionBlockingApplication,
       );
     if (!emailContacts?.length) {
       return;
     }
-
     const ministryNotificationsToSend = emailContacts.map((emailContact) => ({
       userId: auditUser.id,
-      messageType: NotificationMessageType.MinistryFormSubmitted,
+      messageType: NotificationMessageType.ProgramSuspensionBlockingApplication,
       messagePayload: {
         email_address: emailContact,
         template_id: templateId,
@@ -1599,11 +1649,11 @@ export class NotificationActionsService {
           givenNames: notification.givenNames ?? "",
           lastName: notification.lastName,
           birthDate: getDateOnlyFormat(notification.birthDate),
-          studentEmail: notification.email,
-          formCategory: notification.formCategory,
-          formNames: notification.formNames,
-          applicationNumber: notification.applicationNumber ?? "N/A",
+          studentEmail: notification.studentEmail,
+          applicationNumber: notification.applicationNumber,
           dateTime: this.getDateTimeOnPSTTimeZone(),
+          institutionOperatingName: notification.institutionOperatingName,
+          programName: notification.programName,
         },
       },
     }));

--- a/sources/packages/backend/libs/services/src/notifications/notification/notification-actions.service.ts
+++ b/sources/packages/backend/libs/services/src/notifications/notification/notification-actions.service.ts
@@ -1659,8 +1659,8 @@ export class NotificationActionsService {
             institutionOperatingName: notification.institutionOperatingName,
             programName: notification.programName,
           },
-          metadata: notification.metadata,
         },
+        metadata: notification.metadata,
       }));
     // Save notifications to be sent to the ministry into the notification table.
     await this.notificationService.saveNotifications(

--- a/sources/packages/backend/libs/services/src/notifications/notification/notification-actions.service.ts
+++ b/sources/packages/backend/libs/services/src/notifications/notification/notification-actions.service.ts
@@ -1740,12 +1740,12 @@ export class NotificationActionsService {
   /**
    * Creates a ministry notification when a when a program suspension restriction is blocking an application
    * at accept assessment or at e-Cert.
-   * @param notification notification details.
+   * @param notifications notification details.
    * @param entityManager entity manager to execute in transaction.
    */
   async saveProgramSuspensionBlockingApplicationNotification(
-    notification: ProgramSuspensionBlockingApplicationNotification,
-    entityManager: EntityManager,
+    notifications: ProgramSuspensionBlockingApplicationNotification[],
+    entityManager?: EntityManager,
   ): Promise<void> {
     const auditUser = this.systemUsersService.systemUser;
     const { templateId, emailContacts } =
@@ -1757,26 +1757,28 @@ export class NotificationActionsService {
       return;
     }
     const ministryNotificationsToSend =
-      emailContacts.map<SaveNotificationModel>((emailContact) => ({
-        userId: auditUser.id,
-        messageType:
-          NotificationMessageType.ProgramSuspensionBlockingApplication,
-        messagePayload: {
-          email_address: emailContact,
-          template_id: templateId,
-          personalisation: {
-            givenNames: notification.givenNames ?? "",
-            lastName: notification.lastName,
-            birthDate: getDateOnlyFormat(notification.birthDate),
-            studentEmail: notification.studentEmail,
-            applicationNumber: notification.applicationNumber,
-            dateTime: this.getDateTimeOnPSTTimeZone(),
-            institutionOperatingName: notification.institutionOperatingName,
-            programName: notification.programName,
+      emailContacts.flatMap<SaveNotificationModel>((emailContact) =>
+        notifications.map((notification) => ({
+          userId: auditUser.id,
+          messageType:
+            NotificationMessageType.ProgramSuspensionBlockingApplication,
+          messagePayload: {
+            email_address: emailContact,
+            template_id: templateId,
+            personalisation: {
+              givenNames: notification.givenNames ?? "",
+              lastName: notification.lastName,
+              birthDate: getDateOnlyFormat(notification.birthDate),
+              studentEmail: notification.studentEmail,
+              applicationNumber: notification.applicationNumber,
+              dateTime: this.getDateTimeOnPSTTimeZone(),
+              institutionOperatingName: notification.institutionOperatingName,
+              programName: notification.programName,
+            },
           },
-        },
-        metadata: notification.metadata,
-      }));
+          metadata: notification.metadata,
+        })),
+      );
     // Save notifications to be sent to the ministry into the notification table.
     await this.notificationService.saveNotifications(
       ministryNotificationsToSend,

--- a/sources/packages/backend/libs/services/src/notifications/notification/notification-actions.service.ts
+++ b/sources/packages/backend/libs/services/src/notifications/notification/notification-actions.service.ts
@@ -1738,7 +1738,7 @@ export class NotificationActionsService {
   }
 
   /**
-   * Creates a ministry notification when a when a program suspension restriction is blocking an application
+   * Creates a ministry notification when a program suspension restriction is blocking an application
    * at accept assessment or at e-Cert.
    * @param notifications notification details.
    * @param entityManager entity manager to execute in transaction.

--- a/sources/packages/backend/libs/services/src/notifications/notification/notification-actions.service.ts
+++ b/sources/packages/backend/libs/services/src/notifications/notification/notification-actions.service.ts
@@ -731,6 +731,7 @@ export class NotificationActionsService {
     const { templateId, emailContacts } =
       await this.assertNotificationMessageDetails(
         NotificationMessageType.MinistryNotificationDisbursementBlocked,
+        { throwOnMissingEmailContacts: true },
       );
     if (!emailContacts?.length) {
       return;

--- a/sources/packages/backend/libs/services/src/notifications/notification/notification-actions.service.ts
+++ b/sources/packages/backend/libs/services/src/notifications/notification/notification-actions.service.ts
@@ -1635,6 +1635,7 @@ export class NotificationActionsService {
     const { templateId, emailContacts } =
       await this.assertNotificationMessageDetails(
         NotificationMessageType.ProgramSuspensionBlockingApplication,
+        { throwOnMissingEmailContacts: true },
       );
     if (!emailContacts?.length) {
       return;

--- a/sources/packages/backend/libs/services/src/notifications/notification/notification-actions.service.ts
+++ b/sources/packages/backend/libs/services/src/notifications/notification/notification-actions.service.ts
@@ -1287,45 +1287,6 @@ export class NotificationActionsService {
     );
   }
 
-  async saveMinistryFormSubmittedNotification(
-    notification: MinistryFormSubmittedNotification,
-    entityManager: EntityManager,
-  ): Promise<void> {
-    const auditUser = this.systemUsersService.systemUser;
-    const { templateId, emailContacts } =
-      await this.assertNotificationMessageDetails(
-        NotificationMessageType.MinistryFormSubmitted,
-      );
-    if (!emailContacts?.length) {
-      return;
-    }
-
-    const ministryNotificationsToSend = emailContacts.map((emailContact) => ({
-      userId: auditUser.id,
-      messageType: NotificationMessageType.MinistryFormSubmitted,
-      messagePayload: {
-        email_address: emailContact,
-        template_id: templateId,
-        personalisation: {
-          givenNames: notification.givenNames ?? "",
-          lastName: notification.lastName,
-          birthDate: getDateOnlyFormat(notification.birthDate),
-          studentEmail: notification.email,
-          formCategory: notification.formCategory,
-          formNames: notification.formNames,
-          applicationNumber: notification.applicationNumber ?? "N/A",
-          dateTime: this.getDateTimeOnPSTTimeZone(),
-        },
-      },
-    }));
-    // Save notifications to be sent to the ministry into the notification table.
-    await this.notificationService.saveNotifications(
-      ministryNotificationsToSend,
-      auditUser.id,
-      { entityManager },
-    );
-  }
-
   /**
    * Asserts the notification message details of a notification message.
    * @param notificationMessageTypeId id of the notification message.
@@ -1623,45 +1584,42 @@ export class NotificationActionsService {
   }
 
   /**
-   * Creates a ministry notification when a when a program suspension restriction is blocking an application
-   * at accept assessment or at e-Cert.
+   * Creates a ministry notification when a student submits a form submission,
+   * using the form category directly from the dynamic form configuration.
    * @param notification notification details.
    * @param entityManager entity manager to execute in transaction.
    */
-  async saveProgramSuspensionBlockingApplicationNotification(
-    notification: ProgramSuspensionBlockingApplicationNotification,
+  async saveMinistryFormSubmittedNotification(
+    notification: MinistryFormSubmittedNotification,
     entityManager: EntityManager,
   ): Promise<void> {
     const auditUser = this.systemUsersService.systemUser;
     const { templateId, emailContacts } =
       await this.assertNotificationMessageDetails(
-        NotificationMessageType.ProgramSuspensionBlockingApplication,
-        { throwOnMissingEmailContacts: true },
+        NotificationMessageType.MinistryFormSubmitted,
       );
     if (!emailContacts?.length) {
       return;
     }
-    const ministryNotificationsToSend =
-      emailContacts.map<SaveNotificationModel>((emailContact) => ({
-        userId: auditUser.id,
-        messageType:
-          NotificationMessageType.ProgramSuspensionBlockingApplication,
-        messagePayload: {
-          email_address: emailContact,
-          template_id: templateId,
-          personalisation: {
-            givenNames: notification.givenNames ?? "",
-            lastName: notification.lastName,
-            birthDate: getDateOnlyFormat(notification.birthDate),
-            studentEmail: notification.studentEmail,
-            applicationNumber: notification.applicationNumber,
-            dateTime: this.getDateTimeOnPSTTimeZone(),
-            institutionOperatingName: notification.institutionOperatingName,
-            programName: notification.programName,
-          },
+
+    const ministryNotificationsToSend = emailContacts.map((emailContact) => ({
+      userId: auditUser.id,
+      messageType: NotificationMessageType.MinistryFormSubmitted,
+      messagePayload: {
+        email_address: emailContact,
+        template_id: templateId,
+        personalisation: {
+          givenNames: notification.givenNames ?? "",
+          lastName: notification.lastName,
+          birthDate: getDateOnlyFormat(notification.birthDate),
+          studentEmail: notification.email,
+          formCategory: notification.formCategory,
+          formNames: notification.formNames,
+          applicationNumber: notification.applicationNumber ?? "N/A",
+          dateTime: this.getDateTimeOnPSTTimeZone(),
         },
-        metadata: notification.metadata,
-      }));
+      },
+    }));
     // Save notifications to be sent to the ministry into the notification table.
     await this.notificationService.saveNotifications(
       ministryNotificationsToSend,
@@ -1776,6 +1734,54 @@ export class NotificationActionsService {
     await this.notificationService.saveNotifications(
       notificationsToSend,
       auditUser.id,
+    );
+  }
+
+  /**
+   * Creates a ministry notification when a when a program suspension restriction is blocking an application
+   * at accept assessment or at e-Cert.
+   * @param notification notification details.
+   * @param entityManager entity manager to execute in transaction.
+   */
+  async saveProgramSuspensionBlockingApplicationNotification(
+    notification: ProgramSuspensionBlockingApplicationNotification,
+    entityManager: EntityManager,
+  ): Promise<void> {
+    const auditUser = this.systemUsersService.systemUser;
+    const { templateId, emailContacts } =
+      await this.assertNotificationMessageDetails(
+        NotificationMessageType.ProgramSuspensionBlockingApplication,
+        { throwOnMissingEmailContacts: true },
+      );
+    if (!emailContacts?.length) {
+      return;
+    }
+    const ministryNotificationsToSend =
+      emailContacts.map<SaveNotificationModel>((emailContact) => ({
+        userId: auditUser.id,
+        messageType:
+          NotificationMessageType.ProgramSuspensionBlockingApplication,
+        messagePayload: {
+          email_address: emailContact,
+          template_id: templateId,
+          personalisation: {
+            givenNames: notification.givenNames ?? "",
+            lastName: notification.lastName,
+            birthDate: getDateOnlyFormat(notification.birthDate),
+            studentEmail: notification.studentEmail,
+            applicationNumber: notification.applicationNumber,
+            dateTime: this.getDateTimeOnPSTTimeZone(),
+            institutionOperatingName: notification.institutionOperatingName,
+            programName: notification.programName,
+          },
+        },
+        metadata: notification.metadata,
+      }));
+    // Save notifications to be sent to the ministry into the notification table.
+    await this.notificationService.saveNotifications(
+      ministryNotificationsToSend,
+      auditUser.id,
+      { entityManager },
     );
   }
 }

--- a/sources/packages/backend/libs/services/src/notifications/notification/notification.model.ts
+++ b/sources/packages/backend/libs/services/src/notifications/notification/notification.model.ts
@@ -172,7 +172,6 @@ export interface InstitutionRequestsDesignationNotification {
   institutionPrimaryEmail: string;
 }
 
-
 export interface InstitutionAddsPendingProgramNotification {
   institutionName: string;
   institutionOperatingName: string;
@@ -180,7 +179,6 @@ export interface InstitutionAddsPendingProgramNotification {
   institutionPrimaryEmail: string;
   email: string;
 }
-
 
 export interface InstitutionAddsPendingOfferingNotification {
   institutionName: string;
@@ -296,4 +294,18 @@ export interface StudentAcceptAssessmentReminderNotification {
   userId: number;
   applicationNumber: string;
   assessmentId: number;
+}
+
+/**
+ * Notification sent to the ministry when a program suspension restriction
+ * is blocking an application at accept assessment or at e-Cert.
+ */
+export interface ProgramSuspensionBlockingApplicationNotification {
+  givenNames?: string;
+  lastName: string;
+  studentEmail: string;
+  birthDate: string;
+  applicationNumber: string;
+  institutionOperatingName: string;
+  programName: string;
 }

--- a/sources/packages/backend/libs/services/src/notifications/notification/notification.model.ts
+++ b/sources/packages/backend/libs/services/src/notifications/notification/notification.model.ts
@@ -308,4 +308,5 @@ export interface ProgramSuspensionBlockingApplicationNotification {
   applicationNumber: string;
   institutionOperatingName: string;
   programName: string;
+  metadata: { assessmentId: number } | { disbursementId: number };
 }

--- a/sources/packages/backend/libs/services/src/restriction/model/restriction.model.ts
+++ b/sources/packages/backend/libs/services/src/restriction/model/restriction.model.ts
@@ -77,6 +77,10 @@ export enum RestrictionCode {
    * Institution block remittance request restriction.
    */
   REMIT = "REMIT",
+  /**
+   * Institution program suspension restriction.
+   */
+  SUS = "SUS",
 }
 
 /**

--- a/sources/packages/backend/libs/sims-db/src/entities/notification.model.ts
+++ b/sources/packages/backend/libs/sims-db/src/entities/notification.model.ts
@@ -261,4 +261,9 @@ export enum NotificationMessageType {
    * Student notification for assessment reminder.
    */
   StudentAssessmentReminder = 41,
+  /**
+   * Notification sent to the ministry when a program suspension restriction
+   * is blocking an application at accept assessment or at e-Cert.
+   */
+  ProgramSuspensionBlockingApplication = 42,
 }


### PR DESCRIPTION
# Program suspension restriction amendments - 2

## Added new notification
- [x] Added new notification service for the notification  `Program suspension blocking application`.

## Program suspension blocking application at assessment

- [x] Added a processor to `student-application-notifications` to send the ministry notification `Program suspension blocking application` when the application is blocked from accepting assessment by `SUS` restriction. This notification is sent only once per assessment. 

<img width="1504" height="568" alt="image" src="https://github.com/user-attachments/assets/224561dd-ae34-490c-83d4-cc4eb5bd8dbf" />

<img width="802" height="467" alt="image" src="https://github.com/user-attachments/assets/86193e81-372e-46dd-a0df-e64dae32f4fd" />


## Program suspension blocking application at disbursement

- [x] Added a new e-cert notification processor to send the ministry notification `Program suspension blocking application` when the application's eligible disbursement is blocked at e-cert processing by `SUS` restriction. This notification is sent only once per disbursement. 

<img width="1327" height="669" alt="image" src="https://github.com/user-attachments/assets/573ac44b-c18b-4efa-9e07-c45c0fb9b876" />

## Process summary warning for missing notification
- [x] Updated ministry notifications to optionally throw error on missing the email contact configuration in notification message. Enabled this option for few notifications including `Program suspension blocking application`.

<img width="1490" height="489" alt="image" src="https://github.com/user-attachments/assets/17633d1e-b53a-4d0d-b91c-a78fc7d53e40" />

## E2E Tests

- [x] Added tests for notification during block at e-cert generation.

```spec
Scheduler queue processor for full-time-e-cert-integration.
   √ Should block the disbursement and create program suspension blocking application notification when the application location and program has effective institution restriction SUS. (401 ms)
    √ Should block the disbursement but not create a program suspension blocking application notification when the application location and program has effective institution restriction SUS and the notification already exists for the disbursement. (271 ms)

Scheduler queue processor for part-time-e-cert-integration.
   √ Should block the disbursement and create program suspension blocking application notification when the application location and program has effective institution restriction SUS. (245 ms)
    √ Should block the disbursement but not create a program suspension blocking application notification when the application location and program has effective institution restriction SUS and the notification already exists for the disbursement. (274 ms)
```

- [x] Added E2E Tests for notification during block at accept assessment.

```spec
ProgramSuspensionBlockingAssessmentNotification
      √ Should generate program suspension blocking application notification when an application is blocked from confirming assessment due to effective SUS restriction. (267 ms)
      √ Should not generate program suspension blocking application notification when an application is blocked from confirming assessment due to effective SUS restriction and a notification has already been sent for the assessment. (155 ms)
      √ Should not generate program suspension blocking application notification when an application is blocked from confirming assessment due to SUS restriction and the restriction is bypassed. (187 ms)
```
