### PR TITLE
#6161 - Limit offering funded weeks to maximum of 52

### DIFF
--- a/sources/packages/backend/apps/api/src/route-controllers/education-program-offering/_tests_/e2e/education-program-offering.institutions.controller.createOffering.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/education-program-offering/_tests_/e2e/education-program-offering.institutions.controller.createOffering.e2e-spec.ts
@@ -45,7 +45,7 @@ import {
   OfferingYesNoOptions,
   OnlineInstructionModeOptions,
 } from "../../../../services";
-import { getISODateOnlyString } from "@sims/utilities";
+import { addDays, getISODateOnlyString } from "@sims/utilities";
 import { InstitutionUserTypes } from "../../../../auth";
 import { IsNull } from "typeorm";
 import { GC_NOTIFY_TEMPLATE_IDS } from "@sims/test-utils/constants";
@@ -453,6 +453,125 @@ describe("EducationProgramOfferingInstitutionsController(e2e)-createOffering", (
             breakDays: 32,
             eligibleBreakDays: 21,
             ineligibleBreakDays: 11,
+          },
+        ],
+        totalFundedWeeks: studyPeriodBreakdown.totalFundedWeeks,
+        fundedStudyPeriodDays: studyPeriodBreakdown.fundedStudyPeriodDays,
+        unfundedStudyPeriodDays: studyPeriodBreakdown.unfundedStudyPeriodDays,
+      },
+      offeringDeclaration: payload.offeringDeclaration,
+      offeringStatus: OfferingStatus.CreationPending,
+      onlineInstructionMode: payload.onlineInstructionMode,
+    });
+  });
+
+  it("Should create a new offering limiting the funded weeks to 52 when the funded offering period exceeds an year.", async () => {
+    // Arrange
+    const institutionUserToken = await getInstitutionToken(
+      InstitutionTokenTypes.CollegeFUser,
+    );
+    const fakeEducationProgram = createFakeEducationProgram({
+      institution: collegeF,
+      user: collegeFUser,
+    });
+    const savedFakeEducationProgram =
+      await db.educationProgram.save(fakeEducationProgram);
+    const endpoint = `/institutions/education-program-offering/location/${collegeFLocation.id}/education-program/${savedFakeEducationProgram.id}`;
+    const studyBreak = {
+      breakStartDate: getISODateOnlyString(addDays(10)),
+      breakEndDate: getISODateOnlyString(addDays(20)),
+    };
+    const studyPeriodBreakdown = {
+      totalDays: 451,
+      totalFundedWeeks: 52,
+      fundedStudyPeriodDays: 451,
+      unfundedStudyPeriodDays: 0,
+    };
+    const payload: Partial<EducationProgramOfferingAPIInDTO> = {
+      offeringName: "Offering 1",
+      yearOfStudy: 1,
+      offeringIntensity: OfferingIntensity.fullTime,
+      offeringDelivered: OfferingDeliveryOptions.Online,
+      isAviationOffering: OfferingYesNoOptions.No,
+      hasOfferingWILComponent: OfferingYesNoOptions.No,
+      studyStartDate: getISODateOnlyString(new Date()),
+      // The study end date is set to 450 days from now, which exceeds one year.
+      studyEndDate: getISODateOnlyString(addDays(450)),
+      lacksStudyBreaks: false,
+      studyBreaks: [
+        {
+          breakStartDate: studyBreak.breakStartDate,
+          breakEndDate: studyBreak.breakEndDate,
+        },
+      ],
+      offeringType: OfferingTypes.Public,
+      offeringDeclaration: true,
+      actualTuitionCosts: 1234,
+      programRelatedCosts: 3211,
+      mandatoryFees: 456,
+      exceptionalExpenses: 555,
+      onlineInstructionMode: OnlineInstructionModeOptions.SynchronousOnly,
+    };
+
+    // Act/Assert
+    let educationProgramOfferingId: number;
+    await request(app.getHttpServer())
+      .post(endpoint)
+      .send(payload)
+      .auth(institutionUserToken, BEARER_AUTH_TYPE)
+      .expect(HttpStatus.CREATED)
+      .then((response) => {
+        expect(response.body.id).toBeGreaterThan(0);
+        educationProgramOfferingId = response.body.id;
+      });
+    const createdEducationProgramOffering =
+      await db.educationProgramOffering.findOne({
+        select: {
+          name: true,
+          studyStartDate: true,
+          studyEndDate: true,
+          actualTuitionCosts: true,
+          programRelatedCosts: true,
+          mandatoryFees: true,
+          exceptionalExpenses: true,
+          offeringDelivered: true,
+          lacksStudyBreaks: true,
+          offeringType: true,
+          offeringIntensity: true,
+          yearOfStudy: true,
+          isAviationOffering: true,
+          hasOfferingWILComponent: true,
+          studyBreaks: true as unknown,
+          offeringDeclaration: true,
+          offeringStatus: true,
+          onlineInstructionMode: true,
+        },
+        where: { id: educationProgramOfferingId },
+      });
+    expect(createdEducationProgramOffering).toEqual({
+      name: payload.offeringName,
+      studyStartDate: payload.studyStartDate,
+      studyEndDate: payload.studyEndDate,
+      actualTuitionCosts: payload.actualTuitionCosts,
+      programRelatedCosts: payload.programRelatedCosts,
+      mandatoryFees: payload.mandatoryFees,
+      exceptionalExpenses: payload.exceptionalExpenses,
+      offeringDelivered: payload.offeringDelivered,
+      lacksStudyBreaks: payload.lacksStudyBreaks,
+      offeringType: payload.offeringType,
+      offeringIntensity: payload.offeringIntensity,
+      yearOfStudy: payload.yearOfStudy,
+      isAviationOffering: payload.isAviationOffering,
+      hasOfferingWILComponent: payload.hasOfferingWILComponent,
+      studyBreaks: {
+        totalDays: studyPeriodBreakdown.totalDays,
+        studyBreaks: [
+          {
+            breakStartDate: studyBreak.breakStartDate,
+            breakEndDate: studyBreak.breakEndDate,
+            breakDays: 11,
+            eligibleBreakDays: 11,
+            ineligibleBreakDays: 0,
           },
         ],
         totalFundedWeeks: studyPeriodBreakdown.totalFundedWeeks,

--- a/sources/packages/backend/apps/api/src/route-controllers/education-program-offering/_tests_/e2e/education-program-offering.institutions.controller.createOffering.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/education-program-offering/_tests_/e2e/education-program-offering.institutions.controller.createOffering.e2e-spec.ts
@@ -465,7 +465,7 @@ describe("EducationProgramOfferingInstitutionsController(e2e)-createOffering", (
     });
   });
 
-  it("Should create a new offering limiting the funded weeks to 52 when the funded offering period exceeds an year.", async () => {
+  it("Should create a new offering limiting the funded weeks to 52 when the funded offering period exceeds a year.", async () => {
     // Arrange
     const institutionUserToken = await getInstitutionToken(
       InstitutionTokenTypes.CollegeFUser,

--- a/sources/packages/backend/apps/api/src/services/education-program-offering/education-program-offering.service.ts
+++ b/sources/packages/backend/apps/api/src/services/education-program-offering/education-program-offering.service.ts
@@ -45,6 +45,7 @@ import {
   OFFERING_VALIDATIONS_STUDY_BREAK_COMBINED_PERCENTAGE_THRESHOLD,
   OfferingPaginationOptions,
   PaginationOptions,
+  OFFERING_MAX_FUNDED_WEEKS,
 } from "../../utilities";
 import {
   CustomNamedError,
@@ -1687,7 +1688,10 @@ export class EducationProgramOfferingService extends RecordDataModelService<Educ
       studyBreaks,
       fundedStudyPeriodDays: decimalRound(fundedStudyPeriodDays),
       totalDays,
-      totalFundedWeeks: Math.ceil(fundedStudyPeriodDays / 7),
+      totalFundedWeeks: Math.min(
+        Math.ceil(fundedStudyPeriodDays / 7),
+        OFFERING_MAX_FUNDED_WEEKS,
+      ),
       unfundedStudyPeriodDays: decimalRound(unfundedStudyPeriodDays),
       sumOfTotalEligibleBreakDays,
       sumOfTotalIneligibleBreakDays,

--- a/sources/packages/backend/apps/api/src/utilities/system-configurations-constants.ts
+++ b/sources/packages/backend/apps/api/src/utilities/system-configurations-constants.ts
@@ -47,6 +47,12 @@ export const OFFERING_STUDY_BREAK_MIN_DAYS = 6;
  */
 export const OFFERING_STUDY_BREAK_MAX_DAYS = 21;
 /**
+ * Maximum amount of funded weeks allowed for an offering.
+ * Even if the total funded study period days leads to a greater amount of weeks
+ * the total funded weeks will be capped to this value.
+ */
+export const OFFERING_MAX_FUNDED_WEEKS = 52;
+/**
  * Minimal value to an offering year of study.
  */
 export const OFFERING_YEAR_OF_STUDY_MIN_VALUE = 1;

--- a/sources/packages/backend/apps/db-migrations/src/migrations/1787263046790-UpdateOfferingTotalFundedWeeks.ts
+++ b/sources/packages/backend/apps/db-migrations/src/migrations/1787263046790-UpdateOfferingTotalFundedWeeks.ts
@@ -1,0 +1,22 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+import { getSQLFileData } from "../utilities/sqlLoader";
+
+export class UpdateOfferingTotalFundedWeeks1787263046790 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      getSQLFileData(
+        "Update-total-funded-weeks.sql",
+        "EducationProgramsOfferings",
+      ),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      getSQLFileData(
+        "Rollback-update-total-funded-weeks.sql",
+        "EducationProgramsOfferings",
+      ),
+    );
+  }
+}

--- a/sources/packages/backend/apps/db-migrations/src/sql/EducationProgramsOfferings/Rollback-update-total-funded-weeks.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/EducationProgramsOfferings/Rollback-update-total-funded-weeks.sql
@@ -15,4 +15,8 @@ SET
 WHERE
     study_breaks_before_update IS NOT NULL;
 
--- The column study_breaks_before_update is not dropped to be available for any investigation if required.
+ALTER TABLE
+    sims.education_programs_offerings DROP COLUMN study_breaks_before_update;
+
+ALTER TABLE
+    sims.education_programs_offerings_history DROP COLUMN study_breaks_before_update;

--- a/sources/packages/backend/apps/db-migrations/src/sql/EducationProgramsOfferings/Rollback-update-total-funded-weeks.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/EducationProgramsOfferings/Rollback-update-total-funded-weeks.sql
@@ -7,13 +7,18 @@ SET
     study_breaks = jsonb_set(
         study_breaks,
         '{totalFundedWeeks}',
-        to_jsonb(
-            (study_breaks_before_update -> 'totalFundedWeeks') :: SMALLINT
-        ),
+        (study_breaks_before_update -> 'totalFundedWeeks'),
         false
     )
 WHERE
-    study_breaks_before_update IS NOT NULL;
+    study_breaks_before_update IS NOT NULL
+    AND (study_breaks_before_update ->> 'totalDays') = (study_breaks ->> 'totalDays')
+    AND (
+        study_breaks_before_update ->> 'fundedStudyPeriodDays'
+    ) = (study_breaks ->> 'fundedStudyPeriodDays')
+    AND (
+        study_breaks_before_update ->> 'unfundedStudyPeriodDays'
+    ) = (study_breaks ->> 'unfundedStudyPeriodDays');
 
 ALTER TABLE
     sims.education_programs_offerings DROP COLUMN study_breaks_before_update;

--- a/sources/packages/backend/apps/db-migrations/src/sql/EducationProgramsOfferings/Rollback-update-total-funded-weeks.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/EducationProgramsOfferings/Rollback-update-total-funded-weeks.sql
@@ -1,0 +1,18 @@
+-- Update the study_breaks JSONB column to restore the original totalFundedWeeks value before the previous update.
+-- Update is only applied to rows where the study_breaks_before_update column is not null
+-- indicating that the total funded weeks were updated only on these rows where the study_breaks_before_update was populated with the original value before the update.
+UPDATE
+    sims.education_programs_offerings
+SET
+    study_breaks = jsonb_set(
+        study_breaks,
+        '{totalFundedWeeks}',
+        to_jsonb(
+            (study_breaks_before_update -> 'totalFundedWeeks') :: SMALLINT
+        ),
+        false
+    )
+WHERE
+    study_breaks_before_update IS NOT NULL;
+
+-- The column study_breaks_before_update is not dropped to be available for any investigation if required.

--- a/sources/packages/backend/apps/db-migrations/src/sql/EducationProgramsOfferings/Rollback-update-total-funded-weeks.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/EducationProgramsOfferings/Rollback-update-total-funded-weeks.sql
@@ -1,6 +1,6 @@
 -- Update the study_breaks JSONB column to restore the original totalFundedWeeks value before the previous update.
 -- Update is only applied to rows where the study_breaks_before_update column is not null
--- indicating that the total funded weeks were updated only on these rows where the study_breaks_before_update was populated with the original value before the update.
+-- and the totalDays, fundedStudyPeriodDays, and unfundedStudyPeriodDays values match between the study_breaks and study_breaks_before_update columns.
 UPDATE
     sims.education_programs_offerings
 SET

--- a/sources/packages/backend/apps/db-migrations/src/sql/EducationProgramsOfferings/Update-total-funded-weeks.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/EducationProgramsOfferings/Update-total-funded-weeks.sql
@@ -13,7 +13,7 @@ ADD
 
 COMMENT ON COLUMN sims.education_programs_offerings_history.study_breaks_before_update IS 'Historical data from the original table. See original table comments for details.';
 
--- Update the totalFundedWeeks to 52 if it is greater than 52 and store the previous study_breaks value in funded_weeks_before_update column for rollback.
+-- Update the totalFundedWeeks to 52 if it is greater than 52 and store the previous study_breaks value in study_breaks_before_update column for rollback.
 UPDATE
     sims.education_programs_offerings
 SET

--- a/sources/packages/backend/apps/db-migrations/src/sql/EducationProgramsOfferings/Update-total-funded-weeks.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/EducationProgramsOfferings/Update-total-funded-weeks.sql
@@ -25,4 +25,4 @@ SET
         false
     )
 WHERE
-    (study_breaks -> 'totalFundedWeeks') :: SMALLINT > 52;
+    (study_breaks ->> 'totalFundedWeeks') :: INT > 52;

--- a/sources/packages/backend/apps/db-migrations/src/sql/EducationProgramsOfferings/Update-total-funded-weeks.sql
+++ b/sources/packages/backend/apps/db-migrations/src/sql/EducationProgramsOfferings/Update-total-funded-weeks.sql
@@ -1,0 +1,28 @@
+ALTER TABLE
+    sims.education_programs_offerings
+ADD
+    COLUMN study_breaks_before_update JSONB;
+
+COMMENT ON COLUMN sims.education_programs_offerings.study_breaks_before_update IS 'Column created to store the study breaks information before update for rollback.';
+
+-- History table add column.
+ALTER TABLE
+    sims.education_programs_offerings_history
+ADD
+    COLUMN study_breaks_before_update JSONB;
+
+COMMENT ON COLUMN sims.education_programs_offerings_history.study_breaks_before_update IS 'Historical data from the original table. See original table comments for details.';
+
+-- Update the totalFundedWeeks to 52 if it is greater than 52 and store the previous study_breaks value in funded_weeks_before_update column for rollback.
+UPDATE
+    sims.education_programs_offerings
+SET
+    study_breaks_before_update = study_breaks,
+    study_breaks = jsonb_set(
+        study_breaks,
+        '{totalFundedWeeks}',
+        to_jsonb(52),
+        false
+    )
+WHERE
+    (study_breaks -> 'totalFundedWeeks') :: SMALLINT > 52;


### PR DESCRIPTION
# Limit offering funded weeks to maximum of 52

## DB Migration

- [x] DB migration to update all the `totalFundedWeeks`  greaten than 52 to 52.
- [x] The migration creates a column to copy the existing study breaks to be used for rollback.
- [x] The rollback to update the  `totalFundedWeeks` from the copied column is performed based other inputs to study breaks remain unchanged, i.e the offering wasn't updated through application after DB migration.

## API logic update
- [x] API logic updated to cap the total funded weeks to 52.

## E2E Tests
- [x] Added one E2E test to validate the total funded weeks limited to 52.

Note: More E2E Tests will be added when merging back to main.

## Manual tests

<img width="1793" height="754" alt="image" src="https://github.com/user-attachments/assets/c74fb632-4bb8-4e44-87bd-a2ba8e855170" />

## Manual testing via bulk upload
<img width="1498" height="600" alt="image" src="https://github.com/user-attachments/assets/02c9b13b-7252-47bf-a0b8-fb6ddfa7ca33" />

<img width="1269" height="752" alt="image" src="https://github.com/user-attachments/assets/dd007d2b-e661-47c1-a0c1-420c8fc0134a" />

