### PR TITLE
#6230 - Minor SQL adjustment to get preliminary list of applications

### DIFF
--- a/sources/packages/backend/apps/queue-consumers/src/services/application/application.service.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/services/application/application.service.ts
@@ -28,6 +28,7 @@ import { STUDENT_ASSESSMENT_NOTIFICATION_OVERDUE_DAYS } from "@sims/services/con
 import { ECertPreValidationService } from "@sims/integrations/services/disbursement-schedule/e-cert-calculation";
 import { ECertFailedValidation } from "@sims/integrations/services";
 import { RestrictionCode } from "@sims/services";
+import { ProcessSummary } from "@sims/utilities/logger";
 
 interface SecondDisbursementStillPending {
   assessmentId: number;
@@ -464,7 +465,9 @@ export class ApplicationService {
    * Get application that are blocked at accept assessment due to program suspension restriction.
    * @returns applications with assessments blocked by program suspension restriction.
    */
-  async getApplicationsBlockedByProgramSuspension(): Promise<Application[]> {
+  async getApplicationsBlockedByProgramSuspension(options?: {
+    processSummary?: ProcessSummary;
+  }): Promise<Application[]> {
     // Sub query to defined if a notification was already sent to the current assessment.
     const {
       query: notificationExistsQuery,
@@ -492,6 +495,9 @@ export class ApplicationService {
     if (!applicationsPendingAcceptAssessment.length) {
       return [];
     }
+    options?.processSummary?.info(
+      `Applications from restricted institutions pending accept assessment: ${applicationsPendingAcceptAssessment.length}`,
+    );
     // Get the accept assessment validation results for the applications pending accept assessment.
     const applicationIds = applicationsPendingAcceptAssessment.map(
       (application) => application.id,

--- a/sources/packages/backend/apps/queue-consumers/src/services/application/application.service.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/services/application/application.service.ts
@@ -463,6 +463,8 @@ export class ApplicationService {
 
   /**
    * Get application that are blocked at accept assessment due to program suspension restriction.
+   * @param options related options.
+   * - `processSummary` process summary for logging.
    * @returns applications with assessments blocked by program suspension restriction.
    */
   async getApplicationsBlockedByProgramSuspension(options?: {

--- a/sources/packages/backend/apps/queue-consumers/src/services/application/application.service.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/services/application/application.service.ts
@@ -495,8 +495,7 @@ export class ApplicationService {
       return [];
     }
     this.logger.log(
-      "Number of applications from restricted institutions pending accept assessment:",
-      applicationsPendingAcceptAssessment.length,
+      `Number of applications from restricted institutions pending accept assessment: ${applicationsPendingAcceptAssessment.length}`,
     );
     // Get the accept assessment validation results for the applications pending accept assessment.
     const applicationIds = applicationsPendingAcceptAssessment.map(

--- a/sources/packages/backend/apps/queue-consumers/src/services/application/application.service.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/services/application/application.service.ts
@@ -498,7 +498,7 @@ export class ApplicationService {
       return [];
     }
     options?.processSummary?.info(
-      `Applications from restricted institutions pending accept assessment: ${applicationsPendingAcceptAssessment.length}`,
+      `Number of applications from restricted institutions pending accept assessment: ${applicationsPendingAcceptAssessment.length}`,
     );
     // Get the accept assessment validation results for the applications pending accept assessment.
     const applicationIds = applicationsPendingAcceptAssessment.map(

--- a/sources/packages/backend/apps/queue-consumers/src/services/application/application.service.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/services/application/application.service.ts
@@ -477,8 +477,12 @@ export class ApplicationService {
     );
     // Get all applications pending for accept assessment and that have not been notified yet
     // about the program suspension restriction blocking the assessment acceptance.
+    // As these applications are retrieved to be validated further for effective program suspension restriction
+    // applications from institutions having active restrictions only are considered to be more relevant for the validation.
     const applicationsPendingAcceptAssessment =
       await this.getPendingAcceptAssessmentBaseQuery()
+        .innerJoin("institution.restrictions", "institutionRestriction")
+        .andWhere("institutionRestriction.isActive = true")
         .andWhere("application.isArchived = false")
         .andWhere(
           `NOT EXISTS (${notificationExistsQuery})`,

--- a/sources/packages/backend/apps/queue-consumers/src/services/application/application.service.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/services/application/application.service.ts
@@ -17,6 +17,7 @@ import {
   QueryAndParamsForExecution,
 } from "@sims/sims-db";
 import { ConfigService } from "@sims/utilities/config";
+import { LoggerService } from "@sims/utilities/logger";
 import { InjectRepository } from "@nestjs/typeorm";
 import {
   addDays,
@@ -28,7 +29,6 @@ import { STUDENT_ASSESSMENT_NOTIFICATION_OVERDUE_DAYS } from "@sims/services/con
 import { ECertPreValidationService } from "@sims/integrations/services/disbursement-schedule/e-cert-calculation";
 import { ECertFailedValidation } from "@sims/integrations/services";
 import { RestrictionCode } from "@sims/services";
-import { ProcessSummary } from "@sims/utilities/logger";
 
 interface SecondDisbursementStillPending {
   assessmentId: number;
@@ -69,6 +69,7 @@ export class ApplicationService {
     private readonly notificationRepo: Repository<Notification>,
     @InjectRepository(DisbursementSchedule)
     private readonly disbursementScheduleRepo: Repository<DisbursementSchedule>,
+    private readonly logger: LoggerService,
   ) {
     this.inProgressStatusesExistsQuery = this.studentAssessmentRepo
       .createQueryBuilder("studentAssessment")
@@ -463,13 +464,9 @@ export class ApplicationService {
 
   /**
    * Get application that are blocked at accept assessment due to program suspension restriction.
-   * @param options related options.
-   * - `processSummary` process summary for logging.
    * @returns applications with assessments blocked by program suspension restriction.
    */
-  async getApplicationsBlockedByProgramSuspension(options?: {
-    processSummary?: ProcessSummary;
-  }): Promise<Application[]> {
+  async getApplicationsBlockedByProgramSuspension(): Promise<Application[]> {
     // Sub query to defined if a notification was already sent to the current assessment.
     const {
       query: notificationExistsQuery,
@@ -497,8 +494,9 @@ export class ApplicationService {
     if (!applicationsPendingAcceptAssessment.length) {
       return [];
     }
-    options?.processSummary?.info(
-      `Number of applications from restricted institutions pending accept assessment: ${applicationsPendingAcceptAssessment.length}`,
+    this.logger.log(
+      "Number of applications from restricted institutions pending accept assessment:",
+      applicationsPendingAcceptAssessment.length,
     );
     // Get the accept assessment validation results for the applications pending accept assessment.
     const applicationIds = applicationsPendingAcceptAssessment.map(

--- a/sources/packages/backend/apps/queue-consumers/src/services/student-application-notification/student-application-notification-processor/program-suspension-blocking-assessment-notification.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/services/student-application-notification/student-application-notification-processor/program-suspension-blocking-assessment-notification.ts
@@ -26,7 +26,9 @@ export class ProgramSuspensionBlockingAssessmentNotification {
     const notificationLog = new ProcessSummary();
     processSummary.children(notificationLog);
     const applications =
-      await this.applicationService.getApplicationsBlockedByProgramSuspension();
+      await this.applicationService.getApplicationsBlockedByProgramSuspension({
+        processSummary: notificationLog,
+      });
     if (!applications.length) {
       notificationLog.info(
         "No applications blocked by the program suspension restriction without an existing notification were found.",

--- a/sources/packages/backend/apps/queue-consumers/src/services/student-application-notification/student-application-notification-processor/program-suspension-blocking-assessment-notification.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/services/student-application-notification/student-application-notification-processor/program-suspension-blocking-assessment-notification.ts
@@ -26,9 +26,7 @@ export class ProgramSuspensionBlockingAssessmentNotification {
     const notificationLog = new ProcessSummary();
     processSummary.children(notificationLog);
     const applications =
-      await this.applicationService.getApplicationsBlockedByProgramSuspension({
-        processSummary: notificationLog,
-      });
+      await this.applicationService.getApplicationsBlockedByProgramSuspension();
     if (!applications.length) {
       notificationLog.info(
         "No applications blocked by the program suspension restriction without an existing notification were found.",


### PR DESCRIPTION
Fix: If the number of non-archived applications pending accept assessment exceed 65,535 which is the postgres limit for values passed into IN(), the sql breaks.

Solution: Adjusted the query return non-archived applications pending accept assessment only from restricted institutions.

Improvement: Added a log with count of application ids for non-archived applications pending accept assessment from restricted institutions.

<img width="1862" height="127" alt="image" src="https://github.com/user-attachments/assets/a0093951-ea11-4fdd-b8c3-05a7113c0fd4" />
