### PR TITLE
#6509 - Update openshift-tools-installer from v3 to v3.1

### DIFF
--- a/.github/workflows/clamav.yml
+++ b/.github/workflows/clamav.yml
@@ -36,9 +36,10 @@ jobs:
         with:
           ref: ${{ github.ref_name }}
       - name: Install CLI tools from OpenShift Mirror
-        uses: redhat-actions/openshift-tools-installer@v3
+        uses: redhat-actions/openshift-tools-installer@v3.1
         with:
           oc: "4"
+          skip_cache: true
       - name: Log in to OpenShift
         run: |
           oc login --token=${{ secrets.SA_TOKEN }} --server=${{ vars.OPENSHIFT_CLUSTER_URL }}

--- a/.github/workflows/crunchy-db.yml
+++ b/.github/workflows/crunchy-db.yml
@@ -48,9 +48,10 @@ jobs:
         with:
           ref: ${{ github.ref_name }}
       - name: Install CLI tools from OpenShift Mirror
-        uses: redhat-actions/openshift-tools-installer@v3
+        uses: redhat-actions/openshift-tools-installer@v3.1
         with:
           oc: "4"
+          skip_cache: true
       - name: Log in to OpenShift
         run: |
           oc login --token=${{ secrets.SA_TOKEN }} --server=${{ vars.OPENSHIFT_CLUSTER_URL }}

--- a/.github/workflows/crunchy-postgres-install-with-datasource.yml
+++ b/.github/workflows/crunchy-postgres-install-with-datasource.yml
@@ -43,9 +43,10 @@ jobs:
               with:
                   ref: ${{ github.ref_name }}
             - name: Install CLI tools from OpenShift Mirror
-              uses: redhat-actions/openshift-tools-installer@v3
+              uses: redhat-actions/openshift-tools-installer@v3.1
               with:
-                  oc: "4"
+                oc: "4"
+                skip_cache: true
             - name: Log in to OpenShift
               run: |
                   oc login --token="$SA_TOKEN" --server="$OPENSHIFT_CLUSTER_URL"

--- a/.github/workflows/crunchy-postgres-shutdown-startup.yml
+++ b/.github/workflows/crunchy-postgres-shutdown-startup.yml
@@ -33,9 +33,10 @@ jobs:
               with:
                   ref: ${{ github.ref_name }}
             - name: Install CLI tools from OpenShift Mirror
-              uses: redhat-actions/openshift-tools-installer@v3
+              uses: redhat-actions/openshift-tools-installer@v3.1
               with:
-                  oc: "4"
+                oc: "4"
+                skip_cache: true
             - name: Log in to OpenShift
               run: |
                   oc login --token="$SA_TOKEN" --server="$OPENSHIFT_CLUSTER_URL"

--- a/.github/workflows/crunchy-postgres-version-upgrade.yml
+++ b/.github/workflows/crunchy-postgres-version-upgrade.yml
@@ -37,9 +37,10 @@ jobs:
         with:
           ref: ${{ github.ref_name }}
       - name: Install CLI tools from OpenShift Mirror
-        uses: redhat-actions/openshift-tools-installer@v3
+        uses: redhat-actions/openshift-tools-installer@v3.1
         with:
           oc: "4"
+          skip_cache: true
       - name: Log in to OpenShift
         run: |
           oc login --token=${{ secrets.SA_TOKEN }} --server=${{ vars.OPENSHIFT_CLUSTER_URL }}

--- a/.github/workflows/env-setup-build-forms-server.yml
+++ b/.github/workflows/env-setup-build-forms-server.yml
@@ -20,9 +20,10 @@ jobs:
       FORMIO_BUILD_TAG: "${{ github.event.inputs.formioTargetVersion }}-${{ github.run_number }}"
     steps:
       - name: Install CLI tools from OpenShift Mirror
-        uses: redhat-actions/openshift-tools-installer@v3
+        uses: redhat-actions/openshift-tools-installer@v3.1
         with:
           oc: "4"
+          skip_cache: true
       - name: Print env
         run: |
           echo BUILD NAMESPACE: $BUILD_NAMESPACE

--- a/.github/workflows/env-setup-deploy-forms-server.yml
+++ b/.github/workflows/env-setup-deploy-forms-server.yml
@@ -37,9 +37,10 @@ jobs:
       FORMIO_REPLICAS: ${{ vars.FORMIO_REPLICAS }}
     steps:
       - name: Install CLI tools from OpenShift Mirror
-        uses: redhat-actions/openshift-tools-installer@v3
+        uses: redhat-actions/openshift-tools-installer@v3.1
         with:
           oc: "4"
+          skip_cache: true
       - name: Print env
         run: |
           echo NAMESPACE: $NAMESPACE

--- a/.github/workflows/env-setup-deploy-mongo.yml
+++ b/.github/workflows/env-setup-deploy-mongo.yml
@@ -26,9 +26,10 @@ jobs:
         with:
           ref: ${{ github.ref_name }}
       - name: Install CLI tools from OpenShift Mirror
-        uses: redhat-actions/openshift-tools-installer@v3
+        uses: redhat-actions/openshift-tools-installer@v3.1
         with:
           oc: "4"
+          skip_cache: true
       - name: Log in to OpenShift
         run: |
           oc login --token=${{ secrets.SA_TOKEN }} --server=${{ vars.OPENSHIFT_CLUSTER_URL }}

--- a/.github/workflows/env-setup-deploy-secrets.yml
+++ b/.github/workflows/env-setup-deploy-secrets.yml
@@ -81,9 +81,10 @@ jobs:
         with:
           ref: ${{ github.ref_name }}
       - name: Install CLI tools from OpenShift Mirror
-        uses: redhat-actions/openshift-tools-installer@v3
+        uses: redhat-actions/openshift-tools-installer@v3.1
         with:
           oc: "4"
+          skip_cache: true
       - name: Log in to OpenShift
         run: |
           oc login --token=${{ secrets.SA_TOKEN }} --server=${{ vars.OPENSHIFT_CLUSTER_URL }}

--- a/.github/workflows/env-setup-redis-cluster-recovery.yml
+++ b/.github/workflows/env-setup-redis-cluster-recovery.yml
@@ -30,9 +30,10 @@ jobs:
         with:
           ref: ${{ inputs.gitRef }}
       - name: Install CLI tools from OpenShift Mirror
-        uses: redhat-actions/openshift-tools-installer@v3
+        uses: redhat-actions/openshift-tools-installer@v3.1
         with:
           oc: "4"
+          skip_cache: true
       - name: Log in to OpenShift
         run: |
           oc login --token=${{ secrets.SA_TOKEN }} --server=${{ vars.OPENSHIFT_CLUSTER_URL }}

--- a/.github/workflows/env-setup-sysdig-teams.yml
+++ b/.github/workflows/env-setup-sysdig-teams.yml
@@ -18,9 +18,10 @@ jobs:
         with:
           ref: ${{ github.ref_name }}
       - name: Install CLI tools from OpenShift Mirror
-        uses: redhat-actions/openshift-tools-installer@v3
+        uses: redhat-actions/openshift-tools-installer@v3.1
         with:
           oc: "4"
+          skip_cache: true
       - name: Log in to OpenShift
         run: |
           oc login --token=${{ secrets.SA_TOKEN }} --server=${{ vars.OPENSHIFT_CLUSTER_URL }}

--- a/.github/workflows/load-test-build-gateway.yml
+++ b/.github/workflows/load-test-build-gateway.yml
@@ -19,9 +19,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install CLI tools from OpenShift Mirror
-        uses: redhat-actions/openshift-tools-installer@v3
+        uses: redhat-actions/openshift-tools-installer@v3.1
         with:
           oc: "4"
+          skip_cache: true
       - name: Print env
         run: |
           echo BUILD NAMESPACE: $BUILD_NAMESPACE

--- a/.github/workflows/load-test-deploy-gateway.yml
+++ b/.github/workflows/load-test-deploy-gateway.yml
@@ -31,9 +31,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install CLI tools from OpenShift Mirror
-        uses: redhat-actions/openshift-tools-installer@v3
+        uses: redhat-actions/openshift-tools-installer@v3.1
         with:
           oc: "4"
+          skip_cache: true
       - name: Print env
         run: |
           echo Deploy Environment: ${{ inputs.environment }}

--- a/.github/workflows/redis-cluster.yml
+++ b/.github/workflows/redis-cluster.yml
@@ -31,9 +31,10 @@ jobs:
         with:
           ref: ${{ github.ref_name }}
       - name: Install CLI tools from OpenShift Mirror
-        uses: redhat-actions/openshift-tools-installer@v3
+        uses: redhat-actions/openshift-tools-installer@v3.1
         with:
           oc: "4"
+          skip_cache: true
       - name: Log in to OpenShift
         run: |
           oc login --token=${{ secrets.SA_TOKEN }} --server=${{ vars.OPENSHIFT_CLUSTER_URL }}

--- a/.github/workflows/release-build-all.yml
+++ b/.github/workflows/release-build-all.yml
@@ -80,9 +80,10 @@ jobs:
       BUILD_REF: ${{ needs.createTag.outputs.newTag }}
     steps:
       - name: Install CLI tools from OpenShift Mirror
-        uses: redhat-actions/openshift-tools-installer@v3
+        uses: redhat-actions/openshift-tools-installer@v3.1
         with:
           oc: "4"
+          skip_cache: true
       - name: Print env
         run: |
           echo BUILD NAMESPACE: $BUILD_NAMESPACE
@@ -111,9 +112,10 @@ jobs:
       BUILD_REF: ${{ needs.createTag.outputs.newTag }}
     steps:
       - name: Install CLI tools from OpenShift Mirror
-        uses: redhat-actions/openshift-tools-installer@v3
+        uses: redhat-actions/openshift-tools-installer@v3.1
         with:
           oc: "4"
+          skip_cache: true
       - name: Print env
         run: |
           echo BUILD NAMESPACE: $BUILD_NAMESPACE
@@ -142,9 +144,10 @@ jobs:
       BUILD_REF: ${{ needs.createTag.outputs.newTag }}
     steps:
       - name: Install CLI tools from OpenShift Mirror
-        uses: redhat-actions/openshift-tools-installer@v3
+        uses: redhat-actions/openshift-tools-installer@v3.1
         with:
           oc: "4"
+          skip_cache: true
       - name: Print env
         run: |
           echo BUILD NAMESPACE: $BUILD_NAMESPACE
@@ -173,9 +176,10 @@ jobs:
       BUILD_REF: ${{ needs.createTag.outputs.newTag }}
     steps:
       - name: Install CLI tools from OpenShift Mirror
-        uses: redhat-actions/openshift-tools-installer@v3
+        uses: redhat-actions/openshift-tools-installer@v3.1
         with:
           oc: "4"
+          skip_cache: true
       - name: Print env
         run: |
           echo BUILD NAMESPACE: $BUILD_NAMESPACE
@@ -204,9 +208,10 @@ jobs:
       BUILD_REF: ${{ needs.createTag.outputs.newTag }}
     steps:
       - name: Install CLI tools from OpenShift Mirror
-        uses: redhat-actions/openshift-tools-installer@v3
+        uses: redhat-actions/openshift-tools-installer@v3.1
         with:
           oc: "4"
+          skip_cache: true
       - name: Print env
         run: |
           echo BUILD NAMESPACE: $BUILD_NAMESPACE

--- a/.github/workflows/release-deploy-all.yml
+++ b/.github/workflows/release-deploy-all.yml
@@ -152,9 +152,10 @@ jobs:
     needs: env-setup
     steps:
       - name: Install CLI tools from OpenShift Mirror
-        uses: redhat-actions/openshift-tools-installer@v3
+        uses: redhat-actions/openshift-tools-installer@v3.1
         with:
           oc: "4"
+          skip_cache: true
       - name: Print env
         env:
           DEPLOY_ENVIRONMENT: ${{ inputs.environment }}
@@ -186,9 +187,10 @@ jobs:
     needs: [env-setup, run-db-migrations]
     steps:
       - name: Install CLI tools from OpenShift Mirror
-        uses: redhat-actions/openshift-tools-installer@v3
+        uses: redhat-actions/openshift-tools-installer@v3.1
         with:
           oc: "4"
+          skip_cache: true
       - name: Print env
         env:
           DEPLOY_ENVIRONMENT: ${{ inputs.environment }}
@@ -222,9 +224,10 @@ jobs:
     needs: [env-setup, run-db-migrations]
     steps:
       - name: Install CLI tools from OpenShift Mirror
-        uses: redhat-actions/openshift-tools-installer@v3
+        uses: redhat-actions/openshift-tools-installer@v3.1
         with:
           oc: "4"
+          skip_cache: true
       - name: Print env
         env:
           DEPLOY_ENVIRONMENT: ${{ inputs.environment }}
@@ -255,9 +258,10 @@ jobs:
     needs: [env-setup, run-db-migrations]
     steps:
       - name: Install CLI tools from OpenShift Mirror
-        uses: redhat-actions/openshift-tools-installer@v3
+        uses: redhat-actions/openshift-tools-installer@v3.1
         with:
           oc: "4"
+          skip_cache: true
       - name: Print env
         env:
           DEPLOY_ENVIRONMENT: ${{ inputs.environment }}
@@ -289,9 +293,10 @@ jobs:
     needs: [env-setup, run-db-migrations]
     steps:
       - name: Install CLI tools from OpenShift Mirror
-        uses: redhat-actions/openshift-tools-installer@v3
+        uses: redhat-actions/openshift-tools-installer@v3.1
         with:
           oc: "4"
+          skip_cache: true
       - name: Print env
         env:
           DEPLOY_ENVIRONMENT: ${{ inputs.environment }}

--- a/.github/workflows/release-deploy-camunda-formio-definitions.yml
+++ b/.github/workflows/release-deploy-camunda-formio-definitions.yml
@@ -48,9 +48,10 @@ jobs:
       FORMS_SECRET_NAME: ${{ secrets.FORMS_SECRET_NAME }}
     steps:
       - name: Install CLI tools from OpenShift Mirror
-        uses: redhat-actions/openshift-tools-installer@v3
+        uses: redhat-actions/openshift-tools-installer@v3.1
         with:
           oc: "4"
+          skip_cache: true
       - name: Print env
         run: |
           echo BUILD NAMESPACE: "$BUILD_NAMESPACE"

--- a/.github/workflows/release-deploy-db-migrations-repl.yml
+++ b/.github/workflows/release-deploy-db-migrations-repl.yml
@@ -25,9 +25,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install CLI tools from OpenShift Mirror
-        uses: redhat-actions/openshift-tools-installer@v3
+        uses: redhat-actions/openshift-tools-installer@v3.1
         with:
           oc: "4"
+          skip_cache: true
       - name: Print env
         run: |
           echo Deploy Environment: ${{ inputs.environment }}


### PR DESCRIPTION
## Summary
- Fixes a longstanding bug where the action step takes 3 minutes instead of 5s
- Setting skip_cache: true because caching does not save any execution time and requires elevated permissions (actions: write) that introduce a security risk
