### PR TITLE
#4839 - Remove files: Soft deleted (UI)

### DIFF
--- a/sources/packages/web/src/components/common/modals/UserNoteConfirmModal.vue
+++ b/sources/packages/web/src/components/common/modals/UserNoteConfirmModal.vue
@@ -7,7 +7,7 @@
     >
       <template #content>
         <error-summary :errors="modalNotesForm.errors" />
-        <slot name="content">{{ text }}</slot>
+        <slot name="content" :show-parameter="showParameter">{{ text }}</slot>
         <v-textarea
           :label="notesLabel"
           variant="outlined"
@@ -58,6 +58,7 @@ export default defineComponent({
     text: {
       type: String,
       required: false,
+      default: undefined,
     },
     okLabel: {
       type: String,
@@ -72,6 +73,7 @@ export default defineComponent({
     maxWidth: {
       type: Number,
       required: false,
+      default: undefined,
     },
     disablePrimaryButton: {
       type: Boolean,
@@ -135,6 +137,7 @@ export default defineComponent({
       showModal,
       resolvePromise,
       loading,
+      showParameter,
     };
   },
 });

--- a/sources/packages/web/src/components/common/modals/UserNoteConfirmModal.vue
+++ b/sources/packages/web/src/components/common/modals/UserNoteConfirmModal.vue
@@ -2,8 +2,8 @@
   <v-form ref="modalNotesForm">
     <modal-dialog-base
       :title="title"
-      :showDialog="showDialog"
-      :maxWidth="maxWidth"
+      :show-dialog="showDialog"
+      :max-width="maxWidth"
     >
       <template #content>
         <error-summary :errors="modalNotesForm.errors" />
@@ -16,15 +16,18 @@
           :rules="[(v) => checkNotesLengthRule(v, notesLabel)]"
           required
         />
+        <p class="brand-gray-text" v-if="notesDescription">
+          {{ notesDescription }}
+        </p>
       </template>
       <template #footer>
         <footer-buttons
-          :primaryLabel="okLabel"
-          :secondaryLabel="cancelLabel"
-          @primaryClick="resolvePromise(true)"
-          @secondaryClick="resolvePromise(false)"
-          :disablePrimaryButton="disablePrimaryButton"
-          :showSecondaryButton="showSecondaryButton"
+          :primary-label="okLabel"
+          :secondary-label="cancelLabel"
+          @primary-click="resolvePromise(true)"
+          @secondary-click="resolvePromise(false)"
+          :disable-primary-button="disablePrimaryButton"
+          :show-secondary-button="showSecondaryButton"
           :processing="loading"
         />
       </template>
@@ -83,6 +86,10 @@ export default defineComponent({
     notesLabel: {
       type: String,
       default: "Notes",
+    },
+    notesDescription: {
+      type: String,
+      default: undefined,
     },
   },
   setup() {

--- a/sources/packages/web/src/components/common/students/StudentFileUploads.vue
+++ b/sources/packages/web/src/components/common/students/StudentFileUploads.vue
@@ -65,6 +65,19 @@
               <span>{{ item.fileName }}</span>
             </div>
           </template>
+          <template #[`item.action`]="{ item }">
+            <check-permission-role :role="Role.StudentDeleteUploadedFile">
+              <template #="{ notAllowed }">
+                <v-btn
+                  color="primary"
+                  variant="outlined"
+                  :disabled="notAllowed || !!item.deletedAt"
+                  @click="deleteStudentFile(item.uniqueFileName)"
+                  >Delete</v-btn
+                >
+              </template>
+            </check-permission-role>
+          </template>
         </v-data-table>
       </toggle-content>
     </content-group>
@@ -94,6 +107,20 @@
         </v-row>
       </template>
     </formio-modal-dialog>
+    <user-note-confirm-modal
+      title="Delete file"
+      ref="deleteFileModal"
+      ok-label="Delete file"
+    >
+      <template #content>
+        <p>
+          <strong>Attention:</strong> Before proceeding, ensure that all
+          required privacy, records management, and compliance activities have
+          been completed. Once deleted, the file and its contents will no longer
+          be available for viewing or download.
+        </p>
+      </template>
+    </user-note-confirm-modal>
   </body-header-container>
 </template>
 
@@ -108,6 +135,7 @@ import {
   Role,
   StudentFileUploadsHeaders,
   StudentFileUploadsDetails,
+  ApiProcessError,
 } from "@/types";
 import { StudentService } from "@/services/StudentService";
 import {
@@ -119,12 +147,16 @@ import {
 } from "@/composables";
 import FormioModalDialog from "@/components/generic/FormioModalDialog.vue";
 import CheckPermissionRole from "@/components/generic/CheckPermissionRole.vue";
+import UserNoteConfirmModal, {
+  UserNoteModal,
+} from "@/components/common/modals/UserNoteConfirmModal.vue";
 
 export default defineComponent({
   emits: ["uploadFile"],
   components: {
     CheckPermissionRole,
     FormioModalDialog,
+    UserNoteConfirmModal,
   },
   props: {
     studentId: {
@@ -150,6 +182,7 @@ export default defineComponent({
   setup(props, context) {
     const studentFileUploads = ref([] as StudentFileUploadsDetails[]);
     const fileUploadModal = ref({} as ModalDialog<FormIOForm | boolean>);
+    const deleteFileModal = ref({} as ModalDialog<UserNoteModal<string>>);
     const { getISODateHourMinuteString, emptyStringFiller } = useFormatters();
     const fileUtils = useFileUtils();
     const initialData = ref({ studentId: props.studentId });
@@ -178,6 +211,34 @@ export default defineComponent({
       }
     };
 
+    const deleteStudentFile = async (uniqueFileName: string) => {
+      await deleteFileModal.value.showModal(
+        uniqueFileName,
+        deleteStudentFileCall,
+      );
+    };
+
+    const deleteStudentFileCall = async (
+      userNoteModalResult: UserNoteModal<string>,
+    ): Promise<boolean> => {
+      try {
+        await StudentService.shared.deleteStudentUploadedFile(
+          userNoteModalResult.showParameter,
+          { noteDescription: userNoteModalResult.note },
+        );
+        snackBar.success("File deleted.");
+        await loadStudentFileUploads();
+        return true;
+      } catch (error: unknown) {
+        if (error instanceof ApiProcessError) {
+          snackBar.error(error.message);
+          return false;
+        }
+        snackBar.error("An unexpected error happened while deleting the file.");
+      }
+      return false;
+    };
+
     const studentFileUploadHeaders = computed(() => {
       return props.canViewUploadedBy
         ? StudentFileUploadsHeaders
@@ -201,6 +262,8 @@ export default defineComponent({
       initialData,
       studentFileUploadHeaders,
       isMobile,
+      deleteStudentFile,
+      deleteFileModal,
     };
   },
 });

--- a/sources/packages/web/src/components/common/students/StudentFileUploads.vue
+++ b/sources/packages/web/src/components/common/students/StudentFileUploads.vue
@@ -72,7 +72,7 @@
                   color="primary"
                   variant="outlined"
                   :disabled="notAllowed"
-                  @click="deleteStudentFile(item.uniqueFileName)"
+                  @click="deleteStudentFile(item.uniqueFileName, item.fileName)"
                   >Delete</v-btn
                 >
               </template>
@@ -113,7 +113,8 @@
       ok-label="Delete file"
       notes-description="Notes will be visible to StudentAid staff and institutions. This will not be shown to students."
     >
-      <template #content>
+      <template #content="{ showParameter }">
+        <span><strong>File:</strong> {{ showParameter.fileName }}</span>
         <p>
           <strong>Attention:</strong> Before proceeding, ensure that all
           required privacy, records management, and compliance activities have
@@ -152,6 +153,11 @@ import UserNoteConfirmModal, {
   UserNoteModal,
 } from "@/components/common/modals/UserNoteConfirmModal.vue";
 
+interface DeleteFileParameter {
+  uniqueFileName: string;
+  fileName: string;
+}
+
 export default defineComponent({
   emits: ["uploadFile"],
   components: {
@@ -183,7 +189,9 @@ export default defineComponent({
   setup(props, context) {
     const studentFileUploads = ref([] as StudentFileUploadsDetails[]);
     const fileUploadModal = ref({} as ModalDialog<FormIOForm | boolean>);
-    const deleteFileModal = ref({} as ModalDialog<UserNoteModal<string>>);
+    const deleteFileModal = ref(
+      {} as ModalDialog<UserNoteModal<DeleteFileParameter>>,
+    );
     const { getISODateHourMinuteString, emptyStringFiller } = useFormatters();
     const fileUtils = useFileUtils();
     const initialData = ref({ studentId: props.studentId });
@@ -212,19 +220,22 @@ export default defineComponent({
       }
     };
 
-    const deleteStudentFile = async (uniqueFileName: string) => {
+    const deleteStudentFile = async (
+      uniqueFileName: string,
+      fileName: string,
+    ) => {
       await deleteFileModal.value.showModal(
-        uniqueFileName,
+        { uniqueFileName, fileName },
         deleteStudentFileCall,
       );
     };
 
     const deleteStudentFileCall = async (
-      userNoteModalResult: UserNoteModal<string>,
+      userNoteModalResult: UserNoteModal<DeleteFileParameter>,
     ): Promise<boolean> => {
       try {
         await StudentService.shared.deleteStudentUploadedFile(
-          userNoteModalResult.showParameter,
+          userNoteModalResult.showParameter.uniqueFileName,
           { noteDescription: userNoteModalResult.note },
         );
         snackBar.success("File deleted.");

--- a/sources/packages/web/src/components/common/students/StudentFileUploads.vue
+++ b/sources/packages/web/src/components/common/students/StudentFileUploads.vue
@@ -71,7 +71,7 @@
                 <v-btn
                   color="primary"
                   variant="outlined"
-                  :disabled="notAllowed || !!item.deletedAt"
+                  :disabled="notAllowed"
                   @click="deleteStudentFile(item.uniqueFileName)"
                   >Delete</v-btn
                 >
@@ -111,6 +111,7 @@
       title="Delete file"
       ref="deleteFileModal"
       ok-label="Delete file"
+      notes-description="Notes will be visible to StudentAid staff and institutions. This will not be shown to students."
     >
       <template #content>
         <p>

--- a/sources/packages/web/src/services/StudentService.ts
+++ b/sources/packages/web/src/services/StudentService.ts
@@ -18,6 +18,7 @@ import {
   LegacyStudentMatchesAPIOutDTO,
   LegacyStudentMatchesAPIInDTO,
   UpdateModifiedIndependentStatusAPIInDTO,
+  DeleteStudentFileAPIInDTO,
 } from "@/services/http/dto";
 import { AxiosResponse } from "axios";
 
@@ -283,5 +284,17 @@ export class StudentService {
       studentId,
       payload,
     );
+  }
+
+  /**
+   * Soft deletes an uploaded student file.
+   * @param uniqueFileName unique file name (name+guid).
+   * @param payload delete file details.
+   */
+  async deleteStudentUploadedFile(
+    uniqueFileName: string,
+    payload: DeleteStudentFileAPIInDTO,
+  ): Promise<void> {
+    await ApiClient.Students.deleteStudentUploadedFile(uniqueFileName, payload);
   }
 }

--- a/sources/packages/web/src/services/http/StudentApi.ts
+++ b/sources/packages/web/src/services/http/StudentApi.ts
@@ -20,6 +20,7 @@ import {
   LegacyStudentMatchesAPIOutDTO,
   LegacyStudentMatchesAPIInDTO,
   UpdateModifiedIndependentStatusAPIInDTO,
+  DeleteStudentFileAPIInDTO,
 } from "@/services/http/dto";
 
 export class StudentApi extends HttpBaseClient {
@@ -270,6 +271,21 @@ export class StudentApi extends HttpBaseClient {
     await this.patchCall(
       this.addClientRoot(`student/${studentId}/modified-independent-status`),
       payload,
+    );
+  }
+
+  /**
+   * Soft deletes an uploaded student file.
+   * @param uniqueFileName unique file name (name+guid).
+   * @param payload delete file details.
+   */
+  async deleteStudentUploadedFile(
+    uniqueFileName: string,
+    payload: DeleteStudentFileAPIInDTO,
+  ): Promise<void> {
+    await this.deleteCall(
+      this.addClientRoot(`student/file/${uniqueFileName}`),
+      { data: payload },
     );
   }
 }

--- a/sources/packages/web/src/services/http/dto/Student.dto.ts
+++ b/sources/packages/web/src/services/http/dto/Student.dto.ts
@@ -130,6 +130,7 @@ export interface StudentFileDetailsAPIOutDTO extends StudentUploadFileAPIOutDTO 
   metadata: StudentFileMetadataAPIOutDTO;
   groupName: string;
   createdAt: Date;
+  deletedAt?: Date;
 }
 
 /**
@@ -260,3 +261,8 @@ export interface UpdateModifiedIndependentStatusAPIInDTO {
   modifiedIndependentStatus: ModifiedIndependentStatus;
   noteDescription: string;
 }
+
+export interface DeleteStudentFileAPIInDTO {
+  noteDescription: string;
+}
+

--- a/sources/packages/web/src/services/http/dto/Student.dto.ts
+++ b/sources/packages/web/src/services/http/dto/Student.dto.ts
@@ -130,7 +130,6 @@ export interface StudentFileDetailsAPIOutDTO extends StudentUploadFileAPIOutDTO 
   metadata: StudentFileMetadataAPIOutDTO;
   groupName: string;
   createdAt: Date;
-  deletedAt?: Date;
 }
 
 /**
@@ -265,4 +264,3 @@ export interface UpdateModifiedIndependentStatusAPIInDTO {
 export interface DeleteStudentFileAPIInDTO {
   noteDescription: string;
 }
-

--- a/sources/packages/web/src/types/contracts/DataTableContract.ts
+++ b/sources/packages/web/src/types/contracts/DataTableContract.ts
@@ -665,6 +665,7 @@ export const StudentFileUploadsHeaders = [
   { title: "Application", sortable: false, key: "applicationNumber" },
   { title: "Date Submitted", sortable: false, key: "createdAt" },
   { title: "File", sortable: false, key: "fileName" },
+  { title: "Action", sortable: false, key: "action" },
 ];
 
 /**

--- a/sources/packages/web/src/types/contracts/StudentContract.ts
+++ b/sources/packages/web/src/types/contracts/StudentContract.ts
@@ -140,5 +140,4 @@ export interface StudentFileUploadsDetails {
   groupName: string;
   createdAt: Date;
   uploadedBy?: string;
-  deletedAt?: Date;
 }

--- a/sources/packages/web/src/types/contracts/StudentContract.ts
+++ b/sources/packages/web/src/types/contracts/StudentContract.ts
@@ -140,4 +140,5 @@ export interface StudentFileUploadsDetails {
   groupName: string;
   createdAt: Date;
   uploadedBy?: string;
+  deletedAt?: Date;
 }

--- a/sources/packages/web/src/types/contracts/aest/roles.ts
+++ b/sources/packages/web/src/types/contracts/aest/roles.ts
@@ -50,4 +50,5 @@ export enum Role {
   StudentViewScholasticStandingHistory = "student-view-scholastic-standing-history",
   StudentDeleteRestriction = "student-delete-restriction",
   StudentEditDisabilityProfile = "student-edit-disability-profile",
+  StudentDeleteUploadedFile = "student-delete-uploaded-file",
 }


### PR DESCRIPTION
### As a part of this PR, the following UI components were completed:

- Added the delete action corresponding to the student files in the ministry view

<img width="1920" height="1018" alt="delete_1 2026-07-17 08_31_16-" src="https://github.com/user-attachments/assets/e811a903-0fa2-4df0-badb-134ef06e0992" />

-----------------------------------------------------------

- Added the delete files modal dialog with the mandatory student note

<img width="758" height="502" alt="image" src="https://github.com/user-attachments/assets/814099bd-48d2-4133-a976-dee675302fb8" />


<img width="738" height="655" alt="image" src="https://github.com/user-attachments/assets/8b1453ed-0b96-4f7a-884c-6a045b2cf9f5" />


-----------------------------------------------------------

- Deleting the file removes it completely from the view (the fetch of the student files list after the delete does not retrieve the file)

<img width="1920" height="1014" alt="delete_4 2026-07-17 08_37_33-" src="https://github.com/user-attachments/assets/caba6219-7272-4de5-8ca9-508e5859671c" />