### PR TITLE
#6230 - Fix all settled promise

### DIFF
--- a/sources/packages/backend/apps/queue-consumers/src/services/student-application-notification/student-application-notification.service.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/services/student-application-notification/student-application-notification.service.ts
@@ -37,7 +37,18 @@ export class StudentApplicationNotificationService {
       this.ministrySINFileProcessingIssueNotification,
       this.studentAssessmentReminderNotification,
       this.programSuspensionBlockingAssessmentNotification,
-    ].map((notification) => notification.createNotification(processSummary));
-    await Promise.allSettled(notifications);
+    ];
+    const notificationProcessingActions = notifications.map((notification) =>
+      notification.createNotification(processSummary),
+    );
+    const results = await Promise.allSettled(notificationProcessingActions);
+    results.forEach((result, index) => {
+      if (result.status === "rejected") {
+        processSummary.error(
+          `Error while creating ${notifications[index].constructor.name}.`,
+          result.reason,
+        );
+      }
+    });
   }
 }


### PR DESCRIPTION
The usage of `await Promise.allSettled` in student application notifications is silently ignoring the errors. 
Updated the code to fix the silent failure.