### PR TITLE
#2911 - Former youth in care email notification

### DIFF
--- a/sources/packages/backend/apps/api/src/services/application/application.service.ts
+++ b/sources/packages/backend/apps/api/src/services/application/application.service.ts
@@ -32,6 +32,7 @@ import {
   StudentAppeal,
   APPLICATION_EDIT_STATUS_IN_PROGRESS_VALUES,
   RestrictionActionType,
+  NotificationMessageType,
 } from "@sims/sims-db";
 import { StudentFileService } from "../student-file/student-file.service";
 import {
@@ -692,9 +693,10 @@ export class ApplicationService extends RecordDataModelService<Application> {
     });
     if (applicationsCount > APPLICATION_EDIT_COUNT_TO_SEND_NOTIFICATION) {
       const notificationExists =
-        await this.notificationService.checkApplicationEditedTooManyTimesNotificationExists(
+        await this.notificationService.checkNotificationExists(
+          NotificationMessageType.ApplicationEditedTooManyTimesNotification,
+          { applicationNumber },
           transactionalEntityManager,
-          applicationNumber,
         );
       if (!notificationExists) {
         const student = await this.studentService.getStudentById(studentId);

--- a/sources/packages/backend/apps/db-migrations/src/migrations/1783040387408-InsertStudentNotificationFormerYouthInCare.ts
+++ b/sources/packages/backend/apps/db-migrations/src/migrations/1783040387408-InsertStudentNotificationFormerYouthInCare.ts
@@ -1,0 +1,22 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+import { getSQLFileData } from "../utilities/sqlLoader";
+
+export class InsertStudentNotificationFormerYouthInCare1783040387408 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      getSQLFileData(
+        "Insert-student-notification-former-youth-in-care.sql",
+        "NotificationMessages",
+      ),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      getSQLFileData(
+        "Rollback-insert-student-notification-former-youth-in-care.sql",
+        "NotificationMessages",
+      ),
+    );
+  }
+}

--- a/sources/packages/backend/apps/db-migrations/src/sql/NotificationMessages/Insert-student-notification-former-youth-in-care.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/NotificationMessages/Insert-student-notification-former-youth-in-care.sql
@@ -1,0 +1,8 @@
+INSERT INTO
+    sims.notification_messages(id, description, template_id)
+VALUES
+    (
+        43,
+        'Student notification sent when the former youth in care question is answered with anything other than no.',
+        '636dd0c7-fe23-4a25-826b-03202326b580'
+    );

--- a/sources/packages/backend/apps/db-migrations/src/sql/NotificationMessages/Rollback-insert-student-notification-former-youth-in-care.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/NotificationMessages/Rollback-insert-student-notification-former-youth-in-care.sql
@@ -1,0 +1,4 @@
+DELETE FROM
+    sims.notification_messages
+WHERE
+    ID = 43;

--- a/sources/packages/backend/apps/workers/src/controllers/assessment/assessment.controller.ts
+++ b/sources/packages/backend/apps/workers/src/controllers/assessment/assessment.controller.ts
@@ -557,6 +557,7 @@ export class AssessmentController {
     const institutionLocation = offering?.institutionLocation;
     return {
       applicationId: application.id,
+      applicationNumber: application.applicationNumber,
       applicationStatus: application.applicationStatus,
       applicationEditStatus: application.applicationEditStatus,
       hasNOAApproval,

--- a/sources/packages/backend/apps/workers/src/controllers/assessment/assessment.controller.ts
+++ b/sources/packages/backend/apps/workers/src/controllers/assessment/assessment.controller.ts
@@ -557,7 +557,7 @@ export class AssessmentController {
     const institutionLocation = offering?.institutionLocation;
     return {
       applicationId: application.id,
-      applicationNumber: application.applicationNumber,
+      parentApplicationId: application.parentApplication.id,
       applicationStatus: application.applicationStatus,
       applicationEditStatus: application.applicationEditStatus,
       hasNOAApproval,

--- a/sources/packages/backend/apps/workers/src/controllers/assessment/assessment.dto.ts
+++ b/sources/packages/backend/apps/workers/src/controllers/assessment/assessment.dto.ts
@@ -92,6 +92,10 @@ export interface ApplicationAssessmentJobOutDTO {
    */
   applicationId: number;
   /**
+   * Human-readable application number that remains stable across application edits.
+   */
+  applicationNumber: string;
+  /**
    * Current status of the application.
    */
   applicationStatus: ApplicationStatus;

--- a/sources/packages/backend/apps/workers/src/controllers/assessment/assessment.dto.ts
+++ b/sources/packages/backend/apps/workers/src/controllers/assessment/assessment.dto.ts
@@ -92,9 +92,10 @@ export interface ApplicationAssessmentJobOutDTO {
    */
   applicationId: number;
   /**
-   * Human-readable application number that remains stable across application edits.
+   * Parent application id that remains stable across application edits, used to
+   * uniquely identify an application regardless of the number of edits.
    */
-  applicationNumber: string;
+  parentApplicationId: number;
   /**
    * Current status of the application.
    */

--- a/sources/packages/backend/apps/workers/src/controllers/assessment/assessment.dto.ts
+++ b/sources/packages/backend/apps/workers/src/controllers/assessment/assessment.dto.ts
@@ -92,8 +92,7 @@ export interface ApplicationAssessmentJobOutDTO {
    */
   applicationId: number;
   /**
-   * Parent application id that remains stable across application edits, used to
-   * uniquely identify an application regardless of the number of edits.
+   * Parent application id, which remains stable across application edits.
    */
   parentApplicationId: number;
   /**

--- a/sources/packages/backend/apps/workers/src/controllers/index.ts
+++ b/sources/packages/backend/apps/workers/src/controllers/index.ts
@@ -12,3 +12,5 @@ export * from "./disbursement/disbursement.controller";
 export * from "./disbursement/disbursement.dto";
 export * from "./health-check/health.controller";
 export * from "./metrics/metrics.controller";
+export * from "./notification/notification.controller";
+export * from "./notification/notification.dto";

--- a/sources/packages/backend/apps/workers/src/controllers/index.ts
+++ b/sources/packages/backend/apps/workers/src/controllers/index.ts
@@ -12,5 +12,5 @@ export * from "./disbursement/disbursement.controller";
 export * from "./disbursement/disbursement.dto";
 export * from "./health-check/health.controller";
 export * from "./metrics/metrics.controller";
-export * from "./notification/notification.controller";
 export * from "./notification/notification.dto";
+export * from "./notification/notification.controller";

--- a/sources/packages/backend/apps/workers/src/controllers/notification/_tests_/e2e/notification.controller.sendEmailNotification.e2e-spec.ts
+++ b/sources/packages/backend/apps/workers/src/controllers/notification/_tests_/e2e/notification.controller.sendEmailNotification.e2e-spec.ts
@@ -118,13 +118,17 @@ describe("NotificationController(e2e)-sendEmailNotification", () => {
       templateId: GC_NOTIFY_TEMPLATE_IDS.FormerYouthInCareNotification,
       recipientType: WorkflowEmailNotificationRecipient.Student,
       assessmentId: firstApplication.currentAssessment.id,
-      emailNotificationCheckMetadata: { applicationId: firstApplication.id },
+      emailNotificationCheckMetadata: {
+        applicationNumber: firstApplication.applicationNumber,
+      },
     });
     const secondApplicationPayload = createFakeSendEmailNotificationPayload({
       templateId: GC_NOTIFY_TEMPLATE_IDS.FormerYouthInCareNotification,
       recipientType: WorkflowEmailNotificationRecipient.Student,
       assessmentId: secondApplication.currentAssessment.id,
-      emailNotificationCheckMetadata: { applicationId: secondApplication.id },
+      emailNotificationCheckMetadata: {
+        applicationNumber: secondApplication.applicationNumber,
+      },
     });
 
     // Act

--- a/sources/packages/backend/apps/workers/src/controllers/notification/_tests_/e2e/notification.controller.sendEmailNotification.e2e-spec.ts
+++ b/sources/packages/backend/apps/workers/src/controllers/notification/_tests_/e2e/notification.controller.sendEmailNotification.e2e-spec.ts
@@ -1,0 +1,219 @@
+import {
+  createE2EDataSources,
+  E2EDataSources,
+  saveFakeApplication,
+} from "@sims/test-utils";
+import {
+  FAKE_WORKER_JOB_RESULT_PROPERTY,
+  MockedZeebeJobResult,
+} from "../../../../../test/utils/worker-job-mock";
+import { createTestingAppModule } from "../../../../../test/helpers";
+import { NotificationController } from "../../notification.controller";
+import { createFakeSendEmailNotificationPayload } from "./send-email-notification-factory";
+import { WorkflowEmailNotificationRecipient } from "@sims/services/notifications";
+import { GC_NOTIFY_TEMPLATE_IDS } from "@sims/test-utils/constants";
+import { NotificationMessageType } from "@sims/sims-db";
+import { randomUUID } from "node:crypto";
+
+/**
+ * Base id from which auto-generated notification messages are created to avoid
+ * collisions with the notification messages seeded during migrations.
+ */
+const AUTO_GENERATED_NOTIFICATION_MESSAGE_ID_BASE = 1000000;
+
+describe("NotificationController(e2e)-sendEmailNotification", () => {
+  let db: E2EDataSources;
+  let notificationController: NotificationController;
+
+  beforeAll(async () => {
+    const { nestApplication, dataSource } = await createTestingAppModule();
+    db = createE2EDataSources(dataSource);
+    notificationController = nestApplication.get(NotificationController);
+  });
+
+  it("Should create a student email notification loading the student personal information when the recipient is the student.", async () => {
+    // Arrange
+    const savedApplication = await saveFakeApplication(db.dataSource);
+    const { student } = savedApplication;
+    const payload = createFakeSendEmailNotificationPayload({
+      templateId: GC_NOTIFY_TEMPLATE_IDS.FormerYouthInCareNotification,
+      recipientType: WorkflowEmailNotificationRecipient.Student,
+      assessmentId: savedApplication.currentAssessment.id,
+      emailNotificationPersonalisation: { applicationNumber: "1234567890" },
+    });
+
+    // Act
+    const result = await notificationController.sendEmailNotification(payload);
+
+    // Asserts
+    expect(result).toEqual({
+      [FAKE_WORKER_JOB_RESULT_PROPERTY]: MockedZeebeJobResult.Complete,
+    });
+    const createdNotification = await db.notification.findOne({
+      select: {
+        id: true,
+        messagePayload: true,
+        metadata: true,
+        notificationMessage: { id: true },
+      },
+      relations: { notificationMessage: true },
+      where: { user: { id: student.user.id } },
+    });
+    expect(createdNotification).toEqual({
+      id: expect.any(Number),
+      notificationMessage: {
+        id: NotificationMessageType.FormerYouthInCareNotification,
+      },
+      messagePayload: {
+        template_id: GC_NOTIFY_TEMPLATE_IDS.FormerYouthInCareNotification,
+        email_address: student.user.email,
+        personalisation: {
+          applicationNumber: "1234567890",
+          givenNames: student.user.firstName ?? "",
+          lastName: student.user.lastName,
+        },
+      },
+      metadata: null,
+    });
+  });
+
+  it("Should send a new email notification every time when the check metadata is empty allowing a student to receive multiple emails.", async () => {
+    // Arrange
+    const savedApplication = await saveFakeApplication(db.dataSource);
+    const { student } = savedApplication;
+    const payload = createFakeSendEmailNotificationPayload({
+      templateId: GC_NOTIFY_TEMPLATE_IDS.FormerYouthInCareNotification,
+      recipientType: WorkflowEmailNotificationRecipient.Student,
+      assessmentId: savedApplication.currentAssessment.id,
+      emailNotificationCheckMetadata: {},
+    });
+
+    // Act
+    // Execute the worker twice to ensure a new notification is created each time
+    // when no uniqueness criteria is provided.
+    await notificationController.sendEmailNotification(payload);
+    await notificationController.sendEmailNotification(payload);
+
+    // Asserts
+    const notificationsCount = await db.notification.count({
+      where: {
+        user: { id: student.user.id },
+        notificationMessage: {
+          id: NotificationMessageType.FormerYouthInCareNotification,
+        },
+      },
+    });
+    expect(notificationsCount).toBe(2);
+  });
+
+  it("Should create one email notification per application allowing a student with multiple applications to receive one email for each application.", async () => {
+    // Arrange
+    const firstApplication = await saveFakeApplication(db.dataSource);
+    const { student } = firstApplication;
+    // Create a second application for the same student.
+    const secondApplication = await saveFakeApplication(db.dataSource, {
+      student,
+    });
+    const firstApplicationPayload = createFakeSendEmailNotificationPayload({
+      templateId: GC_NOTIFY_TEMPLATE_IDS.FormerYouthInCareNotification,
+      recipientType: WorkflowEmailNotificationRecipient.Student,
+      assessmentId: firstApplication.currentAssessment.id,
+      emailNotificationCheckMetadata: { applicationId: firstApplication.id },
+    });
+    const secondApplicationPayload = createFakeSendEmailNotificationPayload({
+      templateId: GC_NOTIFY_TEMPLATE_IDS.FormerYouthInCareNotification,
+      recipientType: WorkflowEmailNotificationRecipient.Student,
+      assessmentId: secondApplication.currentAssessment.id,
+      emailNotificationCheckMetadata: { applicationId: secondApplication.id },
+    });
+
+    // Act
+    // Execute the worker twice per application to ensure a single notification
+    // is created for each application.
+    await notificationController.sendEmailNotification(firstApplicationPayload);
+    await notificationController.sendEmailNotification(firstApplicationPayload);
+    await notificationController.sendEmailNotification(
+      secondApplicationPayload,
+    );
+    await notificationController.sendEmailNotification(
+      secondApplicationPayload,
+    );
+
+    // Asserts
+    const notificationsCount = await db.notification.count({
+      where: {
+        user: { id: student.user.id },
+        notificationMessage: {
+          id: NotificationMessageType.FormerYouthInCareNotification,
+        },
+      },
+    });
+    // The student has two applications, so exactly two notifications are expected.
+    expect(notificationsCount).toBe(2);
+  });
+
+  it("Should auto-create a notification message when the template id is not associated with any existing notification message.", async () => {
+    // Arrange
+    const savedApplication = await saveFakeApplication(db.dataSource);
+    const { student } = savedApplication;
+    const unknownTemplateId = randomUUID();
+    const payload = createFakeSendEmailNotificationPayload({
+      templateId: unknownTemplateId,
+      recipientType: WorkflowEmailNotificationRecipient.Student,
+      assessmentId: savedApplication.currentAssessment.id,
+    });
+
+    // Act
+    const result = await notificationController.sendEmailNotification(payload);
+
+    // Asserts
+    expect(result).toEqual({
+      [FAKE_WORKER_JOB_RESULT_PROPERTY]: MockedZeebeJobResult.Complete,
+    });
+    const autoCreatedMessage = await db.notificationMessage.findOne({
+      select: { id: true, templateId: true },
+      where: { templateId: unknownTemplateId },
+    });
+    expect(autoCreatedMessage.id).toBeGreaterThanOrEqual(
+      AUTO_GENERATED_NOTIFICATION_MESSAGE_ID_BASE,
+    );
+    const createdNotification = await db.notification.findOne({
+      select: { id: true, notificationMessage: { id: true } },
+      relations: { notificationMessage: true },
+      where: { user: { id: student.user.id } },
+    });
+    expect(createdNotification.notificationMessage.id).toBe(
+      autoCreatedMessage.id,
+    );
+  });
+
+  it("Should not create any email notification when the recipient is the Ministry and no email contact is configured.", async () => {
+    // Arrange
+    // Use an unknown template id so the auto-created notification message has no
+    // email contacts configured.
+    const unknownTemplateId = randomUUID();
+    const payload = createFakeSendEmailNotificationPayload({
+      templateId: unknownTemplateId,
+      recipientType: WorkflowEmailNotificationRecipient.Ministry,
+      emailNotificationPersonalisation: { applicationNumber: "1234567890" },
+    });
+
+    // Act
+    const result = await notificationController.sendEmailNotification(payload);
+
+    // Asserts
+    // The job completes successfully but no notification is created since there
+    // are no email contacts to send the notification to.
+    expect(result).toEqual({
+      [FAKE_WORKER_JOB_RESULT_PROPERTY]: MockedZeebeJobResult.Complete,
+    });
+    const autoCreatedMessage = await db.notificationMessage.findOne({
+      select: { id: true },
+      where: { templateId: unknownTemplateId },
+    });
+    const notificationsCount = await db.notification.count({
+      where: { notificationMessage: { id: autoCreatedMessage.id } },
+    });
+    expect(notificationsCount).toBe(0);
+  });
+});

--- a/sources/packages/backend/apps/workers/src/controllers/notification/_tests_/e2e/notification.controller.sendEmailNotification.e2e-spec.ts
+++ b/sources/packages/backend/apps/workers/src/controllers/notification/_tests_/e2e/notification.controller.sendEmailNotification.e2e-spec.ts
@@ -1,5 +1,6 @@
 import {
   createE2EDataSources,
+  createFakeNotification,
   E2EDataSources,
   saveFakeApplication,
 } from "@sims/test-utils";
@@ -10,10 +11,11 @@ import {
 import { createTestingAppModule } from "../../../../../test/helpers";
 import { NotificationController } from "../../notification.controller";
 import { createFakeSendEmailNotificationPayload } from "./send-email-notification-factory";
-import { WorkflowEmailNotificationRecipient } from "@sims/services/notifications";
+import { EmailNotificationRecipient } from "@sims/services/notifications";
 import { GC_NOTIFY_TEMPLATE_IDS } from "@sims/test-utils/constants";
-import { NotificationMessageType } from "@sims/sims-db";
+import { NotificationMessage, NotificationMessageType } from "@sims/sims-db";
 import { randomUUID } from "node:crypto";
+import { IsNull } from "typeorm";
 
 describe("NotificationController(e2e)-sendEmailNotification", () => {
   let db: E2EDataSources;
@@ -25,16 +27,21 @@ describe("NotificationController(e2e)-sendEmailNotification", () => {
     notificationController = nestApplication.get(NotificationController);
   });
 
-  it("Should create a student email notification loading the student personal information when the recipient is the student.", async () => {
+  it("Should create a student email notification resolving the personalisation from the provided paths when the recipient is the student.", async () => {
     // Arrange
     const savedApplication = await saveFakeApplication(db.dataSource);
     const { student } = savedApplication;
-    const payload = createFakeSendEmailNotificationPayload({
-      templateId: GC_NOTIFY_TEMPLATE_IDS.FormerYouthInCareNotification,
-      recipientType: WorkflowEmailNotificationRecipient.Student,
-      assessmentId: savedApplication.currentAssessment.id,
-      emailNotificationPersonalisation: { applicationNumber: "1234567890" },
-    });
+    const payload = createFakeSendEmailNotificationPayload(
+      GC_NOTIFY_TEMPLATE_IDS.FormerYouthInCareNotification,
+      EmailNotificationRecipient.Student,
+      {
+        assessmentId: savedApplication.currentAssessment.id,
+        personalisation: {
+          givenNames: "studentGivenNames",
+          lastName: "studentLastName",
+        },
+      },
+    );
 
     // Act
     const result = await notificationController.sendEmailNotification(payload);
@@ -62,7 +69,6 @@ describe("NotificationController(e2e)-sendEmailNotification", () => {
         template_id: GC_NOTIFY_TEMPLATE_IDS.FormerYouthInCareNotification,
         email_address: student.user.email,
         personalisation: {
-          applicationNumber: "1234567890",
           givenNames: student.user.firstName ?? "",
           lastName: student.user.lastName,
         },
@@ -71,24 +77,38 @@ describe("NotificationController(e2e)-sendEmailNotification", () => {
     });
   });
 
-  it("Should send a new email notification every time when the check metadata is empty allowing a student to receive multiple emails.", async () => {
+  it("Should create a new email notification when no metadata is provided even if a notification for the same message already exists.", async () => {
     // Arrange
     const savedApplication = await saveFakeApplication(db.dataSource);
     const { student } = savedApplication;
-    const payload = createFakeSendEmailNotificationPayload({
-      templateId: GC_NOTIFY_TEMPLATE_IDS.FormerYouthInCareNotification,
-      recipientType: WorkflowEmailNotificationRecipient.Student,
-      assessmentId: savedApplication.currentAssessment.id,
-      emailNotificationCheckMetadata: {},
-    });
+    // Prepare an existing notification for the same message to ensure a new one
+    // is still created when no uniqueness criteria is provided.
+    const existingNotification = createFakeNotification(
+      {
+        user: student.user,
+        notificationMessage: {
+          id: NotificationMessageType.FormerYouthInCareNotification,
+        } as NotificationMessage,
+      },
+      { initialValue: { metadata: null } },
+    );
+    await db.notification.save(existingNotification);
+    const payload = createFakeSendEmailNotificationPayload(
+      GC_NOTIFY_TEMPLATE_IDS.FormerYouthInCareNotification,
+      EmailNotificationRecipient.Student,
+      {
+        assessmentId: savedApplication.currentAssessment.id,
+        metadata: {},
+      },
+    );
 
     // Act
-    // Execute the worker twice to ensure a new notification is created each time
-    // when no uniqueness criteria is provided.
-    await notificationController.sendEmailNotification(payload);
-    await notificationController.sendEmailNotification(payload);
+    const result = await notificationController.sendEmailNotification(payload);
 
     // Asserts
+    expect(result).toEqual({
+      [FAKE_WORKER_JOB_RESULT_PROPERTY]: MockedZeebeJobResult.Complete,
+    });
     const notificationsCount = await db.notification.count({
       where: {
         user: { id: student.user.id },
@@ -97,47 +117,43 @@ describe("NotificationController(e2e)-sendEmailNotification", () => {
         },
       },
     });
+    // The prepared notification plus the one created by the worker.
     expect(notificationsCount).toBe(2);
   });
 
-  it("Should create one email notification per application allowing a student with multiple applications to receive one email for each application.", async () => {
+  it("Should not create a duplicate email notification when a notification with the same metadata already exists.", async () => {
     // Arrange
-    const firstApplication = await saveFakeApplication(db.dataSource);
-    const { student } = firstApplication;
-    // Create a second application for the same student.
-    const secondApplication = await saveFakeApplication(db.dataSource, {
-      student,
-    });
-    const firstApplicationPayload = createFakeSendEmailNotificationPayload({
-      templateId: GC_NOTIFY_TEMPLATE_IDS.FormerYouthInCareNotification,
-      recipientType: WorkflowEmailNotificationRecipient.Student,
-      assessmentId: firstApplication.currentAssessment.id,
-      emailNotificationCheckMetadata: {
-        parentApplicationId: firstApplication.parentApplication.id,
+    const savedApplication = await saveFakeApplication(db.dataSource);
+    const { student } = savedApplication;
+    const parentApplicationId = savedApplication.parentApplication.id;
+    // Prepare an existing notification with the same metadata to ensure the
+    // worker does not create a duplicate.
+    const existingNotification = createFakeNotification(
+      {
+        user: student.user,
+        notificationMessage: {
+          id: NotificationMessageType.FormerYouthInCareNotification,
+        } as NotificationMessage,
       },
-    });
-    const secondApplicationPayload = createFakeSendEmailNotificationPayload({
-      templateId: GC_NOTIFY_TEMPLATE_IDS.FormerYouthInCareNotification,
-      recipientType: WorkflowEmailNotificationRecipient.Student,
-      assessmentId: secondApplication.currentAssessment.id,
-      emailNotificationCheckMetadata: {
-        parentApplicationId: secondApplication.parentApplication.id,
+      { initialValue: { metadata: { parentApplicationId } } },
+    );
+    await db.notification.save(existingNotification);
+    const payload = createFakeSendEmailNotificationPayload(
+      GC_NOTIFY_TEMPLATE_IDS.FormerYouthInCareNotification,
+      EmailNotificationRecipient.Student,
+      {
+        assessmentId: savedApplication.currentAssessment.id,
+        metadata: { parentApplicationId },
       },
-    });
+    );
 
     // Act
-    // Execute the worker twice per application to ensure a single notification
-    // is created for each application.
-    await notificationController.sendEmailNotification(firstApplicationPayload);
-    await notificationController.sendEmailNotification(firstApplicationPayload);
-    await notificationController.sendEmailNotification(
-      secondApplicationPayload,
-    );
-    await notificationController.sendEmailNotification(
-      secondApplicationPayload,
-    );
+    const result = await notificationController.sendEmailNotification(payload);
 
     // Asserts
+    expect(result).toEqual({
+      [FAKE_WORKER_JOB_RESULT_PROPERTY]: MockedZeebeJobResult.Complete,
+    });
     const notificationsCount = await db.notification.count({
       where: {
         user: { id: student.user.id },
@@ -146,8 +162,66 @@ describe("NotificationController(e2e)-sendEmailNotification", () => {
         },
       },
     });
-    // The student has two applications, so exactly two notifications are expected.
-    expect(notificationsCount).toBe(2);
+    // Only the prepared notification is expected, no duplicate is created.
+    expect(notificationsCount).toBe(1);
+  });
+
+  it("Should create a ministry email notification for each configured email contact when the recipient is the ministry.", async () => {
+    // Arrange
+    const savedApplication = await saveFakeApplication(db.dataSource);
+    const ministryEmailContact = `ministry-${randomUUID()}@example.com`;
+    // Configure the email contacts used to address the ministry notification.
+    await db.notificationMessage.update(
+      NotificationMessageType.FormerYouthInCareNotification,
+      { emailContacts: [ministryEmailContact] },
+    );
+    const payload = createFakeSendEmailNotificationPayload(
+      GC_NOTIFY_TEMPLATE_IDS.FormerYouthInCareNotification,
+      EmailNotificationRecipient.Ministry,
+      {
+        assessmentId: savedApplication.currentAssessment.id,
+        personalisation: { applicationNumber: "applicationNumber" },
+      },
+    );
+
+    // Act
+    const result = await notificationController.sendEmailNotification(payload);
+
+    // Asserts
+    expect(result).toEqual({
+      [FAKE_WORKER_JOB_RESULT_PROPERTY]: MockedZeebeJobResult.Complete,
+    });
+    const createdNotification = await db.notification.findOne({
+      select: {
+        id: true,
+        messagePayload: true,
+        metadata: true,
+        user: { id: true },
+        notificationMessage: { id: true },
+      },
+      relations: { user: true, notificationMessage: true },
+      where: {
+        notificationMessage: {
+          id: NotificationMessageType.FormerYouthInCareNotification,
+        },
+        user: IsNull(),
+      },
+    });
+    expect(createdNotification).toEqual({
+      id: expect.any(Number),
+      user: null,
+      notificationMessage: {
+        id: NotificationMessageType.FormerYouthInCareNotification,
+      },
+      messagePayload: {
+        template_id: GC_NOTIFY_TEMPLATE_IDS.FormerYouthInCareNotification,
+        email_address: ministryEmailContact,
+        personalisation: {
+          applicationNumber: savedApplication.applicationNumber,
+        },
+      },
+      metadata: null,
+    });
   });
 
   it("Should fail the job raising an incident when the template id is not associated with any existing notification message.", async () => {
@@ -155,11 +229,11 @@ describe("NotificationController(e2e)-sendEmailNotification", () => {
     const savedApplication = await saveFakeApplication(db.dataSource);
     const { student } = savedApplication;
     const unknownTemplateId = randomUUID();
-    const payload = createFakeSendEmailNotificationPayload({
-      templateId: unknownTemplateId,
-      recipientType: WorkflowEmailNotificationRecipient.Student,
-      assessmentId: savedApplication.currentAssessment.id,
-    });
+    const payload = createFakeSendEmailNotificationPayload(
+      unknownTemplateId,
+      EmailNotificationRecipient.Student,
+      { assessmentId: savedApplication.currentAssessment.id },
+    );
 
     // Act
     const result = await notificationController.sendEmailNotification(payload);
@@ -170,12 +244,6 @@ describe("NotificationController(e2e)-sendEmailNotification", () => {
     expect(result[FAKE_WORKER_JOB_RESULT_PROPERTY]).toBe(
       MockedZeebeJobResult.Fail,
     );
-    // No notification message is created for the unknown template id.
-    const notificationMessage = await db.notificationMessage.findOne({
-      select: { id: true },
-      where: { templateId: unknownTemplateId },
-    });
-    expect(notificationMessage).toBeNull();
     // No notification is created for the student.
     const notificationsCount = await db.notification.count({
       where: { user: { id: student.user.id } },

--- a/sources/packages/backend/apps/workers/src/controllers/notification/_tests_/e2e/notification.controller.sendEmailNotification.e2e-spec.ts
+++ b/sources/packages/backend/apps/workers/src/controllers/notification/_tests_/e2e/notification.controller.sendEmailNotification.e2e-spec.ts
@@ -85,8 +85,10 @@ describe("NotificationController(e2e)-sendEmailNotification", () => {
     // Arrange
     const savedApplication = await saveFakeApplication(db.dataSource);
     const { student } = savedApplication;
-    // Prepare an existing notification for the same message to ensure a new one
-    // is still created when no uniqueness criteria is provided.
+    // Prepare an existing notification without metadata to ensure the worker
+    // does not create a duplicate when no uniqueness criteria is provided, as
+    // the message type combined with the absence of metadata is enough to
+    // prevent a second email.
     const existingNotification = createFakeNotification({
       user: student.user,
       notificationMessage: {
@@ -115,8 +117,8 @@ describe("NotificationController(e2e)-sendEmailNotification", () => {
         },
       },
     });
-    // The prepared notification plus the one created by the worker.
-    expect(notificationsCount).toBe(2);
+    // Only the prepared notification is expected, no duplicate is created.
+    expect(notificationsCount).toBe(1);
   });
 
   it("Should not create a duplicate email notification when a notification with the same metadata already exists.", async () => {

--- a/sources/packages/backend/apps/workers/src/controllers/notification/_tests_/e2e/notification.controller.sendEmailNotification.e2e-spec.ts
+++ b/sources/packages/backend/apps/workers/src/controllers/notification/_tests_/e2e/notification.controller.sendEmailNotification.e2e-spec.ts
@@ -113,7 +113,7 @@ describe("NotificationController(e2e)-sendEmailNotification", () => {
       recipientType: WorkflowEmailNotificationRecipient.Student,
       assessmentId: firstApplication.currentAssessment.id,
       emailNotificationCheckMetadata: {
-        applicationNumber: firstApplication.applicationNumber,
+        parentApplicationId: firstApplication.parentApplication.id,
       },
     });
     const secondApplicationPayload = createFakeSendEmailNotificationPayload({
@@ -121,7 +121,7 @@ describe("NotificationController(e2e)-sendEmailNotification", () => {
       recipientType: WorkflowEmailNotificationRecipient.Student,
       assessmentId: secondApplication.currentAssessment.id,
       emailNotificationCheckMetadata: {
-        applicationNumber: secondApplication.applicationNumber,
+        parentApplicationId: secondApplication.parentApplication.id,
       },
     });
 
@@ -167,9 +167,9 @@ describe("NotificationController(e2e)-sendEmailNotification", () => {
     // Asserts
     // The job fails, raising an incident, since the template is not seeded and
     // notification messages are no longer created at runtime.
-    expect(result).toEqual({
-      [FAKE_WORKER_JOB_RESULT_PROPERTY]: MockedZeebeJobResult.Fail,
-    });
+    expect(result[FAKE_WORKER_JOB_RESULT_PROPERTY]).toBe(
+      MockedZeebeJobResult.Fail,
+    );
     // No notification message is created for the unknown template id.
     const notificationMessage = await db.notificationMessage.findOne({
       select: { id: true },
@@ -179,34 +179,6 @@ describe("NotificationController(e2e)-sendEmailNotification", () => {
     // No notification is created for the student.
     const notificationsCount = await db.notification.count({
       where: { user: { id: student.user.id } },
-    });
-    expect(notificationsCount).toBe(0);
-  });
-
-  it("Should not create any email notification when the recipient is the Ministry and no email contact is configured.", async () => {
-    // Arrange
-    // Use a seeded notification message that has no email contacts configured.
-    const payload = createFakeSendEmailNotificationPayload({
-      templateId: GC_NOTIFY_TEMPLATE_IDS.FormerYouthInCareNotification,
-      recipientType: WorkflowEmailNotificationRecipient.Ministry,
-      emailNotificationPersonalisation: { applicationNumber: "1234567890" },
-    });
-
-    // Act
-    const result = await notificationController.sendEmailNotification(payload);
-
-    // Asserts
-    // The job completes successfully but no notification is created since there
-    // are no email contacts to send the notification to.
-    expect(result).toEqual({
-      [FAKE_WORKER_JOB_RESULT_PROPERTY]: MockedZeebeJobResult.Complete,
-    });
-    const notificationsCount = await db.notification.count({
-      where: {
-        notificationMessage: {
-          id: NotificationMessageType.FormerYouthInCareNotification,
-        },
-      },
     });
     expect(notificationsCount).toBe(0);
   });

--- a/sources/packages/backend/apps/workers/src/controllers/notification/_tests_/e2e/notification.controller.sendEmailNotification.e2e-spec.ts
+++ b/sources/packages/backend/apps/workers/src/controllers/notification/_tests_/e2e/notification.controller.sendEmailNotification.e2e-spec.ts
@@ -15,12 +15,6 @@ import { GC_NOTIFY_TEMPLATE_IDS } from "@sims/test-utils/constants";
 import { NotificationMessageType } from "@sims/sims-db";
 import { randomUUID } from "node:crypto";
 
-/**
- * Base id from which auto-generated notification messages are created to avoid
- * collisions with the notification messages seeded during migrations.
- */
-const AUTO_GENERATED_NOTIFICATION_MESSAGE_ID_BASE = 1000000;
-
 describe("NotificationController(e2e)-sendEmailNotification", () => {
   let db: E2EDataSources;
   let notificationController: NotificationController;
@@ -156,7 +150,7 @@ describe("NotificationController(e2e)-sendEmailNotification", () => {
     expect(notificationsCount).toBe(2);
   });
 
-  it("Should auto-create a notification message when the template id is not associated with any existing notification message.", async () => {
+  it("Should fail the job raising an incident when the template id is not associated with any existing notification message.", async () => {
     // Arrange
     const savedApplication = await saveFakeApplication(db.dataSource);
     const { student } = savedApplication;
@@ -171,33 +165,29 @@ describe("NotificationController(e2e)-sendEmailNotification", () => {
     const result = await notificationController.sendEmailNotification(payload);
 
     // Asserts
+    // The job fails, raising an incident, since the template is not seeded and
+    // notification messages are no longer created at runtime.
     expect(result).toEqual({
-      [FAKE_WORKER_JOB_RESULT_PROPERTY]: MockedZeebeJobResult.Complete,
+      [FAKE_WORKER_JOB_RESULT_PROPERTY]: MockedZeebeJobResult.Fail,
     });
-    const autoCreatedMessage = await db.notificationMessage.findOne({
-      select: { id: true, templateId: true },
+    // No notification message is created for the unknown template id.
+    const notificationMessage = await db.notificationMessage.findOne({
+      select: { id: true },
       where: { templateId: unknownTemplateId },
     });
-    expect(autoCreatedMessage.id).toBeGreaterThanOrEqual(
-      AUTO_GENERATED_NOTIFICATION_MESSAGE_ID_BASE,
-    );
-    const createdNotification = await db.notification.findOne({
-      select: { id: true, notificationMessage: { id: true } },
-      relations: { notificationMessage: true },
+    expect(notificationMessage).toBeNull();
+    // No notification is created for the student.
+    const notificationsCount = await db.notification.count({
       where: { user: { id: student.user.id } },
     });
-    expect(createdNotification.notificationMessage.id).toBe(
-      autoCreatedMessage.id,
-    );
+    expect(notificationsCount).toBe(0);
   });
 
   it("Should not create any email notification when the recipient is the Ministry and no email contact is configured.", async () => {
     // Arrange
-    // Use an unknown template id so the auto-created notification message has no
-    // email contacts configured.
-    const unknownTemplateId = randomUUID();
+    // Use a seeded notification message that has no email contacts configured.
     const payload = createFakeSendEmailNotificationPayload({
-      templateId: unknownTemplateId,
+      templateId: GC_NOTIFY_TEMPLATE_IDS.FormerYouthInCareNotification,
       recipientType: WorkflowEmailNotificationRecipient.Ministry,
       emailNotificationPersonalisation: { applicationNumber: "1234567890" },
     });
@@ -211,12 +201,12 @@ describe("NotificationController(e2e)-sendEmailNotification", () => {
     expect(result).toEqual({
       [FAKE_WORKER_JOB_RESULT_PROPERTY]: MockedZeebeJobResult.Complete,
     });
-    const autoCreatedMessage = await db.notificationMessage.findOne({
-      select: { id: true },
-      where: { templateId: unknownTemplateId },
-    });
     const notificationsCount = await db.notification.count({
-      where: { notificationMessage: { id: autoCreatedMessage.id } },
+      where: {
+        notificationMessage: {
+          id: NotificationMessageType.FormerYouthInCareNotification,
+        },
+      },
     });
     expect(notificationsCount).toBe(0);
   });

--- a/sources/packages/backend/apps/workers/src/controllers/notification/_tests_/e2e/notification.controller.sendEmailNotification.e2e-spec.ts
+++ b/sources/packages/backend/apps/workers/src/controllers/notification/_tests_/e2e/notification.controller.sendEmailNotification.e2e-spec.ts
@@ -5,6 +5,8 @@ import {
   saveFakeApplication,
 } from "@sims/test-utils";
 import {
+  FAKE_WORKER_JOB_ERROR_CODE_PROPERTY,
+  FAKE_WORKER_JOB_ERROR_MESSAGE_PROPERTY,
   FAKE_WORKER_JOB_RESULT_PROPERTY,
   MockedZeebeJobResult,
 } from "../../../../../test/utils/worker-job-mock";
@@ -16,6 +18,7 @@ import { GC_NOTIFY_TEMPLATE_IDS } from "@sims/test-utils/constants";
 import { NotificationMessage, NotificationMessageType } from "@sims/sims-db";
 import { randomUUID } from "node:crypto";
 import { IsNull } from "typeorm";
+import { NOTIFICATION_MISSING_EMAIL_CONTACTS } from "@sims/services/constants";
 
 describe("NotificationController(e2e)-sendEmailNotification", () => {
   let db: E2EDataSources;
@@ -77,7 +80,7 @@ describe("NotificationController(e2e)-sendEmailNotification", () => {
     });
   });
 
-  it("Should create a new email notification when no metadata is provided even if a notification for the same message already exists.", async () => {
+  it("Should create a new email notification when no metadata is provided.", async () => {
     // Arrange
     const savedApplication = await saveFakeApplication(db.dataSource);
     const { student } = savedApplication;
@@ -206,6 +209,7 @@ describe("NotificationController(e2e)-sendEmailNotification", () => {
         },
         user: IsNull(),
       },
+      order: { id: "DESC" },
     });
     expect(createdNotification).toEqual({
       id: expect.any(Number),
@@ -222,6 +226,35 @@ describe("NotificationController(e2e)-sendEmailNotification", () => {
       },
       metadata: null,
     });
+  });
+
+  it("Should fail the job raising an incident when no email contact is associated with a ministry notification message.", async () => {
+    // Arrange
+    const savedApplication = await saveFakeApplication(db.dataSource);
+    const { student } = savedApplication;
+    const payload = createFakeSendEmailNotificationPayload(
+      GC_NOTIFY_TEMPLATE_IDS.FormerYouthInCareNotification,
+      EmailNotificationRecipient.Ministry,
+      { assessmentId: savedApplication.currentAssessment.id },
+    );
+
+    // Act
+    const result = await notificationController.sendEmailNotification(payload);
+
+    // Asserts
+    // The job fails, raising an incident, since the template is not seeded and
+    // notification messages are no longer created at runtime.
+    expect(result).toEqual({
+      [FAKE_WORKER_JOB_RESULT_PROPERTY]: MockedZeebeJobResult.Error,
+      [FAKE_WORKER_JOB_ERROR_CODE_PROPERTY]:
+        NOTIFICATION_MISSING_EMAIL_CONTACTS,
+      [FAKE_WORKER_JOB_ERROR_MESSAGE_PROPERTY]: `No email contacts are configured for the Ministry notification with template ${GC_NOTIFY_TEMPLATE_IDS.FormerYouthInCareNotification}.`,
+    });
+    // No notification is created for the student.
+    const notificationsCount = await db.notification.count({
+      where: { user: { id: student.user.id } },
+    });
+    expect(notificationsCount).toBe(0);
   });
 
   it("Should fail the job raising an incident when the template id is not associated with any existing notification message.", async () => {
@@ -241,9 +274,12 @@ describe("NotificationController(e2e)-sendEmailNotification", () => {
     // Asserts
     // The job fails, raising an incident, since the template is not seeded and
     // notification messages are no longer created at runtime.
-    expect(result[FAKE_WORKER_JOB_RESULT_PROPERTY]).toBe(
-      MockedZeebeJobResult.Fail,
-    );
+    expect(result).toEqual({
+      [FAKE_WORKER_JOB_RESULT_PROPERTY]: MockedZeebeJobResult.Fail,
+      [FAKE_WORKER_JOB_ERROR_MESSAGE_PROPERTY]: expect.stringContaining(
+        `Notification message not found for template id ${unknownTemplateId}`,
+      ),
+    });
     // No notification is created for the student.
     const notificationsCount = await db.notification.count({
       where: { user: { id: student.user.id } },

--- a/sources/packages/backend/apps/workers/src/controllers/notification/_tests_/e2e/notification.controller.sendEmailNotification.e2e-spec.ts
+++ b/sources/packages/backend/apps/workers/src/controllers/notification/_tests_/e2e/notification.controller.sendEmailNotification.e2e-spec.ts
@@ -19,7 +19,10 @@ import { GC_NOTIFY_TEMPLATE_IDS } from "@sims/test-utils/constants";
 import { NotificationMessage, NotificationMessageType } from "@sims/sims-db";
 import { randomUUID } from "node:crypto";
 import { IsNull } from "typeorm";
-import { NOTIFICATION_MISSING_EMAIL_CONTACTS } from "@sims/services/constants";
+import {
+  NOTIFICATION_MESSAGE_NOT_FOUND,
+  NOTIFICATION_MISSING_EMAIL_CONTACTS,
+} from "@sims/services/constants";
 
 describe("NotificationController(e2e)-sendEmailNotification", () => {
   let db: E2EDataSources;
@@ -270,10 +273,9 @@ describe("NotificationController(e2e)-sendEmailNotification", () => {
     // The job fails, raising an incident, since the template is not seeded and
     // notification messages are no longer created at runtime.
     expect(result).toEqual({
-      [FAKE_WORKER_JOB_RESULT_PROPERTY]: MockedZeebeJobResult.Fail,
-      [FAKE_WORKER_JOB_ERROR_MESSAGE_PROPERTY]: expect.stringContaining(
-        `Notification message not found for template id ${unknownTemplateId}`,
-      ),
+      [FAKE_WORKER_JOB_RESULT_PROPERTY]: MockedZeebeJobResult.Error,
+      [FAKE_WORKER_JOB_ERROR_MESSAGE_PROPERTY]: `Notification message not found for template id ${unknownTemplateId}`,
+      [FAKE_WORKER_JOB_ERROR_CODE_PROPERTY]: NOTIFICATION_MESSAGE_NOT_FOUND,
     });
   });
 });

--- a/sources/packages/backend/apps/workers/src/controllers/notification/_tests_/e2e/notification.controller.sendEmailNotification.e2e-spec.ts
+++ b/sources/packages/backend/apps/workers/src/controllers/notification/_tests_/e2e/notification.controller.sendEmailNotification.e2e-spec.ts
@@ -86,23 +86,17 @@ describe("NotificationController(e2e)-sendEmailNotification", () => {
     const { student } = savedApplication;
     // Prepare an existing notification for the same message to ensure a new one
     // is still created when no uniqueness criteria is provided.
-    const existingNotification = createFakeNotification(
-      {
-        user: student.user,
-        notificationMessage: {
-          id: NotificationMessageType.FormerYouthInCareNotification,
-        } as NotificationMessage,
-      },
-      { initialValue: { metadata: null } },
-    );
+    const existingNotification = createFakeNotification({
+      user: student.user,
+      notificationMessage: {
+        id: NotificationMessageType.FormerYouthInCareNotification,
+      } as NotificationMessage,
+    });
     await db.notification.save(existingNotification);
     const payload = createFakeSendEmailNotificationPayload(
       GC_NOTIFY_TEMPLATE_IDS.FormerYouthInCareNotification,
       EmailNotificationRecipient.Student,
       savedApplication.currentAssessment.id,
-      {
-        metadata: {},
-      },
     );
 
     // Act

--- a/sources/packages/backend/apps/workers/src/controllers/notification/_tests_/e2e/notification.controller.sendEmailNotification.e2e-spec.ts
+++ b/sources/packages/backend/apps/workers/src/controllers/notification/_tests_/e2e/notification.controller.sendEmailNotification.e2e-spec.ts
@@ -232,6 +232,12 @@ describe("NotificationController(e2e)-sendEmailNotification", () => {
     // Arrange
     const savedApplication = await saveFakeApplication(db.dataSource);
     const { student } = savedApplication;
+    // Ensure no email contacts are configured for the ministry notification,
+    // clearing any contacts that a previous test may have persisted.
+    await db.notificationMessage.update(
+      NotificationMessageType.FormerYouthInCareNotification,
+      { emailContacts: null },
+    );
     const payload = createFakeSendEmailNotificationPayload(
       GC_NOTIFY_TEMPLATE_IDS.FormerYouthInCareNotification,
       EmailNotificationRecipient.Ministry,
@@ -242,8 +248,8 @@ describe("NotificationController(e2e)-sendEmailNotification", () => {
     const result = await notificationController.sendEmailNotification(payload);
 
     // Asserts
-    // The job fails, raising an incident, since the template is not seeded and
-    // notification messages are no longer created at runtime.
+    // The job fails, raising an incident, since the ministry notification
+    // message has no email contacts configured.
     expect(result).toEqual({
       [FAKE_WORKER_JOB_RESULT_PROPERTY]: MockedZeebeJobResult.Error,
       [FAKE_WORKER_JOB_ERROR_CODE_PROPERTY]:

--- a/sources/packages/backend/apps/workers/src/controllers/notification/_tests_/e2e/notification.controller.sendEmailNotification.e2e-spec.ts
+++ b/sources/packages/backend/apps/workers/src/controllers/notification/_tests_/e2e/notification.controller.sendEmailNotification.e2e-spec.ts
@@ -3,6 +3,7 @@ import {
   createFakeNotification,
   E2EDataSources,
   saveFakeApplication,
+  saveFakeNotificationMessage,
 } from "@sims/test-utils";
 import {
   FAKE_WORKER_JOB_ERROR_CODE_PROPERTY,
@@ -167,13 +168,14 @@ describe("NotificationController(e2e)-sendEmailNotification", () => {
     // Arrange
     const savedApplication = await saveFakeApplication(db.dataSource);
     const ministryEmailContact = `ministry-${randomUUID()}@example.com`;
-    // Configure the email contacts used to address the ministry notification.
-    await db.notificationMessage.update(
-      NotificationMessageType.FormerYouthInCareNotification,
-      { emailContacts: [ministryEmailContact] },
+    // Create an isolated notification message configured with the email contact used to
+    // address the ministry notification.
+    const ministryNotificationMessage = await saveFakeNotificationMessage(
+      db.dataSource,
+      { initialValue: { emailContacts: [ministryEmailContact] } },
     );
     const payload = createFakeSendEmailNotificationPayload(
-      GC_NOTIFY_TEMPLATE_IDS.FormerYouthInCareNotification,
+      ministryNotificationMessage.templateId,
       EmailNotificationRecipient.Ministry,
       savedApplication.currentAssessment.id,
       {
@@ -198,9 +200,7 @@ describe("NotificationController(e2e)-sendEmailNotification", () => {
       },
       relations: { user: true, notificationMessage: true },
       where: {
-        notificationMessage: {
-          id: NotificationMessageType.FormerYouthInCareNotification,
-        },
+        notificationMessage: { id: ministryNotificationMessage.id },
         user: IsNull(),
       },
       order: { id: "DESC" },
@@ -209,10 +209,10 @@ describe("NotificationController(e2e)-sendEmailNotification", () => {
       id: expect.any(Number),
       user: null,
       notificationMessage: {
-        id: NotificationMessageType.FormerYouthInCareNotification,
+        id: ministryNotificationMessage.id,
       },
       messagePayload: {
-        template_id: GC_NOTIFY_TEMPLATE_IDS.FormerYouthInCareNotification,
+        template_id: ministryNotificationMessage.templateId,
         email_address: ministryEmailContact,
         personalisation: {
           applicationNumber: savedApplication.applicationNumber,
@@ -226,12 +226,6 @@ describe("NotificationController(e2e)-sendEmailNotification", () => {
     // Arrange
     const savedApplication = await saveFakeApplication(db.dataSource);
     const { student } = savedApplication;
-    // Ensure no email contacts are configured for the ministry notification,
-    // clearing any contacts that a previous test may have persisted.
-    await db.notificationMessage.update(
-      NotificationMessageType.FormerYouthInCareNotification,
-      { emailContacts: null },
-    );
     const payload = createFakeSendEmailNotificationPayload(
       GC_NOTIFY_TEMPLATE_IDS.FormerYouthInCareNotification,
       EmailNotificationRecipient.Ministry,

--- a/sources/packages/backend/apps/workers/src/controllers/notification/_tests_/e2e/notification.controller.sendEmailNotification.e2e-spec.ts
+++ b/sources/packages/backend/apps/workers/src/controllers/notification/_tests_/e2e/notification.controller.sendEmailNotification.e2e-spec.ts
@@ -80,7 +80,7 @@ describe("NotificationController(e2e)-sendEmailNotification", () => {
     });
   });
 
-  it("Should create a new email notification when no metadata is provided.", async () => {
+  it("Should create a new email notification when the notification with same templateId and metadata does not already exist.", async () => {
     // Arrange
     const savedApplication = await saveFakeApplication(db.dataSource);
     const { student } = savedApplication;
@@ -260,7 +260,6 @@ describe("NotificationController(e2e)-sendEmailNotification", () => {
   it("Should fail the job raising an incident when the template id is not associated with any existing notification message.", async () => {
     // Arrange
     const savedApplication = await saveFakeApplication(db.dataSource);
-    const { student } = savedApplication;
     const unknownTemplateId = randomUUID();
     const payload = createFakeSendEmailNotificationPayload(
       unknownTemplateId,
@@ -280,10 +279,5 @@ describe("NotificationController(e2e)-sendEmailNotification", () => {
         `Notification message not found for template id ${unknownTemplateId}`,
       ),
     });
-    // No notification is created for the student.
-    const notificationsCount = await db.notification.count({
-      where: { user: { id: student.user.id } },
-    });
-    expect(notificationsCount).toBe(0);
   });
 });

--- a/sources/packages/backend/apps/workers/src/controllers/notification/_tests_/e2e/notification.controller.sendEmailNotification.e2e-spec.ts
+++ b/sources/packages/backend/apps/workers/src/controllers/notification/_tests_/e2e/notification.controller.sendEmailNotification.e2e-spec.ts
@@ -37,8 +37,8 @@ describe("NotificationController(e2e)-sendEmailNotification", () => {
     const payload = createFakeSendEmailNotificationPayload(
       GC_NOTIFY_TEMPLATE_IDS.FormerYouthInCareNotification,
       EmailNotificationRecipient.Student,
+      savedApplication.currentAssessment.id,
       {
-        assessmentId: savedApplication.currentAssessment.id,
         personalisation: {
           givenNames: "studentGivenNames",
           lastName: "studentLastName",
@@ -99,8 +99,8 @@ describe("NotificationController(e2e)-sendEmailNotification", () => {
     const payload = createFakeSendEmailNotificationPayload(
       GC_NOTIFY_TEMPLATE_IDS.FormerYouthInCareNotification,
       EmailNotificationRecipient.Student,
+      savedApplication.currentAssessment.id,
       {
-        assessmentId: savedApplication.currentAssessment.id,
         metadata: {},
       },
     );
@@ -144,8 +144,8 @@ describe("NotificationController(e2e)-sendEmailNotification", () => {
     const payload = createFakeSendEmailNotificationPayload(
       GC_NOTIFY_TEMPLATE_IDS.FormerYouthInCareNotification,
       EmailNotificationRecipient.Student,
+      savedApplication.currentAssessment.id,
       {
-        assessmentId: savedApplication.currentAssessment.id,
         metadata: { parentApplicationId },
       },
     );
@@ -181,8 +181,8 @@ describe("NotificationController(e2e)-sendEmailNotification", () => {
     const payload = createFakeSendEmailNotificationPayload(
       GC_NOTIFY_TEMPLATE_IDS.FormerYouthInCareNotification,
       EmailNotificationRecipient.Ministry,
+      savedApplication.currentAssessment.id,
       {
-        assessmentId: savedApplication.currentAssessment.id,
         personalisation: { applicationNumber: "applicationNumber" },
       },
     );
@@ -235,7 +235,7 @@ describe("NotificationController(e2e)-sendEmailNotification", () => {
     const payload = createFakeSendEmailNotificationPayload(
       GC_NOTIFY_TEMPLATE_IDS.FormerYouthInCareNotification,
       EmailNotificationRecipient.Ministry,
-      { assessmentId: savedApplication.currentAssessment.id },
+      savedApplication.currentAssessment.id,
     );
 
     // Act
@@ -265,7 +265,7 @@ describe("NotificationController(e2e)-sendEmailNotification", () => {
     const payload = createFakeSendEmailNotificationPayload(
       unknownTemplateId,
       EmailNotificationRecipient.Student,
-      { assessmentId: savedApplication.currentAssessment.id },
+      savedApplication.currentAssessment.id,
     );
 
     // Act

--- a/sources/packages/backend/apps/workers/src/controllers/notification/_tests_/e2e/send-email-notification-factory.ts
+++ b/sources/packages/backend/apps/workers/src/controllers/notification/_tests_/e2e/send-email-notification-factory.ts
@@ -1,0 +1,50 @@
+import { IOutputVariables, ZeebeJob } from "@camunda8/sdk/dist/zeebe/types";
+import { createFakeWorkerJob } from "../../../../../test/utils/worker-job-mock";
+import {
+  SendEmailNotificationJobHeaderDTO,
+  SendEmailNotificationJobInDTO,
+} from "../../notification.dto";
+import { WorkflowEmailNotificationRecipient } from "@sims/services/notifications";
+import { NotificationMetadata } from "@sims/sims-db/entities/notification-metadata.type";
+
+/**
+ * Creates a fake send email notification payload.
+ * @param options payload options.
+ * - `templateId` GC Notify template id used to send the email.
+ * - `recipientType` recipient of the notification.
+ * - `assessmentId` assessment id used to load the student personal information.
+ * - `emailNotificationPersonalisation` personalisation provided by the workflow.
+ * - `emailNotificationCheckMetadata` when provided, skips creation if a
+ * notification for the same message already exists with matching metadata.
+ * @returns fake send email notification payload.
+ */
+export function createFakeSendEmailNotificationPayload(options: {
+  templateId: string;
+  recipientType: WorkflowEmailNotificationRecipient;
+  assessmentId?: number;
+  emailNotificationPersonalisation?: Record<string, string | number | string[]>;
+  emailNotificationCheckMetadata?: NotificationMetadata;
+}): Readonly<
+  ZeebeJob<
+    SendEmailNotificationJobInDTO,
+    SendEmailNotificationJobHeaderDTO,
+    IOutputVariables
+  >
+> {
+  return createFakeWorkerJob<
+    SendEmailNotificationJobInDTO,
+    SendEmailNotificationJobHeaderDTO,
+    IOutputVariables
+  >({
+    variables: {
+      assessmentId: options.assessmentId,
+      emailNotificationPersonalisation:
+        options.emailNotificationPersonalisation,
+      emailNotificationCheckMetadata: options.emailNotificationCheckMetadata,
+    },
+    customHeaders: {
+      templateId: options.templateId,
+      recipientType: options.recipientType,
+    },
+  });
+}

--- a/sources/packages/backend/apps/workers/src/controllers/notification/_tests_/e2e/send-email-notification-factory.ts
+++ b/sources/packages/backend/apps/workers/src/controllers/notification/_tests_/e2e/send-email-notification-factory.ts
@@ -23,8 +23,8 @@ import { NotificationMetadata } from "@sims/sims-db/entities/notification-metada
 export function createFakeSendEmailNotificationPayload(
   templateId: string,
   recipientType: EmailNotificationRecipient,
+  assessmentId: number,
   options?: {
-    assessmentId?: number;
     personalisation?: NotificationPersonalisationContext;
     metadata?: NotificationMetadata;
   },
@@ -41,7 +41,7 @@ export function createFakeSendEmailNotificationPayload(
     IOutputVariables
   >({
     variables: {
-      assessmentId: options?.assessmentId,
+      assessmentId,
       personalisation: options?.personalisation,
       metadata: options?.metadata,
     },

--- a/sources/packages/backend/apps/workers/src/controllers/notification/_tests_/e2e/send-email-notification-factory.ts
+++ b/sources/packages/backend/apps/workers/src/controllers/notification/_tests_/e2e/send-email-notification-factory.ts
@@ -1,30 +1,34 @@
 import { IOutputVariables, ZeebeJob } from "@camunda8/sdk/dist/zeebe/types";
 import { createFakeWorkerJob } from "../../../../../test/utils/worker-job-mock";
 import {
+  NotificationPersonalisationContext,
   SendEmailNotificationJobHeaderDTO,
   SendEmailNotificationJobInDTO,
 } from "../../notification.dto";
-import { WorkflowEmailNotificationRecipient } from "@sims/services/notifications";
+import { EmailNotificationRecipient } from "@sims/services/notifications";
 import { NotificationMetadata } from "@sims/sims-db/entities/notification-metadata.type";
 
 /**
  * Creates a fake send email notification payload.
+ * @param templateId GC Notify template id used to send the email.
+ * @param recipientType recipient of the notification.
  * @param options payload options.
- * - `templateId` GC Notify template id used to send the email.
- * - `recipientType` recipient of the notification.
- * - `assessmentId` assessment id used to load the student personal information.
- * - `emailNotificationPersonalisation` personalisation provided by the workflow.
- * - `emailNotificationCheckMetadata` when provided, skips creation if a
- * notification for the same message already exists with matching metadata.
+ * - `assessmentId` assessment id used to load the notification data.
+ * - `personalisation` personalisation context provided by the workflow, mapping
+ * each variable name to a path in the notification data.
+ * - `metadata` when provided, skips creation if a notification for the same
+ * message already exists with matching metadata.
  * @returns fake send email notification payload.
  */
-export function createFakeSendEmailNotificationPayload(options: {
-  templateId: string;
-  recipientType: WorkflowEmailNotificationRecipient;
-  assessmentId?: number;
-  emailNotificationPersonalisation?: Record<string, string | number | string[]>;
-  emailNotificationCheckMetadata?: NotificationMetadata;
-}): Readonly<
+export function createFakeSendEmailNotificationPayload(
+  templateId: string,
+  recipientType: EmailNotificationRecipient,
+  options?: {
+    assessmentId?: number;
+    personalisation?: NotificationPersonalisationContext;
+    metadata?: NotificationMetadata;
+  },
+): Readonly<
   ZeebeJob<
     SendEmailNotificationJobInDTO,
     SendEmailNotificationJobHeaderDTO,
@@ -37,14 +41,13 @@ export function createFakeSendEmailNotificationPayload(options: {
     IOutputVariables
   >({
     variables: {
-      assessmentId: options.assessmentId,
-      emailNotificationPersonalisation:
-        options.emailNotificationPersonalisation,
-      emailNotificationCheckMetadata: options.emailNotificationCheckMetadata,
+      assessmentId: options?.assessmentId,
+      personalisation: options?.personalisation,
+      metadata: options?.metadata,
     },
     customHeaders: {
-      templateId: options.templateId,
-      recipientType: options.recipientType,
+      templateId,
+      recipientType,
     },
   });
 }

--- a/sources/packages/backend/apps/workers/src/controllers/notification/notification.controller.ts
+++ b/sources/packages/backend/apps/workers/src/controllers/notification/notification.controller.ts
@@ -1,0 +1,119 @@
+/**
+ * Workers must be implemented as idempotent methods and also with the ability to allow a retry operation.
+ * The idempotency would ensure the worker can be potentially be called multiple time to process the same job
+ * and it will produce the same impact and same result. To know more about it please check the link
+ * https://docs.camunda.io/docs/components/best-practices/development/dealing-with-problems-and-exceptions/#writing-idempotent-workers.
+ * The retry ability means that, in case of fail, the worker must ensure the data would still be consistent
+ * and a new retry operation would be successfully executed.
+ * Please see the below link also for some best practices for workers.
+ * https://docs.camunda.io/docs/components/best-practices/development/dealing-with-problems-and-exceptions/
+ */
+import { Controller, Logger } from "@nestjs/common";
+import { ZeebeWorker } from "../../zeebe";
+import {
+  SendEmailNotificationJobHeaderDTO,
+  SendEmailNotificationJobInDTO,
+} from "..";
+import { StudentAssessmentService } from "../../services";
+import { createUnexpectedJobFail } from "../../utilities";
+import { Workers } from "@sims/services/constants";
+import { ASSESSMENT_ID } from "@sims/services/workflow/variables/assessment-gateway";
+import {
+  EMAIL_NOTIFICATION_CHECK_METADATA,
+  EMAIL_NOTIFICATION_PERSONALISATION,
+} from "@sims/services/workflow/variables/send-email-notification";
+import { MaxJobsToActivate } from "../../types";
+import { NotificationActionsService } from "@sims/services";
+import { WorkflowEmailNotificationRecipient } from "@sims/services/notifications";
+import { DataSource } from "typeorm";
+import {
+  IOutputVariables,
+  MustReturnJobActionAcknowledgement,
+  ZeebeJob,
+} from "@camunda8/sdk/dist/zeebe/types";
+
+@Controller()
+export class NotificationController {
+  constructor(
+    private readonly dataSource: DataSource,
+    private readonly studentAssessmentService: StudentAssessmentService,
+    private readonly notificationActionsService: NotificationActionsService,
+  ) {}
+
+  /**
+   * Sends a generic email notification triggered by a workflow. The GC Notify
+   * template is resolved (or created) from the provided template id, so new
+   * notifications can be sent without code or migration changes. The recipient
+   * can be either the student or the Ministry:
+   */
+  @ZeebeWorker(Workers.SendEmailNotification, {
+    fetchVariable: [
+      ASSESSMENT_ID,
+      EMAIL_NOTIFICATION_PERSONALISATION,
+      EMAIL_NOTIFICATION_CHECK_METADATA,
+    ],
+    maxJobsToActivate: MaxJobsToActivate.Normal,
+  })
+  async sendEmailNotification(
+    job: Readonly<
+      ZeebeJob<
+        SendEmailNotificationJobInDTO,
+        SendEmailNotificationJobHeaderDTO,
+        IOutputVariables
+      >
+    >,
+  ): Promise<MustReturnJobActionAcknowledgement> {
+    const jobLogger = new Logger(job.type);
+    const { templateId, recipientType } = job.customHeaders;
+    const {
+      assessmentId,
+      emailNotificationPersonalisation,
+      emailNotificationCheckMetadata,
+    } = job.variables;
+    try {
+      await this.dataSource.transaction(async (entityManager) => {
+        switch (recipientType) {
+          case WorkflowEmailNotificationRecipient.Student: {
+            const student =
+              await this.studentAssessmentService.getStudentDetailsForNotificationByAssessmentId(
+                assessmentId,
+                entityManager,
+              );
+            if (!student) {
+              throw new Error(
+                `Student not found for the assessment id ${assessmentId}.`,
+              );
+            }
+            await this.notificationActionsService.saveWorkflowStudentEmailNotification(
+              {
+                templateId,
+                personalisation: emailNotificationPersonalisation,
+                student,
+              },
+              entityManager,
+              { checkMetadata: emailNotificationCheckMetadata },
+            );
+            break;
+          }
+          case WorkflowEmailNotificationRecipient.Ministry:
+            await this.notificationActionsService.saveWorkflowMinistryEmailNotification(
+              {
+                templateId,
+                personalisation: emailNotificationPersonalisation,
+              },
+              entityManager,
+            );
+            break;
+          default:
+            throw new Error(
+              `Unsupported notification recipient type: ${recipientType}.`,
+            );
+        }
+      });
+      jobLogger.log("Workflow email notification created.");
+      return job.complete();
+    } catch (error: unknown) {
+      return createUnexpectedJobFail(error, job, { logger: jobLogger });
+    }
+  }
+}

--- a/sources/packages/backend/apps/workers/src/controllers/notification/notification.controller.ts
+++ b/sources/packages/backend/apps/workers/src/controllers/notification/notification.controller.ts
@@ -18,7 +18,11 @@ import {
 } from "..";
 import { StudentAssessmentService } from "../../services";
 import { createUnexpectedJobFail } from "../../utilities";
-import { Workers, ASSESSMENT_NOT_FOUND } from "@sims/services/constants";
+import {
+  Workers,
+  ASSESSMENT_NOT_FOUND,
+  NOTIFICATION_MISSING_EMAIL_CONTACTS,
+} from "@sims/services/constants";
 import { ASSESSMENT_ID } from "@sims/services/workflow/variables/assessment-gateway";
 import {
   METADATA,
@@ -26,7 +30,10 @@ import {
 } from "@sims/services/workflow/variables/send-email-notification";
 import { MaxJobsToActivate } from "../../types";
 import { NotificationActionsService } from "@sims/services";
-import { EmailNotificationRecipient } from "@sims/services/notifications";
+import {
+  EmailNotificationRecipient,
+  NotificationMessageService,
+} from "@sims/services/notifications";
 import { StudentAssessment } from "@sims/sims-db";
 import { DataSource } from "typeorm";
 import {
@@ -41,6 +48,7 @@ export class NotificationController {
     private readonly dataSource: DataSource,
     private readonly studentAssessmentService: StudentAssessmentService,
     private readonly notificationActionsService: NotificationActionsService,
+    private readonly notificationMessageService: NotificationMessageService,
   ) {}
 
   /**
@@ -66,12 +74,13 @@ export class NotificationController {
   ): Promise<MustReturnJobActionAcknowledgement> {
     const jobLogger = new Logger(job.type);
     const { templateId, recipientType } = job.customHeaders;
-    const { assessmentId, personalisation: personalisationContext, metadata } =
-      job.variables;
+    const {
+      assessmentId,
+      personalisation: personalisationContext,
+      metadata,
+    } = job.variables;
     try {
-      // Load the notification data generically, regardless of the recipient
-      // type, so it can be used to resolve the personalisation and to address
-      // the notification.
+      // Load the notification data to resolve the personalisation.
       const assessment =
         await this.studentAssessmentService.getAssessmentNotificationDetails(
           assessmentId,
@@ -87,6 +96,12 @@ export class NotificationController {
         personalisationContext,
         notificationData,
       );
+
+      const notificationMessage =
+        await this.notificationMessageService.getNotificationMessageByTemplateId(
+          templateId,
+        );
+
       await this.dataSource.transaction(async (entityManager) => {
         switch (recipientType) {
           case EmailNotificationRecipient.Student:
@@ -99,13 +114,24 @@ export class NotificationController {
                   email: notificationData.studentEmail,
                 },
               },
+              notificationMessage,
               entityManager,
               { metadata },
             );
             break;
           case EmailNotificationRecipient.Ministry:
+            if (!notificationMessage.emailContacts?.length) {
+              const errorMessage = `No email contacts are configured for the Ministry notification with template ${templateId}.`;
+              jobLogger.error(errorMessage);
+              return job.error(
+                NOTIFICATION_MISSING_EMAIL_CONTACTS,
+                errorMessage,
+              );
+            }
+
             await this.notificationActionsService.saveWorkflowMinistryEmailNotification(
               { templateId, personalisation },
+              notificationMessage,
               entityManager,
             );
             break;

--- a/sources/packages/backend/apps/workers/src/controllers/notification/notification.controller.ts
+++ b/sources/packages/backend/apps/workers/src/controllers/notification/notification.controller.ts
@@ -23,6 +23,7 @@ import {
   ASSESSMENT_NOT_FOUND,
   NOTIFICATION_MISSING_EMAIL_CONTACTS,
   UNSUPPORTED_NOTIFICATION_RECIPIENT_TYPE,
+  NOTIFICATION_MESSAGE_NOT_FOUND,
 } from "@sims/services/constants";
 import { ASSESSMENT_ID } from "@sims/services/workflow/variables/assessment-gateway";
 import {
@@ -118,9 +119,9 @@ export class NotificationController {
           );
 
         if (!notificationMessage) {
-          throw new Error(
-            `Notification message not found for template id ${templateId}`,
-          );
+          const message = `Notification message not found for template id ${templateId}`;
+          jobLogger.error(message);
+          return job.error(NOTIFICATION_MESSAGE_NOT_FOUND, message);
         }
 
         switch (recipientType) {

--- a/sources/packages/backend/apps/workers/src/controllers/notification/notification.controller.ts
+++ b/sources/packages/backend/apps/workers/src/controllers/notification/notification.controller.ts
@@ -11,20 +11,23 @@
 import { Controller, Logger } from "@nestjs/common";
 import { ZeebeWorker } from "../../zeebe";
 import {
+  NotificationPersonalisationContext,
+  NotificationPersonalisationData,
   SendEmailNotificationJobHeaderDTO,
   SendEmailNotificationJobInDTO,
 } from "..";
 import { StudentAssessmentService } from "../../services";
 import { createUnexpectedJobFail } from "../../utilities";
-import { Workers } from "@sims/services/constants";
+import { Workers, ASSESSMENT_NOT_FOUND } from "@sims/services/constants";
 import { ASSESSMENT_ID } from "@sims/services/workflow/variables/assessment-gateway";
 import {
-  EMAIL_NOTIFICATION_CHECK_METADATA,
-  EMAIL_NOTIFICATION_PERSONALISATION,
+  METADATA,
+  PERSONALISATION,
 } from "@sims/services/workflow/variables/send-email-notification";
 import { MaxJobsToActivate } from "../../types";
 import { NotificationActionsService } from "@sims/services";
-import { WorkflowEmailNotificationRecipient } from "@sims/services/notifications";
+import { EmailNotificationRecipient } from "@sims/services/notifications";
+import { StudentAssessment } from "@sims/sims-db";
 import { DataSource } from "typeorm";
 import {
   IOutputVariables,
@@ -41,16 +44,15 @@ export class NotificationController {
   ) {}
 
   /**
-   * Sends a generic email notification triggered by a workflow.
+   * Sends a generic email notification triggered by a workflow. The notification
+   * data is loaded generically from the assessment and used both to resolve the
+   * personalisation referenced by the workflow and to address the notification
+   * according to the recipient type.
    * @param job Zeebe job that contains the notification details and headers.
    * @returns Zeebe job acknowledgement.
    */
   @ZeebeWorker(Workers.SendEmailNotification, {
-    fetchVariable: [
-      ASSESSMENT_ID,
-      EMAIL_NOTIFICATION_PERSONALISATION,
-      EMAIL_NOTIFICATION_CHECK_METADATA,
-    ],
+    fetchVariable: [ASSESSMENT_ID, PERSONALISATION, METADATA],
     maxJobsToActivate: MaxJobsToActivate.Normal,
   })
   async sendEmailNotification(
@@ -64,42 +66,46 @@ export class NotificationController {
   ): Promise<MustReturnJobActionAcknowledgement> {
     const jobLogger = new Logger(job.type);
     const { templateId, recipientType } = job.customHeaders;
-    const {
-      assessmentId,
-      emailNotificationPersonalisation,
-      emailNotificationCheckMetadata,
-    } = job.variables;
+    const { assessmentId, personalisation: personalisationContext, metadata } =
+      job.variables;
     try {
+      // Load the notification data generically, regardless of the recipient
+      // type, so it can be used to resolve the personalisation and to address
+      // the notification.
+      const assessment =
+        await this.studentAssessmentService.getAssessmentNotificationDetails(
+          assessmentId,
+        );
+      if (!assessment) {
+        const message = `Assessment id ${assessmentId} not found.`;
+        jobLogger.error(message);
+        return job.error(ASSESSMENT_NOT_FOUND, message);
+      }
+      const notificationData =
+        this.buildNotificationPersonalisationData(assessment);
+      const personalisation = this.resolvePersonalisation(
+        personalisationContext,
+        notificationData,
+      );
       await this.dataSource.transaction(async (entityManager) => {
         switch (recipientType) {
-          case WorkflowEmailNotificationRecipient.Student: {
-            const student =
-              await this.studentAssessmentService.getStudentDetailsForNotificationByAssessmentId(
-                assessmentId,
-                entityManager,
-              );
-            if (!student) {
-              throw new Error(
-                `Student not found for the assessment id ${assessmentId}.`,
-              );
-            }
+          case EmailNotificationRecipient.Student:
             await this.notificationActionsService.saveWorkflowStudentEmailNotification(
               {
                 templateId,
-                personalisation: emailNotificationPersonalisation,
-                student,
+                personalisation,
+                student: {
+                  userId: notificationData.studentUserId,
+                  email: notificationData.studentEmail,
+                },
               },
               entityManager,
-              { checkMetadata: emailNotificationCheckMetadata },
+              { metadata },
             );
             break;
-          }
-          case WorkflowEmailNotificationRecipient.Ministry:
+          case EmailNotificationRecipient.Ministry:
             await this.notificationActionsService.saveWorkflowMinistryEmailNotification(
-              {
-                templateId,
-                personalisation: emailNotificationPersonalisation,
-              },
+              { templateId, personalisation },
               entityManager,
             );
             break;
@@ -114,5 +120,48 @@ export class NotificationController {
     } catch (error: unknown) {
       return createUnexpectedJobFail(error, job, { logger: jobLogger });
     }
+  }
+
+  /**
+   * Builds the notification data used as the source of the values referenced by
+   * the personalisation context provided by the workflow.
+   * @param assessment assessment with the associated student details.
+   * @returns notification data resolved from the assessment.
+   */
+  private buildNotificationPersonalisationData(
+    assessment: StudentAssessment,
+  ): NotificationPersonalisationData {
+    const { student } = assessment.application;
+    return {
+      studentUserId: student.user.id,
+      studentEmail: student.user.email,
+      studentGivenNames: student.user.firstName ?? "",
+      studentLastName: student.user.lastName,
+      applicationNumber: assessment.application.applicationNumber,
+    };
+  }
+
+  /**
+   * Resolves the personalisation values sent to GC Notify from the personalisation
+   * context provided by the workflow, mapping each variable name to the
+   * corresponding value in the notification data.
+   * @param personalisationContext personalisation context provided by the
+   * workflow, mapping each variable name to a path in the notification data.
+   * @param notificationData notification data resolved on the API side.
+   * @returns personalisation values to be sent to GC Notify.
+   */
+  private resolvePersonalisation(
+    personalisationContext: NotificationPersonalisationContext | undefined,
+    notificationData: NotificationPersonalisationData,
+  ): Record<string, string | number | string[]> {
+    const personalisation: Record<string, string | number | string[]> = {};
+    if (!personalisationContext) {
+      return personalisation;
+    }
+    for (const [variableName, path] of Object.entries(personalisationContext)) {
+      personalisation[variableName] =
+        notificationData[path as keyof NotificationPersonalisationData];
+    }
+    return personalisation;
   }
 }

--- a/sources/packages/backend/apps/workers/src/controllers/notification/notification.controller.ts
+++ b/sources/packages/backend/apps/workers/src/controllers/notification/notification.controller.ts
@@ -22,6 +22,7 @@ import {
   Workers,
   ASSESSMENT_NOT_FOUND,
   NOTIFICATION_MISSING_EMAIL_CONTACTS,
+  UNSUPPORTED_NOTIFICATION_RECIPIENT_TYPE,
 } from "@sims/services/constants";
 import { ASSESSMENT_ID } from "@sims/services/workflow/variables/assessment-gateway";
 import {
@@ -87,21 +88,22 @@ export class NotificationController {
         // it runs more than once, the duplicate check performed before saving
         // the notification stays reliable and a single email is created. The lock
         // is a requirement of this consumer, not of the service loading the data.
-        await this.studentAssessmentService.acquireAssessmentLock(
-          assessmentId,
-          entityManager,
-        );
+        const lockedAssessment =
+          await this.studentAssessmentService.acquireAssessmentLock(
+            assessmentId,
+            entityManager,
+          );
+        if (!lockedAssessment) {
+          const message = `Assessment id ${assessmentId} not found.`;
+          jobLogger.error(message);
+          return job.error(ASSESSMENT_NOT_FOUND, message);
+        }
         // Load the notification data to resolve the personalisation.
         const assessment =
           await this.studentAssessmentService.getAssessmentNotificationDetails(
             assessmentId,
             entityManager,
           );
-        if (!assessment) {
-          const message = `Assessment id ${assessmentId} not found.`;
-          jobLogger.error(message);
-          return job.error(ASSESSMENT_NOT_FOUND, message);
-        }
         const notificationData =
           this.buildNotificationPersonalisationData(assessment);
         const personalisation = this.resolvePersonalisation(
@@ -153,10 +155,14 @@ export class NotificationController {
               entityManager,
             );
             break;
-          default:
-            throw new Error(
-              `Unsupported notification recipient type: ${recipientType}.`,
+          default: {
+            const errorMessage = `Unsupported notification recipient type: ${recipientType}.`;
+            jobLogger.error(errorMessage);
+            return job.error(
+              UNSUPPORTED_NOTIFICATION_RECIPIENT_TYPE,
+              errorMessage,
             );
+          }
         }
         jobLogger.log("Workflow email notification created.");
         return job.complete();

--- a/sources/packages/backend/apps/workers/src/controllers/notification/notification.controller.ts
+++ b/sources/packages/backend/apps/workers/src/controllers/notification/notification.controller.ts
@@ -81,12 +81,17 @@ export class NotificationController {
     } = job.variables;
     try {
       return await this.dataSource.transaction(async (entityManager) => {
-        // Load the notification data to resolve the personalisation. A
-        // pessimistic write lock is acquired on the assessment as soon as the
+        // A pessimistic write lock is acquired on the assessment as soon as the
         // job starts processing, serializing concurrent executions of the same
         // job for the same assessment. This keeps the worker idempotent: even if
         // it runs more than once, the duplicate check performed before saving
-        // the notification stays reliable and a single email is created.
+        // the notification stays reliable and a single email is created. The lock
+        // is a requirement of this consumer, not of the service loading the data.
+        await this.studentAssessmentService.acquireAssessmentLock(
+          assessmentId,
+          entityManager,
+        );
+        // Load the notification data to resolve the personalisation.
         const assessment =
           await this.studentAssessmentService.getAssessmentNotificationDetails(
             assessmentId,
@@ -110,16 +115,19 @@ export class NotificationController {
             { entityManager },
           );
 
+        if (!notificationMessage) {
+          throw new Error(
+            `Notification message not found for template id ${templateId}`,
+          );
+        }
+
         switch (recipientType) {
           case EmailNotificationRecipient.Student:
-            await this.notificationActionsService.saveWorkflowStudentEmailNotification(
+            await this.notificationActionsService.saveEmailNotification(
               {
-                templateId,
+                userId: notificationData.studentUserId,
+                emailRecipients: [notificationData.studentEmail],
                 personalisation,
-                student: {
-                  userId: notificationData.studentUserId,
-                  email: notificationData.studentEmail,
-                },
               },
               notificationMessage,
               entityManager,
@@ -136,8 +144,11 @@ export class NotificationController {
               );
             }
 
-            await this.notificationActionsService.saveWorkflowMinistryEmailNotification(
-              { templateId, personalisation },
+            await this.notificationActionsService.saveEmailNotification(
+              {
+                emailRecipients: notificationMessage.emailContacts,
+                personalisation,
+              },
               notificationMessage,
               entityManager,
             );
@@ -181,16 +192,18 @@ export class NotificationController {
    * @param personalisationContext personalisation context provided by the
    * workflow, mapping each variable name to a path in the notification data.
    * @param notificationData notification data resolved on the API side.
-   * @returns personalisation values to be sent to GC Notify.
+   * @returns personalisation values to be sent to GC Notify, or undefined when
+   * no personalisation context is provided, letting the notification action
+   * service decide the fallback.
    */
   private resolvePersonalisation(
     personalisationContext: NotificationPersonalisationContext | undefined,
     notificationData: NotificationPersonalisationData,
-  ): Record<string, string | number | string[]> {
-    const personalisation: Record<string, string | number | string[]> = {};
+  ): Record<string, string | number | string[]> | undefined {
     if (!personalisationContext) {
-      return personalisation;
+      return undefined;
     }
+    const personalisation: Record<string, string | number | string[]> = {};
     for (const [variableName, path] of Object.entries(personalisationContext)) {
       personalisation[variableName] =
         notificationData[path as keyof NotificationPersonalisationData];

--- a/sources/packages/backend/apps/workers/src/controllers/notification/notification.controller.ts
+++ b/sources/packages/backend/apps/workers/src/controllers/notification/notification.controller.ts
@@ -80,29 +80,36 @@ export class NotificationController {
       metadata,
     } = job.variables;
     try {
-      // Load the notification data to resolve the personalisation.
-      const assessment =
-        await this.studentAssessmentService.getAssessmentNotificationDetails(
-          assessmentId,
+      return await this.dataSource.transaction(async (entityManager) => {
+        // Load the notification data to resolve the personalisation. A
+        // pessimistic write lock is acquired on the assessment as soon as the
+        // job starts processing, serializing concurrent executions of the same
+        // job for the same assessment. This keeps the worker idempotent: even if
+        // it runs more than once, the duplicate check performed before saving
+        // the notification stays reliable and a single email is created.
+        const assessment =
+          await this.studentAssessmentService.getAssessmentNotificationDetails(
+            assessmentId,
+            entityManager,
+          );
+        if (!assessment) {
+          const message = `Assessment id ${assessmentId} not found.`;
+          jobLogger.error(message);
+          return job.error(ASSESSMENT_NOT_FOUND, message);
+        }
+        const notificationData =
+          this.buildNotificationPersonalisationData(assessment);
+        const personalisation = this.resolvePersonalisation(
+          personalisationContext,
+          notificationData,
         );
-      if (!assessment) {
-        const message = `Assessment id ${assessmentId} not found.`;
-        jobLogger.error(message);
-        return job.error(ASSESSMENT_NOT_FOUND, message);
-      }
-      const notificationData =
-        this.buildNotificationPersonalisationData(assessment);
-      const personalisation = this.resolvePersonalisation(
-        personalisationContext,
-        notificationData,
-      );
 
-      const notificationMessage =
-        await this.notificationMessageService.getNotificationMessageByTemplateId(
-          templateId,
-        );
+        const notificationMessage =
+          await this.notificationMessageService.getNotificationMessageByTemplateId(
+            templateId,
+            { entityManager },
+          );
 
-      await this.dataSource.transaction(async (entityManager) => {
         switch (recipientType) {
           case EmailNotificationRecipient.Student:
             await this.notificationActionsService.saveWorkflowStudentEmailNotification(
@@ -140,9 +147,9 @@ export class NotificationController {
               `Unsupported notification recipient type: ${recipientType}.`,
             );
         }
+        jobLogger.log("Workflow email notification created.");
+        return job.complete();
       });
-      jobLogger.log("Workflow email notification created.");
-      return job.complete();
     } catch (error: unknown) {
       return createUnexpectedJobFail(error, job, { logger: jobLogger });
     }

--- a/sources/packages/backend/apps/workers/src/controllers/notification/notification.controller.ts
+++ b/sources/packages/backend/apps/workers/src/controllers/notification/notification.controller.ts
@@ -41,10 +41,9 @@ export class NotificationController {
   ) {}
 
   /**
-   * Sends a generic email notification triggered by a workflow. The GC Notify
-   * template is resolved (or created) from the provided template id, so new
-   * notifications can be sent without code or migration changes. The recipient
-   * can be either the student or the Ministry:
+   * Sends a generic email notification triggered by a workflow.
+   * @param job Zeebe job that contains the notification details and headers.
+   * @returns Zeebe job acknowledgement.
    */
   @ZeebeWorker(Workers.SendEmailNotification, {
     fetchVariable: [

--- a/sources/packages/backend/apps/workers/src/controllers/notification/notification.dto.ts
+++ b/sources/packages/backend/apps/workers/src/controllers/notification/notification.dto.ts
@@ -1,0 +1,39 @@
+import { WorkflowEmailNotificationRecipient } from "@sims/services/notifications";
+import { NotificationMetadata } from "@sims/sims-db/entities/notification-metadata.type";
+
+/**
+ * Variables required by the send email notification worker.
+ */
+export interface SendEmailNotificationJobInDTO {
+  /**
+   * Assessment id used to load the student personal information when the
+   * recipient of the notification is the student.
+   */
+  assessmentId?: number;
+  /**
+   * Free-form personalisation values provided by the workflow to be merged with
+   * the personal information loaded on the API side before the email is sent.
+   */
+  emailNotificationPersonalisation?: Record<string, string | number | string[]>;
+  /**
+   * Free-form metadata provided by the workflow used to check whether the same
+   * notification was already sent, preventing duplicate emails. When provided,
+   * the notification is created only if no notification for the same message
+   * already exists with matching metadata.
+   */
+  emailNotificationCheckMetadata?: NotificationMetadata;
+}
+
+/**
+ * Headers required by the send email notification worker.
+ */
+export interface SendEmailNotificationJobHeaderDTO {
+  /**
+   * GC Notify template id used to send the email.
+   */
+  templateId: string;
+  /**
+   * Recipient of the notification.
+   */
+  recipientType: WorkflowEmailNotificationRecipient;
+}

--- a/sources/packages/backend/apps/workers/src/controllers/notification/notification.dto.ts
+++ b/sources/packages/backend/apps/workers/src/controllers/notification/notification.dto.ts
@@ -45,7 +45,7 @@ export interface SendEmailNotificationJobInDTO {
   /**
    * Assessment id used to load the notification data on the API side.
    */
-  assessmentId?: number;
+  assessmentId: number;
   /**
    * Personalisation context provided by the workflow, mapping each GC Notify
    * personalisation variable name to the path of the value to be resolved from

--- a/sources/packages/backend/apps/workers/src/controllers/notification/notification.dto.ts
+++ b/sources/packages/backend/apps/workers/src/controllers/notification/notification.dto.ts
@@ -1,27 +1,64 @@
-import { WorkflowEmailNotificationRecipient } from "@sims/services/notifications";
+import { EmailNotificationRecipient } from "@sims/services/notifications";
 import { NotificationMetadata } from "@sims/sims-db/entities/notification-metadata.type";
+
+/**
+ * Personalisation context provided by the workflow, mapping each GC Notify
+ * personalisation variable name to the path of the value in the notification
+ * data resolved on the API side (e.g. `{ givenNames: "studentGivenNames" }`).
+ * The values are not the personalisation data themselves but references to it,
+ * since the personal information is not available in the workflow due to
+ * personal information constraints.
+ */
+export type NotificationPersonalisationContext = Record<string, string>;
+
+/**
+ * Notification data resolved on the API side used as the source of the values
+ * referenced by the personalisation context provided by the workflow.
+ */
+export interface NotificationPersonalisationData {
+  /**
+   * User id of the student, used to address the notification to the student.
+   */
+  studentUserId: number;
+  /**
+   * Email of the student, used to address the notification to the student.
+   */
+  studentEmail: string;
+  /**
+   * Given names of the student.
+   */
+  studentGivenNames: string;
+  /**
+   * Last name of the student.
+   */
+  studentLastName: string;
+  /**
+   * Application number associated with the assessment.
+   */
+  applicationNumber: string;
+}
 
 /**
  * Variables required by the send email notification worker.
  */
 export interface SendEmailNotificationJobInDTO {
   /**
-   * Assessment id used to load the student personal information when the
-   * recipient of the notification is the student.
+   * Assessment id used to load the notification data on the API side.
    */
   assessmentId?: number;
   /**
-   * Free-form personalisation values provided by the workflow to be merged with
-   * the personal information loaded on the API side before the email is sent.
+   * Personalisation context provided by the workflow, mapping each GC Notify
+   * personalisation variable name to the path of the value to be resolved from
+   * the notification data loaded on the API side.
    */
-  emailNotificationPersonalisation?: Record<string, string | number | string[]>;
+  personalisation?: NotificationPersonalisationContext;
   /**
    * Free-form metadata provided by the workflow used to check whether the same
    * notification was already sent, preventing duplicate emails. When provided,
    * the notification is created only if no notification for the same message
    * already exists with matching metadata.
    */
-  emailNotificationCheckMetadata?: NotificationMetadata;
+  metadata?: NotificationMetadata;
 }
 
 /**
@@ -35,5 +72,5 @@ export interface SendEmailNotificationJobHeaderDTO {
   /**
    * Recipient of the notification.
    */
-  recipientType: WorkflowEmailNotificationRecipient;
+  recipientType: EmailNotificationRecipient;
 }

--- a/sources/packages/backend/apps/workers/src/services/student-assessment/student-assessment.service.ts
+++ b/sources/packages/backend/apps/workers/src/services/student-assessment/student-assessment.service.ts
@@ -17,6 +17,7 @@ import {
   INVALID_OPERATION_IN_THE_CURRENT_STATUS,
 } from "@sims/services/constants";
 import { NotificationActionsService, SystemUsersService } from "@sims/services";
+import { WorkflowEmailNotificationStudent } from "@sims/services/notifications";
 
 /**
  * Manages the student assessment related operations.
@@ -317,6 +318,56 @@ export class StudentAssessmentService extends RecordDataModelService<StudentAsse
       auditUserId,
       transactionalEntityManager,
     );
+  }
+
+  /**
+   * Loads the student personal information required to send an email
+   * notification to the student from a given assessment. This information is
+   * loaded on the API side because it is not available in the workflow due to
+   * personal information constraints.
+   * @param assessmentId assessment id used to reach the associated student.
+   * @param entityManager entity manager to execute in transaction.
+   * @returns student notification details or null when the assessment or the
+   * associated student is not found.
+   */
+  async getStudentDetailsForNotificationByAssessmentId(
+    assessmentId: number,
+    entityManager: EntityManager,
+  ): Promise<WorkflowEmailNotificationStudent | null> {
+    const studentAssessment = await entityManager
+      .getRepository(StudentAssessment)
+      .findOne({
+        select: {
+          id: true,
+          application: {
+            id: true,
+            student: {
+              id: true,
+              user: {
+                id: true,
+                firstName: true,
+                lastName: true,
+                email: true,
+              },
+            },
+          },
+        },
+        relations: {
+          application: { student: { user: true } },
+        },
+        where: { id: assessmentId },
+      });
+    if (!studentAssessment) {
+      return null;
+    }
+    const student = studentAssessment.application.student;
+    return {
+      userId: student.user.id,
+      studentId: student.id,
+      givenNames: student.user.firstName,
+      lastName: student.user.lastName,
+      email: student.user.email,
+    };
   }
 
   /**

--- a/sources/packages/backend/apps/workers/src/services/student-assessment/student-assessment.service.ts
+++ b/sources/packages/backend/apps/workers/src/services/student-assessment/student-assessment.service.ts
@@ -124,6 +124,7 @@ export class StudentAssessmentService extends RecordDataModelService<StudentAsse
         "assessment.id",
         "assessment.triggerType",
         "application.id",
+        "application.applicationNumber",
         "application.data",
         "application.applicationStatus",
         "application.applicationEditStatus",

--- a/sources/packages/backend/apps/workers/src/services/student-assessment/student-assessment.service.ts
+++ b/sources/packages/backend/apps/workers/src/services/student-assessment/student-assessment.service.ts
@@ -322,18 +322,31 @@ export class StudentAssessmentService extends RecordDataModelService<StudentAsse
   }
 
   /**
+   * Acquires a pessimistic write lock on the assessment record. Serializes
+   * concurrent executions that require exclusive access to the same assessment.
+   * @param assessmentId assessment to lock.
+   * @param entityManager entity manager to execute within the same transaction,
+   * required to hold the pessimistic lock.
+   * @returns the locked assessment, or null when the assessment is not found.
+   */
+  async acquireAssessmentLock(
+    assessmentId: number,
+    entityManager: EntityManager,
+  ): Promise<StudentAssessment | null> {
+    return entityManager.getRepository(StudentAssessment).findOne({
+      select: { id: true },
+      where: { id: assessmentId },
+      lock: { mode: "pessimistic_write" },
+    });
+  }
+
+  /**
    * Loads the assessment along with the student details required to build the
    * data used to personalise and address a workflow-triggered email
    * notification. This information is loaded on the API side because it is not
    * available in the workflow due to personal information constraints.
-   * A pessimistic write lock is acquired on the assessment record to serialize
-   * concurrent executions of the same job, keeping the worker idempotent (e.g.
-   * preventing duplicate notifications when the same job is processed more than
-   * once). The lock is scoped to the assessment table only, so it can coexist
-   * with the left joins used to reach the student details.
    * @param assessmentId assessment id used to reach the associated student.
-   * @param entityManager entity manager to execute within the same transaction,
-   * required to hold the pessimistic lock.
+   * @param entityManager entity manager to execute within the same transaction.
    * @returns assessment with the associated student details, or null when the
    * assessment is not found.
    */
@@ -362,7 +375,6 @@ export class StudentAssessmentService extends RecordDataModelService<StudentAsse
         application: { student: { user: true } },
       },
       where: { id: assessmentId },
-      lock: { mode: "pessimistic_write", tables: ["student_assessments"] },
     });
   }
 

--- a/sources/packages/backend/apps/workers/src/services/student-assessment/student-assessment.service.ts
+++ b/sources/packages/backend/apps/workers/src/services/student-assessment/student-assessment.service.ts
@@ -362,7 +362,7 @@ export class StudentAssessmentService extends RecordDataModelService<StudentAsse
         application: { student: { user: true } },
       },
       where: { id: assessmentId },
-      lock: { mode: "pessimistic_write", tables: ["StudentAssessment"] },
+      lock: { mode: "pessimistic_write", tables: ["student_assessments"] },
     });
   }
 

--- a/sources/packages/backend/apps/workers/src/services/student-assessment/student-assessment.service.ts
+++ b/sources/packages/backend/apps/workers/src/services/student-assessment/student-assessment.service.ts
@@ -124,7 +124,7 @@ export class StudentAssessmentService extends RecordDataModelService<StudentAsse
         "assessment.id",
         "assessment.triggerType",
         "application.id",
-        "application.applicationNumber",
+        "parentApplication.id",
         "application.data",
         "application.applicationStatus",
         "application.applicationEditStatus",
@@ -174,6 +174,7 @@ export class StudentAssessmentService extends RecordDataModelService<StudentAsse
         "dynamicFormConfiguration.formCategory",
       ])
       .innerJoin("assessment.application", "application")
+      .innerJoin("application.parentApplication", "parentApplication")
       .innerJoin("application.programYear", "programYear")
       .innerJoin("application.student", "student")
       .leftJoin("assessment.offering", "offering")

--- a/sources/packages/backend/apps/workers/src/services/student-assessment/student-assessment.service.ts
+++ b/sources/packages/backend/apps/workers/src/services/student-assessment/student-assessment.service.ts
@@ -326,19 +326,22 @@ export class StudentAssessmentService extends RecordDataModelService<StudentAsse
    * data used to personalise and address a workflow-triggered email
    * notification. This information is loaded on the API side because it is not
    * available in the workflow due to personal information constraints.
+   * A pessimistic write lock is acquired on the assessment record to serialize
+   * concurrent executions of the same job, keeping the worker idempotent (e.g.
+   * preventing duplicate notifications when the same job is processed more than
+   * once). The lock is scoped to the assessment table only, so it can coexist
+   * with the left joins used to reach the student details.
    * @param assessmentId assessment id used to reach the associated student.
-   * @param options options.
-   * - `entityManager` optional entity manager to execute in transaction.
+   * @param entityManager entity manager to execute within the same transaction,
+   * required to hold the pessimistic lock.
    * @returns assessment with the associated student details, or null when the
    * assessment is not found.
    */
   async getAssessmentNotificationDetails(
     assessmentId: number,
-    options?: { entityManager?: EntityManager },
+    entityManager: EntityManager,
   ): Promise<StudentAssessment | null> {
-    const assessmentRepo =
-      options?.entityManager?.getRepository(StudentAssessment) ?? this.repo;
-    return assessmentRepo.findOne({
+    return entityManager.getRepository(StudentAssessment).findOne({
       select: {
         id: true,
         application: {
@@ -359,6 +362,7 @@ export class StudentAssessmentService extends RecordDataModelService<StudentAsse
         application: { student: { user: true } },
       },
       where: { id: assessmentId },
+      lock: { mode: "pessimistic_write", tables: ["StudentAssessment"] },
     });
   }
 

--- a/sources/packages/backend/apps/workers/src/services/student-assessment/student-assessment.service.ts
+++ b/sources/packages/backend/apps/workers/src/services/student-assessment/student-assessment.service.ts
@@ -17,7 +17,6 @@ import {
   INVALID_OPERATION_IN_THE_CURRENT_STATUS,
 } from "@sims/services/constants";
 import { NotificationActionsService, SystemUsersService } from "@sims/services";
-import { WorkflowEmailNotificationStudent } from "@sims/services/notifications";
 
 /**
  * Manages the student assessment related operations.
@@ -323,53 +322,44 @@ export class StudentAssessmentService extends RecordDataModelService<StudentAsse
   }
 
   /**
-   * Loads the student personal information required to send an email
-   * notification to the student from a given assessment. This information is
-   * loaded on the API side because it is not available in the workflow due to
-   * personal information constraints.
+   * Loads the assessment along with the student details required to build the
+   * data used to personalise and address a workflow-triggered email
+   * notification. This information is loaded on the API side because it is not
+   * available in the workflow due to personal information constraints.
    * @param assessmentId assessment id used to reach the associated student.
-   * @param entityManager entity manager to execute in transaction.
-   * @returns student notification details or null when the assessment or the
-   * associated student is not found.
+   * @param options options.
+   * - `entityManager` optional entity manager to execute in transaction.
+   * @returns assessment with the associated student details, or null when the
+   * assessment is not found.
    */
-  async getStudentDetailsForNotificationByAssessmentId(
+  async getAssessmentNotificationDetails(
     assessmentId: number,
-    entityManager: EntityManager,
-  ): Promise<WorkflowEmailNotificationStudent | null> {
-    const studentAssessment = await entityManager
-      .getRepository(StudentAssessment)
-      .findOne({
-        select: {
+    options?: { entityManager?: EntityManager },
+  ): Promise<StudentAssessment | null> {
+    const assessmentRepo =
+      options?.entityManager?.getRepository(StudentAssessment) ?? this.repo;
+    return assessmentRepo.findOne({
+      select: {
+        id: true,
+        application: {
           id: true,
-          application: {
+          applicationNumber: true,
+          student: {
             id: true,
-            student: {
+            user: {
               id: true,
-              user: {
-                id: true,
-                firstName: true,
-                lastName: true,
-                email: true,
-              },
+              firstName: true,
+              lastName: true,
+              email: true,
             },
           },
         },
-        relations: {
-          application: { student: { user: true } },
-        },
-        where: { id: assessmentId },
-      });
-    if (!studentAssessment) {
-      return null;
-    }
-    const student = studentAssessment.application.student;
-    return {
-      userId: student.user.id,
-      studentId: student.id,
-      givenNames: student.user.firstName,
-      lastName: student.user.lastName,
-      email: student.user.email,
-    };
+      },
+      relations: {
+        application: { student: { user: true } },
+      },
+      where: { id: assessmentId },
+    });
   }
 
   /**

--- a/sources/packages/backend/apps/workers/src/workers.module.ts
+++ b/sources/packages/backend/apps/workers/src/workers.module.ts
@@ -11,6 +11,7 @@ import {
   DisbursementController,
   HealthController,
   MetricsController,
+  NotificationController,
 } from "./controllers";
 import {
   StudentAssessmentService,
@@ -67,6 +68,7 @@ import { TerminusModule } from "@nestjs/terminus";
     DisbursementController,
     HealthController,
     MetricsController,
+    NotificationController,
   ],
   providers: [
     ZeebeTransportStrategy,

--- a/sources/packages/backend/apps/workers/test/utils/worker-job-mock.ts
+++ b/sources/packages/backend/apps/workers/test/utils/worker-job-mock.ts
@@ -66,7 +66,7 @@ export function createFakeWorkerJob<
       ({
         resultType: MockedZeebeJobResult.Complete,
         outputVariables: updatedVariables,
-      } as FakeWorkerJobResult),
+      }) as FakeWorkerJobResult,
   );
   job.fail = jest.fn().mockImplementation(
     (errorMessage: string, retries?: number) =>
@@ -74,7 +74,7 @@ export function createFakeWorkerJob<
         resultType: MockedZeebeJobResult.Fail,
         errorMessage,
         retries,
-      } as FakeWorkerJobResult),
+      }) as FakeWorkerJobResult,
   );
   job.error = jest.fn().mockImplementation(
     (errorCode: string, errorMessage?: string) =>
@@ -82,7 +82,7 @@ export function createFakeWorkerJob<
         resultType: MockedZeebeJobResult.Error,
         errorCode,
         errorMessage,
-      } as FakeWorkerJobResult),
+      }) as FakeWorkerJobResult,
   );
   return job;
 }

--- a/sources/packages/backend/libs/services/src/constants/error-code.constants.ts
+++ b/sources/packages/backend/libs/services/src/constants/error-code.constants.ts
@@ -84,3 +84,9 @@ export const FILE_HASH_DUPLICATION_ERROR = "FILE_HASH_DUPLICATION_ERROR";
  */
 export const NOTIFICATION_MISSING_EMAIL_CONTACTS =
   "NOTIFICATION_MISSING_EMAIL_CONTACTS";
+/**
+ * The recipient type provided for a workflow email notification is not
+ * supported, indicating a misconfiguration of the workflow.
+ */
+export const UNSUPPORTED_NOTIFICATION_RECIPIENT_TYPE =
+  "UNSUPPORTED_NOTIFICATION_RECIPIENT_TYPE";

--- a/sources/packages/backend/libs/services/src/constants/error-code.constants.ts
+++ b/sources/packages/backend/libs/services/src/constants/error-code.constants.ts
@@ -85,6 +85,12 @@ export const FILE_HASH_DUPLICATION_ERROR = "FILE_HASH_DUPLICATION_ERROR";
 export const NOTIFICATION_MISSING_EMAIL_CONTACTS =
   "NOTIFICATION_MISSING_EMAIL_CONTACTS";
 /**
+ * Notification message not found for the provided template id, 
+ * which indicates a misconfiguration of the workflow.
+ */
+export const NOTIFICATION_MESSAGE_NOT_FOUND =
+  "NOTIFICATION_MESSAGE_NOT_FOUND";
+/**
  * The recipient type provided for a workflow email notification is not
  * supported, indicating a misconfiguration of the workflow.
  */

--- a/sources/packages/backend/libs/services/src/constants/worker-constants.ts
+++ b/sources/packages/backend/libs/services/src/constants/worker-constants.ts
@@ -17,4 +17,5 @@ export enum Workers {
   CreateIdentifiableSupportingUsers = "create-identifiable-supporting-users",
   WorkflowWrapUp = "workflow-wrap-up",
   VerifyAssessmentCalculationOrder = "verify-assessment-calculation-order",
+  SendEmailNotification = "send-email-notification",
 }

--- a/sources/packages/backend/libs/services/src/notifications/notification-message/notification-message.service.ts
+++ b/sources/packages/backend/libs/services/src/notifications/notification-message/notification-message.service.ts
@@ -4,7 +4,16 @@ import {
   NotificationMessage,
   NotificationMessageType,
 } from "@sims/sims-db";
-import { DataSource, EntityManager } from "typeorm";
+import { DataSource, EntityManager, Repository } from "typeorm";
+
+/**
+ * Base id used to generate the primary key of notification messages that are
+ * automatically created at runtime (e.g. templates triggered by a workflow that
+ * were not previously seeded through a database migration). The high value keeps
+ * these ids in a reserved range, avoiding collisions with the ids manually
+ * assigned to the well-known notification messages defined in migrations.
+ */
+const AUTO_GENERATED_NOTIFICATION_MESSAGE_ID_BASE = 1000000;
 
 @Injectable()
 export class NotificationMessageService extends RecordDataModelService<NotificationMessage> {
@@ -34,5 +43,93 @@ export class NotificationMessageService extends RecordDataModelService<Notificat
         id: notificationMessageTypeId,
       },
     });
+  }
+
+  /**
+   * Retrieves the notification message associated with the provided GC Notify
+   * template id, creating a new notification message record when none exists.
+   * This allows workflows to trigger emails for templates that were not
+   * previously seeded through a database migration, requiring no code or
+   * migration changes to start sending a new notification.
+   * @param templateId GC Notify template id.
+   * @param options options.
+   * - `entityManager` external entity manager to run in a transaction.
+   * @returns notification message details for the provided template id.
+   */
+  async getOrCreateNotificationMessageByTemplateId(
+    templateId: string,
+    options?: { entityManager?: EntityManager },
+  ): Promise<NotificationMessage> {
+    const notificationMessageRepo =
+      options?.entityManager?.getRepository(NotificationMessage) ?? this.repo;
+
+    const existingMessage = await this.getNotificationMessageByTemplateId(
+      templateId,
+      notificationMessageRepo,
+    );
+    if (existingMessage) {
+      return existingMessage;
+    }
+    // Create a new notification message when none exists for the provided template id.
+    return this.createNotificationMessage(templateId, notificationMessageRepo);
+  }
+
+  /**
+   * Retrieves the notification message associated with the provided GC Notify template id.
+   * @param templateId GC Notify template id.
+   * @param notificationMessageRepo notification message repository.
+   * @returns notification message details for the provided template id.
+   */
+  private async getNotificationMessageByTemplateId(
+    templateId: string,
+    notificationMessageRepo: Repository<NotificationMessage>,
+  ): Promise<NotificationMessage> {
+    const existingMessage = await notificationMessageRepo.findOne({
+      select: {
+        id: true,
+        templateId: true,
+        emailContacts: true,
+      },
+      where: {
+        templateId,
+      },
+      order: {
+        id: "ASC",
+      },
+    });
+    return existingMessage;
+  }
+
+  /**
+   * Creates a new notification message for the provided GC Notify template id.
+   * @param templateId GC Notify template id.
+   * @param notificationMessageRepo notification message repository.
+   * @returns notification message details for the newly created template id.
+   */
+  private async createNotificationMessage(
+    templateId: string,
+    notificationMessageRepo: Repository<NotificationMessage>,
+  ): Promise<NotificationMessage> {
+    // Reserve a high id range for the auto-generated notification messages to
+    // avoid collisions with the ids manually assigned through migrations.
+    const maxIdResult = await notificationMessageRepo
+      .createQueryBuilder("notificationMessage")
+      .select("MAX(notificationMessage.id)", "maxId")
+      .where("notificationMessage.id >= :base", {
+        base: AUTO_GENERATED_NOTIFICATION_MESSAGE_ID_BASE,
+      })
+      .getRawOne<{ maxId: number }>();
+    const nextId =
+      (maxIdResult?.maxId ?? AUTO_GENERATED_NOTIFICATION_MESSAGE_ID_BASE - 1) +
+      1;
+    await notificationMessageRepo.insert({
+      id: nextId,
+      templateId,
+      description: `Auto-generated notification message for the template ${templateId}.`,
+    });
+    return this.getNotificationMessageByTemplateId(
+      templateId,
+      notificationMessageRepo,
+    );
   }
 }

--- a/sources/packages/backend/libs/services/src/notifications/notification-message/notification-message.service.ts
+++ b/sources/packages/backend/libs/services/src/notifications/notification-message/notification-message.service.ts
@@ -4,16 +4,7 @@ import {
   NotificationMessage,
   NotificationMessageType,
 } from "@sims/sims-db";
-import { DataSource, EntityManager, Repository } from "typeorm";
-
-/**
- * Base id used to generate the primary key of notification messages that are
- * automatically created at runtime (e.g. templates triggered by a workflow that
- * were not previously seeded through a database migration). The high value keeps
- * these ids in a reserved range, avoiding collisions with the ids manually
- * assigned to the well-known notification messages defined in migrations.
- */
-const AUTO_GENERATED_NOTIFICATION_MESSAGE_ID_BASE = 1000000;
+import { DataSource, EntityManager } from "typeorm";
 
 @Injectable()
 export class NotificationMessageService extends RecordDataModelService<NotificationMessage> {
@@ -47,44 +38,22 @@ export class NotificationMessageService extends RecordDataModelService<Notificat
 
   /**
    * Retrieves the notification message associated with the provided GC Notify
-   * template id, creating a new notification message record when none exists.
-   * This allows workflows to trigger emails for templates that were not
-   * previously seeded through a database migration, requiring no code or
-   * migration changes to start sending a new notification.
+   * template id. The notification messages are expected to be previously seeded
+   * through a database migration, hence an error is raised when none is found
+   * for the provided template id, allowing the caller (e.g. a workflow job) to
+   * fail and raise an incident to be investigated.
    * @param templateId GC Notify template id.
    * @param options options.
    * - `entityManager` external entity manager to run in a transaction.
    * @returns notification message details for the provided template id.
    */
-  async getOrCreateNotificationMessageByTemplateId(
+  async getNotificationMessageByTemplateId(
     templateId: string,
     options?: { entityManager?: EntityManager },
   ): Promise<NotificationMessage> {
     const notificationMessageRepo =
       options?.entityManager?.getRepository(NotificationMessage) ?? this.repo;
-
-    const existingMessage = await this.getNotificationMessageByTemplateId(
-      templateId,
-      notificationMessageRepo,
-    );
-    if (existingMessage) {
-      return existingMessage;
-    }
-    // Create a new notification message when none exists for the provided template id.
-    return this.createNotificationMessage(templateId, notificationMessageRepo);
-  }
-
-  /**
-   * Retrieves the notification message associated with the provided GC Notify template id.
-   * @param templateId GC Notify template id.
-   * @param notificationMessageRepo notification message repository.
-   * @returns notification message details for the provided template id.
-   */
-  private async getNotificationMessageByTemplateId(
-    templateId: string,
-    notificationMessageRepo: Repository<NotificationMessage>,
-  ): Promise<NotificationMessage | null> {
-    const existingMessage = await notificationMessageRepo.findOne({
+    return notificationMessageRepo.findOneOrFail({
       select: {
         id: true,
         templateId: true,
@@ -97,39 +66,5 @@ export class NotificationMessageService extends RecordDataModelService<Notificat
         id: "ASC",
       },
     });
-    return existingMessage;
-  }
-
-  /**
-   * Creates a new notification message for the provided GC Notify template id.
-   * @param templateId GC Notify template id.
-   * @param notificationMessageRepo notification message repository.
-   * @returns notification message details for the newly created template id.
-   */
-  private async createNotificationMessage(
-    templateId: string,
-    notificationMessageRepo: Repository<NotificationMessage>,
-  ): Promise<NotificationMessage> {
-    // Reserve a high id range for the auto-generated notification messages to
-    // avoid collisions with the ids manually assigned through migrations.
-    const maxIdResult = await notificationMessageRepo
-      .createQueryBuilder("notificationMessage")
-      .select("MAX(notificationMessage.id)", "maxId")
-      .where("notificationMessage.id >= :base", {
-        base: AUTO_GENERATED_NOTIFICATION_MESSAGE_ID_BASE,
-      })
-      .getRawOne<{ maxId: number }>();
-    const nextId =
-      (maxIdResult?.maxId ?? AUTO_GENERATED_NOTIFICATION_MESSAGE_ID_BASE - 1) +
-      1;
-    await notificationMessageRepo.insert({
-      id: nextId,
-      templateId,
-      description: `Auto-generated notification message for the template ${templateId}.`,
-    });
-    return this.getNotificationMessageByTemplateId(
-      templateId,
-      notificationMessageRepo,
-    );
   }
 }

--- a/sources/packages/backend/libs/services/src/notifications/notification-message/notification-message.service.ts
+++ b/sources/packages/backend/libs/services/src/notifications/notification-message/notification-message.service.ts
@@ -83,7 +83,7 @@ export class NotificationMessageService extends RecordDataModelService<Notificat
   private async getNotificationMessageByTemplateId(
     templateId: string,
     notificationMessageRepo: Repository<NotificationMessage>,
-  ): Promise<NotificationMessage> {
+  ): Promise<NotificationMessage | null> {
     const existingMessage = await notificationMessageRepo.findOne({
       select: {
         id: true,

--- a/sources/packages/backend/libs/services/src/notifications/notification-message/notification-message.service.ts
+++ b/sources/packages/backend/libs/services/src/notifications/notification-message/notification-message.service.ts
@@ -63,11 +63,6 @@ export class NotificationMessageService extends RecordDataModelService<Notificat
         templateId,
       },
     });
-    if (!notificationMessage) {
-      throw new Error(
-        `Notification message not found for template id ${templateId}`,
-      );
-    }
     return notificationMessage;
   }
 }

--- a/sources/packages/backend/libs/services/src/notifications/notification-message/notification-message.service.ts
+++ b/sources/packages/backend/libs/services/src/notifications/notification-message/notification-message.service.ts
@@ -62,9 +62,6 @@ export class NotificationMessageService extends RecordDataModelService<Notificat
       where: {
         templateId,
       },
-      order: {
-        id: "ASC",
-      },
     });
   }
 }

--- a/sources/packages/backend/libs/services/src/notifications/notification-message/notification-message.service.ts
+++ b/sources/packages/backend/libs/services/src/notifications/notification-message/notification-message.service.ts
@@ -53,7 +53,7 @@ export class NotificationMessageService extends RecordDataModelService<Notificat
   ): Promise<NotificationMessage> {
     const notificationMessageRepo =
       options?.entityManager?.getRepository(NotificationMessage) ?? this.repo;
-    return notificationMessageRepo.findOneOrFail({
+    const notificationMessage = await notificationMessageRepo.findOne({
       select: {
         id: true,
         templateId: true,
@@ -63,5 +63,11 @@ export class NotificationMessageService extends RecordDataModelService<Notificat
         templateId,
       },
     });
+    if (!notificationMessage) {
+      throw new Error(
+        `Notification message not found for template id ${templateId}`,
+      );
+    }
+    return notificationMessage;
   }
 }

--- a/sources/packages/backend/libs/services/src/notifications/notification/notification-actions.service.ts
+++ b/sources/packages/backend/libs/services/src/notifications/notification/notification-actions.service.ts
@@ -44,6 +44,8 @@ import {
   SaveNotificationModel,
   StudentAcceptAssessmentReminderNotification,
   ProgramSuspensionBlockingApplicationNotification,
+  WorkflowStudentEmailNotification,
+  WorkflowEmailNotification,
 } from "..";
 import { NotificationService } from "./notification.service";
 import { LoggerService } from "@sims/utilities/logger";
@@ -423,6 +425,116 @@ export class NotificationActionsService {
     await this.notificationService.saveNotifications(
       [exceptionCompleteNotification],
       auditUserId,
+      { entityManager },
+    );
+  }
+
+  /**
+   * Sends a workflow-triggered email notification to the student. The GC Notify
+   * template is resolved (or created) from the provided template id, so new
+   * notifications can be sent without code or migration changes. The personal
+   * information (email, given names and last name) is loaded on the API side and
+   * merged with the personalisation provided by the workflow, with the API
+   * loaded values taking precedence.
+   * @param notification notification details.
+   * @param entityManager entity manager to execute in transaction.
+   * @param options notification options.
+   * - `checkMetadata` when provided with at least one criteria, skips creation
+   * if a notification for the same message already exists matching all the
+   * provided criteria, preventing duplicate emails. It allows the uniqueness of
+   * the notification to be defined dynamically by the workflow (e.g.
+   * `applicationId` results in once per application). When empty or not
+   * provided, the email is always sent, allowing a student to receive multiple
+   * emails.
+   */
+  async saveWorkflowStudentEmailNotification(
+    notification: WorkflowStudentEmailNotification,
+    entityManager: EntityManager,
+    options?: {
+      checkMetadata?: NotificationMetadata;
+    },
+  ): Promise<void> {
+    const notificationMessage =
+      await this.notificationMessageService.getOrCreateNotificationMessageByTemplateId(
+        notification.templateId,
+        { entityManager },
+      );
+    const messageType = notificationMessage.id;
+    const { student } = notification;
+    // The check metadata is provided by the workflow and defines the uniqueness
+    // scope used to prevent duplicate emails (e.g. `applicationId` sends the
+    // notification once per application).
+    const checkMetadata = options?.checkMetadata;
+    if (checkMetadata && Object.keys(checkMetadata).length) {
+      const notificationExists =
+        await this.notificationService.checkNotificationExists(
+          messageType,
+          checkMetadata,
+          entityManager,
+        );
+      if (notificationExists) {
+        return;
+      }
+    }
+    const studentEmailNotification = {
+      userId: student.userId,
+      messageType,
+      messagePayload: {
+        email_address: student.email,
+        template_id: notificationMessage.templateId,
+        personalisation: {
+          ...notification.personalisation,
+          givenNames: student.givenNames ?? "",
+          lastName: student.lastName,
+        },
+      },
+      metadata: checkMetadata,
+    };
+    await this.notificationService.saveNotifications(
+      [studentEmailNotification],
+      this.systemUsersService.systemUser.id,
+      { entityManager },
+    );
+  }
+
+  /**
+   * Sends a workflow-triggered email notification to the Ministry. The GC Notify
+   * template is resolved (or created) from the provided template id, so new
+   * notifications can be sent without code or migration changes. The
+   * notification is sent to the email contacts configured for the notification
+   * message.
+   * @param notification notification details.
+   * @param auditUserId user that should be considered the one that is causing the changes.
+   * @param entityManager entity manager to execute in transaction.
+   */
+  async saveWorkflowMinistryEmailNotification(
+    notification: WorkflowEmailNotification,
+    entityManager: EntityManager,
+  ): Promise<void> {
+    const notificationMessage =
+      await this.notificationMessageService.getOrCreateNotificationMessageByTemplateId(
+        notification.templateId,
+        { entityManager },
+      );
+    if (!notificationMessage.emailContacts?.length) {
+      this.logger.error(
+        `${NOTIFICATION_MISSING_EMAIL_CONTACTS} No email contacts are configured for the Ministry notification with template ${notification.templateId}.`,
+      );
+      return;
+    }
+    const notificationsToSend = notificationMessage.emailContacts.map(
+      (emailContact) => ({
+        messageType: notificationMessage.id,
+        messagePayload: {
+          email_address: emailContact,
+          template_id: notificationMessage.templateId,
+          personalisation: notification.personalisation ?? {},
+        },
+      }),
+    );
+    await this.notificationService.saveNotifications(
+      notificationsToSend,
+      this.systemUsersService.systemUser.id,
       { entityManager },
     );
   }

--- a/sources/packages/backend/libs/services/src/notifications/notification/notification-actions.service.ts
+++ b/sources/packages/backend/libs/services/src/notifications/notification/notification-actions.service.ts
@@ -504,7 +504,6 @@ export class NotificationActionsService {
    * notification is sent to the email contacts configured for the notification
    * message.
    * @param notification notification details.
-   * @param auditUserId user that should be considered the one that is causing the changes.
    * @param entityManager entity manager to execute in transaction.
    */
   async saveWorkflowMinistryEmailNotification(

--- a/sources/packages/backend/libs/services/src/notifications/notification/notification-actions.service.ts
+++ b/sources/packages/backend/libs/services/src/notifications/notification/notification-actions.service.ts
@@ -447,16 +447,12 @@ export class NotificationActionsService {
    */
   async saveWorkflowStudentEmailNotification(
     notification: WorkflowStudentEmailNotification,
+    notificationMessage: NotificationMessage,
     entityManager: EntityManager,
     options?: {
       metadata?: NotificationMetadata;
     },
   ): Promise<void> {
-    const notificationMessage =
-      await this.notificationMessageService.getNotificationMessageByTemplateId(
-        notification.templateId,
-        { entityManager },
-      );
     const messageType = notificationMessage.id;
     const { student } = notification;
     // The metadata is provided by the workflow and defines the uniqueness
@@ -502,19 +498,9 @@ export class NotificationActionsService {
    */
   async saveWorkflowMinistryEmailNotification(
     notification: WorkflowEmailNotification,
+    notificationMessage: NotificationMessage,
     entityManager: EntityManager,
   ): Promise<void> {
-    const notificationMessage =
-      await this.notificationMessageService.getNotificationMessageByTemplateId(
-        notification.templateId,
-        { entityManager },
-      );
-    if (!notificationMessage.emailContacts?.length) {
-      this.logger.error(
-        `${NOTIFICATION_MISSING_EMAIL_CONTACTS} No email contacts are configured for the Ministry notification with template ${notification.templateId}.`,
-      );
-      return;
-    }
     const notificationsToSend = notificationMessage.emailContacts.map(
       (emailContact) => ({
         messageType: notificationMessage.id,

--- a/sources/packages/backend/libs/services/src/notifications/notification/notification-actions.service.ts
+++ b/sources/packages/backend/libs/services/src/notifications/notification/notification-actions.service.ts
@@ -432,18 +432,16 @@ export class NotificationActionsService {
   /**
    * Sends a workflow-triggered email notification to the student. The GC Notify
    * template is resolved from the provided template id, which is expected to be
-   * previously seeded, otherwise an error is raised. The personal
-   * information (email, given names and last name) is loaded on the API side and
-   * merged with the personalisation provided by the workflow, with the API
-   * loaded values taking precedence.
+   * previously seeded, otherwise an error is raised. The personalisation is
+   * provided already resolved by the caller and sent as is.
    * @param notification notification details.
    * @param entityManager entity manager to execute in transaction.
    * @param options notification options.
-   * - `checkMetadata` when provided with at least one criteria, skips creation
+   * - `metadata` when provided with at least one criteria, skips creation
    * if a notification for the same message already exists matching all the
    * provided criteria, preventing duplicate emails. It allows the uniqueness of
    * the notification to be defined dynamically by the workflow (e.g.
-   * `applicationId` results in once per application). When empty or not
+   * `parentApplicationId` results in once per application). When empty or not
    * provided, the email is always sent, allowing a student to receive multiple
    * emails.
    */
@@ -451,7 +449,7 @@ export class NotificationActionsService {
     notification: WorkflowStudentEmailNotification,
     entityManager: EntityManager,
     options?: {
-      checkMetadata?: NotificationMetadata;
+      metadata?: NotificationMetadata;
     },
   ): Promise<void> {
     const notificationMessage =
@@ -461,15 +459,15 @@ export class NotificationActionsService {
       );
     const messageType = notificationMessage.id;
     const { student } = notification;
-    // The check metadata is provided by the workflow and defines the uniqueness
-    // scope used to prevent duplicate emails (e.g. `applicationId` sends the
-    // notification once per application).
-    const checkMetadata = options?.checkMetadata;
-    if (checkMetadata && Object.keys(checkMetadata).length) {
+    // The metadata is provided by the workflow and defines the uniqueness
+    // scope used to prevent duplicate emails (e.g. `parentApplicationId` sends
+    // the notification once per application).
+    const metadata = options?.metadata;
+    if (metadata && Object.keys(metadata).length) {
       const notificationExists =
         await this.notificationService.checkNotificationExists(
           messageType,
-          checkMetadata,
+          metadata,
           entityManager,
         );
       if (notificationExists) {
@@ -482,13 +480,9 @@ export class NotificationActionsService {
       messagePayload: {
         email_address: student.email,
         template_id: notificationMessage.templateId,
-        personalisation: {
-          ...notification.personalisation,
-          givenNames: student.givenNames ?? "",
-          lastName: student.lastName,
-        },
+        personalisation: notification.personalisation ?? {},
       },
-      metadata: checkMetadata,
+      metadata,
     };
     await this.notificationService.saveNotifications(
       [studentEmailNotification],

--- a/sources/packages/backend/libs/services/src/notifications/notification/notification-actions.service.ts
+++ b/sources/packages/backend/libs/services/src/notifications/notification/notification-actions.service.ts
@@ -440,12 +440,12 @@ export class NotificationActionsService {
    * @param notificationMessage notification message that provides the template.
    * @param entityManager entity manager to execute in transaction.
    * @param options notification options.
-   * - `metadata` when provided with at least one criteria, skips creation
-   * if a notification for the same message already exists matching all the
-   * provided criteria, preventing duplicate emails. It allows the uniqueness of
-   * the notification to be defined dynamically by the workflow (e.g.
-   * `parentApplicationId` results in once per application). When empty or not
-   * provided, the email is always sent, allowing multiple emails to be received.
+   * - `metadata` skips creation if a notification for the same message already
+   * exists matching the provided criteria, preventing duplicate emails. It
+   * allows the uniqueness of the notification to be defined dynamically by the
+   * workflow (e.g. `parentApplicationId` results in once per application). When
+   * not provided, a single notification is allowed for the message type combined
+   * with no metadata, still preventing duplicate emails.
    */
   async saveEmailNotification(
     notification: EmailNotification,
@@ -460,16 +460,14 @@ export class NotificationActionsService {
     // scope used to prevent duplicate emails (e.g. `parentApplicationId` sends
     // the notification once per application).
     const metadata = options?.metadata;
-    if (metadata && Object.keys(metadata).length) {
-      const notificationExists =
-        await this.notificationService.checkNotificationExists(
-          messageType,
-          metadata,
-          entityManager,
-        );
-      if (notificationExists) {
-        return;
-      }
+    const notificationExists =
+      await this.notificationService.checkNotificationExists(
+        messageType,
+        metadata,
+        entityManager,
+      );
+    if (notificationExists) {
+      return;
     }
     const notificationsToSend = notification.emailRecipients.map(
       (emailRecipient) => ({

--- a/sources/packages/backend/libs/services/src/notifications/notification/notification-actions.service.ts
+++ b/sources/packages/backend/libs/services/src/notifications/notification/notification-actions.service.ts
@@ -431,8 +431,8 @@ export class NotificationActionsService {
 
   /**
    * Sends a workflow-triggered email notification to the student. The GC Notify
-   * template is resolved (or created) from the provided template id, so new
-   * notifications can be sent without code or migration changes. The personal
+   * template is resolved from the provided template id, which is expected to be
+   * previously seeded, otherwise an error is raised. The personal
    * information (email, given names and last name) is loaded on the API side and
    * merged with the personalisation provided by the workflow, with the API
    * loaded values taking precedence.
@@ -455,7 +455,7 @@ export class NotificationActionsService {
     },
   ): Promise<void> {
     const notificationMessage =
-      await this.notificationMessageService.getOrCreateNotificationMessageByTemplateId(
+      await this.notificationMessageService.getNotificationMessageByTemplateId(
         notification.templateId,
         { entityManager },
       );
@@ -499,8 +499,8 @@ export class NotificationActionsService {
 
   /**
    * Sends a workflow-triggered email notification to the Ministry. The GC Notify
-   * template is resolved (or created) from the provided template id, so new
-   * notifications can be sent without code or migration changes. The
+   * template is resolved from the provided template id, which is expected to be
+   * previously seeded, otherwise an error is raised. The
    * notification is sent to the email contacts configured for the notification
    * message.
    * @param notification notification details.
@@ -511,7 +511,7 @@ export class NotificationActionsService {
     entityManager: EntityManager,
   ): Promise<void> {
     const notificationMessage =
-      await this.notificationMessageService.getOrCreateNotificationMessageByTemplateId(
+      await this.notificationMessageService.getNotificationMessageByTemplateId(
         notification.templateId,
         { entityManager },
       );

--- a/sources/packages/backend/libs/services/src/notifications/notification/notification-actions.service.ts
+++ b/sources/packages/backend/libs/services/src/notifications/notification/notification-actions.service.ts
@@ -44,8 +44,7 @@ import {
   SaveNotificationModel,
   StudentAcceptAssessmentReminderNotification,
   ProgramSuspensionBlockingApplicationNotification,
-  WorkflowStudentEmailNotification,
-  WorkflowEmailNotification,
+  EmailNotification,
 } from "..";
 import { NotificationService } from "./notification.service";
 import { LoggerService } from "@sims/utilities/logger";
@@ -430,11 +429,15 @@ export class NotificationActionsService {
   }
 
   /**
-   * Sends a workflow-triggered email notification to the student. The GC Notify
-   * template is resolved from the provided template id, which is expected to be
-   * previously seeded, otherwise an error is raised. The personalisation is
-   * provided already resolved by the caller and sent as is.
+   * Sends a workflow-triggered email notification to the provided recipients.
+   * The GC Notify template is resolved from the notification message, which is
+   * expected to be previously seeded, otherwise an error is raised. The
+   * personalisation is provided already resolved by the caller and sent as is.
+   * The same method addresses both student and Ministry notifications, the
+   * difference being the recipients and whether the notification is associated
+   * with a specific user.
    * @param notification notification details.
+   * @param notificationMessage notification message that provides the template.
    * @param entityManager entity manager to execute in transaction.
    * @param options notification options.
    * - `metadata` when provided with at least one criteria, skips creation
@@ -442,11 +445,10 @@ export class NotificationActionsService {
    * provided criteria, preventing duplicate emails. It allows the uniqueness of
    * the notification to be defined dynamically by the workflow (e.g.
    * `parentApplicationId` results in once per application). When empty or not
-   * provided, the email is always sent, allowing a student to receive multiple
-   * emails.
+   * provided, the email is always sent, allowing multiple emails to be received.
    */
-  async saveWorkflowStudentEmailNotification(
-    notification: WorkflowStudentEmailNotification,
+  async saveEmailNotification(
+    notification: EmailNotification,
     notificationMessage: NotificationMessage,
     entityManager: EntityManager,
     options?: {
@@ -454,7 +456,6 @@ export class NotificationActionsService {
     },
   ): Promise<void> {
     const messageType = notificationMessage.id;
-    const { student } = notification;
     // The metadata is provided by the workflow and defines the uniqueness
     // scope used to prevent duplicate emails (e.g. `parentApplicationId` sends
     // the notification once per application).
@@ -470,45 +471,16 @@ export class NotificationActionsService {
         return;
       }
     }
-    const studentEmailNotification = {
-      userId: student.userId,
-      messageType,
-      messagePayload: {
-        email_address: student.email,
-        template_id: notificationMessage.templateId,
-        personalisation: notification.personalisation ?? {},
-      },
-      metadata,
-    };
-    await this.notificationService.saveNotifications(
-      [studentEmailNotification],
-      this.systemUsersService.systemUser.id,
-      { entityManager },
-    );
-  }
-
-  /**
-   * Sends a workflow-triggered email notification to the Ministry. The GC Notify
-   * template is resolved from the provided template id, which is expected to be
-   * previously seeded, otherwise an error is raised. The
-   * notification is sent to the email contacts configured for the notification
-   * message.
-   * @param notification notification details.
-   * @param entityManager entity manager to execute in transaction.
-   */
-  async saveWorkflowMinistryEmailNotification(
-    notification: WorkflowEmailNotification,
-    notificationMessage: NotificationMessage,
-    entityManager: EntityManager,
-  ): Promise<void> {
-    const notificationsToSend = notificationMessage.emailContacts.map(
-      (emailContact) => ({
-        messageType: notificationMessage.id,
+    const notificationsToSend = notification.emailRecipients.map(
+      (emailRecipient) => ({
+        userId: notification.userId,
+        messageType,
         messagePayload: {
-          email_address: emailContact,
+          email_address: emailRecipient,
           template_id: notificationMessage.templateId,
           personalisation: notification.personalisation ?? {},
         },
+        metadata,
       }),
     );
     await this.notificationService.saveNotifications(

--- a/sources/packages/backend/libs/services/src/notifications/notification/notification.model.ts
+++ b/sources/packages/backend/libs/services/src/notifications/notification/notification.model.ts
@@ -80,6 +80,54 @@ export interface StudentNotification {
   applicationNumber?: string;
 }
 
+/**
+ * Recipient of a workflow-triggered email notification.
+ */
+export enum WorkflowEmailNotificationRecipient {
+  /**
+   * The notification is sent to the student.
+   */
+  Student = "student",
+  /**
+   * The notification is sent to the Ministry.
+   */
+  Ministry = "ministry",
+}
+
+/**
+ * Student personal information required to send a workflow-triggered email
+ * notification to the student. Loaded on the API side because it is not
+ * available in the workflow due to personal information constraints.
+ */
+export interface WorkflowEmailNotificationStudent {
+  userId: number;
+  studentId: number;
+  givenNames?: string;
+  lastName: string;
+  email: string;
+}
+
+/**
+ * Details required to send a generic workflow-triggered email notification to
+ * the student. The GC Notify template is resolved (or created) from the provided
+ * template id, allowing new notifications to be sent without code or migration
+ * changes.
+ */
+export interface WorkflowStudentEmailNotification extends WorkflowEmailNotification {
+  student: WorkflowEmailNotificationStudent;
+}
+
+/**
+ * Details required to send a generic workflow-triggered email notification to
+ * the email contacts configured for the notification message (e.g. Ministry).
+ * The GC Notify template is resolved (or created) from the provided template id,
+ * allowing new notifications to be sent without code or migration changes.
+ */
+export interface WorkflowEmailNotification {
+  templateId: string;
+  personalisation?: Record<string, string | number | string[]>;
+}
+
 export interface DisbursementBlockedNotification {
   givenNames: string;
   lastName: string;

--- a/sources/packages/backend/libs/services/src/notifications/notification/notification.model.ts
+++ b/sources/packages/backend/libs/services/src/notifications/notification/notification.model.ts
@@ -87,39 +87,32 @@ export enum EmailNotificationRecipient {
   /**
    * The notification is sent to the student.
    */
-  Student = "student",
+  Student = "Student",
   /**
    * The notification is sent to the Ministry.
    */
-  Ministry = "ministry",
+  Ministry = "Ministry",
 }
 
 /**
- * Student addressing information required to send a workflow-triggered email
- * notification to the student.
+ * Details required to send a generic workflow-triggered email notification. The
+ * GC Notify template is resolved from the notification message, which is
+ * expected to be previously seeded, otherwise an error is raised. The
+ * personalisation is provided already resolved by the caller and sent as is.
  */
-export interface WorkflowEmailNotificationStudent {
-  userId: number;
-  email: string;
-}
-
-/**
- * Details required to send a generic workflow-triggered email notification to
- * the student. The GC Notify template is resolved from the provided template id,
- * which is expected to be previously seeded, otherwise an error is raised.
- */
-export interface WorkflowStudentEmailNotification extends WorkflowEmailNotification {
-  student: WorkflowEmailNotificationStudent;
-}
-
-/**
- * Details required to send a generic workflow-triggered email notification to
- * the email contacts configured for the notification message (e.g. Ministry).
- * The GC Notify template is resolved from the provided template id, which is
- * expected to be previously seeded, otherwise an error is raised.
- */
-export interface WorkflowEmailNotification {
-  templateId: string;
+export interface EmailNotification {
+  /**
+   * User the notification is addressed to. Not provided for notifications that
+   * are not associated with a specific user (e.g. Ministry notifications).
+   */
+  userId?: number;
+  /**
+   * Email recipients the notification is sent to.
+   */
+  emailRecipients: string[];
+  /**
+   * Personalisation values sent to GC Notify, already resolved by the caller.
+   */
   personalisation?: Record<string, string | number | string[]>;
 }
 

--- a/sources/packages/backend/libs/services/src/notifications/notification/notification.model.ts
+++ b/sources/packages/backend/libs/services/src/notifications/notification/notification.model.ts
@@ -109,9 +109,8 @@ export interface WorkflowEmailNotificationStudent {
 
 /**
  * Details required to send a generic workflow-triggered email notification to
- * the student. The GC Notify template is resolved (or created) from the provided
- * template id, allowing new notifications to be sent without code or migration
- * changes.
+ * the student. The GC Notify template is resolved from the provided template id,
+ * which is expected to be previously seeded, otherwise an error is raised.
  */
 export interface WorkflowStudentEmailNotification extends WorkflowEmailNotification {
   student: WorkflowEmailNotificationStudent;
@@ -120,8 +119,8 @@ export interface WorkflowStudentEmailNotification extends WorkflowEmailNotificat
 /**
  * Details required to send a generic workflow-triggered email notification to
  * the email contacts configured for the notification message (e.g. Ministry).
- * The GC Notify template is resolved (or created) from the provided template id,
- * allowing new notifications to be sent without code or migration changes.
+ * The GC Notify template is resolved from the provided template id, which is
+ * expected to be previously seeded, otherwise an error is raised.
  */
 export interface WorkflowEmailNotification {
   templateId: string;

--- a/sources/packages/backend/libs/services/src/notifications/notification/notification.model.ts
+++ b/sources/packages/backend/libs/services/src/notifications/notification/notification.model.ts
@@ -83,7 +83,7 @@ export interface StudentNotification {
 /**
  * Recipient of a workflow-triggered email notification.
  */
-export enum WorkflowEmailNotificationRecipient {
+export enum EmailNotificationRecipient {
   /**
    * The notification is sent to the student.
    */
@@ -95,15 +95,11 @@ export enum WorkflowEmailNotificationRecipient {
 }
 
 /**
- * Student personal information required to send a workflow-triggered email
- * notification to the student. Loaded on the API side because it is not
- * available in the workflow due to personal information constraints.
+ * Student addressing information required to send a workflow-triggered email
+ * notification to the student.
  */
 export interface WorkflowEmailNotificationStudent {
   userId: number;
-  studentId: number;
-  givenNames?: string;
-  lastName: string;
   email: string;
 }
 

--- a/sources/packages/backend/libs/services/src/notifications/notification/notification.service.ts
+++ b/sources/packages/backend/libs/services/src/notifications/notification/notification.service.ts
@@ -7,6 +7,7 @@ import {
   PermanentFailureError,
   NotificationMessageType,
 } from "@sims/sims-db";
+import { NotificationMetadata } from "@sims/sims-db/entities/notification-metadata.type";
 import {
   DataSource,
   EntityManager,
@@ -123,30 +124,40 @@ export class NotificationService extends RecordDataModelService<Notification> {
   }
 
   /**
-   * Checks if a notification exists for the provided application number.
-   * @param transactionalEntityManager entity manager to be part of the transaction.
-   * @param applicationNumber related application number.
-   * @returns boolean true if the notification exists, else false.
+   * Checks if a notification of the provided type already exists matching all
+   * the provided metadata criteria. Used to prevent sending duplicate emails
+   * while allowing the uniqueness scope to be defined dynamically.
+   * - Pass `{ studentId }` to enforce a single notification per student.
+   * - Pass `{ applicationNumber }` to enforce a single notification per application.
+   * - Multiple criteria can be combined and all must match an existing notification.
+   * @param notificationMessageType notification message type to be verified.
+   * @param metadata metadata criteria that must all match an existing notification.
+   * @param entityManager entity manager to be part of the transaction.
+   * @returns true if a matching notification already exists, otherwise false.
    */
-  async checkApplicationEditedTooManyTimesNotificationExists(
-    transactionalEntityManager: EntityManager,
-    applicationNumber: string,
+  async checkNotificationExists(
+    notificationMessageType: NotificationMessageType,
+    metadata: NotificationMetadata,
+    entityManager: EntityManager,
   ): Promise<boolean> {
-    return transactionalEntityManager
+    const query = entityManager
       .getRepository(Notification)
       .createQueryBuilder("notification")
       .innerJoin("notification.notificationMessage", "notificationMessage")
       .where("notificationMessage.id = :notificationMessageId", {
-        notificationMessageId:
-          NotificationMessageType.ApplicationEditedTooManyTimesNotification,
-      })
-      .andWhere(
-        "notification.metadata->>'applicationNumber' = :applicationNumber",
-        {
-          applicationNumber,
-        },
-      )
-      .getExists();
+        notificationMessageId: notificationMessageType,
+      });
+    for (const [key, value] of Object.entries(metadata)) {
+      // Guard the metadata key against injection since it is interpolated into
+      // the JSON path, which cannot be provided as a bound parameter.
+      if (!/^\w+$/.test(key)) {
+        throw new Error(`Invalid notification metadata key: ${key}.`);
+      }
+      query.andWhere(`notification.metadata->>'${key}' = :${key}`, {
+        [key]: value,
+      });
+    }
+    return query.getExists();
   }
 
   /**

--- a/sources/packages/backend/libs/services/src/notifications/notification/notification.service.ts
+++ b/sources/packages/backend/libs/services/src/notifications/notification/notification.service.ts
@@ -142,7 +142,7 @@ export class NotificationService extends RecordDataModelService<Notification> {
     return entityManager.getRepository(Notification).exists({
       where: {
         notificationMessage: { id: notificationMessageType },
-        metadata,
+        metadata: metadata ?? null,
       },
     });
   }

--- a/sources/packages/backend/libs/services/src/notifications/notification/notification.service.ts
+++ b/sources/packages/backend/libs/services/src/notifications/notification/notification.service.ts
@@ -148,13 +148,16 @@ export class NotificationService extends RecordDataModelService<Notification> {
         notificationMessageId: notificationMessageType,
       });
     for (const [key, value] of Object.entries(metadata)) {
+      if (value === undefined || value === null) {
+        continue;
+      }
       // Guard the metadata key against injection since it is interpolated into
       // the JSON path, which cannot be provided as a bound parameter.
       if (!/^\w+$/.test(key)) {
         throw new Error(`Invalid notification metadata key: ${key}.`);
       }
       query.andWhere(`notification.metadata->>'${key}' = :${key}`, {
-        [key]: value,
+        [key]: String(value),
       });
     }
     return query.getExists();

--- a/sources/packages/backend/libs/services/src/notifications/notification/notification.service.ts
+++ b/sources/packages/backend/libs/services/src/notifications/notification/notification.service.ts
@@ -127,7 +127,6 @@ export class NotificationService extends RecordDataModelService<Notification> {
    * Checks if a notification of the provided type already exists matching all
    * the provided metadata criteria. Used to prevent sending duplicate emails
    * while allowing the uniqueness scope to be defined dynamically.
-   * - Pass `{ studentId }` to enforce a single notification per student.
    * - Pass `{ applicationNumber }` to enforce a single notification per application.
    * - Multiple criteria can be combined and all must match an existing notification.
    * @param notificationMessageType notification message type to be verified.

--- a/sources/packages/backend/libs/services/src/notifications/notification/notification.service.ts
+++ b/sources/packages/backend/libs/services/src/notifications/notification/notification.service.ts
@@ -124,14 +124,13 @@ export class NotificationService extends RecordDataModelService<Notification> {
   }
 
   /**
-   * Checks if a notification of the provided type already exists matching all
-   * the provided metadata criteria. Used to prevent sending duplicate emails
-   * while allowing the uniqueness scope to be defined dynamically.
+   * Checks if a notification of the provided type already exists matching the
+   * provided metadata. Used to prevent sending duplicate emails while allowing
+   * the uniqueness scope to be defined dynamically.
    * - Pass `{ parentApplicationId }` to enforce a single notification per
    * application, remaining stable across application edits.
-   * - Multiple criteria can be combined and all must match an existing notification.
    * @param notificationMessageType notification message type to be verified.
-   * @param metadata metadata criteria that must all match an existing notification.
+   * @param metadata metadata that must match an existing notification.
    * @param entityManager entity manager to be part of the transaction.
    * @returns true if a matching notification already exists, otherwise false.
    */
@@ -140,27 +139,12 @@ export class NotificationService extends RecordDataModelService<Notification> {
     metadata: NotificationMetadata,
     entityManager: EntityManager,
   ): Promise<boolean> {
-    const query = entityManager
-      .getRepository(Notification)
-      .createQueryBuilder("notification")
-      .innerJoin("notification.notificationMessage", "notificationMessage")
-      .where("notificationMessage.id = :notificationMessageId", {
-        notificationMessageId: notificationMessageType,
-      });
-    for (const [key, value] of Object.entries(metadata)) {
-      if (value === undefined || value === null) {
-        continue;
-      }
-      // Guard the metadata key against injection since it is interpolated into
-      // the JSON path, which cannot be provided as a bound parameter.
-      if (!/^\w+$/.test(key)) {
-        throw new Error(`Invalid notification metadata key: ${key}.`);
-      }
-      query.andWhere(`notification.metadata->>'${key}' = :${key}`, {
-        [key]: String(value),
-      });
-    }
-    return query.getExists();
+    return entityManager.getRepository(Notification).exists({
+      where: {
+        notificationMessage: { id: notificationMessageType },
+        metadata,
+      },
+    });
   }
 
   /**

--- a/sources/packages/backend/libs/services/src/notifications/notification/notification.service.ts
+++ b/sources/packages/backend/libs/services/src/notifications/notification/notification.service.ts
@@ -127,7 +127,8 @@ export class NotificationService extends RecordDataModelService<Notification> {
    * Checks if a notification of the provided type already exists matching all
    * the provided metadata criteria. Used to prevent sending duplicate emails
    * while allowing the uniqueness scope to be defined dynamically.
-   * - Pass `{ applicationNumber }` to enforce a single notification per application.
+   * - Pass `{ parentApplicationId }` to enforce a single notification per
+   * application, remaining stable across application edits.
    * - Multiple criteria can be combined and all must match an existing notification.
    * @param notificationMessageType notification message type to be verified.
    * @param metadata metadata criteria that must all match an existing notification.

--- a/sources/packages/backend/libs/services/src/notifications/notifications.module.ts
+++ b/sources/packages/backend/libs/services/src/notifications/notifications.module.ts
@@ -12,6 +12,10 @@ import { NotificationService } from "./notification/notification.service";
     NotificationService,
     NotificationMessageService,
   ],
-  exports: [NotificationActionsService, NotificationService],
+  exports: [
+    NotificationActionsService,
+    NotificationService,
+    NotificationMessageService,
+  ],
 })
 export class NotificationsModule {}

--- a/sources/packages/backend/libs/services/src/workflow/variables/assessment-gateway.ts
+++ b/sources/packages/backend/libs/services/src/workflow/variables/assessment-gateway.ts
@@ -12,6 +12,11 @@ export const ASSESSMENT_DATA = "assessmentData";
  */
 export const APPLICATION_ID = "applicationId";
 /**
+ * Human-readable application number that remains stable across application edits.
+ * Created while loading the assessment data.
+ */
+export const APPLICATION_NUMBER = "applicationNumber";
+/**
  * Institution offering program id if selected by the student.
  * If not selected a PIR will be needed.
  */

--- a/sources/packages/backend/libs/services/src/workflow/variables/assessment-gateway.ts
+++ b/sources/packages/backend/libs/services/src/workflow/variables/assessment-gateway.ts
@@ -12,11 +12,6 @@ export const ASSESSMENT_DATA = "assessmentData";
  */
 export const APPLICATION_ID = "applicationId";
 /**
- * Human-readable application number that remains stable across application edits.
- * Created while loading the assessment data.
- */
-export const APPLICATION_NUMBER = "applicationNumber";
-/**
  * Institution offering program id if selected by the student.
  * If not selected a PIR will be needed.
  */

--- a/sources/packages/backend/libs/services/src/workflow/variables/send-email-notification.ts
+++ b/sources/packages/backend/libs/services/src/workflow/variables/send-email-notification.ts
@@ -1,0 +1,14 @@
+/**
+ * Free-form personalisation values provided by the workflow to be merged with
+ * the personal information loaded on the API side (e.g. student given names and
+ * last name) before the email is sent.
+ */
+export const EMAIL_NOTIFICATION_PERSONALISATION = "emailNotificationPersonalisation";
+/**
+ * Free-form metadata provided by the workflow used to check whether the same
+ * notification was already sent, preventing duplicate emails. It defines the
+ * uniqueness scope of the notification dynamically (e.g. `applicationId` results
+ * in once per application). When empty or not provided, the existence check is
+ * skipped and the email is always sent.
+ */
+export const EMAIL_NOTIFICATION_CHECK_METADATA = "emailNotificationCheckMetadata";

--- a/sources/packages/backend/libs/services/src/workflow/variables/send-email-notification.ts
+++ b/sources/packages/backend/libs/services/src/workflow/variables/send-email-notification.ts
@@ -7,8 +7,9 @@ export const EMAIL_NOTIFICATION_PERSONALISATION = "emailNotificationPersonalisat
 /**
  * Free-form metadata provided by the workflow used to check whether the same
  * notification was already sent, preventing duplicate emails. It defines the
- * uniqueness scope of the notification dynamically (e.g. `applicationId` results
- * in once per application). When empty or not provided, the existence check is
- * skipped and the email is always sent.
+ * uniqueness scope of the notification dynamically (e.g. `applicationNumber`
+ * results in once per application, remaining stable across application edits).
+ * When empty or not provided, the existence check is skipped and the email is
+ * always sent.
  */
 export const EMAIL_NOTIFICATION_CHECK_METADATA = "emailNotificationCheckMetadata";

--- a/sources/packages/backend/libs/services/src/workflow/variables/send-email-notification.ts
+++ b/sources/packages/backend/libs/services/src/workflow/variables/send-email-notification.ts
@@ -7,7 +7,7 @@ export const EMAIL_NOTIFICATION_PERSONALISATION = "emailNotificationPersonalisat
 /**
  * Free-form metadata provided by the workflow used to check whether the same
  * notification was already sent, preventing duplicate emails. It defines the
- * uniqueness scope of the notification dynamically (e.g. `applicationNumber`
+ * uniqueness scope of the notification dynamically (e.g. `parentApplicationId`
  * results in once per application, remaining stable across application edits).
  * When empty or not provided, the existence check is skipped and the email is
  * always sent.

--- a/sources/packages/backend/libs/services/src/workflow/variables/send-email-notification.ts
+++ b/sources/packages/backend/libs/services/src/workflow/variables/send-email-notification.ts
@@ -1,9 +1,9 @@
 /**
- * Free-form personalisation values provided by the workflow to be merged with
- * the personal information loaded on the API side (e.g. student given names and
- * last name) before the email is sent.
+ * Personalisation context provided by the workflow, mapping each GC Notify
+ * personalisation variable name to the path of the value to be resolved from
+ * the notification data loaded on the API side (e.g. `studentGivenNames`).
  */
-export const EMAIL_NOTIFICATION_PERSONALISATION = "emailNotificationPersonalisation";
+export const PERSONALISATION = "personalisation";
 /**
  * Free-form metadata provided by the workflow used to check whether the same
  * notification was already sent, preventing duplicate emails. It defines the
@@ -12,4 +12,4 @@ export const EMAIL_NOTIFICATION_PERSONALISATION = "emailNotificationPersonalisat
  * When empty or not provided, the existence check is skipped and the email is
  * always sent.
  */
-export const EMAIL_NOTIFICATION_CHECK_METADATA = "emailNotificationCheckMetadata";
+export const METADATA = "metadata";

--- a/sources/packages/backend/libs/sims-db/src/entities/notification-metadata.type.ts
+++ b/sources/packages/backend/libs/sims-db/src/entities/notification-metadata.type.ts
@@ -4,5 +4,6 @@
 export interface NotificationMetadata {
   disbursementId?: number;
   applicationNumber?: string;
+  parentApplicationId?: number;
   assessmentId?: number;
 }

--- a/sources/packages/backend/libs/sims-db/src/entities/notification.model.ts
+++ b/sources/packages/backend/libs/sims-db/src/entities/notification.model.ts
@@ -266,4 +266,9 @@ export enum NotificationMessageType {
    * is blocking an application at accept assessment or at e-Cert.
    */
   ProgramSuspensionBlockingApplication = 42,
+  /**
+   * Student notification sent when the former youth in care question is
+   * answered with anything other than "no" (e.g. "yes" or "prefer not to answer").
+   */
+  FormerYouthInCareNotification = 43,
 }

--- a/sources/packages/backend/libs/sims-db/src/entities/notification.model.ts
+++ b/sources/packages/backend/libs/sims-db/src/entities/notification.model.ts
@@ -268,7 +268,7 @@ export enum NotificationMessageType {
   ProgramSuspensionBlockingApplication = 42,
   /**
    * Student notification sent when the former youth in care question is
-   * answered with anything other than "no" (e.g. "yes" or "prefer not to answer").
+   * answered with anything other than "no" (i.e. "yes" or "prefer not to answer").
    */
   FormerYouthInCareNotification = 43,
 }

--- a/sources/packages/backend/libs/test-utils/src/constants/notification.constants.ts
+++ b/sources/packages/backend/libs/test-utils/src/constants/notification.constants.ts
@@ -16,4 +16,5 @@ export const GC_NOTIFY_TEMPLATE_IDS = {
     "999e31e1-ea2d-4583-a17c-106906340266",
   InstitutionAddsPendingOfferingNotification:
     "9f0a0f79-05a6-4b81-9e71-6a85906601ef",
+  FormerYouthInCareNotification: "636dd0c7-fe23-4a25-826b-03202326b580",
 } as const;

--- a/sources/packages/backend/libs/test-utils/src/factories/notification.ts
+++ b/sources/packages/backend/libs/test-utils/src/factories/notification.ts
@@ -6,6 +6,7 @@ import {
   User,
 } from "@sims/sims-db";
 import { faker } from "@faker-js/faker";
+import { DataSource } from "typeorm";
 
 /**
  * Creates a fake message payload.
@@ -56,4 +57,54 @@ export function createFakeNotification(
   notification.createdAt = options?.initialValue?.createdAt;
   notification.dateSent = options?.initialValue?.dateSent;
   return notification;
+}
+
+/**
+ * Creates a fake notification message (the template that defines a notification,
+ * seeded in the database during migrations) without persisting it.
+ * @param options notification message options.
+ * - `initialValue` notification message initial values.
+ * @returns created notification message.
+ */
+export function createFakeNotificationMessage(options?: {
+  initialValue?: Partial<NotificationMessage>;
+}): NotificationMessage {
+  const notificationMessage = new NotificationMessage();
+  notificationMessage.id = options?.initialValue?.id;
+  notificationMessage.description =
+    options?.initialValue?.description ??
+    `Fake notification message ${faker.string.alpha({ length: 10 })}`;
+  notificationMessage.templateId =
+    options?.initialValue?.templateId ?? faker.string.uuid();
+  notificationMessage.emailContacts = options?.initialValue?.emailContacts;
+  return notificationMessage;
+}
+
+/**
+ * Persists a fake notification message to be used in isolation by a test. When
+ * no id is provided, a negative id is assigned so the created message does not
+ * collide with the notification messages seeded by the database seeder, keeping
+ * the test isolated from the seeded data.
+ * @param dataSource data source to persist the notification message.
+ * @param options notification message options.
+ * - `initialValue` notification message initial values.
+ * @returns persisted notification message.
+ */
+export async function saveFakeNotificationMessage(
+  dataSource: DataSource,
+  options?: {
+    initialValue?: Partial<NotificationMessage>;
+  },
+): Promise<NotificationMessage> {
+  const notificationMessageRepo = dataSource.getRepository(NotificationMessage);
+  const notificationMessage = createFakeNotificationMessage(options);
+  if (notificationMessage.id == null) {
+    // Use negative ids to avoid colliding with the seeded notification messages.
+    const currentMinId = await notificationMessageRepo
+      .createQueryBuilder("notificationMessage")
+      .select("MIN(notificationMessage.id)", "min")
+      .getRawOne<{ min: number | null }>();
+    notificationMessage.id = Math.min(currentMinId?.min ?? 0, 0) - 1;
+  }
+  return notificationMessageRepo.save(notificationMessage);
 }

--- a/sources/packages/backend/libs/test-utils/src/factories/notification.ts
+++ b/sources/packages/backend/libs/test-utils/src/factories/notification.ts
@@ -81,10 +81,10 @@ export function createFakeNotificationMessage(options?: {
 }
 
 /**
- * Persists a fake notification message to be used in isolation by a test. When
- * no id is provided, a negative id is assigned so the created message does not
- * collide with the notification messages seeded by the database seeder, keeping
- * the test isolated from the seeded data.
+ * Persists a fake notification message to be used in isolation by a test. A
+ * negative id is assigned so the created message does not collide with the
+ * notification messages seeded by the database seeder, keeping the test isolated
+ * from the seeded data.
  * @param dataSource data source to persist the notification message.
  * @param options notification message options.
  * - `initialValue` notification message initial values.
@@ -98,13 +98,13 @@ export async function saveFakeNotificationMessage(
 ): Promise<NotificationMessage> {
   const notificationMessageRepo = dataSource.getRepository(NotificationMessage);
   const notificationMessage = createFakeNotificationMessage(options);
-  if (notificationMessage.id == null) {
-    // Use negative ids to avoid colliding with the seeded notification messages.
-    const currentMinId = await notificationMessageRepo
-      .createQueryBuilder("notificationMessage")
-      .select("MIN(notificationMessage.id)", "min")
-      .getRawOne<{ min: number | null }>();
-    notificationMessage.id = Math.min(currentMinId?.min ?? 0, 0) - 1;
-  }
+  // Assign a negative id, decreasing from the current minimum id, so the created
+  // message never collides with the notification messages seeded by the database
+  // seeder, keeping the test isolated from the seeded data.
+  const currentMinId = await notificationMessageRepo
+    .createQueryBuilder("notificationMessage")
+    .select("MIN(notificationMessage.id)", "min")
+    .getRawOne<{ min: number }>();
+  notificationMessage.id = Math.min(currentMinId.min, 0) - 1;
   return notificationMessageRepo.save(notificationMessage);
 }

--- a/sources/packages/backend/package-lock.json
+++ b/sources/packages/backend/package-lock.json
@@ -620,7 +620,6 @@
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -1121,7 +1120,6 @@
       "resolved": "https://registry.npmjs.org/@bull-board/api/-/api-8.1.2.tgz",
       "integrity": "sha512-6NGYCIRhHJmmoCwAFA1z4lPpR/D/BdOjyERd2MMeG4Samu05FSjzKKdN55S3ga30EcXeENfYzmNn6IDmVz5OTg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "redis-info": "^3.1.0"
       },
@@ -1160,7 +1158,6 @@
       "resolved": "https://registry.npmjs.org/@bull-board/ui/-/ui-8.1.2.tgz",
       "integrity": "sha512-gC5u9XUSiRile4/VC+WHXtaPvfZV4Mrrz8MSvPe32Hjl2MXStfSuEOb+9Tw/WMpNSZ442tGpFZLz0RDh1Yo3jg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@bull-board/api": "8.1.2"
       }
@@ -3215,7 +3212,6 @@
       "resolved": "https://registry.npmjs.org/@nestjs/axios/-/axios-4.0.1.tgz",
       "integrity": "sha512-68pFJgu+/AZbWkGu65Z3r55bTsCPlgyKaV4BSG8yUAD72q1PPuyVRgUwFv6BxdnibTUHlyxm06FmYWNC+bjN7A==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@nestjs/common": "^10.0.0 || ^11.0.0",
         "axios": "^1.3.1",
@@ -3242,7 +3238,6 @@
       "resolved": "https://registry.npmjs.org/@nestjs/bull-shared/-/bull-shared-11.0.4.tgz",
       "integrity": "sha512-VBJcDHSAzxQnpcDfA0kt9MTGUD1XZzfByV70su0W0eDCQ9aqIEBlzWRW21tv9FG9dIut22ysgDidshdjlnczLw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "2.8.1"
       },
@@ -3504,7 +3499,6 @@
       "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-11.1.28.tgz",
       "integrity": "sha512-bRImsxibie+AM7xjdwcrm/gr5YeacI65kSBNzTufa1Ib5iwziaY/lqMtRh9THq6pbV4e1HP9aI2ZxGUumnmaoQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "file-type": "21.3.4",
         "iterare": "1.2.1",
@@ -3536,7 +3530,6 @@
       "resolved": "https://registry.npmjs.org/@nestjs/core/-/core-11.1.28.tgz",
       "integrity": "sha512-06m63xIRj8+l8uOeh/8LnYupGubkyu4f+bPKIadaSui6vK9KpXgoz7HveT1yOVLcEt0M0oCOEW5EuEXZkEmBBQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-safe-stringify": "2.1.1",
         "iterare": "1.2.1",
@@ -3609,7 +3602,6 @@
       "resolved": "https://registry.npmjs.org/@nestjs/microservices/-/microservices-11.1.28.tgz",
       "integrity": "sha512-8uRs6/UrhXvd8YCrYKcNUwWA7b8jcbYH03WBKWJ2A3bc6+WcHA6yXq7Px30yemAGBtIIMXkHeL88dO2usVI5zg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "iterare": "1.2.1",
         "tslib": "2.8.1"
@@ -3678,7 +3670,6 @@
       "resolved": "https://registry.npmjs.org/@nestjs/platform-express/-/platform-express-11.1.28.tgz",
       "integrity": "sha512-hU+9Sz4m+onHrR5AmelI59QKmY/Re546bPnygnpqqeQdHDiJpBgjWbL4t6Jr73CBpS60cpyng7WzjgphNB9iwA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cors": "2.8.6",
         "express": "5.2.1",
@@ -3865,7 +3856,6 @@
       "resolved": "https://registry.npmjs.org/@nestjs/typeorm/-/typeorm-11.0.3.tgz",
       "integrity": "sha512-zJ+E5l7auVVA7c0PsvcMdyvRPKTUqU5s2ToYmOA2QEsXQ42qbUGtK4+1HlRfpHqBkCSXP+phiH4luvf9DyJNog==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@nestjs/common": "^10.0.0 || ^11.0.0",
         "@nestjs/core": "^10.0.0 || ^11.0.0",
@@ -4013,7 +4003,6 @@
       "resolved": "https://registry.npmjs.org/@redis/client/-/client-5.12.1.tgz",
       "integrity": "sha512-7aPGWeqA3uFm43o19umzdl16CEjK/JQGtSXVPevplTaOU3VJA/rseBC1QvYUz9lLDIMBimc4SW/zrW4S89BaCA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cluster-key-slot": "1.1.2"
       },
@@ -4546,7 +4535,6 @@
       "integrity": "sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/body-parser": "*",
         "@types/express-serve-static-core": "^5.0.0",
@@ -4694,7 +4682,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.1.tgz",
       "integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~8.3.0"
       }
@@ -4952,7 +4939,6 @@
       "integrity": "sha512-gwh4gvvlaVDKKxyfxMG+Gnu1u9X0OQBwyGLkbwB65dIzBKnxeRiJlNFqlI3zwVhNXJIs6qV7mlFCn/BIajlVig==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.63.0",
         "@typescript-eslint/types": "8.63.0",
@@ -5665,7 +5651,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5727,7 +5712,6 @@
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -5957,7 +5941,6 @@
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.1.tgz",
       "integrity": "sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
@@ -6392,7 +6375,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -6481,7 +6463,6 @@
       "resolved": "https://registry.npmjs.org/bull/-/bull-4.16.5.tgz",
       "integrity": "sha512-lDsx2BzkKe7gkCYiT5Acj02DpTwDznl/VNN7Psn7M3USPG7Vs/BaClZJJTAG+ufAR9++N1/NiUTdaFBWDIl5TQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cron-parser": "^4.9.0",
         "get-port": "^5.1.1",
@@ -6699,7 +6680,6 @@
       "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "readdirp": "^4.0.1"
       },
@@ -6756,15 +6736,13 @@
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/class-transformer/-/class-transformer-0.5.1.tgz",
       "integrity": "sha512-SQa1Ws6hUbfC98vKGxZH3KFY0Y1lm5Zm0SY8XX9zbK7FJCyVEac3ATW0RIpwzW+oOfmHE5PMPufDG9hCfoEOMw==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/class-validator": {
       "version": "0.15.1",
       "resolved": "https://registry.npmjs.org/class-validator/-/class-validator-0.15.1.tgz",
       "integrity": "sha512-LqoS80HBBSCVhz/3KloUly0ovokxpdOLR++Al3J3+dHXWt9sTKlKd4eYtoxhxyUjoe5+UcIM+5k9MIxyBWnRTw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/validator": "^13.15.3",
         "libphonenumber-js": "^1.11.1",
@@ -7775,7 +7753,6 @@
       "integrity": "sha512-6lVbcqSodALYo+4ELD0heG6lFiFxnLMuLkiMi2qV8LMp54N8tE8FT1GMH+ev4Ti00nFjNze2+Su6DsV5OQW3Dg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "workspaces": [
         "packages/*"
       ],
@@ -7835,7 +7812,6 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -8203,7 +8179,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -8572,7 +8547,6 @@
       "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -9630,7 +9604,6 @@
       "integrity": "sha512-Yi1jqNC/Oq0N4hBgNH/YvBpP1P57QqundgytzYqy3yqAa7NZPNjSoi4SGbRAXDMdBzNE6xBCi5U7RgfrvMEUVQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "30.4.2",
         "@jest/types": "30.4.1",
@@ -11272,7 +11245,6 @@
       "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
@@ -12771,14 +12743,14 @@
     "node_modules/pause": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/pause/-/pause-0.0.1.tgz",
-      "integrity": "sha512-KG8UEiEVkR3wGEb4m5yZkVCzigAD+cVEJck2CzYZO37ZGJfctvVptVO192MwrtPhzONn6go8ylnOdMhKqi4nfg=="
+      "integrity": "sha512-KG8UEiEVkR3wGEb4m5yZkVCzigAD+cVEJck2CzYZO37ZGJfctvVptVO192MwrtPhzONn6go8ylnOdMhKqi4nfg==",
+      "peer": true
     },
     "node_modules/pg": {
       "version": "8.22.0",
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.22.0.tgz",
       "integrity": "sha512-8wih1vVIBMxoUM2oB4soJsD9tDnDpLv4OXBJ+EJzFsvycD+lfyIreC2gGHq78f8jbLLt+bvlPTFdFZfJkOuzAA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.14.0",
         "pg-pool": "^3.14.0",
@@ -13046,7 +13018,6 @@
       "integrity": "sha512-/FVl766LpUfB5vXgCYOYa0MeV/441Ia99AeICQIQFTY/Nw0roZwULcXpku5i1/m5kt/baz+s4Zogspd839HSMg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -13320,7 +13291,6 @@
       "resolved": "https://registry.npmjs.org/redis/-/redis-5.12.1.tgz",
       "integrity": "sha512-LDsoVvb/CpoV9EN3FXvgvSHNJWuCIzl9MiO3ppOevuGLpSGJhwfQjpEwfFJcQvNSddHADDdZaWx0HnmMxRXG7g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@redis/bloom": "5.12.1",
         "@redis/client": "5.12.1",
@@ -13366,8 +13336,7 @@
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
       "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
-      "license": "Apache-2.0",
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
@@ -13490,7 +13459,6 @@
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
       "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -14717,7 +14685,6 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -14983,7 +14950,6 @@
       "resolved": "https://registry.npmjs.org/typeorm/-/typeorm-0.3.30.tgz",
       "integrity": "sha512-8T35PzjefOdqc2ZR9mwLQj0pUGp6lQhMbK2EvVMwJVJWlaoHm0v/Q6dThNOZkFchD+0yMg8gwjKM28ePiLSXSQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@sqltools/formatter": "^1.2.5",
         "ansis": "^4.2.0",
@@ -15136,7 +15102,6 @@
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -15358,6 +15323,7 @@
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
       "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.4.0"
       }
@@ -15454,7 +15420,6 @@
       "integrity": "sha512-yur8LyJoeiWh47dErD+Ok7vlbmDsJ3UbbRPAoxbGJ54WpE2y5yVo5G/inUzujnYgw3tPmBRdn+G7PoxXaYC33w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "^1.0.8",
         "@types/json-schema": "^7.0.15",

--- a/sources/packages/backend/package-lock.json
+++ b/sources/packages/backend/package-lock.json
@@ -620,6 +620,7 @@
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -1120,6 +1121,7 @@
       "resolved": "https://registry.npmjs.org/@bull-board/api/-/api-8.1.2.tgz",
       "integrity": "sha512-6NGYCIRhHJmmoCwAFA1z4lPpR/D/BdOjyERd2MMeG4Samu05FSjzKKdN55S3ga30EcXeENfYzmNn6IDmVz5OTg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "redis-info": "^3.1.0"
       },
@@ -1158,6 +1160,7 @@
       "resolved": "https://registry.npmjs.org/@bull-board/ui/-/ui-8.1.2.tgz",
       "integrity": "sha512-gC5u9XUSiRile4/VC+WHXtaPvfZV4Mrrz8MSvPe32Hjl2MXStfSuEOb+9Tw/WMpNSZ442tGpFZLz0RDh1Yo3jg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@bull-board/api": "8.1.2"
       }
@@ -3212,6 +3215,7 @@
       "resolved": "https://registry.npmjs.org/@nestjs/axios/-/axios-4.0.1.tgz",
       "integrity": "sha512-68pFJgu+/AZbWkGu65Z3r55bTsCPlgyKaV4BSG8yUAD72q1PPuyVRgUwFv6BxdnibTUHlyxm06FmYWNC+bjN7A==",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@nestjs/common": "^10.0.0 || ^11.0.0",
         "axios": "^1.3.1",
@@ -3238,6 +3242,7 @@
       "resolved": "https://registry.npmjs.org/@nestjs/bull-shared/-/bull-shared-11.0.4.tgz",
       "integrity": "sha512-VBJcDHSAzxQnpcDfA0kt9MTGUD1XZzfByV70su0W0eDCQ9aqIEBlzWRW21tv9FG9dIut22ysgDidshdjlnczLw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "2.8.1"
       },
@@ -3499,6 +3504,7 @@
       "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-11.1.28.tgz",
       "integrity": "sha512-bRImsxibie+AM7xjdwcrm/gr5YeacI65kSBNzTufa1Ib5iwziaY/lqMtRh9THq6pbV4e1HP9aI2ZxGUumnmaoQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "file-type": "21.3.4",
         "iterare": "1.2.1",
@@ -3530,6 +3536,7 @@
       "resolved": "https://registry.npmjs.org/@nestjs/core/-/core-11.1.28.tgz",
       "integrity": "sha512-06m63xIRj8+l8uOeh/8LnYupGubkyu4f+bPKIadaSui6vK9KpXgoz7HveT1yOVLcEt0M0oCOEW5EuEXZkEmBBQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-safe-stringify": "2.1.1",
         "iterare": "1.2.1",
@@ -3602,6 +3609,7 @@
       "resolved": "https://registry.npmjs.org/@nestjs/microservices/-/microservices-11.1.28.tgz",
       "integrity": "sha512-8uRs6/UrhXvd8YCrYKcNUwWA7b8jcbYH03WBKWJ2A3bc6+WcHA6yXq7Px30yemAGBtIIMXkHeL88dO2usVI5zg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "iterare": "1.2.1",
         "tslib": "2.8.1"
@@ -3670,6 +3678,7 @@
       "resolved": "https://registry.npmjs.org/@nestjs/platform-express/-/platform-express-11.1.28.tgz",
       "integrity": "sha512-hU+9Sz4m+onHrR5AmelI59QKmY/Re546bPnygnpqqeQdHDiJpBgjWbL4t6Jr73CBpS60cpyng7WzjgphNB9iwA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cors": "2.8.6",
         "express": "5.2.1",
@@ -3856,6 +3865,7 @@
       "resolved": "https://registry.npmjs.org/@nestjs/typeorm/-/typeorm-11.0.3.tgz",
       "integrity": "sha512-zJ+E5l7auVVA7c0PsvcMdyvRPKTUqU5s2ToYmOA2QEsXQ42qbUGtK4+1HlRfpHqBkCSXP+phiH4luvf9DyJNog==",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@nestjs/common": "^10.0.0 || ^11.0.0",
         "@nestjs/core": "^10.0.0 || ^11.0.0",
@@ -4003,6 +4013,7 @@
       "resolved": "https://registry.npmjs.org/@redis/client/-/client-5.12.1.tgz",
       "integrity": "sha512-7aPGWeqA3uFm43o19umzdl16CEjK/JQGtSXVPevplTaOU3VJA/rseBC1QvYUz9lLDIMBimc4SW/zrW4S89BaCA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cluster-key-slot": "1.1.2"
       },
@@ -4535,6 +4546,7 @@
       "integrity": "sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/body-parser": "*",
         "@types/express-serve-static-core": "^5.0.0",
@@ -4682,6 +4694,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.1.tgz",
       "integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~8.3.0"
       }
@@ -4939,6 +4952,7 @@
       "integrity": "sha512-gwh4gvvlaVDKKxyfxMG+Gnu1u9X0OQBwyGLkbwB65dIzBKnxeRiJlNFqlI3zwVhNXJIs6qV7mlFCn/BIajlVig==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.63.0",
         "@typescript-eslint/types": "8.63.0",
@@ -5651,6 +5665,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5712,6 +5727,7 @@
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -5941,6 +5957,7 @@
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.1.tgz",
       "integrity": "sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
@@ -6375,6 +6392,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -6463,6 +6481,7 @@
       "resolved": "https://registry.npmjs.org/bull/-/bull-4.16.5.tgz",
       "integrity": "sha512-lDsx2BzkKe7gkCYiT5Acj02DpTwDznl/VNN7Psn7M3USPG7Vs/BaClZJJTAG+ufAR9++N1/NiUTdaFBWDIl5TQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cron-parser": "^4.9.0",
         "get-port": "^5.1.1",
@@ -6680,6 +6699,7 @@
       "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "readdirp": "^4.0.1"
       },
@@ -6736,13 +6756,15 @@
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/class-transformer/-/class-transformer-0.5.1.tgz",
       "integrity": "sha512-SQa1Ws6hUbfC98vKGxZH3KFY0Y1lm5Zm0SY8XX9zbK7FJCyVEac3ATW0RIpwzW+oOfmHE5PMPufDG9hCfoEOMw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/class-validator": {
       "version": "0.15.1",
       "resolved": "https://registry.npmjs.org/class-validator/-/class-validator-0.15.1.tgz",
       "integrity": "sha512-LqoS80HBBSCVhz/3KloUly0ovokxpdOLR++Al3J3+dHXWt9sTKlKd4eYtoxhxyUjoe5+UcIM+5k9MIxyBWnRTw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/validator": "^13.15.3",
         "libphonenumber-js": "^1.11.1",
@@ -7753,6 +7775,7 @@
       "integrity": "sha512-6lVbcqSodALYo+4ELD0heG6lFiFxnLMuLkiMi2qV8LMp54N8tE8FT1GMH+ev4Ti00nFjNze2+Su6DsV5OQW3Dg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "workspaces": [
         "packages/*"
       ],
@@ -7812,6 +7835,7 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -8179,6 +8203,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -8547,6 +8572,7 @@
       "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -9604,6 +9630,7 @@
       "integrity": "sha512-Yi1jqNC/Oq0N4hBgNH/YvBpP1P57QqundgytzYqy3yqAa7NZPNjSoi4SGbRAXDMdBzNE6xBCi5U7RgfrvMEUVQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "30.4.2",
         "@jest/types": "30.4.1",
@@ -11245,6 +11272,7 @@
       "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
@@ -12743,14 +12771,14 @@
     "node_modules/pause": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/pause/-/pause-0.0.1.tgz",
-      "integrity": "sha512-KG8UEiEVkR3wGEb4m5yZkVCzigAD+cVEJck2CzYZO37ZGJfctvVptVO192MwrtPhzONn6go8ylnOdMhKqi4nfg==",
-      "peer": true
+      "integrity": "sha512-KG8UEiEVkR3wGEb4m5yZkVCzigAD+cVEJck2CzYZO37ZGJfctvVptVO192MwrtPhzONn6go8ylnOdMhKqi4nfg=="
     },
     "node_modules/pg": {
       "version": "8.22.0",
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.22.0.tgz",
       "integrity": "sha512-8wih1vVIBMxoUM2oB4soJsD9tDnDpLv4OXBJ+EJzFsvycD+lfyIreC2gGHq78f8jbLLt+bvlPTFdFZfJkOuzAA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.14.0",
         "pg-pool": "^3.14.0",
@@ -13018,6 +13046,7 @@
       "integrity": "sha512-/FVl766LpUfB5vXgCYOYa0MeV/441Ia99AeICQIQFTY/Nw0roZwULcXpku5i1/m5kt/baz+s4Zogspd839HSMg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -13291,6 +13320,7 @@
       "resolved": "https://registry.npmjs.org/redis/-/redis-5.12.1.tgz",
       "integrity": "sha512-LDsoVvb/CpoV9EN3FXvgvSHNJWuCIzl9MiO3ppOevuGLpSGJhwfQjpEwfFJcQvNSddHADDdZaWx0HnmMxRXG7g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@redis/bloom": "5.12.1",
         "@redis/client": "5.12.1",
@@ -13336,7 +13366,8 @@
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
       "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
@@ -13459,6 +13490,7 @@
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
       "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -14685,6 +14717,7 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -14950,6 +14983,7 @@
       "resolved": "https://registry.npmjs.org/typeorm/-/typeorm-0.3.30.tgz",
       "integrity": "sha512-8T35PzjefOdqc2ZR9mwLQj0pUGp6lQhMbK2EvVMwJVJWlaoHm0v/Q6dThNOZkFchD+0yMg8gwjKM28ePiLSXSQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@sqltools/formatter": "^1.2.5",
         "ansis": "^4.2.0",
@@ -15102,6 +15136,7 @@
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -15323,7 +15358,6 @@
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
       "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.4.0"
       }
@@ -15420,6 +15454,7 @@
       "integrity": "sha512-yur8LyJoeiWh47dErD+Ok7vlbmDsJ3UbbRPAoxbGJ54WpE2y5yVo5G/inUzujnYgw3tPmBRdn+G7PoxXaYC33w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "^1.0.8",
         "@types/json-schema": "^7.0.15",

--- a/sources/packages/backend/workflow/src/workflow-definitions/assessment-gateway-v2.bpmn
+++ b/sources/packages/backend/workflow/src/workflow-definitions/assessment-gateway-v2.bpmn
@@ -633,6 +633,7 @@ Note: the workflow process should continue its execution as a regular reassessme
       <bpmn:extensionElements>
         <zeebe:ioMapping>
           <zeebe:output source="=null" target="applicationId" />
+          <zeebe:output source="=null" target="applicationNumber" />
           <zeebe:output source="=assessmentId" target="assessmentId" />
           <zeebe:output source="=null" target="applicationExceptionStatus" />
           <zeebe:output source="=null" target="studentDataSelectedOffering" />
@@ -942,7 +943,7 @@ Note: the workflow process should continue its execution as a regular reassessme
           <zeebe:header key="recipientType" value="student" />
         </zeebe:taskHeaders>
         <zeebe:ioMapping>
-          <zeebe:input source="={applicationId: applicationId}" target="emailNotificationCheckMetadata" />
+          <zeebe:input source="={applicationNumber: applicationNumber}" target="emailNotificationCheckMetadata" />
         </zeebe:ioMapping>
       </bpmn:extensionElements>
       <bpmn:incoming>former-youth-in-care-send-flow</bpmn:incoming>

--- a/sources/packages/backend/workflow/src/workflow-definitions/assessment-gateway-v2.bpmn
+++ b/sources/packages/backend/workflow/src/workflow-definitions/assessment-gateway-v2.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bioc="http://bpmn.io/schema/bpmn/biocolor/1.0" xmlns:color="http://www.omg.org/spec/BPMN/non-normative/color/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.47.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.6.0" camunda:diagramRelationId="f874f098-96b6-491d-81ec-ecf7a0d8c67a">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bioc="http://bpmn.io/schema/bpmn/biocolor/1.0" xmlns:color="http://www.omg.org/spec/BPMN/non-normative/color/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.43.1" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.6.0" camunda:diagramRelationId="f874f098-96b6-491d-81ec-ecf7a0d8c67a">
   <bpmn:collaboration id="Collaboration_0z9wj8q">
     <bpmn:participant id="application-in-progress" name="Assessment" processRef="assessment-gateway-v2" />
     <bpmn:group id="Group_19tqt3y" categoryValueRef="CategoryValue_1l89ztr" />
@@ -78,6 +78,9 @@ Note: the workflow process should continue its execution as a regular reassessme
         <bpmn:flowNodeRef>Gateway_1aawyrx</bpmn:flowNodeRef>
         <bpmn:flowNodeRef>pir-workflow-wrap-up-task</bpmn:flowNodeRef>
         <bpmn:flowNodeRef>Event_1mj2hkh</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>former-youth-in-care-gateway</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>send-former-youth-in-care-email-task</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>former-youth-in-care-join-gateway</bpmn:flowNodeRef>
       </bpmn:lane>
       <bpmn:lane id="Lane_1bfd2e9" name="Assessment/reassessment calculation">
         <bpmn:flowNodeRef>verify-assessment-calculation-timer</bpmn:flowNodeRef>
@@ -599,7 +602,7 @@ Note: the workflow process should continue its execution as a regular reassessme
       <bpmn:outgoing>Flow_0106iy0</bpmn:outgoing>
     </bpmn:serviceTask>
     <bpmn:exclusiveGateway id="Gateway_0wavgao" name="Check edit status" default="Flow_0ljbhnq">
-      <bpmn:incoming>assessment-flow</bpmn:incoming>
+      <bpmn:incoming>Flow_1gjp61i</bpmn:incoming>
       <bpmn:outgoing>Flow_0ljbhnq</bpmn:outgoing>
       <bpmn:outgoing>change-in-progress-flow</bpmn:outgoing>
     </bpmn:exclusiveGateway>
@@ -776,7 +779,7 @@ Note: the workflow process should continue its execution as a regular reassessme
     <bpmn:sequenceFlow id="Flow_0106iy0" sourceRef="update-application-status-to-in-progress-task" targetRef="Activity_069nn9n" />
     <bpmn:sequenceFlow id="Flow_1w081qo" sourceRef="Activity_069nn9n" targetRef="Gateway_1aawyrx" />
     <bpmn:sequenceFlow id="Flow_0ljbhnq" sourceRef="Gateway_0wavgao" targetRef="update-application-status-to-in-progress-task" />
-    <bpmn:sequenceFlow id="assessment-flow" name="Original Assessment" sourceRef="assessment-process-type-gateway" targetRef="Gateway_0wavgao">
+    <bpmn:sequenceFlow id="assessment-flow" name="Original Assessment" sourceRef="assessment-process-type-gateway" targetRef="former-youth-in-care-gateway">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=assessmentTriggerType = "Original assessment"</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
     <bpmn:sequenceFlow id="Flow_0rxxozm" sourceRef="load-assessment-data-submit-or-reassessment-subprocess" targetRef="assessment-process-type-gateway" />
@@ -926,6 +929,36 @@ Note: the workflow process should continue its execution as a regular reassessme
       <bpmn:outgoing>Flow_17bbn8b</bpmn:outgoing>
     </bpmn:scriptTask>
     <bpmn:sequenceFlow id="Flow_17bbn8b" sourceRef="Activity_1vyml74" targetRef="Gateway_1hwknxt" />
+    <bpmn:exclusiveGateway id="former-youth-in-care-gateway" name="Former youth in care?" default="Flow_10xaz6e">
+      <bpmn:incoming>assessment-flow</bpmn:incoming>
+      <bpmn:outgoing>former-youth-in-care-send-flow</bpmn:outgoing>
+      <bpmn:outgoing>Flow_10xaz6e</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:serviceTask id="send-former-youth-in-care-email-task" name="Send former youth in care email">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="send-email-notification" />
+        <zeebe:taskHeaders>
+          <zeebe:header key="templateId" value="636dd0c7-fe23-4a25-826b-03202326b580" />
+          <zeebe:header key="recipientType" value="student" />
+        </zeebe:taskHeaders>
+        <zeebe:ioMapping>
+          <zeebe:input source="={applicationId: applicationId}" target="emailNotificationCheckMetadata" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+      <bpmn:incoming>former-youth-in-care-send-flow</bpmn:incoming>
+      <bpmn:outgoing>former-youth-in-care-email-sent-flow</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="former-youth-in-care-send-flow" sourceRef="former-youth-in-care-gateway" targetRef="send-former-youth-in-care-email-task">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=studentDataYouthInCare != null and studentDataYouthInCare != "no"</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_10xaz6e" sourceRef="former-youth-in-care-gateway" targetRef="former-youth-in-care-join-gateway" />
+    <bpmn:sequenceFlow id="former-youth-in-care-email-sent-flow" sourceRef="send-former-youth-in-care-email-task" targetRef="former-youth-in-care-join-gateway" />
+    <bpmn:exclusiveGateway id="former-youth-in-care-join-gateway" default="Flow_1gjp61i">
+      <bpmn:incoming>Flow_10xaz6e</bpmn:incoming>
+      <bpmn:incoming>former-youth-in-care-email-sent-flow</bpmn:incoming>
+      <bpmn:outgoing>Flow_1gjp61i</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:sequenceFlow id="Flow_1gjp61i" sourceRef="former-youth-in-care-join-gateway" targetRef="Gateway_0wavgao" />
   </bpmn:process>
   <bpmn:message id="Message_1clo0eh" name="program-info-request-completed">
     <bpmn:extensionElements>
@@ -1133,6 +1166,19 @@ Note: the workflow process should continue its execution as a regular reassessme
         <dc:Bounds x="1587" y="440" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="former-youth-in-care-gateway_di" bpmnElement="former-youth-in-care-gateway" isMarkerVisible="true">
+        <dc:Bounds x="745" y="155" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="731" y="118" width="78" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="send-former-youth-in-care-email-task_di" bpmnElement="send-former-youth-in-care-email-task">
+        <dc:Bounds x="830" y="140" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="former-youth-in-care-join-gateway_di" bpmnElement="former-youth-in-care-join-gateway" isMarkerVisible="true">
+        <dc:Bounds x="745" y="235" width="50" height="50" />
+      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_1r28emd_di" bpmnElement="identifiable-parents-creation" isExpanded="true">
         <dc:Bounds x="2060" y="790" width="580" height="200" />
       </bpmndi:BPMNShape>
@@ -1186,7 +1232,7 @@ Note: the workflow process should continue its execution as a regular reassessme
       <bpmndi:BPMNShape id="Gateway_0wavgao_di" bpmnElement="Gateway_0wavgao" isMarkerVisible="true">
         <dc:Bounds x="745" y="317" width="50" height="50" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="727" y="284" width="85" height="14" />
+          <dc:Bounds x="649.5" y="335" width="85" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Gateway_1c05kxg_di" bpmnElement="assessment-process-type-gateway" isMarkerVisible="true">
@@ -1652,10 +1698,11 @@ Note: the workflow process should continue its execution as a regular reassessme
         <di:waypoint x="850" y="342" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_07vurqq_di" bpmnElement="assessment-flow">
-        <di:waypoint x="675" y="342" />
-        <di:waypoint x="745" y="342" />
+        <di:waypoint x="650" y="317" />
+        <di:waypoint x="650" y="180" />
+        <di:waypoint x="745" y="180" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="671" y="307" width="60" height="27" />
+          <dc:Bounds x="655" y="145" width="60" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0rxxozm_di" bpmnElement="Flow_0rxxozm">
@@ -1747,6 +1794,23 @@ Note: the workflow process should continue its execution as a regular reassessme
       <bpmndi:BPMNEdge id="Flow_17bbn8b_di" bpmnElement="Flow_17bbn8b">
         <di:waypoint x="3710" y="1360" />
         <di:waypoint x="3735" y="1360" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0xqg8e1_di" bpmnElement="former-youth-in-care-send-flow">
+        <di:waypoint x="795" y="180" />
+        <di:waypoint x="830" y="180" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_10xaz6e_di" bpmnElement="Flow_10xaz6e">
+        <di:waypoint x="770" y="205" />
+        <di:waypoint x="770" y="235" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0ozpwlc_di" bpmnElement="former-youth-in-care-email-sent-flow">
+        <di:waypoint x="880" y="220" />
+        <di:waypoint x="880" y="260" />
+        <di:waypoint x="795" y="260" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1gjp61i_di" bpmnElement="Flow_1gjp61i">
+        <di:waypoint x="770" y="285" />
+        <di:waypoint x="770" y="317" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="BPMNShape_0vf0jbr" bpmnElement="Group_19tqt3y">
         <dc:Bounds x="1930" y="250" width="730" height="170" />

--- a/sources/packages/backend/workflow/src/workflow-definitions/assessment-gateway-v2.bpmn
+++ b/sources/packages/backend/workflow/src/workflow-definitions/assessment-gateway-v2.bpmn
@@ -109,9 +109,9 @@ Note: the workflow process should continue its execution as a regular reassessme
         <bpmn:flowNodeRef>assessment-process-type-gateway</bpmn:flowNodeRef>
         <bpmn:flowNodeRef>identifiable-parents-creation</bpmn:flowNodeRef>
         <bpmn:flowNodeRef>Activity_069nn9n</bpmn:flowNodeRef>
-        <bpmn:flowNodeRef>send-former-youth-in-care-email-task</bpmn:flowNodeRef>
         <bpmn:flowNodeRef>former-youth-in-care-join-gateway</bpmn:flowNodeRef>
         <bpmn:flowNodeRef>former-youth-in-care-gateway</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>send-former-youth-in-care-email-task</bpmn:flowNodeRef>
       </bpmn:lane>
     </bpmn:laneSet>
     <bpmn:intermediateCatchEvent id="verify-assessment-calculation-timer">
@@ -936,6 +936,16 @@ Note: the workflow process should continue its execution as a regular reassessme
     <bpmn:sequenceFlow id="Flow_1ef3map" sourceRef="assessment-start-event" targetRef="associate-workflow-instance-task" />
     <bpmn:sequenceFlow id="Flow_1wrj7fh" sourceRef="associate-workflow-instance-task" targetRef="load-assessment-data-submit-or-reassessment-subprocess" />
     <bpmn:sequenceFlow id="Flow_0rxxozm" sourceRef="load-assessment-data-submit-or-reassessment-subprocess" targetRef="assessment-process-type-gateway" />
+    <bpmn:exclusiveGateway id="former-youth-in-care-join-gateway" default="Flow_1gjp61i">
+      <bpmn:incoming>Flow_10xaz6e</bpmn:incoming>
+      <bpmn:incoming>former-youth-in-care-email-sent-flow</bpmn:incoming>
+      <bpmn:outgoing>Flow_1gjp61i</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:exclusiveGateway id="former-youth-in-care-gateway" name="Former youth in care?" default="Flow_10xaz6e">
+      <bpmn:incoming>assessment-flow</bpmn:incoming>
+      <bpmn:outgoing>former-youth-in-care-send-flow</bpmn:outgoing>
+      <bpmn:outgoing>Flow_10xaz6e</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
     <bpmn:serviceTask id="send-former-youth-in-care-email-task" name="Send former youth in care email">
       <bpmn:extensionElements>
         <zeebe:taskDefinition type="send-email-notification" />
@@ -950,16 +960,6 @@ Note: the workflow process should continue its execution as a regular reassessme
       <bpmn:incoming>former-youth-in-care-send-flow</bpmn:incoming>
       <bpmn:outgoing>former-youth-in-care-email-sent-flow</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:exclusiveGateway id="former-youth-in-care-join-gateway" default="Flow_1gjp61i">
-      <bpmn:incoming>Flow_10xaz6e</bpmn:incoming>
-      <bpmn:incoming>former-youth-in-care-email-sent-flow</bpmn:incoming>
-      <bpmn:outgoing>Flow_1gjp61i</bpmn:outgoing>
-    </bpmn:exclusiveGateway>
-    <bpmn:exclusiveGateway id="former-youth-in-care-gateway" name="Former youth in care?" default="Flow_10xaz6e">
-      <bpmn:incoming>assessment-flow</bpmn:incoming>
-      <bpmn:outgoing>former-youth-in-care-send-flow</bpmn:outgoing>
-      <bpmn:outgoing>Flow_10xaz6e</bpmn:outgoing>
-    </bpmn:exclusiveGateway>
   </bpmn:process>
   <bpmn:message id="Message_1clo0eh" name="program-info-request-completed">
     <bpmn:extensionElements>
@@ -1001,12 +1001,12 @@ Note: the workflow process should continue its execution as a regular reassessme
         <dc:Bounds x="152" y="85" width="5058" height="1530" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Lane_1bfd2e9_di" bpmnElement="Lane_1bfd2e9" isHorizontal="true">
-        <dc:Bounds x="182" y="1155" width="5028" height="460" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Lane_0lvs868_di" bpmnElement="Lane_0lvs868" isHorizontal="true">
         <dc:Bounds x="182" y="85" width="5028" height="1070" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Lane_1bfd2e9_di" bpmnElement="Lane_1bfd2e9" isHorizontal="true">
+        <dc:Bounds x="182" y="1155" width="5028" height="460" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_1b54j4j_di" bpmnElement="verify-assessment-calculation-timer">
@@ -1266,17 +1266,8 @@ Note: the workflow process should continue its execution as a regular reassessme
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="send-former-youth-in-care-email-task_di" bpmnElement="send-former-youth-in-care-email-task">
-        <dc:Bounds x="870" y="200" width="100" height="80" />
+        <dc:Bounds x="860" y="384" width="100" height="80" />
         <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="former-youth-in-care-join-gateway_di" bpmnElement="former-youth-in-care-join-gateway" isMarkerVisible="true">
-        <dc:Bounds x="965" y="322" width="50" height="50" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="former-youth-in-care-gateway_di" bpmnElement="former-youth-in-care-gateway" isMarkerVisible="true">
-        <dc:Bounds x="795" y="322" width="50" height="50" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="781" y="381.5" width="78" height="27" />
-        </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_1r28emd_di" bpmnElement="identifiable-parents-creation" isExpanded="true">
         <dc:Bounds x="2370" y="795" width="580" height="200" />
@@ -1317,6 +1308,15 @@ Note: the workflow process should continue its execution as a regular reassessme
       <bpmndi:BPMNShape id="Activity_069nn9n_di" bpmnElement="Activity_069nn9n" isExpanded="false">
         <dc:Bounds x="1290" y="307" width="100" height="80" />
         <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="former-youth-in-care-join-gateway_di" bpmnElement="former-youth-in-care-join-gateway" isMarkerVisible="true">
+        <dc:Bounds x="965" y="322" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="former-youth-in-care-gateway_di" bpmnElement="former-youth-in-care-gateway" isMarkerVisible="true">
+        <dc:Bounds x="795" y="322" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="781" y="284.5" width="78" height="27" />
+        </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNEdge id="Flow_0bza37i_di" bpmnElement="Flow_0bza37i">
         <di:waypoint x="3005" y="1485" />
@@ -1788,18 +1788,18 @@ Note: the workflow process should continue its execution as a regular reassessme
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0xqg8e1_di" bpmnElement="former-youth-in-care-send-flow">
-        <di:waypoint x="820" y="322" />
-        <di:waypoint x="820" y="240" />
-        <di:waypoint x="870" y="240" />
+        <di:waypoint x="820" y="372" />
+        <di:waypoint x="820" y="424" />
+        <di:waypoint x="860" y="424" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_10xaz6e_di" bpmnElement="Flow_10xaz6e">
         <di:waypoint x="845" y="347" />
         <di:waypoint x="965" y="347" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0ozpwlc_di" bpmnElement="former-youth-in-care-email-sent-flow">
-        <di:waypoint x="970" y="240" />
-        <di:waypoint x="990" y="240" />
-        <di:waypoint x="990" y="322" />
+        <di:waypoint x="960" y="424" />
+        <di:waypoint x="990" y="424" />
+        <di:waypoint x="990" y="372" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1ef3map_di" bpmnElement="Flow_1ef3map">
         <di:waypoint x="288" y="348" />
@@ -1812,26 +1812,6 @@ Note: the workflow process should continue its execution as a regular reassessme
       <bpmndi:BPMNEdge id="Flow_0rxxozm_di" bpmnElement="Flow_0rxxozm">
         <di:waypoint x="570" y="347" />
         <di:waypoint x="655" y="347" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Association_1gbgxzr_di" bpmnElement="Association_1gbgxzr">
-        <di:waypoint x="3510" y="876" />
-        <di:waypoint x="3473" y="1010" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Association_1ek1rle_di" bpmnElement="Association_1ek1rle">
-        <di:waypoint x="2770" y="1377" />
-        <di:waypoint x="2358" y="1476" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Association_0z482ud_di" bpmnElement="Association_0z482ud">
-        <di:waypoint x="1740" y="800" />
-        <di:waypoint x="2322" y="542" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Association_110g427_di" bpmnElement="Association_110g427">
-        <di:waypoint x="3514" y="590" />
-        <di:waypoint x="3470" y="575" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Association_1wys3mp_di" bpmnElement="Association_1wys3mp">
-        <di:waypoint x="3482" y="690" />
-        <di:waypoint x="3493" y="697" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="BPMNShape_0vf0jbr" bpmnElement="Group_19tqt3y">
         <dc:Bounds x="1860" y="340" width="730" height="170" />
@@ -1877,6 +1857,26 @@ Note: the workflow process should continue its execution as a regular reassessme
         <dc:Bounds x="1500" y="800" width="300" height="127" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Association_1gbgxzr_di" bpmnElement="Association_1gbgxzr">
+        <di:waypoint x="3510" y="876" />
+        <di:waypoint x="3473" y="1010" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Association_1ek1rle_di" bpmnElement="Association_1ek1rle">
+        <di:waypoint x="2770" y="1377" />
+        <di:waypoint x="2358" y="1476" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Association_110g427_di" bpmnElement="Association_110g427">
+        <di:waypoint x="3514" y="590" />
+        <di:waypoint x="3470" y="575" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Association_1wys3mp_di" bpmnElement="Association_1wys3mp">
+        <di:waypoint x="3482" y="690" />
+        <di:waypoint x="3493" y="697" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Association_0z482ud_di" bpmnElement="Association_0z482ud">
+        <di:waypoint x="1740" y="800" />
+        <di:waypoint x="2322" y="542" />
+      </bpmndi:BPMNEdge>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1tu9mrb">

--- a/sources/packages/backend/workflow/src/workflow-definitions/assessment-gateway-v2.bpmn
+++ b/sources/packages/backend/workflow/src/workflow-definitions/assessment-gateway-v2.bpmn
@@ -951,7 +951,7 @@ Note: the workflow process should continue its execution as a regular reassessme
         <zeebe:taskDefinition type="send-email-notification" />
         <zeebe:taskHeaders>
           <zeebe:header key="templateId" value="636dd0c7-fe23-4a25-826b-03202326b580" />
-          <zeebe:header key="recipientType" value="student" />
+          <zeebe:header key="recipientType" value="Student" />
         </zeebe:taskHeaders>
         <zeebe:ioMapping>
           <zeebe:input source="={givenNames: &#34;studentGivenNames&#34;, lastName: &#34;studentLastName&#34;}" target="personalisation" />

--- a/sources/packages/backend/workflow/src/workflow-definitions/assessment-gateway-v2.bpmn
+++ b/sources/packages/backend/workflow/src/workflow-definitions/assessment-gateway-v2.bpmn
@@ -1814,70 +1814,70 @@ Note: the workflow process should continue its execution as a regular reassessme
         <di:waypoint x="570" y="347" />
         <di:waypoint x="655" y="347" />
       </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Association_1ek1rle_di" bpmnElement="Association_1ek1rle">
+        <di:waypoint x="2770" y="1392" />
+        <di:waypoint x="2736" y="1410" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Association_110g427_di" bpmnElement="Association_110g427">
+        <di:waypoint x="3640" y="544" />
+        <di:waypoint x="3570" y="572" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Association_1wys3mp_di" bpmnElement="Association_1wys3mp">
+        <di:waypoint x="3640" y="660" />
+        <di:waypoint x="3530" y="700" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Association_1gbgxzr_di" bpmnElement="Association_1gbgxzr">
+        <di:waypoint x="3494" y="935" />
+        <di:waypoint x="3664" y="970" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Association_0z482ud_di" bpmnElement="Association_0z482ud">
+        <di:waypoint x="2063" y="710" />
+        <di:waypoint x="2324" y="544" />
+      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="BPMNShape_0vf0jbr" bpmnElement="Group_19tqt3y">
-        <dc:Bounds x="1860" y="340" width="730" height="170" />
+        <dc:Bounds x="2245" y="255" width="730" height="170" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="2187" y="347" width="78" height="27" />
+          <dc:Bounds x="2572" y="262" width="78" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="BPMNShape_04nqxe3" bpmnElement="Group_0uz5ydc">
-        <dc:Bounds x="1860" y="530" width="730" height="280" />
+        <dc:Bounds x="2245" y="440" width="730" height="280" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="2188" y="537" width="76" height="27" />
+          <dc:Bounds x="2573" y="447" width="76" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="BPMNShape_0mw83as" bpmnElement="Group_0ldd4rw">
-        <dc:Bounds x="1860" y="830" width="880" height="350" />
+        <dc:Bounds x="2250" y="745" width="880" height="350" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="2261" y="836" width="78" height="27" />
+          <dc:Bounds x="2651" y="751" width="78" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Group_0vb3fvp_di" bpmnElement="Group_0vb3fvp">
-        <dc:Bounds x="2150" y="1310" width="700" height="290" />
+        <dc:Bounds x="2540" y="1255" width="700" height="290" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="2450" y="1320" width="60" height="40" />
+          <dc:Bounds x="2840" y="1265" width="60" height="40" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="TextAnnotation_0g9dtl6_di" bpmnElement="TextAnnotation_0g9dtl6">
-        <dc:Bounds x="2170" y="1460" width="188" height="110" />
+        <dc:Bounds x="2570" y="1410" width="188" height="110" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="BPMNShape_0m4ufpe" bpmnElement="TextAnnotation_1qwxwaf">
-        <dc:Bounds x="3250" y="590" width="310" height="40" />
+        <dc:Bounds x="3640" y="520" width="310" height="40" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="BPMNShape_0ouejj4" bpmnElement="TextAnnotation_17tw6q4">
-        <dc:Bounds x="3250" y="690" width="353" height="55" />
+        <dc:Bounds x="3640" y="630" width="353" height="55" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="TextAnnotation_1inm7cq_di" bpmnElement="TextAnnotation_1inm7cq">
-        <dc:Bounds x="3190" y="1010" width="481" height="70" />
+        <dc:Bounds x="3560" y="970" width="481" height="70" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="BPMNShape_0xhexpd" bpmnElement="TextAnnotation_1q6xzna">
-        <dc:Bounds x="1500" y="800" width="300" height="127" />
+        <dc:Bounds x="1850" y="710" width="300" height="127" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="Association_1gbgxzr_di" bpmnElement="Association_1gbgxzr">
-        <di:waypoint x="3510" y="876" />
-        <di:waypoint x="3473" y="1010" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Association_1ek1rle_di" bpmnElement="Association_1ek1rle">
-        <di:waypoint x="2770" y="1377" />
-        <di:waypoint x="2358" y="1476" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Association_110g427_di" bpmnElement="Association_110g427">
-        <di:waypoint x="3514" y="590" />
-        <di:waypoint x="3470" y="575" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Association_1wys3mp_di" bpmnElement="Association_1wys3mp">
-        <di:waypoint x="3482" y="690" />
-        <di:waypoint x="3493" y="697" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Association_0z482ud_di" bpmnElement="Association_0z482ud">
-        <di:waypoint x="1740" y="800" />
-        <di:waypoint x="2322" y="542" />
-      </bpmndi:BPMNEdge>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1tu9mrb">

--- a/sources/packages/backend/workflow/src/workflow-definitions/assessment-gateway-v2.bpmn
+++ b/sources/packages/backend/workflow/src/workflow-definitions/assessment-gateway-v2.bpmn
@@ -929,7 +929,7 @@ Note: the workflow process should continue its execution as a regular reassessme
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=assessmentTriggerType = "Original assessment"</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
     <bpmn:sequenceFlow id="former-youth-in-care-send-flow" sourceRef="former-youth-in-care-gateway" targetRef="send-former-youth-in-care-email-task">
-      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=studentDataYouthInCare != null and studentDataYouthInCare != "no"</bpmn:conditionExpression>
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=studentDataYouthInCare != "no"</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
     <bpmn:sequenceFlow id="Flow_10xaz6e" sourceRef="former-youth-in-care-gateway" targetRef="former-youth-in-care-join-gateway" />
     <bpmn:sequenceFlow id="former-youth-in-care-email-sent-flow" sourceRef="send-former-youth-in-care-email-task" targetRef="former-youth-in-care-join-gateway" />
@@ -954,7 +954,8 @@ Note: the workflow process should continue its execution as a regular reassessme
           <zeebe:header key="recipientType" value="student" />
         </zeebe:taskHeaders>
         <zeebe:ioMapping>
-          <zeebe:input source="={parentApplicationId: parentApplicationId}" target="emailNotificationCheckMetadata" />
+          <zeebe:input source="={givenNames: &#34;studentGivenNames&#34;, lastName: &#34;studentLastName&#34;}" target="personalisation" />
+          <zeebe:input source="={parentApplicationId: parentApplicationId}" target="metadata" />
         </zeebe:ioMapping>
       </bpmn:extensionElements>
       <bpmn:incoming>former-youth-in-care-send-flow</bpmn:incoming>
@@ -1265,10 +1266,6 @@ Note: the workflow process should continue its execution as a regular reassessme
           <dc:Bounds x="578" y="319" width="84" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="send-former-youth-in-care-email-task_di" bpmnElement="send-former-youth-in-care-email-task">
-        <dc:Bounds x="860" y="384" width="100" height="80" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_1r28emd_di" bpmnElement="identifiable-parents-creation" isExpanded="true">
         <dc:Bounds x="2370" y="795" width="580" height="200" />
       </bpmndi:BPMNShape>
@@ -1317,6 +1314,10 @@ Note: the workflow process should continue its execution as a regular reassessme
         <bpmndi:BPMNLabel>
           <dc:Bounds x="781" y="284.5" width="78" height="27" />
         </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="send-former-youth-in-care-email-task_di" bpmnElement="send-former-youth-in-care-email-task">
+        <dc:Bounds x="860" y="384" width="100" height="80" />
+        <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNEdge id="Flow_0bza37i_di" bpmnElement="Flow_0bza37i">
         <di:waypoint x="3005" y="1485" />

--- a/sources/packages/backend/workflow/src/workflow-definitions/assessment-gateway-v2.bpmn
+++ b/sources/packages/backend/workflow/src/workflow-definitions/assessment-gateway-v2.bpmn
@@ -23,65 +23,18 @@
 Note: the workflow process should continue its execution as a regular reassessment.</bpmn:text>
     </bpmn:textAnnotation>
     <bpmn:association id="Association_1gbgxzr" associationDirection="None" sourceRef="changed-with-approval-flow" targetRef="TextAnnotation_1inm7cq" />
-    <bpmn:association id="Association_1ek1rle" sourceRef="verify-assessment-calculation-order-task" targetRef="TextAnnotation_0g9dtl6" />
-    <bpmn:association id="Association_110g427" associationDirection="None" sourceRef="TextAnnotation_1qwxwaf" targetRef="application-change-request-approval-task" />
-    <bpmn:association id="Association_1wys3mp" associationDirection="None" sourceRef="TextAnnotation_17tw6q4" targetRef="minitry-approval-change-in-progress-still-pending-gateway" />
     <bpmn:textAnnotation id="TextAnnotation_1q6xzna">
       <bpmn:text>There are two conditions under which a supporting user is created:
  1. The 2025-26 and earlier applications where the partner is able to report. These applications have studentDataIsYourPartnerAbleToReport = true.
  2. All 2026-27 and later applications. These applications have the renamed property studentDataPartnerIsAbleToReport.</bpmn:text>
     </bpmn:textAnnotation>
+    <bpmn:association id="Association_1ek1rle" sourceRef="verify-assessment-calculation-order-task" targetRef="TextAnnotation_0g9dtl6" />
+    <bpmn:association id="Association_110g427" associationDirection="None" sourceRef="TextAnnotation_1qwxwaf" targetRef="application-change-request-approval-task" />
+    <bpmn:association id="Association_1wys3mp" associationDirection="None" sourceRef="TextAnnotation_17tw6q4" targetRef="minitry-approval-change-in-progress-still-pending-gateway" />
     <bpmn:association id="Association_0z482ud" associationDirection="None" sourceRef="TextAnnotation_1q6xzna" targetRef="Gateway_176fysj" />
   </bpmn:collaboration>
   <bpmn:process id="assessment-gateway-v2" name="Assessment Gateway V2" isExecutable="true">
     <bpmn:laneSet id="LaneSet_07shl28">
-      <bpmn:lane id="Lane_0lvs868" name="Applications In Progress">
-        <bpmn:flowNodeRef>Gateway_0jc5bz6</bpmn:flowNodeRef>
-        <bpmn:flowNodeRef>student-income-verification-subprocess</bpmn:flowNodeRef>
-        <bpmn:flowNodeRef>partner-income-verification-subprocess</bpmn:flowNodeRef>
-        <bpmn:flowNodeRef>retrieve-supporting-info-for-partner-subprocess</bpmn:flowNodeRef>
-        <bpmn:flowNodeRef>create-identifiable-partner-task</bpmn:flowNodeRef>
-        <bpmn:flowNodeRef>Gateway_176fysj</bpmn:flowNodeRef>
-        <bpmn:flowNodeRef>Gateway_05k6rp7</bpmn:flowNodeRef>
-        <bpmn:flowNodeRef>Gateway_1jdrla2</bpmn:flowNodeRef>
-        <bpmn:flowNodeRef>in-progress-main-parallel-info-gathering-gateway</bpmn:flowNodeRef>
-        <bpmn:flowNodeRef>verify-application-exceptions-retry-timer</bpmn:flowNodeRef>
-        <bpmn:flowNodeRef>application-exception-verified-message</bpmn:flowNodeRef>
-        <bpmn:flowNodeRef>verify-application-exceptions-pending-gateway</bpmn:flowNodeRef>
-        <bpmn:flowNodeRef>verify-application-exceptions-status-gateway</bpmn:flowNodeRef>
-        <bpmn:flowNodeRef>Gateway_04wt04t</bpmn:flowNodeRef>
-        <bpmn:flowNodeRef>verify-application-exceptions-task</bpmn:flowNodeRef>
-        <bpmn:flowNodeRef>Gateway_1knnojd</bpmn:flowNodeRef>
-        <bpmn:flowNodeRef>Gateway_139oo1r</bpmn:flowNodeRef>
-        <bpmn:flowNodeRef>load-assessment-data-pre-assessment-subprocess</bpmn:flowNodeRef>
-        <bpmn:flowNodeRef>application-change-request-approval-task</bpmn:flowNodeRef>
-        <bpmn:flowNodeRef>minitry-approval-change-in-progress-pending-timer</bpmn:flowNodeRef>
-        <bpmn:flowNodeRef>minitry-approval-change-in-progress-pending-gateway</bpmn:flowNodeRef>
-        <bpmn:flowNodeRef>minitry-approval-change-in-progress-still-pending-gateway</bpmn:flowNodeRef>
-        <bpmn:flowNodeRef>minitry-approval-change-request-assessed-gateway</bpmn:flowNodeRef>
-        <bpmn:flowNodeRef>minitry-approval-change-in-progress-pending-message</bpmn:flowNodeRef>
-        <bpmn:flowNodeRef>Gateway_1imkna6</bpmn:flowNodeRef>
-        <bpmn:flowNodeRef>change-request-workflow-wrap-up-task</bpmn:flowNodeRef>
-        <bpmn:flowNodeRef>minitry-approval-change-declined-end-event</bpmn:flowNodeRef>
-        <bpmn:flowNodeRef>application-exception-end-event</bpmn:flowNodeRef>
-        <bpmn:flowNodeRef>exceptions-workflow-wrap-up-task</bpmn:flowNodeRef>
-        <bpmn:flowNodeRef>identifiable-parents-creation</bpmn:flowNodeRef>
-        <bpmn:flowNodeRef>parents-verification-has-dependant-gateway</bpmn:flowNodeRef>
-        <bpmn:flowNodeRef>Gateway_0ny5tkb</bpmn:flowNodeRef>
-        <bpmn:flowNodeRef>Activity_069nn9n</bpmn:flowNodeRef>
-        <bpmn:flowNodeRef>update-application-status-to-in-progress-task</bpmn:flowNodeRef>
-        <bpmn:flowNodeRef>Gateway_0wavgao</bpmn:flowNodeRef>
-        <bpmn:flowNodeRef>assessment-process-type-gateway</bpmn:flowNodeRef>
-        <bpmn:flowNodeRef>load-assessment-data-submit-or-reassessment-subprocess</bpmn:flowNodeRef>
-        <bpmn:flowNodeRef>associate-workflow-instance-task</bpmn:flowNodeRef>
-        <bpmn:flowNodeRef>assessment-start-event</bpmn:flowNodeRef>
-        <bpmn:flowNodeRef>Gateway_1aawyrx</bpmn:flowNodeRef>
-        <bpmn:flowNodeRef>pir-workflow-wrap-up-task</bpmn:flowNodeRef>
-        <bpmn:flowNodeRef>Event_1mj2hkh</bpmn:flowNodeRef>
-        <bpmn:flowNodeRef>former-youth-in-care-gateway</bpmn:flowNodeRef>
-        <bpmn:flowNodeRef>send-former-youth-in-care-email-task</bpmn:flowNodeRef>
-        <bpmn:flowNodeRef>former-youth-in-care-join-gateway</bpmn:flowNodeRef>
-      </bpmn:lane>
       <bpmn:lane id="Lane_1bfd2e9" name="Assessment/reassessment calculation">
         <bpmn:flowNodeRef>verify-assessment-calculation-timer</bpmn:flowNodeRef>
         <bpmn:flowNodeRef>verify-assessment-calculation-order-gateway</bpmn:flowNodeRef>
@@ -112,6 +65,53 @@ Note: the workflow process should continue its execution as a regular reassessme
         <bpmn:flowNodeRef>Gateway_1hwknxt</bpmn:flowNodeRef>
         <bpmn:flowNodeRef>Activity_0d78x0s</bpmn:flowNodeRef>
         <bpmn:flowNodeRef>Activity_1vyml74</bpmn:flowNodeRef>
+      </bpmn:lane>
+      <bpmn:lane id="Lane_0lvs868" name="Applications In Progress">
+        <bpmn:flowNodeRef>Gateway_0jc5bz6</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>student-income-verification-subprocess</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>partner-income-verification-subprocess</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>retrieve-supporting-info-for-partner-subprocess</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>create-identifiable-partner-task</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Gateway_176fysj</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Gateway_05k6rp7</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Gateway_1jdrla2</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>in-progress-main-parallel-info-gathering-gateway</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>verify-application-exceptions-retry-timer</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>application-exception-verified-message</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>verify-application-exceptions-pending-gateway</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>verify-application-exceptions-status-gateway</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Gateway_04wt04t</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>verify-application-exceptions-task</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Gateway_1knnojd</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Gateway_139oo1r</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>load-assessment-data-pre-assessment-subprocess</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>application-change-request-approval-task</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>minitry-approval-change-in-progress-pending-timer</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>minitry-approval-change-in-progress-pending-gateway</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>minitry-approval-change-in-progress-still-pending-gateway</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>minitry-approval-change-request-assessed-gateway</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>minitry-approval-change-in-progress-pending-message</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Gateway_1imkna6</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>change-request-workflow-wrap-up-task</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>minitry-approval-change-declined-end-event</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>application-exception-end-event</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>exceptions-workflow-wrap-up-task</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>parents-verification-has-dependant-gateway</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Gateway_0ny5tkb</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>update-application-status-to-in-progress-task</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Gateway_0wavgao</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Gateway_1aawyrx</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>pir-workflow-wrap-up-task</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Event_1mj2hkh</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>assessment-start-event</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>associate-workflow-instance-task</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>load-assessment-data-submit-or-reassessment-subprocess</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>assessment-process-type-gateway</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>identifiable-parents-creation</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Activity_069nn9n</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>send-former-youth-in-care-email-task</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>former-youth-in-care-join-gateway</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>former-youth-in-care-gateway</bpmn:flowNodeRef>
       </bpmn:lane>
     </bpmn:laneSet>
     <bpmn:intermediateCatchEvent id="verify-assessment-calculation-timer">
@@ -427,69 +427,6 @@ Note: the workflow process should continue its execution as a regular reassessme
       <bpmn:incoming>verify-application-exceptions-status-denied-flow</bpmn:incoming>
       <bpmn:outgoing>Flow_0puhcea</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:subProcess id="identifiable-parents-creation">
-      <bpmn:incoming>parents-verification-dependantstatus-dependant-flow</bpmn:incoming>
-      <bpmn:outgoing>Flow_0ne5hoq</bpmn:outgoing>
-      <bpmn:multiInstanceLoopCharacteristics>
-        <bpmn:extensionElements>
-          <zeebe:loopCharacteristics inputCollection="=studentDataParents" inputElement="parent" outputCollection="identifiable_parents_creation_output" outputElement="={&#10;  create_identifiable_parent_task_passthrough: create_identifiable_parent_task_passthrough,&#10;  retrieve_identifiable_parent_info_subprocess_passthrough: retrieve_identifiable_parent_info_subprocess_passthrough,&#10;  parent_income_verification_subprocess_passthrough: parent_income_verification_subprocess_passthrough&#10;}" />
-        </bpmn:extensionElements>
-      </bpmn:multiInstanceLoopCharacteristics>
-      <bpmn:startEvent id="start-supporting-user-creation">
-        <bpmn:outgoing>Flow_1g9cp6m</bpmn:outgoing>
-      </bpmn:startEvent>
-      <bpmn:callActivity id="retrieve-identifiable-parent-info-subprocess" name="Retrieve parent information">
-        <bpmn:extensionElements>
-          <zeebe:calledElement processId="supporting-user-information-request" propagateAllChildVariables="false" />
-          <zeebe:ioMapping>
-            <zeebe:input source="=createdSupportingUserId" target="supportingUserId" />
-            <zeebe:input source="=[&#34;retrieve-supporting-info-for-parent-&#34; + string(loopCounter) + &#34;-subprocess&#34;]" target="parentSubprocesses" />
-            <zeebe:output source="=totalIncome" target="supportingUserParentTotalIncome" />
-            <zeebe:output source="=&#34;retrieve-identifiable-parent-info-subprocess&#34;" target="retrieve_identifiable_parent_info_subprocess_passthrough" />
-            <zeebe:output source="=supportingUserId" target="parentSupportingUserId" />
-          </zeebe:ioMapping>
-        </bpmn:extensionElements>
-        <bpmn:incoming>Flow_0u3bioj</bpmn:incoming>
-        <bpmn:outgoing>Flow_1j7259r</bpmn:outgoing>
-      </bpmn:callActivity>
-      <bpmn:callActivity id="parent-income-verification-subprocess" name="Parent Income Verification">
-        <bpmn:extensionElements>
-          <zeebe:calledElement processId="cra-integration-income-verification" propagateAllChildVariables="false" />
-          <zeebe:ioMapping>
-            <zeebe:input source="=supportingUserParentTotalIncome" target="reportedIncome" />
-            <zeebe:input source="=parentSupportingUserId" target="supportingUserId" />
-            <zeebe:input source="=[&#34;parent-&#34; + string(loopCounter) + &#34;-income-verification-subprocess&#34;]" target="parentSubprocesses" />
-            <zeebe:input source="=applicationId" target="applicationId" />
-            <zeebe:input source="=programYearStartDate" target="programYearStartDate" />
-            <zeebe:output source="=&#34;parent-income-verification-subprocess&#34;" target="parent_income_verification_subprocess_passthrough" />
-            <zeebe:output source="=supportingUserId" target="parentSupportingUserId" />
-          </zeebe:ioMapping>
-        </bpmn:extensionElements>
-        <bpmn:incoming>Flow_1j7259r</bpmn:incoming>
-        <bpmn:outgoing>Flow_0jh200l</bpmn:outgoing>
-      </bpmn:callActivity>
-      <bpmn:endEvent id="end-supporting-user-creation">
-        <bpmn:incoming>Flow_0jh200l</bpmn:incoming>
-      </bpmn:endEvent>
-      <bpmn:serviceTask id="create-identifiable-parent-task" name="Create identifiable parent">
-        <bpmn:extensionElements>
-          <zeebe:taskDefinition type="create-identifiable-supporting-users" />
-          <zeebe:ioMapping>
-            <zeebe:input source="=&#34;Parent&#34;" target="supportingUserType" />
-            <zeebe:input source="=&#34;parents[&#34; + string(loopCounter - 1) + &#34;].parentFullName&#34;" target="fullNamePropertyFilter" />
-            <zeebe:input source="=parent.parentIsAbleToReport = &#34;yes&#34;" target="isAbleToReport" />
-            <zeebe:output source="=createdSupportingUserId" target="createdSupportingUserId" />
-            <zeebe:output source="=create_identifiable_parent_task_passthrough" target="create_identifiable_parent_task_passthrough" />
-          </zeebe:ioMapping>
-        </bpmn:extensionElements>
-        <bpmn:incoming>Flow_1g9cp6m</bpmn:incoming>
-        <bpmn:outgoing>Flow_0u3bioj</bpmn:outgoing>
-      </bpmn:serviceTask>
-      <bpmn:sequenceFlow id="Flow_1g9cp6m" sourceRef="start-supporting-user-creation" targetRef="create-identifiable-parent-task" />
-      <bpmn:sequenceFlow id="Flow_0u3bioj" sourceRef="create-identifiable-parent-task" targetRef="retrieve-identifiable-parent-info-subprocess" />
-      <bpmn:sequenceFlow id="Flow_1j7259r" sourceRef="retrieve-identifiable-parent-info-subprocess" targetRef="parent-income-verification-subprocess" />
-      <bpmn:sequenceFlow id="Flow_0jh200l" sourceRef="parent-income-verification-subprocess" targetRef="end-supporting-user-creation" />
-    </bpmn:subProcess>
     <bpmn:exclusiveGateway id="parents-verification-has-dependant-gateway">
       <bpmn:incoming>Flow_18xo3dr</bpmn:incoming>
       <bpmn:outgoing>parents-verification-dependantstatus-independant-flow</bpmn:outgoing>
@@ -500,96 +437,6 @@ Note: the workflow process should continue its execution as a regular reassessme
       <bpmn:incoming>Flow_0ne5hoq</bpmn:incoming>
       <bpmn:outgoing>Flow_1uh1kyu</bpmn:outgoing>
     </bpmn:exclusiveGateway>
-    <bpmn:subProcess id="Activity_069nn9n" name="Program Information Request (PIR)">
-      <bpmn:extensionElements />
-      <bpmn:incoming>Flow_0106iy0</bpmn:incoming>
-      <bpmn:outgoing>Flow_1w081qo</bpmn:outgoing>
-      <bpmn:sequenceFlow id="Flow_16gxaj4" sourceRef="Gateway_1hpk9e2" targetRef="Gateway_1bhx82g" />
-      <bpmn:sequenceFlow id="Flow_04c1epy" sourceRef="Gateway_1bhx82g" targetRef="Event_1xk3f7n" />
-      <bpmn:sequenceFlow id="Flow_14vcuyq" sourceRef="program-info-request-completed-message" targetRef="Gateway_1hpk9e2" />
-      <bpmn:sequenceFlow id="Flow_0iqatyc" name="Yes" sourceRef="pir-pending-gateway" targetRef="Gateway_1hpk9e2">
-        <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=programInfoStatus != "Required"</bpmn:conditionExpression>
-      </bpmn:sequenceFlow>
-      <bpmn:sequenceFlow id="Flow_13y9h8r" sourceRef="program-info-required-task" targetRef="pir-pending-gateway" />
-      <bpmn:sequenceFlow id="Flow_1ubrqt9" sourceRef="pir-pending-event-gateway" targetRef="program-info-request-completed-message" />
-      <bpmn:sequenceFlow id="Flow_1t82u52" name="No" sourceRef="pir-pending-gateway" targetRef="pir-pending-event-gateway">
-        <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=programInfoStatus = "Required"</bpmn:conditionExpression>
-      </bpmn:sequenceFlow>
-      <bpmn:sequenceFlow id="Flow_0820hd3" name="Needs PIR" sourceRef="needs-pir-gateway" targetRef="program-info-required-task">
-        <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=studentDataSelectedOffering = null</bpmn:conditionExpression>
-      </bpmn:sequenceFlow>
-      <bpmn:sequenceFlow id="Flow_0nr901q" sourceRef="Event_0uzu9fw" targetRef="needs-pir-gateway" />
-      <bpmn:sequenceFlow id="Flow_0vlzpfm" sourceRef="program-info-not-required-task" targetRef="Gateway_1bhx82g" />
-      <bpmn:sequenceFlow id="Flow_0q4dox9" name="PIR not required" sourceRef="needs-pir-gateway" targetRef="program-info-not-required-task">
-        <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=studentDataSelectedOffering != null</bpmn:conditionExpression>
-      </bpmn:sequenceFlow>
-      <bpmn:sequenceFlow id="Flow_0mc1ufv" sourceRef="program-info-request-timer" targetRef="program-info-required-task" />
-      <bpmn:sequenceFlow id="Flow_09spiyj" sourceRef="pir-pending-event-gateway" targetRef="program-info-request-timer" />
-      <bpmn:exclusiveGateway id="Gateway_1bhx82g">
-        <bpmn:incoming>Flow_0vlzpfm</bpmn:incoming>
-        <bpmn:incoming>Flow_16gxaj4</bpmn:incoming>
-        <bpmn:outgoing>Flow_04c1epy</bpmn:outgoing>
-      </bpmn:exclusiveGateway>
-      <bpmn:exclusiveGateway id="Gateway_1hpk9e2">
-        <bpmn:incoming>Flow_14vcuyq</bpmn:incoming>
-        <bpmn:incoming>Flow_0iqatyc</bpmn:incoming>
-        <bpmn:outgoing>Flow_16gxaj4</bpmn:outgoing>
-      </bpmn:exclusiveGateway>
-      <bpmn:endEvent id="Event_1xk3f7n">
-        <bpmn:incoming>Flow_04c1epy</bpmn:incoming>
-      </bpmn:endEvent>
-      <bpmn:startEvent id="Event_0uzu9fw" name="">
-        <bpmn:outgoing>Flow_0nr901q</bpmn:outgoing>
-      </bpmn:startEvent>
-      <bpmn:intermediateCatchEvent id="program-info-request-completed-message">
-        <bpmn:incoming>Flow_1ubrqt9</bpmn:incoming>
-        <bpmn:outgoing>Flow_14vcuyq</bpmn:outgoing>
-        <bpmn:messageEventDefinition id="MessageEventDefinition_01uds19" messageRef="Message_1clo0eh" />
-      </bpmn:intermediateCatchEvent>
-      <bpmn:serviceTask id="program-info-required-task" name="Program Info required">
-        <bpmn:extensionElements>
-          <zeebe:taskDefinition type="program-info-request" />
-          <zeebe:taskHeaders>
-            <zeebe:header key="programInfoStatus" value="Required" />
-          </zeebe:taskHeaders>
-        </bpmn:extensionElements>
-        <bpmn:incoming>Flow_0mc1ufv</bpmn:incoming>
-        <bpmn:incoming>Flow_0820hd3</bpmn:incoming>
-        <bpmn:outgoing>Flow_13y9h8r</bpmn:outgoing>
-      </bpmn:serviceTask>
-      <bpmn:exclusiveGateway id="pir-pending-gateway" name="Completed?">
-        <bpmn:incoming>Flow_13y9h8r</bpmn:incoming>
-        <bpmn:outgoing>Flow_0iqatyc</bpmn:outgoing>
-        <bpmn:outgoing>Flow_1t82u52</bpmn:outgoing>
-      </bpmn:exclusiveGateway>
-      <bpmn:eventBasedGateway id="pir-pending-event-gateway">
-        <bpmn:incoming>Flow_1t82u52</bpmn:incoming>
-        <bpmn:outgoing>Flow_09spiyj</bpmn:outgoing>
-        <bpmn:outgoing>Flow_1ubrqt9</bpmn:outgoing>
-      </bpmn:eventBasedGateway>
-      <bpmn:exclusiveGateway id="needs-pir-gateway">
-        <bpmn:incoming>Flow_0nr901q</bpmn:incoming>
-        <bpmn:outgoing>Flow_0q4dox9</bpmn:outgoing>
-        <bpmn:outgoing>Flow_0820hd3</bpmn:outgoing>
-      </bpmn:exclusiveGateway>
-      <bpmn:serviceTask id="program-info-not-required-task" name="Program Info not required">
-        <bpmn:extensionElements>
-          <zeebe:taskDefinition type="program-info-request" />
-          <zeebe:taskHeaders>
-            <zeebe:header key="programInfoStatus" value="Not Required" />
-          </zeebe:taskHeaders>
-        </bpmn:extensionElements>
-        <bpmn:incoming>Flow_0q4dox9</bpmn:incoming>
-        <bpmn:outgoing>Flow_0vlzpfm</bpmn:outgoing>
-      </bpmn:serviceTask>
-      <bpmn:intermediateCatchEvent id="program-info-request-timer">
-        <bpmn:incoming>Flow_09spiyj</bpmn:incoming>
-        <bpmn:outgoing>Flow_0mc1ufv</bpmn:outgoing>
-        <bpmn:timerEventDefinition id="TimerEventDefinition_08dhknx">
-          <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">PT12H</bpmn:timeDuration>
-        </bpmn:timerEventDefinition>
-      </bpmn:intermediateCatchEvent>
-    </bpmn:subProcess>
     <bpmn:serviceTask id="update-application-status-to-in-progress-task" name="Update Application Status to &#39;In Progress&#39;">
       <bpmn:extensionElements>
         <zeebe:taskDefinition type="update-application-status" />
@@ -606,50 +453,6 @@ Note: the workflow process should continue its execution as a regular reassessme
       <bpmn:outgoing>Flow_0ljbhnq</bpmn:outgoing>
       <bpmn:outgoing>change-in-progress-flow</bpmn:outgoing>
     </bpmn:exclusiveGateway>
-    <bpmn:exclusiveGateway id="assessment-process-type-gateway" name="Assessment type">
-      <bpmn:incoming>Flow_0rxxozm</bpmn:incoming>
-      <bpmn:outgoing>assessment-flow</bpmn:outgoing>
-      <bpmn:outgoing>reassessment-flow</bpmn:outgoing>
-    </bpmn:exclusiveGateway>
-    <bpmn:callActivity id="load-assessment-data-submit-or-reassessment-subprocess" name="Load consolidated data (Submit or Reassessment)">
-      <bpmn:extensionElements>
-        <zeebe:calledElement processId="load-assessment-consolidated-data" propagateAllChildVariables="true" />
-        <zeebe:ioMapping>
-          <zeebe:input source="=[&#34;load-assessment-data-submit-or-reassessment-subprocess&#34;]" target="parentSubprocesses" />
-          <zeebe:input source="=&#34;load-assessment-data-submit-or-reassessment-subprocess&#34;" target="load_assessment_data_submit_or_reassessment_subprocess_passthrough" />
-        </zeebe:ioMapping>
-      </bpmn:extensionElements>
-      <bpmn:incoming>Flow_1wrj7fh</bpmn:incoming>
-      <bpmn:outgoing>Flow_0rxxozm</bpmn:outgoing>
-    </bpmn:callActivity>
-    <bpmn:serviceTask id="associate-workflow-instance-task" name="Associate workflow instance">
-      <bpmn:extensionElements>
-        <zeebe:taskDefinition type="associate-workflow-instance" />
-      </bpmn:extensionElements>
-      <bpmn:incoming>Flow_1ef3map</bpmn:incoming>
-      <bpmn:outgoing>Flow_1wrj7fh</bpmn:outgoing>
-    </bpmn:serviceTask>
-    <bpmn:startEvent id="assessment-start-event">
-      <bpmn:extensionElements>
-        <zeebe:ioMapping>
-          <zeebe:output source="=null" target="applicationId" />
-          <zeebe:output source="=null" target="parentApplicationId" />
-          <zeebe:output source="=assessmentId" target="assessmentId" />
-          <zeebe:output source="=null" target="applicationExceptionStatus" />
-          <zeebe:output source="=null" target="studentDataSelectedOffering" />
-          <zeebe:output source="=null" target="studentDataDependantstatus" />
-          <zeebe:output source="=null" target="studentDataRelationshipStatus" />
-          <zeebe:output source="=null" target="studentDataIsYourPartnerAbleToReport" />
-          <zeebe:output source="=null" target="parent1TotalIncome" />
-          <zeebe:output source="=null" target="parent2TotalIncome" />
-          <zeebe:output source="=null" target="partner1TotalIncome" />
-          <zeebe:output source="=null" target="studentDataTaxReturnIncome" />
-          <zeebe:output source="=null" target="studentDataCurrentYearIncome" />
-          <zeebe:output source="=[]" target="parentSubprocesses" />
-        </zeebe:ioMapping>
-      </bpmn:extensionElements>
-      <bpmn:outgoing>Flow_1ef3map</bpmn:outgoing>
-    </bpmn:startEvent>
     <bpmn:exclusiveGateway id="Gateway_1aawyrx">
       <bpmn:incoming>Flow_1w081qo</bpmn:incoming>
       <bpmn:outgoing>Flow_1daizvx</bpmn:outgoing>
@@ -668,128 +471,6 @@ Note: the workflow process should continue its execution as a regular reassessme
     <bpmn:endEvent id="Event_1mj2hkh">
       <bpmn:incoming>Flow_0jh9h56</bpmn:incoming>
     </bpmn:endEvent>
-    <bpmn:sequenceFlow id="Flow_0bza37i" sourceRef="verify-assessment-calculation-order-gateway" targetRef="verify-assessment-calculation-timer" />
-    <bpmn:sequenceFlow id="Flow_0umbeot" sourceRef="verify-assessment-calculation-timer" targetRef="verify-assessment-calculation-order-task" />
-    <bpmn:sequenceFlow id="Flow_16zz7zb" name="Waiting for another assessment to complete" sourceRef="ready-for-calculation-gateway" targetRef="verify-assessment-calculation-order-gateway">
-      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=isReadyForCalculation = false</bpmn:conditionExpression>
-    </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="Flow_1eip27h" sourceRef="verify-assessment-calculation-order-gateway" targetRef="release-assessment-calculation-message" />
-    <bpmn:sequenceFlow id="Flow_0wp1s62" sourceRef="verify-assessment-calculation-order-task" targetRef="ready-for-calculation-gateway" />
-    <bpmn:sequenceFlow id="Flow_0mpuqex" name="Yes" sourceRef="ready-for-calculation-gateway" targetRef="Gateway_11qgy63">
-      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=isReadyForCalculation = true</bpmn:conditionExpression>
-    </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="Flow_0358dxp" sourceRef="release-assessment-calculation-message" targetRef="verify-assessment-calculation-order-task" />
-    <bpmn:sequenceFlow id="Flow_1btetiq" sourceRef="load-assessment-data-pre-assessment-subprocess" targetRef="verify-assessment-calculation-order-task" />
-    <bpmn:sequenceFlow id="reassessment-flow" name="Reassessment" sourceRef="assessment-process-type-gateway" targetRef="verify-assessment-calculation-order-task">
-      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=assessmentTriggerType != "Original assessment"</bpmn:conditionExpression>
-    </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="Flow_0hfjqs0" name="Full Time" sourceRef="Gateway_11qgy63" targetRef="Activity_0t108ac">
-      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=offeringIntensity = "Full Time"</bpmn:conditionExpression>
-    </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="Flow_1j6gqvf" sourceRef="Activity_0t108ac" targetRef="Activity_0cqcjwg" />
-    <bpmn:sequenceFlow id="Flow_0e3pl88" name="Part Time" sourceRef="Gateway_11qgy63" targetRef="Activity_09v8xl0">
-      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=offeringIntensity = "Part Time"</bpmn:conditionExpression>
-    </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="Flow_1k200x2" sourceRef="Activity_09v8xl0" targetRef="Activity_0w3u365" />
-    <bpmn:sequenceFlow id="Flow_17yc7mz" sourceRef="Activity_0w3u365" targetRef="save-disbursement-part-time-task" />
-    <bpmn:sequenceFlow id="Flow_0qmdwld" sourceRef="Activity_0cqcjwg" targetRef="save-disbursement-task" />
-    <bpmn:sequenceFlow id="Flow_1y2j9iz" sourceRef="save-disbursement-part-time-task" targetRef="save-assessment-data-part-time-task" />
-    <bpmn:sequenceFlow id="Flow_0wed99j" sourceRef="save-disbursement-task" targetRef="save-assessment-data-task" />
-    <bpmn:sequenceFlow id="Flow_1f8ymzi" sourceRef="save-assessment-data-part-time-task" targetRef="Activity_0d78x0s" />
-    <bpmn:sequenceFlow id="Flow_1izp0bk" sourceRef="save-assessment-data-task" targetRef="Activity_1vyml74" />
-    <bpmn:sequenceFlow id="Flow_1mpwyku" sourceRef="Gateway_1hwknxt" targetRef="associate-msfaa-task" />
-    <bpmn:sequenceFlow id="Flow_1mbspca" sourceRef="student-income-verification-subprocess" targetRef="Gateway_0jc5bz6" />
-    <bpmn:sequenceFlow id="Flow_1uh1kyu" sourceRef="Gateway_0ny5tkb" targetRef="Gateway_0jc5bz6" />
-    <bpmn:sequenceFlow id="Flow_1rn6agw" sourceRef="Gateway_1jdrla2" targetRef="Gateway_0jc5bz6" />
-    <bpmn:sequenceFlow id="Flow_16d5gro" sourceRef="Gateway_0jc5bz6" targetRef="Gateway_1imkna6" />
-    <bpmn:sequenceFlow id="Flow_18qbsu1" sourceRef="in-progress-main-parallel-info-gathering-gateway" targetRef="student-income-verification-subprocess" />
-    <bpmn:sequenceFlow id="Flow_1wde0bi" sourceRef="retrieve-supporting-info-for-partner-subprocess" targetRef="partner-income-verification-subprocess" />
-    <bpmn:sequenceFlow id="Flow_0jrbmj3" sourceRef="partner-income-verification-subprocess" targetRef="Gateway_1jdrla2" />
-    <bpmn:sequenceFlow id="Flow_03zfrkx" sourceRef="create-identifiable-partner-task" targetRef="retrieve-supporting-info-for-partner-subprocess" />
-    <bpmn:sequenceFlow id="Flow_14701yl" sourceRef="Gateway_176fysj" targetRef="create-identifiable-partner-task">
-      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=studentDataIsYourPartnerAbleToReport = true or studentDataPartnerIsAbleToReport != null</bpmn:conditionExpression>
-    </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="Flow_0emvz6f" name="Yes" sourceRef="Gateway_05k6rp7" targetRef="Gateway_176fysj">
-      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=studentDataRelationshipStatus = "married"</bpmn:conditionExpression>
-    </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="Flow_1gii09j" name="Skip creation. Only for 2025/2026 and earlier." sourceRef="Gateway_176fysj" targetRef="Gateway_1jdrla2" />
-    <bpmn:sequenceFlow id="Flow_0v2i46e" sourceRef="in-progress-main-parallel-info-gathering-gateway" targetRef="Gateway_05k6rp7" />
-    <bpmn:sequenceFlow id="Flow_1u0qixu" name="No" sourceRef="Gateway_05k6rp7" targetRef="Gateway_1jdrla2">
-      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=studentDataRelationshipStatus != "married"</bpmn:conditionExpression>
-    </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="Flow_10de3as" sourceRef="Gateway_1knnojd" targetRef="in-progress-main-parallel-info-gathering-gateway" />
-    <bpmn:sequenceFlow id="Flow_18xo3dr" sourceRef="in-progress-main-parallel-info-gathering-gateway" targetRef="parents-verification-has-dependant-gateway" />
-    <bpmn:sequenceFlow id="Flow_1txrz77" sourceRef="Gateway_0f9knk0" targetRef="Event_0w0bgro" />
-    <bpmn:sequenceFlow id="Flow_0rkzx2d" sourceRef="Event_0w0bgro" targetRef="workflow-wrap-up-task" />
-    <bpmn:sequenceFlow id="Flow_0mt0uyq" sourceRef="workflow-wrap-up-task" targetRef="Event_0mtgfbi" />
-    <bpmn:sequenceFlow id="Flow_10lg2ud" sourceRef="verify-application-exceptions-pending-gateway" targetRef="verify-application-exceptions-retry-timer" />
-    <bpmn:sequenceFlow id="verify-application-exceptions-retry-timer-flow" sourceRef="verify-application-exceptions-retry-timer" targetRef="verify-application-exceptions-task" />
-    <bpmn:sequenceFlow id="Flow_1v0ju0g" sourceRef="verify-application-exceptions-pending-gateway" targetRef="application-exception-verified-message" />
-    <bpmn:sequenceFlow id="Flow_0ws0afg" sourceRef="application-exception-verified-message" targetRef="verify-application-exceptions-status-gateway" />
-    <bpmn:sequenceFlow id="verify-application-exceptions-pending-flow" name="Pending" sourceRef="Gateway_04wt04t" targetRef="verify-application-exceptions-pending-gateway">
-      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=applicationExceptionStatus = "Pending"</bpmn:conditionExpression>
-    </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="verify-application-exceptions-not-pending-flow" name="Not pending" sourceRef="Gateway_04wt04t" targetRef="verify-application-exceptions-status-gateway">
-      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=applicationExceptionStatus != "Pending"</bpmn:conditionExpression>
-    </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="verify-application-exceptions-status-denied-flow" name="Declined" sourceRef="verify-application-exceptions-status-gateway" targetRef="exceptions-workflow-wrap-up-task">
-      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=applicationExceptionStatus = "Declined"</bpmn:conditionExpression>
-    </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="verify-application-exceptions-status-approved-flow" name="Approved" sourceRef="verify-application-exceptions-status-gateway" targetRef="Gateway_1knnojd">
-      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=applicationExceptionStatus = "Approved"</bpmn:conditionExpression>
-    </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="Flow_04f30nk" sourceRef="verify-application-exceptions-task" targetRef="Gateway_04wt04t" />
-    <bpmn:sequenceFlow id="Flow_1daizvx" name="PIR Not required or Completed" sourceRef="Gateway_1aawyrx" targetRef="verify-application-exceptions-task">
-      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=programInfoStatus = "Not Required" or programInfoStatus = "Completed"</bpmn:conditionExpression>
-    </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="change-in-progress-flow" name="Change in progress" sourceRef="Gateway_0wavgao" targetRef="Gateway_1knnojd">
-      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=applicationEditStatus = "Change in progress"</bpmn:conditionExpression>
-    </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="not-a-change-request-flow" name="Regular flow" sourceRef="Gateway_1imkna6" targetRef="Gateway_139oo1r" />
-    <bpmn:sequenceFlow id="changed-with-approval-flow" name="Changed with approval" sourceRef="minitry-approval-change-request-assessed-gateway" targetRef="Gateway_139oo1r">
-      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=applicationEditStatus = "Changed with approval"</bpmn:conditionExpression>
-    </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="Flow_0prddd0" sourceRef="Gateway_139oo1r" targetRef="load-assessment-data-pre-assessment-subprocess" />
-    <bpmn:sequenceFlow id="minitry-approval-change-in-progress-flow" name="Change request in progress" sourceRef="Gateway_1imkna6" targetRef="application-change-request-approval-task">
-      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=applicationEditStatus = "Change in progress"</bpmn:conditionExpression>
-    </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="minitry-approval-change-in-progress-timer-flow" sourceRef="minitry-approval-change-in-progress-pending-timer" targetRef="application-change-request-approval-task" />
-    <bpmn:sequenceFlow id="Flow_10nfd6c" sourceRef="application-change-request-approval-task" targetRef="minitry-approval-change-in-progress-still-pending-gateway" />
-    <bpmn:sequenceFlow id="minitry-approval-change-in-progress-pending-timer-flow" sourceRef="minitry-approval-change-in-progress-pending-gateway" targetRef="minitry-approval-change-in-progress-pending-timer" />
-    <bpmn:sequenceFlow id="minitry-approval-change-in-progress-pending-flow" name="Pending" sourceRef="minitry-approval-change-in-progress-still-pending-gateway" targetRef="minitry-approval-change-in-progress-pending-gateway">
-      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=applicationEditStatus = "Change pending approval"</bpmn:conditionExpression>
-    </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="minitry-approval-change-in-progress-pending-message-flow" sourceRef="minitry-approval-change-in-progress-pending-gateway" targetRef="minitry-approval-change-in-progress-pending-message" />
-    <bpmn:sequenceFlow id="minitry-approval-change-in-progress-decision-made-flow" name="No longer pending" sourceRef="minitry-approval-change-in-progress-still-pending-gateway" targetRef="minitry-approval-change-request-assessed-gateway" />
-    <bpmn:sequenceFlow id="minitry-approval-change-in-progress-message-received-flow" sourceRef="minitry-approval-change-in-progress-pending-message" targetRef="minitry-approval-change-request-assessed-gateway" />
-    <bpmn:sequenceFlow id="change-declined-flow" name="Change declined or cancelled" sourceRef="minitry-approval-change-request-assessed-gateway" targetRef="change-request-workflow-wrap-up-task">
-      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=list contains([
-  "Change declined",
-  "Change cancelled"
-], applicationEditStatus)</bpmn:conditionExpression>
-    </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="Flow_0jltxxn" sourceRef="change-request-workflow-wrap-up-task" targetRef="minitry-approval-change-declined-end-event" />
-    <bpmn:sequenceFlow id="Flow_0puhcea" sourceRef="exceptions-workflow-wrap-up-task" targetRef="application-exception-end-event" />
-    <bpmn:sequenceFlow id="parents-verification-dependantstatus-dependant-flow" name="Dependant" sourceRef="parents-verification-has-dependant-gateway" targetRef="identifiable-parents-creation">
-      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=studentDataDependantstatus = "dependant"</bpmn:conditionExpression>
-    </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="Flow_0ne5hoq" sourceRef="identifiable-parents-creation" targetRef="Gateway_0ny5tkb" />
-    <bpmn:sequenceFlow id="parents-verification-dependantstatus-independant-flow" name="Independant" sourceRef="parents-verification-has-dependant-gateway" targetRef="Gateway_0ny5tkb">
-      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=studentDataDependantstatus != "dependant"</bpmn:conditionExpression>
-    </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="Flow_0106iy0" sourceRef="update-application-status-to-in-progress-task" targetRef="Activity_069nn9n" />
-    <bpmn:sequenceFlow id="Flow_1w081qo" sourceRef="Activity_069nn9n" targetRef="Gateway_1aawyrx" />
-    <bpmn:sequenceFlow id="Flow_0ljbhnq" sourceRef="Gateway_0wavgao" targetRef="update-application-status-to-in-progress-task" />
-    <bpmn:sequenceFlow id="assessment-flow" name="Original Assessment" sourceRef="assessment-process-type-gateway" targetRef="former-youth-in-care-gateway">
-      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=assessmentTriggerType = "Original assessment"</bpmn:conditionExpression>
-    </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="Flow_0rxxozm" sourceRef="load-assessment-data-submit-or-reassessment-subprocess" targetRef="assessment-process-type-gateway" />
-    <bpmn:sequenceFlow id="Flow_1wrj7fh" sourceRef="associate-workflow-instance-task" targetRef="load-assessment-data-submit-or-reassessment-subprocess" />
-    <bpmn:sequenceFlow id="Flow_1ef3map" sourceRef="assessment-start-event" targetRef="associate-workflow-instance-task" />
-    <bpmn:sequenceFlow id="Flow_04qzwk1" name="PIR Declined" sourceRef="Gateway_1aawyrx" targetRef="pir-workflow-wrap-up-task">
-      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=programInfoStatus = "Declined"</bpmn:conditionExpression>
-    </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="Flow_0jh9h56" sourceRef="pir-workflow-wrap-up-task" targetRef="Event_1mj2hkh" />
     <bpmn:endEvent id="Event_0mtgfbi">
       <bpmn:incoming>Flow_0mt0uyq</bpmn:incoming>
     </bpmn:endEvent>
@@ -887,20 +568,6 @@ Note: the workflow process should continue its execution as a regular reassessme
       <bpmn:incoming>Flow_0mayggl</bpmn:incoming>
       <bpmn:outgoing>Flow_0p1lgm7</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:sequenceFlow id="Flow_01iq5cw" name="Has NOA Approval" sourceRef="Gateway_1m2js1c" targetRef="update-noa-status-to-not-required-task">
-      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=applicationHasNOAApproval = true</bpmn:conditionExpression>
-    </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="Flow_0hmh3m7" sourceRef="update-noa-status-to-not-required-task" targetRef="Gateway_04wql0w" />
-    <bpmn:sequenceFlow id="Flow_1wkpr1a" name="Application Completed" sourceRef="Gateway_1xse027" targetRef="update-noa-status-to-not-required-application-completed-task">
-      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=applicationStatus = "Completed"</bpmn:conditionExpression>
-    </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="Flow_1o87o98" sourceRef="update-noa-status-to-not-required-application-completed-task" targetRef="Gateway_0f9knk0" />
-    <bpmn:sequenceFlow id="Flow_1atzf7v" sourceRef="associate-msfaa-task" targetRef="Gateway_1xse027" />
-    <bpmn:sequenceFlow id="Flow_1cb5fpw" name="Application Not Completed" sourceRef="Gateway_1xse027" targetRef="Gateway_1m2js1c" />
-    <bpmn:sequenceFlow id="Flow_0p1lgm7" sourceRef="update-noa-status-to-required-task" targetRef="Gateway_04wql0w" />
-    <bpmn:sequenceFlow id="Flow_0z518wc" sourceRef="Gateway_04wql0w" targetRef="Gateway_0f9knk0" />
-    <bpmn:sequenceFlow id="Flow_1a4wzic" name="Does Not Have NOA Approval" sourceRef="Gateway_1m2js1c" targetRef="update-application-status-to-assessment-task" />
-    <bpmn:sequenceFlow id="Flow_0mayggl" sourceRef="update-application-status-to-assessment-task" targetRef="update-noa-status-to-required-task" />
     <bpmn:exclusiveGateway id="Gateway_1hwknxt">
       <bpmn:incoming>Flow_13rnc99</bpmn:incoming>
       <bpmn:incoming>Flow_17bbn8b</bpmn:incoming>
@@ -917,7 +584,6 @@ Note: the workflow process should continue its execution as a regular reassessme
       <bpmn:incoming>Flow_1f8ymzi</bpmn:incoming>
       <bpmn:outgoing>Flow_13rnc99</bpmn:outgoing>
     </bpmn:scriptTask>
-    <bpmn:sequenceFlow id="Flow_13rnc99" sourceRef="Activity_0d78x0s" targetRef="Gateway_1hwknxt" />
     <bpmn:scriptTask id="Activity_1vyml74" name="Configure application appeals eligibility">
       <bpmn:extensionElements>
         <zeebe:script expression="=[&#10;  {&#10;    formName: &#34;stepparentwaiverappeal&#34;,&#10;    isEligible: isEligibleForStepParentWaiverAppeal = true&#10;  },&#10;  {&#10;    formName: &#34;roomandboardcostsappeal&#34;,&#10;    isEligible: isEligibleForRoomAndBoardAppeal = true&#10;  },&#10;  {&#10;    formName: &#34;studentcurrentyearincomeappeal&#34;,&#10;    isEligible: isEligibleForStudentCurrentYearIncomeAppeal = true&#10;  },&#10;  {&#10;    formName: &#34;partnercurrentyearincomeappeal&#34;,&#10;    isEligible: isEligibleForPartnerCurrentYearIncomeAppeal = true&#10;  },&#10;  {&#10;    formName: &#34;studentexceptionalexpenseappeal&#34;,&#10;    isEligible: isEligibleForExceptionalExpenseAppeal = true&#10;  },&#10;  {&#10;    formName: &#34;parentcurrentyearincomeappeal&#34;,&#10;    isEligible: isEligibleForParentCurrentYearIncomeAppeal = true&#10;  },&#10;  {&#10;    formName: &#34;ftaccessibilitygranteligibilityappeal&#34;,&#10;    isEligible: isEligibleForFTAccessibilityGrantEligibilityAppeal = true&#10;  },&#10;  {&#10;    formName: &#34;ftsfainternationalinstitutionseligibilityappeal&#34;,&#10;    isEligible: isEligibleForFTSFAInternationalInstitutionsEligibilityAppeal = true&#10;  },&#10;    {&#10;    formName: &#34;ftcanadastudentgranteligibilityappeal&#34;,&#10;    isEligible: isEligibleForFTCanadaStudentGrantEligibilityAppeal = true&#10;  },&#10;  &#10;  {&#10;    formName: &#34;ftsfaeligibilityoutofprovinceprivateinstitutionsappeal&#34;,&#10;    isEligible: isEligibleForFTOOPPrivateGrantEligibilityAppeal = true&#10;  }&#10;]" resultVariable="applicationAppealsEligibilityDetails" />
@@ -929,12 +595,347 @@ Note: the workflow process should continue its execution as a regular reassessme
       <bpmn:incoming>Flow_1izp0bk</bpmn:incoming>
       <bpmn:outgoing>Flow_17bbn8b</bpmn:outgoing>
     </bpmn:scriptTask>
-    <bpmn:sequenceFlow id="Flow_17bbn8b" sourceRef="Activity_1vyml74" targetRef="Gateway_1hwknxt" />
-    <bpmn:exclusiveGateway id="former-youth-in-care-gateway" name="Former youth in care?" default="Flow_10xaz6e">
-      <bpmn:incoming>assessment-flow</bpmn:incoming>
-      <bpmn:outgoing>former-youth-in-care-send-flow</bpmn:outgoing>
-      <bpmn:outgoing>Flow_10xaz6e</bpmn:outgoing>
+    <bpmn:startEvent id="assessment-start-event">
+      <bpmn:extensionElements>
+        <zeebe:ioMapping>
+          <zeebe:output source="=null" target="applicationId" />
+          <zeebe:output source="=null" target="parentApplicationId" />
+          <zeebe:output source="=assessmentId" target="assessmentId" />
+          <zeebe:output source="=null" target="applicationExceptionStatus" />
+          <zeebe:output source="=null" target="studentDataSelectedOffering" />
+          <zeebe:output source="=null" target="studentDataDependantstatus" />
+          <zeebe:output source="=null" target="studentDataRelationshipStatus" />
+          <zeebe:output source="=null" target="studentDataIsYourPartnerAbleToReport" />
+          <zeebe:output source="=null" target="parent1TotalIncome" />
+          <zeebe:output source="=null" target="parent2TotalIncome" />
+          <zeebe:output source="=null" target="partner1TotalIncome" />
+          <zeebe:output source="=null" target="studentDataTaxReturnIncome" />
+          <zeebe:output source="=null" target="studentDataCurrentYearIncome" />
+          <zeebe:output source="=[]" target="parentSubprocesses" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+      <bpmn:outgoing>Flow_1ef3map</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:serviceTask id="associate-workflow-instance-task" name="Associate workflow instance">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="associate-workflow-instance" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1ef3map</bpmn:incoming>
+      <bpmn:outgoing>Flow_1wrj7fh</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:callActivity id="load-assessment-data-submit-or-reassessment-subprocess" name="Load consolidated data (Submit or Reassessment)">
+      <bpmn:extensionElements>
+        <zeebe:calledElement processId="load-assessment-consolidated-data" propagateAllChildVariables="true" />
+        <zeebe:ioMapping>
+          <zeebe:input source="=[&#34;load-assessment-data-submit-or-reassessment-subprocess&#34;]" target="parentSubprocesses" />
+          <zeebe:input source="=&#34;load-assessment-data-submit-or-reassessment-subprocess&#34;" target="load_assessment_data_submit_or_reassessment_subprocess_passthrough" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1wrj7fh</bpmn:incoming>
+      <bpmn:outgoing>Flow_0rxxozm</bpmn:outgoing>
+    </bpmn:callActivity>
+    <bpmn:exclusiveGateway id="assessment-process-type-gateway" name="Assessment type">
+      <bpmn:incoming>Flow_0rxxozm</bpmn:incoming>
+      <bpmn:outgoing>assessment-flow</bpmn:outgoing>
+      <bpmn:outgoing>reassessment-flow</bpmn:outgoing>
     </bpmn:exclusiveGateway>
+    <bpmn:subProcess id="identifiable-parents-creation">
+      <bpmn:incoming>parents-verification-dependantstatus-dependant-flow</bpmn:incoming>
+      <bpmn:outgoing>Flow_0ne5hoq</bpmn:outgoing>
+      <bpmn:multiInstanceLoopCharacteristics>
+        <bpmn:extensionElements>
+          <zeebe:loopCharacteristics inputCollection="=studentDataParents" inputElement="parent" outputCollection="identifiable_parents_creation_output" outputElement="={&#10;  create_identifiable_parent_task_passthrough: create_identifiable_parent_task_passthrough,&#10;  retrieve_identifiable_parent_info_subprocess_passthrough: retrieve_identifiable_parent_info_subprocess_passthrough,&#10;  parent_income_verification_subprocess_passthrough: parent_income_verification_subprocess_passthrough&#10;}" />
+        </bpmn:extensionElements>
+      </bpmn:multiInstanceLoopCharacteristics>
+      <bpmn:startEvent id="start-supporting-user-creation">
+        <bpmn:outgoing>Flow_1g9cp6m</bpmn:outgoing>
+      </bpmn:startEvent>
+      <bpmn:callActivity id="retrieve-identifiable-parent-info-subprocess" name="Retrieve parent information">
+        <bpmn:extensionElements>
+          <zeebe:calledElement processId="supporting-user-information-request" propagateAllChildVariables="false" />
+          <zeebe:ioMapping>
+            <zeebe:input source="=createdSupportingUserId" target="supportingUserId" />
+            <zeebe:input source="=[&#34;retrieve-supporting-info-for-parent-&#34; + string(loopCounter) + &#34;-subprocess&#34;]" target="parentSubprocesses" />
+            <zeebe:output source="=totalIncome" target="supportingUserParentTotalIncome" />
+            <zeebe:output source="=&#34;retrieve-identifiable-parent-info-subprocess&#34;" target="retrieve_identifiable_parent_info_subprocess_passthrough" />
+            <zeebe:output source="=supportingUserId" target="parentSupportingUserId" />
+          </zeebe:ioMapping>
+        </bpmn:extensionElements>
+        <bpmn:incoming>Flow_0u3bioj</bpmn:incoming>
+        <bpmn:outgoing>Flow_1j7259r</bpmn:outgoing>
+      </bpmn:callActivity>
+      <bpmn:callActivity id="parent-income-verification-subprocess" name="Parent Income Verification">
+        <bpmn:extensionElements>
+          <zeebe:calledElement processId="cra-integration-income-verification" propagateAllChildVariables="false" />
+          <zeebe:ioMapping>
+            <zeebe:input source="=supportingUserParentTotalIncome" target="reportedIncome" />
+            <zeebe:input source="=parentSupportingUserId" target="supportingUserId" />
+            <zeebe:input source="=[&#34;parent-&#34; + string(loopCounter) + &#34;-income-verification-subprocess&#34;]" target="parentSubprocesses" />
+            <zeebe:input source="=applicationId" target="applicationId" />
+            <zeebe:input source="=programYearStartDate" target="programYearStartDate" />
+            <zeebe:output source="=&#34;parent-income-verification-subprocess&#34;" target="parent_income_verification_subprocess_passthrough" />
+            <zeebe:output source="=supportingUserId" target="parentSupportingUserId" />
+          </zeebe:ioMapping>
+        </bpmn:extensionElements>
+        <bpmn:incoming>Flow_1j7259r</bpmn:incoming>
+        <bpmn:outgoing>Flow_0jh200l</bpmn:outgoing>
+      </bpmn:callActivity>
+      <bpmn:endEvent id="end-supporting-user-creation">
+        <bpmn:incoming>Flow_0jh200l</bpmn:incoming>
+      </bpmn:endEvent>
+      <bpmn:serviceTask id="create-identifiable-parent-task" name="Create identifiable parent">
+        <bpmn:extensionElements>
+          <zeebe:taskDefinition type="create-identifiable-supporting-users" />
+          <zeebe:ioMapping>
+            <zeebe:input source="=&#34;Parent&#34;" target="supportingUserType" />
+            <zeebe:input source="=&#34;parents[&#34; + string(loopCounter - 1) + &#34;].parentFullName&#34;" target="fullNamePropertyFilter" />
+            <zeebe:input source="=parent.parentIsAbleToReport = &#34;yes&#34;" target="isAbleToReport" />
+            <zeebe:output source="=createdSupportingUserId" target="createdSupportingUserId" />
+            <zeebe:output source="=create_identifiable_parent_task_passthrough" target="create_identifiable_parent_task_passthrough" />
+          </zeebe:ioMapping>
+        </bpmn:extensionElements>
+        <bpmn:incoming>Flow_1g9cp6m</bpmn:incoming>
+        <bpmn:outgoing>Flow_0u3bioj</bpmn:outgoing>
+      </bpmn:serviceTask>
+      <bpmn:sequenceFlow id="Flow_1g9cp6m" sourceRef="start-supporting-user-creation" targetRef="create-identifiable-parent-task" />
+      <bpmn:sequenceFlow id="Flow_0u3bioj" sourceRef="create-identifiable-parent-task" targetRef="retrieve-identifiable-parent-info-subprocess" />
+      <bpmn:sequenceFlow id="Flow_1j7259r" sourceRef="retrieve-identifiable-parent-info-subprocess" targetRef="parent-income-verification-subprocess" />
+      <bpmn:sequenceFlow id="Flow_0jh200l" sourceRef="parent-income-verification-subprocess" targetRef="end-supporting-user-creation" />
+    </bpmn:subProcess>
+    <bpmn:subProcess id="Activity_069nn9n" name="Program Information Request (PIR)">
+      <bpmn:extensionElements />
+      <bpmn:incoming>Flow_0106iy0</bpmn:incoming>
+      <bpmn:outgoing>Flow_1w081qo</bpmn:outgoing>
+      <bpmn:sequenceFlow id="Flow_16gxaj4" sourceRef="Gateway_1hpk9e2" targetRef="Gateway_1bhx82g" />
+      <bpmn:sequenceFlow id="Flow_04c1epy" sourceRef="Gateway_1bhx82g" targetRef="Event_1xk3f7n" />
+      <bpmn:sequenceFlow id="Flow_14vcuyq" sourceRef="program-info-request-completed-message" targetRef="Gateway_1hpk9e2" />
+      <bpmn:sequenceFlow id="Flow_0iqatyc" name="Yes" sourceRef="pir-pending-gateway" targetRef="Gateway_1hpk9e2">
+        <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=programInfoStatus != "Required"</bpmn:conditionExpression>
+      </bpmn:sequenceFlow>
+      <bpmn:sequenceFlow id="Flow_13y9h8r" sourceRef="program-info-required-task" targetRef="pir-pending-gateway" />
+      <bpmn:sequenceFlow id="Flow_1ubrqt9" sourceRef="pir-pending-event-gateway" targetRef="program-info-request-completed-message" />
+      <bpmn:sequenceFlow id="Flow_1t82u52" name="No" sourceRef="pir-pending-gateway" targetRef="pir-pending-event-gateway">
+        <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=programInfoStatus = "Required"</bpmn:conditionExpression>
+      </bpmn:sequenceFlow>
+      <bpmn:sequenceFlow id="Flow_0820hd3" name="Needs PIR" sourceRef="needs-pir-gateway" targetRef="program-info-required-task">
+        <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=studentDataSelectedOffering = null</bpmn:conditionExpression>
+      </bpmn:sequenceFlow>
+      <bpmn:sequenceFlow id="Flow_0nr901q" sourceRef="Event_0uzu9fw" targetRef="needs-pir-gateway" />
+      <bpmn:sequenceFlow id="Flow_0vlzpfm" sourceRef="program-info-not-required-task" targetRef="Gateway_1bhx82g" />
+      <bpmn:sequenceFlow id="Flow_0q4dox9" name="PIR not required" sourceRef="needs-pir-gateway" targetRef="program-info-not-required-task">
+        <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=studentDataSelectedOffering != null</bpmn:conditionExpression>
+      </bpmn:sequenceFlow>
+      <bpmn:sequenceFlow id="Flow_0mc1ufv" sourceRef="program-info-request-timer" targetRef="program-info-required-task" />
+      <bpmn:sequenceFlow id="Flow_09spiyj" sourceRef="pir-pending-event-gateway" targetRef="program-info-request-timer" />
+      <bpmn:exclusiveGateway id="Gateway_1bhx82g">
+        <bpmn:incoming>Flow_0vlzpfm</bpmn:incoming>
+        <bpmn:incoming>Flow_16gxaj4</bpmn:incoming>
+        <bpmn:outgoing>Flow_04c1epy</bpmn:outgoing>
+      </bpmn:exclusiveGateway>
+      <bpmn:exclusiveGateway id="Gateway_1hpk9e2">
+        <bpmn:incoming>Flow_14vcuyq</bpmn:incoming>
+        <bpmn:incoming>Flow_0iqatyc</bpmn:incoming>
+        <bpmn:outgoing>Flow_16gxaj4</bpmn:outgoing>
+      </bpmn:exclusiveGateway>
+      <bpmn:endEvent id="Event_1xk3f7n">
+        <bpmn:incoming>Flow_04c1epy</bpmn:incoming>
+      </bpmn:endEvent>
+      <bpmn:startEvent id="Event_0uzu9fw" name="">
+        <bpmn:outgoing>Flow_0nr901q</bpmn:outgoing>
+      </bpmn:startEvent>
+      <bpmn:intermediateCatchEvent id="program-info-request-completed-message">
+        <bpmn:incoming>Flow_1ubrqt9</bpmn:incoming>
+        <bpmn:outgoing>Flow_14vcuyq</bpmn:outgoing>
+        <bpmn:messageEventDefinition id="MessageEventDefinition_01uds19" messageRef="Message_1clo0eh" />
+      </bpmn:intermediateCatchEvent>
+      <bpmn:serviceTask id="program-info-required-task" name="Program Info required">
+        <bpmn:extensionElements>
+          <zeebe:taskDefinition type="program-info-request" />
+          <zeebe:taskHeaders>
+            <zeebe:header key="programInfoStatus" value="Required" />
+          </zeebe:taskHeaders>
+        </bpmn:extensionElements>
+        <bpmn:incoming>Flow_0mc1ufv</bpmn:incoming>
+        <bpmn:incoming>Flow_0820hd3</bpmn:incoming>
+        <bpmn:outgoing>Flow_13y9h8r</bpmn:outgoing>
+      </bpmn:serviceTask>
+      <bpmn:exclusiveGateway id="pir-pending-gateway" name="Completed?">
+        <bpmn:incoming>Flow_13y9h8r</bpmn:incoming>
+        <bpmn:outgoing>Flow_0iqatyc</bpmn:outgoing>
+        <bpmn:outgoing>Flow_1t82u52</bpmn:outgoing>
+      </bpmn:exclusiveGateway>
+      <bpmn:eventBasedGateway id="pir-pending-event-gateway">
+        <bpmn:incoming>Flow_1t82u52</bpmn:incoming>
+        <bpmn:outgoing>Flow_09spiyj</bpmn:outgoing>
+        <bpmn:outgoing>Flow_1ubrqt9</bpmn:outgoing>
+      </bpmn:eventBasedGateway>
+      <bpmn:exclusiveGateway id="needs-pir-gateway">
+        <bpmn:incoming>Flow_0nr901q</bpmn:incoming>
+        <bpmn:outgoing>Flow_0q4dox9</bpmn:outgoing>
+        <bpmn:outgoing>Flow_0820hd3</bpmn:outgoing>
+      </bpmn:exclusiveGateway>
+      <bpmn:serviceTask id="program-info-not-required-task" name="Program Info not required">
+        <bpmn:extensionElements>
+          <zeebe:taskDefinition type="program-info-request" />
+          <zeebe:taskHeaders>
+            <zeebe:header key="programInfoStatus" value="Not Required" />
+          </zeebe:taskHeaders>
+        </bpmn:extensionElements>
+        <bpmn:incoming>Flow_0q4dox9</bpmn:incoming>
+        <bpmn:outgoing>Flow_0vlzpfm</bpmn:outgoing>
+      </bpmn:serviceTask>
+      <bpmn:intermediateCatchEvent id="program-info-request-timer">
+        <bpmn:incoming>Flow_09spiyj</bpmn:incoming>
+        <bpmn:outgoing>Flow_0mc1ufv</bpmn:outgoing>
+        <bpmn:timerEventDefinition id="TimerEventDefinition_08dhknx">
+          <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">PT12H</bpmn:timeDuration>
+        </bpmn:timerEventDefinition>
+      </bpmn:intermediateCatchEvent>
+    </bpmn:subProcess>
+    <bpmn:sequenceFlow id="Flow_0bza37i" sourceRef="verify-assessment-calculation-order-gateway" targetRef="verify-assessment-calculation-timer" />
+    <bpmn:sequenceFlow id="Flow_0umbeot" sourceRef="verify-assessment-calculation-timer" targetRef="verify-assessment-calculation-order-task" />
+    <bpmn:sequenceFlow id="Flow_16zz7zb" name="Waiting for another assessment to complete" sourceRef="ready-for-calculation-gateway" targetRef="verify-assessment-calculation-order-gateway">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=isReadyForCalculation = false</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_1eip27h" sourceRef="verify-assessment-calculation-order-gateway" targetRef="release-assessment-calculation-message" />
+    <bpmn:sequenceFlow id="Flow_0wp1s62" sourceRef="verify-assessment-calculation-order-task" targetRef="ready-for-calculation-gateway" />
+    <bpmn:sequenceFlow id="Flow_0mpuqex" name="Yes" sourceRef="ready-for-calculation-gateway" targetRef="Gateway_11qgy63">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=isReadyForCalculation = true</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_0358dxp" sourceRef="release-assessment-calculation-message" targetRef="verify-assessment-calculation-order-task" />
+    <bpmn:sequenceFlow id="Flow_1btetiq" sourceRef="load-assessment-data-pre-assessment-subprocess" targetRef="verify-assessment-calculation-order-task" />
+    <bpmn:sequenceFlow id="reassessment-flow" name="Reassessment" sourceRef="assessment-process-type-gateway" targetRef="verify-assessment-calculation-order-task">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=assessmentTriggerType != "Original assessment"</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_0hfjqs0" name="Full Time" sourceRef="Gateway_11qgy63" targetRef="Activity_0t108ac">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=offeringIntensity = "Full Time"</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_1j6gqvf" sourceRef="Activity_0t108ac" targetRef="Activity_0cqcjwg" />
+    <bpmn:sequenceFlow id="Flow_0e3pl88" name="Part Time" sourceRef="Gateway_11qgy63" targetRef="Activity_09v8xl0">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=offeringIntensity = "Part Time"</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_1k200x2" sourceRef="Activity_09v8xl0" targetRef="Activity_0w3u365" />
+    <bpmn:sequenceFlow id="Flow_17yc7mz" sourceRef="Activity_0w3u365" targetRef="save-disbursement-part-time-task" />
+    <bpmn:sequenceFlow id="Flow_0qmdwld" sourceRef="Activity_0cqcjwg" targetRef="save-disbursement-task" />
+    <bpmn:sequenceFlow id="Flow_1y2j9iz" sourceRef="save-disbursement-part-time-task" targetRef="save-assessment-data-part-time-task" />
+    <bpmn:sequenceFlow id="Flow_0wed99j" sourceRef="save-disbursement-task" targetRef="save-assessment-data-task" />
+    <bpmn:sequenceFlow id="Flow_1f8ymzi" sourceRef="save-assessment-data-part-time-task" targetRef="Activity_0d78x0s" />
+    <bpmn:sequenceFlow id="Flow_1izp0bk" sourceRef="save-assessment-data-task" targetRef="Activity_1vyml74" />
+    <bpmn:sequenceFlow id="Flow_1mbspca" sourceRef="student-income-verification-subprocess" targetRef="Gateway_0jc5bz6" />
+    <bpmn:sequenceFlow id="Flow_1uh1kyu" sourceRef="Gateway_0ny5tkb" targetRef="Gateway_0jc5bz6" />
+    <bpmn:sequenceFlow id="Flow_1rn6agw" sourceRef="Gateway_1jdrla2" targetRef="Gateway_0jc5bz6" />
+    <bpmn:sequenceFlow id="Flow_16d5gro" sourceRef="Gateway_0jc5bz6" targetRef="Gateway_1imkna6" />
+    <bpmn:sequenceFlow id="Flow_18qbsu1" sourceRef="in-progress-main-parallel-info-gathering-gateway" targetRef="student-income-verification-subprocess" />
+    <bpmn:sequenceFlow id="Flow_1wde0bi" sourceRef="retrieve-supporting-info-for-partner-subprocess" targetRef="partner-income-verification-subprocess" />
+    <bpmn:sequenceFlow id="Flow_0jrbmj3" sourceRef="partner-income-verification-subprocess" targetRef="Gateway_1jdrla2" />
+    <bpmn:sequenceFlow id="Flow_03zfrkx" sourceRef="create-identifiable-partner-task" targetRef="retrieve-supporting-info-for-partner-subprocess" />
+    <bpmn:sequenceFlow id="Flow_14701yl" sourceRef="Gateway_176fysj" targetRef="create-identifiable-partner-task">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=studentDataIsYourPartnerAbleToReport = true or studentDataPartnerIsAbleToReport != null</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_0emvz6f" name="Yes" sourceRef="Gateway_05k6rp7" targetRef="Gateway_176fysj">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=studentDataRelationshipStatus = "married"</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_1gii09j" name="Skip creation. Only for 2025/2026 and earlier." sourceRef="Gateway_176fysj" targetRef="Gateway_1jdrla2" />
+    <bpmn:sequenceFlow id="Flow_0v2i46e" sourceRef="in-progress-main-parallel-info-gathering-gateway" targetRef="Gateway_05k6rp7" />
+    <bpmn:sequenceFlow id="Flow_1u0qixu" name="No" sourceRef="Gateway_05k6rp7" targetRef="Gateway_1jdrla2">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=studentDataRelationshipStatus != "married"</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_10de3as" sourceRef="Gateway_1knnojd" targetRef="in-progress-main-parallel-info-gathering-gateway" />
+    <bpmn:sequenceFlow id="Flow_18xo3dr" sourceRef="in-progress-main-parallel-info-gathering-gateway" targetRef="parents-verification-has-dependant-gateway" />
+    <bpmn:sequenceFlow id="Flow_10lg2ud" sourceRef="verify-application-exceptions-pending-gateway" targetRef="verify-application-exceptions-retry-timer" />
+    <bpmn:sequenceFlow id="verify-application-exceptions-retry-timer-flow" sourceRef="verify-application-exceptions-retry-timer" targetRef="verify-application-exceptions-task" />
+    <bpmn:sequenceFlow id="Flow_1v0ju0g" sourceRef="verify-application-exceptions-pending-gateway" targetRef="application-exception-verified-message" />
+    <bpmn:sequenceFlow id="Flow_0ws0afg" sourceRef="application-exception-verified-message" targetRef="verify-application-exceptions-status-gateway" />
+    <bpmn:sequenceFlow id="verify-application-exceptions-pending-flow" name="Pending" sourceRef="Gateway_04wt04t" targetRef="verify-application-exceptions-pending-gateway">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=applicationExceptionStatus = "Pending"</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="verify-application-exceptions-not-pending-flow" name="Not pending" sourceRef="Gateway_04wt04t" targetRef="verify-application-exceptions-status-gateway">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=applicationExceptionStatus != "Pending"</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="verify-application-exceptions-status-denied-flow" name="Declined" sourceRef="verify-application-exceptions-status-gateway" targetRef="exceptions-workflow-wrap-up-task">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=applicationExceptionStatus = "Declined"</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="verify-application-exceptions-status-approved-flow" name="Approved" sourceRef="verify-application-exceptions-status-gateway" targetRef="Gateway_1knnojd">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=applicationExceptionStatus = "Approved"</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_04f30nk" sourceRef="verify-application-exceptions-task" targetRef="Gateway_04wt04t" />
+    <bpmn:sequenceFlow id="Flow_1daizvx" name="PIR Not required or Completed" sourceRef="Gateway_1aawyrx" targetRef="verify-application-exceptions-task">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=programInfoStatus = "Not Required" or programInfoStatus = "Completed"</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="change-in-progress-flow" name="Change in progress" sourceRef="Gateway_0wavgao" targetRef="Gateway_1knnojd">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=applicationEditStatus = "Change in progress"</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="not-a-change-request-flow" name="Regular flow" sourceRef="Gateway_1imkna6" targetRef="Gateway_139oo1r" />
+    <bpmn:sequenceFlow id="changed-with-approval-flow" name="Changed with approval" sourceRef="minitry-approval-change-request-assessed-gateway" targetRef="Gateway_139oo1r">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=applicationEditStatus = "Changed with approval"</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_0prddd0" sourceRef="Gateway_139oo1r" targetRef="load-assessment-data-pre-assessment-subprocess" />
+    <bpmn:sequenceFlow id="minitry-approval-change-in-progress-flow" name="Change request in progress" sourceRef="Gateway_1imkna6" targetRef="application-change-request-approval-task">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=applicationEditStatus = "Change in progress"</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="minitry-approval-change-in-progress-timer-flow" sourceRef="minitry-approval-change-in-progress-pending-timer" targetRef="application-change-request-approval-task" />
+    <bpmn:sequenceFlow id="Flow_10nfd6c" sourceRef="application-change-request-approval-task" targetRef="minitry-approval-change-in-progress-still-pending-gateway" />
+    <bpmn:sequenceFlow id="minitry-approval-change-in-progress-pending-timer-flow" sourceRef="minitry-approval-change-in-progress-pending-gateway" targetRef="minitry-approval-change-in-progress-pending-timer" />
+    <bpmn:sequenceFlow id="minitry-approval-change-in-progress-pending-flow" name="Pending" sourceRef="minitry-approval-change-in-progress-still-pending-gateway" targetRef="minitry-approval-change-in-progress-pending-gateway">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=applicationEditStatus = "Change pending approval"</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="minitry-approval-change-in-progress-pending-message-flow" sourceRef="minitry-approval-change-in-progress-pending-gateway" targetRef="minitry-approval-change-in-progress-pending-message" />
+    <bpmn:sequenceFlow id="minitry-approval-change-in-progress-decision-made-flow" name="No longer pending" sourceRef="minitry-approval-change-in-progress-still-pending-gateway" targetRef="minitry-approval-change-request-assessed-gateway" />
+    <bpmn:sequenceFlow id="minitry-approval-change-in-progress-message-received-flow" sourceRef="minitry-approval-change-in-progress-pending-message" targetRef="minitry-approval-change-request-assessed-gateway" />
+    <bpmn:sequenceFlow id="change-declined-flow" name="Change declined or cancelled" sourceRef="minitry-approval-change-request-assessed-gateway" targetRef="change-request-workflow-wrap-up-task">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=list contains([
+  "Change declined",
+  "Change cancelled"
+], applicationEditStatus)</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_0jltxxn" sourceRef="change-request-workflow-wrap-up-task" targetRef="minitry-approval-change-declined-end-event" />
+    <bpmn:sequenceFlow id="Flow_0puhcea" sourceRef="exceptions-workflow-wrap-up-task" targetRef="application-exception-end-event" />
+    <bpmn:sequenceFlow id="parents-verification-dependantstatus-dependant-flow" name="Dependant" sourceRef="parents-verification-has-dependant-gateway" targetRef="identifiable-parents-creation">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=studentDataDependantstatus = "dependant"</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="parents-verification-dependantstatus-independant-flow" name="Independant" sourceRef="parents-verification-has-dependant-gateway" targetRef="Gateway_0ny5tkb">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=studentDataDependantstatus != "dependant"</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_0ne5hoq" sourceRef="identifiable-parents-creation" targetRef="Gateway_0ny5tkb" />
+    <bpmn:sequenceFlow id="Flow_0ljbhnq" sourceRef="Gateway_0wavgao" targetRef="update-application-status-to-in-progress-task" />
+    <bpmn:sequenceFlow id="Flow_0106iy0" sourceRef="update-application-status-to-in-progress-task" targetRef="Activity_069nn9n" />
+    <bpmn:sequenceFlow id="Flow_1gjp61i" sourceRef="former-youth-in-care-join-gateway" targetRef="Gateway_0wavgao" />
+    <bpmn:sequenceFlow id="Flow_1w081qo" sourceRef="Activity_069nn9n" targetRef="Gateway_1aawyrx" />
+    <bpmn:sequenceFlow id="Flow_04qzwk1" name="PIR Declined" sourceRef="Gateway_1aawyrx" targetRef="pir-workflow-wrap-up-task">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=programInfoStatus = "Declined"</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_0jh9h56" sourceRef="pir-workflow-wrap-up-task" targetRef="Event_1mj2hkh" />
+    <bpmn:sequenceFlow id="Flow_0mt0uyq" sourceRef="workflow-wrap-up-task" targetRef="Event_0mtgfbi" />
+    <bpmn:sequenceFlow id="Flow_0rkzx2d" sourceRef="Event_0w0bgro" targetRef="workflow-wrap-up-task" />
+    <bpmn:sequenceFlow id="Flow_1txrz77" sourceRef="Gateway_0f9knk0" targetRef="Event_0w0bgro" />
+    <bpmn:sequenceFlow id="Flow_01iq5cw" name="Has NOA Approval" sourceRef="Gateway_1m2js1c" targetRef="update-noa-status-to-not-required-task">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=applicationHasNOAApproval = true</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_0hmh3m7" sourceRef="update-noa-status-to-not-required-task" targetRef="Gateway_04wql0w" />
+    <bpmn:sequenceFlow id="Flow_1wkpr1a" name="Application Completed" sourceRef="Gateway_1xse027" targetRef="update-noa-status-to-not-required-application-completed-task">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=applicationStatus = "Completed"</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_1o87o98" sourceRef="update-noa-status-to-not-required-application-completed-task" targetRef="Gateway_0f9knk0" />
+    <bpmn:sequenceFlow id="Flow_1atzf7v" sourceRef="associate-msfaa-task" targetRef="Gateway_1xse027" />
+    <bpmn:sequenceFlow id="Flow_1cb5fpw" name="Application Not Completed" sourceRef="Gateway_1xse027" targetRef="Gateway_1m2js1c" />
+    <bpmn:sequenceFlow id="Flow_0p1lgm7" sourceRef="update-noa-status-to-required-task" targetRef="Gateway_04wql0w" />
+    <bpmn:sequenceFlow id="Flow_0z518wc" sourceRef="Gateway_04wql0w" targetRef="Gateway_0f9knk0" />
+    <bpmn:sequenceFlow id="Flow_1a4wzic" name="Does Not Have NOA Approval" sourceRef="Gateway_1m2js1c" targetRef="update-application-status-to-assessment-task" />
+    <bpmn:sequenceFlow id="Flow_1mpwyku" sourceRef="Gateway_1hwknxt" targetRef="associate-msfaa-task" />
+    <bpmn:sequenceFlow id="Flow_0mayggl" sourceRef="update-application-status-to-assessment-task" targetRef="update-noa-status-to-required-task" />
+    <bpmn:sequenceFlow id="Flow_13rnc99" sourceRef="Activity_0d78x0s" targetRef="Gateway_1hwknxt" />
+    <bpmn:sequenceFlow id="Flow_17bbn8b" sourceRef="Activity_1vyml74" targetRef="Gateway_1hwknxt" />
+    <bpmn:sequenceFlow id="assessment-flow" name="Original Assessment" sourceRef="assessment-process-type-gateway" targetRef="former-youth-in-care-gateway">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=assessmentTriggerType = "Original assessment"</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="former-youth-in-care-send-flow" sourceRef="former-youth-in-care-gateway" targetRef="send-former-youth-in-care-email-task">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=studentDataYouthInCare != null and studentDataYouthInCare != "no"</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_10xaz6e" sourceRef="former-youth-in-care-gateway" targetRef="former-youth-in-care-join-gateway" />
+    <bpmn:sequenceFlow id="former-youth-in-care-email-sent-flow" sourceRef="send-former-youth-in-care-email-task" targetRef="former-youth-in-care-join-gateway" />
+    <bpmn:sequenceFlow id="Flow_1ef3map" sourceRef="assessment-start-event" targetRef="associate-workflow-instance-task" />
+    <bpmn:sequenceFlow id="Flow_1wrj7fh" sourceRef="associate-workflow-instance-task" targetRef="load-assessment-data-submit-or-reassessment-subprocess" />
+    <bpmn:sequenceFlow id="Flow_0rxxozm" sourceRef="load-assessment-data-submit-or-reassessment-subprocess" targetRef="assessment-process-type-gateway" />
     <bpmn:serviceTask id="send-former-youth-in-care-email-task" name="Send former youth in care email">
       <bpmn:extensionElements>
         <zeebe:taskDefinition type="send-email-notification" />
@@ -949,17 +950,16 @@ Note: the workflow process should continue its execution as a regular reassessme
       <bpmn:incoming>former-youth-in-care-send-flow</bpmn:incoming>
       <bpmn:outgoing>former-youth-in-care-email-sent-flow</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:sequenceFlow id="former-youth-in-care-send-flow" sourceRef="former-youth-in-care-gateway" targetRef="send-former-youth-in-care-email-task">
-      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=studentDataYouthInCare != null and studentDataYouthInCare != "no"</bpmn:conditionExpression>
-    </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="Flow_10xaz6e" sourceRef="former-youth-in-care-gateway" targetRef="former-youth-in-care-join-gateway" />
-    <bpmn:sequenceFlow id="former-youth-in-care-email-sent-flow" sourceRef="send-former-youth-in-care-email-task" targetRef="former-youth-in-care-join-gateway" />
     <bpmn:exclusiveGateway id="former-youth-in-care-join-gateway" default="Flow_1gjp61i">
       <bpmn:incoming>Flow_10xaz6e</bpmn:incoming>
       <bpmn:incoming>former-youth-in-care-email-sent-flow</bpmn:incoming>
       <bpmn:outgoing>Flow_1gjp61i</bpmn:outgoing>
     </bpmn:exclusiveGateway>
-    <bpmn:sequenceFlow id="Flow_1gjp61i" sourceRef="former-youth-in-care-join-gateway" targetRef="Gateway_0wavgao" />
+    <bpmn:exclusiveGateway id="former-youth-in-care-gateway" name="Former youth in care?" default="Flow_10xaz6e">
+      <bpmn:incoming>assessment-flow</bpmn:incoming>
+      <bpmn:outgoing>former-youth-in-care-send-flow</bpmn:outgoing>
+      <bpmn:outgoing>Flow_10xaz6e</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
   </bpmn:process>
   <bpmn:message id="Message_1clo0eh" name="program-info-request-completed">
     <bpmn:extensionElements>
@@ -998,885 +998,885 @@ Note: the workflow process should continue its execution as a regular reassessme
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Collaboration_0z9wj8q">
       <bpmndi:BPMNShape id="Participant_0y53svc_di" bpmnElement="application-in-progress" isHorizontal="true">
-        <dc:Bounds x="170" y="80" width="4730" height="1530" />
+        <dc:Bounds x="152" y="85" width="5058" height="1530" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Lane_1bfd2e9_di" bpmnElement="Lane_1bfd2e9" isHorizontal="true">
-        <dc:Bounds x="200" y="1150" width="4700" height="460" />
+        <dc:Bounds x="182" y="1155" width="5028" height="460" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Lane_0lvs868_di" bpmnElement="Lane_0lvs868" isHorizontal="true">
-        <dc:Bounds x="200" y="80" width="4700" height="1070" />
+        <dc:Bounds x="182" y="85" width="5028" height="1070" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_1b54j4j_di" bpmnElement="verify-assessment-calculation-timer">
-        <dc:Bounds x="2602" y="1462" width="36" height="36" />
+        <dc:Bounds x="2912" y="1467" width="36" height="36" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Gateway_1q0d1tl_di" bpmnElement="verify-assessment-calculation-order-gateway">
-        <dc:Bounds x="2695" y="1455" width="50" height="50" />
+        <dc:Bounds x="3005" y="1460" width="50" height="50" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Gateway_16whgqa_di" bpmnElement="ready-for-calculation-gateway" isMarkerVisible="true">
-        <dc:Bounds x="2775" y="1335" width="50" height="50" />
+        <dc:Bounds x="3085" y="1340" width="50" height="50" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="2820" y="1280" width="90" height="40" />
+          <dc:Bounds x="3131" y="1285" width="89" height="40" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_1b7ywcj_di" bpmnElement="verify-assessment-calculation-order-task">
-        <dc:Bounds x="2460" y="1320" width="100" height="80" />
+        <dc:Bounds x="2770" y="1325" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_1kvpx37_di" bpmnElement="Activity_0t108ac">
-        <dc:Bounds x="3080" y="1320" width="100" height="80" />
+        <dc:Bounds x="3390" y="1325" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Gateway_11qgy63_di" bpmnElement="Gateway_11qgy63" isMarkerVisible="true">
-        <dc:Bounds x="2955" y="1335" width="50" height="50" />
+        <dc:Bounds x="3265" y="1340" width="50" height="50" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="BPMNShape_0j2xd1b" bpmnElement="Activity_09v8xl0">
-        <dc:Bounds x="3080" y="1420" width="100" height="80" />
+        <dc:Bounds x="3390" y="1425" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="BPMNShape_0tm8tcs" bpmnElement="Activity_0w3u365">
-        <dc:Bounds x="3220" y="1420" width="100" height="80" />
+        <dc:Bounds x="3530" y="1425" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_1n7bhaz_di" bpmnElement="Activity_0cqcjwg">
-        <dc:Bounds x="3220" y="1320" width="100" height="80" />
+        <dc:Bounds x="3530" y="1325" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="BPMNShape_0hgpw0i" bpmnElement="save-disbursement-part-time-task">
-        <dc:Bounds x="3360" y="1420" width="100" height="80" />
+        <dc:Bounds x="3670" y="1425" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="BPMNShape_1rrwclw" bpmnElement="save-disbursement-task">
-        <dc:Bounds x="3360" y="1320" width="100" height="80" />
+        <dc:Bounds x="3670" y="1325" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="BPMNShape_10gkyni" bpmnElement="save-assessment-data-part-time-task">
-        <dc:Bounds x="3490" y="1420" width="100" height="80" />
+        <dc:Bounds x="3800" y="1425" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_0kunf9f_di" bpmnElement="save-assessment-data-task">
-        <dc:Bounds x="3490" y="1320" width="100" height="80" />
+        <dc:Bounds x="3800" y="1325" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="BPMNShape_0gfaqjk" bpmnElement="Gateway_0jc5bz6">
-        <dc:Bounds x="2905" y="317" width="50" height="50" />
+        <dc:Bounds x="3215" y="322" width="50" height="50" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="BPMNShape_1r6pjw3" bpmnElement="student-income-verification-subprocess">
-        <dc:Bounds x="2250" y="302" width="100" height="80" />
+        <dc:Bounds x="2560" y="307" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="BPMNShape_1c34e2g" bpmnElement="partner-income-verification-subprocess">
-        <dc:Bounds x="2410" y="490" width="100" height="80" />
+        <dc:Bounds x="2720" y="495" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="BPMNShape_02m7l5a" bpmnElement="retrieve-supporting-info-for-partner-subprocess">
-        <dc:Bounds x="2269" y="490" width="100" height="80" />
+        <dc:Bounds x="2579" y="495" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="BPMNShape_1sauqjd" bpmnElement="create-identifiable-partner-task">
-        <dc:Bounds x="2127" y="490" width="100" height="80" />
+        <dc:Bounds x="2437" y="495" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="BPMNShape_166k2o1" bpmnElement="Gateway_176fysj" isMarkerVisible="true">
-        <dc:Bounds x="2005" y="505" width="50" height="50" />
+        <dc:Bounds x="2315" y="510" width="50" height="50" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Gateway_05k6rp7_di" bpmnElement="Gateway_05k6rp7" isMarkerVisible="true">
-        <dc:Bounds x="1943" y="605" width="50" height="50" />
+        <dc:Bounds x="2253" y="610" width="50" height="50" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="1971" y="593" width="65" height="14" />
+          <dc:Bounds x="2281" y="598" width="65" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="BPMNShape_0fi04ur" bpmnElement="Gateway_1jdrla2" isMarkerVisible="true">
-        <dc:Bounds x="2515" y="605" width="50" height="50" />
+        <dc:Bounds x="2825" y="610" width="50" height="50" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Gateway_1472xxr_di" bpmnElement="in-progress-main-parallel-info-gathering-gateway">
-        <dc:Bounds x="1865" y="316" width="50" height="50" />
+        <dc:Bounds x="2175" y="321" width="50" height="50" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_0teq2x0_di" bpmnElement="release-assessment-calculation-message">
-        <dc:Bounds x="2602" y="1372" width="36" height="36" />
+        <dc:Bounds x="2912" y="1377" width="36" height="36" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_0f2fffe_di" bpmnElement="verify-application-exceptions-retry-timer">
-        <dc:Bounds x="1488" y="401" width="36" height="36" />
+        <dc:Bounds x="1798" y="406" width="36" height="36" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_15lqlgc_di" bpmnElement="application-exception-verified-message">
-        <dc:Bounds x="1554" y="323" width="36" height="36" />
+        <dc:Bounds x="1864" y="328" width="36" height="36" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Gateway_13zjxus_di" bpmnElement="verify-application-exceptions-pending-gateway">
-        <dc:Bounds x="1481" y="316" width="50" height="50" />
+        <dc:Bounds x="1791" y="321" width="50" height="50" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Gateway_18nbhar_di" bpmnElement="verify-application-exceptions-status-gateway" isMarkerVisible="true">
-        <dc:Bounds x="1612" y="316" width="50" height="50" />
+        <dc:Bounds x="1922" y="321" width="50" height="50" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Gateway_04wt04t_di" bpmnElement="Gateway_04wt04t" isMarkerVisible="true">
-        <dc:Bounds x="1375" y="316" width="50" height="50" />
+        <dc:Bounds x="1685" y="321" width="50" height="50" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="1375" y="365" width="53" height="27" />
+          <dc:Bounds x="1685" y="370" width="54" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="BPMNShape_1801h2l" bpmnElement="verify-application-exceptions-task">
-        <dc:Bounds x="1240" y="301" width="100" height="80" />
+        <dc:Bounds x="1550" y="306" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Gateway_1knnojd_di" bpmnElement="Gateway_1knnojd" isMarkerVisible="true">
-        <dc:Bounds x="1765" y="316" width="50" height="50" />
+        <dc:Bounds x="2075" y="321" width="50" height="50" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Gateway_139oo1r_di" bpmnElement="Gateway_139oo1r" isMarkerVisible="true">
-        <dc:Bounds x="3045" y="905" width="50" height="50" />
+        <dc:Bounds x="3355" y="910" width="50" height="50" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_15mfyg8_di" bpmnElement="load-assessment-data-pre-assessment-subprocess">
-        <dc:Bounds x="3020" y="990" width="100" height="80" />
+        <dc:Bounds x="3330" y="995" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="BPMNShape_1q15yac" bpmnElement="application-change-request-approval-task" bioc:stroke="#6b3c00" bioc:fill="#ffe0b2" color:background-color="#ffe0b2" color:border-color="#6b3c00">
-        <dc:Bounds x="3160" y="530" width="100" height="80" />
+        <dc:Bounds x="3470" y="535" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="BPMNShape_1bskmj6" bpmnElement="minitry-approval-change-in-progress-pending-timer" bioc:stroke="#6b3c00" bioc:fill="#ffe0b2" color:background-color="#ffe0b2" color:border-color="#6b3c00">
-        <dc:Bounds x="3072" y="552" width="36" height="36" />
+        <dc:Bounds x="3382" y="557" width="36" height="36" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="BPMNShape_14ymg5g" bpmnElement="minitry-approval-change-in-progress-pending-gateway" bioc:stroke="#6b3c00" bioc:fill="#ffe0b2" color:background-color="#ffe0b2" color:border-color="#6b3c00">
-        <dc:Bounds x="3065" y="675" width="50" height="50" />
+        <dc:Bounds x="3375" y="680" width="50" height="50" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="BPMNShape_0nzczwc" bpmnElement="minitry-approval-change-in-progress-still-pending-gateway" isMarkerVisible="true" bioc:stroke="#6b3c00" bioc:fill="#ffe0b2" color:background-color="#ffe0b2" color:border-color="#6b3c00">
-        <dc:Bounds x="3175" y="675" width="50" height="50" />
+        <dc:Bounds x="3485" y="680" width="50" height="50" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="3232" y="687" width="53" height="27" />
+          <dc:Bounds x="3542" y="692" width="54" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="BPMNShape_18hr0ql" bpmnElement="minitry-approval-change-request-assessed-gateway" isMarkerVisible="true" bioc:stroke="#6b3c00" bioc:fill="#ffe0b2" color:background-color="#ffe0b2" color:border-color="#6b3c00">
-        <dc:Bounds x="3175" y="795" width="50" height="50" />
+        <dc:Bounds x="3485" y="800" width="50" height="50" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="BPMNShape_14f4jm3" bpmnElement="minitry-approval-change-in-progress-pending-message" bioc:stroke="#6b3c00" bioc:fill="#ffe0b2" color:background-color="#ffe0b2" color:border-color="#6b3c00">
-        <dc:Bounds x="3070" y="802" width="36" height="36" />
+        <dc:Bounds x="3380" y="807" width="36" height="36" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Gateway_1imkna6_di" bpmnElement="Gateway_1imkna6" isMarkerVisible="true">
-        <dc:Bounds x="3055" y="415" width="50" height="50" />
+        <dc:Bounds x="3365" y="420" width="50" height="50" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="BPMNShape_07n5f2c" bpmnElement="change-request-workflow-wrap-up-task" bioc:stroke="#831311" bioc:fill="#ffcdd2" color:background-color="#ffcdd2" color:border-color="#831311">
-        <dc:Bounds x="3350" y="780" width="100" height="80" />
+        <dc:Bounds x="3660" y="785" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="BPMNShape_1bczfyn" bpmnElement="minitry-approval-change-declined-end-event" bioc:stroke="#831311" bioc:fill="#ffcdd2" color:background-color="#ffcdd2" color:border-color="#831311">
-        <dc:Bounds x="3502" y="802" width="36" height="36" />
+        <dc:Bounds x="3812" y="807" width="36" height="36" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_016am96_di" bpmnElement="application-exception-end-event" bioc:stroke="#831311" bioc:fill="#ffcdd2" color:background-color="#ffcdd2" color:border-color="#831311">
-        <dc:Bounds x="1619" y="572" width="36" height="36" />
+        <dc:Bounds x="1929" y="577" width="36" height="36" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="BPMNShape_11pvkh4" bpmnElement="exceptions-workflow-wrap-up-task" bioc:stroke="#831311" bioc:fill="#ffcdd2" color:background-color="#ffcdd2" color:border-color="#831311">
-        <dc:Bounds x="1587" y="440" width="100" height="80" />
+        <dc:Bounds x="1897" y="445" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="former-youth-in-care-gateway_di" bpmnElement="former-youth-in-care-gateway" isMarkerVisible="true">
-        <dc:Bounds x="745" y="155" width="50" height="50" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="731" y="118" width="78" height="27" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="send-former-youth-in-care-email-task_di" bpmnElement="send-former-youth-in-care-email-task">
-        <dc:Bounds x="830" y="140" width="100" height="80" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="former-youth-in-care-join-gateway_di" bpmnElement="former-youth-in-care-join-gateway" isMarkerVisible="true">
-        <dc:Bounds x="745" y="235" width="50" height="50" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_1r28emd_di" bpmnElement="identifiable-parents-creation" isExpanded="true">
-        <dc:Bounds x="2060" y="790" width="580" height="200" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_18hxtfw_di" bpmnElement="start-supporting-user-creation">
-        <dc:Bounds x="2097" y="872" width="36" height="36" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="BPMNShape_1kqsmts" bpmnElement="retrieve-identifiable-parent-info-subprocess">
-        <dc:Bounds x="2295" y="850" width="100" height="80" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="BPMNShape_0fe0kex" bpmnElement="parent-income-verification-subprocess">
-        <dc:Bounds x="2435" y="850" width="100" height="80" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_0mkozot_di" bpmnElement="end-supporting-user-creation">
-        <dc:Bounds x="2577" y="872" width="36" height="36" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="BPMNShape_0wlj7rd" bpmnElement="create-identifiable-parent-task">
-        <dc:Bounds x="2165" y="850" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="Flow_1g9cp6m_di" bpmnElement="Flow_1g9cp6m">
-        <di:waypoint x="2133" y="890" />
-        <di:waypoint x="2165" y="890" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0u3bioj_di" bpmnElement="Flow_0u3bioj">
-        <di:waypoint x="2265" y="890" />
-        <di:waypoint x="2295" y="890" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1j7259r_di" bpmnElement="Flow_1j7259r">
-        <di:waypoint x="2395" y="890" />
-        <di:waypoint x="2435" y="890" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0jh200l_di" bpmnElement="Flow_0jh200l">
-        <di:waypoint x="2535" y="890" />
-        <di:waypoint x="2577" y="890" />
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="Gateway_1rt1s2i_di" bpmnElement="parents-verification-has-dependant-gateway" isMarkerVisible="true">
-        <dc:Bounds x="1955" y="940" width="50" height="50" />
+        <dc:Bounds x="2265" y="945" width="50" height="50" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="BPMNShape_0cru9d8" bpmnElement="Gateway_0ny5tkb" isMarkerVisible="true">
-        <dc:Bounds x="2715" y="940" width="50" height="50" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_069nn9n_di" bpmnElement="Activity_069nn9n" isExpanded="false">
-        <dc:Bounds x="980" y="302" width="100" height="80" />
-        <bpmndi:BPMNLabel />
+        <dc:Bounds x="3025" y="945" width="50" height="50" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_1f1vf25_di" bpmnElement="update-application-status-to-in-progress-task">
-        <dc:Bounds x="850" y="302" width="100" height="80" />
+        <dc:Bounds x="1160" y="307" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Gateway_0wavgao_di" bpmnElement="Gateway_0wavgao" isMarkerVisible="true">
-        <dc:Bounds x="745" y="317" width="50" height="50" />
+        <dc:Bounds x="1055" y="322" width="50" height="50" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="649.5" y="335" width="85" height="14" />
+          <dc:Bounds x="1037" y="298" width="85" height="14" />
         </bpmndi:BPMNLabel>
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Gateway_1c05kxg_di" bpmnElement="assessment-process-type-gateway" isMarkerVisible="true">
-        <dc:Bounds x="625" y="317" width="50" height="50" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="548" y="314" width="83" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_0yu5184_di" bpmnElement="load-assessment-data-submit-or-reassessment-subprocess">
-        <dc:Bounds x="440" y="302" width="100" height="80" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_11aa2j4_di" bpmnElement="associate-workflow-instance-task">
-        <dc:Bounds x="290" y="303" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="assessment-start-event">
-        <dc:Bounds x="222" y="325" width="36" height="36" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Gateway_1aawyrx_di" bpmnElement="Gateway_1aawyrx" isMarkerVisible="true">
-        <dc:Bounds x="1125" y="317" width="50" height="50" />
+        <dc:Bounds x="1435" y="322" width="50" height="50" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="BPMNShape_1l72rhw" bpmnElement="pir-workflow-wrap-up-task" bioc:stroke="#831311" bioc:fill="#ffcdd2" color:background-color="#ffcdd2" color:border-color="#831311">
-        <dc:Bounds x="1100" y="440" width="100" height="80" />
+        <dc:Bounds x="1410" y="445" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_1mj2hkh_di" bpmnElement="Event_1mj2hkh" bioc:stroke="#831311" bioc:fill="#ffcdd2" color:background-color="#ffcdd2" color:border-color="#831311">
-        <dc:Bounds x="1132" y="572" width="36" height="36" />
+        <dc:Bounds x="1442" y="577" width="36" height="36" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_0mtgfbi_di" bpmnElement="Event_0mtgfbi" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
-        <dc:Bounds x="4842" y="1332" width="36" height="36" />
+        <dc:Bounds x="5152" y="1337" width="36" height="36" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_0dcydtn_di" bpmnElement="workflow-wrap-up-task" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
-        <dc:Bounds x="4690" y="1310" width="100" height="80" />
+        <dc:Bounds x="5000" y="1315" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_0w0bgro_di" bpmnElement="Event_0w0bgro">
-        <dc:Bounds x="4612" y="1332" width="36" height="36" />
+        <dc:Bounds x="4922" y="1337" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="4601" y="1375" width="67" height="27" />
+          <dc:Bounds x="4911" y="1380" width="68" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="BPMNShape_05dcqr1" bpmnElement="update-noa-status-to-not-required-task">
-        <dc:Bounds x="4310" y="1380" width="100" height="80" />
+        <dc:Bounds x="4620" y="1385" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="BPMNShape_1kjbwdp" bpmnElement="update-noa-status-to-not-required-application-completed-task">
-        <dc:Bounds x="4310" y="1480" width="100" height="80" />
+        <dc:Bounds x="4620" y="1485" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Gateway_1xse027_di" bpmnElement="Gateway_1xse027" isMarkerVisible="true">
-        <dc:Bounds x="3955" y="1335" width="50" height="50" />
+        <dc:Bounds x="4265" y="1340" width="50" height="50" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="BPMNShape_054vajm" bpmnElement="Gateway_04wql0w" isMarkerVisible="true">
-        <dc:Bounds x="4435" y="1325" width="50" height="50" />
+        <dc:Bounds x="4745" y="1330" width="50" height="50" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Gateway_0f9knk0_di" bpmnElement="Gateway_0f9knk0" isMarkerVisible="true">
-        <dc:Bounds x="4535" y="1325" width="50" height="50" />
+        <dc:Bounds x="4845" y="1330" width="50" height="50" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Gateway_1m2js1c_di" bpmnElement="Gateway_1m2js1c" isMarkerVisible="true">
-        <dc:Bounds x="4065" y="1335" width="50" height="50" />
+        <dc:Bounds x="4375" y="1340" width="50" height="50" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="BPMNShape_19j2z1x" bpmnElement="associate-msfaa-task">
-        <dc:Bounds x="3830" y="1320" width="100" height="80" />
+        <dc:Bounds x="4140" y="1325" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="BPMNShape_1usikde" bpmnElement="update-application-status-to-assessment-task">
-        <dc:Bounds x="4160" y="1240" width="100" height="80" />
+        <dc:Bounds x="4470" y="1245" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="BPMNShape_012hpqk" bpmnElement="update-noa-status-to-required-task">
-        <dc:Bounds x="4320" y="1240" width="100" height="80" />
+        <dc:Bounds x="4630" y="1245" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Gateway_1hwknxt_di" bpmnElement="Gateway_1hwknxt" isMarkerVisible="true">
-        <dc:Bounds x="3735" y="1335" width="50" height="50" />
+        <dc:Bounds x="4045" y="1340" width="50" height="50" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="BPMNShape_1bv2wa1" bpmnElement="Activity_0d78x0s">
-        <dc:Bounds x="3610" y="1420" width="100" height="80" />
+        <dc:Bounds x="3920" y="1425" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="BPMNShape_0dvkb3l" bpmnElement="Activity_1vyml74">
-        <dc:Bounds x="3610" y="1320" width="100" height="80" />
+        <dc:Bounds x="3920" y="1325" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="assessment-start-event">
+        <dc:Bounds x="252" y="330" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_11aa2j4_di" bpmnElement="associate-workflow-instance-task">
+        <dc:Bounds x="320" y="308" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0yu5184_di" bpmnElement="load-assessment-data-submit-or-reassessment-subprocess">
+        <dc:Bounds x="470" y="307" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_1c05kxg_di" bpmnElement="assessment-process-type-gateway" isMarkerVisible="true">
+        <dc:Bounds x="655" y="322" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="578" y="319" width="84" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="send-former-youth-in-care-email-task_di" bpmnElement="send-former-youth-in-care-email-task">
+        <dc:Bounds x="870" y="200" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="former-youth-in-care-join-gateway_di" bpmnElement="former-youth-in-care-join-gateway" isMarkerVisible="true">
+        <dc:Bounds x="965" y="322" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="former-youth-in-care-gateway_di" bpmnElement="former-youth-in-care-gateway" isMarkerVisible="true">
+        <dc:Bounds x="795" y="322" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="781" y="381.5" width="78" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1r28emd_di" bpmnElement="identifiable-parents-creation" isExpanded="true">
+        <dc:Bounds x="2370" y="795" width="580" height="200" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_18hxtfw_di" bpmnElement="start-supporting-user-creation">
+        <dc:Bounds x="2407" y="877" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1kqsmts" bpmnElement="retrieve-identifiable-parent-info-subprocess">
+        <dc:Bounds x="2605" y="855" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0fe0kex" bpmnElement="parent-income-verification-subprocess">
+        <dc:Bounds x="2745" y="855" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0mkozot_di" bpmnElement="end-supporting-user-creation">
+        <dc:Bounds x="2887" y="877" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0wlj7rd" bpmnElement="create-identifiable-parent-task">
+        <dc:Bounds x="2475" y="855" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1g9cp6m_di" bpmnElement="Flow_1g9cp6m">
+        <di:waypoint x="2443" y="895" />
+        <di:waypoint x="2475" y="895" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0u3bioj_di" bpmnElement="Flow_0u3bioj">
+        <di:waypoint x="2575" y="895" />
+        <di:waypoint x="2605" y="895" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1j7259r_di" bpmnElement="Flow_1j7259r">
+        <di:waypoint x="2705" y="895" />
+        <di:waypoint x="2745" y="895" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0jh200l_di" bpmnElement="Flow_0jh200l">
+        <di:waypoint x="2845" y="895" />
+        <di:waypoint x="2887" y="895" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Activity_069nn9n_di" bpmnElement="Activity_069nn9n" isExpanded="false">
+        <dc:Bounds x="1290" y="307" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNEdge id="Flow_0bza37i_di" bpmnElement="Flow_0bza37i">
-        <di:waypoint x="2695" y="1480" />
-        <di:waypoint x="2638" y="1480" />
+        <di:waypoint x="3005" y="1485" />
+        <di:waypoint x="2948" y="1485" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0umbeot_di" bpmnElement="Flow_0umbeot">
-        <di:waypoint x="2602" y="1480" />
-        <di:waypoint x="2510" y="1480" />
-        <di:waypoint x="2510" y="1400" />
+        <di:waypoint x="2912" y="1485" />
+        <di:waypoint x="2820" y="1485" />
+        <di:waypoint x="2820" y="1405" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_16zz7zb_di" bpmnElement="Flow_16zz7zb">
-        <di:waypoint x="2800" y="1385" />
-        <di:waypoint x="2800" y="1480" />
-        <di:waypoint x="2745" y="1480" />
+        <di:waypoint x="3110" y="1390" />
+        <di:waypoint x="3110" y="1485" />
+        <di:waypoint x="3055" y="1485" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="2805" y="1430" width="71" height="53" />
+          <dc:Bounds x="3115" y="1435" width="71" height="53" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1eip27h_di" bpmnElement="Flow_1eip27h">
-        <di:waypoint x="2720" y="1455" />
-        <di:waypoint x="2720" y="1390" />
-        <di:waypoint x="2638" y="1390" />
+        <di:waypoint x="3030" y="1460" />
+        <di:waypoint x="3030" y="1395" />
+        <di:waypoint x="2948" y="1395" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0wp1s62_di" bpmnElement="Flow_0wp1s62">
-        <di:waypoint x="2560" y="1360" />
-        <di:waypoint x="2775" y="1360" />
+        <di:waypoint x="2870" y="1365" />
+        <di:waypoint x="3085" y="1365" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0mpuqex_di" bpmnElement="Flow_0mpuqex">
-        <di:waypoint x="2825" y="1360" />
-        <di:waypoint x="2955" y="1360" />
+        <di:waypoint x="3135" y="1365" />
+        <di:waypoint x="3265" y="1365" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="2881" y="1342" width="18" height="14" />
+          <dc:Bounds x="3191" y="1347" width="18" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0358dxp_di" bpmnElement="Flow_0358dxp">
-        <di:waypoint x="2602" y="1390" />
-        <di:waypoint x="2560" y="1390" />
+        <di:waypoint x="2912" y="1395" />
+        <di:waypoint x="2870" y="1395" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1btetiq_di" bpmnElement="Flow_1btetiq">
-        <di:waypoint x="3070" y="1070" />
-        <di:waypoint x="3070" y="1200" />
-        <di:waypoint x="2510" y="1200" />
-        <di:waypoint x="2510" y="1320" />
+        <di:waypoint x="3380" y="1075" />
+        <di:waypoint x="3380" y="1205" />
+        <di:waypoint x="2820" y="1205" />
+        <di:waypoint x="2820" y="1325" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="2487" y="1523" width="85" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0ozt4pg_di" bpmnElement="reassessment-flow">
-        <di:waypoint x="650" y="367" />
-        <di:waypoint x="650" y="1360" />
-        <di:waypoint x="2460" y="1360" />
+        <di:waypoint x="680" y="372" />
+        <di:waypoint x="680" y="1365" />
+        <di:waypoint x="2770" y="1365" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="664" y="455" width="74" height="14" />
+          <dc:Bounds x="695" y="460" width="73" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0hfjqs0_di" bpmnElement="Flow_0hfjqs0">
-        <di:waypoint x="3005" y="1360" />
-        <di:waypoint x="3080" y="1360" />
+        <di:waypoint x="3315" y="1365" />
+        <di:waypoint x="3390" y="1365" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="3020" y="1342" width="45" height="14" />
+          <dc:Bounds x="3330" y="1347" width="45" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1j6gqvf_di" bpmnElement="Flow_1j6gqvf">
-        <di:waypoint x="3180" y="1360" />
-        <di:waypoint x="3220" y="1360" />
+        <di:waypoint x="3490" y="1365" />
+        <di:waypoint x="3530" y="1365" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0e3pl88_di" bpmnElement="Flow_0e3pl88">
-        <di:waypoint x="2980" y="1385" />
-        <di:waypoint x="2980" y="1460" />
-        <di:waypoint x="3080" y="1460" />
+        <di:waypoint x="3290" y="1390" />
+        <di:waypoint x="3290" y="1465" />
+        <di:waypoint x="3390" y="1465" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="3018" y="1443" width="48" height="14" />
+          <dc:Bounds x="3328" y="1448" width="48" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1k200x2_di" bpmnElement="Flow_1k200x2">
-        <di:waypoint x="3180" y="1460" />
-        <di:waypoint x="3220" y="1460" />
+        <di:waypoint x="3490" y="1465" />
+        <di:waypoint x="3530" y="1465" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_17yc7mz_di" bpmnElement="Flow_17yc7mz">
-        <di:waypoint x="3320" y="1460" />
-        <di:waypoint x="3360" y="1460" />
+        <di:waypoint x="3630" y="1465" />
+        <di:waypoint x="3670" y="1465" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0qmdwld_di" bpmnElement="Flow_0qmdwld">
-        <di:waypoint x="3320" y="1360" />
-        <di:waypoint x="3360" y="1360" />
+        <di:waypoint x="3630" y="1365" />
+        <di:waypoint x="3670" y="1365" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="BPMNEdge_0jquq8b" bpmnElement="Flow_1y2j9iz">
-        <di:waypoint x="3460" y="1460" />
-        <di:waypoint x="3490" y="1460" />
+        <di:waypoint x="3770" y="1465" />
+        <di:waypoint x="3800" y="1465" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0wed99j_di" bpmnElement="Flow_0wed99j">
-        <di:waypoint x="3460" y="1360" />
-        <di:waypoint x="3490" y="1360" />
+        <di:waypoint x="3770" y="1365" />
+        <di:waypoint x="3800" y="1365" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1f8ymzi_di" bpmnElement="Flow_1f8ymzi">
-        <di:waypoint x="3590" y="1460" />
-        <di:waypoint x="3610" y="1460" />
+        <di:waypoint x="3900" y="1465" />
+        <di:waypoint x="3920" y="1465" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1izp0bk_di" bpmnElement="Flow_1izp0bk">
-        <di:waypoint x="3590" y="1360" />
-        <di:waypoint x="3610" y="1360" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1mpwyku_di" bpmnElement="Flow_1mpwyku">
-        <di:waypoint x="3785" y="1360" />
-        <di:waypoint x="3830" y="1360" />
+        <di:waypoint x="3900" y="1365" />
+        <di:waypoint x="3920" y="1365" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1mbspca_di" bpmnElement="Flow_1mbspca">
-        <di:waypoint x="2350" y="342" />
-        <di:waypoint x="2905" y="342" />
+        <di:waypoint x="2660" y="347" />
+        <di:waypoint x="3215" y="347" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1uh1kyu_di" bpmnElement="Flow_1uh1kyu">
-        <di:waypoint x="2765" y="965" />
-        <di:waypoint x="2860" y="965" />
-        <di:waypoint x="2860" y="342" />
-        <di:waypoint x="2905" y="342" />
+        <di:waypoint x="3075" y="970" />
+        <di:waypoint x="3170" y="970" />
+        <di:waypoint x="3170" y="347" />
+        <di:waypoint x="3215" y="347" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1rn6agw_di" bpmnElement="Flow_1rn6agw">
-        <di:waypoint x="2565" y="630" />
-        <di:waypoint x="2860" y="630" />
-        <di:waypoint x="2860" y="342" />
-        <di:waypoint x="2905" y="342" />
+        <di:waypoint x="2875" y="635" />
+        <di:waypoint x="3170" y="635" />
+        <di:waypoint x="3170" y="347" />
+        <di:waypoint x="3215" y="347" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_16d5gro_di" bpmnElement="Flow_16d5gro">
-        <di:waypoint x="2955" y="342" />
-        <di:waypoint x="3080" y="342" />
-        <di:waypoint x="3080" y="415" />
+        <di:waypoint x="3265" y="347" />
+        <di:waypoint x="3390" y="347" />
+        <di:waypoint x="3390" y="420" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_18qbsu1_di" bpmnElement="Flow_18qbsu1">
-        <di:waypoint x="1915" y="341" />
-        <di:waypoint x="2250" y="341" />
+        <di:waypoint x="2225" y="346" />
+        <di:waypoint x="2560" y="346" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1wde0bi_di" bpmnElement="Flow_1wde0bi">
-        <di:waypoint x="2369" y="530" />
-        <di:waypoint x="2410" y="530" />
+        <di:waypoint x="2679" y="535" />
+        <di:waypoint x="2720" y="535" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0jrbmj3_di" bpmnElement="Flow_0jrbmj3">
-        <di:waypoint x="2510" y="530" />
-        <di:waypoint x="2540" y="530" />
-        <di:waypoint x="2540" y="605" />
+        <di:waypoint x="2820" y="535" />
+        <di:waypoint x="2850" y="535" />
+        <di:waypoint x="2850" y="610" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_03zfrkx_di" bpmnElement="Flow_03zfrkx">
-        <di:waypoint x="2227" y="530" />
-        <di:waypoint x="2269" y="530" />
+        <di:waypoint x="2537" y="535" />
+        <di:waypoint x="2579" y="535" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_14701yl_di" bpmnElement="Flow_14701yl">
-        <di:waypoint x="2055" y="530" />
-        <di:waypoint x="2127" y="530" />
+        <di:waypoint x="2365" y="535" />
+        <di:waypoint x="2437" y="535" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="2038" y="486" width="84" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0emvz6f_di" bpmnElement="Flow_0emvz6f">
-        <di:waypoint x="1968" y="605" />
-        <di:waypoint x="1968" y="530" />
-        <di:waypoint x="2005" y="530" />
+        <di:waypoint x="2278" y="610" />
+        <di:waypoint x="2278" y="535" />
+        <di:waypoint x="2315" y="535" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="1969" y="513" width="18" height="14" />
+          <dc:Bounds x="2279" y="518" width="18" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1gii09j_di" bpmnElement="Flow_1gii09j">
-        <di:waypoint x="2030" y="555" />
-        <di:waypoint x="2030" y="630" />
-        <di:waypoint x="2515" y="630" />
+        <di:waypoint x="2340" y="560" />
+        <di:waypoint x="2340" y="635" />
+        <di:waypoint x="2825" y="635" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="2213" y="636" width="74" height="53" />
+          <dc:Bounds x="2523" y="641" width="74" height="53" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0v2i46e_di" bpmnElement="Flow_0v2i46e">
-        <di:waypoint x="1890" y="366" />
-        <di:waypoint x="1890" y="630" />
-        <di:waypoint x="1943" y="630" />
+        <di:waypoint x="2200" y="371" />
+        <di:waypoint x="2200" y="635" />
+        <di:waypoint x="2253" y="635" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1u0qixu_di" bpmnElement="Flow_1u0qixu">
-        <di:waypoint x="1968" y="655" />
-        <di:waypoint x="1968" y="690" />
-        <di:waypoint x="2540" y="690" />
-        <di:waypoint x="2540" y="655" />
+        <di:waypoint x="2278" y="660" />
+        <di:waypoint x="2278" y="695" />
+        <di:waypoint x="2850" y="695" />
+        <di:waypoint x="2850" y="660" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="1976" y="672" width="15" height="14" />
+          <dc:Bounds x="2286" y="677" width="15" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_10de3as_di" bpmnElement="Flow_10de3as">
-        <di:waypoint x="1815" y="341" />
-        <di:waypoint x="1865" y="341" />
+        <di:waypoint x="2125" y="346" />
+        <di:waypoint x="2175" y="346" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_18xo3dr_di" bpmnElement="Flow_18xo3dr">
-        <di:waypoint x="1890" y="366" />
-        <di:waypoint x="1890" y="965" />
-        <di:waypoint x="1955" y="965" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1txrz77_di" bpmnElement="Flow_1txrz77">
-        <di:waypoint x="4585" y="1350" />
-        <di:waypoint x="4612" y="1350" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0rkzx2d_di" bpmnElement="Flow_0rkzx2d">
-        <di:waypoint x="4648" y="1350" />
-        <di:waypoint x="4690" y="1350" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0mt0uyq_di" bpmnElement="Flow_0mt0uyq">
-        <di:waypoint x="4790" y="1350" />
-        <di:waypoint x="4842" y="1350" />
+        <di:waypoint x="2200" y="371" />
+        <di:waypoint x="2200" y="970" />
+        <di:waypoint x="2265" y="970" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_10lg2ud_di" bpmnElement="Flow_10lg2ud">
-        <di:waypoint x="1506" y="366" />
-        <di:waypoint x="1506" y="401" />
+        <di:waypoint x="1816" y="371" />
+        <di:waypoint x="1816" y="406" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0mjvscf_di" bpmnElement="verify-application-exceptions-retry-timer-flow">
-        <di:waypoint x="1488" y="419" />
-        <di:waypoint x="1290" y="419" />
-        <di:waypoint x="1290" y="381" />
+        <di:waypoint x="1798" y="424" />
+        <di:waypoint x="1600" y="424" />
+        <di:waypoint x="1600" y="386" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1v0ju0g_di" bpmnElement="Flow_1v0ju0g">
-        <di:waypoint x="1531" y="341" />
-        <di:waypoint x="1554" y="341" />
+        <di:waypoint x="1841" y="346" />
+        <di:waypoint x="1864" y="346" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0ws0afg_di" bpmnElement="Flow_0ws0afg">
-        <di:waypoint x="1590" y="341" />
-        <di:waypoint x="1612" y="341" />
+        <di:waypoint x="1900" y="346" />
+        <di:waypoint x="1922" y="346" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_031ttjr_di" bpmnElement="verify-application-exceptions-pending-flow">
-        <di:waypoint x="1425" y="341" />
-        <di:waypoint x="1481" y="341" />
+        <di:waypoint x="1735" y="346" />
+        <di:waypoint x="1791" y="346" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="1427" y="327" width="41" height="14" />
+          <dc:Bounds x="1737" y="332" width="41" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1a8bc8b_di" bpmnElement="verify-application-exceptions-not-pending-flow">
-        <di:waypoint x="1400" y="316" />
-        <di:waypoint x="1400" y="280" />
-        <di:waypoint x="1637" y="280" />
-        <di:waypoint x="1637" y="316" />
+        <di:waypoint x="1710" y="321" />
+        <di:waypoint x="1710" y="285" />
+        <di:waypoint x="1947" y="285" />
+        <di:waypoint x="1947" y="321" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="1470" y="262" width="60" height="14" />
+          <dc:Bounds x="1780" y="267" width="60" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_10abeca_di" bpmnElement="verify-application-exceptions-status-denied-flow">
-        <di:waypoint x="1637" y="366" />
-        <di:waypoint x="1637" y="440" />
+        <di:waypoint x="1947" y="371" />
+        <di:waypoint x="1947" y="445" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="1640" y="381" width="43" height="14" />
+          <dc:Bounds x="1950" y="386" width="43" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1pm5g4l_di" bpmnElement="verify-application-exceptions-status-approved-flow">
-        <di:waypoint x="1662" y="341" />
-        <di:waypoint x="1765" y="341" />
+        <di:waypoint x="1972" y="346" />
+        <di:waypoint x="2075" y="346" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="1676" y="328" width="47" height="14" />
+          <dc:Bounds x="1986" y="333" width="48" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_04f30nk_di" bpmnElement="Flow_04f30nk">
-        <di:waypoint x="1340" y="341" />
-        <di:waypoint x="1375" y="341" />
+        <di:waypoint x="1650" y="346" />
+        <di:waypoint x="1685" y="346" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1daizvx_di" bpmnElement="Flow_1daizvx">
-        <di:waypoint x="1174" y="341" />
-        <di:waypoint x="1240" y="341" />
+        <di:waypoint x="1484" y="346" />
+        <di:waypoint x="1550" y="346" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="1159" y="286" width="82" height="27" />
+          <dc:Bounds x="1469" y="291" width="82" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0ox1o19_di" bpmnElement="change-in-progress-flow">
-        <di:waypoint x="770" y="367" />
-        <di:waypoint x="770" y="690" />
-        <di:waypoint x="1790" y="680" />
-        <di:waypoint x="1790" y="366" />
+        <di:waypoint x="1080" y="372" />
+        <di:waypoint x="1080" y="695" />
+        <di:waypoint x="2100" y="685" />
+        <di:waypoint x="2100" y="371" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="1255" y="646" width="51" height="27" />
+          <dc:Bounds x="1565" y="651" width="51" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0g0yluv_di" bpmnElement="not-a-change-request-flow">
-        <di:waypoint x="3055" y="440" />
-        <di:waypoint x="2950" y="440" />
-        <di:waypoint x="2950" y="930" />
-        <di:waypoint x="3045" y="930" />
+        <di:waypoint x="3365" y="445" />
+        <di:waypoint x="3260" y="445" />
+        <di:waypoint x="3260" y="935" />
+        <di:waypoint x="3355" y="935" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="2958" y="443" width="63" height="14" />
+          <dc:Bounds x="3269" y="448" width="62" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1x1k7zp_di" bpmnElement="changed-with-approval-flow">
-        <di:waypoint x="3200" y="845" />
-        <di:waypoint x="3200" y="930" />
-        <di:waypoint x="3095" y="930" />
+        <di:waypoint x="3510" y="850" />
+        <di:waypoint x="3510" y="935" />
+        <di:waypoint x="3405" y="935" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="3126" y="868" width="68" height="27" />
+          <dc:Bounds x="3436" y="873" width="68" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0prddd0_di" bpmnElement="Flow_0prddd0">
-        <di:waypoint x="3070" y="955" />
-        <di:waypoint x="3070" y="990" />
+        <di:waypoint x="3380" y="960" />
+        <di:waypoint x="3380" y="995" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0mllry2_di" bpmnElement="minitry-approval-change-in-progress-flow">
-        <di:waypoint x="3105" y="440" />
-        <di:waypoint x="3210" y="440" />
-        <di:waypoint x="3210" y="530" />
+        <di:waypoint x="3415" y="445" />
+        <di:waypoint x="3520" y="445" />
+        <di:waypoint x="3520" y="535" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="3115" y="447" width="90" height="27" />
+          <dc:Bounds x="3425" y="452" width="90" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="BPMNEdge_00giejb" bpmnElement="minitry-approval-change-in-progress-timer-flow">
-        <di:waypoint x="3108" y="570" />
-        <di:waypoint x="3160" y="570" />
+        <di:waypoint x="3418" y="575" />
+        <di:waypoint x="3470" y="575" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="BPMNEdge_0wpx398" bpmnElement="Flow_10nfd6c">
-        <di:waypoint x="3200" y="610" />
-        <di:waypoint x="3200" y="675" />
+        <di:waypoint x="3510" y="615" />
+        <di:waypoint x="3510" y="680" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="BPMNEdge_1yh6tri" bpmnElement="minitry-approval-change-in-progress-pending-timer-flow">
-        <di:waypoint x="3090" y="675" />
-        <di:waypoint x="3090" y="588" />
+        <di:waypoint x="3400" y="680" />
+        <di:waypoint x="3400" y="593" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="BPMNEdge_10kwile" bpmnElement="minitry-approval-change-in-progress-pending-flow">
-        <di:waypoint x="3175" y="700" />
-        <di:waypoint x="3115" y="700" />
+        <di:waypoint x="3485" y="705" />
+        <di:waypoint x="3425" y="705" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="3128" y="683" width="41" height="14" />
+          <dc:Bounds x="3438" y="688" width="41" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="BPMNEdge_16ajxf8" bpmnElement="minitry-approval-change-in-progress-pending-message-flow">
-        <di:waypoint x="3090" y="725" />
-        <di:waypoint x="3090" y="802" />
+        <di:waypoint x="3400" y="730" />
+        <di:waypoint x="3400" y="807" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="BPMNEdge_0nl7k6l" bpmnElement="minitry-approval-change-in-progress-decision-made-flow">
-        <di:waypoint x="3200" y="725" />
-        <di:waypoint x="3200" y="795" />
+        <di:waypoint x="3510" y="730" />
+        <di:waypoint x="3510" y="800" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="3205" y="747" width="90" height="14" />
+          <dc:Bounds x="3515" y="752" width="90" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="BPMNEdge_0jzdi8d" bpmnElement="minitry-approval-change-in-progress-message-received-flow">
-        <di:waypoint x="3106" y="820" />
-        <di:waypoint x="3175" y="820" />
+        <di:waypoint x="3416" y="825" />
+        <di:waypoint x="3485" y="825" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="BPMNEdge_085jk0z" bpmnElement="change-declined-flow">
-        <di:waypoint x="3225" y="820" />
-        <di:waypoint x="3350" y="820" />
+        <di:waypoint x="3535" y="825" />
+        <di:waypoint x="3660" y="825" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="3218" y="826" width="83" height="27" />
+          <dc:Bounds x="3528" y="831" width="83" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0jltxxn_di" bpmnElement="Flow_0jltxxn">
-        <di:waypoint x="3450" y="820" />
-        <di:waypoint x="3502" y="820" />
+        <di:waypoint x="3760" y="825" />
+        <di:waypoint x="3812" y="825" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0puhcea_di" bpmnElement="Flow_0puhcea">
-        <di:waypoint x="1637" y="520" />
-        <di:waypoint x="1637" y="572" />
+        <di:waypoint x="1947" y="525" />
+        <di:waypoint x="1947" y="577" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0j75jrb_di" bpmnElement="parents-verification-dependantstatus-dependant-flow">
-        <di:waypoint x="1980" y="940" />
-        <di:waypoint x="1980" y="890" />
-        <di:waypoint x="2060" y="890" />
+        <di:waypoint x="2290" y="945" />
+        <di:waypoint x="2290" y="895" />
+        <di:waypoint x="2370" y="895" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="1989" y="875" width="55" height="14" />
+          <dc:Bounds x="2300" y="880" width="54" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0u84es9_di" bpmnElement="parents-verification-dependantstatus-independant-flow">
+        <di:waypoint x="2290" y="995" />
+        <di:waypoint x="2290" y="1055" />
+        <di:waypoint x="3050" y="1055" />
+        <di:waypoint x="3050" y="995" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="2300" y="1038" width="62" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0ne5hoq_di" bpmnElement="Flow_0ne5hoq">
-        <di:waypoint x="2640" y="890" />
-        <di:waypoint x="2740" y="890" />
-        <di:waypoint x="2740" y="940" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0u84es9_di" bpmnElement="parents-verification-dependantstatus-independant-flow">
-        <di:waypoint x="1980" y="990" />
-        <di:waypoint x="1980" y="1050" />
-        <di:waypoint x="2740" y="1050" />
-        <di:waypoint x="2740" y="990" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="1989" y="1033" width="63" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0106iy0_di" bpmnElement="Flow_0106iy0">
-        <di:waypoint x="950" y="342" />
-        <di:waypoint x="980" y="342" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1w081qo_di" bpmnElement="Flow_1w081qo">
-        <di:waypoint x="1080" y="342" />
-        <di:waypoint x="1125" y="342" />
+        <di:waypoint x="2950" y="895" />
+        <di:waypoint x="3050" y="895" />
+        <di:waypoint x="3050" y="945" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0ljbhnq_di" bpmnElement="Flow_0ljbhnq">
-        <di:waypoint x="795" y="342" />
-        <di:waypoint x="850" y="342" />
+        <di:waypoint x="1105" y="347" />
+        <di:waypoint x="1160" y="347" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_07vurqq_di" bpmnElement="assessment-flow">
-        <di:waypoint x="650" y="317" />
-        <di:waypoint x="650" y="180" />
-        <di:waypoint x="745" y="180" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="655" y="145" width="60" height="27" />
-        </bpmndi:BPMNLabel>
+      <bpmndi:BPMNEdge id="Flow_0106iy0_di" bpmnElement="Flow_0106iy0">
+        <di:waypoint x="1260" y="347" />
+        <di:waypoint x="1290" y="347" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0rxxozm_di" bpmnElement="Flow_0rxxozm">
-        <di:waypoint x="540" y="342" />
-        <di:waypoint x="625" y="342" />
+      <bpmndi:BPMNEdge id="Flow_1gjp61i_di" bpmnElement="Flow_1gjp61i">
+        <di:waypoint x="1015" y="347" />
+        <di:waypoint x="1055" y="347" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1wrj7fh_di" bpmnElement="Flow_1wrj7fh">
-        <di:waypoint x="390" y="342" />
-        <di:waypoint x="440" y="342" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1ef3map_di" bpmnElement="Flow_1ef3map">
-        <di:waypoint x="258" y="343" />
-        <di:waypoint x="290" y="343" />
+      <bpmndi:BPMNEdge id="Flow_1w081qo_di" bpmnElement="Flow_1w081qo">
+        <di:waypoint x="1390" y="347" />
+        <di:waypoint x="1435" y="347" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_04qzwk1_di" bpmnElement="Flow_04qzwk1">
-        <di:waypoint x="1150" y="367" />
-        <di:waypoint x="1150" y="440" />
+        <di:waypoint x="1460" y="372" />
+        <di:waypoint x="1460" y="445" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="1157" y="405" width="65" height="14" />
+          <dc:Bounds x="1467" y="410" width="65" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0jh9h56_di" bpmnElement="Flow_0jh9h56">
-        <di:waypoint x="1150" y="520" />
-        <di:waypoint x="1150" y="572" />
+        <di:waypoint x="1460" y="525" />
+        <di:waypoint x="1460" y="577" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0mt0uyq_di" bpmnElement="Flow_0mt0uyq">
+        <di:waypoint x="5100" y="1355" />
+        <di:waypoint x="5152" y="1355" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0rkzx2d_di" bpmnElement="Flow_0rkzx2d">
+        <di:waypoint x="4958" y="1355" />
+        <di:waypoint x="5000" y="1355" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1txrz77_di" bpmnElement="Flow_1txrz77">
+        <di:waypoint x="4895" y="1355" />
+        <di:waypoint x="4922" y="1355" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_01iq5cw_di" bpmnElement="Flow_01iq5cw">
-        <di:waypoint x="4090" y="1385" />
-        <di:waypoint x="4090" y="1420" />
-        <di:waypoint x="4310" y="1420" />
+        <di:waypoint x="4400" y="1390" />
+        <di:waypoint x="4400" y="1425" />
+        <di:waypoint x="4620" y="1425" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="4103" y="1386" width="48" height="27" />
+          <dc:Bounds x="4414" y="1391" width="47" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0hmh3m7_di" bpmnElement="Flow_0hmh3m7">
-        <di:waypoint x="4410" y="1420" />
-        <di:waypoint x="4460" y="1420" />
-        <di:waypoint x="4460" y="1375" />
+        <di:waypoint x="4720" y="1425" />
+        <di:waypoint x="4770" y="1425" />
+        <di:waypoint x="4770" y="1380" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1wkpr1a_di" bpmnElement="Flow_1wkpr1a">
-        <di:waypoint x="3980" y="1385" />
-        <di:waypoint x="3980" y="1520" />
-        <di:waypoint x="4310" y="1520" />
+        <di:waypoint x="4290" y="1390" />
+        <di:waypoint x="4290" y="1525" />
+        <di:waypoint x="4620" y="1525" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="3983" y="1486" width="54" height="27" />
+          <dc:Bounds x="4293" y="1491" width="54" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1o87o98_di" bpmnElement="Flow_1o87o98">
-        <di:waypoint x="4410" y="1520" />
-        <di:waypoint x="4560" y="1520" />
-        <di:waypoint x="4560" y="1375" />
+        <di:waypoint x="4720" y="1525" />
+        <di:waypoint x="4870" y="1525" />
+        <di:waypoint x="4870" y="1380" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1atzf7v_di" bpmnElement="Flow_1atzf7v">
-        <di:waypoint x="3930" y="1360" />
-        <di:waypoint x="3955" y="1360" />
+        <di:waypoint x="4240" y="1365" />
+        <di:waypoint x="4265" y="1365" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1cb5fpw_di" bpmnElement="Flow_1cb5fpw">
-        <di:waypoint x="4005" y="1360" />
-        <di:waypoint x="4065" y="1360" />
+        <di:waypoint x="4315" y="1365" />
+        <di:waypoint x="4375" y="1365" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="3998" y="1326" width="74" height="27" />
+          <dc:Bounds x="4308" y="1331" width="74" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0p1lgm7_di" bpmnElement="Flow_0p1lgm7">
-        <di:waypoint x="4420" y="1280" />
-        <di:waypoint x="4460" y="1280" />
-        <di:waypoint x="4460" y="1325" />
+        <di:waypoint x="4730" y="1285" />
+        <di:waypoint x="4770" y="1285" />
+        <di:waypoint x="4770" y="1330" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0z518wc_di" bpmnElement="Flow_0z518wc">
-        <di:waypoint x="4485" y="1350" />
-        <di:waypoint x="4535" y="1350" />
+        <di:waypoint x="4795" y="1355" />
+        <di:waypoint x="4845" y="1355" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1a4wzic_di" bpmnElement="Flow_1a4wzic">
-        <di:waypoint x="4090" y="1335" />
-        <di:waypoint x="4090" y="1280" />
-        <di:waypoint x="4160" y="1280" />
+        <di:waypoint x="4400" y="1340" />
+        <di:waypoint x="4400" y="1285" />
+        <di:waypoint x="4470" y="1285" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="4076" y="1246" width="75" height="27" />
+          <dc:Bounds x="4386" y="1251" width="75" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1mpwyku_di" bpmnElement="Flow_1mpwyku">
+        <di:waypoint x="4095" y="1365" />
+        <di:waypoint x="4140" y="1365" />
+      </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0mayggl_di" bpmnElement="Flow_0mayggl">
-        <di:waypoint x="4260" y="1280" />
-        <di:waypoint x="4320" y="1280" />
+        <di:waypoint x="4570" y="1285" />
+        <di:waypoint x="4630" y="1285" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_13rnc99_di" bpmnElement="Flow_13rnc99">
-        <di:waypoint x="3710" y="1460" />
-        <di:waypoint x="3760" y="1460" />
-        <di:waypoint x="3760" y="1385" />
+        <di:waypoint x="4020" y="1465" />
+        <di:waypoint x="4070" y="1465" />
+        <di:waypoint x="4070" y="1390" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_17bbn8b_di" bpmnElement="Flow_17bbn8b">
-        <di:waypoint x="3710" y="1360" />
-        <di:waypoint x="3735" y="1360" />
+        <di:waypoint x="4020" y="1365" />
+        <di:waypoint x="4045" y="1365" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_07vurqq_di" bpmnElement="assessment-flow">
+        <di:waypoint x="705" y="347" />
+        <di:waypoint x="795" y="347" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="707" y="312" width="60" height="27" />
+        </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0xqg8e1_di" bpmnElement="former-youth-in-care-send-flow">
-        <di:waypoint x="795" y="180" />
-        <di:waypoint x="830" y="180" />
+        <di:waypoint x="820" y="322" />
+        <di:waypoint x="820" y="240" />
+        <di:waypoint x="870" y="240" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_10xaz6e_di" bpmnElement="Flow_10xaz6e">
-        <di:waypoint x="770" y="205" />
-        <di:waypoint x="770" y="235" />
+        <di:waypoint x="845" y="347" />
+        <di:waypoint x="965" y="347" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0ozpwlc_di" bpmnElement="former-youth-in-care-email-sent-flow">
-        <di:waypoint x="880" y="220" />
-        <di:waypoint x="880" y="260" />
-        <di:waypoint x="795" y="260" />
+        <di:waypoint x="970" y="240" />
+        <di:waypoint x="990" y="240" />
+        <di:waypoint x="990" y="322" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1gjp61i_di" bpmnElement="Flow_1gjp61i">
-        <di:waypoint x="770" y="285" />
-        <di:waypoint x="770" y="317" />
+      <bpmndi:BPMNEdge id="Flow_1ef3map_di" bpmnElement="Flow_1ef3map">
+        <di:waypoint x="288" y="348" />
+        <di:waypoint x="320" y="348" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1wrj7fh_di" bpmnElement="Flow_1wrj7fh">
+        <di:waypoint x="420" y="347" />
+        <di:waypoint x="470" y="347" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0rxxozm_di" bpmnElement="Flow_0rxxozm">
+        <di:waypoint x="570" y="347" />
+        <di:waypoint x="655" y="347" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Association_1gbgxzr_di" bpmnElement="Association_1gbgxzr">
+        <di:waypoint x="3510" y="876" />
+        <di:waypoint x="3473" y="1010" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Association_1ek1rle_di" bpmnElement="Association_1ek1rle">
+        <di:waypoint x="2770" y="1377" />
+        <di:waypoint x="2358" y="1476" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Association_0z482ud_di" bpmnElement="Association_0z482ud">
+        <di:waypoint x="1740" y="800" />
+        <di:waypoint x="2322" y="542" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Association_110g427_di" bpmnElement="Association_110g427">
+        <di:waypoint x="3514" y="590" />
+        <di:waypoint x="3470" y="575" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Association_1wys3mp_di" bpmnElement="Association_1wys3mp">
+        <di:waypoint x="3482" y="690" />
+        <di:waypoint x="3493" y="697" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="BPMNShape_0vf0jbr" bpmnElement="Group_19tqt3y">
-        <dc:Bounds x="1930" y="250" width="730" height="170" />
+        <dc:Bounds x="1860" y="340" width="730" height="170" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="2257" y="257" width="78" height="27" />
+          <dc:Bounds x="2187" y="347" width="78" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="BPMNShape_04nqxe3" bpmnElement="Group_0uz5ydc">
-        <dc:Bounds x="1930" y="440" width="730" height="280" />
+        <dc:Bounds x="1860" y="530" width="730" height="280" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="2258" y="447" width="76" height="27" />
+          <dc:Bounds x="2188" y="537" width="76" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="BPMNShape_0mw83as" bpmnElement="Group_0ldd4rw">
-        <dc:Bounds x="1930" y="740" width="880" height="350" />
+        <dc:Bounds x="1860" y="830" width="880" height="350" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="2331" y="746" width="78" height="27" />
+          <dc:Bounds x="2261" y="836" width="78" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Group_0vb3fvp_di" bpmnElement="Group_0vb3fvp">
-        <dc:Bounds x="2220" y="1220" width="700" height="290" />
+        <dc:Bounds x="2150" y="1310" width="700" height="290" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="2520" y="1230" width="60" height="40" />
+          <dc:Bounds x="2450" y="1320" width="60" height="40" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="TextAnnotation_0g9dtl6_di" bpmnElement="TextAnnotation_0g9dtl6">
-        <dc:Bounds x="2240" y="1370" width="188" height="110" />
+        <dc:Bounds x="2170" y="1460" width="188" height="110" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="BPMNShape_0m4ufpe" bpmnElement="TextAnnotation_1qwxwaf">
-        <dc:Bounds x="3320" y="500" width="310" height="40" />
+        <dc:Bounds x="3250" y="590" width="310" height="40" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="BPMNShape_0ouejj4" bpmnElement="TextAnnotation_17tw6q4">
-        <dc:Bounds x="3320" y="600" width="353" height="55" />
+        <dc:Bounds x="3250" y="690" width="353" height="55" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="TextAnnotation_1inm7cq_di" bpmnElement="TextAnnotation_1inm7cq">
-        <dc:Bounds x="3260" y="920" width="481" height="70" />
+        <dc:Bounds x="3190" y="1010" width="481" height="70" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="BPMNShape_0xhexpd" bpmnElement="TextAnnotation_1q6xzna">
-        <dc:Bounds x="1570" y="710" width="299.99462134251297" height="127.36660929432014" />
+        <dc:Bounds x="1500" y="800" width="300" height="127" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="Association_1gbgxzr_di" bpmnElement="Association_1gbgxzr">
-        <di:waypoint x="3200" y="871" />
-        <di:waypoint x="3273" y="920" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Association_1ek1rle_di" bpmnElement="Association_1ek1rle">
-        <di:waypoint x="2460" y="1374" />
-        <di:waypoint x="2428" y="1383" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Association_110g427_di" bpmnElement="Association_110g427">
-        <di:waypoint x="3320" y="536" />
-        <di:waypoint x="3260" y="564" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Association_1wys3mp_di" bpmnElement="Association_1wys3mp">
-        <di:waypoint x="3320" y="647" />
-        <di:waypoint x="3219" y="694" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Association_0z482ud_di" bpmnElement="Association_0z482ud">
-        <di:waypoint x="1776" y="710" />
-        <di:waypoint x="2015" y="540" />
-      </bpmndi:BPMNEdge>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1tu9mrb">

--- a/sources/packages/backend/workflow/src/workflow-definitions/assessment-gateway-v2.bpmn
+++ b/sources/packages/backend/workflow/src/workflow-definitions/assessment-gateway-v2.bpmn
@@ -633,7 +633,7 @@ Note: the workflow process should continue its execution as a regular reassessme
       <bpmn:extensionElements>
         <zeebe:ioMapping>
           <zeebe:output source="=null" target="applicationId" />
-          <zeebe:output source="=null" target="applicationNumber" />
+          <zeebe:output source="=null" target="parentApplicationId" />
           <zeebe:output source="=assessmentId" target="assessmentId" />
           <zeebe:output source="=null" target="applicationExceptionStatus" />
           <zeebe:output source="=null" target="studentDataSelectedOffering" />
@@ -943,7 +943,7 @@ Note: the workflow process should continue its execution as a regular reassessme
           <zeebe:header key="recipientType" value="student" />
         </zeebe:taskHeaders>
         <zeebe:ioMapping>
-          <zeebe:input source="={applicationNumber: applicationNumber}" target="emailNotificationCheckMetadata" />
+          <zeebe:input source="={parentApplicationId: parentApplicationId}" target="emailNotificationCheckMetadata" />
         </zeebe:ioMapping>
       </bpmn:extensionElements>
       <bpmn:incoming>former-youth-in-care-send-flow</bpmn:incoming>

--- a/sources/packages/backend/workflow/src/workflow-definitions/assessment-gateway-v2.bpmn
+++ b/sources/packages/backend/workflow/src/workflow-definitions/assessment-gateway-v2.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bioc="http://bpmn.io/schema/bpmn/biocolor/1.0" xmlns:color="http://www.omg.org/spec/BPMN/non-normative/color/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.43.1" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.6.0" camunda:diagramRelationId="f874f098-96b6-491d-81ec-ecf7a0d8c67a">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bioc="http://bpmn.io/schema/bpmn/biocolor/1.0" xmlns:color="http://www.omg.org/spec/BPMN/non-normative/color/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.49.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.6.0" camunda:diagramRelationId="f874f098-96b6-491d-81ec-ecf7a0d8c67a">
   <bpmn:collaboration id="Collaboration_0z9wj8q">
     <bpmn:participant id="application-in-progress" name="Assessment" processRef="assessment-gateway-v2" />
     <bpmn:group id="Group_19tqt3y" categoryValueRef="CategoryValue_1l89ztr" />
@@ -928,10 +928,10 @@ Note: the workflow process should continue its execution as a regular reassessme
     <bpmn:sequenceFlow id="assessment-flow" name="Original Assessment" sourceRef="assessment-process-type-gateway" targetRef="former-youth-in-care-gateway">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=assessmentTriggerType = "Original assessment"</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="former-youth-in-care-send-flow" sourceRef="former-youth-in-care-gateway" targetRef="send-former-youth-in-care-email-task">
+    <bpmn:sequenceFlow id="former-youth-in-care-send-flow" name="Yes" sourceRef="former-youth-in-care-gateway" targetRef="send-former-youth-in-care-email-task">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=studentDataYouthInCare != "no"</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="Flow_10xaz6e" sourceRef="former-youth-in-care-gateway" targetRef="former-youth-in-care-join-gateway" />
+    <bpmn:sequenceFlow id="Flow_10xaz6e" name="No" sourceRef="former-youth-in-care-gateway" targetRef="former-youth-in-care-join-gateway" />
     <bpmn:sequenceFlow id="former-youth-in-care-email-sent-flow" sourceRef="send-former-youth-in-care-email-task" targetRef="former-youth-in-care-join-gateway" />
     <bpmn:sequenceFlow id="Flow_1ef3map" sourceRef="assessment-start-event" targetRef="associate-workflow-instance-task" />
     <bpmn:sequenceFlow id="Flow_1wrj7fh" sourceRef="associate-workflow-instance-task" targetRef="load-assessment-data-submit-or-reassessment-subprocess" />
@@ -1792,10 +1792,16 @@ Note: the workflow process should continue its execution as a regular reassessme
         <di:waypoint x="820" y="372" />
         <di:waypoint x="820" y="424" />
         <di:waypoint x="860" y="424" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="826" y="395" width="18" height="14" />
+        </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_10xaz6e_di" bpmnElement="Flow_10xaz6e">
         <di:waypoint x="845" y="347" />
         <di:waypoint x="965" y="347" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="898" y="329" width="15" height="14" />
+        </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0ozpwlc_di" bpmnElement="former-youth-in-care-email-sent-flow">
         <di:waypoint x="960" y="424" />
@@ -1813,26 +1819,6 @@ Note: the workflow process should continue its execution as a regular reassessme
       <bpmndi:BPMNEdge id="Flow_0rxxozm_di" bpmnElement="Flow_0rxxozm">
         <di:waypoint x="570" y="347" />
         <di:waypoint x="655" y="347" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Association_1ek1rle_di" bpmnElement="Association_1ek1rle">
-        <di:waypoint x="2770" y="1392" />
-        <di:waypoint x="2736" y="1410" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Association_110g427_di" bpmnElement="Association_110g427">
-        <di:waypoint x="3640" y="544" />
-        <di:waypoint x="3570" y="572" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Association_1wys3mp_di" bpmnElement="Association_1wys3mp">
-        <di:waypoint x="3640" y="660" />
-        <di:waypoint x="3530" y="700" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Association_1gbgxzr_di" bpmnElement="Association_1gbgxzr">
-        <di:waypoint x="3494" y="935" />
-        <di:waypoint x="3664" y="970" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Association_0z482ud_di" bpmnElement="Association_0z482ud">
-        <di:waypoint x="2063" y="710" />
-        <di:waypoint x="2324" y="544" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="BPMNShape_0vf0jbr" bpmnElement="Group_19tqt3y">
         <dc:Bounds x="2245" y="255" width="730" height="170" />
@@ -1878,6 +1864,26 @@ Note: the workflow process should continue its execution as a regular reassessme
         <dc:Bounds x="1850" y="710" width="300" height="127" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Association_1gbgxzr_di" bpmnElement="Association_1gbgxzr">
+        <di:waypoint x="3494" y="935" />
+        <di:waypoint x="3664" y="970" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Association_1ek1rle_di" bpmnElement="Association_1ek1rle">
+        <di:waypoint x="2770" y="1392" />
+        <di:waypoint x="2736" y="1410" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Association_110g427_di" bpmnElement="Association_110g427">
+        <di:waypoint x="3640" y="544" />
+        <di:waypoint x="3570" y="572" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Association_1wys3mp_di" bpmnElement="Association_1wys3mp">
+        <di:waypoint x="3640" y="660" />
+        <di:waypoint x="3530" y="700" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Association_0z482ud_di" bpmnElement="Association_0z482ud">
+        <di:waypoint x="2063" y="710" />
+        <di:waypoint x="2324" y="544" />
+      </bpmndi:BPMNEdge>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1tu9mrb">

--- a/sources/packages/backend/workflow/src/workflow-definitions/load-assessment-consolidated-data.bpmn
+++ b/sources/packages/backend/workflow/src/workflow-definitions/load-assessment-consolidated-data.bpmn
@@ -15,6 +15,7 @@
           <zeebe:header key="assessmentTriggerType" value="triggerType" />
           <zeebe:header key="applicationExceptionsStrategy" value="data.applicationExceptionsStrategy" />
           <zeebe:header key="applicationId" value="applicationId" />
+          <zeebe:header key="applicationNumber" value="applicationNumber" />
           <zeebe:header key="applicationStatus" value="applicationStatus" />
           <zeebe:header key="applicationEditStatus" value="applicationEditStatus" />
           <zeebe:header key="applicationHasNOAApproval" value="hasNOAApproval" />

--- a/sources/packages/backend/workflow/src/workflow-definitions/load-assessment-consolidated-data.bpmn
+++ b/sources/packages/backend/workflow/src/workflow-definitions/load-assessment-consolidated-data.bpmn
@@ -15,7 +15,7 @@
           <zeebe:header key="assessmentTriggerType" value="triggerType" />
           <zeebe:header key="applicationExceptionsStrategy" value="data.applicationExceptionsStrategy" />
           <zeebe:header key="applicationId" value="applicationId" />
-          <zeebe:header key="applicationNumber" value="applicationNumber" />
+          <zeebe:header key="parentApplicationId" value="parentApplicationId" />
           <zeebe:header key="applicationStatus" value="applicationStatus" />
           <zeebe:header key="applicationEditStatus" value="applicationEditStatus" />
           <zeebe:header key="applicationHasNOAApproval" value="hasNOAApproval" />

--- a/sources/packages/backend/workflow/test/2025-2026/assessment-gateway/assessment-gateway.originalAssessment.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2025-2026/assessment-gateway/assessment-gateway.originalAssessment.e2e-spec.ts
@@ -37,7 +37,7 @@ import {
   PROGRAM_YEAR,
   PROGRAM_YEAR_BASE_ID,
 } from "../constants/program-year.constants";
-import { AssessmentDataType } from "@sims/test-utils";
+import { AssessmentDataType, YesNoOptions } from "@sims/test-utils";
 import { ZeebeGrpcClient } from "@camunda8/sdk/dist/zeebe";
 
 describe(`E2E Test Workflow assessment gateway on original assessment for ${PROGRAM_YEAR}`, () => {
@@ -615,6 +615,53 @@ describe(`E2E Test Workflow assessment gateway on original assessment for ${PROG
       assessmentGatewayResponse.variables,
       WorkflowServiceTasks.ProgramInfoNotRequired,
       WorkflowServiceTasks.VerifyApplicationExceptions,
+    );
+  });
+
+  it("Should not send the former youth in care email when the student declares not to be a former youth in care.", async () => {
+    // Arrange
+
+    // Assessment consolidated mocked data with the student declaring not to be a former youth in care.
+    const assessmentConsolidatedData: AssessmentConsolidatedData = {
+      assessmentTriggerType: AssessmentTriggerType.OriginalAssessment,
+      ...createFakeConsolidatedFulltimeData(PROGRAM_YEAR),
+      ...createFakeSingleIndependentStudentData(),
+      studentDataYouthInCare: YesNoOptions.No,
+      // Application with PIR not required.
+      studentDataSelectedOffering: 1,
+    };
+
+    const workersMockedData = createWorkersMockedData([
+      createLoadAssessmentDataTaskMock({ assessmentConsolidatedData }),
+      createProgramInfoNotRequiredTaskMock(),
+      createVerifyApplicationExceptionsTaskMock(),
+      createIncomeRequestTaskMock({
+        incomeVerificationId: incomeVerificationId++,
+        subprocesses: WorkflowSubprocesses.StudentIncomeVerification,
+      }),
+      createCheckIncomeRequestTaskMock({
+        subprocesses: WorkflowSubprocesses.StudentIncomeVerification,
+      }),
+      createVerifyAssessmentCalculationOrderTaskMock(),
+    ]);
+
+    const currentAssessmentId = assessmentId++;
+
+    // Act
+    const assessmentGatewayResponse =
+      await zeebeClientProvider.createProcessInstanceWithResult({
+        bpmnProcessId: DEFAULT_ASSESSMENT_GATEWAY,
+        variables: {
+          [ASSESSMENT_ID]: currentAssessmentId,
+          ...workersMockedData,
+        },
+        requestTimeout: PROCESS_INSTANCE_CREATE_TIMEOUT,
+      });
+
+    // Assert
+    expectNotToPassThroughServiceTasks(
+      assessmentGatewayResponse.variables,
+      WorkflowServiceTasks.SendFormerYouthInCareEmail,
     );
   });
 

--- a/sources/packages/backend/workflow/test/2025-2026/assessment-gateway/assessment-gateway.originalAssessment.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2025-2026/assessment-gateway/assessment-gateway.originalAssessment.e2e-spec.ts
@@ -618,6 +618,53 @@ describe(`E2E Test Workflow assessment gateway on original assessment for ${PROG
     );
   });
 
+  it("Should send the former youth in care email when the student declares to be a former youth in care.", async () => {
+    // Arrange
+
+    // Assessment consolidated mocked data with the student declaring to be a former youth in care.
+    const assessmentConsolidatedData: AssessmentConsolidatedData = {
+      assessmentTriggerType: AssessmentTriggerType.OriginalAssessment,
+      ...createFakeConsolidatedFulltimeData(PROGRAM_YEAR),
+      ...createFakeSingleIndependentStudentData(),
+      studentDataYouthInCare: YesNoOptions.Yes,
+      // Application with PIR not required.
+      studentDataSelectedOffering: 1,
+    };
+
+    const workersMockedData = createWorkersMockedData([
+      createLoadAssessmentDataTaskMock({ assessmentConsolidatedData }),
+      createProgramInfoNotRequiredTaskMock(),
+      createVerifyApplicationExceptionsTaskMock(),
+      createIncomeRequestTaskMock({
+        incomeVerificationId: incomeVerificationId++,
+        subprocesses: WorkflowSubprocesses.StudentIncomeVerification,
+      }),
+      createCheckIncomeRequestTaskMock({
+        subprocesses: WorkflowSubprocesses.StudentIncomeVerification,
+      }),
+      createVerifyAssessmentCalculationOrderTaskMock(),
+    ]);
+
+    const currentAssessmentId = assessmentId++;
+
+    // Act
+    const assessmentGatewayResponse =
+      await zeebeClientProvider.createProcessInstanceWithResult({
+        bpmnProcessId: DEFAULT_ASSESSMENT_GATEWAY,
+        variables: {
+          [ASSESSMENT_ID]: currentAssessmentId,
+          ...workersMockedData,
+        },
+        requestTimeout: PROCESS_INSTANCE_CREATE_TIMEOUT,
+      });
+
+    // Assert
+    expectToPassThroughServiceTasks(
+      assessmentGatewayResponse.variables,
+      WorkflowServiceTasks.SendFormerYouthInCareEmail,
+    );
+  });
+
   it("Should not send the former youth in care email when the student declares not to be a former youth in care.", async () => {
     // Arrange
 

--- a/sources/packages/backend/workflow/test/2026-2027/assessment-gateway/assessment-gateway.originalAssessment.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2026-2027/assessment-gateway/assessment-gateway.originalAssessment.e2e-spec.ts
@@ -680,6 +680,53 @@ describe(`E2E Test Workflow assessment gateway on original assessment for ${PROG
     }
   });
 
+  it("Should not send the former youth in care email when the student declares not to be a former youth in care.", async () => {
+    // Arrange
+
+    // Assessment consolidated mocked data with the student declaring not to be a former youth in care.
+    const assessmentConsolidatedData: AssessmentConsolidatedData = {
+      assessmentTriggerType: AssessmentTriggerType.OriginalAssessment,
+      ...createFakeConsolidatedFulltimeData(PROGRAM_YEAR),
+      ...createFakeSingleIndependentStudentData(),
+      studentDataYouthInCare: YesNoOptions.No,
+      // Application with PIR not required.
+      studentDataSelectedOffering: 1,
+    };
+
+    const workersMockedData = createWorkersMockedData([
+      createLoadAssessmentDataTaskMock({ assessmentConsolidatedData }),
+      createProgramInfoNotRequiredTaskMock(),
+      createVerifyApplicationExceptionsTaskMock(),
+      createIncomeRequestTaskMock({
+        incomeVerificationId: incomeVerificationId++,
+        subprocesses: WorkflowSubprocesses.StudentIncomeVerification,
+      }),
+      createCheckIncomeRequestTaskMock({
+        subprocesses: WorkflowSubprocesses.StudentIncomeVerification,
+      }),
+      createVerifyAssessmentCalculationOrderTaskMock(),
+    ]);
+
+    const currentAssessmentId = assessmentId++;
+
+    // Act
+    const assessmentGatewayResponse =
+      await zeebeClientProvider.createProcessInstanceWithResult({
+        bpmnProcessId: DEFAULT_ASSESSMENT_GATEWAY,
+        variables: {
+          [ASSESSMENT_ID]: currentAssessmentId,
+          ...workersMockedData,
+        },
+        requestTimeout: PROCESS_INSTANCE_CREATE_TIMEOUT,
+      });
+
+    // Assert
+    expectNotToPassThroughServiceTasks(
+      assessmentGatewayResponse.variables,
+      WorkflowServiceTasks.SendFormerYouthInCareEmail,
+    );
+  });
+
   afterAll(async () => {
     await zeebeClientProvider?.close();
   });

--- a/sources/packages/backend/workflow/test/2026-2027/assessment-gateway/assessment-gateway.originalAssessment.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2026-2027/assessment-gateway/assessment-gateway.originalAssessment.e2e-spec.ts
@@ -680,6 +680,53 @@ describe(`E2E Test Workflow assessment gateway on original assessment for ${PROG
     }
   });
 
+  it("Should send the former youth in care email when the student declares to be a former youth in care.", async () => {
+    // Arrange
+
+    // Assessment consolidated mocked data with the student declaring to be a former youth in care.
+    const assessmentConsolidatedData: AssessmentConsolidatedData = {
+      assessmentTriggerType: AssessmentTriggerType.OriginalAssessment,
+      ...createFakeConsolidatedFulltimeData(PROGRAM_YEAR),
+      ...createFakeSingleIndependentStudentData(),
+      studentDataYouthInCare: YesNoOptions.Yes,
+      // Application with PIR not required.
+      studentDataSelectedOffering: 1,
+    };
+
+    const workersMockedData = createWorkersMockedData([
+      createLoadAssessmentDataTaskMock({ assessmentConsolidatedData }),
+      createProgramInfoNotRequiredTaskMock(),
+      createVerifyApplicationExceptionsTaskMock(),
+      createIncomeRequestTaskMock({
+        incomeVerificationId: incomeVerificationId++,
+        subprocesses: WorkflowSubprocesses.StudentIncomeVerification,
+      }),
+      createCheckIncomeRequestTaskMock({
+        subprocesses: WorkflowSubprocesses.StudentIncomeVerification,
+      }),
+      createVerifyAssessmentCalculationOrderTaskMock(),
+    ]);
+
+    const currentAssessmentId = assessmentId++;
+
+    // Act
+    const assessmentGatewayResponse =
+      await zeebeClientProvider.createProcessInstanceWithResult({
+        bpmnProcessId: DEFAULT_ASSESSMENT_GATEWAY,
+        variables: {
+          [ASSESSMENT_ID]: currentAssessmentId,
+          ...workersMockedData,
+        },
+        requestTimeout: PROCESS_INSTANCE_CREATE_TIMEOUT,
+      });
+
+    // Assert
+    expectToPassThroughServiceTasks(
+      assessmentGatewayResponse.variables,
+      WorkflowServiceTasks.SendFormerYouthInCareEmail,
+    );
+  });
+
   it("Should not send the former youth in care email when the student declares not to be a former youth in care.", async () => {
     // Arrange
 

--- a/sources/packages/backend/workflow/test/test-utils/constants/workflow-variables-constants.ts
+++ b/sources/packages/backend/workflow/test/test-utils/constants/workflow-variables-constants.ts
@@ -23,6 +23,7 @@ export enum WorkflowServiceTasks {
   SaveDisbursementSchedulesPartTime = "save-disbursement-part-time-task",
   AssociateMSFAA = "associate-msfaa-task",
   VerifyAssessmentCalculationOrderTask = "verify-assessment-calculation-order-task",
+  SendFormerYouthInCareEmail = "send-former-youth-in-care-email-task",
   // Workflow - CRA Integration Income Verification
   CreateIncomeRequest = "create-income-request-task",
   CheckIncomeRequest = "check-income-request-task",


### PR DESCRIPTION
### Summary

Sends a student notification when an application is created with "Former youth in care" question is answered.
New worker that allows sending email notifications directly from camunda.

The code changes are prepared to send notifications without a database migration that inserts gc notify template data, however it is not used in this feature and it was only tested using e2e tests.

<img width="1321" height="879" alt="image" src="https://github.com/user-attachments/assets/d95cc93f-0ea4-463b-9d0c-2ef639ed4b89" />
note: the workflow above was changed to use ApplicationParentId instead of ApplicationId to check for uniqueness since application Id can change with edits.
<img width="805" height="462" alt="image" src="https://github.com/user-attachments/assets/3d84a562-41a7-4018-b486-fb7283536b59" />
