### PR TITLE
#6418 - Resolve restriction notes

### DIFF
--- a/sources/packages/web/src/components/common/modals/UserNoteConfirmModal.vue
+++ b/sources/packages/web/src/components/common/modals/UserNoteConfirmModal.vue
@@ -29,6 +29,7 @@
               :secondary-label="cancelLabel"
               @primary-click="resolvePromise(true)"
               @secondary-click="resolvePromise(false)"
+              :show-primary-button="showPrimaryButton"
               :disable-primary-button="disablePrimaryButton || notAllowed"
               :show-secondary-button="showSecondaryButton"
               :processing="loading"
@@ -90,6 +91,11 @@ export default defineComponent({
       type: Number,
       required: false,
       default: undefined,
+    },
+    showPrimaryButton: {
+      type: Boolean,
+      required: false,
+      default: true,
     },
     disablePrimaryButton: {
       type: Boolean,

--- a/sources/packages/web/src/components/common/modals/UserNoteConfirmModal.vue
+++ b/sources/packages/web/src/components/common/modals/UserNoteConfirmModal.vue
@@ -9,6 +9,7 @@
         <error-summary :errors="modalNotesForm.errors" />
         <slot name="content" :show-parameter="showParameter">{{ text }}</slot>
         <v-textarea
+          v-if="showNotes"
           :label="notesLabel"
           variant="outlined"
           hide-details="auto"
@@ -21,7 +22,22 @@
         </p>
       </template>
       <template #footer>
+        <check-permission-role v-if="allowedRole" :role="allowedRole">
+          <template #="{ notAllowed }">
+            <footer-buttons
+              :primary-label="okLabel"
+              :secondary-label="cancelLabel"
+              @primary-click="resolvePromise(true)"
+              @secondary-click="resolvePromise(false)"
+              :disable-primary-button="disablePrimaryButton || notAllowed"
+              :show-secondary-button="showSecondaryButton"
+              :processing="loading"
+            />
+          </template>
+        </check-permission-role>
+
         <footer-buttons
+          v-else
           :primary-label="okLabel"
           :secondary-label="cancelLabel"
           @primary-click="resolvePromise(true)"
@@ -36,10 +52,11 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, ref } from "vue";
+import { defineComponent, PropType, ref } from "vue";
 import ModalDialogBase from "@/components/generic/ModalDialogBase.vue";
+import CheckPermissionRole from "@/components/generic/CheckPermissionRole.vue";
 import { useModalDialog, useRules } from "@/composables";
-import { VForm } from "@/types";
+import { Role, VForm } from "@/types";
 
 export interface UserNoteModal<T> {
   showParameter: T;
@@ -48,6 +65,7 @@ export interface UserNoteModal<T> {
 
 export default defineComponent({
   components: {
+    CheckPermissionRole,
     ModalDialogBase,
   },
   props: {
@@ -62,12 +80,10 @@ export default defineComponent({
     },
     okLabel: {
       type: String,
-      required: true,
       default: "Ok",
     },
     cancelLabel: {
       type: String,
-      required: true,
       default: "Cancel",
     },
     maxWidth: {
@@ -91,6 +107,15 @@ export default defineComponent({
     },
     notesDescription: {
       type: String,
+      default: undefined,
+    },
+    showNotes: {
+      type: Boolean,
+      default: true,
+    },
+    allowedRole: {
+      type: String as PropType<Role>,
+      required: false,
       default: undefined,
     },
   },

--- a/sources/packages/web/src/components/common/modals/UserNoteConfirmModal.vue
+++ b/sources/packages/web/src/components/common/modals/UserNoteConfirmModal.vue
@@ -9,7 +9,6 @@
         <error-summary :errors="modalNotesForm.errors" />
         <slot name="content" :show-parameter="showParameter">{{ text }}</slot>
         <v-textarea
-          v-if="showNotes"
           :label="notesLabel"
           variant="outlined"
           hide-details="auto"
@@ -22,23 +21,7 @@
         </p>
       </template>
       <template #footer>
-        <check-permission-role v-if="allowedRole" :role="allowedRole">
-          <template #="{ notAllowed }">
-            <footer-buttons
-              :primary-label="okLabel"
-              :secondary-label="cancelLabel"
-              @primary-click="resolvePromise(true)"
-              @secondary-click="resolvePromise(false)"
-              :show-primary-button="showPrimaryButton"
-              :disable-primary-button="disablePrimaryButton || notAllowed"
-              :show-secondary-button="showSecondaryButton"
-              :processing="loading"
-            />
-          </template>
-        </check-permission-role>
-
         <footer-buttons
-          v-else
           :primary-label="okLabel"
           :secondary-label="cancelLabel"
           @primary-click="resolvePromise(true)"
@@ -53,11 +36,10 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, PropType, ref } from "vue";
+import { defineComponent, ref } from "vue";
 import ModalDialogBase from "@/components/generic/ModalDialogBase.vue";
-import CheckPermissionRole from "@/components/generic/CheckPermissionRole.vue";
 import { useModalDialog, useRules } from "@/composables";
-import { Role, VForm } from "@/types";
+import { VForm } from "@/types";
 
 export interface UserNoteModal<T> {
   showParameter: T;
@@ -66,7 +48,6 @@ export interface UserNoteModal<T> {
 
 export default defineComponent({
   components: {
-    CheckPermissionRole,
     ModalDialogBase,
   },
   props: {
@@ -81,21 +62,18 @@ export default defineComponent({
     },
     okLabel: {
       type: String,
+      required: true,
       default: "Ok",
     },
     cancelLabel: {
       type: String,
+      required: true,
       default: "Cancel",
     },
     maxWidth: {
       type: Number,
       required: false,
       default: undefined,
-    },
-    showPrimaryButton: {
-      type: Boolean,
-      required: false,
-      default: true,
     },
     disablePrimaryButton: {
       type: Boolean,
@@ -113,15 +91,6 @@ export default defineComponent({
     },
     notesDescription: {
       type: String,
-      default: undefined,
-    },
-    showNotes: {
-      type: Boolean,
-      default: true,
-    },
-    allowedRole: {
-      type: String as PropType<Role>,
-      required: false,
       default: undefined,
     },
   },

--- a/sources/packages/web/src/components/common/restriction/ViewRestriction.vue
+++ b/sources/packages/web/src/components/common/restriction/ViewRestriction.vue
@@ -1,131 +1,113 @@
 <template>
-  <v-form ref="viewRestrictionForm">
-    <modal-dialog-base title="View restriction" :showDialog="showDialog">
-      <template #content>
-        <error-summary :errors="viewRestrictionForm.errors" />
-        <h3 class="category-header-medium">Restriction information</h3>
-        <content-group>
+  <user-note-confirm-modal
+    title="View restriction"
+    ref="viewRestrictionModal"
+    :allowed-role="allowedRole"
+    :ok-label="allowUserToEdit ? 'Resolve restriction' : 'Close'"
+    :show-secondary-button="allowUserToEdit"
+    notes-label="Resolution reason"
+    :show-notes="allowUserToEdit"
+  >
+    <template #content>
+      <h3 class="category-header-medium">Restriction information</h3>
+      <content-group>
+        <title-value
+          property-title="Category"
+          :property-value="restrictionData?.restrictionCategory"
+        />
+        <title-value
+          property-title="Reason"
+          :property-value="restrictionData?.description"
+        />
+        <title-value
+          v-if="restrictionData?.restrictionNote"
+          property-title="Notes"
+          :property-value="restrictionData?.restrictionNote"
+        />
+        <v-row
+          ><v-col
+            ><title-value
+              property-title="Date created"
+              :property-value="
+                dateOnlyLongString(restrictionData?.createdAt)
+              " /></v-col
+          ><v-col
+            ><title-value
+              property-title="Created by"
+              :property-value="restrictionData?.createdBy" /></v-col
+          ><v-col
+            ><title-value property-title="Status" /><status-chip-restriction
+              :is-active="!!restrictionData?.isActive"
+              :deleted-at="restrictionData?.deletedAt" /></v-col
+        ></v-row>
+      </content-group>
+      <template v-if="showResolution">
+        <h3 class="category-header-medium mt-2">Resolution</h3>
+        <content-group
+          v-if="
+            !restrictionData?.isActive &&
+            restrictionData?.restrictionType !== RestrictionType.Federal
+          "
+        >
           <title-value
-            propertyTitle="Category"
-            :propertyValue="restrictionData.restrictionCategory"
-          />
-          <title-value
-            propertyTitle="Reason"
-            :propertyValue="restrictionData.description"
-          />
-          <title-value
-            v-if="restrictionData.restrictionNote"
-            propertyTitle="Notes"
-            :propertyValue="restrictionData.restrictionNote"
+            property-title="Resolution reason"
+            :property-value="restrictionData?.resolutionNote"
           />
           <v-row
             ><v-col
               ><title-value
-                propertyTitle="Date created"
-                :propertyValue="
-                  dateOnlyLongString(restrictionData.createdAt)
+                property-title="Date resolved"
+                :property-value="
+                  dateOnlyLongString(restrictionData?.resolvedAt)
                 " /></v-col
             ><v-col
               ><title-value
-                propertyTitle="Created by"
-                :propertyValue="restrictionData.createdBy" /></v-col
-            ><v-col
-              ><title-value propertyTitle="Status" /><status-chip-restriction
-                :is-active="restrictionData.isActive"
-                :deleted-at="restrictionData.deletedAt" /></v-col
+                property-title="Resolved by"
+                :property-value="restrictionData?.resolvedBy" /></v-col
           ></v-row>
         </content-group>
-        <template v-if="showResolution">
-          <h3 class="category-header-medium mt-2">Resolution</h3>
-          <v-textarea
-            v-if="allowUserToEdit"
-            label="Resolution reason"
-            v-model="formModel.resolutionNote"
-            variant="outlined"
-            :rules="[(v) => checkResolutionNotesLength(v)]"
+      </template>
+      <template v-if="showDeletion">
+        <h3 class="category-header-medium mt-2">Deletion</h3>
+        <content-group>
+          <title-value
+            property-title="Deletion reason"
+            :property-value="restrictionData?.deletionNote"
           />
-          <content-group
-            v-if="
-              !restrictionData.isActive &&
-              restrictionData.restrictionType !== RestrictionType.Federal
-            "
-          >
-            <title-value
-              propertyTitle="Resolution reason"
-              :propertyValue="restrictionData.resolutionNote"
-            />
-            <v-row
-              ><v-col
-                ><title-value
-                  propertyTitle="Date resolved"
-                  :propertyValue="
-                    dateOnlyLongString(restrictionData.resolvedAt)
-                  " /></v-col
-              ><v-col
-                ><title-value
-                  propertyTitle="Resolved by"
-                  :propertyValue="restrictionData.resolvedBy" /></v-col
-            ></v-row>
-          </content-group>
-        </template>
-        <template v-if="showDeletion">
-          <h3 class="category-header-medium mt-2">Deletion</h3>
-          <content-group>
-            <title-value
-              propertyTitle="Deletion reason"
-              :propertyValue="restrictionData.deletionNote"
-            />
-            <v-row
-              ><v-col
-                ><title-value
-                  propertyTitle="Date deleted"
-                  :propertyValue="
-                    dateOnlyLongString(restrictionData.deletedAt)
-                  " /></v-col
-              ><v-col
-                ><title-value
-                  propertyTitle="Deleted by"
-                  :propertyValue="restrictionData.deletedBy" /></v-col
-            ></v-row>
-          </content-group>
-        </template>
+          <v-row
+            ><v-col
+              ><title-value
+                property-title="Date deleted"
+                :property-value="
+                  dateOnlyLongString(restrictionData?.deletedAt)
+                " /></v-col
+            ><v-col
+              ><title-value
+                property-title="Deleted by"
+                :property-value="restrictionData?.deletedBy" /></v-col
+          ></v-row>
+        </content-group>
       </template>
-      <template #footer>
-        <check-permission-role :role="allowedRole">
-          <template #="{ notAllowed }">
-            <footer-buttons
-              :primaryLabel="allowUserToEdit ? 'Resolve restriction' : 'Close'"
-              secondaryLabel="Cancel"
-              @primaryClick="allowUserToEdit ? submit() : cancel()"
-              @secondaryClick="cancel"
-              :disablePrimaryButton="allowUserToEdit && notAllowed"
-              :showSecondaryButton="allowUserToEdit"
-            />
-          </template>
-        </check-permission-role>
-      </template>
-    </modal-dialog-base>
-  </v-form>
+    </template>
+  </user-note-confirm-modal>
 </template>
 
 <script lang="ts">
 import { PropType, ref, reactive, computed, defineComponent } from "vue";
-import ModalDialogBase from "@/components/generic/ModalDialogBase.vue";
-import ErrorSummary from "@/components/generic/ErrorSummary.vue";
-import { useFormatters, useModalDialog, useValidators } from "@/composables";
-import { Role, RestrictionType, VForm, RestrictionStatus } from "@/types";
-import CheckPermissionRole from "@/components/generic/CheckPermissionRole.vue";
+import UserNoteConfirmModal, {
+  UserNoteModal,
+} from "@/components/common/modals/UserNoteConfirmModal.vue";
+import { ModalDialog, useFormatters } from "@/composables";
+import { Role, RestrictionType, RestrictionStatus } from "@/types";
 import { RestrictionDetailAPIOutDTO } from "@/services/http/dto";
 import StatusChipRestriction from "@/components/generic/StatusChipRestriction.vue";
 import TitleValue from "@/components/generic/TitleValue.vue";
 
 export default defineComponent({
   components: {
-    ModalDialogBase,
-    CheckPermissionRole,
-    ErrorSummary,
     StatusChipRestriction,
     TitleValue,
+    UserNoteConfirmModal,
   },
   props: {
     restrictionData: {
@@ -143,42 +125,28 @@ export default defineComponent({
     },
   },
   setup(props) {
-    const NOTES_MAX_CHARACTERS = 500;
-    const { checkMaxCharacters } = useValidators();
     const { dateOnlyLongString } = useFormatters();
-    const { showDialog, showModal, resolvePromise } = useModalDialog<
-      RestrictionDetailAPIOutDTO | false
-    >();
-    const viewRestrictionForm = ref({} as VForm);
+    const viewRestrictionModal = ref(
+      {} as ModalDialog<UserNoteModal<unknown> | false>,
+    );
     const formModel = reactive({} as RestrictionDetailAPIOutDTO);
 
-    const submit = async () => {
-      const validationResult = await viewRestrictionForm.value.validate();
-      if (!validationResult.valid) {
-        return;
+    const showModal = async (): Promise<RestrictionDetailAPIOutDTO | false> => {
+      if (!props.restrictionData) {
+        return false;
+      }
+      const modalResult = await viewRestrictionModal.value.showModal();
+      if (!modalResult) {
+        return false;
       }
       formModel.restrictionId = props.restrictionData.restrictionId;
-      resolvePromise(formModel);
-    };
-
-    const cancel = () => {
-      viewRestrictionForm.value.reset();
-      viewRestrictionForm.value.resetValidation();
-      resolvePromise(false);
-    };
-
-    const checkResolutionNotesLength = (notes: string) => {
-      if (notes) {
-        return (
-          checkMaxCharacters(notes, NOTES_MAX_CHARACTERS) ||
-          `Max ${NOTES_MAX_CHARACTERS} characters.`
-        );
-      }
-      return "Resolution reason is required.";
+      formModel.resolutionNote = modalResult.note;
+      return formModel;
     };
 
     const allowUserToEdit = computed(
       () =>
+        !!props.restrictionData &&
         !props.restrictionData.deletedAt &&
         props.restrictionData.isActive &&
         props.restrictionData.restrictionType !== RestrictionType.Federal &&
@@ -186,6 +154,9 @@ export default defineComponent({
     );
 
     const showResolution = computed(() => {
+      if (!props.restrictionData) {
+        return false;
+      }
       if (props.restrictionData.deletedAt) {
         // Show resolution section if the restriction was deleted, but has some note.
         return !!props.restrictionData.resolutionNote;
@@ -201,20 +172,16 @@ export default defineComponent({
     });
 
     const showDeletion = computed(() => {
-      return !!props.restrictionData.deletedAt;
+      return !!props.restrictionData?.deletedAt;
     });
 
     return {
-      showDialog,
+      viewRestrictionModal,
       showModal,
       RestrictionType,
-      submit,
-      cancel,
-      viewRestrictionForm,
       Role,
       formModel,
       RestrictionStatus,
-      checkResolutionNotesLength,
       allowUserToEdit,
       showResolution,
       showDeletion,

--- a/sources/packages/web/src/components/common/restriction/ViewRestriction.vue
+++ b/sources/packages/web/src/components/common/restriction/ViewRestriction.vue
@@ -3,8 +3,9 @@
     title="View restriction"
     ref="viewRestrictionModal"
     :allowed-role="allowedRole"
-    :ok-label="allowUserToEdit ? 'Resolve restriction' : 'Close'"
-    :show-secondary-button="allowUserToEdit"
+    :show-primary-button="allowUserToEdit"
+    ok-label="Resolve restriction"
+    :cancel-label="allowUserToEdit ? 'Cancel' : 'Close'"
     notes-label="Resolution reason"
     :show-notes="allowUserToEdit"
   >
@@ -132,9 +133,6 @@ export default defineComponent({
     const formModel = reactive({} as RestrictionDetailAPIOutDTO);
 
     const showModal = async (): Promise<RestrictionDetailAPIOutDTO | false> => {
-      if (!props.restrictionData) {
-        return false;
-      }
       const modalResult = await viewRestrictionModal.value.showModal();
       if (!modalResult) {
         return false;
@@ -154,9 +152,6 @@ export default defineComponent({
     );
 
     const showResolution = computed(() => {
-      if (!props.restrictionData) {
-        return false;
-      }
       if (props.restrictionData.deletedAt) {
         // Show resolution section if the restriction was deleted, but has some note.
         return !!props.restrictionData.resolutionNote;
@@ -172,7 +167,7 @@ export default defineComponent({
     });
 
     const showDeletion = computed(() => {
-      return !!props.restrictionData?.deletedAt;
+      return !!props.restrictionData.deletedAt;
     });
 
     return {

--- a/sources/packages/web/src/components/common/restriction/ViewRestriction.vue
+++ b/sources/packages/web/src/components/common/restriction/ViewRestriction.vue
@@ -146,8 +146,10 @@ const submit = async () => {
 
   formModel.restrictionId = props.restrictionData.restrictionId;
   const payload = { ...formModel };
-  resolvePromise(payload);
-  viewRestrictionForm.value.reset();
+  const resolved = await resolvePromise(payload);
+  if (resolved) {
+    viewRestrictionForm.value.reset();
+  }
 };
 
 const cancel = () => {

--- a/sources/packages/web/src/components/common/restriction/ViewRestriction.vue
+++ b/sources/packages/web/src/components/common/restriction/ViewRestriction.vue
@@ -1,187 +1,189 @@
 <template>
-  <user-note-confirm-modal
-    title="View restriction"
-    ref="viewRestrictionModal"
-    :allowed-role="allowedRole"
-    :show-primary-button="allowUserToEdit"
-    ok-label="Resolve restriction"
-    :cancel-label="allowUserToEdit ? 'Cancel' : 'Close'"
-    notes-label="Resolution reason"
-    :show-notes="allowUserToEdit"
-  >
-    <template #content>
-      <h3 class="category-header-medium">Restriction information</h3>
-      <content-group>
-        <title-value
-          property-title="Category"
-          :property-value="restrictionData?.restrictionCategory"
-        />
-        <title-value
-          property-title="Reason"
-          :property-value="restrictionData?.description"
-        />
-        <title-value
-          v-if="restrictionData?.restrictionNote"
-          property-title="Notes"
-          :property-value="restrictionData?.restrictionNote"
-        />
-        <v-row
-          ><v-col
-            ><title-value
-              property-title="Date created"
-              :property-value="
-                dateOnlyLongString(restrictionData?.createdAt)
-              " /></v-col
-          ><v-col
-            ><title-value
-              property-title="Created by"
-              :property-value="restrictionData?.createdBy" /></v-col
-          ><v-col
-            ><title-value property-title="Status" /><status-chip-restriction
-              :is-active="!!restrictionData?.isActive"
-              :deleted-at="restrictionData?.deletedAt" /></v-col
-        ></v-row>
-      </content-group>
-      <template v-if="showResolution">
-        <h3 class="category-header-medium mt-2">Resolution</h3>
-        <content-group
-          v-if="
-            !restrictionData?.isActive &&
-            restrictionData?.restrictionType !== RestrictionType.Federal
-          "
-        >
-          <title-value
-            property-title="Resolution reason"
-            :property-value="restrictionData?.resolutionNote"
-          />
-          <v-row
-            ><v-col
-              ><title-value
-                property-title="Date resolved"
-                :property-value="
-                  dateOnlyLongString(restrictionData?.resolvedAt)
-                " /></v-col
-            ><v-col
-              ><title-value
-                property-title="Resolved by"
-                :property-value="restrictionData?.resolvedBy" /></v-col
-          ></v-row>
-        </content-group>
-      </template>
-      <template v-if="showDeletion">
-        <h3 class="category-header-medium mt-2">Deletion</h3>
+  <v-form ref="viewRestrictionForm">
+    <modal-dialog-base title="View restriction" :show-dialog="showDialog">
+      <template #content>
+        <error-summary :errors="viewRestrictionForm.errors" />
+        <h3 class="category-header-medium">Restriction information</h3>
         <content-group>
           <title-value
-            property-title="Deletion reason"
-            :property-value="restrictionData?.deletionNote"
+            property-title="Category"
+            :property-value="restrictionData.restrictionCategory"
+          />
+          <title-value
+            property-title="Reason"
+            :property-value="restrictionData.description"
+          />
+          <title-value
+            v-if="restrictionData.restrictionNote"
+            property-title="Notes"
+            :property-value="restrictionData.restrictionNote"
           />
           <v-row
             ><v-col
               ><title-value
-                property-title="Date deleted"
+                property-title="Date created"
                 :property-value="
-                  dateOnlyLongString(restrictionData?.deletedAt)
+                  dateOnlyLongString(restrictionData.createdAt)
                 " /></v-col
             ><v-col
               ><title-value
-                property-title="Deleted by"
-                :property-value="restrictionData?.deletedBy" /></v-col
+                property-title="Created by"
+                :property-value="restrictionData.createdBy" /></v-col
+            ><v-col
+              ><title-value property-title="Status" /><status-chip-restriction
+                :is-active="restrictionData.isActive"
+                :deleted-at="restrictionData.deletedAt" /></v-col
           ></v-row>
         </content-group>
+        <template v-if="showResolution">
+          <h3 class="category-header-medium mt-2">Resolution</h3>
+          <v-textarea
+            v-if="allowUserToEdit"
+            label="Resolution reason"
+            v-model="formModel.resolutionNote"
+            variant="outlined"
+            :rules="[(v) => checkNotesLengthRule(v, 'Resolution Reason')]"
+          />
+          <content-group
+            v-if="
+              !restrictionData.isActive &&
+              restrictionData.restrictionType !== RestrictionType.Federal
+            "
+          >
+            <title-value
+              property-title="Resolution reason"
+              :property-value="restrictionData.resolutionNote"
+            />
+            <v-row
+              ><v-col
+                ><title-value
+                  property-title="Date resolved"
+                  :property-value="
+                    dateOnlyLongString(restrictionData.resolvedAt)
+                  " /></v-col
+              ><v-col
+                ><title-value
+                  property-title="Resolved by"
+                  :property-value="restrictionData.resolvedBy" /></v-col
+            ></v-row>
+          </content-group>
+        </template>
+        <template v-if="showDeletion">
+          <h3 class="category-header-medium mt-2">Deletion</h3>
+          <content-group>
+            <title-value
+              property-title="Deletion reason"
+              :property-value="restrictionData.deletionNote"
+            />
+            <v-row
+              ><v-col
+                ><title-value
+                  property-title="Date deleted"
+                  :property-value="
+                    dateOnlyLongString(restrictionData.deletedAt)
+                  " /></v-col
+              ><v-col
+                ><title-value
+                  property-title="Deleted by"
+                  :property-value="restrictionData.deletedBy" /></v-col
+            ></v-row>
+          </content-group>
+        </template>
       </template>
-    </template>
-  </user-note-confirm-modal>
+      <template #footer>
+        <check-permission-role :role="allowedRole">
+          <template #="{ notAllowed }">
+            <footer-buttons
+              :primary-label="allowUserToEdit ? 'Resolve restriction' : 'Close'"
+              secondary-label="Cancel"
+              @primary-click="allowUserToEdit ? submit() : cancel()"
+              @secondary-click="cancel"
+              :disable-primary-button="allowUserToEdit && notAllowed"
+              :show-secondary-button="allowUserToEdit"
+            />
+          </template>
+        </check-permission-role>
+      </template>
+    </modal-dialog-base>
+  </v-form>
 </template>
 
-<script lang="ts">
-import { PropType, ref, reactive, computed, defineComponent } from "vue";
-import UserNoteConfirmModal, {
-  UserNoteModal,
-} from "@/components/common/modals/UserNoteConfirmModal.vue";
-import { ModalDialog, useFormatters } from "@/composables";
-import { Role, RestrictionType, RestrictionStatus } from "@/types";
+<script setup lang="ts">
+import { ref, reactive, computed } from "vue";
+import ModalDialogBase from "@/components/generic/ModalDialogBase.vue";
+import ErrorSummary from "@/components/generic/ErrorSummary.vue";
+import { useFormatters, useModalDialog, useRules } from "@/composables";
+import { Role, RestrictionType } from "@/types";
+import type { VForm } from "@/types";
+import CheckPermissionRole from "@/components/generic/CheckPermissionRole.vue";
 import { RestrictionDetailAPIOutDTO } from "@/services/http/dto";
 import StatusChipRestriction from "@/components/generic/StatusChipRestriction.vue";
 import TitleValue from "@/components/generic/TitleValue.vue";
 
-export default defineComponent({
-  components: {
-    StatusChipRestriction,
-    TitleValue,
-    UserNoteConfirmModal,
-  },
-  props: {
-    restrictionData: {
-      type: Object as PropType<RestrictionDetailAPIOutDTO>,
-      required: true,
-    },
-    allowedRole: {
-      type: String as PropType<Role>,
-      required: true,
-    },
-    canResolveRestriction: {
-      type: Boolean,
-      required: false,
-      default: false,
-    },
-  },
-  setup(props) {
-    const { dateOnlyLongString } = useFormatters();
-    const viewRestrictionModal = ref(
-      {} as ModalDialog<UserNoteModal<unknown> | false>,
-    );
-    const formModel = reactive({} as RestrictionDetailAPIOutDTO);
+interface Props {
+  restrictionData: RestrictionDetailAPIOutDTO;
+  allowedRole: Role;
+  canResolveRestriction?: boolean;
+}
 
-    const showModal = async (): Promise<RestrictionDetailAPIOutDTO | false> => {
-      const modalResult = await viewRestrictionModal.value.showModal();
-      if (!modalResult) {
-        return false;
-      }
-      formModel.restrictionId = props.restrictionData.restrictionId;
-      formModel.resolutionNote = modalResult.note;
-      return formModel;
-    };
+const props = withDefaults(defineProps<Props>(), {
+  canResolveRestriction: false,
+});
 
-    const allowUserToEdit = computed(
-      () =>
-        !!props.restrictionData &&
-        !props.restrictionData.deletedAt &&
-        props.restrictionData.isActive &&
-        props.restrictionData.restrictionType !== RestrictionType.Federal &&
-        props.canResolveRestriction,
-    );
+const { checkNotesLengthRule } = useRules();
+const { dateOnlyLongString } = useFormatters();
+const { showDialog, showModal, resolvePromise } = useModalDialog<
+  RestrictionDetailAPIOutDTO | false
+>();
+const viewRestrictionForm = ref({} as VForm);
+const formModel = reactive({} as RestrictionDetailAPIOutDTO);
 
-    const showResolution = computed(() => {
-      if (props.restrictionData.deletedAt) {
-        // Show resolution section if the restriction was deleted, but has some note.
-        return !!props.restrictionData.resolutionNote;
-      }
-      return (
-        props.canResolveRestriction &&
-        props.restrictionData.restrictionType !== RestrictionType.Federal &&
-        // If no resolution note is present, consider no resolution was provided.
-        // For instance, resolved provincial restrictions imported from legacy
-        // will not have a resolution associated with it.
-        (props.restrictionData.isActive || props.restrictionData.resolutionNote)
-      );
-    });
+const submit = async () => {
+  const validationResult = await viewRestrictionForm.value.validate();
+  if (!validationResult.valid) {
+    return;
+  }
 
-    const showDeletion = computed(() => {
-      return !!props.restrictionData.deletedAt;
-    });
+  formModel.restrictionId = props.restrictionData.restrictionId;
+  const payload = { ...formModel };
+  resolvePromise(payload);
+  viewRestrictionForm.value.reset();
+};
 
-    return {
-      viewRestrictionModal,
-      showModal,
-      RestrictionType,
-      Role,
-      formModel,
-      RestrictionStatus,
-      allowUserToEdit,
-      showResolution,
-      showDeletion,
-      dateOnlyLongString,
-    };
-  },
+const cancel = () => {
+  viewRestrictionForm.value.reset();
+  resolvePromise(false);
+};
+
+const allowUserToEdit = computed(
+  () =>
+    !props.restrictionData.deletedAt &&
+    props.restrictionData.isActive &&
+    props.restrictionData.restrictionType !== RestrictionType.Federal &&
+    props.canResolveRestriction,
+);
+
+const showResolution = computed(() => {
+  if (props.restrictionData.deletedAt) {
+    // Show resolution section if the restriction was deleted, but has some note.
+    return !!props.restrictionData.resolutionNote;
+  }
+
+  return (
+    props.canResolveRestriction &&
+    props.restrictionData.restrictionType !== RestrictionType.Federal &&
+    // If no resolution note is present, consider no resolution was provided.
+    // For instance, resolved provincial restrictions imported from legacy
+    // will not have a resolution associated with it.
+    (props.restrictionData.isActive || props.restrictionData.resolutionNote)
+  );
+});
+
+const showDeletion = computed(() => {
+  return !!props.restrictionData.deletedAt;
+});
+
+defineExpose({
+  showModal,
 });
 </script>

--- a/sources/packages/web/src/components/common/students/StudentRestrictions.vue
+++ b/sources/packages/web/src/components/common/students/StudentRestrictions.vue
@@ -133,7 +133,6 @@ import {
   ApiProcessError,
   RestrictionType,
   StudentRestrictionsHeaders,
-  RestrictionDetail,
 } from "@/types";
 import StatusChipRestriction from "@/components/generic/StatusChipRestriction.vue";
 import CheckPermissionRole from "@/components/generic/CheckPermissionRole.vue";
@@ -183,7 +182,7 @@ export default defineComponent({
     const studentRestrictions = ref<RestrictionSummaryAPIOutDTO[]>([]);
     const { dateOnlyLongString } = useFormatters();
     const showModal = ref(false);
-    const viewRestriction = ref({} as ModalDialog<RestrictionDetail | false>);
+    const viewRestriction = ref({} as ModalDialog<RestrictionDetailAPIOutDTO>);
     const addRestriction = ref(
       {} as ModalDialog<AssignRestrictionAPIInDTO | false>,
     );
@@ -211,14 +210,12 @@ export default defineComponent({
           studentRestriction.value.updatedAt,
         );
       }
-      const viewStudentRestrictionData =
-        await viewRestriction.value.showModal();
-      if (viewStudentRestrictionData) {
-        await resolveRestriction(viewStudentRestrictionData);
-      }
+      await viewRestriction.value.showModal(undefined, resolveRestriction);
     };
 
-    const resolveRestriction = async (data: RestrictionDetailAPIOutDTO) => {
+    const resolveRestriction = async (
+      data: RestrictionDetailAPIOutDTO,
+    ): Promise<boolean> => {
       try {
         const payload = {
           noteDescription: data.resolutionNote,
@@ -232,8 +229,14 @@ export default defineComponent({
         snackBar.success(
           "The given restriction has been resolved and resolution notes added.",
         );
-      } catch {
-        snackBar.error("Unexpected error while resolving the restriction.");
+        return true;
+      } catch (error: unknown) {
+        if (error instanceof ApiProcessError) {
+          snackBar.error(error.message);
+        } else {
+          snackBar.error("Unexpected error while resolving the restriction.");
+        }
+        return false;
       }
     };
 

--- a/sources/packages/web/src/views/aest/institution/Restrictions.vue
+++ b/sources/packages/web/src/views/aest/institution/Restrictions.vue
@@ -59,7 +59,7 @@
               <v-btn
                 color="primary"
                 variant="outlined"
-                @click="viewIInstitutionRestriction(item.restrictionId)"
+                @click="viewInstitutionRestriction(item.restrictionId)"
               >
                 View
               </v-btn>
@@ -166,7 +166,7 @@ export default defineComponent({
       ]);
     };
 
-    const viewIInstitutionRestriction = async (restrictionId: number) => {
+    const viewInstitutionRestriction = async (restrictionId: number) => {
       institutionRestriction.value =
         await RestrictionService.shared.getInstitutionRestrictionDetail(
           props.institutionId,
@@ -267,7 +267,7 @@ export default defineComponent({
       DEFAULT_PAGE_LIMIT,
       ITEMS_PER_PAGE,
       institutionRestriction,
-      viewIInstitutionRestriction,
+      viewInstitutionRestriction,
       viewRestriction,
       showModal,
       resolveRestriction,

--- a/sources/packages/web/src/views/aest/institution/Restrictions.vue
+++ b/sources/packages/web/src/views/aest/institution/Restrictions.vue
@@ -70,7 +70,6 @@
       <view-restriction-modal
         ref="viewRestriction"
         :restriction-data="institutionRestriction"
-        @submit-resolution-data="resolveRestriction"
         :allowed-role="Role.InstitutionResolveRestriction"
         :can-resolve-restriction="true"
       />

--- a/sources/packages/web/src/views/aest/institution/Restrictions.vue
+++ b/sources/packages/web/src/views/aest/institution/Restrictions.vue
@@ -101,7 +101,6 @@ import {
   Role,
   InstitutionRestrictionsHeaders,
   ApiProcessError,
-  RestrictionDetail,
   RestrictedParty,
 } from "@/types";
 import StatusChipRestriction from "@/components/generic/StatusChipRestriction.vue";
@@ -139,7 +138,7 @@ export default defineComponent({
     const { updateInstitutionRestrictionState } =
       useInstitutionRestrictionState();
     const showModal = ref(false);
-    const viewRestriction = ref({} as ModalDialog<RestrictionDetail | false>);
+    const viewRestriction = ref({} as ModalDialog<RestrictionDetailAPIOutDTO>);
     const addRestriction = ref(
       {} as ModalDialog<AssignInstitutionRestrictionAPIInDTO | false>,
     );
@@ -179,14 +178,12 @@ export default defineComponent({
           institutionRestriction.value.updatedAt,
         );
       }
-      const viewInstitutionRestrictionData =
-        await viewRestriction.value.showModal();
-      if (viewInstitutionRestrictionData) {
-        await resolveRestriction(viewInstitutionRestrictionData);
-      }
+      await viewRestriction.value.showModal(undefined, resolveRestriction);
     };
 
-    const resolveRestriction = async (data: RestrictionDetailAPIOutDTO) => {
+    const resolveRestriction = async (
+      data: RestrictionDetailAPIOutDTO,
+    ): Promise<boolean> => {
       try {
         const payload = {
           noteDescription: data.resolutionNote,
@@ -200,12 +197,14 @@ export default defineComponent({
         snackBar.success(
           "The given restriction has been resolved and resolution notes added.",
         );
+        return true;
       } catch (error: unknown) {
         if (error instanceof ApiProcessError) {
           snackBar.error(error.message);
-          return;
+        } else {
+          snackBar.error("Unexpected error while resolving the restriction.");
         }
-        snackBar.error("Unexpected error while resolving the restriction.");
+        return false;
       }
     };
 


### PR DESCRIPTION
## Summary
- Updated `ViewRestrictions` component so that note can be reset without impacting form submission.
- Updated to use callback to modal stays open after backend failure.
- Converted `ViewRestrictions` to script setup.
- Minor cleanup in `Restrictions`.

## Screenshots
### Ministry - Institution Restrictions
#### View
<img width="827" height="815" alt="image" src="https://github.com/user-attachments/assets/5f2849d8-b9d8-4d03-86c1-72b01e31a23f" />

#### API failure
<img width="981" height="733" alt="image" src="https://github.com/user-attachments/assets/d5cd9c81-fdee-403e-9b28-e23789f0c7a9" />

#### First Resolution
<img width="819" height="947" alt="image" src="https://github.com/user-attachments/assets/0bf530f3-d2d5-4b52-bf9e-33ddf237628f" />
<img width="824" height="824" alt="image" src="https://github.com/user-attachments/assets/260cd906-7ae0-49cc-b426-f27f936d0452" />

#### Second Resolution
<img width="823" height="820" alt="image" src="https://github.com/user-attachments/assets/8340c115-faf7-4497-9c02-dd96ac0e7d8a" />

### Ministry - Student Restrictions
#### View
<img width="824" height="763" alt="image" src="https://github.com/user-attachments/assets/13641b81-7cfb-42d4-9bb8-d8153b9a9603" />

#### First Resolution
<img width="817" height="945" alt="image" src="https://github.com/user-attachments/assets/dfd9a4a0-d701-4ab9-a503-2331214f8625" />
<img width="829" height="813" alt="image" src="https://github.com/user-attachments/assets/8e3d9903-119c-4a2e-86bf-5e17f6377fe6" />

#### Second Resolution
<img width="819" height="748" alt="image" src="https://github.com/user-attachments/assets/07a2f39b-7aef-403f-a756-d0680d794d29" />
