### PR TITLE
#6438 - Release 4.1.0 - Sonar Cloud Warnings - Part 2

### DIFF
--- a/.github/workflows/release-build-all.yml
+++ b/.github/workflows/release-build-all.yml
@@ -1,6 +1,6 @@
 name: Release - Build All
 run-name: Release - Build all from ${{ github.ref_name }}(build ${{ github.run_number }})
-
+permissions: {}
 concurrency: release-build-all
 
 on:

--- a/.github/workflows/release-build-all.yml
+++ b/.github/workflows/release-build-all.yml
@@ -1,8 +1,5 @@
 name: Release - Build All
 run-name: Release - Build all from ${{ github.ref_name }}(build ${{ github.run_number }})
-permissions:
-  contents: write
-  actions: read
 
 concurrency: release-build-all
 
@@ -32,6 +29,8 @@ jobs:
   # Print variables for logging and debugging purposes.
   checkEnv:
     name: Check Env variables
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     if: github.event.pull_request.merged == true || github.event_name == 'workflow_dispatch'
     steps:
@@ -45,6 +44,8 @@ jobs:
   # Create new tag.
   createTag:
     name: Create tag
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     needs: checkEnv
     steps:
@@ -73,6 +74,8 @@ jobs:
   # Build migrations.
   build-migrations:
     name: Build migrations
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     needs: createTag
     env:
@@ -102,6 +105,8 @@ jobs:
   # Build SIMS-API
   build-sims-api:
     name: Build SIMS-API
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     needs: createTag
     env:
@@ -131,6 +136,8 @@ jobs:
   # Build Workers
   build-workers:
     name: Build Workers
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     needs: createTag
     env:
@@ -160,6 +167,8 @@ jobs:
   # Build Queue Consumers
   build-queue-consumers:
     name: Build Queue Consumers
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     needs: createTag
     env:
@@ -189,6 +198,8 @@ jobs:
   # Build Web/Frontend
   build-web-frontend:
     name: Build Web/Frontend
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     needs: createTag
     env:
@@ -221,6 +232,8 @@ jobs:
   deployAlltoDEV:
     if: github.event_name == 'pull_request' && vars.ALLOW_AUTOMATIC_MAIN_BRANCH_DEPLOY_TO_DEV == 'true' && github.ref_name == 'main'
     name: Deploy All to DEV
+    permissions:
+      contents: read
     needs:
       [
         createTag,

--- a/.github/workflows/release-build-all.yml
+++ b/.github/workflows/release-build-all.yml
@@ -29,8 +29,6 @@ jobs:
   # Print variables for logging and debugging purposes.
   checkEnv:
     name: Check Env variables
-    permissions:
-      contents: read
     runs-on: ubuntu-latest
     if: github.event.pull_request.merged == true || github.event_name == 'workflow_dispatch'
     steps:

--- a/.github/workflows/release-deploy-all.yml
+++ b/.github/workflows/release-deploy-all.yml
@@ -1,8 +1,5 @@
 name: Release - Deploy All
 run-name: Release - Deploy all from ${{ github.ref_name }} to ${{ inputs.environment }}
-permissions:
-  contents: read
-  actions: read
 
 on:
   workflow_dispatch:
@@ -133,6 +130,8 @@ env:
 jobs:
   env-setup:
     name: Setup Dynamic Environment Variables
+    permissions:
+      contents: read
     environment: ${{ inputs.environment }}
     runs-on: ubuntu-latest
     outputs:
@@ -146,6 +145,8 @@ jobs:
   # Run DB migrations.
   run-db-migrations:
     name: Run DB Migrations
+    permissions:
+      contents: read
     environment: ${{ inputs.environment }}
     runs-on: ubuntu-latest
     needs: env-setup
@@ -178,6 +179,8 @@ jobs:
   # Deploy SIMS API.
   deploy-sims-api:
     name: Deploy SIMS-API
+    permissions:
+      contents: read
     environment: ${{ inputs.environment }}
     runs-on: ubuntu-latest
     needs: [env-setup, run-db-migrations]
@@ -210,6 +213,8 @@ jobs:
   # Deploy workers.
   deploy-workers:
     name: Deploy Workers
+    permissions:
+      contents: read
     environment: ${{ inputs.environment }}
     env:
       DISABLE_ORM_CACHE: true
@@ -243,6 +248,8 @@ jobs:
   # Deploy queue consumers.
   deploy-queue-consumers:
     name: Deploy Queue Consumers
+    permissions:
+      contents: read
     environment: ${{ inputs.environment }}
     runs-on: ubuntu-latest
     needs: [env-setup, run-db-migrations]
@@ -275,6 +282,8 @@ jobs:
   # Deploy Web/Frontend.
   deploy-web-frontend:
     name: Deploy Web/Frontend
+    permissions:
+      contents: read
     environment: ${{ inputs.environment }}
     runs-on: ubuntu-latest
     needs: [env-setup, run-db-migrations]
@@ -307,6 +316,8 @@ jobs:
   # Deploy Camunda and Form.io Definitions
   deployCamundaFormioDefinitions:
     name: Deploy Camunda and Form.io definitions
+    permissions:
+      contents: read
     needs: [env-setup, deploy-sims-api]
     uses: ./.github/workflows/release-deploy-camunda-formio-definitions.yml
     with:

--- a/.github/workflows/release-deploy-all.yml
+++ b/.github/workflows/release-deploy-all.yml
@@ -130,8 +130,6 @@ env:
 jobs:
   env-setup:
     name: Setup Dynamic Environment Variables
-    permissions:
-      contents: read
     environment: ${{ inputs.environment }}
     runs-on: ubuntu-latest
     outputs:

--- a/.github/workflows/release-deploy-all.yml
+++ b/.github/workflows/release-deploy-all.yml
@@ -1,5 +1,6 @@
 name: Release - Deploy All
 run-name: Release - Deploy all from ${{ github.ref_name }} to ${{ inputs.environment }}
+permissions: {}
 
 on:
   workflow_dispatch:

--- a/.github/workflows/repo-checks-tests.yml
+++ b/.github/workflows/repo-checks-tests.yml
@@ -5,6 +5,7 @@
 # To allow access to the secrets in both cases, the test users' passwords (or any other secret) are defined at the
 # repository level and also at the `dependabot` secrets for now.
 name: Repo Checks - Tests
+permissions: {}
 
 on: [pull_request]
 

--- a/.github/workflows/repo-checks-tests.yml
+++ b/.github/workflows/repo-checks-tests.yml
@@ -29,7 +29,6 @@ jobs:
     name: SIMS API E2E Tests
     permissions:
       contents: read
-      actions: read
       checks: write
       pull-requests: write
       statuses: write

--- a/.github/workflows/repo-checks-tests.yml
+++ b/.github/workflows/repo-checks-tests.yml
@@ -5,12 +5,6 @@
 # To allow access to the secrets in both cases, the test users' passwords (or any other secret) are defined at the
 # repository level and also at the `dependabot` secrets for now.
 name: Repo Checks - Tests
-permissions:
-  contents: read
-  actions: read
-  checks: write
-  pull-requests: write
-  statuses: write
 
 on: [pull_request]
 
@@ -33,6 +27,12 @@ env:
 jobs:
   api-e2e-tests:
     name: SIMS API E2E Tests
+    permissions:
+      contents: read
+      actions: read
+      checks: write
+      pull-requests: write
+      statuses: write
     runs-on: ubuntu-latest
     env:
       API_PORT: 3000
@@ -87,6 +87,12 @@ jobs:
           comment_footer: false
   workers-e2e-tests:
     name: Workflow Workers E2E Tests
+    permissions:
+      contents: read
+      actions: read
+      checks: write
+      pull-requests: write
+      statuses: write
     runs-on: ubuntu-latest
     env:
       WORKERS_PORT: 3020
@@ -114,6 +120,9 @@ jobs:
           comment_footer: false
   workflow-e2e-tests:
     name: Workflow E2E Tests
+    permissions:
+      contents: read
+      actions: read
     runs-on: ubuntu-latest
     steps:
       # Checkout the PR branch.
@@ -126,6 +135,12 @@ jobs:
           make e2e-tests-workflow
   queue-consumers-e2e-tests:
     name: Queue Consumers E2E Tests
+    permissions:
+      contents: read
+      actions: read
+      checks: write
+      pull-requests: write
+      statuses: write
     runs-on: ubuntu-latest
     env:
       QUEUE_CONSUMERS_PORT: 3001
@@ -157,6 +172,12 @@ jobs:
           comment_footer: false
   backend-unit-tests:
     name: Backend Unit Tests
+    permissions:
+      contents: read
+      actions: read
+      checks: write
+      pull-requests: write
+      statuses: write
     runs-on: ubuntu-latest
     steps:
       # Checkout the PR branch.

--- a/.github/workflows/repo-checks-tests.yml
+++ b/.github/workflows/repo-checks-tests.yml
@@ -88,7 +88,6 @@ jobs:
     name: Workflow Workers E2E Tests
     permissions:
       contents: read
-      actions: read
       checks: write
       pull-requests: write
       statuses: write
@@ -121,7 +120,6 @@ jobs:
     name: Workflow E2E Tests
     permissions:
       contents: read
-      actions: read
     runs-on: ubuntu-latest
     steps:
       # Checkout the PR branch.
@@ -136,7 +134,6 @@ jobs:
     name: Queue Consumers E2E Tests
     permissions:
       contents: read
-      actions: read
       checks: write
       pull-requests: write
       statuses: write
@@ -173,7 +170,6 @@ jobs:
     name: Backend Unit Tests
     permissions:
       contents: read
-      actions: read
       checks: write
       pull-requests: write
       statuses: write


### PR DESCRIPTION
Minor GitHub Actions adjustments to resolve SonarCloud issues.

Use these three workflows to set a pattern.
- Deny all permissions at the workflow level; and
- Assign specific permissions at every job scope.

The above would be a combination of SonarCloud and Copilot recommendations.