### PR TITLE
#6356 - BUG: Prod: Form IO: PT PIR Course name and Course dates no longer display

### DIFF
--- a/sources/packages/forms/src/form-definitions/programinformationrequest.json
+++ b/sources/packages/forms/src/form-definitions/programinformationrequest.json
@@ -9,6 +9,56 @@
   ],
   "components": [
     {
+      "label": "Application submitted date",
+      "persistent": "client-only",
+      "key": "applicationSubmittedDate",
+      "type": "hidden",
+      "input": true,
+      "tableView": false
+    },
+    {
+      "input": true,
+      "tableView": true,
+      "key": "isSelectedOfferingPartTime",
+      "label": "isSelectedOfferingPartTime",
+      "type": "hidden",
+      "calculateValue": "value = data.offeringIntensitySelectedByStudent === 'Part Time'"
+    },
+    {
+      "input": true,
+      "tableView": false,
+      "key": "selectedOfferingEndDate",
+      "label": "Selected offering end date",
+      "type": "hidden",
+      "lockKey": true,
+      "isNew": false
+    },
+    {
+      "label": "pirStatus",
+      "key": "pirStatus",
+      "type": "hidden",
+      "input": true,
+      "tableView": false
+    },
+    {
+      "label": "Is application submitted after the deadline for the selected study end date",
+      "persistent": "client-only",
+      "calculateValue": "/**\r\n * Checks if the study end date of the offering selected to complete PIR\r\n * is less than application submission deadline weeks from application submission date.\r\n * \r\n * Or in other words is application submitted date after the deadline date for the study end date based on deadline weeks.\r\n */\r\n\r\nvalue =\r\n  !!data.selectedOfferingEndDate &&\r\n  !!data.applicationSubmittedDate &&\r\n  !!data.applicationSubmissionDeadlineWeeks &&\r\n  utils.custom.isLessThanGivenWeeks(data.selectedOfferingEndDate, data.applicationSubmissionDeadlineWeeks, {referenceDate: data.applicationSubmittedDate});\r\n",
+      "key": "isApplicationSubmittedAfterDeadlineForStudyEndDate",
+      "type": "hidden",
+      "input": true,
+      "tableView": false,
+      "lockKey": true
+    },
+    {
+      "label": "Application submission deadline weeks",
+      "persistent": "client-only",
+      "key": "applicationSubmissionDeadlineWeeks",
+      "type": "hidden",
+      "input": true,
+      "tableView": false
+    },
+    {
       "label": "Student Name",
       "tag": "p",
       "attrs": [
@@ -246,16 +296,19 @@
           "label": "Data Grid",
           "disableAddingRemovingRows": true,
           "reorder": false,
-          "addAnotherPosition": "bottom",
           "layoutFixed": false,
           "enableRowGroups": false,
           "initEmpty": false,
           "customClass": "formio-datagrid-unset",
           "hideLabel": true,
           "tableView": false,
+          "defaultValue": [
+            {}
+          ],
+          "validateWhenHidden": false,
           "key": "courseDetails",
           "conditional": {
-            "show": "true",
+            "show": true,
             "when": "isSelectedOfferingPartTime",
             "eq": "true"
           },
@@ -517,70 +570,6 @@
           "hideOnChildrenHidden": false
         }
       ]
-    },
-    {
-      "label": "Application submitted date",
-      "persistent": "client-only",
-      "key": "applicationSubmittedDate",
-      "type": "hidden",
-      "input": true,
-      "tableView": false
-    },
-    {
-      "input": true,
-      "tableView": true,
-      "key": "isSelectedOfferingPartTime",
-      "label": "isSelectedOfferingPartTime",
-      "type": "hidden",
-      "calculateValue": "value = data.offeringIntensitySelectedByStudent === 'Part Time'"
-    },
-    {
-      "label": "pirStatus",
-      "key": "pirStatus",
-      "type": "hidden",
-      "input": true,
-      "tableView": false
-    },
-    {
-      "label": "applicationId",
-      "key": "applicationId",
-      "type": "hidden",
-      "input": true,
-      "tableView": false
-    },
-    {
-      "label": "applicationStatus",
-      "key": "applicationStatus",
-      "type": "hidden",
-      "input": true,
-      "tableView": false
-    },
-    {
-      "input": true,
-      "tableView": false,
-      "key": "selectedOfferingEndDate",
-      "label": "Selected offering end date",
-      "type": "hidden",
-      "lockKey": true,
-      "isNew": false
-    },
-    {
-      "label": "Is application submitted after the deadline for the selected study end date",
-      "persistent": "client-only",
-      "calculateValue": "/**\r\n * Checks if the study end date of the offering selected to complete PIR\r\n * is less than application submission deadline weeks from application submission date.\r\n * \r\n * Or in other words is application submitted date after the deadline date for the study end date based on deadline weeks.\r\n */\r\n\r\nvalue =\r\n  !!data.selectedOfferingEndDate &&\r\n  !!data.applicationSubmittedDate &&\r\n  !!data.applicationSubmissionDeadlineWeeks &&\r\n  utils.custom.isLessThanGivenWeeks(data.selectedOfferingEndDate, data.applicationSubmissionDeadlineWeeks, {referenceDate: data.applicationSubmittedDate});\r\n",
-      "key": "isApplicationSubmittedAfterDeadlineForStudyEndDate",
-      "type": "hidden",
-      "input": true,
-      "tableView": false,
-      "lockKey": true
-    },
-    {
-      "label": "Application submission deadline weeks",
-      "persistent": "client-only",
-      "key": "applicationSubmissionDeadlineWeeks",
-      "type": "hidden",
-      "input": true,
-      "tableView": false
     }
   ]
 }

--- a/sources/packages/web/src/assets/css/formio-shared.scss
+++ b/sources/packages/web/src/assets/css/formio-shared.scss
@@ -607,7 +607,7 @@
 }
 .ff-form-container .formio-datagrid-unset .table td,
 .ff-form-container .formio-datagrid-unset .table th {
-  padding: 0;
+  padding: 10px;
 }
 
 // CSS for panel component border to match Figma.


### PR DESCRIPTION
- Moved the hidden fields to the top to allow the logic to be applied to the grid.
- Only the `isSelectedOfferingPartTime` was required for this fix. The others were moved for consistency.
- Minor padding adjustments were made in the style shared by similar tables for the "study breaks" ("confirm enrollment" and "scholastic standing").

<img width="1880" height="990" alt="image" src="https://github.com/user-attachments/assets/d88c25c3-c4d3-44fa-8f3d-a58087e42214" />
