### PR TITLE
#6282 - Institution under review restriction - E2E Tests

### DIFF
--- a/sources/packages/backend/apps/api/src/route-controllers/application/_tests_/e2e/application.students.controller.submitApplication.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/application/_tests_/e2e/application.students.controller.submitApplication.e2e-spec.ts
@@ -21,6 +21,7 @@ import {
   saveFakeSFASIndividual,
   RestrictionCode,
   ensureProgramYearExistsForPartTimeOnly,
+  saveFakeInstitutionRestriction,
 } from "@sims/test-utils";
 import {
   Application,
@@ -29,6 +30,7 @@ import {
   EducationProgramOffering,
   OfferingIntensity,
   ProgramYear,
+  RestrictionType,
   Student,
 } from "@sims/sims-db";
 import { addDays, getISODateOnlyString } from "@sims/utilities";
@@ -38,6 +40,7 @@ import { AppStudentsModule } from "../../../../app.students.module";
 import { createFakeSFASPartTimeApplication } from "@sims/test-utils/factories/sfas-part-time-application";
 import { createFakeSFASApplication } from "@sims/test-utils/factories/sfas-application";
 import { ConfigServiceMockHelper } from "@sims/test-utils/mocks";
+import { ACTIVE_INSTITUTION_RESTRICTION } from "../../../../constants";
 
 describe("ApplicationStudentsController(e2e)-submitApplication", () => {
   let app: INestApplication;
@@ -1044,6 +1047,49 @@ describe("ApplicationStudentsController(e2e)-submitApplication", () => {
       });
   });
 
+  it("Should throw a forbidden error when submitting an application for an institution under review.", async () => {
+    // Arrange
+    const { student, draftApplication, payload, selectedOffering } =
+      await saveApplicationDraftReadyForSubmission();
+    // Associate the IUR restriction to the institution under review location.
+    const iurRestriction = await db.restriction.findOneOrFail({
+      select: { id: true },
+      where: {
+        restrictionType: RestrictionType.Institution,
+        restrictionCode: RestrictionCode.IUR,
+      },
+    });
+    await saveFakeInstitutionRestriction(db, {
+      restriction: iurRestriction,
+      institution: selectedOffering.institutionLocation.institution,
+    });
+
+    const endpoint = `/students/application/${draftApplication.id}/submit`;
+    const token = await getStudentToken(
+      FakeStudentUsersTypes.FakeStudentUserType1,
+    );
+    const dryRunSubmissionMock = jest.fn().mockResolvedValue({
+      valid: true,
+      formName: FormNames.Application,
+      data: { data: payload.data },
+    });
+    formService.dryRunSubmission = dryRunSubmissionMock;
+    // Mock the user received in the token.
+    await mockJWTUserInfo(appModule, student.user);
+
+    // Act/Assert
+    await request(app.getHttpServer())
+      .patch(endpoint)
+      .send(payload)
+      .auth(token, BEARER_AUTH_TYPE)
+      .expect(HttpStatus.FORBIDDEN)
+      .expect({
+        message:
+          "The application cannot be submitted at this time because the institution associated with your application is currently restricted.",
+        errorType: ACTIVE_INSTITUTION_RESTRICTION,
+      });
+  });
+
   /**
    * Save a draft application ready for submission.
    * @param options optional parameters for saving the application.
@@ -1057,6 +1103,7 @@ describe("ApplicationStudentsController(e2e)-submitApplication", () => {
     student: Student;
     draftApplication: Application;
     payload: SaveApplicationAPIInDTO;
+    selectedOffering: EducationProgramOffering;
   }> {
     // Create a student and a draft application.
     const student = await saveFakeStudent(db.dataSource);
@@ -1093,6 +1140,7 @@ describe("ApplicationStudentsController(e2e)-submitApplication", () => {
       student,
       draftApplication,
       payload,
+      selectedOffering,
     };
   }
 

--- a/sources/packages/backend/apps/api/src/route-controllers/application/_tests_/e2e/application.students.controller.submitApplication.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/application/_tests_/e2e/application.students.controller.submitApplication.e2e-spec.ts
@@ -1095,7 +1095,7 @@ describe("ApplicationStudentsController(e2e)-submitApplication", () => {
    * @param options optional parameters for saving the application.
    * - `programYear` the program year to associate with the application.
    * If not provided, the recent active program year will be used.
-   * @returns the student, draft application, and payload.
+   * @returns the student, draft application, payload, and selected offering for the application.
    */
   async function saveApplicationDraftReadyForSubmission(options?: {
     programYear?: ProgramYear;

--- a/sources/packages/backend/apps/api/src/route-controllers/institution-locations/_tests_/e2e/institution-location.students.controller.getOptionsList.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/institution-locations/_tests_/e2e/institution-location.students.controller.getOptionsList.e2e-spec.ts
@@ -66,7 +66,7 @@ describe("InstitutionLocationStudentsController(e2e)-getOptionsList", () => {
       });
   });
 
-  it("Should get the list of all designated institutions locations which should contain the newly created designated location and not the newly created location from the institution under review when student requests all locations.", async () => {
+  it("Should get the list of all designated institution locations excluding the location that belongs to an institution under review when student requests all locations.", async () => {
     // Arrange
     // Create two distinct designation agreements, to have two distinct institutions,
     // one of them will be under review (IUR).

--- a/sources/packages/backend/apps/api/src/route-controllers/institution-locations/_tests_/e2e/institution-location.students.controller.getOptionsList.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/institution-locations/_tests_/e2e/institution-location.students.controller.getOptionsList.e2e-spec.ts
@@ -25,7 +25,7 @@ describe("InstitutionLocationStudentsController(e2e)-getOptionsList", () => {
     db = createE2EDataSources(dataSource);
   });
 
-  it("Should get the list of all designated institution locations which should contains the newly created designated location and not the newly created non designated location when student requests all locations.", async () => {
+  it("Should get the list of all designated institution locations which should contain the newly created designated location and not the newly created non-designated location when a student requests all locations.", async () => {
     // Arrange
     const newDesignation = await saveFakeDesignationAgreementLocation(db, {
       numberOfLocations: 2,
@@ -66,7 +66,7 @@ describe("InstitutionLocationStudentsController(e2e)-getOptionsList", () => {
       });
   });
 
-  it("Should get the list of all designated institution locations excluding the location that belongs to an institution under review when student requests all locations.", async () => {
+  it("Should get the list of all designated institution locations, excluding the location that belongs to an institution under review, when a student requests all locations.", async () => {
     // Arrange
     // Create two distinct designation agreements, to have two distinct institutions,
     // one of them will be under review (IUR).

--- a/sources/packages/backend/apps/api/src/route-controllers/institution-locations/_tests_/e2e/institution-location.students.controller.getOptionsList.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/institution-locations/_tests_/e2e/institution-location.students.controller.getOptionsList.e2e-spec.ts
@@ -45,23 +45,21 @@ describe("InstitutionLocationStudentsController(e2e)-getOptionsList", () => {
     const token = await getStudentToken(
       FakeStudentUsersTypes.FakeStudentUserType1,
     );
+
     // Act/Assert
     await request(app.getHttpServer())
       .get(endpoint)
       .auth(token, BEARER_AUTH_TYPE)
       .expect(HttpStatus.OK)
       .expect((response) => {
-        expect(response.body).toEqual(
-          expect.arrayContaining([
-            expect.objectContaining({
-              id: designatedLocation.institutionLocation.id,
-              description: designatedLocation.institutionLocation.name,
-            }),
-            expect.not.objectContaining({
-              id: nonDesignatedLocation.institutionLocation.id,
-              description: nonDesignatedLocation.institutionLocation.name,
-            }),
-          ]),
+        const locationIds = response.body.map(
+          (location: { id: number }) => location.id,
+        );
+        expect(locationIds).toContain(
+          designatedLocation.institutionLocation.id,
+        );
+        expect(locationIds).not.toContain(
+          nonDesignatedLocation.institutionLocation.id,
         );
       });
   });
@@ -106,17 +104,14 @@ describe("InstitutionLocationStudentsController(e2e)-getOptionsList", () => {
       .auth(token, BEARER_AUTH_TYPE)
       .expect(HttpStatus.OK)
       .expect((response) => {
-        expect(response.body).toEqual(
-          expect.arrayContaining([
-            expect.objectContaining({
-              id: designatedLocation.institutionLocation.id,
-              description: designatedLocation.institutionLocation.name,
-            }),
-            expect.not.objectContaining({
-              id: underReviewLocation.institutionLocation.id,
-              description: underReviewLocation.institutionLocation.name,
-            }),
-          ]),
+        const locationIds = response.body.map(
+          (location: { id: number }) => location.id,
+        );
+        expect(locationIds).toContain(
+          designatedLocation.institutionLocation.id,
+        );
+        expect(locationIds).not.toContain(
+          underReviewLocation.institutionLocation.id,
         );
       });
   });

--- a/sources/packages/backend/apps/api/src/route-controllers/institution-locations/_tests_/e2e/institution-location.students.controller.getOptionsList.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/institution-locations/_tests_/e2e/institution-location.students.controller.getOptionsList.e2e-spec.ts
@@ -8,9 +8,12 @@ import {
 } from "../../../../testHelpers";
 import {
   E2EDataSources,
+  RestrictionCode,
   createE2EDataSources,
   saveFakeDesignationAgreementLocation,
+  saveFakeInstitutionRestriction,
 } from "@sims/test-utils";
+import { RestrictionType } from "@sims/sims-db";
 
 describe("InstitutionLocationStudentsController(e2e)-getOptionsList", () => {
   let app: INestApplication;
@@ -22,7 +25,7 @@ describe("InstitutionLocationStudentsController(e2e)-getOptionsList", () => {
     db = createE2EDataSources(dataSource);
   });
 
-  it("Should get the list of all designated institution location which should contain the only newly created designated location and not the newly created non designated location when student requests.", async () => {
+  it("Should get the list of all designated institution locations which should contains the newly created designated location and not the newly created non designated location when student requests all locations.", async () => {
     // Arrange
     const newDesignation = await saveFakeDesignationAgreementLocation(db, {
       numberOfLocations: 2,
@@ -57,6 +60,61 @@ describe("InstitutionLocationStudentsController(e2e)-getOptionsList", () => {
             expect.not.objectContaining({
               id: nonDesignatedLocation.institutionLocation.id,
               description: nonDesignatedLocation.institutionLocation.name,
+            }),
+          ]),
+        );
+      });
+  });
+
+  it("Should get the list of all designated institutions locations which should contain the newly created designated location and not the newly created location from the institution under review when student requests all locations.", async () => {
+    // Arrange
+    // Create two distinct designation agreements, to have two distinct institutions,
+    // one of them will be under review (IUR).
+    const [newDesignation, newDesignationIUR] = await Promise.all([
+      saveFakeDesignationAgreementLocation(db, {
+        numberOfLocations: 1,
+      }),
+      saveFakeDesignationAgreementLocation(db, {
+        numberOfLocations: 1,
+      }),
+    ]);
+    const [designatedLocation] = newDesignation.designationAgreementLocations;
+    const [underReviewLocation] =
+      newDesignationIUR.designationAgreementLocations;
+
+    // Associate the IUR restriction to the institution under review location.
+    const iurRestriction = await db.restriction.findOneOrFail({
+      select: { id: true },
+      where: {
+        restrictionType: RestrictionType.Institution,
+        restrictionCode: RestrictionCode.IUR,
+      },
+    });
+    await saveFakeInstitutionRestriction(db, {
+      restriction: iurRestriction,
+      institution: underReviewLocation.institutionLocation.institution,
+    });
+
+    const endpoint = "/students/location/options-list";
+    const token = await getStudentToken(
+      FakeStudentUsersTypes.FakeStudentUserType1,
+    );
+
+    // Act/Assert
+    await request(app.getHttpServer())
+      .get(endpoint)
+      .auth(token, BEARER_AUTH_TYPE)
+      .expect(HttpStatus.OK)
+      .expect((response) => {
+        expect(response.body).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              id: designatedLocation.institutionLocation.id,
+              description: designatedLocation.institutionLocation.name,
+            }),
+            expect.not.objectContaining({
+              id: underReviewLocation.institutionLocation.id,
+              description: underReviewLocation.institutionLocation.name,
             }),
           ]),
         );

--- a/sources/packages/backend/libs/test-utils/src/models/common.model.ts
+++ b/sources/packages/backend/libs/test-utils/src/models/common.model.ts
@@ -167,4 +167,8 @@ export enum RestrictionCode {
    * Institution block remittance request restriction.
    */
   REMIT = "REMIT",
+  /**
+   * Institution under review restriction.
+   */
+  IUR = "IUR",
 }


### PR DESCRIPTION
## Missing critical E2E tests highlighted in previous PRs.

- Should throw a forbidden error when submitting an application for an institution under review.
- Should get the list of all designated institution locations excluding the location that belongs to an institution under review when student requests all locations.

## Previously added E2E tests as part of this effort.

- Should return an institution restriction and prevent the assessment acceptance when there is an effective restriction on institution with an action to 'Stop accept assessment'.
- Should not allow NOA approval of a Part-time application when the current assessment is associated with an institution that has some restriction with an 'Stop accept assessment' action.
- Should not allow NOA approval of a Full-time application when the current assessment is associated with an institution that has some restriction with an 'Stop accept assessment' action.
