### PR TITLE
#6507 - Fix health probes for openshift deployments

### DIFF
--- a/devops/openshift/api-deploy.yml
+++ b/devops/openshift/api-deploy.yml
@@ -273,23 +273,26 @@ objects:
                 requests:
                   cpu: ${CPU_REQUEST}
                   memory: ${MEMORY_REQUEST}
-              readinessProbe:
-                failureThreshold: 3
-                successThreshold: 1
+              startupProbe:
                 httpGet:
                   path: /health/timeout/1500
                   port: "${{PORT}}"
-                initialDelaySeconds: 30
+                timeoutSeconds: 3
+                periodSeconds: 3
+                failureThreshold: 20
+              readinessProbe:
+                failureThreshold: 3
+                httpGet:
+                  path: /health/timeout/1500
+                  port: "${{PORT}}"
                 periodSeconds: 30
                 timeoutSeconds: 3
               livenessProbe:
                 failureThreshold: 3
-                successThreshold: 1
                 httpGet:
                   path: /health/timeout/3000
                   port: "${{PORT}}"
                   scheme: HTTP
-                initialDelaySeconds: 30
                 periodSeconds: 30
                 timeoutSeconds: 5
   - apiVersion: v1

--- a/devops/openshift/forms-deploy.yml
+++ b/devops/openshift/forms-deploy.yml
@@ -85,23 +85,23 @@ objects:
                   memory: "${MEMORY_REQUEST}"
                 limits:
                   memory: "${MEMORY_LIMIT}"
+              startupProbe:
+                tcpSocket:
+                  port: 3001
+                periodSeconds: 5
+                timeoutSeconds: 1
+                failureThreshold: 20
               livenessProbe:
                 tcpSocket:
-                  path: "/ops/healthz"
                   port: 3001
-                  scheme: HTTP
                 timeoutSeconds: 1
                 periodSeconds: 10
-                successThreshold: 1
                 failureThreshold: 3
               readinessProbe:
                 tcpSocket:
-                  path: "/ops/readyz"
                   port: 3001
-                  scheme: HTTP
                 timeoutSeconds: 1
                 periodSeconds: 10
-                successThreshold: 1
                 failureThreshold: 3
               terminationMessagePath: "/dev/termination-log"
               terminationMessagePolicy: File

--- a/devops/openshift/queue-consumers-deploy.yml
+++ b/devops/openshift/queue-consumers-deploy.yml
@@ -280,23 +280,26 @@ objects:
                 requests:
                   cpu: ${CPU_REQUEST}
                   memory: ${MEMORY_REQUEST}
-              readinessProbe:
-                failureThreshold: 3
-                successThreshold: 1
+              startupProbe:
                 httpGet:
                   path: /health/timeout/1500
                   port: "${{PORT}}"
-                initialDelaySeconds: 10
+                periodSeconds: 3
+                timeoutSeconds: 2
+                failureThreshold: 20                  
+              readinessProbe:
+                httpGet:
+                  path: /health/timeout/1500
+                  port: "${{PORT}}"
+                failureThreshold: 3
                 periodSeconds: 10
                 timeoutSeconds: 3
               livenessProbe:
-                failureThreshold: 3
-                successThreshold: 1
                 httpGet:
                   path: /health/timeout/3000
                   port: "${{PORT}}"
                   scheme: HTTP
-                initialDelaySeconds: 30
+                failureThreshold: 3
                 periodSeconds: 30
                 timeoutSeconds: 5
   - apiVersion: v1

--- a/devops/openshift/queue-consumers-deploy.yml
+++ b/devops/openshift/queue-consumers-deploy.yml
@@ -286,7 +286,7 @@ objects:
                   port: "${{PORT}}"
                 periodSeconds: 3
                 timeoutSeconds: 2
-                failureThreshold: 20                  
+                failureThreshold: 20
               readinessProbe:
                 httpGet:
                   path: /health/timeout/1500

--- a/devops/openshift/web-deploy.yml
+++ b/devops/openshift/web-deploy.yml
@@ -43,23 +43,26 @@ objects:
                 requests:
                   cpu: ${CPU_REQUEST}
                   memory: ${MEMORY_REQUEST}
-              readinessProbe:
-                failureThreshold: 3
-                successThreshold: 1
+              startupProbe:
                 httpGet:
                   path: /
                   port: "${{PORT}}"
-                initialDelaySeconds: 20
+                periodSeconds: 3
+                timeoutSeconds: 2
+                failureThreshold: 20
+              readinessProbe:
+                failureThreshold: 3
+                httpGet:
+                  path: /
+                  port: "${{PORT}}"
                 periodSeconds: 30
                 timeoutSeconds: 15
               livenessProbe:
                 failureThreshold: 3
-                successThreshold: 1
                 httpGet:
                   path: /
                   port: "${{PORT}}"
                   scheme: HTTP
-                initialDelaySeconds: 10
                 periodSeconds: 30
                 timeoutSeconds: 15
   - apiVersion: v1


### PR DESCRIPTION
## Summary

- Pods are taking a long time to enter Ready state which delays deployment and GitHub Actions completion
- Adds startup probes to the API, Forms, Queue Consumers, and Web OpenShift deployments.
- Removes default probe values.
- Removes invalid `path` and `scheme` values from the Forms TCP socket probes.
- Allow startup probes to gate readiness and liveness checks instead of relying on initial delays.

General Logic:
- Only Startup Probe is active initially with a much shorter interval than the regular probes. If the startup probe fails for 60 seconds (periodSeconds * failureThereshold) the pod is restarted
- Once the startup probe is healthy the regular livenessprobe and readinessprobe take over. These run for the same periods and timeouts as before (30s)
## Validation

- Pods enter healthy status in 5s instead of 60s

```
old pod status (61s difference between initialize and ready):

    - type: Initialized
      status: 'True'
      lastProbeTime: null
      lastTransitionTime: '2026-08-18T16:15:39Z'
    - type: Ready
      status: 'True'
      lastProbeTime: null
      lastTransitionTime: '2026-08-18T16:16:40Z'
```

```
new pod status (7s difference between initialize and ready):

    - type: Initialized
      status: 'True'
      lastProbeTime: null
      lastTransitionTime: '2026-08-24T23:28:25Z'
    - type: Ready
      status: 'True'
      lastProbeTime: null
      lastTransitionTime: '2026-08-24T23:28:32Z'
```