### PR TITLE
#6375 - BUG: Student notification for change request review completed missing personalization

### DIFF
--- a/sources/packages/backend/apps/api/src/route-controllers/application-change-request/_tests_/e2e/application-change-request.aest.controller.assessApplicationChangeRequest.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/application-change-request/_tests_/e2e/application-change-request.aest.controller.assessApplicationChangeRequest.e2e-spec.ts
@@ -250,6 +250,7 @@ describe("ApplicationChangeRequestAESTController(e2e)-assessApplicationChangeReq
       personalisation: {
         givenNames: changeRequest.student.user.firstName ?? "",
         lastName: changeRequest.student.user.lastName,
+        application: changeRequest.applicationNumber,
         date: `${getPSTPDTDateTime(now)} PST/PDT`,
       },
     });
@@ -371,6 +372,7 @@ describe("ApplicationChangeRequestAESTController(e2e)-assessApplicationChangeReq
       personalisation: {
         givenNames: changeRequest.student.user.firstName ?? "",
         lastName: changeRequest.student.user.lastName,
+        application: changeRequest.applicationNumber,
         date: `${getPSTPDTDateTime(now)} PST/PDT`,
       },
     });
@@ -472,6 +474,7 @@ describe("ApplicationChangeRequestAESTController(e2e)-assessApplicationChangeReq
       personalisation: {
         givenNames: changeRequest.student.user.firstName ?? "",
         lastName: changeRequest.student.user.lastName,
+        application: changeRequest.applicationNumber,
         date: `${getPSTPDTDateTime(now)} PST/PDT`,
       },
     });

--- a/sources/packages/backend/apps/api/src/services/application-change-request/application-change-request.service.ts
+++ b/sources/packages/backend/apps/api/src/services/application-change-request/application-change-request.service.ts
@@ -7,7 +7,6 @@ import {
   FormSubmission,
   getUserFullNameLikeSearch,
   NoteType,
-  Student,
   StudentAppeal,
   User,
 } from "@sims/sims-db";
@@ -109,7 +108,7 @@ export class ApplicationChangeRequestService {
         await Promise.all([
           applicationRepo.save(changeRequestApplication),
           this.saveChangeRequestReviewCompletedNotification(
-            changeRequestApplication.student.id,
+            changeRequestApplication,
             auditUserId,
             transactionalEntityManager,
           ),
@@ -154,7 +153,7 @@ export class ApplicationChangeRequestService {
       await Promise.all([
         applicationRepo.save(changeRequestApplication),
         this.saveChangeRequestReviewCompletedNotification(
-          changeRequestApplication.student.id,
+          changeRequestApplication,
           auditUserId,
           transactionalEntityManager,
         ),
@@ -169,29 +168,24 @@ export class ApplicationChangeRequestService {
 
   /**
    * Creates a student notification when a change request review is completed by the ministry.
-   * @param studentId student ID to load the notification data.
+   * @param changeRequestApplication the change request application with the student information
+   * required to send the notification.
    * @param auditUserId user who completed the change request review.
    * @param entityManager entity manager for the current transaction.
    */
   private async saveChangeRequestReviewCompletedNotification(
-    studentId: number,
+    changeRequestApplication: Application,
     auditUserId: number,
     entityManager: EntityManager,
   ): Promise<void> {
-    const student = await entityManager.getRepository(Student).findOneOrFail({
-      select: {
-        id: true,
-        user: { id: true, firstName: true, lastName: true, email: true },
-      },
-      relations: { user: true },
-      where: { id: studentId },
-    });
+    const student = changeRequestApplication.student;
     await this.notificationActionsService.saveStudentChangeRequestReviewCompletedNotification(
       {
         givenNames: student.user.firstName,
         lastName: student.user.lastName,
         toAddress: student.user.email,
         userId: student.user.id,
+        applicationNumber: changeRequestApplication.applicationNumber,
       },
       auditUserId,
       entityManager,

--- a/sources/packages/backend/apps/api/src/services/application/application.service.ts
+++ b/sources/packages/backend/apps/api/src/services/application/application.service.ts
@@ -1061,6 +1061,7 @@ export class ApplicationService extends RecordDataModelService<Application> {
             id: true,
             firstName: true,
             lastName: true,
+            email: true,
           },
         },
         ...(options?.loadDynamicData


### PR DESCRIPTION
- Fix: the application variable was missing in the notification personalization payload.
- Updated E2E tests to ensure the variable will be present.
- Email sent from my local environment.

<img width="782" height="665" alt="image" src="https://github.com/user-attachments/assets/ebe21a3c-4c1d-4891-ad26-85dd73c62057" />

_Note:_ PROD warning alerts were disabled on PROD due to some past CAS warnings that were generating too many notifications. The warnings are now enabled again, and we can monitor them and have them changed to info (with a biz agreement).