### PR TITLE
#6389 - Assessment: Interface assessed need calculation

### DIFF
--- a/sources/packages/backend/workflow/src/workflow-definitions/fulltime-assessment-2025-2026.bpmn
+++ b/sources/packages/backend/workflow/src/workflow-definitions/fulltime-assessment-2025-2026.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" id="Definitions_0ihicdz" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.43.1" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.6.0" camunda:diagramRelationId="7a75e87a-6774-4e60-9a94-5dbbe3be143a">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" id="Definitions_0ihicdz" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.46.1" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.6.0" camunda:diagramRelationId="7a75e87a-6774-4e60-9a94-5dbbe3be143a">
   <bpmn:message id="Message_3q4oc02" name="Message_3q4oc02" />
   <bpmn:collaboration id="Collaboration_1cf99un">
     <bpmn:participant id="Participant_1mct69m" name="fulltime-assessment-2025-2026" processRef="fulltime-assessment-2025-2026" />
@@ -162,6 +162,14 @@ calculatedDataParent2EstimatedIncomeDeductions
 calculatedDataParent1TaxRate</bpmn:text>
     </bpmn:textAnnotation>
     <bpmn:association id="Association_013h80t" associationDirection="None" sourceRef="Activity_17g355h" targetRef="TextAnnotation_0acv2yp" />
+    <bpmn:group id="Group_0tzz616" />
+    <bpmn:textAnnotation id="TextAnnotation_01utjft">
+      <bpmn:text>Variables created in this scope that will be consumed in upcoming logic must have their creation ensured for all the flows.
+For instance:
+- calculatedDataTotalEligibleDependants
+- calculatedDataTotalChildcareDependants</bpmn:text>
+    </bpmn:textAnnotation>
+    <bpmn:association id="Association_139zks3" associationDirection="None" sourceRef="TextAnnotation_01utjft" targetRef="Group_0tzz616" />
   </bpmn:collaboration>
   <bpmn:process id="fulltime-assessment-2025-2026" isExecutable="true">
     <bpmn:laneSet id="LaneSet_0i75wz3">
@@ -2125,6 +2133,7 @@ If distance education/blended learning program or if married and claiming separa
           <zeebe:output source="=max(calculatedDataTotalEligibleParent1Dependants,calculatedDataTotalEligibleParent2Dependants)" target="calculatedDataTotalParentEligibleDependants" />
           <zeebe:output source="=max(calculatedDataTotalEligibleParent1ContributionDependants,calculatedDataTotalEligibleParent2ContributionDependants)" target="calculatedDataTotalParentEligibleContributionDependants" />
           <zeebe:output source="=0" target="calculatedDataTotalEligibleDependants" />
+          <zeebe:output source="=0" target="calculatedDataTotalChildcareDependants" />
         </zeebe:ioMapping>
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_0ovh763</bpmn:incoming>
@@ -2136,6 +2145,7 @@ If distance education/blended learning program or if married and claiming separa
           <zeebe:output source="=if parent1DependentTable = null then 0 else&#10;  count(&#10;parent1DependentTable[&#10;// 0-18 years of age: eligible.&#10;date(item.dateOfBirth) &#62;= (date(offeringStudyStartDate) - duration(&#34;P18Y&#34;))&#10;// 19-22 years of age: post-sec must be Yes or Tax is Yes.&#10;or (&#10;  date(item.dateOfBirth) &#60; (date(offeringStudyStartDate) - duration(&#34;P18Y&#34;))&#10;  and date(item.dateOfBirth) &#62;= (date(offeringStudyStartDate) - duration(&#34;P22Y&#34;))&#10;  and (item.attendingPostSecondarySchool = &#34;yes&#34; or item.declaredOnTaxes = &#34;yes&#34;)&#10;)&#10;// &#62; 22 years: eligible if Tax is Yes.&#10;or (&#10;  date(item.dateOfBirth) &#60; (date(offeringStudyStartDate) - duration(&#34;P22Y&#34;))&#10;  and item.declaredOnTaxes = &#34;yes&#34;&#10;)&#10;]&#10;  )" target="calculatedDataTotalParentEligibleDependants" />
           <zeebe:output source="=// 19-22 years of age: post-sec must be Yes&#10;if parent1DependentTable = null then 1 else&#10;  count(&#10;parent1DependentTable[&#10;  date(item.dateOfBirth) &#60; (date(offeringStudyStartDate) - duration(&#34;P18Y&#34;))&#10;  and date(item.dateOfBirth) &#62;= (date(offeringStudyStartDate) - duration(&#34;P22Y&#34;))&#10;  and item.attendingPostSecondarySchool = &#34;yes&#34;&#10;]&#10;  )+1" target="calculatedDataTotalParentEligibleContributionDependants" />
           <zeebe:output source="=0" target="calculatedDataTotalEligibleDependants" />
+          <zeebe:output source="=0" target="calculatedDataTotalChildcareDependants" />
         </zeebe:ioMapping>
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_1li9w29</bpmn:incoming>
@@ -2204,6 +2214,7 @@ If distance education/blended learning program or if married and claiming separa
           <zeebe:output source="=if appealDataParentDependentTable = null then 0 else&#10;  count(&#10;appealDataParentDependentTable[&#10;// 0-18 years of age: eligible.&#10;date(item.dateOfBirth) &#62;= (date(offeringStudyStartDate) - duration(&#34;P18Y&#34;))&#10;// 19-22 years of age: post-sec must be Yes or Tax is Yes.&#10;or (&#10;  date(item.dateOfBirth) &#60; (date(offeringStudyStartDate) - duration(&#34;P18Y&#34;))&#10;  and date(item.dateOfBirth) &#62;= (date(offeringStudyStartDate) - duration(&#34;P22Y&#34;))&#10;  and (item.attendingPostSecondarySchool = &#34;yes&#34; or item.declaredOnTaxes = &#34;yes&#34;)&#10;)&#10;// &#62; 22 years: eligible if Tax is Yes.&#10;or (&#10;  date(item.dateOfBirth) &#60; (date(offeringStudyStartDate) - duration(&#34;P22Y&#34;))&#10;  and item.declaredOnTaxes = &#34;yes&#34;&#10;)&#10;]&#10;  )" target="calculatedDataTotalParentEligibleDependants" />
           <zeebe:output source="=// 19-22 years of age: post-sec must be Yes&#10;if appealDataParentDependentTable = null then 1 else&#10;  count(&#10;appealDataParentDependentTable[&#10;  date(item.dateOfBirth) &#60; (date(offeringStudyStartDate) - duration(&#34;P18Y&#34;))&#10;  and date(item.dateOfBirth) &#62;= (date(offeringStudyStartDate) - duration(&#34;P22Y&#34;))&#10;  and item.attendingPostSecondarySchool = &#34;yes&#34;&#10;]&#10;  )+1" target="calculatedDataTotalParentEligibleContributionDependants" />
           <zeebe:output source="=0" target="calculatedDataTotalEligibleDependants" />
+          <zeebe:output source="=0" target="calculatedDataTotalChildcareDependants" />
         </zeebe:ioMapping>
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_1m2uh8r</bpmn:incoming>
@@ -4849,6 +4860,13 @@ The total parent deductions are rounded half up (5.5 = 6) to align with our whol
         <dc:Bounds x="1165" y="140" width="305" height="100" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Group_0tzz616_di" bpmnElement="Group_0tzz616">
+        <dc:Bounds x="1740" y="255" width="95" height="423" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1hysyo3" bpmnElement="TextAnnotation_01utjft">
+        <dc:Bounds x="1700" y="750" width="305" height="98" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
       <bpmndi:BPMNEdge id="Association_1cey5l7_di" bpmnElement="Association_1cey5l7">
         <di:waypoint x="7617" y="1728" />
         <di:waypoint x="7637" y="1845" />
@@ -4924,6 +4942,10 @@ The total parent deductions are rounded half up (5.5 = 6) to align with our whol
       <bpmndi:BPMNEdge id="Association_013h80t_di" bpmnElement="Association_013h80t">
         <di:waypoint x="1261" y="351" />
         <di:waypoint x="1235" y="240" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Association_139zks3_di" bpmnElement="Association_139zks3">
+        <di:waypoint x="1843" y="750" />
+        <di:waypoint x="1817" y="678" />
       </bpmndi:BPMNEdge>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/sources/packages/backend/workflow/src/workflow-definitions/fulltime-assessment-2026-2027.bpmn
+++ b/sources/packages/backend/workflow/src/workflow-definitions/fulltime-assessment-2026-2027.bpmn
@@ -137,6 +137,14 @@ calculatedDataParent1TaxRate</bpmn:text>
 Will not change based on institution or appeal</bpmn:text>
     </bpmn:textAnnotation>
     <bpmn:association id="Association_069y725" associationDirection="None" sourceRef="TextAnnotation_0eilku9" targetRef="Event_1jlyysi" />
+    <bpmn:group id="Group_0tzz616" />
+    <bpmn:textAnnotation id="TextAnnotation_01utjft">
+      <bpmn:text>Variables created in this scope that will be consumed in upcoming logic must have their creation ensured for all the flows.
+For instance:
+- calculatedDataTotalEligibleDependants
+- calculatedDataTotalChildcareDependants</bpmn:text>
+    </bpmn:textAnnotation>
+    <bpmn:association id="Association_17pjjzp" associationDirection="None" sourceRef="TextAnnotation_01utjft" targetRef="Group_0tzz616" />
   </bpmn:collaboration>
   <bpmn:process id="fulltime-assessment-2026-2027" isExecutable="true">
     <bpmn:laneSet id="LaneSet_0i75wz3">
@@ -1957,6 +1965,7 @@ There is also a per application limit based on the number of weeks in the offeri
           <zeebe:output source="=max(calculatedDataTotalEligibleParent1Dependants,calculatedDataTotalEligibleParent2Dependants)" target="calculatedDataTotalParentEligibleDependants" />
           <zeebe:output source="=max(calculatedDataTotalEligibleParent1ContributionDependants,calculatedDataTotalEligibleParent2ContributionDependants)" target="calculatedDataTotalParentEligibleContributionDependants" />
           <zeebe:output source="=0" target="calculatedDataTotalEligibleDependants" />
+          <zeebe:output source="=0" target="calculatedDataTotalChildcareDependants" />
         </zeebe:ioMapping>
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_0ovh763</bpmn:incoming>
@@ -1968,6 +1977,7 @@ There is also a per application limit based on the number of weeks in the offeri
           <zeebe:output source="=if parent1DependentTable = null then 0 else&#10;  count(&#10;parent1DependentTable[&#10;// 0-18 years of age: eligible.&#10;date(item.dateOfBirth) &#62;= (date(offeringStudyStartDate) - duration(&#34;P18Y&#34;))&#10;// 19-22 years of age: post-sec must be Yes or Tax is Yes.&#10;or (&#10;  date(item.dateOfBirth) &#60; (date(offeringStudyStartDate) - duration(&#34;P18Y&#34;))&#10;  and date(item.dateOfBirth) &#62;= (date(offeringStudyStartDate) - duration(&#34;P22Y&#34;))&#10;  and (item.attendingPostSecondarySchool = &#34;yes&#34; or item.declaredOnTaxes = &#34;yes&#34;)&#10;)&#10;// &#62; 22 years: eligible if Tax is Yes.&#10;or (&#10;  date(item.dateOfBirth) &#60; (date(offeringStudyStartDate) - duration(&#34;P22Y&#34;))&#10;  and item.declaredOnTaxes = &#34;yes&#34;&#10;)&#10;]&#10;  )" target="calculatedDataTotalParentEligibleDependants" />
           <zeebe:output source="=// 19-22 years of age: post-sec must be Yes&#10;if parent1DependentTable = null then 1 else&#10;  count(&#10;parent1DependentTable[&#10;  date(item.dateOfBirth) &#60; (date(offeringStudyStartDate) - duration(&#34;P18Y&#34;))&#10;  and date(item.dateOfBirth) &#62;= (date(offeringStudyStartDate) - duration(&#34;P22Y&#34;))&#10;  and item.attendingPostSecondarySchool = &#34;yes&#34;&#10;]&#10;  )+1" target="calculatedDataTotalParentEligibleContributionDependants" />
           <zeebe:output source="=0" target="calculatedDataTotalEligibleDependants" />
+          <zeebe:output source="=0" target="calculatedDataTotalChildcareDependants" />
         </zeebe:ioMapping>
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_1li9w29</bpmn:incoming>
@@ -1979,6 +1989,7 @@ There is also a per application limit based on the number of weeks in the offeri
           <zeebe:output source="=if appealDataParentDependentTable = null then 0 else&#10;  count(&#10;appealDataParentDependentTable[&#10;// 0-18 years of age: eligible.&#10;date(item.dateOfBirth) &#62;= (date(offeringStudyStartDate) - duration(&#34;P18Y&#34;))&#10;// 19-22 years of age: post-sec must be Yes or Tax is Yes.&#10;or (&#10;  date(item.dateOfBirth) &#60; (date(offeringStudyStartDate) - duration(&#34;P18Y&#34;))&#10;  and date(item.dateOfBirth) &#62;= (date(offeringStudyStartDate) - duration(&#34;P22Y&#34;))&#10;  and (item.attendingPostSecondarySchool = &#34;yes&#34; or item.declaredOnTaxes = &#34;yes&#34;)&#10;)&#10;// &#62; 22 years: eligible if Tax is Yes.&#10;or (&#10;  date(item.dateOfBirth) &#60; (date(offeringStudyStartDate) - duration(&#34;P22Y&#34;))&#10;  and item.declaredOnTaxes = &#34;yes&#34;&#10;)&#10;]&#10;  )" target="calculatedDataTotalParentEligibleDependants" />
           <zeebe:output source="=// 19-22 years of age: post-sec must be Yes&#10;if appealDataParentDependentTable = null then 1 else&#10;  count(&#10;appealDataParentDependentTable[&#10;  date(item.dateOfBirth) &#60; (date(offeringStudyStartDate) - duration(&#34;P18Y&#34;))&#10;  and date(item.dateOfBirth) &#62;= (date(offeringStudyStartDate) - duration(&#34;P22Y&#34;))&#10;  and item.attendingPostSecondarySchool = &#34;yes&#34;&#10;]&#10;  )+1" target="calculatedDataTotalParentEligibleContributionDependants" />
           <zeebe:output source="=0" target="calculatedDataTotalEligibleDependants" />
+          <zeebe:output source="=0" target="calculatedDataTotalChildcareDependants" />
         </zeebe:ioMapping>
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_1m2uh8r</bpmn:incoming>
@@ -4974,6 +4985,13 @@ Federal Unmet Provincial Need = Provincial portion of Fed Need less Adjusted BCS
         <dc:Bounds x="10160" y="2480" width="268" height="40" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Group_0tzz616_di" bpmnElement="Group_0tzz616">
+        <dc:Bounds x="1920" y="255" width="95" height="423" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1kdpkir" bpmnElement="TextAnnotation_01utjft">
+        <dc:Bounds x="1910" y="750" width="305" height="98" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
       <bpmndi:BPMNEdge id="Association_0q448eh_di" bpmnElement="Association_0q448eh">
         <di:waypoint x="3441" y="1138" />
         <di:waypoint x="3443" y="1113" />
@@ -5029,6 +5047,10 @@ Federal Unmet Provincial Need = Provincial portion of Fed Need less Adjusted BCS
       <bpmndi:BPMNEdge id="Association_069y725_di" bpmnElement="Association_069y725">
         <di:waypoint x="10160" y="2500" />
         <di:waypoint x="10118" y="2415" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Association_17pjjzp_di" bpmnElement="Association_17pjjzp">
+        <di:waypoint x="2039" y="750" />
+        <di:waypoint x="2005" y="678" />
       </bpmndi:BPMNEdge>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/sources/packages/backend/workflow/test/2025-2026/assessment-gateway/assessment-gateway.originalAssessment.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2025-2026/assessment-gateway/assessment-gateway.originalAssessment.e2e-spec.ts
@@ -164,11 +164,11 @@ describe(`E2E Test Workflow assessment gateway on original assessment for ${PROG
         studentSpouseContributionWeeks: null,
         interfaceNeed: null,
         dependantPostSecondaryQuantity: null,
-        totalChildcareDependants: null,
+        totalChildcareDependants: 0,
         parentalAssets: null,
         interfaceAdditionalTransportationAmount: null,
         totalDaycareCosts11YearsOrUnder: null,
-        totalChildCareCost: null,
+        totalChildCareCost: 0,
         federalFSCExempt: false,
         dependantInfantQuantity: null,
         returnTransportationCost: 0,
@@ -197,7 +197,7 @@ describe(`E2E Test Workflow assessment gateway on original assessment for ${PROG
         parentalContribution: 20000,
         interfacePolicyApplies: false,
         partnerStudyWeeks: null,
-        eligibleDependantsForCSGD: null,
+        eligibleDependantsForCSGD: 0,
       },
     });
   });

--- a/sources/packages/backend/workflow/test/2025-2026/fulltime-assessment/costs/fulltime-assessment-costs-interface-policy.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2025-2026/fulltime-assessment/costs/fulltime-assessment-costs-interface-policy.e2e-spec.ts
@@ -144,14 +144,15 @@ describe(`E2E Test Workflow full-time-assessment-${PROGRAM_YEAR}-costs-interface
       createFakeConsolidatedFulltimeData(PROGRAM_YEAR);
     assessmentConsolidatedData.studentDataIncomeAssistanceAmount = 1000;
     assessmentConsolidatedData.studentDataRelationshipStatus = "married";
-    assessmentConsolidatedData.partner1HasEmploymentInsuranceBenefits =
+    assessmentConsolidatedData.studentDataIsYourPartnerAbleToReport = false;
+    assessmentConsolidatedData.studentDataPartnerHasEmploymentInsuranceBenefits =
       YesNoOptions.No;
-    assessmentConsolidatedData.partner1HasTotalIncomeAssistance =
+    assessmentConsolidatedData.studentDataPartnerHasTotalIncomeAssistance =
       YesNoOptions.No;
-    assessmentConsolidatedData.partner1HasFedralProvincialPDReceipt =
+    assessmentConsolidatedData.studentDataPartnerHasFedralProvincialPDReceipt =
       YesNoOptions.No;
-    assessmentConsolidatedData.partner1TotalIncome = 0;
-    assessmentConsolidatedData.partner1BCEAIncomeAssistanceAmount = 1000;
+    assessmentConsolidatedData.studentDataEstimatedSpouseIncome = 0;
+    assessmentConsolidatedData.studentDataPartnerBCEAIncomeAssistanceAmount = 1000;
     assessmentConsolidatedData.studentDataGovernmentFundingCosts = 100;
 
     // Act

--- a/sources/packages/backend/workflow/test/2025-2026/fulltime-assessment/costs/fulltime-assessment-costs-interface-policy.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2025-2026/fulltime-assessment/costs/fulltime-assessment-costs-interface-policy.e2e-spec.ts
@@ -22,9 +22,30 @@ describe(`E2E Test Workflow full-time-assessment-${PROGRAM_YEAR}-costs-interface
     expect(
       calculatedAssessment.variables.calculatedDataInterfacePolicyApplies,
     ).toBe(true);
+    // Assert updated variables from the interface policy calculations.
     expect(
-      calculatedAssessment.variables.calculatedDataInterfaceNeed,
-    ).toBeGreaterThanOrEqual(0);
+      calculatedAssessment.variables.calculatedDataInterfaceEducationCosts,
+    ).toBe(22500);
+    expect(
+      calculatedAssessment.variables.calculatedDataInterfaceChildCareCosts,
+    ).toBe(0);
+    expect(
+      calculatedAssessment.variables
+        .calculatedDataInterfaceTransportationAmount,
+    ).toBe(368);
+    expect(
+      calculatedAssessment.variables
+        .calculatedDataInterfaceAdditionalTransportationAmount,
+    ).toBe(0);
+    expect(calculatedAssessment.variables.calculatedDataInterfaceNeed).toBe(
+      22868,
+    );
+    expect(
+      calculatedAssessment.variables.calculatedDataProvincialAssessedNeed,
+    ).toBe(22868);
+    expect(
+      calculatedAssessment.variables.calculatedDataFederalAssessedNeed,
+    ).toBeGreaterThanOrEqual(22868);
   });
 
   it("Should show interface policy applies when a married student who declares less than $1500 income assistance and has a partner that will receive BCEA income assistance of $1500 or more.", async () => {
@@ -52,9 +73,30 @@ describe(`E2E Test Workflow full-time-assessment-${PROGRAM_YEAR}-costs-interface
     expect(
       calculatedAssessment.variables.calculatedDataInterfacePolicyApplies,
     ).toBe(true);
+    // Assert updated variables from the interface policy calculations.
     expect(
-      calculatedAssessment.variables.calculatedDataInterfaceNeed,
-    ).toBeGreaterThanOrEqual(0);
+      calculatedAssessment.variables.calculatedDataInterfaceEducationCosts,
+    ).toBe(22500);
+    expect(
+      calculatedAssessment.variables.calculatedDataInterfaceChildCareCosts,
+    ).toBe(0);
+    expect(
+      calculatedAssessment.variables
+        .calculatedDataInterfaceTransportationAmount,
+    ).toBe(368);
+    expect(
+      calculatedAssessment.variables
+        .calculatedDataInterfaceAdditionalTransportationAmount,
+    ).toBe(0);
+    expect(calculatedAssessment.variables.calculatedDataInterfaceNeed).toBe(
+      22868,
+    );
+    expect(
+      calculatedAssessment.variables.calculatedDataProvincialAssessedNeed,
+    ).toBe(22868);
+    expect(
+      calculatedAssessment.variables.calculatedDataFederalAssessedNeed,
+    ).toBeGreaterThanOrEqual(22868);
   });
 
   it("Should show interface policy does not apply when a student declares income assistance of less than $1500.", async () => {
@@ -102,15 +144,14 @@ describe(`E2E Test Workflow full-time-assessment-${PROGRAM_YEAR}-costs-interface
       createFakeConsolidatedFulltimeData(PROGRAM_YEAR);
     assessmentConsolidatedData.studentDataIncomeAssistanceAmount = 1000;
     assessmentConsolidatedData.studentDataRelationshipStatus = "married";
-    assessmentConsolidatedData.studentDataIsYourPartnerAbleToReport = false;
-    assessmentConsolidatedData.studentDataPartnerHasEmploymentInsuranceBenefits =
+    assessmentConsolidatedData.partner1HasEmploymentInsuranceBenefits =
       YesNoOptions.No;
-    assessmentConsolidatedData.studentDataPartnerHasTotalIncomeAssistance =
+    assessmentConsolidatedData.partner1HasTotalIncomeAssistance =
       YesNoOptions.No;
-    assessmentConsolidatedData.studentDataPartnerHasFedralProvincialPDReceipt =
+    assessmentConsolidatedData.partner1HasFedralProvincialPDReceipt =
       YesNoOptions.No;
-    assessmentConsolidatedData.studentDataEstimatedSpouseIncome = 0;
-    assessmentConsolidatedData.studentDataPartnerBCEAIncomeAssistanceAmount = 1000;
+    assessmentConsolidatedData.partner1TotalIncome = 0;
+    assessmentConsolidatedData.partner1BCEAIncomeAssistanceAmount = 1000;
     assessmentConsolidatedData.studentDataGovernmentFundingCosts = 100;
 
     // Act
@@ -179,6 +220,56 @@ describe(`E2E Test Workflow full-time-assessment-${PROGRAM_YEAR}-costs-interface
     expect(
       calculatedAssessment.variables.calculatedDataFederalAssessedNeed,
     ).toBe(calculatedAssessment.variables.calculatedDataInterfaceNeed);
+  });
+
+  it("Should show interface policy applies for a single dependant student when the student declares income assistance of $1500 or more.", async () => {
+    // Arrange
+    const assessmentConsolidatedData =
+      createFakeConsolidatedFulltimeData(PROGRAM_YEAR);
+    assessmentConsolidatedData.studentDataIncomeAssistanceAmount = 1500;
+    assessmentConsolidatedData.studentDataRelationshipStatus = "single";
+    assessmentConsolidatedData.studentDataDependantstatus = "dependant";
+    assessmentConsolidatedData.studentDataNumberOfParents = 1;
+    assessmentConsolidatedData.studentDataParents = [
+      {
+        parentIsAbleToReport: YesNoOptions.Yes,
+      },
+    ];
+    assessmentConsolidatedData.parent1TotalIncome = 40000;
+
+    // Act
+    const calculatedAssessment = await executeFullTimeAssessmentForProgramYear(
+      PROGRAM_YEAR,
+      assessmentConsolidatedData,
+    );
+    // Assert
+    expect(
+      calculatedAssessment.variables.calculatedDataInterfacePolicyApplies,
+    ).toBe(true);
+    // Assert updated variables from the interface policy calculations.
+    expect(
+      calculatedAssessment.variables.calculatedDataInterfaceEducationCosts,
+    ).toBe(22500);
+    expect(
+      calculatedAssessment.variables.calculatedDataInterfaceChildCareCosts,
+    ).toBe(0);
+    expect(
+      calculatedAssessment.variables
+        .calculatedDataInterfaceTransportationAmount,
+    ).toBe(368);
+    expect(
+      calculatedAssessment.variables
+        .calculatedDataInterfaceAdditionalTransportationAmount,
+    ).toBe(0);
+    expect(calculatedAssessment.variables.calculatedDataInterfaceNeed).toBe(
+      22868,
+    );
+    expect(
+      calculatedAssessment.variables.calculatedDataProvincialAssessedNeed,
+    ).toBe(22868);
+    expect(
+      calculatedAssessment.variables.calculatedDataFederalAssessedNeed,
+    ).toBeGreaterThanOrEqual(22868);
   });
 
   afterAll(async () => {

--- a/sources/packages/backend/workflow/test/2025-2026/fulltime-assessment/costs/fulltime-assessment-costs-interface-policy.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2025-2026/fulltime-assessment/costs/fulltime-assessment-costs-interface-policy.e2e-spec.ts
@@ -7,7 +7,7 @@ import {
 import { PROGRAM_YEAR } from "../../constants/program-year.constants";
 
 describe(`E2E Test Workflow full-time-assessment-${PROGRAM_YEAR}-costs-interface-policy.`, () => {
-  it("Should show interface policy applies when a student declares income assistance of $1500 or more.", async () => {
+  it("Should calculate interface policy applies when a student declares income assistance of $1500 or more.", async () => {
     // Arrange
     const assessmentConsolidatedData =
       createFakeConsolidatedFulltimeData(PROGRAM_YEAR);
@@ -45,10 +45,10 @@ describe(`E2E Test Workflow full-time-assessment-${PROGRAM_YEAR}-costs-interface
     ).toBe(22868);
     expect(
       calculatedAssessment.variables.calculatedDataFederalAssessedNeed,
-    ).toBeGreaterThanOrEqual(22868);
+    ).toBe(22868);
   });
 
-  it("Should show interface policy applies when a married student who declares less than $1500 income assistance and has a partner that will receive BCEA income assistance of $1500 or more.", async () => {
+  it("Should calculate interface policy applies when a married student who declares less than $1500 income assistance and has a partner that will receive BCEA income assistance of $1500 or more.", async () => {
     // Arrange
     const assessmentConsolidatedData =
       createFakeConsolidatedFulltimeData(PROGRAM_YEAR);
@@ -96,10 +96,10 @@ describe(`E2E Test Workflow full-time-assessment-${PROGRAM_YEAR}-costs-interface
     ).toBe(22868);
     expect(
       calculatedAssessment.variables.calculatedDataFederalAssessedNeed,
-    ).toBeGreaterThanOrEqual(22868);
+    ).toBe(22868);
   });
 
-  it("Should show interface policy does not apply when a student declares income assistance of less than $1500.", async () => {
+  it("Should calculate interface policy does not apply when a student declares income assistance of less than $1500.", async () => {
     // Arrange
     const assessmentConsolidatedData =
       createFakeConsolidatedFulltimeData(PROGRAM_YEAR);
@@ -119,7 +119,7 @@ describe(`E2E Test Workflow full-time-assessment-${PROGRAM_YEAR}-costs-interface
     );
   });
 
-  it("Should show interface policy does not apply when a student declares no income assistance amount.", async () => {
+  it("Should calculate interface policy does not apply when a student declares no income assistance amount.", async () => {
     // Arrange
     const assessmentConsolidatedData =
       createFakeConsolidatedFulltimeData(PROGRAM_YEAR);
@@ -138,7 +138,7 @@ describe(`E2E Test Workflow full-time-assessment-${PROGRAM_YEAR}-costs-interface
     );
   });
 
-  it("Should show interface policy does not apply when a married student declares income assistance of less than $1500 and has a partner that will receive BCEA income assistance of less than $1500.", async () => {
+  it("Should calculate interface policy does not apply when a married student declares income assistance of less than $1500 and has a partner that will receive BCEA income assistance of less than $1500.", async () => {
     // Arrange
     const assessmentConsolidatedData =
       createFakeConsolidatedFulltimeData(PROGRAM_YEAR);
@@ -223,7 +223,7 @@ describe(`E2E Test Workflow full-time-assessment-${PROGRAM_YEAR}-costs-interface
     ).toBe(calculatedAssessment.variables.calculatedDataInterfaceNeed);
   });
 
-  it("Should show interface policy applies for a single dependant student when the student declares income assistance of $1500 or more.", async () => {
+  it("Should calculate interface policy applies for a single dependant student when the student declares income assistance of $1500 or more.", async () => {
     // Arrange
     const assessmentConsolidatedData =
       createFakeConsolidatedFulltimeData(PROGRAM_YEAR);
@@ -270,7 +270,7 @@ describe(`E2E Test Workflow full-time-assessment-${PROGRAM_YEAR}-costs-interface
     ).toBe(22868);
     expect(
       calculatedAssessment.variables.calculatedDataFederalAssessedNeed,
-    ).toBeGreaterThanOrEqual(22868);
+    ).toBe(22868);
   });
 
   afterAll(async () => {

--- a/sources/packages/backend/workflow/test/2026-2027/assessment-gateway/assessment-gateway.originalAssessment.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2026-2027/assessment-gateway/assessment-gateway.originalAssessment.e2e-spec.ts
@@ -202,11 +202,11 @@ describe(`E2E Test Workflow assessment gateway on original assessment for ${PROG
         studentSpouseContributionWeeks: null,
         interfaceNeed: null,
         dependantPostSecondaryQuantity: null,
-        totalChildcareDependants: null,
+        totalChildcareDependants: 0,
         parentalAssets: null,
         interfaceAdditionalTransportationAmount: null,
         totalDaycareCosts11YearsOrUnder: null,
-        totalChildCareCost: null,
+        totalChildCareCost: 0,
         federalFSCExempt: false,
         dependantInfantQuantity: null,
         returnTransportationCost: 0,
@@ -235,7 +235,7 @@ describe(`E2E Test Workflow assessment gateway on original assessment for ${PROG
         parentalContribution: 10000,
         interfacePolicyApplies: false,
         partnerStudyWeeks: null,
-        eligibleDependantsForCSGD: null,
+        eligibleDependantsForCSGD: 0,
       },
     });
   });

--- a/sources/packages/backend/workflow/test/2026-2027/fulltime-assessment/costs/fulltime-assessment-costs-interface-policy.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2026-2027/fulltime-assessment/costs/fulltime-assessment-costs-interface-policy.e2e-spec.ts
@@ -22,9 +22,30 @@ describe(`E2E Test Workflow full-time-assessment-${PROGRAM_YEAR}-costs-interface
     expect(
       calculatedAssessment.variables.calculatedDataInterfacePolicyApplies,
     ).toBe(true);
+    // Assert updated variables from the interface policy calculations.
     expect(
-      calculatedAssessment.variables.calculatedDataInterfaceNeed,
-    ).toBeGreaterThanOrEqual(0);
+      calculatedAssessment.variables.calculatedDataInterfaceEducationCosts,
+    ).toBe(22500);
+    expect(
+      calculatedAssessment.variables.calculatedDataInterfaceChildCareCosts,
+    ).toBe(0);
+    expect(
+      calculatedAssessment.variables
+        .calculatedDataInterfaceTransportationAmount,
+    ).toBe(368);
+    expect(
+      calculatedAssessment.variables
+        .calculatedDataInterfaceAdditionalTransportationAmount,
+    ).toBe(0);
+    expect(calculatedAssessment.variables.calculatedDataInterfaceNeed).toBe(
+      22868,
+    );
+    expect(
+      calculatedAssessment.variables.calculatedDataProvincialAssessedNeed,
+    ).toBe(22868);
+    expect(
+      calculatedAssessment.variables.calculatedDataFederalAssessedNeed,
+    ).toBeGreaterThanOrEqual(22868);
   });
 
   it("Should show interface policy applies when a married student who declares less than $1500 income assistance and has a partner that will receive BCEA income assistance of $1500 or more.", async () => {
@@ -51,9 +72,30 @@ describe(`E2E Test Workflow full-time-assessment-${PROGRAM_YEAR}-costs-interface
     expect(
       calculatedAssessment.variables.calculatedDataInterfacePolicyApplies,
     ).toBe(true);
+    // Assert updated variables from the interface policy calculations.
     expect(
-      calculatedAssessment.variables.calculatedDataInterfaceNeed,
-    ).toBeGreaterThanOrEqual(0);
+      calculatedAssessment.variables.calculatedDataInterfaceEducationCosts,
+    ).toBe(22500);
+    expect(
+      calculatedAssessment.variables.calculatedDataInterfaceChildCareCosts,
+    ).toBe(0);
+    expect(
+      calculatedAssessment.variables
+        .calculatedDataInterfaceTransportationAmount,
+    ).toBe(368);
+    expect(
+      calculatedAssessment.variables
+        .calculatedDataInterfaceAdditionalTransportationAmount,
+    ).toBe(0);
+    expect(calculatedAssessment.variables.calculatedDataInterfaceNeed).toBe(
+      22868,
+    );
+    expect(
+      calculatedAssessment.variables.calculatedDataProvincialAssessedNeed,
+    ).toBe(22868);
+    expect(
+      calculatedAssessment.variables.calculatedDataFederalAssessedNeed,
+    ).toBeGreaterThanOrEqual(22868);
   });
 
   it("Should show interface policy does not apply when a student declares income assistance of less than $1500.", async () => {
@@ -177,6 +219,56 @@ describe(`E2E Test Workflow full-time-assessment-${PROGRAM_YEAR}-costs-interface
     expect(
       calculatedAssessment.variables.calculatedDataFederalAssessedNeed,
     ).toBe(calculatedAssessment.variables.calculatedDataInterfaceNeed);
+  });
+
+  it("Should show interface policy applies for a single dependant student when the student declares income assistance of $1500 or more.", async () => {
+    // Arrange
+    const assessmentConsolidatedData =
+      createFakeConsolidatedFulltimeData(PROGRAM_YEAR);
+    assessmentConsolidatedData.studentDataIncomeAssistanceAmount = 1500;
+    assessmentConsolidatedData.studentDataRelationshipStatus = "single";
+    assessmentConsolidatedData.studentDataDependantstatus = "dependant";
+    assessmentConsolidatedData.studentDataNumberOfParents = 1;
+    assessmentConsolidatedData.studentDataParents = [
+      {
+        parentIsAbleToReport: YesNoOptions.Yes,
+      },
+    ];
+    assessmentConsolidatedData.parent1TotalIncome = 40000;
+
+    // Act
+    const calculatedAssessment = await executeFullTimeAssessmentForProgramYear(
+      PROGRAM_YEAR,
+      assessmentConsolidatedData,
+    );
+    // Assert
+    expect(
+      calculatedAssessment.variables.calculatedDataInterfacePolicyApplies,
+    ).toBe(true);
+    // Assert updated variables from the interface policy calculations.
+    expect(
+      calculatedAssessment.variables.calculatedDataInterfaceEducationCosts,
+    ).toBe(22500);
+    expect(
+      calculatedAssessment.variables.calculatedDataInterfaceChildCareCosts,
+    ).toBe(0);
+    expect(
+      calculatedAssessment.variables
+        .calculatedDataInterfaceTransportationAmount,
+    ).toBe(368);
+    expect(
+      calculatedAssessment.variables
+        .calculatedDataInterfaceAdditionalTransportationAmount,
+    ).toBe(0);
+    expect(calculatedAssessment.variables.calculatedDataInterfaceNeed).toBe(
+      22868,
+    );
+    expect(
+      calculatedAssessment.variables.calculatedDataProvincialAssessedNeed,
+    ).toBe(22868);
+    expect(
+      calculatedAssessment.variables.calculatedDataFederalAssessedNeed,
+    ).toBeGreaterThanOrEqual(22868);
   });
 
   afterAll(async () => {

--- a/sources/packages/backend/workflow/test/2026-2027/fulltime-assessment/costs/fulltime-assessment-costs-interface-policy.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2026-2027/fulltime-assessment/costs/fulltime-assessment-costs-interface-policy.e2e-spec.ts
@@ -7,7 +7,7 @@ import {
 import { PROGRAM_YEAR } from "../../constants/program-year.constants";
 
 describe(`E2E Test Workflow full-time-assessment-${PROGRAM_YEAR}-costs-interface-policy.`, () => {
-  it("Should show interface policy applies when a student declares income assistance of $1500 or more.", async () => {
+  it("Should calculate interface policy applies when a student declares income assistance of $1500 or more.", async () => {
     // Arrange
     const assessmentConsolidatedData =
       createFakeConsolidatedFulltimeData(PROGRAM_YEAR);
@@ -45,10 +45,10 @@ describe(`E2E Test Workflow full-time-assessment-${PROGRAM_YEAR}-costs-interface
     ).toBe(22868);
     expect(
       calculatedAssessment.variables.calculatedDataFederalAssessedNeed,
-    ).toBeGreaterThanOrEqual(22868);
+    ).toBe(22868);
   });
 
-  it("Should show interface policy applies when a married student who declares less than $1500 income assistance and has a partner that will receive BCEA income assistance of $1500 or more.", async () => {
+  it("Should calculate interface policy applies when a married student who declares less than $1500 income assistance and has a partner that will receive BCEA income assistance of $1500 or more.", async () => {
     // Arrange
     const assessmentConsolidatedData =
       createFakeConsolidatedFulltimeData(PROGRAM_YEAR);
@@ -95,10 +95,10 @@ describe(`E2E Test Workflow full-time-assessment-${PROGRAM_YEAR}-costs-interface
     ).toBe(22868);
     expect(
       calculatedAssessment.variables.calculatedDataFederalAssessedNeed,
-    ).toBeGreaterThanOrEqual(22868);
+    ).toBe(22868);
   });
 
-  it("Should show interface policy does not apply when a student declares income assistance of less than $1500.", async () => {
+  it("Should calculate interface policy does not apply when a student declares income assistance of less than $1500.", async () => {
     // Arrange
     const assessmentConsolidatedData =
       createFakeConsolidatedFulltimeData(PROGRAM_YEAR);
@@ -118,7 +118,7 @@ describe(`E2E Test Workflow full-time-assessment-${PROGRAM_YEAR}-costs-interface
     );
   });
 
-  it("Should show interface policy does not apply when a student declares no income assistance amount.", async () => {
+  it("Should calculate interface policy does not apply when a student declares no income assistance amount.", async () => {
     // Arrange
     const assessmentConsolidatedData =
       createFakeConsolidatedFulltimeData(PROGRAM_YEAR);
@@ -137,7 +137,7 @@ describe(`E2E Test Workflow full-time-assessment-${PROGRAM_YEAR}-costs-interface
     );
   });
 
-  it("Should show interface policy does not apply when a married student declares income assistance of less than $1500 and has a partner that will receive BCEA income assistance of less than $1500.", async () => {
+  it("Should calculate interface policy does not apply when a married student declares income assistance of less than $1500 and has a partner that will receive BCEA income assistance of less than $1500.", async () => {
     // Arrange
     const assessmentConsolidatedData =
       createFakeConsolidatedFulltimeData(PROGRAM_YEAR);
@@ -221,7 +221,7 @@ describe(`E2E Test Workflow full-time-assessment-${PROGRAM_YEAR}-costs-interface
     ).toBe(calculatedAssessment.variables.calculatedDataInterfaceNeed);
   });
 
-  it("Should show interface policy applies for a single dependant student when the student declares income assistance of $1500 or more.", async () => {
+  it("Should calculate interface policy applies for a single dependant student when the student declares income assistance of $1500 or more.", async () => {
     // Arrange
     const assessmentConsolidatedData =
       createFakeConsolidatedFulltimeData(PROGRAM_YEAR);
@@ -268,7 +268,7 @@ describe(`E2E Test Workflow full-time-assessment-${PROGRAM_YEAR}-costs-interface
     ).toBe(22868);
     expect(
       calculatedAssessment.variables.calculatedDataFederalAssessedNeed,
-    ).toBeGreaterThanOrEqual(22868);
+    ).toBe(22868);
   });
 
   afterAll(async () => {


### PR DESCRIPTION
Branch sync-up from 3.6.1 to 3.7.0 to main.

Added E2E tests to validate the interface policy for a single dependent student. The ones present were testing single independent by default.