### PR TITLE
#3958 - Application offering change view - update offering description

### DIFF
--- a/sources/packages/backend/apps/api/src/route-controllers/application-offering-change-request/application-offering-change-request.controller.service.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/application-offering-change-request/application-offering-change-request.controller.service.ts
@@ -5,7 +5,7 @@ import {
   ApplicationOfferingDetailsAPIOutDTO,
   ApplicationOfferingChangeDetailsAPIOutDTO,
 } from "./models/application-offering-change-request.dto";
-import { getUserFullName } from "../../utilities";
+import { getOfferingNameAndPeriod, getUserFullName } from "../../utilities";
 
 @Injectable()
 export class ApplicationOfferingChangeRequestControllerService {
@@ -117,7 +117,9 @@ export class ApplicationOfferingChangeRequestControllerService {
       ...applicationOfferingDetails,
       id: request.id,
       applicationId: request.application.id,
-      requestedOfferingDescription: request.requestedOffering.name,
+      requestedOfferingDescription: getOfferingNameAndPeriod(
+        request.requestedOffering,
+      ),
       requestedOfferingProgramId: request.requestedOffering.educationProgram.id,
       requestedOfferingProgramName:
         request.requestedOffering.educationProgram.name,

--- a/sources/packages/backend/apps/api/src/services/application-offering-change-request/application-offering-change-request.service.ts
+++ b/sources/packages/backend/apps/api/src/services/application-offering-change-request/application-offering-change-request.service.ts
@@ -288,6 +288,9 @@ export class ApplicationOfferingChangeRequestService {
         requestedOffering: {
           id: true,
           name: true,
+          studyStartDate: true,
+          studyEndDate: true,
+          yearOfStudy: true,
           educationProgram: {
             id: true,
             name: true,

--- a/sources/packages/web/src/views/institution/locations/request-a-change/RequestAChangeFormSubmit.vue
+++ b/sources/packages/web/src/views/institution/locations/request-a-change/RequestAChangeFormSubmit.vue
@@ -4,14 +4,14 @@
       <header-navigator
         title="Request an Application Change"
         sub-title="Request a Change"
-        :routeLocation="goBackRouteParams"
+        :route-location="goBackRouteParams"
       />
     </template>
     <request-a-change-form
-      :locationId="locationId"
-      :offeringId="activeOfferingId"
-      :studentName="studentName"
-      :applicationNumber="applicationNumber"
+      :location-id="locationId"
+      :offering-id="activeOfferingId"
+      :student-name="studentName"
+      :application-number="applicationNumber"
     >
       <v-form ref="requestAChangeForm">
         <v-autocomplete
@@ -25,7 +25,7 @@
           item-value="id"
           class="mt-4"
           v-model="selectedProgram"
-          @update:modelValue="selectedProgramChanged"
+          @update:model-value="selectedProgramChanged"
           :rules="[(v: string) => checkNullOrEmptyRule(v, 'Program')]"
         />
         <v-autocomplete
@@ -39,8 +39,8 @@
           item-title="description"
           item-value="id"
           v-model="selectedOffering"
-          :rules="[(v:string) => checkNullOrEmptyRule(v, 'Offering')]"
-          @update:modelValue="offeringOnChange"
+          :rules="[(v: string) => checkNullOrEmptyRule(v, 'Offering')]"
+          @update:model-value="offeringOnChange"
         />
         <banner
           v-if="isPastOfferingEndDate"
@@ -56,18 +56,15 @@
           hide-details="auto"
           class="mt-4"
           v-model="reasonForChange"
-          :rules="[(v:string) => checkLengthRule(v, 500, 'Reason for change')]"
+          :rules="[(v: string) => checkLengthRule(v, 500, 'Reason for change')]"
         />
-        <p class="mt-1 brand-gray-text">
-          This note is visible to students and StudentAid BC staff.
-        </p>
       </v-form>
       <footer-buttons
         :processing="processing"
-        primaryLabel="Submit requested change"
-        @primaryClick="submit"
-        @secondaryClick="cancel"
-        :disablePrimaryButton="isReadOnlyUser(locationId)"
+        primary-label="Submit requested change"
+        @primary-click="submit"
+        @secondary-click="cancel"
+        :disable-primary-button="isReadOnlyUser(locationId)"
       />
     </request-a-change-form>
   </full-page-container>
@@ -179,7 +176,7 @@ export default defineComponent({
           params: {
             locationId: props.locationId,
           },
-        } as RouteLocationRaw),
+        }) as RouteLocationRaw,
     );
 
     const cancel = () => {

--- a/sources/packages/web/src/views/institution/locations/request-a-change/RequestAChangeFormView.vue
+++ b/sources/packages/web/src/views/institution/locations/request-a-change/RequestAChangeFormView.vue
@@ -4,14 +4,14 @@
       <header-navigator
         title="Request an Application Change"
         :sub-title="subTitle"
-        :routeLocation="goBackRouteParams"
+        :route-location="goBackRouteParams"
       />
     </template>
     <request-a-change-form
-      :locationId="locationId"
-      :offeringId="changeRequest.activeOfferingId"
-      :studentName="changeRequest.studentFullName"
-      :applicationNumber="changeRequest.applicationNumber"
+      :location-id="locationId"
+      :offering-id="changeRequest.activeOfferingId"
+      :student-name="changeRequest.studentFullName"
+      :application-number="changeRequest.applicationNumber"
       :status="changeRequest.status"
     >
       <v-text-field
@@ -36,18 +36,20 @@
         class="mt-4"
         v-model="changeRequest.reason"
       />
-      <p class="mt-1 brand-gray-text">
-        This note is visible to students and StudentAid BC staff.
-      </p>
-      <v-textarea
-        v-if="showNotesFromStudentAidBC"
-        :readonly="true"
-        label="Notes from StudentAid BC"
-        variant="outlined"
-        hide-details="auto"
-        class="mt-4"
-        v-model="changeRequest.assessedNoteDescription"
-      />
+      <template v-if="showNotesFromStudentAidBC">
+        <p class="mt-1 brand-gray-text">
+          This note is visible to students and StudentAid BC staff.
+        </p>
+        <v-textarea
+          v-if="showNotesFromStudentAidBC"
+          :readonly="true"
+          label="Notes from StudentAid BC"
+          variant="outlined"
+          hide-details="auto"
+          class="mt-4"
+          v-model="changeRequest.assessedNoteDescription"
+        />
+      </template>
     </request-a-change-form>
   </full-page-container>
 </template>
@@ -101,7 +103,7 @@ export default defineComponent({
           params: {
             locationId: props.locationId,
           },
-        } as RouteLocationRaw),
+        }) as RouteLocationRaw,
     );
 
     const showNotesFromStudentAidBC = computed(() => {

--- a/sources/packages/web/src/views/institution/locations/request-a-change/RequestAChangeFormView.vue
+++ b/sources/packages/web/src/views/institution/locations/request-a-change/RequestAChangeFormView.vue
@@ -41,7 +41,6 @@
           This note is visible to students and StudentAid BC staff.
         </p>
         <v-textarea
-          v-if="showNotesFromStudentAidBC"
           :readonly="true"
           label="Notes from StudentAid BC"
           variant="outlined"


### PR DESCRIPTION
## Application offering change view -  update offering description

- [x] Update the offering description to be in sync with offering description coming from options API
**In progress request**
<img width="1330" height="561" alt="image" src="https://github.com/user-attachments/assets/ddb0ab27-bcb2-4883-bb55-38e9256c20de" />

**Completed request**
<img width="1411" height="810" alt="image" src="https://github.com/user-attachments/assets/ee9b9b8c-c38d-4027-b63e-10706f356d8d" />

- [x] Minor UI update to remove the label of notes component when it is not relevant. Notes is present only when the request is completed by ministry staff.
<img width="1345" height="549" alt="image" src="https://github.com/user-attachments/assets/45783625-19b0-4231-afc3-64bd8df4eb7b" />
