### PR TITLE
#6437 - npm updates for v4.0.0 (web)

### DIFF
--- a/sources/packages/web/package-lock.json
+++ b/sources/packages/web/package-lock.json
@@ -18,15 +18,15 @@
         "bootstrap-icons": "^1.13.1",
         "class-transformer": "^0.5.1",
         "class-validator": "^0.15.1",
-        "dayjs": "^1.11.21",
+        "dayjs": "^1.11.23",
         "http-status-codes": "^2.3.0",
         "keycloak-js": "^26.2.4",
         "mitt": "^3.0.1",
         "tslib": "^2.8.1",
-        "uuid": "^14.0.1",
+        "uuid": "^14.0.2",
         "vue": "^3.5.41",
         "vue-router": "^5.2.0",
-        "vuetify": "^4.1.8",
+        "vuetify": "^4.1.11",
         "vuex": "^4.1.0"
       },
       "devDependencies": {
@@ -1962,9 +1962,9 @@
       "license": "MIT"
     },
     "node_modules/dayjs": {
-      "version": "1.11.21",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.21.tgz",
-      "integrity": "sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA==",
+      "version": "1.11.23",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.23.tgz",
+      "integrity": "sha512-QDTCU0M0MxR3hQfnlDJfwekQiaanm1ubOD231u73WBckQ/fsamwRLiE2GBz6D3a/xF1NgfiDLJjXBa1hYOYTtQ==",
       "license": "MIT"
     },
     "node_modules/debug": {
@@ -4235,9 +4235,9 @@
       "peer": true
     },
     "node_modules/uuid": {
-      "version": "14.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.1.tgz",
-      "integrity": "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==",
+      "version": "14.0.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.2.tgz",
+      "integrity": "sha512-xZe/16rV4aa+HGSOCiY2YeLT1OybRLrrkL/Rqaq7p7GMVXjFh+6wN4oMYgjFmnSnhY8t6Xpdl2l9qmnHYuMHwQ==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
@@ -4484,9 +4484,9 @@
       }
     },
     "node_modules/vuetify": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-4.1.8.tgz",
-      "integrity": "sha512-003D/8b5462uZCD5CMRTZF3smADmOn47mzthNY0aP/xkslovR5yIc1qXjPdFN0LHcu+p3GEAVmMQabldaIQ5pg==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-4.1.11.tgz",
+      "integrity": "sha512-pMzGsjha58Lbg9n/icMXCxcQN9rTczcOdMq3wMU1Qe+cfufl28eX4VUUzLwSsDgmLjTtUGsgZIkyYZFQy+SmIw==",
       "license": "MIT",
       "funding": {
         "type": "github",

--- a/sources/packages/web/package.json
+++ b/sources/packages/web/package.json
@@ -22,15 +22,15 @@
     "bootstrap-icons": "^1.13.1",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.15.1",
-    "dayjs": "^1.11.21",
+    "dayjs": "^1.11.23",
     "http-status-codes": "^2.3.0",
     "keycloak-js": "^26.2.4",
     "mitt": "^3.0.1",
     "tslib": "^2.8.1",
-    "uuid": "^14.0.1",
+    "uuid": "^14.0.2",
     "vue": "^3.5.41",
     "vue-router": "^5.2.0",
-    "vuetify": "^4.1.8",
+    "vuetify": "^4.1.11",
     "vuex": "^4.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Overview

Updates web application npm dependencies for the v4.0.0 release.

## Updated packages

| Package | Previous version | Updated version |
| --- | --- | --- |
| `dayjs` | `^1.11.21` | `^1.11.23` |
| `uuid` | `^14.0.1` | `^14.0.2` |
| `vuetify` | `^4.1.8` | `^4.1.11` |

The npm lockfile was regenerated to align the resolved dependency versions with these updates.

## Validation

- Package lockfile was regenerated with `npm i --package-lock-only`.