### PR TITLE
#6305 - Private offering not showing on PIR

### DIFF
--- a/sources/packages/forms/src/form-definitions/programinformationrequest.json
+++ b/sources/packages/forms/src/form-definitions/programinformationrequest.json
@@ -401,8 +401,9 @@
           "validate": {
             "required": true
           },
+          "validateWhenHidden": false,
           "key": "selectedOffering",
-          "customConditional": "show =!data.denyProgramInformationRequest && (\r\n  // While the PIR is being completed by the user.\r\n  (data.pirStatus === \"Required\" && !data.showCustomOffering)\r\n  // Or when it was completed in some way with a public offering.\r\n  || (data.pirStatus !== \"Required\" && data.offeringType === \"Public\"));\r\n  \r\n",
+          "customConditional": "show =!data.denyProgramInformationRequest;",
           "type": "select",
           "input": true,
           "searchThreshold": 0.3
@@ -439,7 +440,7 @@
           "leftIcon": "fa fa-plus-circle",
           "tableView": false,
           "key": "createOffering",
-          "customConditional": "show = data.isReadOnlyUser !== true && data.selectedProgram;",
+          "customConditional": "show = data.pirStatus === \"Required\" && data.isReadOnlyUser !== true && data.selectedProgram;",
           "type": "button",
           "custom": "form.emit('customEvent', {\n  type: \"routeToCreateOffering\"\n});",
           "input": true


### PR DESCRIPTION
## Summary
- Updated logic so private offerings show when viewing PIR with status not Required.
- Updated logic so that Create Offering button is hidden (not just disabled) PIR with status not Required.
- There is a new Bug (ticket TBD) to deal with the missing Course info for PT offerings (see the blank Course in screenshots) that will be handled in a separate PR.

## Screenshots
### Institution -> Location -> PIR (Required)
<img width="1027" height="843" alt="image" src="https://github.com/user-attachments/assets/26b002e7-9cbd-4667-bda5-a413705c4432" />

### Institution -> Location -> PIR (Completed)
<img width="1095" height="792" alt="image" src="https://github.com/user-attachments/assets/1a5a7fcd-4dcf-4396-b5b5-59ec0a52c3f4" />

