### PR TITLE
#6547 - BUG - breaks in study

### DIFF
--- a/sources/packages/backend/apps/api/src/route-controllers/education-program-offering/_tests_/e2e/education-program-offering.institutions.controller.requestChange.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/education-program-offering/_tests_/e2e/education-program-offering.institutions.controller.requestChange.e2e-spec.ts
@@ -98,6 +98,7 @@ describe("EducationProgramOfferingInstitutionsController(e2e)-requestChange", ()
           studyStartDate: "2023-09-01",
           studyEndDate: "2024-06-30",
           submittedDate: new Date(),
+          lacksStudyBreaks: false,
         },
       },
     );

--- a/sources/packages/backend/apps/api/src/route-controllers/education-program-offering/education-program-offering.controller.service.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/education-program-offering/education-program-offering.controller.service.ts
@@ -217,7 +217,7 @@ export class EducationProgramOfferingControllerService {
       operatingName: institutionLocation.institution.operatingName,
       legalOperatingName: institutionLocation.institution.legalOperatingName,
       primaryEmail: institutionLocation.institution.primaryEmail,
-      // Ignore any study breaks submitted if not study breaks are indicated in the payload.
+      // Ignore any study breaks submitted if no study breaks are indicated in the payload.
       studyBreaks: payload.lacksStudyBreaks ? [] : payload.studyBreaks,
       programContext: program,
       institutionContext: {

--- a/sources/packages/backend/apps/api/src/route-controllers/education-program-offering/education-program-offering.controller.service.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/education-program-offering/education-program-offering.controller.service.ts
@@ -217,7 +217,8 @@ export class EducationProgramOfferingControllerService {
       operatingName: institutionLocation.institution.operatingName,
       legalOperatingName: institutionLocation.institution.legalOperatingName,
       primaryEmail: institutionLocation.institution.primaryEmail,
-      studyBreaks: payload.studyBreaks,
+      // Ignore any study breaks submitted if not study breaks are indicated in the payload.
+      studyBreaks: payload.lacksStudyBreaks ? [] : payload.studyBreaks,
       programContext: program,
       institutionContext: {
         isBCPrivate:

--- a/sources/packages/backend/libs/test-utils/src/factories/education-program-offering.ts
+++ b/sources/packages/backend/libs/test-utils/src/factories/education-program-offering.ts
@@ -47,7 +47,7 @@ export function createFakeEducationProgramOffering(
   offering.mandatoryFees = faker.number.int(1000);
   offering.exceptionalExpenses = faker.number.int(1000);
   offering.offeringDelivered = "offeringDelivered";
-  offering.lacksStudyBreaks = true;
+  offering.lacksStudyBreaks = options?.initialValues?.lacksStudyBreaks ?? true;
   offering.educationProgram =
     relations?.program ??
     createFakeEducationProgram(


### PR DESCRIPTION
# The issue

- Even when no study breaks are provided, the form.io submission contains an empty entry for study breaks that correctly fails validation.
- Other validators in the offering model are passing even while validating the empty study break.

## The fix

- Some attempts were made to force form.io to remove the hidden empty fields from the submission, such as:
  -  using `clearOnHide`;
  - moving the conditional from the form.io UI to the custom condition;
  - changing the default value to an empty array when `lackStudyBreaks' was `true`.

_Note:_ fixed an E2E where `lackStudyBreaks' was `true` and the API was wrongly saving the provided study breaks.

## Final fix

- Sanitizing the received payload to prevent any study break information from passing over to the next layers if `lacksStudyBreaks` is `true`.

_Note:_ A possible fix would be to include a validator to ensure no study breaks are present if `lackStudyBreaks' is `true`, but it would demand further investigation to ensure form.io data does not contain empty study breaks, or they must be removed prior to the API submission. The current fix was considered "good enough"; it ensures data sanitization similar to the CSV bulk upload, and it is centralized on the server side.

<img width="1456" height="562" alt="image" src="https://github.com/user-attachments/assets/a992d4a8-ea6a-40c7-9f42-31dd42c18ac2" />

## E2E Test

- An E2E test will be added for the main sync-up.
