### PR TITLE
#6323 - Disability status failed submission

### DIFF
--- a/sources/packages/backend/apps/api/src/route-controllers/form-submission/models/form-submission.dto.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/form-submission/models/form-submission.dto.ts
@@ -4,7 +4,7 @@ import {
   FormSubmissionStatus,
   NOTE_DESCRIPTION_MAX_LENGTH,
 } from "@sims/sims-db";
-import { JSON_10KB } from "../../../constants";
+import { JSON_20KB } from "../../../constants";
 import {
   KnownSupplementaryData,
   KnownSupplementaryDataKey,
@@ -205,7 +205,7 @@ export class FormSubmissionItemAPIInDTO {
   @IsPositive()
   dynamicConfigurationId: number;
   @IsDefined()
-  @JsonMaxSize(JSON_10KB)
+  @JsonMaxSize(JSON_20KB)
   formData: KnownSupplementaryData & Record<string, unknown>;
   @IsDefined()
   files: string[];


### PR DESCRIPTION
## Summary
- Disability status submission failed due to a payload larger than 10kb when many long file names are present.
- Note: The full payload in testing is larger than 20kb because it includes additional attributes outside of formData (which has the validator).
- Confirmed no other endpoints which use the 10kb validator will have this issue.

## Screenshots
### Student -> Forms -> Disability status application
**25 long file names**
<img width="670" height="1113" alt="image" src="https://github.com/user-attachments/assets/d47d55aa-f9e4-472f-b03f-f70e66369e02" />
<img width="546" height="68" alt="image" src="https://github.com/user-attachments/assets/29c17e77-79e7-415e-9d45-26eef2adb31b" />

**Successful submission**
<img width="2280" height="584" alt="image" src="https://github.com/user-attachments/assets/41283fd8-25f2-4b17-97fa-4b1ca5fbbb3a" />





