### PR TITLE
#4809 - FT Assessment: min grant amount for CSG-FTDEP and CSG-FT

### DIFF
--- a/sources/packages/backend/workflow/src/workflow-definitions/fulltime-assessment-2025-2026.bpmn
+++ b/sources/packages/backend/workflow/src/workflow-definitions/fulltime-assessment-2025-2026.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" id="Definitions_0ihicdz" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.46.1" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.6.0" camunda:diagramRelationId="7a75e87a-6774-4e60-9a94-5dbbe3be143a">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" id="Definitions_0ihicdz" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.49.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.6.0" camunda:diagramRelationId="7a75e87a-6774-4e60-9a94-5dbbe3be143a">
   <bpmn:message id="Message_3q4oc02" name="Message_3q4oc02" />
   <bpmn:collaboration id="Collaboration_1cf99un">
     <bpmn:participant id="Participant_1mct69m" name="fulltime-assessment-2025-2026" processRef="fulltime-assessment-2025-2026" />
@@ -1168,7 +1168,7 @@ Federal Unmet Provincial Need = Provincial portion of Fed Need less Adjusted BCS
         <zeebe:ioMapping>
           <zeebe:output source="=dmnFullTimeAwardAllowableLimits.limitAwardCSGFWeeklyRate-(dmnFullTimeAwardFamilySizeVariables.limitAwardCSGFWeeklyPhaseoutRate * (calculatedDataTotalFamilyIncome - dmnFullTimeAwardFamilySizeVariables.limitAwardCSGFIncomeCap))" target="federalAwardCSGFSlopedAmount" />
           <zeebe:output source="=min(dmnFullTimeAwardAllowableLimits.limitAwardCSGFWeeklyRate,federalAwardCSGFSlopedAmount)" target="federalAwardCSGFAmount" />
-          <zeebe:output source="=if (awardEligibilityCSGF = true)&#10;then&#10;max(min(federalAwardCSGFAmount*offeringWeeks,dmnFullTimeAwardAllowableLimits.limitAwardCSGFAmount),0)&#10;else&#10;0" target="federalAwardNetCSGFAmount" />
+          <zeebe:output source="=if (awardEligibilityCSGF = true)&#10;then&#10;  max(&#10;    min(federalAwardCSGFAmount*offeringWeeks, dmnFullTimeAwardAllowableLimits.limitAwardCSGFAmount),&#10;    dmnFullTimeAwardAllowableLimits.limitAwardCSGFMinAward&#10;  )&#10;else&#10;0" target="federalAwardNetCSGFAmount" />
         </zeebe:ioMapping>
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_11g68x6</bpmn:incoming>

--- a/sources/packages/backend/workflow/src/workflow-definitions/fulltime-assessment-2026-2027.bpmn
+++ b/sources/packages/backend/workflow/src/workflow-definitions/fulltime-assessment-2026-2027.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" id="Definitions_0ihicdz" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.46.1" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.6.0" camunda:diagramRelationId="7a75e87a-6774-4e60-9a94-5dbbe3be143a">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" id="Definitions_0ihicdz" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.49.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.6.0" camunda:diagramRelationId="7a75e87a-6774-4e60-9a94-5dbbe3be143a">
   <bpmn:message id="Message_3q4oc02" name="Message_3q4oc02" />
   <bpmn:collaboration id="Collaboration_1cf99un">
     <bpmn:participant id="Participant_1mct69m" name="fulltime-assessment-2026-2027" processRef="fulltime-assessment-2026-2027" />
@@ -2281,7 +2281,7 @@ Map the correct 1 or 2 values for each of the values used to calculate income, d
         <zeebe:ioMapping>
           <zeebe:output source="=dmnFullTimeAwardAllowableLimits.limitAwardCSGFWeeklyRate-(dmnFullTimeAwardFamilySizeVariables.limitAwardCSGFWeeklyPhaseoutRate * (calculatedDataTotalFamilyIncome - dmnFullTimeAwardFamilySizeVariables.limitAwardCSGFIncomeCap))" target="federalAwardCSGFSlopedAmount" />
           <zeebe:output source="=min(dmnFullTimeAwardAllowableLimits.limitAwardCSGFWeeklyRate,federalAwardCSGFSlopedAmount)" target="federalAwardCSGFAmount" />
-          <zeebe:output source="=if (awardEligibilityCSGF = true)&#10;then&#10;max(min(federalAwardCSGFAmount*offeringWeeks,dmnFullTimeAwardAllowableLimits.limitAwardCSGFAmount),0)&#10;else&#10;0" target="federalAwardNetCSGFAmount" />
+          <zeebe:output source="=if (awardEligibilityCSGF = true)&#10;then&#10;  max(&#10;    min(federalAwardCSGFAmount*offeringWeeks, dmnFullTimeAwardAllowableLimits.limitAwardCSGFAmount),&#10;    dmnFullTimeAwardAllowableLimits.limitAwardCSGFMinAward&#10;  )&#10;else&#10;0" target="federalAwardNetCSGFAmount" />
         </zeebe:ioMapping>
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_11g68x6</bpmn:incoming>

--- a/sources/packages/backend/workflow/src/workflow-definitions/fulltime-assessment-decisions.dmn
+++ b/sources/packages/backend/workflow/src/workflow-definitions/fulltime-assessment-decisions.dmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" xmlns:modeler="http://camunda.org/schema/modeler/1.0" xmlns:camunda="http://camunda.org/schema/1.0/dmn" id="dmnFullTimeAssessmentDecisions" name="dmnFullTimeAssessmentDecisions" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="5.46.1" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.6.0" camunda:diagramRelationId="1a575ead-1e6d-468c-901a-766a35569b38">
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" xmlns:modeler="http://camunda.org/schema/modeler/1.0" xmlns:camunda="http://camunda.org/schema/1.0/dmn" id="dmnFullTimeAssessmentDecisions" name="dmnFullTimeAssessmentDecisions" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="5.49.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.6.0" camunda:diagramRelationId="1a575ead-1e6d-468c-901a-766a35569b38">
   <decision id="dmnFullTimeProgramYearMaximums" name="dmnFullTimeProgramYearMaximums">
     <decisionTable id="DecisionTable_1oyvbif">
       <input id="InputClause_02zjhj9" label="programYear">
@@ -2687,7 +2687,8 @@
       </input>
       <output id="OutputClause_1wgs16b" label="limitAwardCSGPAmount" name="limitAwardCSGPAmount" typeRef="string" />
       <output id="OutputClause_1n9ubqe" label="limitAwardCSGDWeeklyRate" name="limitAwardCSGDWeeklyRate" typeRef="string" biodi:width="218" />
-      <output id="OutputClause_1t1gc34" label="limitAwardCSGDMinAward" name="limitAwardCSGDMinAward" typeRef="string" />
+      <output id="OutputClause_1t1gc34" label="limitAwardCSGDMinAward" name="limitAwardCSGDMinAward" typeRef="string" biodi:width="192" />
+      <output id="OutputClause_1donr5a" label="limitAwardCSGFMinAward" name="limitAwardCSGFMinAward" typeRef="string" biodi:width="192" />
       <output id="OutputClause_03jyuzn" label="limitAwardCSGFAmount" name="limitAwardCSGFAmount" typeRef="string" />
       <output id="OutputClause_0004ypj" label="limitAwardCSGFWeeklyRate" name="limitAwardCSGFWeeklyRate" typeRef="string" biodi:width="240" />
       <output id="OutputClause_0uaxqsy" label="limitAwardCSGTProratedAmount" name="limitAwardCSGTProratedAmount" typeRef="string" />
@@ -2714,6 +2715,9 @@
           <text>3200 / 8 * 12 / 52</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_16p6pyf">
+          <text>100</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1bvrd97">
           <text>100</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_0ndsy0d">
@@ -2775,6 +2779,9 @@
         <outputEntry id="LiteralExpression_1gq6z9v">
           <text>100</text>
         </outputEntry>
+        <outputEntry id="LiteralExpression_0b1optz">
+          <text>100</text>
+        </outputEntry>
         <outputEntry id="LiteralExpression_0m30qdj">
           <text>4200</text>
         </outputEntry>
@@ -2834,6 +2841,9 @@
         <outputEntry id="LiteralExpression_1daeanc">
           <text>100</text>
         </outputEntry>
+        <outputEntry id="LiteralExpression_1v70dve">
+          <text>100</text>
+        </outputEntry>
         <outputEntry id="LiteralExpression_1rq1wim">
           <text>6300</text>
         </outputEntry>
@@ -2891,6 +2901,9 @@
           <text>round half up(2240 * (1/8) * 12 * (1/52),2)</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_1gajigv">
+          <text>100</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_07x5lii">
           <text>100</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_11xiwxw">

--- a/sources/packages/backend/workflow/test/2025-2026/fulltime-assessment/awards-amount/fulltime-assessment-awards-amount-CSGD.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2025-2026/fulltime-assessment/awards-amount/fulltime-assessment-awards-amount-CSGD.e2e-spec.ts
@@ -48,7 +48,6 @@ describe(`E2E Test Workflow fulltime-assessment-${PROGRAM_YEAR}-awards-amount-CS
     assessmentConsolidatedData.programLength =
       ProgramLengthOptions.TwoToThreeYears;
     assessmentConsolidatedData.offeringWeeks = 8;
-    // Set the value close to the limit of the limitAwardCSGFThresholdIncome for a family size of 1 for.
     assessmentConsolidatedData.studentDataTaxReturnIncome = 96000;
     assessmentConsolidatedData.studentDataDependants = [
       createFakeStudentDependentEligibleForChildcareCost(
@@ -65,7 +64,7 @@ describe(`E2E Test Workflow fulltime-assessment-${PROGRAM_YEAR}-awards-amount-CS
 
     // Assert
     expect(calculatedAssessment.variables.awardEligibilityCSGD).toBe(true);
-    // Ensure federalAwardNetCSGDAmount is less than 100.
+    // Ensure federalAwardCSGDAmount is less than 100.
     expect(calculatedAssessment.variables.federalAwardCSGDAmount).toBeLessThan(
       100,
     );

--- a/sources/packages/backend/workflow/test/2025-2026/fulltime-assessment/awards-amount/fulltime-assessment-awards-amount-CSGD.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2025-2026/fulltime-assessment/awards-amount/fulltime-assessment-awards-amount-CSGD.e2e-spec.ts
@@ -1,0 +1,80 @@
+import { CredentialType, ProgramLengthOptions } from "../../../models";
+import {
+  ZeebeMockedClient,
+  createFakeConsolidatedFulltimeData,
+  executeFullTimeAssessmentForProgramYear,
+} from "../../../test-utils";
+import {
+  createFakeStudentDependentEligibleForChildcareCost,
+  DependentChildCareEligibility,
+} from "../../../test-utils/factories";
+import { PROGRAM_YEAR } from "../../constants/program-year.constants";
+
+describe(`E2E Test Workflow fulltime-assessment-${PROGRAM_YEAR}-awards-amount-CSGD.`, () => {
+  it("Should determine the correct amount when the student is eligible for the award.", async () => {
+    // Arrange
+    const assessmentConsolidatedData =
+      createFakeConsolidatedFulltimeData(PROGRAM_YEAR);
+    assessmentConsolidatedData.programCredentialType =
+      CredentialType.UnderGraduateCertificate;
+    assessmentConsolidatedData.programLength =
+      ProgramLengthOptions.TwoToThreeYears;
+    assessmentConsolidatedData.offeringWeeks = 8;
+    assessmentConsolidatedData.studentDataTaxReturnIncome = 10000;
+    assessmentConsolidatedData.studentDataDependants = [
+      createFakeStudentDependentEligibleForChildcareCost(
+        DependentChildCareEligibility.Eligible0To11YearsOld,
+        assessmentConsolidatedData.offeringStudyStartDate,
+      ),
+    ];
+
+    // Act
+    const calculatedAssessment = await executeFullTimeAssessmentForProgramYear(
+      PROGRAM_YEAR,
+      assessmentConsolidatedData,
+    );
+
+    // Assert
+    expect(calculatedAssessment.variables.awardEligibilityCSGD).toBe(true);
+    expect(calculatedAssessment.variables.federalAwardNetCSGDAmount).toBe(517);
+  });
+
+  it("Should set the amount at a minimum amount of 100 when award is eligible.", async () => {
+    // Arrange
+    const assessmentConsolidatedData =
+      createFakeConsolidatedFulltimeData(PROGRAM_YEAR);
+    assessmentConsolidatedData.programCredentialType =
+      CredentialType.UnderGraduateCertificate;
+    assessmentConsolidatedData.programLength =
+      ProgramLengthOptions.TwoToThreeYears;
+    assessmentConsolidatedData.offeringWeeks = 8;
+    // Set the value close to the limit of the limitAwardCSGFThresholdIncome for a family size of 1 for.
+    assessmentConsolidatedData.studentDataTaxReturnIncome = 96000;
+    assessmentConsolidatedData.studentDataDependants = [
+      createFakeStudentDependentEligibleForChildcareCost(
+        DependentChildCareEligibility.Eligible0To11YearsOld,
+        assessmentConsolidatedData.offeringStudyStartDate,
+      ),
+    ];
+
+    // Act
+    const calculatedAssessment = await executeFullTimeAssessmentForProgramYear(
+      PROGRAM_YEAR,
+      assessmentConsolidatedData,
+    );
+
+    // Assert
+    expect(calculatedAssessment.variables.awardEligibilityCSGD).toBe(true);
+    // Ensure federalAwardNetCSGDAmount is less than 100.
+    expect(calculatedAssessment.variables.federalAwardCSGDAmount).toBeLessThan(
+      100,
+    );
+    // Ensure federalAwardNetCSGDAmount is set to 100.
+    expect(calculatedAssessment.variables.federalAwardNetCSGDAmount).toBe(100);
+  });
+
+  afterAll(async () => {
+    // Closes the singleton instance created during test executions.
+    await ZeebeMockedClient.getMockedZeebeInstance().close();
+  });
+});

--- a/sources/packages/backend/workflow/test/2025-2026/fulltime-assessment/awards-amount/fulltime-assessment-awards-amount-CSGF.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2025-2026/fulltime-assessment/awards-amount/fulltime-assessment-awards-amount-CSGF.e2e-spec.ts
@@ -29,6 +29,35 @@ describe(`E2E Test Workflow fulltime-assessment-${PROGRAM_YEAR}-awards-amount-CS
     expect(calculatedAssessment.variables.federalAwardNetCSGFAmount).toBe(6300);
   });
 
+  it("Should set the CSGF amount at a minimum amount of 100 when award is eligible.", async () => {
+    // Arrange
+    const assessmentConsolidatedData =
+      createFakeConsolidatedFulltimeData(PROGRAM_YEAR);
+    assessmentConsolidatedData.programCredentialType =
+      CredentialType.UnderGraduateCertificate;
+    assessmentConsolidatedData.programLength =
+      ProgramLengthOptions.TwoToThreeYears;
+    assessmentConsolidatedData.offeringWeeks = 16;
+    // Set the value close to the limit of the limitAwardCSGFThresholdIncome for a family size of 1 for.
+    assessmentConsolidatedData.studentDataTaxReturnIncome = 68320;
+
+    // Act
+    const calculatedAssessment = await executeFullTimeAssessmentForProgramYear(
+      PROGRAM_YEAR,
+      assessmentConsolidatedData,
+    );
+
+    // Assert
+    expect(calculatedAssessment.variables.awardEligibilityCSGF).toBe(true);
+    // Ensure federalAwardCSGFAmount is between 0 and 100.
+    expect(
+      calculatedAssessment.variables.federalAwardCSGFAmount *
+        calculatedAssessment.variables.offeringWeeks,
+    ).toBeLessThan(100);
+    // Ensure finalFederalAwardNetCSGFAmount is set to 100.
+    expect(calculatedAssessment.variables.federalAwardNetCSGFAmount).toBe(100);
+  });
+
   afterAll(async () => {
     // Closes the singleton instance created during test executions.
     await ZeebeMockedClient.getMockedZeebeInstance().close();

--- a/sources/packages/backend/workflow/test/2025-2026/fulltime-assessment/awards-amount/fulltime-assessment-awards-amount-CSGF.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2025-2026/fulltime-assessment/awards-amount/fulltime-assessment-awards-amount-CSGF.e2e-spec.ts
@@ -29,7 +29,7 @@ describe(`E2E Test Workflow fulltime-assessment-${PROGRAM_YEAR}-awards-amount-CS
     expect(calculatedAssessment.variables.federalAwardNetCSGFAmount).toBe(6300);
   });
 
-  it("Should set the CSGF amount at a minimum amount of 100 when award is eligible.", async () => {
+  it("Should set the amount at a minimum amount of 100 when award is eligible.", async () => {
     // Arrange
     const assessmentConsolidatedData =
       createFakeConsolidatedFulltimeData(PROGRAM_YEAR);

--- a/sources/packages/backend/workflow/test/2025-2026/fulltime-assessment/awards-amount/fulltime-assessment-awards-amount-CSGF.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2025-2026/fulltime-assessment/awards-amount/fulltime-assessment-awards-amount-CSGF.e2e-spec.ts
@@ -38,7 +38,7 @@ describe(`E2E Test Workflow fulltime-assessment-${PROGRAM_YEAR}-awards-amount-CS
     assessmentConsolidatedData.programLength =
       ProgramLengthOptions.TwoToThreeYears;
     assessmentConsolidatedData.offeringWeeks = 16;
-    // Set the value close to the limit of the limitAwardCSGFThresholdIncome for a family size of 1 for.
+    // Set income close to the CSGF threshold for a family size of 1.
     assessmentConsolidatedData.studentDataTaxReturnIncome = 68320;
 
     // Act

--- a/sources/packages/backend/workflow/test/2026-2027/fulltime-assessment/awards-amount/fulltime-assessment-awards-amount-CSGD.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2026-2027/fulltime-assessment/awards-amount/fulltime-assessment-awards-amount-CSGD.e2e-spec.ts
@@ -1,0 +1,81 @@
+import { CredentialType, ProgramLengthOptions } from "../../../models";
+import {
+  ZeebeMockedClient,
+  createFakeConsolidatedFulltimeData,
+  executeFullTimeAssessmentForProgramYear,
+} from "../../../test-utils";
+import {
+  createFakeStudentDependentEligibleForChildcareCost,
+  DependentChildCareEligibility,
+} from "../../../test-utils/factories";
+import { PROGRAM_YEAR } from "../../constants/program-year.constants";
+
+describe(`E2E Test Workflow fulltime-assessment-${PROGRAM_YEAR}-awards-amount-CSGD.`, () => {
+  it("Should determine the correct amount when the student is eligible for the award.", async () => {
+    // Arrange
+    const assessmentConsolidatedData =
+      createFakeConsolidatedFulltimeData(PROGRAM_YEAR);
+    assessmentConsolidatedData.programCredentialType =
+      CredentialType.UnderGraduateCertificate;
+    assessmentConsolidatedData.programLength =
+      ProgramLengthOptions.TwoToThreeYears;
+    assessmentConsolidatedData.offeringWeeks = 8;
+    // Set the value close to the limit of the limitAwardCSGFThresholdIncome for a family size of 1 for.
+    assessmentConsolidatedData.studentDataTaxReturnIncome = 10000;
+    assessmentConsolidatedData.studentDataDependants = [
+      createFakeStudentDependentEligibleForChildcareCost(
+        DependentChildCareEligibility.Eligible0To11YearsOld,
+        assessmentConsolidatedData.offeringStudyStartDate,
+      ),
+    ];
+
+    // Act
+    const calculatedAssessment = await executeFullTimeAssessmentForProgramYear(
+      PROGRAM_YEAR,
+      assessmentConsolidatedData,
+    );
+
+    // Assert
+    expect(calculatedAssessment.variables.awardEligibilityCSGD).toBe(true);
+    expect(calculatedAssessment.variables.federalAwardNetCSGDAmount).toBe(517);
+  });
+
+  it("Should set the amount at a minimum amount of 100 when award is eligible.", async () => {
+    // Arrange
+    const assessmentConsolidatedData =
+      createFakeConsolidatedFulltimeData(PROGRAM_YEAR);
+    assessmentConsolidatedData.programCredentialType =
+      CredentialType.UnderGraduateCertificate;
+    assessmentConsolidatedData.programLength =
+      ProgramLengthOptions.TwoToThreeYears;
+    assessmentConsolidatedData.offeringWeeks = 8;
+    // Set the value close to the limit of the limitAwardCSGFThresholdIncome for a family size of 1 for.
+    assessmentConsolidatedData.studentDataTaxReturnIncome = 98017;
+    assessmentConsolidatedData.studentDataDependants = [
+      createFakeStudentDependentEligibleForChildcareCost(
+        DependentChildCareEligibility.Eligible0To11YearsOld,
+        assessmentConsolidatedData.offeringStudyStartDate,
+      ),
+    ];
+
+    // Act
+    const calculatedAssessment = await executeFullTimeAssessmentForProgramYear(
+      PROGRAM_YEAR,
+      assessmentConsolidatedData,
+    );
+
+    // Assert
+    expect(calculatedAssessment.variables.awardEligibilityCSGD).toBe(true);
+    // Ensure federalAwardNetCSGDAmount is less than 100.
+    expect(calculatedAssessment.variables.federalAwardCSGDAmount).toBeLessThan(
+      100,
+    );
+    // Ensure federalAwardNetCSGDAmount is set to 100.
+    expect(calculatedAssessment.variables.federalAwardNetCSGDAmount).toBe(100);
+  });
+
+  afterAll(async () => {
+    // Closes the singleton instance created during test executions.
+    await ZeebeMockedClient.getMockedZeebeInstance().close();
+  });
+});

--- a/sources/packages/backend/workflow/test/2026-2027/fulltime-assessment/awards-amount/fulltime-assessment-awards-amount-CSGD.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2026-2027/fulltime-assessment/awards-amount/fulltime-assessment-awards-amount-CSGD.e2e-spec.ts
@@ -20,7 +20,6 @@ describe(`E2E Test Workflow fulltime-assessment-${PROGRAM_YEAR}-awards-amount-CS
     assessmentConsolidatedData.programLength =
       ProgramLengthOptions.TwoToThreeYears;
     assessmentConsolidatedData.offeringWeeks = 8;
-    // Set the value close to the limit of the limitAwardCSGFThresholdIncome for a family size of 1 for.
     assessmentConsolidatedData.studentDataTaxReturnIncome = 10000;
     assessmentConsolidatedData.studentDataDependants = [
       createFakeStudentDependentEligibleForChildcareCost(
@@ -49,7 +48,6 @@ describe(`E2E Test Workflow fulltime-assessment-${PROGRAM_YEAR}-awards-amount-CS
     assessmentConsolidatedData.programLength =
       ProgramLengthOptions.TwoToThreeYears;
     assessmentConsolidatedData.offeringWeeks = 8;
-    // Set the value close to the limit of the limitAwardCSGFThresholdIncome for a family size of 1 for.
     assessmentConsolidatedData.studentDataTaxReturnIncome = 98017;
     assessmentConsolidatedData.studentDataDependants = [
       createFakeStudentDependentEligibleForChildcareCost(
@@ -66,7 +64,7 @@ describe(`E2E Test Workflow fulltime-assessment-${PROGRAM_YEAR}-awards-amount-CS
 
     // Assert
     expect(calculatedAssessment.variables.awardEligibilityCSGD).toBe(true);
-    // Ensure federalAwardNetCSGDAmount is less than 100.
+    // Ensure federalAwardCSGDAmount is less than 100.
     expect(calculatedAssessment.variables.federalAwardCSGDAmount).toBeLessThan(
       100,
     );

--- a/sources/packages/backend/workflow/test/2026-2027/fulltime-assessment/awards-amount/fulltime-assessment-awards-amount-CSGF.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2026-2027/fulltime-assessment/awards-amount/fulltime-assessment-awards-amount-CSGF.e2e-spec.ts
@@ -29,7 +29,7 @@ describe(`E2E Test Workflow fulltime-assessment-${PROGRAM_YEAR}-awards-amount-CS
     expect(calculatedAssessment.variables.federalAwardNetCSGFAmount).toBe(6300);
   });
 
-  it("Should set the CSGF amount at a minimum amount of 100 when award is eligible.", async () => {
+  it("Should set the amount at a minimum amount of 100 when award is eligible.", async () => {
     // Arrange
     const assessmentConsolidatedData =
       createFakeConsolidatedFulltimeData(PROGRAM_YEAR);

--- a/sources/packages/backend/workflow/test/2026-2027/fulltime-assessment/awards-amount/fulltime-assessment-awards-amount-CSGF.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2026-2027/fulltime-assessment/awards-amount/fulltime-assessment-awards-amount-CSGF.e2e-spec.ts
@@ -38,7 +38,6 @@ describe(`E2E Test Workflow fulltime-assessment-${PROGRAM_YEAR}-awards-amount-CS
     assessmentConsolidatedData.programLength =
       ProgramLengthOptions.TwoToThreeYears;
     assessmentConsolidatedData.offeringWeeks = 16;
-    // Set the value close to the limit of the limitAwardCSGFThresholdIncome for a family size of 1 for.
     assessmentConsolidatedData.studentDataTaxReturnIncome = 69980;
 
     // Act

--- a/sources/packages/backend/workflow/test/2026-2027/fulltime-assessment/awards-amount/fulltime-assessment-awards-amount-CSGF.e2e-spec.ts
+++ b/sources/packages/backend/workflow/test/2026-2027/fulltime-assessment/awards-amount/fulltime-assessment-awards-amount-CSGF.e2e-spec.ts
@@ -29,6 +29,35 @@ describe(`E2E Test Workflow fulltime-assessment-${PROGRAM_YEAR}-awards-amount-CS
     expect(calculatedAssessment.variables.federalAwardNetCSGFAmount).toBe(6300);
   });
 
+  it("Should set the CSGF amount at a minimum amount of 100 when award is eligible.", async () => {
+    // Arrange
+    const assessmentConsolidatedData =
+      createFakeConsolidatedFulltimeData(PROGRAM_YEAR);
+    assessmentConsolidatedData.programCredentialType =
+      CredentialType.UnderGraduateCertificate;
+    assessmentConsolidatedData.programLength =
+      ProgramLengthOptions.TwoToThreeYears;
+    assessmentConsolidatedData.offeringWeeks = 16;
+    // Set the value close to the limit of the limitAwardCSGFThresholdIncome for a family size of 1 for.
+    assessmentConsolidatedData.studentDataTaxReturnIncome = 69980;
+
+    // Act
+    const calculatedAssessment = await executeFullTimeAssessmentForProgramYear(
+      PROGRAM_YEAR,
+      assessmentConsolidatedData,
+    );
+
+    // Assert
+    expect(calculatedAssessment.variables.awardEligibilityCSGF).toBe(true);
+    // Ensure federalAwardCSGFAmount is between 0 and 100.
+    expect(
+      calculatedAssessment.variables.federalAwardCSGFAmount *
+        calculatedAssessment.variables.offeringWeeks,
+    ).toBeLessThan(100);
+    // Ensure finalFederalAwardNetCSGFAmount is set to 100.
+    expect(calculatedAssessment.variables.federalAwardNetCSGFAmount).toBe(100);
+  });
+
   afterAll(async () => {
     // Closes the singleton instance created during test executions.
     await ZeebeMockedClient.getMockedZeebeInstance().close();

--- a/sources/packages/backend/workflow/test/models/assessment.model.ts
+++ b/sources/packages/backend/workflow/test/models/assessment.model.ts
@@ -78,10 +78,7 @@ export interface StudentAdditionalTransportationAppealData extends JSONDoc {
 }
 
 export type RelationshipStatusType =
-  | "single"
-  | "other"
-  | "married"
-  | "marriedUnable";
+  "single" | "other" | "married" | "marriedUnable";
 
 export type DependantStatusType = "independant" | "dependant";
 
@@ -484,6 +481,7 @@ export interface CalculatedAssessmentModel {
   // CSGF
   assessmentEligibilityCSGF: boolean;
   awardEligibilityCSGF: number;
+  federalAwardCSGFAmount: number;
   federalAwardNetCSGFAmount: number;
   provincialAwardNetCSGFAmount: number;
   // BCAG


### PR DESCRIPTION
- Adjusted `CSGF` to have a minimum of $100, following the same implementation as `CSGD`.
- Created some generic E2E tests for `CSGF` (amounts were not tested before).
- Created tests to ensure the minimum will take effect once the awards are eligible.

Please note that the current ACs do not represent this implementation. [This comment](https://github.com/bcgov/SIMS/issues/4809#issuecomment-5335796725) was raised to the business to be adjusted to reflect the conversation during the daily meeting.

<img width="562" height="435" alt="image" src="https://github.com/user-attachments/assets/028137f9-d583-4449-82f5-0fb18b5c3d2b" />
