### PR TITLE
#6437 - npm package upgrades for v4.0.0 (tasks)

### DIFF
--- a/devops/tasks/package-lock.json
+++ b/devops/tasks/package-lock.json
@@ -1,20 +1,20 @@
 {
-    "name": "sims-task-executor",
+    "name": "sims-tasks-executor",
     "version": "1.0.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
-            "name": "sims-task-executor",
+            "name": "sims-tasks-executor",
             "version": "1.0.0",
             "dependencies": {
-                "@kubernetes/client-node": "^1.4.0",
-                "dayjs": "^1.11.21",
-                "dotenv": "^16.6.1",
+                "@kubernetes/client-node": "^2.0.0",
+                "dayjs": "^1.11.23",
+                "dotenv": "^17.4.2",
                 "jwt-decode": "^4.0.0"
             },
             "devDependencies": {
-                "@types/node": "^25.9.3",
+                "@types/node": "^26.2.0",
                 "tsx": "^4.19.2",
                 "typescript": "^6.0.3"
             }
@@ -486,43 +486,28 @@
             }
         },
         "node_modules/@kubernetes/client-node": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/@kubernetes/client-node/-/client-node-1.4.0.tgz",
-            "integrity": "sha512-Zge3YvF7DJi264dU1b3wb/GmzR99JhUpqTvp+VGHfwZT+g7EOOYNScDJNZwXy9cszyIGPIs0VHr+kk8e95qqrA==",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@kubernetes/client-node/-/client-node-2.0.0.tgz",
+            "integrity": "sha512-Jx2cRxEVb4XkDNiR/cg8SX9dH6ZHdMhKmZdQcfhn2vdBWHdb2ldwM0P3I0dK4msYhFmC6TCODsNHH144IpA06w==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@types/js-yaml": "^4.0.1",
-                "@types/node": "^24.0.0",
-                "@types/node-fetch": "^2.6.13",
+                "@types/node": "^26.0.0",
                 "@types/stream-buffers": "^3.0.3",
                 "form-data": "^4.0.0",
                 "hpagent": "^1.2.0",
                 "isomorphic-ws": "^5.0.0",
-                "js-yaml": "^4.1.0",
+                "js-yaml": "^5.1.0",
                 "jsonpath-plus": "^10.3.0",
-                "node-fetch": "^2.7.0",
                 "openid-client": "^6.1.3",
                 "rfc4648": "^1.3.0",
-                "socks-proxy-agent": "^8.0.4",
+                "socks": "^2.8.4",
+                "socks-proxy-agent": "^10.0.0",
                 "stream-buffers": "^3.0.2",
                 "tar-fs": "^3.0.9",
+                "undici": "^8.7.0",
                 "ws": "^8.18.2"
             }
-        },
-        "node_modules/@kubernetes/client-node/node_modules/@types/node": {
-            "version": "24.13.2",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.2.tgz",
-            "integrity": "sha512-fRa09kZTgu8o71KFcDjUFuc7F+dEbZYZmkI0mg5YBTRs0yMKjYHsq/c0urDKeDb+D5qVgXOdFcuu+DZPKOITwA==",
-            "license": "MIT",
-            "dependencies": {
-                "undici-types": "~7.18.0"
-            }
-        },
-        "node_modules/@kubernetes/client-node/node_modules/argparse": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-            "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-            "license": "Python-2.0"
         },
         "node_modules/@kubernetes/client-node/node_modules/form-data": {
             "version": "4.0.6",
@@ -549,28 +534,6 @@
                 "url": "https://github.com/sponsors/panva"
             }
         },
-        "node_modules/@kubernetes/client-node/node_modules/js-yaml": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-            "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/puzrin"
-                },
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/nodeca"
-                }
-            ],
-            "license": "MIT",
-            "dependencies": {
-                "argparse": "^2.0.1"
-            },
-            "bin": {
-                "js-yaml": "bin/js-yaml.js"
-            }
-        },
         "node_modules/@kubernetes/client-node/node_modules/openid-client": {
             "version": "6.8.4",
             "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-6.8.4.tgz",
@@ -583,12 +546,6 @@
             "funding": {
                 "url": "https://github.com/sponsors/panva"
             }
-        },
-        "node_modules/@kubernetes/client-node/node_modules/undici-types": {
-            "version": "7.18.2",
-            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
-            "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
-            "license": "MIT"
         },
         "node_modules/@kubernetes/client-node/node_modules/ws": {
             "version": "8.21.0",
@@ -618,38 +575,12 @@
             "license": "MIT"
         },
         "node_modules/@types/node": {
-            "version": "25.9.3",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.3.tgz",
-            "integrity": "sha512-603BddQMv3pUcr4U2dhujk83N2tTDVr/34wII2B6bJy6g+8WD6yUb11jszNs0gdi4PesVWl7ABt8nYMVpnLUcg==",
+            "version": "26.2.0",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-26.2.0.tgz",
+            "integrity": "sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg==",
             "license": "MIT",
             "dependencies": {
-                "undici-types": ">=7.24.0 <7.24.7"
-            }
-        },
-        "node_modules/@types/node-fetch": {
-            "version": "2.6.13",
-            "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.13.tgz",
-            "integrity": "sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==",
-            "license": "MIT",
-            "dependencies": {
-                "@types/node": "*",
-                "form-data": "^4.0.4"
-            }
-        },
-        "node_modules/@types/node-fetch/node_modules/form-data": {
-            "version": "4.0.6",
-            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
-            "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
-            "license": "MIT",
-            "dependencies": {
-                "asynckit": "^0.4.0",
-                "combined-stream": "^1.0.8",
-                "es-set-tostringtag": "^2.1.0",
-                "hasown": "^2.0.4",
-                "mime-types": "^2.1.35"
-            },
-            "engines": {
-                "node": ">= 6"
+                "undici-types": "~8.3.0"
             }
         },
         "node_modules/@types/stream-buffers": {
@@ -662,13 +593,19 @@
             }
         },
         "node_modules/agent-base": {
-            "version": "7.1.4",
-            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
-            "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+            "version": "9.0.0",
+            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-9.0.0.tgz",
+            "integrity": "sha512-TQf59BsZnytt8GdJKLPfUZ54g/iaUL2OWDSFCCvMOhsHduDQxO8xC4PNeyIkVcA5KwL2phPSv0douC0fgWzmnA==",
             "license": "MIT",
             "engines": {
-                "node": ">= 14"
+                "node": ">= 20"
             }
+        },
+        "node_modules/argparse": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+            "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+            "license": "Python-2.0"
         },
         "node_modules/asynckit": {
             "version": "0.4.0",
@@ -808,9 +745,9 @@
             }
         },
         "node_modules/dayjs": {
-            "version": "1.11.21",
-            "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.21.tgz",
-            "integrity": "sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA==",
+            "version": "1.11.23",
+            "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.23.tgz",
+            "integrity": "sha512-QDTCU0M0MxR3hQfnlDJfwekQiaanm1ubOD231u73WBckQ/fsamwRLiE2GBz6D3a/xF1NgfiDLJjXBa1hYOYTtQ==",
             "license": "MIT"
         },
         "node_modules/debug": {
@@ -840,9 +777,9 @@
             }
         },
         "node_modules/dotenv": {
-            "version": "16.6.1",
-            "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
-            "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+            "version": "17.4.2",
+            "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+            "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
             "license": "BSD-2-Clause",
             "engines": {
                 "node": ">=12"
@@ -1098,9 +1035,9 @@
             }
         },
         "node_modules/ip-address": {
-            "version": "10.2.0",
-            "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-            "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+            "version": "10.5.0",
+            "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.5.0.tgz",
+            "integrity": "sha512-R5SnVLJmgYYvf2F2ZgwSBnelz5G4q5AxIC277GDfUaNbrZKNANcBC7RHqYYePlszf4kBolVkJauG0ZjHHFh55g==",
             "license": "MIT",
             "engines": {
                 "node": ">= 12"
@@ -1113,6 +1050,28 @@
             "license": "MIT",
             "peerDependencies": {
                 "ws": "*"
+            }
+        },
+        "node_modules/js-yaml": {
+            "version": "5.3.0",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.3.0.tgz",
+            "integrity": "sha512-muutsYr+e2+d3rTgUGslq5rxbBlUy3cJ61IsHag2QNDQV+7zXWjkUpmALIajhrlLlrgRUiymj6U3zUr/TMK84Q==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/puzrin"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/nodeca"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "argparse": "^2.0.1"
+            },
+            "bin": {
+                "js-yaml": "bin/js-yaml.mjs"
             }
         },
         "node_modules/jsep": {
@@ -1187,26 +1146,6 @@
             "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
             "license": "MIT"
         },
-        "node_modules/node-fetch": {
-            "version": "2.7.0",
-            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-            "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-            "license": "MIT",
-            "dependencies": {
-                "whatwg-url": "^5.0.0"
-            },
-            "engines": {
-                "node": "4.x || >=6.0.0"
-            },
-            "peerDependencies": {
-                "encoding": "^0.1.0"
-            },
-            "peerDependenciesMeta": {
-                "encoding": {
-                    "optional": true
-                }
-            }
-        },
         "node_modules/oauth4webapi": {
             "version": "3.8.6",
             "resolved": "https://registry.npmjs.org/oauth4webapi/-/oauth4webapi-3.8.6.tgz",
@@ -1266,17 +1205,17 @@
             }
         },
         "node_modules/socks-proxy-agent": {
-            "version": "8.0.5",
-            "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
-            "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
+            "version": "10.1.0",
+            "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-10.1.0.tgz",
+            "integrity": "sha512-WlMj/67cEJ6MDI1OcsnjuYKDNDoyPCCYZ249kuuXPiMDw9F8PXkVaQ7YWu3siTydfQ/4BEZcvGzu+aYvz7dDCQ==",
             "license": "MIT",
             "dependencies": {
-                "agent-base": "^7.1.2",
+                "agent-base": "9.0.0",
                 "debug": "^4.3.4",
                 "socks": "^2.8.3"
             },
             "engines": {
-                "node": ">= 14"
+                "node": ">= 20"
             }
         },
         "node_modules/stream-buffers": {
@@ -1343,12 +1282,6 @@
                 "b4a": "^1.6.4"
             }
         },
-        "node_modules/tr46": {
-            "version": "0.0.3",
-            "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-            "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-            "license": "MIT"
-        },
         "node_modules/tsx": {
             "version": "4.22.4",
             "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.4.tgz",
@@ -1382,27 +1315,20 @@
                 "node": ">=14.17"
             }
         },
-        "node_modules/undici-types": {
-            "version": "7.24.6",
-            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
-            "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
-            "license": "MIT"
-        },
-        "node_modules/webidl-conversions": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-            "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-            "license": "BSD-2-Clause"
-        },
-        "node_modules/whatwg-url": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-            "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+        "node_modules/undici": {
+            "version": "8.10.0",
+            "resolved": "https://registry.npmjs.org/undici/-/undici-8.10.0.tgz",
+            "integrity": "sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==",
             "license": "MIT",
-            "dependencies": {
-                "tr46": "~0.0.3",
-                "webidl-conversions": "^3.0.0"
+            "engines": {
+                "node": ">=22.19.0"
             }
+        },
+        "node_modules/undici-types": {
+            "version": "8.3.0",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+            "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+            "license": "MIT"
         },
         "node_modules/wrappy": {
             "version": "1.0.2",

--- a/devops/tasks/package.json
+++ b/devops/tasks/package.json
@@ -10,13 +10,13 @@
         "validate-oc-sa-token-expiry": "tsx src/sa-token/main.ts"
     },
     "dependencies": {
-        "@kubernetes/client-node": "^1.4.0",
-        "dayjs": "^1.11.21",
-        "dotenv": "^16.6.1",
+        "@kubernetes/client-node": "^2.0.0",
+        "dayjs": "^1.11.23",
+        "dotenv": "^17.4.2",
         "jwt-decode": "^4.0.0"
     },
     "devDependencies": {
-        "@types/node": "^25.9.3",
+        "@types/node": "^26.2.0",
         "tsx": "^4.19.2",
         "typescript": "^6.0.3"
     }


### PR DESCRIPTION
## Overview

Updates the SIMS maintenance task executor dependencies for the v4.0.0 release.

## Updated packages

| Package | Previous version | Updated version |
| --- | --- | --- |
| `@kubernetes/client-node` | `^1.4.0` | `^2.0.0` |
| `dayjs` | `^1.11.21` | `^1.11.23` |
| `dotenv` | `^16.6.1` | `^17.4.2` |
| `@types/node` | `^25.9.3` | `^26.2.0` |

The lockfile was regenerated to align the resolved dependency graph. The Kubernetes client update replaces its legacy `node-fetch` stack with `undici` and updates related transitive packages, including `js-yaml`, `socks-proxy-agent`, `agent-base`, `ip-address`, and `undici-types`.

## Validation

- `npm ci` completed with 0 reported vulnerabilities.
- `npm exec --no tsc -- --noEmit` passed in `devops/tasks`.
- `git diff --check` passed.