### PR TITLE
#6552 - White screen error for student profile creation

### DIFF
--- a/sims.code-workspace
+++ b/sims.code-workspace
@@ -164,6 +164,7 @@
       "AVIR",
       "bcag",
       "BCLM",
+      "bcsc",
       "BCSC",
       "BCSG",
       "bcsl",

--- a/sources/packages/web/src/types/ApplicationToken.ts
+++ b/sources/packages/web/src/types/ApplicationToken.ts
@@ -71,12 +71,12 @@ export interface BCSCParsedToken extends ApplicationToken {
   familyName: string;
   gender: string;
   givenName: string;
-  address: {
-    locality: string;
-    region: string;
-    postal_code: string;
-    country: string;
-    street_address: string;
+  address?: {
+    locality?: string;
+    region?: string;
+    postal_code?: string;
+    country?: string;
+    street_address?: string;
   };
 }
 

--- a/sources/packages/web/src/views/student/StudentProfileCreate.vue
+++ b/sources/packages/web/src/views/student/StudentProfileCreate.vue
@@ -74,11 +74,13 @@ export default defineComponent({
         data.canadaPostalCode =
           bcscParsedToken.address?.postal_code?.replaceAll(/\s+/g, "") ?? "";
       }
-      data.country = bcscParsedToken.address?.country;
-      data.selectedCountry =
-        bcscParsedToken.address?.country === CANADA_COUNTRY_CODE
-          ? "Canada"
-          : "other";
+      if (bcscParsedToken.address?.country) {
+        data.country = bcscParsedToken.address.country;
+        data.selectedCountry =
+          bcscParsedToken.address.country === CANADA_COUNTRY_CODE
+            ? "Canada"
+            : "other";
+      }
     };
 
     const populateBCSCUserData = (data: StudentProfileFormModel) => {

--- a/sources/packages/web/src/views/student/StudentProfileCreate.vue
+++ b/sources/packages/web/src/views/student/StudentProfileCreate.vue
@@ -60,23 +60,26 @@ export default defineComponent({
     const isDataReady = ref(false);
 
     const populateBCSCAddressFields = (data: StudentProfileFormModel) => {
+      if (!bcscParsedToken.address) {
+        return;
+      }
       // BCSC users address fields to StudentProfileFormModel.
-      if (bcscParsedToken.address?.street_address) {
+      if (bcscParsedToken.address.street_address) {
         data.addressLine1 = bcscParsedToken.address.street_address.replace(
           /\r\n|\n/g,
           " ",
         );
       }
-      if (bcscParsedToken.address?.locality) {
-        data.city = bcscParsedToken.address?.locality;
+      if (bcscParsedToken.address.locality) {
+        data.city = bcscParsedToken.address.locality;
       }
-      if (bcscParsedToken.address?.country === CANADA_COUNTRY_CODE) {
-        data.provinceState = bcscParsedToken.address?.region;
+      if (bcscParsedToken.address.country === CANADA_COUNTRY_CODE) {
+        data.provinceState = bcscParsedToken.address.region;
         // Remove spaces from postal code.
         data.canadaPostalCode =
-          bcscParsedToken.address?.postal_code?.replaceAll(/\s+/g, "") ?? "";
+          bcscParsedToken.address.postal_code?.replaceAll(/\s+/g, "") ?? "";
       }
-      if (bcscParsedToken.address?.country) {
+      if (bcscParsedToken.address.country) {
         data.country = bcscParsedToken.address.country;
         data.selectedCountry =
           bcscParsedToken.address.country === CANADA_COUNTRY_CODE

--- a/sources/packages/web/src/views/student/StudentProfileCreate.vue
+++ b/sources/packages/web/src/views/student/StudentProfileCreate.vue
@@ -61,22 +61,22 @@ export default defineComponent({
 
     const populateBCSCAddressFields = (data: StudentProfileFormModel) => {
       // BCSC users address fields to StudentProfileFormModel.
-      if (bcscParsedToken.address.street_address) {
+      if (bcscParsedToken.address?.street_address) {
         data.addressLine1 = bcscParsedToken.address.street_address.replace(
           /\r\n|\n/g,
           " ",
         );
       }
-      data.city = bcscParsedToken.address.locality;
-      if (bcscParsedToken.address.country === CANADA_COUNTRY_CODE) {
-        data.provinceState = bcscParsedToken.address.region;
+      data.city = bcscParsedToken.address?.locality;
+      if (bcscParsedToken.address?.country === CANADA_COUNTRY_CODE) {
+        data.provinceState = bcscParsedToken.address?.region;
         // Remove spaces from postal code.
         data.canadaPostalCode =
-          bcscParsedToken.address.postal_code?.replaceAll(/\s+/g, "") ?? "";
+          bcscParsedToken.address?.postal_code?.replaceAll(/\s+/g, "") ?? "";
       }
-      data.country = bcscParsedToken.address.country;
+      data.country = bcscParsedToken.address?.country;
       data.selectedCountry =
-        bcscParsedToken.address.country === CANADA_COUNTRY_CODE
+        bcscParsedToken.address?.country === CANADA_COUNTRY_CODE
           ? "Canada"
           : "other";
     };

--- a/sources/packages/web/src/views/student/StudentProfileCreate.vue
+++ b/sources/packages/web/src/views/student/StudentProfileCreate.vue
@@ -67,7 +67,9 @@ export default defineComponent({
           " ",
         );
       }
-      data.city = bcscParsedToken.address?.locality;
+      if (bcscParsedToken.address?.locality) {
+        data.city = bcscParsedToken.address?.locality;
+      }
       if (bcscParsedToken.address?.country === CANADA_COUNTRY_CODE) {
         data.provinceState = bcscParsedToken.address?.region;
         // Remove spaces from postal code.


### PR DESCRIPTION
Prevent BCSC from missing address information to break the UI.

## JACK - full address present

<img width="896" height="406" alt="image" src="https://github.com/user-attachments/assets/3056bf60-fa18-4e1c-86d7-073b04a7f84b" />

<img width="1177" height="503" alt="image" src="https://github.com/user-attachments/assets/c1c47153-ebab-4977-bbbd-9acfa637e3df" />

## Missing street address

<img width="1171" height="511" alt="image" src="https://github.com/user-attachments/assets/756bc2d4-c715-4313-917d-124ded17240a" />

## All address-related info deleted

<img width="950" height="237" alt="image" src="https://github.com/user-attachments/assets/7de0549c-397f-4cfb-a15d-e346bfd2f075" />

<img width="1181" height="512" alt="image" src="https://github.com/user-attachments/assets/8a8b7327-28a4-4d5c-a394-af70739da9f3" />

## Country is present as Canada but is missing the postal code and region.

<img width="1172" height="495" alt="image" src="https://github.com/user-attachments/assets/4bd5c6db-ed3c-4403-9101-5cd335fc5541" />

```json
"address": {
    "country": "CA"
  },
```





