### PR TITLE
#6445 - Prevent script injection in release deploy workflow

### DIFF
--- a/.github/workflows/release-deploy-all.yml
+++ b/.github/workflows/release-deploy-all.yml
@@ -155,8 +155,10 @@ jobs:
         with:
           oc: "4"
       - name: Print env
+        env:
+          DEPLOY_ENVIRONMENT: ${{ inputs.environment }}
         run: |
-          echo Deploy Environment: ${{ inputs.environment }}
+          echo "Deploy Environment: $DEPLOY_ENVIRONMENT"
           echo GIT REF: ${{ needs.env-setup.outputs.build-ref }}
           echo BUILD NAMESPACE: $BUILD_NAMESPACE
           echo OC CLI Version: $(oc version)
@@ -184,8 +186,10 @@ jobs:
         with:
           oc: "4"
       - name: Print env
+        env:
+          DEPLOY_ENVIRONMENT: ${{ inputs.environment }}
         run: |
-          echo Deploy ENVIRONMENT: ${{ inputs.environment }}
+          echo "Deploy ENVIRONMENT: $DEPLOY_ENVIRONMENT"
           echo GIT REF: ${{ needs.env-setup.outputs.build-ref }}
           echo BUILD NAMESPACE: $BUILD_NAMESPACE
           echo OC CLI Version: $(oc version)
@@ -215,8 +219,10 @@ jobs:
         with:
           oc: "4"
       - name: Print env
+        env:
+          DEPLOY_ENVIRONMENT: ${{ inputs.environment }}
         run: |
-          echo BUILD ENVIRONMENT: ${{ inputs.environment }}
+          echo "BUILD ENVIRONMENT: $DEPLOY_ENVIRONMENT"
           echo GIT REF: ${{ needs.env-setup.outputs.build-ref }}
           echo OC CLI Version: $(oc version)
       - name: Checkout Target Branch
@@ -243,8 +249,10 @@ jobs:
         with:
           oc: "4"
       - name: Print env
+        env:
+          DEPLOY_ENVIRONMENT: ${{ inputs.environment }}
         run: |
-          echo Deploy ENVIRONMENT: ${{ inputs.environment }}
+          echo "Deploy ENVIRONMENT: $DEPLOY_ENVIRONMENT"
           echo GIT REF: ${{ needs.env-setup.outputs.build-ref }}
           echo BUILD NAMESPACE: $BUILD_NAMESPACE
           echo OC CLI Version: $(oc version)
@@ -272,8 +280,10 @@ jobs:
         with:
           oc: "4"
       - name: Print env
+        env:
+          DEPLOY_ENVIRONMENT: ${{ inputs.environment }}
         run: |
-          echo Deploy ENVIRONMENT: ${{ inputs.environment }}
+          echo "Deploy ENVIRONMENT: $DEPLOY_ENVIRONMENT"
           echo GIT REF: ${{ needs.env-setup.outputs.build-ref }}
           echo BUILD NAMESPACE: $BUILD_NAMESPACE
           echo OC CLI Version: $(oc version)


### PR DESCRIPTION
## Summary

- Pass the deployment environment to each diagnostic shell step through `DEPLOY_ENVIRONMENT`.
- Replace direct `${{ inputs.environment }}` interpolation inside `run` blocks with standard shell expansion.
- Prevent user-controlled workflow input from being interpreted as shell commands while preserving deployment diagnostics.

## Validation

- `git diff --check`
- Confirmed no direct `inputs.environment` interpolation remains within workflow `run` blocks.
- Secret scan of the change reported no secrets.

Closes #6445.