### PR TITLE
#6267 - Cancel appeals on application edit and cancel - E2E Tests

### DIFF
--- a/sources/packages/backend/apps/api/src/route-controllers/application/_tests_/e2e/application-form-submission-utils.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/application/_tests_/e2e/application-form-submission-utils.ts
@@ -36,6 +36,7 @@ export async function assertCancelledApplicationScopedFormSubmissions(
     where: {
       application: { id: applicationId },
     },
+    order: { id: "ASC" },
     loadEagerRelations: false,
   });
   const auditUser = { id: auditUserId };
@@ -76,7 +77,7 @@ export async function assertFormSubmissionNotUpdated(
   expect(formSubmission.cancellationReason).not.toBe(
     notExpectedCancellationReason,
   );
-  expect(formSubmission.submissionStatusUpdatedOn).not.toBe(
+  expect(formSubmission.submissionStatusUpdatedOn).not.toEqual(
     notExpectedSubmissionStatusDate,
   );
 }

--- a/sources/packages/backend/apps/api/src/route-controllers/application/_tests_/e2e/application-form-submission-utils.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/application/_tests_/e2e/application-form-submission-utils.ts
@@ -1,0 +1,82 @@
+import {
+  FormSubmissionCancellationReason,
+  FormSubmissionStatus,
+} from "@sims/sims-db";
+import { E2EDataSources } from "@sims/test-utils";
+
+/**
+ * Verify if all the application scoped form submissions are cancelled.
+ * @param db E2EDataSources instance to access the database.
+ * @param applicationId form submission application ID.
+ * @param cancellationReason form submission cancellation reason.
+ * @param expectedFormSubmissionIds  expected form submission IDs that should be cancelled.
+ * @param auditUser user who performed the cancellation.
+ * @param auditDate date when the cancellation was performed.
+ */
+export async function assertCancelledApplicationScopedFormSubmissions(
+  db: E2EDataSources,
+  applicationId: number,
+  cancellationReason: FormSubmissionCancellationReason,
+  expectedFormSubmissionIds: number[],
+  auditUserId: number,
+  auditDate: Date,
+): Promise<void> {
+  // Verify if all the application scoped form submissions are cancelled.
+  const updatedFormSubmissions = await db.formSubmission.find({
+    select: {
+      id: true,
+      submissionStatus: true,
+      cancellationReason: true,
+      submissionStatusUpdatedBy: { id: true },
+      submissionStatusUpdatedOn: true,
+      modifier: { id: true },
+      updatedAt: true,
+    },
+    relations: { submissionStatusUpdatedBy: true, modifier: true },
+    where: {
+      application: { id: applicationId },
+    },
+    loadEagerRelations: false,
+  });
+  const auditUser = { id: auditUserId };
+  expect(updatedFormSubmissions).toEqual(
+    expectedFormSubmissionIds.map((id) => ({
+      id,
+      submissionStatus: FormSubmissionStatus.Cancelled,
+      cancellationReason,
+      submissionStatusUpdatedBy: auditUser,
+      submissionStatusUpdatedOn: auditDate,
+      modifier: auditUser,
+      updatedAt: auditDate,
+    })),
+  );
+}
+
+/**
+ * Verify if a form submission was not updated.
+ * @param db E2EDataSources instance to access the database.
+ * @param formSubmissionId form submission ID.
+ * @param notExpectedCancellationReason cancellation reason that should not be set.
+ * @param notExpectedSubmissionStatusDate submission status date that should not be set.
+ */
+export async function assertFormSubmissionNotUpdated(
+  db: E2EDataSources,
+  formSubmissionId: number,
+  notExpectedCancellationReason: FormSubmissionCancellationReason,
+  notExpectedSubmissionStatusDate: Date,
+): Promise<void> {
+  const formSubmission = await db.formSubmission.findOne({
+    select: {
+      id: true,
+      submissionStatusUpdatedOn: true,
+      cancellationReason: true,
+    },
+    where: { id: formSubmissionId },
+  });
+  expect(formSubmission.cancellationReason).not.toBe(
+    notExpectedCancellationReason,
+  );
+  expect(formSubmission.submissionStatusUpdatedOn).not.toBe(
+    notExpectedSubmissionStatusDate,
+  );
+}

--- a/sources/packages/backend/apps/api/src/route-controllers/application/_tests_/e2e/application.students.controller.cancelStudentApplication.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/application/_tests_/e2e/application.students.controller.cancelStudentApplication.e2e-spec.ts
@@ -1,0 +1,347 @@
+import { HttpStatus, INestApplication } from "@nestjs/common";
+import { TestingModule } from "@nestjs/testing";
+import request from "supertest";
+import {
+  AESTGroups,
+  BEARER_AUTH_TYPE,
+  createTestingAppModule,
+  FakeStudentUsersTypes,
+  getAESTUser,
+  getStudentToken,
+  mockJWTUserInfo,
+  mockUserLoginInfo,
+  resetMockJWTUserInfo,
+} from "../../../../testHelpers";
+import {
+  createE2EDataSources,
+  E2EDataSources,
+  saveFakeApplication,
+  saveFakeFormSubmissionFromInputTestData,
+} from "@sims/test-utils";
+import {
+  ApplicationStatus,
+  FormCategory,
+  FormSubmissionCancellationReason,
+  FormSubmissionDecisionStatus,
+  FormSubmissionStatus,
+  StudentAssessmentStatus,
+  User,
+} from "@sims/sims-db";
+import MockDate from "mockdate";
+import { beforeEach } from "node:test";
+import {
+  DynamicConfigurationTestData,
+  createFakeFormConfigurations,
+} from "../../../form-submission/_tests_/e2e/form-submission-utils";
+import {
+  assertCancelledApplicationScopedFormSubmissions,
+  assertFormSubmissionNotUpdated,
+} from "./application-form-submission-utils";
+
+describe("ApplicationStudentsController(e2e)-cancelStudentApplication", () => {
+  let app: INestApplication;
+  let appModule: TestingModule;
+  let db: E2EDataSources;
+  let ministryUser: User;
+  let formConfigs: DynamicConfigurationTestData;
+
+  beforeAll(async () => {
+    const { nestApplication, module, dataSource } =
+      await createTestingAppModule();
+    app = nestApplication;
+    appModule = module;
+    db = createE2EDataSources(dataSource);
+    const auditUser = await getAESTUser(
+      dataSource,
+      AESTGroups.BusinessAdministrators,
+    );
+    ministryUser = { id: auditUser.id } as User;
+    formConfigs = await createFakeFormConfigurations(app, db);
+  });
+
+  beforeEach(async () => {
+    await resetMockJWTUserInfo(appModule);
+    MockDate.reset();
+  });
+
+  it(
+    `Should cancel a student application and update the current assessment status to ${StudentAssessmentStatus.CancellationRequested}` +
+      ` when the application has current assessment created and application status is ${ApplicationStatus.Assessment}`,
+    async () => {
+      // Arrange
+      const application = await saveFakeApplication(db.dataSource, undefined, {
+        applicationStatus: ApplicationStatus.Assessment,
+      });
+      const student = application.student;
+      const token = await getStudentToken(
+        FakeStudentUsersTypes.FakeStudentUserType1,
+      );
+      await mockJWTUserInfo(appModule, student.user);
+      const now = new Date();
+      MockDate.set(now);
+
+      // Act/Assert
+      await request(app.getHttpServer())
+        .patch(getEndpoint(application.id))
+        .auth(token, BEARER_AUTH_TYPE)
+        .expect(HttpStatus.OK);
+
+      const cancelledApplication = await db.application.findOne({
+        select: {
+          id: true,
+          applicationStatus: true,
+          applicationStatusUpdatedOn: true,
+          modifier: { id: true },
+          updatedAt: true,
+          currentAssessment: {
+            id: true,
+            studentAssessmentStatus: true,
+            studentAssessmentStatusUpdatedOn: true,
+            modifier: { id: true },
+            updatedAt: true,
+          },
+        },
+        relations: {
+          modifier: true,
+          currentAssessment: { modifier: true },
+        },
+        where: { id: application.id },
+        loadEagerRelations: false,
+      });
+      const auditUser = { id: student.user.id };
+      // Expected updated fields.
+      expect(cancelledApplication).toEqual({
+        id: application.id,
+        applicationStatus: ApplicationStatus.Cancelled,
+        applicationStatusUpdatedOn: now,
+        modifier: auditUser,
+        updatedAt: now,
+        currentAssessment: {
+          id: application.currentAssessment.id,
+          studentAssessmentStatus:
+            StudentAssessmentStatus.CancellationRequested,
+          studentAssessmentStatusUpdatedOn: now,
+          modifier: auditUser,
+          updatedAt: now,
+        },
+      });
+    },
+  );
+
+  [
+    FormSubmissionStatus.Pending,
+    FormSubmissionStatus.Completed,
+    FormSubmissionStatus.Declined,
+  ].forEach((submissionStatus) => {
+    it(
+      "Should cancel a student application and also cancel the application scoped form submission" +
+        ` when application status is ${ApplicationStatus.Assessment} and the application has a form submission with submission status ${submissionStatus}.`,
+      async () => {
+        // Arrange
+        const application = await saveFakeApplication(
+          db.dataSource,
+          undefined,
+          {
+            applicationStatus: ApplicationStatus.Assessment,
+          },
+        );
+        const student = application.student;
+        const formSubmission = await saveFakeFormSubmissionFromInputTestData(
+          db,
+          {
+            now: new Date(),
+            student,
+            application,
+            formCategory: FormCategory.StudentAppeal,
+            submissionStatus,
+            ministryAuditUser: ministryUser,
+            formSubmissionItems: [
+              {
+                dynamicFormConfiguration: formConfigs.studentAppealApplicationA,
+                decisions: [
+                  {
+                    decisionStatus: FormSubmissionDecisionStatus.Approved,
+                  },
+                ],
+              },
+            ],
+          },
+        );
+        const token = await getStudentToken(
+          FakeStudentUsersTypes.FakeStudentUserType1,
+        );
+        await mockJWTUserInfo(appModule, student.user);
+        const now = new Date();
+        MockDate.set(now);
+
+        // Act/Assert
+        await request(app.getHttpServer())
+          .patch(getEndpoint(application.id))
+          .auth(token, BEARER_AUTH_TYPE)
+          .expect(HttpStatus.OK);
+
+        // Verify if the application is cancelled.
+        const isApplicationCancelled = await db.application.exists({
+          where: {
+            id: application.id,
+            applicationStatus: ApplicationStatus.Cancelled,
+          },
+        });
+        expect(isApplicationCancelled).toBe(true);
+
+        // Verify if all the application scoped form submissions are cancelled.
+        await assertCancelledApplicationScopedFormSubmissions(
+          db,
+          application.id,
+          FormSubmissionCancellationReason.ApplicationCancelled,
+          [formSubmission.id],
+          student.user.id,
+          now,
+        );
+      },
+    );
+  });
+
+  it(
+    "Should cancel a student application but not update the application scoped form submission" +
+      ` when application status is ${ApplicationStatus.Assessment} and the application has a form submission that is already cancelled.`,
+    async () => {
+      // Arrange
+      const application = await saveFakeApplication(db.dataSource, undefined, {
+        applicationStatus: ApplicationStatus.Assessment,
+      });
+      const student = application.student;
+      const formSubmission = await saveFakeFormSubmissionFromInputTestData(db, {
+        now: new Date(),
+        student,
+        application,
+        formCategory: FormCategory.StudentAppeal,
+        submissionStatus: FormSubmissionStatus.Cancelled,
+        cancellationReason:
+          FormSubmissionCancellationReason.StudentCancelledSubmission,
+        ministryAuditUser: ministryUser,
+        formSubmissionItems: [
+          {
+            dynamicFormConfiguration: formConfigs.studentAppealApplicationA,
+            decisions: [
+              {
+                decisionStatus: FormSubmissionDecisionStatus.Approved,
+              },
+            ],
+          },
+        ],
+      });
+      const token = await getStudentToken(
+        FakeStudentUsersTypes.FakeStudentUserType1,
+      );
+      await mockJWTUserInfo(appModule, student.user);
+      const now = new Date();
+      MockDate.set(now);
+
+      // Act/Assert
+      await request(app.getHttpServer())
+        .patch(getEndpoint(application.id))
+        .auth(token, BEARER_AUTH_TYPE)
+        .expect(HttpStatus.OK);
+
+      // Verify if the application is cancelled.
+      const isApplicationCancelled = await db.application.exists({
+        where: {
+          id: application.id,
+          applicationStatus: ApplicationStatus.Cancelled,
+        },
+      });
+      expect(isApplicationCancelled).toBe(true);
+      // Verify if the application scoped form submission is not updated since it was already cancelled.
+      await assertFormSubmissionNotUpdated(
+        db,
+        formSubmission.id,
+        FormSubmissionCancellationReason.ApplicationCancelled,
+        now,
+      );
+    },
+  );
+
+  [
+    ApplicationStatus.Completed,
+    ApplicationStatus.Cancelled,
+    ApplicationStatus.Edited,
+  ].forEach((applicationStatus) => {
+    it(`Should throw a not found exception when the application status is ${applicationStatus}.`, async () => {
+      // Arrange
+      const application = await saveFakeApplication(db.dataSource, undefined, {
+        applicationStatus,
+      });
+      const token = await getStudentToken(
+        FakeStudentUsersTypes.FakeStudentUserType1,
+      );
+      await mockUserLoginInfo(appModule, application.student);
+
+      // Act/Assert
+      await request(app.getHttpServer())
+        .patch(getEndpoint(application.id))
+        .auth(token, BEARER_AUTH_TYPE)
+        .expect(HttpStatus.NOT_FOUND)
+        .expect({
+          message:
+            "Application not found or it is not in the correct state to be cancelled.",
+          error: "Not Found",
+          statusCode: HttpStatus.NOT_FOUND,
+        });
+    });
+  });
+
+  it("Should throw a not found exception when the application does not belong to the student.", async () => {
+    // Arrange
+    const application = await saveFakeApplication(db.dataSource, undefined, {
+      applicationStatus: ApplicationStatus.Assessment,
+    });
+    const token = await getStudentToken(
+      FakeStudentUsersTypes.FakeStudentUserType1,
+    );
+
+    // Act/Assert
+    await request(app.getHttpServer())
+      .patch(getEndpoint(application.id))
+      .auth(token, BEARER_AUTH_TYPE)
+      .expect(HttpStatus.NOT_FOUND)
+      .expect({
+        message:
+          "Application not found or it is not in the correct state to be cancelled.",
+        error: "Not Found",
+        statusCode: HttpStatus.NOT_FOUND,
+      });
+  });
+
+  it("Should throw a NotFoundException when the application does not exist.", async () => {
+    // Arrange
+    const token = await getStudentToken(
+      FakeStudentUsersTypes.FakeStudentUserType1,
+    );
+
+    // Act/Assert
+    await request(app.getHttpServer())
+      .patch(getEndpoint(9999999))
+      .auth(token, BEARER_AUTH_TYPE)
+      .expect(HttpStatus.NOT_FOUND)
+      .expect({
+        message:
+          "Application not found or it is not in the correct state to be cancelled.",
+        error: "Not Found",
+        statusCode: HttpStatus.NOT_FOUND,
+      });
+  });
+
+  afterAll(async () => {
+    await app?.close();
+  });
+});
+
+/**
+ * Get the endpoint for cancelling a student application.
+ * @param applicationId
+ * @returns endpoint for cancelling a student application.
+ */
+function getEndpoint(applicationId: number): string {
+  return `/students/application/${applicationId}/cancel`;
+}

--- a/sources/packages/backend/apps/api/src/route-controllers/application/_tests_/e2e/application.students.controller.cancelStudentApplication.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/application/_tests_/e2e/application.students.controller.cancelStudentApplication.e2e-spec.ts
@@ -28,7 +28,6 @@ import {
   User,
 } from "@sims/sims-db";
 import MockDate from "mockdate";
-import { beforeEach } from "node:test";
 import {
   DynamicConfigurationTestData,
   createFakeFormConfigurations,
@@ -66,7 +65,7 @@ describe("ApplicationStudentsController(e2e)-cancelStudentApplication", () => {
 
   it(
     `Should cancel a student application and update the current assessment status to ${StudentAssessmentStatus.CancellationRequested}` +
-      ` when the application has current assessment created and application status is ${ApplicationStatus.Assessment}`,
+      ` when the application has current assessment created and application status is ${ApplicationStatus.Assessment}.`,
     async () => {
       // Arrange
       const application = await saveFakeApplication(db.dataSource, undefined, {

--- a/sources/packages/backend/apps/api/src/route-controllers/application/_tests_/e2e/application.students.controller.cancelStudentApplication.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/application/_tests_/e2e/application.students.controller.cancelStudentApplication.e2e-spec.ts
@@ -339,7 +339,7 @@ describe("ApplicationStudentsController(e2e)-cancelStudentApplication", () => {
 
 /**
  * Get the endpoint for cancelling a student application.
- * @param applicationId
+ * @param applicationId application ID to be cancelled.
  * @returns endpoint for cancelling a student application.
  */
 function getEndpoint(applicationId: number): string {

--- a/sources/packages/backend/apps/api/src/route-controllers/application/_tests_/e2e/application.students.controller.submitApplication.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/application/_tests_/e2e/application.students.controller.submitApplication.e2e-spec.ts
@@ -981,7 +981,7 @@ describe("ApplicationStudentsController(e2e)-submitApplication", () => {
     FormSubmissionStatus.Completed,
     FormSubmissionStatus.Declined,
   ].forEach((submissionStatus) => {
-    it(`Should edit an application and and also cancel the application scoped form submission when the form submission status is ${submissionStatus}.`, async () => {
+    it(`Should edit an application and also cancel the application scoped form submission when the form submission status is ${submissionStatus}.`, async () => {
       // Arrange
       const student = await saveFakeStudent(db.dataSource);
       // Create a submitted application to be edited.
@@ -996,7 +996,7 @@ describe("ApplicationStudentsController(e2e)-submitApplication", () => {
           offeringIntensity: OfferingIntensity.fullTime,
         },
       );
-      // Create a form submission that is expected to be cancel on application edit.
+      // Create a form submission that is expected to be cancelled on application edit.
       const formSubmission = await saveFakeFormSubmissionFromInputTestData(db, {
         now: new Date(),
         student,
@@ -1072,7 +1072,7 @@ describe("ApplicationStudentsController(e2e)-submitApplication", () => {
     });
   });
 
-  it("Should edit an application and but not update the application scoped form submission when the form submission status is already cancelled.", async () => {
+  it("Should edit an application but not update the application scoped form submission when the form submission status is already cancelled.", async () => {
     // Arrange
     const student = await saveFakeStudent(db.dataSource);
     // Create a submitted application to be edited.

--- a/sources/packages/backend/apps/api/src/route-controllers/application/_tests_/e2e/application.students.controller.submitApplication.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/application/_tests_/e2e/application.students.controller.submitApplication.e2e-spec.ts
@@ -3,9 +3,11 @@ import { TestingModule } from "@nestjs/testing";
 import request from "supertest";
 import { DataSource } from "typeorm";
 import {
+  AESTGroups,
   BEARER_AUTH_TYPE,
   createTestingAppModule,
   FakeStudentUsersTypes,
+  getAESTUser,
   getStudentToken,
   mockJWTUserInfo,
   resetMockJWTUserInfo,
@@ -22,17 +24,25 @@ import {
   RestrictionCode,
   ensureProgramYearExistsForPartTimeOnly,
   saveFakeInstitutionRestriction,
+  saveFakeFormSubmissionFromInputTestData,
 } from "@sims/test-utils";
 import {
   Application,
   ApplicationData,
   ApplicationStatus,
   EducationProgramOffering,
+  FormCategory,
+  FormSubmissionCancellationReason,
+  FormSubmissionDecisionStatus,
+  FormSubmissionStatus,
   OfferingIntensity,
   ProgramYear,
+  RelationshipStatus,
   RestrictionType,
   Student,
+  User,
 } from "@sims/sims-db";
+import MockDate from "mockdate";
 import { addDays, getISODateOnlyString } from "@sims/utilities";
 import { SaveApplicationAPIInDTO } from "../../models/application.dto";
 import { FormNames, FormService } from "../../../../services";
@@ -41,6 +51,14 @@ import { createFakeSFASPartTimeApplication } from "@sims/test-utils/factories/sf
 import { createFakeSFASApplication } from "@sims/test-utils/factories/sfas-application";
 import { ConfigServiceMockHelper } from "@sims/test-utils/mocks";
 import { ACTIVE_INSTITUTION_RESTRICTION } from "../../../../constants";
+import {
+  createFakeFormConfigurations,
+  DynamicConfigurationTestData,
+} from "../../../form-submission/_tests_/e2e/form-submission-utils";
+import {
+  assertCancelledApplicationScopedFormSubmissions,
+  assertFormSubmissionNotUpdated,
+} from "./application-form-submission-utils";
 
 describe("ApplicationStudentsController(e2e)-submitApplication", () => {
   let app: INestApplication;
@@ -50,6 +68,8 @@ describe("ApplicationStudentsController(e2e)-submitApplication", () => {
   let formService: FormService;
   let recentActiveProgramYear: ProgramYear;
   let configServiceMockHelper: ConfigServiceMockHelper;
+  let formConfigs: DynamicConfigurationTestData;
+  let ministryUser: User;
   // All tests in this describe mock the Form.io dryRunSubmission because the application
   // form has too many required fields. The minimal stub payloads are intentionally
   // incomplete to test specific application submission business logic (e.g., study date
@@ -74,6 +94,12 @@ describe("ApplicationStudentsController(e2e)-submitApplication", () => {
       where: { active: true },
       order: { startDate: "DESC" },
     });
+    formConfigs = await createFakeFormConfigurations(app, db);
+    const auditUser = await getAESTUser(
+      dataSource,
+      AESTGroups.BusinessAdministrators,
+    );
+    ministryUser = { id: auditUser.id } as User;
     // To check the study dates overlap error, the BYPASS_APPLICATION_SUBMIT_VALIDATIONS needs to be set false.
     process.env.BYPASS_APPLICATION_SUBMIT_VALIDATIONS = "false";
   });
@@ -81,6 +107,7 @@ describe("ApplicationStudentsController(e2e)-submitApplication", () => {
   beforeEach(() => {
     resetMockJWTUserInfo(appModule);
     configServiceMockHelper.allowBetaUsersOnly(false);
+    MockDate.reset();
   });
 
   it("Should throw study dates overlap error when an application submitted for a student via the SIMS system has overlapping study start or study end dates with another application.", async () => {
@@ -948,6 +975,190 @@ describe("ApplicationStudentsController(e2e)-submitApplication", () => {
       ).toBe(true);
     },
   );
+
+  [
+    FormSubmissionStatus.Pending,
+    FormSubmissionStatus.Completed,
+    FormSubmissionStatus.Declined,
+  ].forEach((submissionStatus) => {
+    it(`Should edit an application and and also cancel the application scoped form submission when the form submission status is ${submissionStatus}.`, async () => {
+      // Arrange
+      const student = await saveFakeStudent(db.dataSource);
+      // Create a submitted application to be edited.
+      const application = await saveFakeApplication(
+        db.dataSource,
+        {
+          student,
+          programYear: recentActiveProgramYear,
+        },
+        {
+          applicationStatus: ApplicationStatus.Enrolment,
+          offeringIntensity: OfferingIntensity.fullTime,
+        },
+      );
+      // Create a form submission that is expected to be cancel on application edit.
+      const formSubmission = await saveFakeFormSubmissionFromInputTestData(db, {
+        now: new Date(),
+        student,
+        application,
+        formCategory: FormCategory.StudentAppeal,
+        submissionStatus,
+        ministryAuditUser: ministryUser,
+        formSubmissionItems: [
+          {
+            dynamicFormConfiguration: formConfigs.studentAppealApplicationA,
+            decisions: [
+              {
+                decisionStatus: FormSubmissionDecisionStatus.Approved,
+              },
+            ],
+          },
+        ],
+      });
+      const offering = application.currentAssessment.offering;
+      const applicationData = {
+        selectedProgram: offering.educationProgram.id,
+        selectedOffering: offering.id,
+        selectedLocation: offering.institutionLocation.id,
+        relationshipStatus: RelationshipStatus.Single,
+        studentNumber: "1001",
+      };
+      const payload = {
+        associatedFiles: [],
+        data: applicationData,
+        programYearId: recentActiveProgramYear.id,
+      } as SaveApplicationAPIInDTO;
+      const endpoint = `/students/application/${application.id}/submit`;
+      const token = await getStudentToken(
+        FakeStudentUsersTypes.FakeStudentUserType1,
+      );
+      const dryRunSubmissionMock = jest.fn().mockResolvedValue({
+        valid: true,
+        formName: FormNames.Application,
+        data: { data: applicationData },
+      });
+      formService.dryRunSubmission = dryRunSubmissionMock;
+      // Mock the user received in the token.
+      await mockJWTUserInfo(appModule, student.user);
+      const now = new Date();
+      MockDate.set(now);
+
+      // Act
+      await request(app.getHttpServer())
+        .patch(endpoint)
+        .send(payload)
+        .auth(token, BEARER_AUTH_TYPE)
+        .expect(HttpStatus.OK)
+        .expect({});
+
+      // Assert
+      // Assert that the application status is updated to Edited.
+      const isApplicationEdited = await db.application.exists({
+        where: {
+          id: application.id,
+          applicationStatus: ApplicationStatus.Edited,
+        },
+      });
+      expect(isApplicationEdited).toBe(true);
+      // Verify if all the application scoped form submissions are cancelled.
+      await assertCancelledApplicationScopedFormSubmissions(
+        db,
+        application.id,
+        FormSubmissionCancellationReason.ApplicationEdited,
+        [formSubmission.id],
+        student.user.id,
+        now,
+      );
+    });
+  });
+
+  it("Should edit an application and but not update the application scoped form submission when the form submission status is already cancelled.", async () => {
+    // Arrange
+    const student = await saveFakeStudent(db.dataSource);
+    // Create a submitted application to be edited.
+    const application = await saveFakeApplication(
+      db.dataSource,
+      {
+        student,
+        programYear: recentActiveProgramYear,
+      },
+      {
+        applicationStatus: ApplicationStatus.Enrolment,
+        offeringIntensity: OfferingIntensity.fullTime,
+      },
+    );
+    // Create a form submission that is already cancelled.
+    const formSubmission = await saveFakeFormSubmissionFromInputTestData(db, {
+      now: new Date(),
+      student,
+      application,
+      formCategory: FormCategory.StudentAppeal,
+      submissionStatus: FormSubmissionStatus.Cancelled,
+      ministryAuditUser: ministryUser,
+      formSubmissionItems: [
+        {
+          dynamicFormConfiguration: formConfigs.studentAppealApplicationA,
+          decisions: [
+            {
+              decisionStatus: FormSubmissionDecisionStatus.Approved,
+            },
+          ],
+        },
+      ],
+    });
+    const offering = application.currentAssessment.offering;
+    const applicationData = {
+      selectedProgram: offering.educationProgram.id,
+      selectedOffering: offering.id,
+      selectedLocation: offering.institutionLocation.id,
+      relationshipStatus: RelationshipStatus.Single,
+      studentNumber: "1001",
+    };
+    const payload = {
+      associatedFiles: [],
+      data: applicationData,
+      programYearId: recentActiveProgramYear.id,
+    } as SaveApplicationAPIInDTO;
+    const endpoint = `/students/application/${application.id}/submit`;
+    const token = await getStudentToken(
+      FakeStudentUsersTypes.FakeStudentUserType1,
+    );
+    const dryRunSubmissionMock = jest.fn().mockResolvedValue({
+      valid: true,
+      formName: FormNames.Application,
+      data: { data: applicationData },
+    });
+    formService.dryRunSubmission = dryRunSubmissionMock;
+    // Mock the user received in the token.
+    await mockJWTUserInfo(appModule, student.user);
+    const now = new Date();
+    MockDate.set(now);
+
+    // Act
+    await request(app.getHttpServer())
+      .patch(endpoint)
+      .send(payload)
+      .auth(token, BEARER_AUTH_TYPE)
+      .expect(HttpStatus.OK)
+      .expect({});
+
+    // Assert
+    // Assert that the application status is updated to Edited.
+    const isApplicationEdited = await db.application.exists({
+      where: {
+        id: application.id,
+        applicationStatus: ApplicationStatus.Edited,
+      },
+    });
+    expect(isApplicationEdited).toBe(true);
+    // Verify if the application scoped form submission is not updated since it was already cancelled.
+    await assertFormSubmissionNotUpdated(
+      db,
+      formSubmission.id,
+      FormSubmissionCancellationReason.ApplicationEdited,
+      now,
+    );
+  });
 
   it("Should submit a full-time application when the student is configured as a beta user.", async () => {
     // Arrange

--- a/sources/packages/backend/libs/test-utils/src/factories/form-submission.ts
+++ b/sources/packages/backend/libs/test-utils/src/factories/form-submission.ts
@@ -91,6 +91,10 @@ export interface FormSubmissionTestInputData {
    * Indicates whether the form submission is assessed or not.
    */
   isAssessed?: boolean;
+  /**
+   * Form submission cancellation reason.
+   */
+  cancellationReason?: FormSubmissionCancellationReason;
 }
 
 /**
@@ -132,9 +136,12 @@ export async function saveFakeFormSubmissionFromInputTestData(
   ].includes(testInputData.submissionStatus)
     ? testInputData.ministryAuditUser
     : student.user;
+  const cancellationReason =
+    testInputData.cancellationReason ??
+    FormSubmissionCancellationReason.StudentCancelledSubmission;
   formSubmission.cancellationReason =
     testInputData.submissionStatus === FormSubmissionStatus.Cancelled
-      ? FormSubmissionCancellationReason.StudentCancelledSubmission
+      ? cancellationReason
       : null;
   formSubmission.formSubmissionItems = [];
   await db.formSubmission.save(formSubmission);

--- a/sources/packages/web/src/components/form-submissions/CancelledFormSubmissionBanner.vue
+++ b/sources/packages/web/src/components/form-submissions/CancelledFormSubmissionBanner.vue
@@ -32,7 +32,7 @@ const applicationScopedBannerDetails = computed<BannerDetails | undefined>(
     if (!canShowApplicationScopedBanner.value) {
       return;
     }
-    const header = "Appeal No Longer Active";
+    const header = "Appeal no longer active";
     switch (props.cancellationReason) {
       case FormSubmissionCancellationReason.StudentCancelledSubmission:
         return {


### PR DESCRIPTION
## E2E Tests

- [x] Added E2E Tests for application cancel involving application scoped form submission cancellations.
```spec
ApplicationStudentsController(e2e)-cancelStudentApplication
    √ Should cancel a student application and update the current assessment status to Cancellation requested when the application has current assessment created and application status is Assessment (188 ms)
    √ Should cancel a student application and also cancel the application scoped form submission when application status is Assessment and the application has a form submission with submission status Pending. (127 ms)
    √ Should cancel a student application and also cancel the application scoped form submission when application status is Assessment and the application has a form submission with submission status Completed. (98 ms)
    √ Should cancel a student application and also cancel the application scoped form submission when application status is Assessment and the application has a form submission with submission status Declined. (98 ms)
    √ Should cancel a student application but not update the application scoped form submission when application status is Assessment and the application has a form submission that is already cancelled. (93 ms)
    √ Should throw a not found exception when the application status is Completed. (58 ms)
    √ Should throw a not found exception when the application status is Cancelled. (49 ms)
    √ Should throw a not found exception when the application status is Edited. (51 ms)
    √ Should throw a not found exception when the application does not belong to the student. (55 ms)
    √ Should throw a NotFoundException when the application does not exist. (6 ms)
```
- [x] Added E2E for application edit involving application scoped form submission cancellations.
```spec
ApplicationStudentsController(e2e)-submitApplication
   √ Should edit an application and and also cancel the application scoped form submission when the form submission status is Pending. (131 ms)
    √ Should edit an application and and also cancel the application scoped form submission when the form submission status is Completed. (122 ms)
    √ Should edit an application and and also cancel the application scoped form submission when the form submission status is Declined. (140 ms)
    √ Should edit an application and but not update the application scoped form submission when the form submission status is already cancelled. (112 ms)
```

## Minor content update
- [x] Update the cancelled appeal banner header casing as `Appeal no longer active` based on update from business.