### PR TITLE
#6389 - Assessment: Interface assessed need calculation

### DIFF
--- a/sources/packages/backend/workflow/src/workflow-definitions/fulltime-assessment-2025-2026.bpmn
+++ b/sources/packages/backend/workflow/src/workflow-definitions/fulltime-assessment-2025-2026.bpmn
@@ -164,7 +164,7 @@ calculatedDataParent1TaxRate</bpmn:text>
     <bpmn:association id="Association_013h80t" associationDirection="None" sourceRef="Activity_17g355h" targetRef="TextAnnotation_0acv2yp" />
     <bpmn:group id="Group_0tzz616" />
     <bpmn:textAnnotation id="TextAnnotation_01utjft">
-      <bpmn:text>Variables created in this scope that will be consumed in upcoming logic, must have their creation ensured for all the flows.
+      <bpmn:text>Variables created in this scope that will be consumed in upcoming logic must have their creation ensured for all the flows.
 For instance:
 - calculatedDataTotalEligibleDependants
 - calculatedDataTotalChildcareDependants</bpmn:text>
@@ -4654,10 +4654,6 @@ The total parent deductions are rounded half up (5.5 = 6) to align with our whol
         <di:waypoint x="863" y="594" />
         <di:waypoint x="804" y="458" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Association_139zks3_di" bpmnElement="Association_139zks3">
-        <di:waypoint x="1843" y="750" />
-        <di:waypoint x="1817" y="678" />
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="Group_0lerduq_di" bpmnElement="Group_0lerduq">
         <dc:Bounds x="5200" y="1180" width="870" height="760" />
         <bpmndi:BPMNLabel>
@@ -4864,6 +4860,13 @@ The total parent deductions are rounded half up (5.5 = 6) to align with our whol
         <dc:Bounds x="1165" y="140" width="305" height="100" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Group_0tzz616_di" bpmnElement="Group_0tzz616">
+        <dc:Bounds x="1740" y="255" width="95" height="423" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1hysyo3" bpmnElement="TextAnnotation_01utjft">
+        <dc:Bounds x="1700" y="750" width="305" height="98" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
       <bpmndi:BPMNEdge id="Association_1cey5l7_di" bpmnElement="Association_1cey5l7">
         <di:waypoint x="7617" y="1728" />
         <di:waypoint x="7637" y="1845" />
@@ -4940,13 +4943,10 @@ The total parent deductions are rounded half up (5.5 = 6) to align with our whol
         <di:waypoint x="1261" y="351" />
         <di:waypoint x="1235" y="240" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNShape id="Group_0tzz616_di" bpmnElement="Group_0tzz616">
-        <dc:Bounds x="1740" y="255" width="95" height="423" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="BPMNShape_1hysyo3" bpmnElement="TextAnnotation_01utjft">
-        <dc:Bounds x="1700" y="750" width="305" height="98" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Association_139zks3_di" bpmnElement="Association_139zks3">
+        <di:waypoint x="1843" y="750" />
+        <di:waypoint x="1817" y="678" />
+      </bpmndi:BPMNEdge>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>
   <bpmndi:BPMNDiagram id="BPMNDiagram_0lbfbig">

--- a/sources/packages/backend/workflow/src/workflow-definitions/fulltime-assessment-2025-2026.bpmn
+++ b/sources/packages/backend/workflow/src/workflow-definitions/fulltime-assessment-2025-2026.bpmn
@@ -2133,6 +2133,7 @@ If distance education/blended learning program or if married and claiming separa
           <zeebe:output source="=max(calculatedDataTotalEligibleParent1Dependants,calculatedDataTotalEligibleParent2Dependants)" target="calculatedDataTotalParentEligibleDependants" />
           <zeebe:output source="=max(calculatedDataTotalEligibleParent1ContributionDependants,calculatedDataTotalEligibleParent2ContributionDependants)" target="calculatedDataTotalParentEligibleContributionDependants" />
           <zeebe:output source="=0" target="calculatedDataTotalEligibleDependants" />
+          <zeebe:output source="=0" target="calculatedDataTotalChildcareDependants" />
         </zeebe:ioMapping>
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_0ovh763</bpmn:incoming>
@@ -2144,6 +2145,7 @@ If distance education/blended learning program or if married and claiming separa
           <zeebe:output source="=if parent1DependentTable = null then 0 else&#10;  count(&#10;parent1DependentTable[&#10;// 0-18 years of age: eligible.&#10;date(item.dateOfBirth) &#62;= (date(offeringStudyStartDate) - duration(&#34;P18Y&#34;))&#10;// 19-22 years of age: post-sec must be Yes or Tax is Yes.&#10;or (&#10;  date(item.dateOfBirth) &#60; (date(offeringStudyStartDate) - duration(&#34;P18Y&#34;))&#10;  and date(item.dateOfBirth) &#62;= (date(offeringStudyStartDate) - duration(&#34;P22Y&#34;))&#10;  and (item.attendingPostSecondarySchool = &#34;yes&#34; or item.declaredOnTaxes = &#34;yes&#34;)&#10;)&#10;// &#62; 22 years: eligible if Tax is Yes.&#10;or (&#10;  date(item.dateOfBirth) &#60; (date(offeringStudyStartDate) - duration(&#34;P22Y&#34;))&#10;  and item.declaredOnTaxes = &#34;yes&#34;&#10;)&#10;]&#10;  )" target="calculatedDataTotalParentEligibleDependants" />
           <zeebe:output source="=// 19-22 years of age: post-sec must be Yes&#10;if parent1DependentTable = null then 1 else&#10;  count(&#10;parent1DependentTable[&#10;  date(item.dateOfBirth) &#60; (date(offeringStudyStartDate) - duration(&#34;P18Y&#34;))&#10;  and date(item.dateOfBirth) &#62;= (date(offeringStudyStartDate) - duration(&#34;P22Y&#34;))&#10;  and item.attendingPostSecondarySchool = &#34;yes&#34;&#10;]&#10;  )+1" target="calculatedDataTotalParentEligibleContributionDependants" />
           <zeebe:output source="=0" target="calculatedDataTotalEligibleDependants" />
+          <zeebe:output source="=0" target="calculatedDataTotalChildcareDependants" />
         </zeebe:ioMapping>
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_1li9w29</bpmn:incoming>
@@ -2212,6 +2214,7 @@ If distance education/blended learning program or if married and claiming separa
           <zeebe:output source="=if appealDataParentDependentTable = null then 0 else&#10;  count(&#10;appealDataParentDependentTable[&#10;// 0-18 years of age: eligible.&#10;date(item.dateOfBirth) &#62;= (date(offeringStudyStartDate) - duration(&#34;P18Y&#34;))&#10;// 19-22 years of age: post-sec must be Yes or Tax is Yes.&#10;or (&#10;  date(item.dateOfBirth) &#60; (date(offeringStudyStartDate) - duration(&#34;P18Y&#34;))&#10;  and date(item.dateOfBirth) &#62;= (date(offeringStudyStartDate) - duration(&#34;P22Y&#34;))&#10;  and (item.attendingPostSecondarySchool = &#34;yes&#34; or item.declaredOnTaxes = &#34;yes&#34;)&#10;)&#10;// &#62; 22 years: eligible if Tax is Yes.&#10;or (&#10;  date(item.dateOfBirth) &#60; (date(offeringStudyStartDate) - duration(&#34;P22Y&#34;))&#10;  and item.declaredOnTaxes = &#34;yes&#34;&#10;)&#10;]&#10;  )" target="calculatedDataTotalParentEligibleDependants" />
           <zeebe:output source="=// 19-22 years of age: post-sec must be Yes&#10;if appealDataParentDependentTable = null then 1 else&#10;  count(&#10;appealDataParentDependentTable[&#10;  date(item.dateOfBirth) &#60; (date(offeringStudyStartDate) - duration(&#34;P18Y&#34;))&#10;  and date(item.dateOfBirth) &#62;= (date(offeringStudyStartDate) - duration(&#34;P22Y&#34;))&#10;  and item.attendingPostSecondarySchool = &#34;yes&#34;&#10;]&#10;  )+1" target="calculatedDataTotalParentEligibleContributionDependants" />
           <zeebe:output source="=0" target="calculatedDataTotalEligibleDependants" />
+          <zeebe:output source="=0" target="calculatedDataTotalChildcareDependants" />
         </zeebe:ioMapping>
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_1m2uh8r</bpmn:incoming>

--- a/sources/packages/backend/workflow/src/workflow-definitions/fulltime-assessment-2025-2026.bpmn
+++ b/sources/packages/backend/workflow/src/workflow-definitions/fulltime-assessment-2025-2026.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" id="Definitions_0ihicdz" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.43.1" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.6.0" camunda:diagramRelationId="7a75e87a-6774-4e60-9a94-5dbbe3be143a">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" id="Definitions_0ihicdz" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.46.1" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.6.0" camunda:diagramRelationId="7a75e87a-6774-4e60-9a94-5dbbe3be143a">
   <bpmn:message id="Message_3q4oc02" name="Message_3q4oc02" />
   <bpmn:collaboration id="Collaboration_1cf99un">
     <bpmn:participant id="Participant_1mct69m" name="fulltime-assessment-2025-2026" processRef="fulltime-assessment-2025-2026" />
@@ -162,6 +162,14 @@ calculatedDataParent2EstimatedIncomeDeductions
 calculatedDataParent1TaxRate</bpmn:text>
     </bpmn:textAnnotation>
     <bpmn:association id="Association_013h80t" associationDirection="None" sourceRef="Activity_17g355h" targetRef="TextAnnotation_0acv2yp" />
+    <bpmn:group id="Group_0tzz616" />
+    <bpmn:textAnnotation id="TextAnnotation_01utjft">
+      <bpmn:text>Variables created in this scope that will be consumed in upcoming logic, must have their creation ensured for all the flows.
+For instance:
+- calculatedDataTotalEligibleDependants
+- calculatedDataTotalChildcareDependants</bpmn:text>
+    </bpmn:textAnnotation>
+    <bpmn:association id="Association_139zks3" associationDirection="None" sourceRef="TextAnnotation_01utjft" targetRef="Group_0tzz616" />
   </bpmn:collaboration>
   <bpmn:process id="fulltime-assessment-2025-2026" isExecutable="true">
     <bpmn:laneSet id="LaneSet_0i75wz3">
@@ -4643,6 +4651,10 @@ The total parent deductions are rounded half up (5.5 = 6) to align with our whol
         <di:waypoint x="863" y="594" />
         <di:waypoint x="804" y="458" />
       </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Association_139zks3_di" bpmnElement="Association_139zks3">
+        <di:waypoint x="1843" y="750" />
+        <di:waypoint x="1817" y="678" />
+      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="Group_0lerduq_di" bpmnElement="Group_0lerduq">
         <dc:Bounds x="5200" y="1180" width="870" height="760" />
         <bpmndi:BPMNLabel>
@@ -4925,6 +4937,13 @@ The total parent deductions are rounded half up (5.5 = 6) to align with our whol
         <di:waypoint x="1261" y="351" />
         <di:waypoint x="1235" y="240" />
       </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Group_0tzz616_di" bpmnElement="Group_0tzz616">
+        <dc:Bounds x="1740" y="255" width="95" height="423" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1hysyo3" bpmnElement="TextAnnotation_01utjft">
+        <dc:Bounds x="1700" y="750" width="305" height="98" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>
   <bpmndi:BPMNDiagram id="BPMNDiagram_0lbfbig">

--- a/sources/packages/backend/workflow/src/workflow-definitions/fulltime-assessment-2026-2027.bpmn
+++ b/sources/packages/backend/workflow/src/workflow-definitions/fulltime-assessment-2026-2027.bpmn
@@ -137,6 +137,14 @@ calculatedDataParent1TaxRate</bpmn:text>
 Will not change based on institution or appeal</bpmn:text>
     </bpmn:textAnnotation>
     <bpmn:association id="Association_069y725" associationDirection="None" sourceRef="TextAnnotation_0eilku9" targetRef="Event_1jlyysi" />
+    <bpmn:group id="Group_0tzz616" />
+    <bpmn:textAnnotation id="TextAnnotation_01utjft">
+      <bpmn:text>Variables created in this scope that will be consumed in upcoming logic, must have their creation ensured for all the flows.
+For instance:
+- calculatedDataTotalEligibleDependants
+- calculatedDataTotalChildcareDependants</bpmn:text>
+    </bpmn:textAnnotation>
+    <bpmn:association id="Association_17pjjzp" associationDirection="None" sourceRef="TextAnnotation_01utjft" targetRef="Group_0tzz616" />
   </bpmn:collaboration>
   <bpmn:process id="fulltime-assessment-2026-2027" isExecutable="true">
     <bpmn:laneSet id="LaneSet_0i75wz3">
@@ -1957,6 +1965,7 @@ There is also a per application limit based on the number of weeks in the offeri
           <zeebe:output source="=max(calculatedDataTotalEligibleParent1Dependants,calculatedDataTotalEligibleParent2Dependants)" target="calculatedDataTotalParentEligibleDependants" />
           <zeebe:output source="=max(calculatedDataTotalEligibleParent1ContributionDependants,calculatedDataTotalEligibleParent2ContributionDependants)" target="calculatedDataTotalParentEligibleContributionDependants" />
           <zeebe:output source="=0" target="calculatedDataTotalEligibleDependants" />
+          <zeebe:output source="=0" target="calculatedDataTotalChildcareDependants" />
         </zeebe:ioMapping>
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_0ovh763</bpmn:incoming>
@@ -1968,6 +1977,7 @@ There is also a per application limit based on the number of weeks in the offeri
           <zeebe:output source="=if parent1DependentTable = null then 0 else&#10;  count(&#10;parent1DependentTable[&#10;// 0-18 years of age: eligible.&#10;date(item.dateOfBirth) &#62;= (date(offeringStudyStartDate) - duration(&#34;P18Y&#34;))&#10;// 19-22 years of age: post-sec must be Yes or Tax is Yes.&#10;or (&#10;  date(item.dateOfBirth) &#60; (date(offeringStudyStartDate) - duration(&#34;P18Y&#34;))&#10;  and date(item.dateOfBirth) &#62;= (date(offeringStudyStartDate) - duration(&#34;P22Y&#34;))&#10;  and (item.attendingPostSecondarySchool = &#34;yes&#34; or item.declaredOnTaxes = &#34;yes&#34;)&#10;)&#10;// &#62; 22 years: eligible if Tax is Yes.&#10;or (&#10;  date(item.dateOfBirth) &#60; (date(offeringStudyStartDate) - duration(&#34;P22Y&#34;))&#10;  and item.declaredOnTaxes = &#34;yes&#34;&#10;)&#10;]&#10;  )" target="calculatedDataTotalParentEligibleDependants" />
           <zeebe:output source="=// 19-22 years of age: post-sec must be Yes&#10;if parent1DependentTable = null then 1 else&#10;  count(&#10;parent1DependentTable[&#10;  date(item.dateOfBirth) &#60; (date(offeringStudyStartDate) - duration(&#34;P18Y&#34;))&#10;  and date(item.dateOfBirth) &#62;= (date(offeringStudyStartDate) - duration(&#34;P22Y&#34;))&#10;  and item.attendingPostSecondarySchool = &#34;yes&#34;&#10;]&#10;  )+1" target="calculatedDataTotalParentEligibleContributionDependants" />
           <zeebe:output source="=0" target="calculatedDataTotalEligibleDependants" />
+          <zeebe:output source="=0" target="calculatedDataTotalChildcareDependants" />
         </zeebe:ioMapping>
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_1li9w29</bpmn:incoming>
@@ -1979,6 +1989,7 @@ There is also a per application limit based on the number of weeks in the offeri
           <zeebe:output source="=if appealDataParentDependentTable = null then 0 else&#10;  count(&#10;appealDataParentDependentTable[&#10;// 0-18 years of age: eligible.&#10;date(item.dateOfBirth) &#62;= (date(offeringStudyStartDate) - duration(&#34;P18Y&#34;))&#10;// 19-22 years of age: post-sec must be Yes or Tax is Yes.&#10;or (&#10;  date(item.dateOfBirth) &#60; (date(offeringStudyStartDate) - duration(&#34;P18Y&#34;))&#10;  and date(item.dateOfBirth) &#62;= (date(offeringStudyStartDate) - duration(&#34;P22Y&#34;))&#10;  and (item.attendingPostSecondarySchool = &#34;yes&#34; or item.declaredOnTaxes = &#34;yes&#34;)&#10;)&#10;// &#62; 22 years: eligible if Tax is Yes.&#10;or (&#10;  date(item.dateOfBirth) &#60; (date(offeringStudyStartDate) - duration(&#34;P22Y&#34;))&#10;  and item.declaredOnTaxes = &#34;yes&#34;&#10;)&#10;]&#10;  )" target="calculatedDataTotalParentEligibleDependants" />
           <zeebe:output source="=// 19-22 years of age: post-sec must be Yes&#10;if appealDataParentDependentTable = null then 1 else&#10;  count(&#10;appealDataParentDependentTable[&#10;  date(item.dateOfBirth) &#60; (date(offeringStudyStartDate) - duration(&#34;P18Y&#34;))&#10;  and date(item.dateOfBirth) &#62;= (date(offeringStudyStartDate) - duration(&#34;P22Y&#34;))&#10;  and item.attendingPostSecondarySchool = &#34;yes&#34;&#10;]&#10;  )+1" target="calculatedDataTotalParentEligibleContributionDependants" />
           <zeebe:output source="=0" target="calculatedDataTotalEligibleDependants" />
+          <zeebe:output source="=0" target="calculatedDataTotalChildcareDependants" />
         </zeebe:ioMapping>
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_1m2uh8r</bpmn:incoming>
@@ -4790,6 +4801,10 @@ Federal Unmet Provincial Need = Provincial portion of Fed Need less Adjusted BCS
         <di:waypoint x="10460" y="2320" />
         <di:waypoint x="10542" y="2320" />
       </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Association_17pjjzp_di" bpmnElement="Association_17pjjzp">
+        <di:waypoint x="2039" y="750" />
+        <di:waypoint x="2005" y="678" />
+      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="Group_0lerduq_di" bpmnElement="Group_0lerduq">
         <dc:Bounds x="5290" y="1180" width="870" height="760" />
         <bpmndi:BPMNLabel>
@@ -5030,6 +5045,13 @@ Federal Unmet Provincial Need = Provincial portion of Fed Need less Adjusted BCS
         <di:waypoint x="10160" y="2500" />
         <di:waypoint x="10118" y="2415" />
       </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Group_0tzz616_di" bpmnElement="Group_0tzz616">
+        <dc:Bounds x="1920" y="255" width="95" height="423" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1kdpkir" bpmnElement="TextAnnotation_01utjft">
+        <dc:Bounds x="1910" y="750" width="305" height="98" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>
   <bpmndi:BPMNDiagram id="BPMNDiagram_0lbfbig">

--- a/sources/packages/backend/workflow/src/workflow-definitions/fulltime-assessment-2026-2027.bpmn
+++ b/sources/packages/backend/workflow/src/workflow-definitions/fulltime-assessment-2026-2027.bpmn
@@ -139,7 +139,7 @@ Will not change based on institution or appeal</bpmn:text>
     <bpmn:association id="Association_069y725" associationDirection="None" sourceRef="TextAnnotation_0eilku9" targetRef="Event_1jlyysi" />
     <bpmn:group id="Group_0tzz616" />
     <bpmn:textAnnotation id="TextAnnotation_01utjft">
-      <bpmn:text>Variables created in this scope that will be consumed in upcoming logic, must have their creation ensured for all the flows.
+      <bpmn:text>Variables created in this scope that will be consumed in upcoming logic must have their creation ensured for all the flows.
 For instance:
 - calculatedDataTotalEligibleDependants
 - calculatedDataTotalChildcareDependants</bpmn:text>
@@ -4801,10 +4801,6 @@ Federal Unmet Provincial Need = Provincial portion of Fed Need less Adjusted BCS
         <di:waypoint x="10460" y="2320" />
         <di:waypoint x="10542" y="2320" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Association_17pjjzp_di" bpmnElement="Association_17pjjzp">
-        <di:waypoint x="2039" y="750" />
-        <di:waypoint x="2005" y="678" />
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="Group_0lerduq_di" bpmnElement="Group_0lerduq">
         <dc:Bounds x="5290" y="1180" width="870" height="760" />
         <bpmndi:BPMNLabel>
@@ -4989,6 +4985,13 @@ Federal Unmet Provincial Need = Provincial portion of Fed Need less Adjusted BCS
         <dc:Bounds x="10160" y="2480" width="268" height="40" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Group_0tzz616_di" bpmnElement="Group_0tzz616">
+        <dc:Bounds x="1920" y="255" width="95" height="423" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1kdpkir" bpmnElement="TextAnnotation_01utjft">
+        <dc:Bounds x="1910" y="750" width="305" height="98" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
       <bpmndi:BPMNEdge id="Association_0q448eh_di" bpmnElement="Association_0q448eh">
         <di:waypoint x="3441" y="1138" />
         <di:waypoint x="3443" y="1113" />
@@ -5045,13 +5048,10 @@ Federal Unmet Provincial Need = Provincial portion of Fed Need less Adjusted BCS
         <di:waypoint x="10160" y="2500" />
         <di:waypoint x="10118" y="2415" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNShape id="Group_0tzz616_di" bpmnElement="Group_0tzz616">
-        <dc:Bounds x="1920" y="255" width="95" height="423" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="BPMNShape_1kdpkir" bpmnElement="TextAnnotation_01utjft">
-        <dc:Bounds x="1910" y="750" width="305" height="98" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Association_17pjjzp_di" bpmnElement="Association_17pjjzp">
+        <di:waypoint x="2039" y="750" />
+        <di:waypoint x="2005" y="678" />
+      </bpmndi:BPMNEdge>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>
   <bpmndi:BPMNDiagram id="BPMNDiagram_0lbfbig">

--- a/sources/packages/backend/workflow/test/2025-2026/assessment-gateway/assessment-gateway.originalAssessment.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2025-2026/assessment-gateway/assessment-gateway.originalAssessment.e2e-spec.ts
@@ -164,11 +164,11 @@ describe(`E2E Test Workflow assessment gateway on original assessment for ${PROG
         studentSpouseContributionWeeks: null,
         interfaceNeed: null,
         dependantPostSecondaryQuantity: null,
-        totalChildcareDependants: null,
+        totalChildcareDependants: 0,
         parentalAssets: null,
         interfaceAdditionalTransportationAmount: null,
         totalDaycareCosts11YearsOrUnder: null,
-        totalChildCareCost: null,
+        totalChildCareCost: 0,
         federalFSCExempt: false,
         dependantInfantQuantity: null,
         returnTransportationCost: 0,
@@ -197,7 +197,7 @@ describe(`E2E Test Workflow assessment gateway on original assessment for ${PROG
         parentalContribution: 20000,
         interfacePolicyApplies: false,
         partnerStudyWeeks: null,
-        eligibleDependantsForCSGD: null,
+        eligibleDependantsForCSGD: 0,
       },
     });
   });

--- a/sources/packages/backend/workflow/test/2026-2027/assessment-gateway/assessment-gateway.originalAssessment.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2026-2027/assessment-gateway/assessment-gateway.originalAssessment.e2e-spec.ts
@@ -202,11 +202,11 @@ describe(`E2E Test Workflow assessment gateway on original assessment for ${PROG
         studentSpouseContributionWeeks: null,
         interfaceNeed: null,
         dependantPostSecondaryQuantity: null,
-        totalChildcareDependants: null,
+        totalChildcareDependants: 0,
         parentalAssets: null,
         interfaceAdditionalTransportationAmount: null,
         totalDaycareCosts11YearsOrUnder: null,
-        totalChildCareCost: null,
+        totalChildCareCost: 0,
         federalFSCExempt: false,
         dependantInfantQuantity: null,
         returnTransportationCost: 0,
@@ -235,7 +235,7 @@ describe(`E2E Test Workflow assessment gateway on original assessment for ${PROG
         parentalContribution: 10000,
         interfacePolicyApplies: false,
         partnerStudyWeeks: null,
-        eligibleDependantsForCSGD: null,
+        eligibleDependantsForCSGD: 0,
       },
     });
   });


### PR DESCRIPTION
# Issue analysis

- The issue affects Full-time 2025/26 and 2026/27.
- Able to reproduce the issue locally for a dependent student.
- The main root cause was the missing initialization of the variable `calculatedDataTotalChildcareDependants`.

<img width="1052" height="762" alt="image" src="https://github.com/user-attachments/assets/0f591585-8c27-4a89-8cb3-8e11c5c9cc87" />

- When it does not follow the highlighted path below, the variable `calculatedDataTotalChildcareDependants` is not initialized. 
  - Please note that the same happens for the `calculatedDataTotalEligibleDependants`, but in this case, zero is assigned for the non-related flows. A comment was added to the workflow to prevent the same issue from happening in the future.

<img width="1570" height="965" alt="image" src="https://github.com/user-attachments/assets/801e5f20-190c-4be7-8a8f-548bd78a6d8f" />

## Missing `calculatedDataTotalChildcareDependants` would potentially impact the below.

### Assessment Eligibility (assessmentEligibilityCSGD)

<img width="1430" height="680" alt="image" src="https://github.com/user-attachments/assets/8c96651d-0be0-4005-bd2d-bc76decdb724" />

### Calculate Max CSGD

<img width="1218" height="481" alt="image" src="https://github.com/user-attachments/assets/c744d78a-6a6c-4e6d-9a2b-95988045b10d" />

## Calculate Total Child Care Cost

<img width="1367" height="594" alt="image" src="https://github.com/user-attachments/assets/e94de5e4-09f5-4b8a-993c-e9aa7a12f71f" />

## Fix

- The variable `calculatedDataTotalChildcareDependants` is not initialized in the same way as the `calculatedDataTotalEligibleDependants`.

<img width="1230" height="729" alt="image" src="https://github.com/user-attachments/assets/ec1d898c-7125-4fba-8c1d-b575d70e122c" />

### Same application after the fix was applied

<img width="1047" height="823" alt="image" src="https://github.com/user-attachments/assets/0aa4fd8b-ee7a-47c7-9e5d-4fb38b70d124" />


