### PR TITLE
#6322 - Scroll to page header when refreshed on cancel

### DIFF
--- a/sources/packages/web/src/components/form-submissions/FormSubmissionApproval.vue
+++ b/sources/packages/web/src/components/form-submissions/FormSubmissionApproval.vue
@@ -2,6 +2,7 @@
   <body-header-container :enable-card-view="false">
     <template #header>
       <form-submission-approval-header
+        ref="formSubmissionApprovalHeader"
         :form-submission="formSubmission"
         :loading="formSubmissionLoading"
       />
@@ -253,6 +254,8 @@ export default defineComponent({
         InstanceType<typeof VTextarea>
       >(),
     );
+    const formSubmissionApprovalHeader =
+      ref<InstanceType<typeof FormSubmissionApprovalHeader>>();
 
     /**
      * Decision options to be selected by the user
@@ -481,6 +484,13 @@ export default defineComponent({
             const modalResult = await outdatedDecisionModal.value.showModal();
             if (modalResult) {
               await reloadFormSubmissionItem(decision.submissionItemId);
+              // If the form submission was cancelled, scroll to the top of the page to show the user the status chip with the updated status.
+              if (error.errorType === FORM_SUBMISSION_CANCELLED) {
+                formSubmissionApprovalHeader.value?.$el?.scrollIntoView({
+                  behavior: "smooth",
+                  block: "center",
+                });
+              }
             }
             return;
           }
@@ -604,6 +614,7 @@ export default defineComponent({
       formSubmissionLoading,
       isDecisionSectionReadOnly,
       canShowDecisionSection,
+      formSubmissionApprovalHeader,
     };
   },
 });

--- a/sources/packages/web/src/components/form-submissions/FormSubmissionApproval.vue
+++ b/sources/packages/web/src/components/form-submissions/FormSubmissionApproval.vue
@@ -486,7 +486,7 @@ export default defineComponent({
               await reloadFormSubmissionItem(decision.submissionItemId);
               // If the form submission was cancelled, scroll to the top of the page to show the user the status chip with the updated status.
               if (error.errorType === FORM_SUBMISSION_CANCELLED) {
-                formSubmissionApprovalHeader.value?.$el?.scrollIntoView({
+                formSubmissionApprovalHeader.value?.$el?.scrollIntoView?.({
                   behavior: "smooth",
                   block: "center",
                 });


### PR DESCRIPTION
Added UI update to scroll to the page header when ministry user click on outdated modal to refresh the page and the form submission was cancelled. 


https://github.com/user-attachments/assets/a91823f4-938c-432d-a49e-077f5ef314d8

