### PR TITLE
#6104 - Program classification typo

### DIFF
--- a/sources/packages/forms/src/form-definitions/educationprogram.json
+++ b/sources/packages/forms/src/form-definitions/educationprogram.json
@@ -262,13 +262,15 @@
               "input": true
             },
             {
-              "label": "National Occupational Classifcation (NOC)",
+              "label": "National Occupational Classification (NOC)",
               "description": "Format (#####) Optional**",
+              "applyMaskOn": "change",
               "tableView": true,
               "validate": {
                 "pattern": "[0-9]{5}",
                 "customMessage": "Incorrect Format"
               },
+              "validateWhenHidden": false,
               "key": "nocCode",
               "logic": [
                 {


### PR DESCRIPTION
## Summary
- Fixed typo on program page.
 
## Screenshots
### Institution -> Location -> Programs -> Create Program
<img width="1331" height="767" alt="image" src="https://github.com/user-attachments/assets/dac4b27b-9e55-46da-852d-b685021d4ed8" />