### PR TITLE
#6370 - Content: Personal Information: Protected Person bullet updates

### DIFF
--- a/sources/packages/forms/src/form-definitions/sfaa2025-26-ft.json
+++ b/sources/packages/forms/src/form-definitions/sfaa2025-26-ft.json
@@ -1850,7 +1850,7 @@
                       "value": ""
                     }
                   ],
-                  "content": "Upload proof of citizenship",
+                  "content": "Upload proof of status",
                   "refreshOnChange": false,
                   "customClass": "header-md",
                   "key": "html49",
@@ -2052,7 +2052,7 @@
                               "value": ""
                             }
                           ],
-                          "content": "<h4 class=\"category-header-medium-small\">Documents required:</h4>\n<ul>\n  <li><b>Valid Confirmation of SIN document; and</b></li>\n  <li>Notice of Decision (issued by Immigration and Refugee Board) or</li>\n  <li>Verification of Status document (IMM5009) or</li>\n  <li>Confirmation of Protected Persons Status document (IMM5292)</li>\n</ul>",
+                          "content": "<h4 class=\"category-header-medium-small\">Documents Required:</h4>\n<ol>\n  <li>\n    Temporary SIN (900-series) or confirmation of temporary SIN that is valid\n    for the entire period of study; <em>and</em>\n  </li>\n  <li>\n    Proof of Identity\n    <ul>\n      <li>\n        A Refugee Protection Identity Document issued by IRCC as of March 2025,\n        or\n      </li>\n      <li>\n        A Refugee Protection Claimant Document issued by IRCC prior to March\n        2025; <em>and</em>\n      </li>\n    </ul>\n  </li>\n  <li>\n    Proof of Protected Person or Refugee Status\n    <ul>\n      <li>\n        A Notice of Decision issued by the Immigration and Refugee Board\n        confirming status, or\n      </li>\n      <li>\n        Verification of Status document issued by IRCC (Protected Persons\n        Status Document issued prior to January 2013 are acceptable as well)\n      </li>\n    </ul>\n  </li>\n</ol>",
                           "refreshOnChange": false,
                           "customClass": "align-bullets",
                           "key": "html15",
@@ -2068,7 +2068,7 @@
                               "value": ""
                             }
                           ],
-                          "content": "<h4 class=\"category-header-medium-small\">Instructions:</h4>\n<ul>\n  <li>Upload a photo or scanned copy of your documentation</li>\n  <li>Rename your document to <br/>\"<strong>FirstnameLastname_Citizenship_ProtectedPerson</strong>\"</li>\n  (e.g. JessLee_Citizenship_ProtectedPerson)\n</ul>\n",
+                          "content": "<h4 class=\"category-header-medium-small\">Instructions:</h4>\n<ul>\n  <li>Upload a colour copy of your documentation</li>\n  <li>Rename your document to <br/>\"<strong>FirstnameLastname_Citizenship_ProtectedPerson</strong>\"</li>\n  (e.g. JessLee_Citizenship_ProtectedPerson)\n</ul>\n",
                           "refreshOnChange": false,
                           "customClass": "align-bullets",
                           "key": "html38",

--- a/sources/packages/forms/src/form-definitions/sfaa2025-26-pt.json
+++ b/sources/packages/forms/src/form-definitions/sfaa2025-26-pt.json
@@ -2180,7 +2180,7 @@
                           "value": ""
                         }
                       ],
-                      "content": "<h4 class=\"category-header-medium-small\">Instructions:</h4>\r\n<ul>\r\n  <li>Upload a colour copy of your documentation</li>\r\n  <li>Rename your document to <br/>\"<strong>FirstnameLastname_Citizenship_ProtectedPerson</strong>\"</li>\r\n  (e.g. JessLee_Citizenship_ProtectedPerson)\r\n</ul>",
+                      "content": "<h4 class=\"category-header-medium-small\">Instructions:</h4>\n<ul>\n  <li>Upload a colour copy of your documentation</li>\n  <li>Rename your document to <br/>\"<strong>FirstnameLastname_Citizenship_ProtectedPerson</strong>\"</li>\n  (e.g. JessLee_Citizenship_ProtectedPerson)\n</ul>\n",
                       "refreshOnChange": false,
                       "customClass": "align-bullets",
                       "key": "html38",

--- a/sources/packages/forms/src/form-definitions/sfaa2025-26-pt.json
+++ b/sources/packages/forms/src/form-definitions/sfaa2025-26-pt.json
@@ -2030,7 +2030,7 @@
                       "value": ""
                     }
                   ],
-                  "content": "Upload proof of citizenship",
+                  "content": "Upload proof of status",
                   "refreshOnChange": false,
                   "customClass": "header-md",
                   "key": "html49",
@@ -2164,7 +2164,7 @@
                           "value": ""
                         }
                       ],
-                      "content": "<h4 class=\"category-header-medium-small\">Documents required:</h4>\n<ul>\n  <li><b>Valid Confirmation of SIN document; and</b></li>\n  <li>Notice of Decision (issued by Immigration and Refugee Board) or</li>\n  <li>Verification of Status document (IMM5009) or</li>\n  <li>Confirmation of Protected Persons Status document (IMM5292)</li>\n</ul>",
+                      "content": "<h4 class=\"category-header-medium-small\">Documents Required:</h4>\r\n<ol>\r\n  <li>\r\n    Temporary SIN (900-series) or confirmation of temporary SIN that is valid\r\n    for the entire period of study; <em>and</em>\r\n  </li>\r\n  <li>\r\n    Proof of Identity\r\n    <ul>\r\n      <li>\r\n        A Refugee Protection Identity Document issued by IRCC as of March 2025,\r\n        or\r\n      </li>\r\n      <li>\r\n        A Refugee Protection Claimant Document issued by IRCC prior to March\r\n        2025; <em>and</em>\r\n      </li>\r\n    </ul>\r\n  </li>\r\n  <li>\r\n    Proof of Protected Person or Refugee Status\r\n    <ul>\r\n      <li>\r\n        A Notice of Decision issued by the Immigration and Refugee Board\r\n        confirming status, or\r\n      </li>\r\n      <li>\r\n        Verification of Status document issued by IRCC (Protected Persons\r\n        Status Document issued prior to January 2013 are acceptable as well)\r\n      </li>\r\n    </ul>\r\n  </li>\r\n</ol>",
                       "refreshOnChange": false,
                       "customClass": "align-bullets",
                       "key": "html15",
@@ -2180,7 +2180,7 @@
                           "value": ""
                         }
                       ],
-                      "content": "<h4 class=\"category-header-medium-small\">Instructions:</h4>\n<ul>\n  <li>Upload a photo or scanned copy of your documentation</li>\n  <li>Rename your document to <br/>\"<strong>FirstnameLastname_Citizenship_ProtectedPerson</strong>\"</li>\n  (e.g. JessLee_Citizenship_ProtectedPerson)\n</ul>\n",
+                      "content": "<h4 class=\"category-header-medium-small\">Instructions:</h4>\r\n<ul>\r\n  <li>Upload a colour copy of your documentation</li>\r\n  <li>Rename your document to <br/>\"<strong>FirstnameLastname_Citizenship_ProtectedPerson</strong>\"</li>\r\n  (e.g. JessLee_Citizenship_ProtectedPerson)\r\n</ul>",
                       "refreshOnChange": false,
                       "customClass": "align-bullets",
                       "key": "html38",

--- a/sources/packages/forms/src/form-definitions/sfaa2026-27-ft.json
+++ b/sources/packages/forms/src/form-definitions/sfaa2026-27-ft.json
@@ -1850,7 +1850,7 @@
                       "value": ""
                     }
                   ],
-                  "content": "Upload proof of citizenship",
+                  "content": "Upload proof of status",
                   "refreshOnChange": false,
                   "customClass": "header-md",
                   "key": "html49",
@@ -2052,7 +2052,7 @@
                               "value": ""
                             }
                           ],
-                          "content": "<h4 class=\"category-header-medium-small\">Documents required:</h4>\n<ul>\n  <li><b>Valid Confirmation of SIN document; and</b></li>\n  <li>Notice of Decision (issued by Immigration and Refugee Board) or</li>\n  <li>Verification of Status document (IMM5009) or</li>\n  <li>Confirmation of Protected Persons Status document (IMM5292)</li>\n</ul>",
+                          "content": "<h4 class=\"category-header-medium-small\">Documents Required:</h4>\r\n<ol>\r\n  <li>\r\n    Temporary SIN (900-series) or confirmation of temporary SIN that is valid\r\n    for the entire period of study; <em>and</em>\r\n  </li>\r\n  <li>\r\n    Proof of Identity\r\n    <ul>\r\n      <li>\r\n        A Refugee Protection Identity Document issued by IRCC as of March 2025,\r\n        or\r\n      </li>\r\n      <li>\r\n        A Refugee Protection Claimant Document issued by IRCC prior to March\r\n        2025; <em>and</em>\r\n      </li>\r\n    </ul>\r\n  </li>\r\n  <li>\r\n    Proof of Protected Person or Refugee Status\r\n    <ul>\r\n      <li>\r\n        A Notice of Decision issued by the Immigration and Refugee Board\r\n        confirming status, or\r\n      </li>\r\n      <li>\r\n        Verification of Status document issued by IRCC (Protected Persons\r\n        Status Document issued prior to January 2013 are acceptable as well)\r\n      </li>\r\n    </ul>\r\n  </li>\r\n</ol>",
                           "refreshOnChange": false,
                           "customClass": "align-bullets",
                           "key": "html15",
@@ -2068,7 +2068,7 @@
                               "value": ""
                             }
                           ],
-                          "content": "<h4 class=\"category-header-medium-small\">Instructions:</h4>\n<ul>\n  <li>Upload a photo or scanned copy of your documentation</li>\n  <li>Rename your document to <br/>\"<strong>FirstnameLastname_Citizenship_ProtectedPerson</strong>\"</li>\n  (e.g. JessLee_Citizenship_ProtectedPerson)\n</ul>\n",
+                          "content": "<h4 class=\"category-header-medium-small\">Instructions:</h4>\n<ul>\n  <li>Upload a colour copy of your documentation</li>\n  <li>Rename your document to <br/>\"<strong>FirstnameLastname_Citizenship_ProtectedPerson</strong>\"</li>\n  (e.g. JessLee_Citizenship_ProtectedPerson)\n</ul>\n",
                           "refreshOnChange": false,
                           "customClass": "align-bullets",
                           "key": "html38",

--- a/sources/packages/forms/src/form-definitions/sfaa2026-27-pt.json
+++ b/sources/packages/forms/src/form-definitions/sfaa2026-27-pt.json
@@ -2248,7 +2248,7 @@
                               "value": ""
                             }
                           ],
-                          "content": "<h4 class=\"category-header-medium-small\">Instructions:</h4>\r\n<ul>\r\n  <li>Upload a colour copy of your documentation</li>\r\n  <li>Rename your document to <br/>\"<strong>FirstnameLastname_Citizenship_ProtectedPerson</strong>\"</li>\r\n  (e.g. JessLee_Citizenship_ProtectedPerson)\r\n</ul>",
+                          "content": "<h4 class=\"category-header-medium-small\">Instructions:</h4>\n<ul>\n  <li>Upload a colour copy of your documentation</li>\n  <li>Rename your document to <br/>\"<strong>FirstnameLastname_Citizenship_ProtectedPerson</strong>\"</li>\n  (e.g. JessLee_Citizenship_ProtectedPerson)\n</ul>\n",
                           "refreshOnChange": false,
                           "customClass": "align-bullets",
                           "key": "html38",

--- a/sources/packages/forms/src/form-definitions/sfaa2026-27-pt.json
+++ b/sources/packages/forms/src/form-definitions/sfaa2026-27-pt.json
@@ -2030,7 +2030,7 @@
                       "value": ""
                     }
                   ],
-                  "content": "Upload proof of citizenship",
+                  "content": "Upload proof of status",
                   "refreshOnChange": false,
                   "customClass": "header-md",
                   "key": "html49",
@@ -2232,7 +2232,7 @@
                               "value": ""
                             }
                           ],
-                          "content": "<h4 class=\"category-header-medium-small\">Documents required:</h4>\n<ul>\n  <li><b>Valid Confirmation of SIN document; and</b></li>\n  <li>Notice of Decision (issued by Immigration and Refugee Board) or</li>\n  <li>Verification of Status document (IMM5009) or</li>\n  <li>Confirmation of Protected Persons Status document (IMM5292)</li>\n</ul>",
+                          "content": "<h4 class=\"category-header-medium-small\">Documents Required:</h4>\r\n<ol>\r\n  <li>\r\n    Temporary SIN (900-series) or confirmation of temporary SIN that is valid\r\n    for the entire period of study; <em>and</em>\r\n  </li>\r\n  <li>\r\n    Proof of Identity\r\n    <ul>\r\n      <li>\r\n        A Refugee Protection Identity Document issued by IRCC as of March 2025,\r\n        or\r\n      </li>\r\n      <li>\r\n        A Refugee Protection Claimant Document issued by IRCC prior to March\r\n        2025; <em>and</em>\r\n      </li>\r\n    </ul>\r\n  </li>\r\n  <li>\r\n    Proof of Protected Person or Refugee Status\r\n    <ul>\r\n      <li>\r\n        A Notice of Decision issued by the Immigration and Refugee Board\r\n        confirming status, or\r\n      </li>\r\n      <li>\r\n        Verification of Status document issued by IRCC (Protected Persons\r\n        Status Document issued prior to January 2013 are acceptable as well)\r\n      </li>\r\n    </ul>\r\n  </li>\r\n</ol>",
                           "refreshOnChange": false,
                           "customClass": "align-bullets",
                           "key": "html15",
@@ -2248,7 +2248,7 @@
                               "value": ""
                             }
                           ],
-                          "content": "<h4 class=\"category-header-medium-small\">Instructions:</h4>\n<ul>\n  <li>Upload a photo or scanned copy of your documentation</li>\n  <li>Rename your document to <br/>\"<strong>FirstnameLastname_Citizenship_ProtectedPerson</strong>\"</li>\n  (e.g. JessLee_Citizenship_ProtectedPerson)\n</ul>\n",
+                          "content": "<h4 class=\"category-header-medium-small\">Instructions:</h4>\r\n<ul>\r\n  <li>Upload a colour copy of your documentation</li>\r\n  <li>Rename your document to <br/>\"<strong>FirstnameLastname_Citizenship_ProtectedPerson</strong>\"</li>\r\n  (e.g. JessLee_Citizenship_ProtectedPerson)\r\n</ul>",
                           "refreshOnChange": false,
                           "customClass": "align-bullets",
                           "key": "html38",

--- a/sources/packages/web/src/assets/css/base.scss
+++ b/sources/packages/web/src/assets/css/base.scss
@@ -20,6 +20,10 @@ strong {
   @extend .font-bold;
 }
 
+em {
+  font-style: italic;
+}
+
 .bold-text {
   @extend .font-bold;
   font-style: $font-style-normal;

--- a/sources/packages/web/src/assets/css/base.scss
+++ b/sources/packages/web/src/assets/css/base.scss
@@ -4,6 +4,11 @@ html * {
   font-style: $font-style-normal;
   line-height: 20px;
 }
+
+html em {
+  font-style: italic;
+}
+
 // todo: when all v-navigation-drawer is updated, remove this class.
 .body-background {
   background: $default-background;
@@ -18,10 +23,6 @@ html * {
 
 strong {
   @extend .font-bold;
-}
-
-em {
-  font-style: italic;
 }
 
 .bold-text {


### PR DESCRIPTION
- Adjusted content for protected persons for 2025/26, 2026/27, full-time and part-time.
- Confirmed with the business that the "Upload proof of status" change should be applied for "Protected person" and "Permanent resident".
<img width="596" height="451" alt="image" src="https://github.com/user-attachments/assets/972014b1-a91f-4ffe-ad88-fe8651f88ab2" />

- Adjust the `italic` style to be applied to the `<em>` HTML tag.

<img width="1472" height="826" alt="image" src="https://github.com/user-attachments/assets/1c5fb95d-ab19-4b54-8a53-a8a54425214e" />
