### PR TITLE
#6437 - docker base image upgrades for v4.0.0

### DIFF
--- a/sources/packages/backend/apps/api/Dockerfile
+++ b/sources/packages/backend/apps/api/Dockerfile
@@ -2,7 +2,7 @@
 # Artifactory registry is passed as a build argument to avoid hardcoding it in the Dockerfile.
 # The default value (docker.io) allows dependabot to resolve and update the base image when an update is available.
 ARG DOCKER_REGISTRY=docker.io
-FROM ${DOCKER_REGISTRY}/node:26.5.0-alpine3.24
+FROM ${DOCKER_REGISTRY}/node:26.7.0-alpine3.24
 
 ENV npm_config_cache=/app/.npm
 

--- a/sources/packages/backend/apps/api/Dockerfile.dev
+++ b/sources/packages/backend/apps/api/Dockerfile.dev
@@ -1,5 +1,5 @@
 # Base Image
-FROM node:26.5.0-alpine3.24
+FROM node:26.7.0-alpine3.24
 
 WORKDIR /app
 

--- a/sources/packages/backend/apps/load-test-gateway/Dockerfile
+++ b/sources/packages/backend/apps/load-test-gateway/Dockerfile
@@ -2,7 +2,7 @@
 # Artifactory registry is passed as a build argument to avoid hardcoding it in the Dockerfile.
 # The default value (docker.io) allows dependabot to resolve and update the base image when an update is available.
 ARG DOCKER_REGISTRY=docker.io
-FROM ${DOCKER_REGISTRY}/node:26.5.0-alpine3.24
+FROM ${DOCKER_REGISTRY}/node:26.7.0-alpine3.24
 
 ENV npm_config_cache=/app/.npm
 

--- a/sources/packages/backend/apps/load-test-gateway/Dockerfile.dev
+++ b/sources/packages/backend/apps/load-test-gateway/Dockerfile.dev
@@ -1,5 +1,5 @@
 # Base Image
-FROM node:26.5.0-alpine3.24
+FROM node:26.7.0-alpine3.24
 
 WORKDIR /app
 

--- a/sources/packages/backend/apps/queue-consumers/Dockerfile
+++ b/sources/packages/backend/apps/queue-consumers/Dockerfile
@@ -2,7 +2,7 @@
 # Artifactory registry is passed as a build argument to avoid hardcoding it in the Dockerfile.
 # The default value (docker.io) allows dependabot to resolve and update the base image when an update is available.
 ARG DOCKER_REGISTRY=docker.io
-FROM ${DOCKER_REGISTRY}/node:26.5.0-alpine3.24
+FROM ${DOCKER_REGISTRY}/node:26.7.0-alpine3.24
 
 ENV npm_config_cache=/app/.npm
 

--- a/sources/packages/backend/apps/queue-consumers/Dockerfile.dev
+++ b/sources/packages/backend/apps/queue-consumers/Dockerfile.dev
@@ -1,5 +1,5 @@
 # Base Image
-FROM node:26.5.0-alpine3.24
+FROM node:26.7.0-alpine3.24
 
 WORKDIR /app
 

--- a/sources/packages/backend/apps/workers/Dockerfile
+++ b/sources/packages/backend/apps/workers/Dockerfile
@@ -2,7 +2,7 @@
 # Artifactory registry is passed as a build argument to avoid hardcoding it in the Dockerfile.
 # The default value (docker.io) allows dependabot to resolve and update the base image when an update is available.
 ARG DOCKER_REGISTRY=docker.io
-FROM ${DOCKER_REGISTRY}/node:26.5.0-alpine3.24
+FROM ${DOCKER_REGISTRY}/node:26.7.0-alpine3.24
 
 ENV npm_config_cache=/app/.npm
 

--- a/sources/packages/backend/apps/workers/Dockerfile.dev
+++ b/sources/packages/backend/apps/workers/Dockerfile.dev
@@ -1,5 +1,5 @@
 # Base Image
-FROM node:26.5.0-alpine3.24
+FROM node:26.7.0-alpine3.24
 
 WORKDIR /app
 

--- a/sources/packages/backend/migrations/Dockerfile
+++ b/sources/packages/backend/migrations/Dockerfile
@@ -2,7 +2,7 @@
 # Artifactory registry is passed as a build argument to avoid hardcoding it in the Dockerfile.
 # The default value (docker.io) allows dependabot to resolve and update the base image when an update is available.
 ARG DOCKER_REGISTRY=docker.io
-FROM ${DOCKER_REGISTRY}/node:26.5.0-alpine3.24
+FROM ${DOCKER_REGISTRY}/node:26.7.0-alpine3.24
 
 ENV npm_config_cache=/app/.npm
 

--- a/sources/packages/backend/migrations/Dockerfile.dev
+++ b/sources/packages/backend/migrations/Dockerfile.dev
@@ -1,5 +1,5 @@
 # Image to run all the migrations related to application deployment.
-FROM node:26.5.0-alpine3.24
+FROM node:26.7.0-alpine3.24
 
 WORKDIR /app
 

--- a/sources/packages/backend/workflow/Dockerfile.dev
+++ b/sources/packages/backend/workflow/Dockerfile.dev
@@ -1,5 +1,5 @@
 # Base Image
-FROM node:26.5.0-alpine3.24
+FROM node:26.7.0-alpine3.24
 
 WORKDIR /app
 

--- a/sources/packages/web/Dockerfile
+++ b/sources/packages/web/Dockerfile
@@ -4,7 +4,7 @@
 # Artifactory registry is passed as a build argument to avoid hardcoding it in the Dockerfile.
 # The default value (docker.io) allows dependabot to resolve and update the base image when an update is available.
 ARG DOCKER_REGISTRY=docker.io
-FROM ${DOCKER_REGISTRY}/node:26.5.0-alpine3.24 AS builder
+FROM ${DOCKER_REGISTRY}/node:26.7.0-alpine3.24 AS builder
 
 # Application Port.
 ENV PORT=3030

--- a/sources/packages/web/Dockerfile.dev
+++ b/sources/packages/web/Dockerfile.dev
@@ -1,5 +1,5 @@
 # "builder" stage, based on Node.js, to build and compile the frontend.
-FROM node:26.5.0-alpine3.24 AS builder
+FROM node:26.7.0-alpine3.24 AS builder
 
 # Application Port.
 ENV PORT=8080


### PR DESCRIPTION
## Overview

Updates Docker base images used by SIMS services for the v4.0.0 release.

## Updated base images

| Image | Previous version | Updated version | Affected services |
| --- | --- | --- | --- |
| Node.js | `26.5.0-alpine3.24` | `26.7.0-alpine3.24` | API, load-test gateway, queue consumers, workers, migrations, workflow development image, and web builder images |

The Node.js image update is applied to 13 Dockerfiles across production and development build definitions.

## Validation

- Reviewed the committed Dockerfile diff against `main`.
- No application source or configuration changes are included.