### PR TITLE
#4379 - Gracefully terminate applications

### DIFF
--- a/sources/packages/backend/apps/api/src/main.ts
+++ b/sources/packages/backend/apps/api/src/main.ts
@@ -13,12 +13,15 @@ import helmet from "helmet";
 import { SystemUsersService } from "@sims/services";
 import { AppExternalModule } from "./app.external.module";
 
-async function bootstrap() {
+async function bootstrap(): Promise<void> {
   await KeycloakConfig.load();
   const app = await NestFactory.create<NestExpressApplication>(AppModule, {
     bufferLogs: true,
     bodyParser: false,
   });
+
+  // Listens to termination signals so open connections can be gracefully closed.
+  app.enableShutdownHooks();
 
   // Trust upstream proxy headers to resolve client IP addresses correctly.
   app.set(TRUST_PROXY_SETTING, TRUSTED_PROXY_HOPS);

--- a/sources/packages/backend/apps/load-test-gateway/src/main.ts
+++ b/sources/packages/backend/apps/load-test-gateway/src/main.ts
@@ -35,7 +35,7 @@ async function bootstrap(): Promise<void> {
   await app.listen(loadTestAPIPort);
 
   // Logging node http server error
-  app.getHttpServer().on("error", (error) => {
+  app.getHttpServer().on("error", (error: unknown) => {
     logger.error(`Load test server received ${error}`, undefined, "Bootstrap");
     exit(1);
   });
@@ -44,7 +44,7 @@ async function bootstrap(): Promise<void> {
     "Bootstrap",
   );
 }
-bootstrap().catch((error) => {
+bootstrap().catch((error: unknown) => {
   const logger = new LoggerService();
   logger.error(
     `Load test gateway bootstrap exception: ${error}`,

--- a/sources/packages/backend/apps/load-test-gateway/src/main.ts
+++ b/sources/packages/backend/apps/load-test-gateway/src/main.ts
@@ -3,13 +3,16 @@ import { NestFactory } from "@nestjs/core";
 import { LoadTestModule } from "./load-test.module";
 import { KeycloakConfig } from "@sims/auth/config";
 import { LoggerService } from "@sims/utilities/logger";
-import { exit } from "process";
+import { exit } from "node:process";
 import { NestExpressApplication } from "@nestjs/platform-express";
 import { ValidationPipe } from "@nestjs/common";
 
-async function bootstrap() {
+async function bootstrap(): Promise<void> {
   await KeycloakConfig.load();
   const app = await NestFactory.create<NestExpressApplication>(LoadTestModule);
+
+  // Listens to termination signals so open connections can be gracefully closed.
+  app.enableShutdownHooks();
 
   // Get the injected logger.
   const logger = await app.resolve(LoggerService);
@@ -32,7 +35,7 @@ async function bootstrap() {
   await app.listen(loadTestAPIPort);
 
   // Logging node http server error
-  app.getHttpServer().on("error", (error: unknown) => {
+  app.getHttpServer().on("error", (error) => {
     logger.error(`Load test server received ${error}`, undefined, "Bootstrap");
     exit(1);
   });
@@ -41,7 +44,7 @@ async function bootstrap() {
     "Bootstrap",
   );
 }
-bootstrap().catch((error: unknown) => {
+bootstrap().catch((error) => {
   const logger = new LoggerService();
   logger.error(
     `Load test gateway bootstrap exception: ${error}`,

--- a/sources/packages/backend/apps/queue-consumers/src/main.ts
+++ b/sources/packages/backend/apps/queue-consumers/src/main.ts
@@ -8,9 +8,13 @@ import { SystemUsersService } from "@sims/services";
 import cookieParser from "cookie-parser";
 import { NestExpressApplication } from "@nestjs/platform-express";
 
-(async () => {
+(async (): Promise<void> => {
   const app =
     await NestFactory.create<NestExpressApplication>(QueueConsumersModule);
+
+  // Listens to termination signals so open connections can be gracefully closed.
+  app.enableShutdownHooks();
+
   const config = app.get<ConfigService>(ConfigService);
 
   // Trust upstream proxy headers to resolve client IP addresses correctly.

--- a/sources/packages/backend/apps/workers/src/main.ts
+++ b/sources/packages/backend/apps/workers/src/main.ts
@@ -6,8 +6,12 @@ import { ZeebeTransportStrategy } from "./zeebe/zeebe-transport-strategy";
 import { ConfigService } from "@sims/utilities/config";
 import { SystemUsersService } from "@sims/services";
 
-(async () => {
+(async (): Promise<void> => {
   const workers = await NestFactory.create(WorkersModule, { bufferLogs: true });
+
+  // Listens to termination signals so open connections can be gracefully closed.
+  workers.enableShutdownHooks();
+
   const config = workers.get(ConfigService);
   // Get the injected logger.
   const logger = await workers.resolve(LoggerService);

--- a/sources/packages/backend/apps/workers/src/zeebe/zeebe-transport-strategy.ts
+++ b/sources/packages/backend/apps/workers/src/zeebe/zeebe-transport-strategy.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger, OnApplicationShutdown } from "@nestjs/common";
+import { Injectable, Logger } from "@nestjs/common";
 import {
   CustomTransportStrategy,
   Server,
@@ -22,7 +22,7 @@ import {
 @Injectable()
 export class ZeebeTransportStrategy
   extends Server
-  implements CustomTransportStrategy, OnApplicationShutdown
+  implements CustomTransportStrategy
 {
   constructor(
     private readonly zeebeClient: ZeebeGrpcClient,
@@ -132,14 +132,5 @@ export class ZeebeTransportStrategy
    */
   unwrap<T = never>(): T {
     throw new Error("Not available for this transport strategy.");
-  }
-
-  // Step 2: Fully close the Zeebe client connection
-  async onApplicationShutdown(signal?: string): Promise<void> {
-    this.logger.log(
-      `Signal (${signal}) received: Closing Zeebe client connection...`,
-    );
-    await this.close();
-    this.logger.log(`Zeebe client connection closed.`);
   }
 }

--- a/sources/packages/backend/apps/workers/src/zeebe/zeebe-transport-strategy.ts
+++ b/sources/packages/backend/apps/workers/src/zeebe/zeebe-transport-strategy.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger } from "@nestjs/common";
+import { Injectable, Logger, OnApplicationShutdown } from "@nestjs/common";
 import {
   CustomTransportStrategy,
   Server,
@@ -22,7 +22,7 @@ import {
 @Injectable()
 export class ZeebeTransportStrategy
   extends Server
-  implements CustomTransportStrategy
+  implements CustomTransportStrategy, OnApplicationShutdown
 {
   constructor(
     private readonly zeebeClient: ZeebeGrpcClient,
@@ -35,7 +35,7 @@ export class ZeebeTransportStrategy
    * Identify all Zeebe workers in the controllers and create the
    * respective Zeebe workers to handle all the jobs.
    */
-  async listen(callback: () => void) {
+  async listen(callback: () => void): Promise<void> {
     const initializationLogger = new Logger("Worker Initialization");
     const handlers = this.getHandlers();
     handlers.forEach((handler: MessageHandler, taskType: string) => {
@@ -86,8 +86,8 @@ export class ZeebeTransportStrategy
       // an Observable. The Promise will be returned from a
       // controller when it finishes as expected returning
       // some value. The Observable will be returned as a
-      // result of an unhandled exception when a RpcExecption
-      // will be generated and the RpcExpectionHandler will
+      // result of an unhandled exception when a RpcException
+      // will be generated and the RpcExceptionHandler will
       // wrap this exception as an Observable object.
       const jobResult = await jobHandler(job);
       if (isObservable(jobResult)) {
@@ -97,7 +97,7 @@ export class ZeebeTransportStrategy
         await lastValueFrom(jobResult);
       }
       return jobResult;
-    } catch (error: unknown) {
+    } catch (error) {
       jobLogger.error(
         `Unhandled exception while processing job ${job.type} from processInstanceKey ${job.processInstanceKey}`,
       );
@@ -110,7 +110,7 @@ export class ZeebeTransportStrategy
   /**
    * Handles the application close.
    */
-  async close() {
+  async close(): Promise<void> {
     if (this.zeebeClient) {
       await this.zeebeClient.close();
     }
@@ -121,7 +121,7 @@ export class ZeebeTransportStrategy
    * This is an abstract method from the Server class.
    * @see https://docs.nestjs.com/microservices/custom-transport#creating-a-strategy
    */
-  on() {
+  on(): void {
     throw new Error("Not available for this transport strategy.");
   }
 
@@ -132,5 +132,14 @@ export class ZeebeTransportStrategy
    */
   unwrap<T = never>(): T {
     throw new Error("Not available for this transport strategy.");
+  }
+
+  // Step 2: Fully close the Zeebe client connection
+  async onApplicationShutdown(signal?: string): Promise<void> {
+    this.logger.log(
+      `Signal (${signal}) received: Closing Zeebe client connection...`,
+    );
+    await this.close();
+    this.logger.log(`Zeebe client connection closed.`);
   }
 }

--- a/sources/packages/backend/apps/workers/src/zeebe/zeebe-transport-strategy.ts
+++ b/sources/packages/backend/apps/workers/src/zeebe/zeebe-transport-strategy.ts
@@ -97,7 +97,7 @@ export class ZeebeTransportStrategy
         await lastValueFrom(jobResult);
       }
       return jobResult;
-    } catch (error) {
+    } catch (error: unknown) {
       jobLogger.error(
         `Unhandled exception while processing job ${job.type} from processInstanceKey ${job.processInstanceKey}`,
       );

--- a/sources/packages/backend/libs/services/src/queue/queue.module.ts
+++ b/sources/packages/backend/libs/services/src/queue/queue.module.ts
@@ -1,10 +1,13 @@
-import { Global, Module } from "@nestjs/common";
+import { Global, Logger, Module, OnApplicationShutdown } from "@nestjs/common";
 import {
   BullModule,
   BullRootModuleOptions,
   BullModuleOptions,
   BullModuleAsyncOptions,
+  getQueueToken,
 } from "@nestjs/bull";
+import { ModuleRef } from "@nestjs/core";
+import { Queue } from "bull";
 import Redis, { Cluster, RedisOptions } from "ioredis";
 import { ConfigModule, ConfigService } from "@sims/utilities/config";
 import { QueueNames } from "@sims/utilities";
@@ -29,7 +32,51 @@ import { DatabaseModule } from "@sims/sims-db";
   providers: [QueueService],
   exports: [BullModule, QueueService],
 })
-export class QueueModule {}
+export class QueueModule implements OnApplicationShutdown {
+  private readonly logger = new Logger(QueueModule.name);
+
+  constructor(private readonly moduleRef: ModuleRef) {}
+
+  /**
+   * Invoked during application shutdown. Intercepts and closes each registered
+   * Bull queue while logging the teardown sequence.
+   */
+  async onApplicationShutdown(signal?: string): Promise<void> {
+    this.logger.log(`Signal (${signal}) received: Closing queue connections.`);
+
+    const queueNames = Object.values(QueueNames);
+
+    await Promise.allSettled(
+      queueNames.map(async (queueName: string) => {
+        try {
+          const queue = this.moduleRef.get<Queue>(getQueueToken(queueName), {
+            strict: false,
+          });
+
+          if (!queue) {
+            this.logger.warn(
+              `Queue '${queueName}' token not found during shutdown.`,
+            );
+            return;
+          }
+
+          this.logger.log(
+            `Closing queue '${queueName}' and its Redis connections...`,
+          );
+
+          // Closing the queue stops processing and closes all underlying Redis clients
+          await queue.close();
+
+          this.logger.log(`Queue '${queueName}' successfully closed.`);
+        } catch (error) {
+          this.logger.error(`Error closing queue '${queueName}':`, error);
+        }
+      }),
+    );
+
+    this.logger.log(`Queue client connections closed.`);
+  }
+}
 
 /**
  * Connection factory which returns connection properties

--- a/sources/packages/backend/libs/services/src/queue/queue.module.ts
+++ b/sources/packages/backend/libs/services/src/queue/queue.module.ts
@@ -4,10 +4,7 @@ import {
   BullRootModuleOptions,
   BullModuleOptions,
   BullModuleAsyncOptions,
-  getQueueToken,
 } from "@nestjs/bull";
-import { ModuleRef } from "@nestjs/core";
-import { Queue } from "bull";
 import Redis, { Cluster, RedisOptions } from "ioredis";
 import { ConfigModule, ConfigService } from "@sims/utilities/config";
 import { QueueNames } from "@sims/utilities";
@@ -35,46 +32,15 @@ import { DatabaseModule } from "@sims/sims-db";
 export class QueueModule implements OnApplicationShutdown {
   private readonly logger = new Logger(QueueModule.name);
 
-  constructor(private readonly moduleRef: ModuleRef) {}
-
   /**
-   * Invoked during application shutdown. Intercepts and closes each registered
-   * Bull queue while logging the teardown sequence.
+   * Logs the shutdown signal. Each Bull queue closes itself automatically
+   * during shutdown through its own hook registered by `@nestjs/bull`.
+   * @param signal signal that triggered the shutdown.
    */
-  async onApplicationShutdown(signal?: string): Promise<void> {
-    this.logger.log(`Signal (${signal}) received: Closing queue connections.`);
-
-    const queueNames = Object.values(QueueNames);
-
-    await Promise.allSettled(
-      queueNames.map(async (queueName: string) => {
-        try {
-          const queue = this.moduleRef.get<Queue>(getQueueToken(queueName), {
-            strict: false,
-          });
-
-          if (!queue) {
-            this.logger.warn(
-              `Queue '${queueName}' token not found during shutdown.`,
-            );
-            return;
-          }
-
-          this.logger.log(
-            `Closing queue '${queueName}' and its Redis connections...`,
-          );
-
-          // Closing the queue stops processing and closes all underlying Redis clients
-          await queue.close();
-
-          this.logger.log(`Queue '${queueName}' successfully closed.`);
-        } catch (error) {
-          this.logger.error(`Error closing queue '${queueName}':`, error);
-        }
-      }),
+  onApplicationShutdown(signal?: string): void {
+    this.logger.log(
+      `Signal (${signal}) received: queue connections will be closed automatically.`,
     );
-
-    this.logger.log(`Queue client connections closed.`);
   }
 }
 

--- a/sources/packages/backend/libs/services/src/queue/queue.module.ts
+++ b/sources/packages/backend/libs/services/src/queue/queue.module.ts
@@ -39,7 +39,7 @@ export class QueueModule implements OnApplicationShutdown {
    */
   onApplicationShutdown(signal?: string): void {
     this.logger.log(
-      `Signal (${signal}) received: queue connections will be closed automatically.`,
+      `Signal (${signal}) received: Closing Queue connections...`,
     );
   }
 }

--- a/sources/packages/backend/libs/services/src/zeebe/zeebe.module.ts
+++ b/sources/packages/backend/libs/services/src/zeebe/zeebe.module.ts
@@ -43,7 +43,11 @@ export class ZeebeModule implements OnApplicationShutdown {
     this.logger.log(
       `Signal (${signal}) received: Closing Zeebe client connection...`,
     );
-    await this.zeebeClient.close();
-    this.logger.log("Zeebe client connection closed.");
+    try {
+      await this.zeebeClient.close();
+      this.logger.log("Zeebe client connection closed.");
+    } catch (error: unknown) {
+      this.logger.error("Error during Zeebe client teardown:", error);
+    }
   }
 }

--- a/sources/packages/backend/libs/services/src/zeebe/zeebe.module.ts
+++ b/sources/packages/backend/libs/services/src/zeebe/zeebe.module.ts
@@ -1,4 +1,10 @@
-import { Module, DynamicModule, Provider } from "@nestjs/common";
+import {
+  DynamicModule,
+  Logger,
+  Module,
+  OnApplicationShutdown,
+  Provider,
+} from "@nestjs/common";
 import { Camunda8 } from "@camunda8/sdk";
 import { ZeebeGrpcClient } from "@camunda8/sdk/dist/zeebe";
 
@@ -7,7 +13,11 @@ import { ZeebeGrpcClient } from "@camunda8/sdk/dist/zeebe";
  * to be shared and injected globally.
  */
 @Module({})
-export class ZeebeModule {
+export class ZeebeModule implements OnApplicationShutdown {
+  private readonly logger = new Logger(ZeebeModule.name);
+
+  constructor(private readonly zeebeClient: ZeebeGrpcClient) {}
+
   static forRoot(): DynamicModule {
     const camunda8 = new Camunda8();
     const zeebeClientProvider: Provider = {
@@ -20,5 +30,20 @@ export class ZeebeModule {
       providers: [zeebeClientProvider],
       exports: [zeebeClientProvider],
     };
+  }
+
+  /**
+   * Closes the shared Zeebe client connection while the application is
+   * gracefully shutting down. The close call is idempotent, so it is safe
+   * even when a transport strategy (e.g. the workers app) has already
+   * closed the same client.
+   * @param signal signal that triggered the shutdown.
+   */
+  async onApplicationShutdown(signal?: string): Promise<void> {
+    this.logger.log(
+      `Signal (${signal}) received: Closing Zeebe client connection...`,
+    );
+    await this.zeebeClient.close();
+    this.logger.log("Zeebe client connection closed.");
   }
 }

--- a/sources/packages/backend/libs/services/src/zeebe/zeebe.module.ts
+++ b/sources/packages/backend/libs/services/src/zeebe/zeebe.module.ts
@@ -34,9 +34,13 @@ export class ZeebeModule implements OnApplicationShutdown {
 
   /**
    * Closes the shared Zeebe client connection while the application is
-   * gracefully shutting down. The close call is idempotent, so it is safe
-   * even when a transport strategy (e.g. the workers app) has already
-   * closed the same client.
+   * gracefully shutting down. Unlike TypeORM's DataSource or Bull's queues,
+   * the Zeebe client is not auto-managed by NestJS, so it must be closed
+   * explicitly. `close()` already drains every worker created from this
+   * client before closing the underlying gRPC channel, so no additional
+   * per-worker draining logic is required. The close call is idempotent,
+   * so it is safe even when a transport strategy (e.g. the workers app)
+   * has already closed the same client.
    * @param signal signal that triggered the shutdown.
    */
   async onApplicationShutdown(signal?: string): Promise<void> {

--- a/sources/packages/backend/libs/sims-db/src/database.module.ts
+++ b/sources/packages/backend/libs/sims-db/src/database.module.ts
@@ -25,8 +25,7 @@ export class DatabaseModule implements OnApplicationShutdown {
    */
   onApplicationShutdown(signal?: string): void {
     this.logger.log(
-      `Signal (${signal}) received: TypeORM DataSource connection will be closed automatically.`,
+      `Signal (${signal}) received: Closing TypeORM DataSource connections...`,
     );
   }
 }
-

--- a/sources/packages/backend/libs/sims-db/src/database.module.ts
+++ b/sources/packages/backend/libs/sims-db/src/database.module.ts
@@ -1,5 +1,6 @@
-import { Global, Module } from "@nestjs/common";
-import { TypeOrmModule } from "@nestjs/typeorm";
+import { Global, Logger, Module, OnApplicationShutdown } from "@nestjs/common";
+import { InjectDataSource, TypeOrmModule } from "@nestjs/typeorm";
+import { DataSource } from "typeorm";
 import { DBEntities, ormConfig } from "./data-source";
 
 @Global()
@@ -14,4 +15,27 @@ import { DBEntities, ormConfig } from "./data-source";
   ],
   exports: [TypeOrmModule],
 })
-export class DatabaseModule {}
+export class DatabaseModule implements OnApplicationShutdown {
+  private readonly logger = new Logger(DatabaseModule.name);
+
+  constructor(@InjectDataSource() private readonly dataSource: DataSource) {}
+
+  async onApplicationShutdown(signal?: string): Promise<void> {
+    this.logger.log(
+      `Signal (${signal}) received: Closing TypeORM DataSource connection...`,
+    );
+
+    if (this.dataSource.isInitialized) {
+      try {
+        // TypeORM root module auto-closes connections, but calling destroy()
+        // explicitly ensures it happens cleanly before module disposal finishes.
+        await this.dataSource.destroy();
+        this.logger.log("TypeORM connection pool successfully closed.");
+      } catch (error) {
+        this.logger.error("Error during TypeORM connection teardown:", error);
+      }
+    } else {
+      this.logger.log("TypeORM DataSource was already disconnected.");
+    }
+  }
+}

--- a/sources/packages/backend/libs/sims-db/src/database.module.ts
+++ b/sources/packages/backend/libs/sims-db/src/database.module.ts
@@ -1,6 +1,5 @@
 import { Global, Logger, Module, OnApplicationShutdown } from "@nestjs/common";
-import { InjectDataSource, TypeOrmModule } from "@nestjs/typeorm";
-import { DataSource } from "typeorm";
+import { TypeOrmModule } from "@nestjs/typeorm";
 import { DBEntities, ormConfig } from "./data-source";
 
 @Global()
@@ -18,24 +17,16 @@ import { DBEntities, ormConfig } from "./data-source";
 export class DatabaseModule implements OnApplicationShutdown {
   private readonly logger = new Logger(DatabaseModule.name);
 
-  constructor(@InjectDataSource() private readonly dataSource: DataSource) {}
-
-  async onApplicationShutdown(signal?: string): Promise<void> {
+  /**
+   * Logs the shutdown signal. The TypeORM DataSource closes itself
+   * automatically during shutdown through its own hook registered by
+   * `@nestjs/typeorm`'s `TypeOrmModule.forRoot`.
+   * @param signal signal that triggered the shutdown.
+   */
+  onApplicationShutdown(signal?: string): void {
     this.logger.log(
-      `Signal (${signal}) received: Closing TypeORM DataSource connection...`,
+      `Signal (${signal}) received: TypeORM DataSource connection will be closed automatically.`,
     );
-
-    if (this.dataSource.isInitialized) {
-      try {
-        // TypeORM root module auto-closes connections, but calling destroy()
-        // explicitly ensures it happens cleanly before module disposal finishes.
-        await this.dataSource.destroy();
-        this.logger.log("TypeORM connection pool successfully closed.");
-      } catch (error) {
-        this.logger.error("Error during TypeORM connection teardown:", error);
-      }
-    } else {
-      this.logger.log("TypeORM DataSource was already disconnected.");
-    }
   }
 }
+

--- a/sources/packages/backend/libs/test-utils/src/mocks/zeebe-client-mock.ts
+++ b/sources/packages/backend/libs/test-utils/src/mocks/zeebe-client-mock.ts
@@ -31,4 +31,5 @@ export function resetZeebeModuleMock(mockedZBClient: ZeebeGrpcClient): void {
   mockedZBClient.createProcessInstance = jest.fn();
   mockedZBClient.publishMessage = jest.fn();
   mockedZBClient.cancelProcessInstance = jest.fn();
+  mockedZBClient.close = jest.fn();
 }


### PR DESCRIPTION
### Summary

Enables shutdown hooks in nestjs
Implements and adds logs to modules onApplicationShutdown for troubleshooting purposes.

### Tests

Tests with a transaction and added temporary logs/await for 40 seconds results in an error and rollback as per below:

<img width="898" height="452" alt="image" src="https://github.com/user-attachments/assets/b5d99bba-77e6-409f-8951-da1a09e06f9f" />
<img width="892" height="157" alt="image" src="https://github.com/user-attachments/assets/265f4b67-f91d-4af9-a908-a427331aae48" />


Queue-consumer logs when testing docker stop command:
<img width="1081" height="660" alt="image" src="https://github.com/user-attachments/assets/e1124e33-6874-40c3-ba28-dad7db46dc1f" />
<img width="1071" height="818" alt="image" src="https://github.com/user-attachments/assets/c537ed0f-e1d2-4e51-9aac-7dd9c83864cd" />

Workers logs when testing docker stop command:
<img width="863" height="413" alt="image" src="https://github.com/user-attachments/assets/966e43fe-c050-4e9d-855f-cb8ebcbeed40" />

API logs when testing docker stop command:
<img width="1073" height="621" alt="image" src="https://github.com/user-attachments/assets/53b05faa-3728-4b16-9822-c24206233c57" />
