### PR TITLE
#6547 - BUG - breaks in study

### DIFF
--- a/sources/packages/backend/apps/api/src/route-controllers/education-program-offering/_tests_/e2e/education-program-offering.institutions.controller.requestChange.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/education-program-offering/_tests_/e2e/education-program-offering.institutions.controller.requestChange.e2e-spec.ts
@@ -98,6 +98,7 @@ describe("EducationProgramOfferingInstitutionsController(e2e)-requestChange", ()
           studyStartDate: "2023-09-01",
           studyEndDate: "2024-06-30",
           submittedDate: new Date(),
+          lacksStudyBreaks: false,
         },
       },
     );

--- a/sources/packages/backend/apps/api/src/route-controllers/education-program-offering/_tests_/e2e/education-program-offering.institutions.controller.updateProgramOffering.e2e-spec.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/education-program-offering/_tests_/e2e/education-program-offering.institutions.controller.updateProgramOffering.e2e-spec.ts
@@ -213,6 +213,108 @@ describe("EducationProgramOfferingInstitutionsController(e2e)-updateProgramOffer
     );
   });
 
+  it("Should update a new offering, removing study breaks when passed valid data and lacksStudyBreaks is true.", async () => {
+    // Arrange
+    const institutionUserToken = await getInstitutionToken(
+      InstitutionTokenTypes.CollegeFUser,
+    );
+    const fakeEducationProgram = createFakeEducationProgram({
+      institution: collegeF,
+      user: collegeFUser,
+    });
+    fakeEducationProgram.sabcCode = faker.string.alpha({
+      length: 4,
+      casing: "upper",
+    });
+    const savedFakeEducationProgram =
+      await db.educationProgram.save(fakeEducationProgram);
+    const newOffering = createFakeEducationProgramOffering(
+      collegeFUser,
+      savedFakeEducationProgram,
+      collegeFLocation,
+    );
+    newOffering.parentOffering = newOffering;
+    const savedEducationProgramOffering =
+      await db.educationProgramOffering.save(newOffering);
+
+    const endpoint = `/institutions/education-program-offering/location/${collegeFLocation.id}/education-program/${savedFakeEducationProgram.id}/offering/${savedEducationProgramOffering.id}`;
+    const studyBreak = {
+      breakStartDate: "2023-12-01",
+      breakEndDate: "2024-01-01",
+    };
+    const studyPeriodBreakdown = {
+      totalDays: 304,
+      totalFundedWeeks: 44,
+      fundedStudyPeriodDays: 304,
+      unfundedStudyPeriodDays: 0,
+    };
+    const payload = {
+      offeringName: "Updated offering name",
+      yearOfStudy: 1,
+      offeringIntensity: OfferingIntensity.fullTime,
+      offeringDelivered: OfferingDeliveryOptions.Onsite,
+      isAviationOffering: OfferingYesNoOptions.No,
+      hasOfferingWILComponent: "no",
+      studyStartDate: "2023-09-01",
+      studyEndDate: "2024-06-30",
+      lacksStudyBreaks: true,
+      // Study breaks should be removed when lacksStudyBreaks is true.
+      studyBreaks: [
+        {
+          breakStartDate: studyBreak.breakStartDate,
+          breakEndDate: studyBreak.breakEndDate,
+        },
+      ],
+      offeringType: OfferingTypes.Public,
+      offeringDeclaration: true,
+      actualTuitionCosts: 1234,
+      programRelatedCosts: 3211,
+      mandatoryFees: 456,
+      exceptionalExpenses: 555,
+    };
+
+    // Act/Assert
+    await request(app.getHttpServer())
+      .patch(endpoint)
+      .send(payload)
+      .auth(institutionUserToken, BEARER_AUTH_TYPE)
+      .expect(HttpStatus.OK)
+      .expect({});
+    const updatedEducationProgramOffering =
+      await db.educationProgramOffering.findOne({
+        where: { id: savedEducationProgramOffering.id },
+      });
+    expect(updatedEducationProgramOffering).toEqual(
+      expect.objectContaining({
+        name: payload.offeringName,
+        studyStartDate: payload.studyStartDate,
+        studyEndDate: payload.studyEndDate,
+        actualTuitionCosts: payload.actualTuitionCosts,
+        programRelatedCosts: payload.programRelatedCosts,
+        mandatoryFees: payload.mandatoryFees,
+        exceptionalExpenses: payload.exceptionalExpenses,
+        offeringDelivered: payload.offeringDelivered,
+        lacksStudyBreaks: payload.lacksStudyBreaks,
+        offeringType: payload.offeringType,
+        offeringIntensity: payload.offeringIntensity,
+        yearOfStudy: payload.yearOfStudy,
+        isAviationOffering: payload.isAviationOffering,
+        hasOfferingWILComponent: payload.hasOfferingWILComponent,
+        offeringWILType: null,
+        studyBreaks: {
+          totalDays: studyPeriodBreakdown.totalDays,
+          studyBreaks: [],
+          totalFundedWeeks: studyPeriodBreakdown.totalFundedWeeks,
+          fundedStudyPeriodDays: studyPeriodBreakdown.fundedStudyPeriodDays,
+          unfundedStudyPeriodDays: studyPeriodBreakdown.unfundedStudyPeriodDays,
+        },
+        offeringDeclaration: payload.offeringDeclaration,
+        assessedDate: null,
+        offeringStatus: OfferingStatus.CreationPending,
+      }),
+    );
+  });
+
   it(
     "Should update an existing offering without any restriction impact when the offering location and program" +
       ` have effective restriction with action type ${RestrictionActionType.StopOfferingCreate}.`,

--- a/sources/packages/backend/apps/api/src/route-controllers/education-program-offering/education-program-offering.controller.service.ts
+++ b/sources/packages/backend/apps/api/src/route-controllers/education-program-offering/education-program-offering.controller.service.ts
@@ -217,7 +217,8 @@ export class EducationProgramOfferingControllerService {
       operatingName: institutionLocation.institution.operatingName,
       legalOperatingName: institutionLocation.institution.legalOperatingName,
       primaryEmail: institutionLocation.institution.primaryEmail,
-      studyBreaks: payload.studyBreaks,
+      // Ignore any study breaks submitted if no study breaks are indicated in the payload.
+      studyBreaks: payload.lacksStudyBreaks ? [] : payload.studyBreaks,
       programContext: program,
       institutionContext: {
         isBCPrivate:

--- a/sources/packages/backend/libs/test-utils/src/factories/education-program-offering.ts
+++ b/sources/packages/backend/libs/test-utils/src/factories/education-program-offering.ts
@@ -47,7 +47,7 @@ export function createFakeEducationProgramOffering(
   offering.mandatoryFees = faker.number.int(1000);
   offering.exceptionalExpenses = faker.number.int(1000);
   offering.offeringDelivered = "offeringDelivered";
-  offering.lacksStudyBreaks = true;
+  offering.lacksStudyBreaks = options?.initialValues?.lacksStudyBreaks ?? true;
   offering.educationProgram =
     relations?.program ??
     createFakeEducationProgram(


### PR DESCRIPTION
# The issue

- Even when no study breaks are provided, the form.io submission contains an empty entry for study breaks that correctly fails validation.
- Other validators in the offering model are passing even while validating the empty study break.

## The fix

- Some attempts were made to force form.io to remove the hidden empty fields from the submission, such as:
  -  using `clearOnHide`;
  - moving the conditional from the form.io UI to the custom condition;
- changing the default value to an empty array when `lackStudyBreaks' was `true`.

_Note:_ fixed an E2E where `lackStudyBreaks' was `true` and the API was wrongly saving the provided study breaks.

## Final fix

- Sanitizing the received payload to prevent any study break information from passing over to the next layers if `lacksStudyBreaks` is `true`.

_Note:_ A possible fix would be to include a validator to ensure no study breaks are present if `lackStudyBreaks' is `true`, but it would demand further investigation to ensure form.io data does not contain empty study breaks, or they must be removed prior to the API submission. The current fix was considered "good enough"; it ensures data sanitization similar to the CSV bulk upload, and it is centralized on the server side.

<img width="1456" height="562" alt="image"
src="https://github.com/user-attachments/assets/a992d4a8-ea6a-40c7-9f42-31dd42c18ac2" />